### PR TITLE
fstab-generator: handle nofail mounts with timer-based trigger

### DIFF
--- a/man/systemd.mount.xml
+++ b/man/systemd.mount.xml
@@ -127,11 +127,15 @@
     <filename>quotaon.service</filename> are added.</para>
 
     <para>For mount units with <varname>DefaultDependencies=yes</varname> in the <literal>[Unit]</literal> section (the
-    default) a couple additional dependencies are added. Mount units referring to local file systems automatically gain
-    an <varname>After=</varname> dependency on <filename>local-fs-pre.target</filename>. Network mount units
-    automatically acquire <varname>After=</varname> dependencies on <filename>remote-fs-pre.target</filename>,
-    <filename>network.target</filename> and <filename>network-online.target</filename>. Towards the latter a
-    <varname>Wants=</varname> unit is added as well. Mount units referring to local and network file systems are
+    default) a few additional dependencies are added. Mount units referring to local file systems automatically gain
+    an <varname>After=</varname> dependency on <filename>local-fs-pre.target</filename> and, once they are mounted,
+    gain a <varname>Before=</varname> dependency on <filename>local-fs.target</filename>.  This last ensures they are not
+    unmounted too early. Similarly network mount units automatically acquire <varname>After=</varname> dependencies on
+    <filename>remote-fs-pre.target</filename>, <filename>network.target</filename> and
+    <filename>network-online.target</filename>, as well as a <varname>Before=</varname> dependency on
+    <filename>remote-fs.target</filename> after the filesystem is mounted.
+    A <varname>Wants=</varname> dependency on <filename>network-online.target</filename> is added as well.
+    Mount units referring to local and network file systems are
     distinguished by their file system type specification. In some cases this is not sufficient (for example network
     block device based mounts, such as iSCSI), in which case <option>_netdev</option> may be added to the mount option
     string of the unit, which forces systemd to consider the mount unit a network mount. Mount units (regardless if

--- a/src/core/mount.c
+++ b/src/core/mount.c
@@ -1492,6 +1492,11 @@ static int mount_setup_existing_unit(
                 load_extras = true;
         }
 
+        if (!mount_is_extrinsic(MOUNT(u)) && u->default_dependencies &&
+            !mount_is_network(p))
+                /* Ensure nofail mounts are unmounted in the correct sequence */
+                unit_add_dependency_by_name(u, UNIT_BEFORE, SPECIAL_LOCAL_FS_TARGET, NULL, true);
+
         if (u->load_state == UNIT_NOT_FOUND) {
                 u->load_state = UNIT_LOADED;
                 u->load_error = 0;


### PR DESCRIPTION
fstab-generator omits the Before=fs-XXX.target dependency
on automount and nofail mounts.
This causes a problem at shutdown.  As the mounts are not "Before"
anything, they are initiated immediately, and might run while
services that use the mounts are still running.
This cause the mount to fail and never get unmounted.

This is particularly problematic for NFS the network can get shutdown
after these unmounts failed, and while services are still running.
If that happens, then any services (such as login sessions) using
the NFS mounts can block indefinitely - particularly if they had
written something to the NFS filesystem recently.  They cannot exit
until the data is written, and that cannot happen with the network down.

So we need that "Before=" dependency, but we don't want fs-XXX.target
to have to wait for the mount to complete.

For automounts, there is no difficulty.  The mount unit isn't activated
in the same transaction as the fs-XXX.target, so the ordering is not
effective.  We can re-instate the Before= dependency for automounts
without causing any problems.

For nofail mounts we need a little more work.  automounts set a good
example to follow.  If the mount unit is activated in a separate
transaction, the Before= dependency can be restored without causing
and delays are startup.  This is easily done with a timer unit.

So this patch:
 - restores the "Before=" dependency, so all mount units get it.
 - changes "nofail" handling to work much like "automount" except that
   a timer unit is created instead of an automount unit.  This timer
   unit has OnActiveSec=0 and triggers the mount unit.

Fixes #5991