### PR TITLE
Cache unit file states to avoid walking filesytem repeatedly [REVIEW COMMENTS]

### DIFF
--- a/src/core/dbus-manager.c
+++ b/src/core/dbus-manager.c
@@ -1318,7 +1318,7 @@ static int method_list_unit_files(sd_bus *bus, sd_bus_message *message, void *us
         if (!h)
                 return -ENOMEM;
 
-        r = unit_file_get_list(m->running_as == SYSTEMD_SYSTEM ? UNIT_FILE_SYSTEM : UNIT_FILE_USER, NULL, h);
+        r = unit_file_get_list(m->running_as == SYSTEMD_SYSTEM ? UNIT_FILE_SYSTEM : UNIT_FILE_USER, NULL, h, m->enabled);
         if (r < 0)
                 goto fail;
 
@@ -1367,7 +1367,7 @@ static int method_get_unit_file_state(sd_bus *bus, sd_bus_message *message, void
 
         scope = m->running_as == SYSTEMD_SYSTEM ? UNIT_FILE_SYSTEM : UNIT_FILE_USER;
 
-        state = unit_file_get_state(scope, NULL, name);
+        state = unit_file_get_state(scope, NULL, name, m->enabled);
         if (state < 0)
                 return state;
 

--- a/src/core/manager.c
+++ b/src/core/manager.c
@@ -460,6 +460,10 @@ int manager_new(SystemdRunningAs running_as, Manager **_m) {
         if (r < 0)
                 goto fail;
 
+        m->enabled = enabled_context_new();
+        if (!m->enabled)
+                goto fail;
+
         r = sd_event_default(&m->event);
         if (r < 0)
                 goto fail;
@@ -793,6 +797,7 @@ void manager_free(Manager *m) {
         hashmap_free(m->watch_pids1);
         hashmap_free(m->watch_pids2);
         hashmap_free(m->watch_bus);
+        enabled_context_free(m->enabled);
 
         set_free(m->failed_units);
 

--- a/src/core/manager.h
+++ b/src/core/manager.h
@@ -69,6 +69,7 @@ typedef enum ManagerExitCode {
 #include "unit-name.h"
 #include "exit-status.h"
 #include "show-status.h"
+#include "install.h"
 
 struct Manager {
         /* Note that the set of units we know of is allowed to be
@@ -78,6 +79,7 @@ struct Manager {
         /* Active jobs and units */
         Hashmap *units;  /* name string => Unit object n:1 */
         Hashmap *jobs;   /* job id => Job object 1:1 */
+        EnabledContext *enabled; /* name string => is enabled */
 
         /* To make it easy to iterate through the units of a specific
          * type we maintain a per type linked list */

--- a/src/core/unit.c
+++ b/src/core/unit.c
@@ -2801,7 +2801,7 @@ UnitFileState unit_get_unit_file_state(Unit *u) {
         if (u->unit_file_state < 0 && u->fragment_path)
                 u->unit_file_state = unit_file_get_state(
                                 u->manager->running_as == SYSTEMD_SYSTEM ? UNIT_FILE_SYSTEM : UNIT_FILE_USER,
-                                NULL, basename(u->fragment_path));
+                                NULL, basename(u->fragment_path), u->manager->enabled);
 
         return u->unit_file_state;
 }

--- a/src/shared/install.h
+++ b/src/shared/install.h
@@ -73,6 +73,11 @@ typedef struct {
         char **required_by;
 } InstallInfo;
 
+typedef struct {
+        Hashmap* symlinks;
+        Hashmap* dirs;
+} EnabledContext;
+
 int unit_file_enable(UnitFileScope scope, bool runtime, const char *root_dir, char **files, bool force, UnitFileChange **changes, unsigned *n_changes);
 int unit_file_disable(UnitFileScope scope, bool runtime, const char *root_dir, char **files, UnitFileChange **changes, unsigned *n_changes);
 int unit_file_reenable(UnitFileScope scope, bool runtime, const char *root_dir, char **files, bool force, UnitFileChange **changes, unsigned *n_changes);
@@ -83,9 +88,9 @@ int unit_file_unmask(UnitFileScope scope, bool runtime, const char *root_dir, ch
 int unit_file_set_default(UnitFileScope scope, const char *root_dir, const char *file, bool force, UnitFileChange **changes, unsigned *n_changes);
 int unit_file_get_default(UnitFileScope scope, const char *root_dir, char **name);
 
-UnitFileState unit_file_get_state(UnitFileScope scope, const char *root_dir, const char *filename);
+UnitFileState unit_file_get_state(UnitFileScope scope, const char *root_dir, const char *filename, EnabledContext *ec);
 
-int unit_file_get_list(UnitFileScope scope, const char *root_dir, Hashmap *h);
+int unit_file_get_list(UnitFileScope scope, const char *root_dir, Hashmap *h, EnabledContext *ec);
 
 void unit_file_list_free(Hashmap *h);
 void unit_file_changes_free(UnitFileChange *changes, unsigned n_changes);
@@ -97,3 +102,7 @@ UnitFileState unit_file_state_from_string(const char *s) _pure_;
 
 const char *unit_file_change_type_to_string(UnitFileChangeType s) _const_;
 UnitFileChangeType unit_file_change_type_from_string(const char *s) _pure_;
+
+EnabledContext *enabled_context_new(void);
+void enabled_context_free(EnabledContext *ec);
+

--- a/src/systemctl/systemctl.c
+++ b/src/systemctl/systemctl.c
@@ -1339,7 +1339,7 @@ static int list_unit_files(sd_bus *bus, char **args) {
                 if (!h)
                         return log_oom();
 
-                r = unit_file_get_list(arg_scope, arg_root, h);
+                r = unit_file_get_list(arg_scope, arg_root, h, NULL);
                 if (r < 0) {
                         unit_file_list_free(h);
                         log_error("Failed to get unit file list: %s", strerror(-r));
@@ -5334,7 +5334,7 @@ static int unit_is_enabled(sd_bus *bus, char **args) {
                 STRV_FOREACH(name, names) {
                         UnitFileState state;
 
-                        state = unit_file_get_state(arg_scope, arg_root, *name);
+                        state = unit_file_get_state(arg_scope, arg_root, *name, NULL);
                         if (state < 0) {
                                 log_error("Failed to get unit file state for %s: %s", *name, strerror(-state));
                                 return state;

--- a/src/test/test-install.c
+++ b/src/test/test-install.c
@@ -41,7 +41,7 @@ static void dump_changes(UnitFileChange *c, unsigned n) {
         }
 }
 
-int main(int argc, char* argv[]) {
+static void test_install(EnabledContext *ec) {
         Hashmap *h;
         UnitFileList *p;
         Iterator i;
@@ -52,13 +52,13 @@ int main(int argc, char* argv[]) {
         unsigned n_changes = 0;
 
         h = hashmap_new(string_hash_func, string_compare_func);
-        r = unit_file_get_list(UNIT_FILE_SYSTEM, NULL, h);
+        r = unit_file_get_list(UNIT_FILE_SYSTEM, NULL, h, ec);
         assert_se(r == 0);
 
         HASHMAP_FOREACH(p, h, i) {
                 UnitFileState s;
 
-                s = unit_file_get_state(UNIT_FILE_SYSTEM, NULL, basename(p->path));
+                s = unit_file_get_state(UNIT_FILE_SYSTEM, NULL, basename(p->path), ec);
 
                 assert_se(p->state == s);
 
@@ -82,7 +82,7 @@ int main(int argc, char* argv[]) {
         dump_changes(changes, n_changes);
         unit_file_changes_free(changes, n_changes);
 
-        assert_se(unit_file_get_state(UNIT_FILE_SYSTEM, NULL, files[0]) == UNIT_FILE_ENABLED);
+        assert_se(unit_file_get_state(UNIT_FILE_SYSTEM, NULL, files[0], ec) == UNIT_FILE_ENABLED);
 
         log_error("disable");
 
@@ -95,7 +95,7 @@ int main(int argc, char* argv[]) {
         dump_changes(changes, n_changes);
         unit_file_changes_free(changes, n_changes);
 
-        assert_se(unit_file_get_state(UNIT_FILE_SYSTEM, NULL, files[0]) == UNIT_FILE_DISABLED);
+        assert_se(unit_file_get_state(UNIT_FILE_SYSTEM, NULL, files[0], ec) == UNIT_FILE_DISABLED);
 
         log_error("mask");
         changes = NULL;
@@ -110,7 +110,7 @@ int main(int argc, char* argv[]) {
         dump_changes(changes, n_changes);
         unit_file_changes_free(changes, n_changes);
 
-        assert_se(unit_file_get_state(UNIT_FILE_SYSTEM, NULL, files[0]) == UNIT_FILE_MASKED);
+        assert_se(unit_file_get_state(UNIT_FILE_SYSTEM, NULL, files[0], ec) == UNIT_FILE_MASKED);
 
         log_error("unmask");
         changes = NULL;
@@ -125,7 +125,7 @@ int main(int argc, char* argv[]) {
         dump_changes(changes, n_changes);
         unit_file_changes_free(changes, n_changes);
 
-        assert_se(unit_file_get_state(UNIT_FILE_SYSTEM, NULL, files[0]) == UNIT_FILE_DISABLED);
+        assert_se(unit_file_get_state(UNIT_FILE_SYSTEM, NULL, files[0], ec) == UNIT_FILE_DISABLED);
 
         log_error("mask");
         changes = NULL;
@@ -137,7 +137,7 @@ int main(int argc, char* argv[]) {
         dump_changes(changes, n_changes);
         unit_file_changes_free(changes, n_changes);
 
-        assert_se(unit_file_get_state(UNIT_FILE_SYSTEM, NULL, files[0]) == UNIT_FILE_MASKED);
+        assert_se(unit_file_get_state(UNIT_FILE_SYSTEM, NULL, files[0], ec) == UNIT_FILE_MASKED);
 
         log_error("disable");
         changes = NULL;
@@ -152,7 +152,7 @@ int main(int argc, char* argv[]) {
         dump_changes(changes, n_changes);
         unit_file_changes_free(changes, n_changes);
 
-        assert_se(unit_file_get_state(UNIT_FILE_SYSTEM, NULL, files[0]) == UNIT_FILE_MASKED);
+        assert_se(unit_file_get_state(UNIT_FILE_SYSTEM, NULL, files[0], ec) == UNIT_FILE_MASKED);
 
         log_error("umask");
         changes = NULL;
@@ -164,7 +164,7 @@ int main(int argc, char* argv[]) {
         dump_changes(changes, n_changes);
         unit_file_changes_free(changes, n_changes);
 
-        assert_se(unit_file_get_state(UNIT_FILE_SYSTEM, NULL, files[0]) == UNIT_FILE_DISABLED);
+        assert_se(unit_file_get_state(UNIT_FILE_SYSTEM, NULL, files[0], ec) == UNIT_FILE_DISABLED);
 
         log_error("enable files2");
         changes = NULL;
@@ -176,7 +176,7 @@ int main(int argc, char* argv[]) {
         dump_changes(changes, n_changes);
         unit_file_changes_free(changes, n_changes);
 
-        assert_se(unit_file_get_state(UNIT_FILE_SYSTEM, NULL, basename(files2[0])) == UNIT_FILE_ENABLED);
+        assert_se(unit_file_get_state(UNIT_FILE_SYSTEM, NULL, basename(files2[0]), ec) == UNIT_FILE_ENABLED);
 
         log_error("disable files2");
         changes = NULL;
@@ -188,7 +188,7 @@ int main(int argc, char* argv[]) {
         dump_changes(changes, n_changes);
         unit_file_changes_free(changes, n_changes);
 
-        assert_se(unit_file_get_state(UNIT_FILE_SYSTEM, NULL, basename(files2[0])) == _UNIT_FILE_STATE_INVALID);
+        assert_se(unit_file_get_state(UNIT_FILE_SYSTEM, NULL, basename(files2[0]), ec) == _UNIT_FILE_STATE_INVALID);
 
         log_error("link files2");
         changes = NULL;
@@ -200,7 +200,7 @@ int main(int argc, char* argv[]) {
         dump_changes(changes, n_changes);
         unit_file_changes_free(changes, n_changes);
 
-        assert_se(unit_file_get_state(UNIT_FILE_SYSTEM, NULL, basename(files2[0])) == UNIT_FILE_LINKED);
+        assert_se(unit_file_get_state(UNIT_FILE_SYSTEM, NULL, basename(files2[0]), ec) == UNIT_FILE_LINKED);
 
         log_error("disable files2");
         changes = NULL;
@@ -212,7 +212,7 @@ int main(int argc, char* argv[]) {
         dump_changes(changes, n_changes);
         unit_file_changes_free(changes, n_changes);
 
-        assert_se(unit_file_get_state(UNIT_FILE_SYSTEM, NULL, basename(files2[0])) == _UNIT_FILE_STATE_INVALID);
+        assert_se(unit_file_get_state(UNIT_FILE_SYSTEM, NULL, basename(files2[0]), ec) == _UNIT_FILE_STATE_INVALID);
 
         log_error("link files2");
         changes = NULL;
@@ -224,7 +224,7 @@ int main(int argc, char* argv[]) {
         dump_changes(changes, n_changes);
         unit_file_changes_free(changes, n_changes);
 
-        assert_se(unit_file_get_state(UNIT_FILE_SYSTEM, NULL, basename(files2[0])) == UNIT_FILE_LINKED);
+        assert_se(unit_file_get_state(UNIT_FILE_SYSTEM, NULL, basename(files2[0]), ec) == UNIT_FILE_LINKED);
 
         log_error("reenable files2");
         changes = NULL;
@@ -236,7 +236,7 @@ int main(int argc, char* argv[]) {
         dump_changes(changes, n_changes);
         unit_file_changes_free(changes, n_changes);
 
-        assert_se(unit_file_get_state(UNIT_FILE_SYSTEM, NULL, basename(files2[0])) == UNIT_FILE_ENABLED);
+        assert_se(unit_file_get_state(UNIT_FILE_SYSTEM, NULL, basename(files2[0]), ec) == UNIT_FILE_ENABLED);
 
         log_error("disable files2");
         changes = NULL;
@@ -248,7 +248,7 @@ int main(int argc, char* argv[]) {
         dump_changes(changes, n_changes);
         unit_file_changes_free(changes, n_changes);
 
-        assert_se(unit_file_get_state(UNIT_FILE_SYSTEM, NULL, basename(files2[0])) == _UNIT_FILE_STATE_INVALID);
+        assert_se(unit_file_get_state(UNIT_FILE_SYSTEM, NULL, basename(files2[0]), ec) == _UNIT_FILE_STATE_INVALID);
         log_error("preset files");
         changes = NULL;
         n_changes = 0;
@@ -259,7 +259,17 @@ int main(int argc, char* argv[]) {
         dump_changes(changes, n_changes);
         unit_file_changes_free(changes, n_changes);
 
-        assert_se(unit_file_get_state(UNIT_FILE_SYSTEM, NULL, basename(files[0])) == UNIT_FILE_ENABLED);
+        assert_se(unit_file_get_state(UNIT_FILE_SYSTEM, NULL, basename(files[0]), ec) == UNIT_FILE_ENABLED);
+}
+
+int main(int argc, char* argv[]) {
+        EnabledContext *ec;
+
+        test_install(NULL);
+
+        ec = enabled_context_new();
+        assert(ec);
+        test_install(ec);
 
         return 0;
 }

--- a/src/test/test-unit-file.c
+++ b/src/test/test-unit-file.c
@@ -47,7 +47,7 @@ static int test_unit_file_get_set(void) {
         h = hashmap_new(string_hash_func, string_compare_func);
         assert(h);
 
-        r = unit_file_get_list(UNIT_FILE_SYSTEM, NULL, h);
+        r = unit_file_get_list(UNIT_FILE_SYSTEM, NULL, h, NULL);
         log_full(r == 0 ? LOG_INFO : LOG_ERR,
                  "unit_file_get_list: %s", strerror(-r));
         if (r < 0)


### PR DESCRIPTION
Figuring out whether a unit file is enabled currently takes O(files+links).
Pre-caching a reverse mapping of unit->symlinks reduces this to amortized O(1)