### PR TITLE
kmod-setup: define has_virtio_rng() only in a case when HAVE_KMOD is …

### DIFF
--- a/src/core/kmod-setup.c
+++ b/src/core/kmod-setup.c
@@ -47,7 +47,6 @@ static void systemd_kmod_log(
         log_internalv(LOG_DEBUG, 0, file, line, fn, format, args);
         REENABLE_WARNING;
 }
-#endif
 
 static int has_virtio_rng_nftw_cb(
                 const char *fpath,
@@ -83,6 +82,7 @@ static int has_virtio_rng_nftw_cb(
 static bool has_virtio_rng(void) {
         return (nftw("/sys/devices/pci0000:00", has_virtio_rng_nftw_cb, 64, FTW_MOUNT|FTW_PHYS|FTW_ACTIONRETVAL) == FTW_STOP);
 }
+#endif
 
 int kmod_setup(void) {
 #ifdef HAVE_KMOD


### PR DESCRIPTION
…enabled

in other way we will get a warning message:

```
../src/core/kmod-setup.c:83:13: warning: ‘has_virtio_rng’ defined but not used [-Wunused-function]

  static bool has_virtio_rng(void) {
             ^~~~~~~~~~~~~~
```