### PR TITLE
tmpfiles: remove old ICE and X11 sockets at boot

### DIFF
--- a/tmpfiles.d/x11.conf
+++ b/tmpfiles.d/x11.conf
@@ -8,14 +8,12 @@
 # See tmpfiles.d(5) for details
 
 # Make sure these are created by default so that nobody else can
-d /tmp/.X11-unix 1777 root root 10d
-d /tmp/.ICE-unix 1777 root root 10d
-d /tmp/.XIM-unix 1777 root root 10d
-d /tmp/.font-unix 1777 root root 10d
-d /tmp/.Test-unix 1777 root root 10d
+# or empty them at startup
+D! /tmp/.X11-unix 1777 root root 10d
+D! /tmp/.ICE-unix 1777 root root 10d
+D! /tmp/.XIM-unix 1777 root root 10d
+D! /tmp/.font-unix 1777 root root 10d
+D! /tmp/.Test-unix 1777 root root 10d
 
 # Unlink the X11 lock files
 r! /tmp/.X[0-9]*-lock
-# Cleanup old sockets if any
-r! /tmp/.X11-unix/X[0-9]*
-r! /tmp/.ICE-unix/[0-9]*

--- a/tmpfiles.d/x11.conf
+++ b/tmpfiles.d/x11.conf
@@ -16,3 +16,6 @@ d /tmp/.Test-unix 1777 root root 10d
 
 # Unlink the X11 lock files
 r! /tmp/.X[0-9]*-lock
+# Cleanup old sockets if any
+r! /tmp/.X11-unix/X[0-9]*
+r! /tmp/.ICE-unix/[0-9]*


### PR DESCRIPTION
When not using tmpfs based /tmp, leftover sockets
might prevent X startup. Ensure directory is clean at boot time.