### PR TITLE
add secure_getenv for musl

### DIFF
--- a/src/basic/meson.build
+++ b/src/basic/meson.build
@@ -140,6 +140,7 @@ basic_sources = files('''
         missing_random.h
         missing_resource.h
         missing_sched.h
+        missing_secure_getenv.c
         missing_securebits.h
         missing_socket.h
         missing_stat.h

--- a/src/basic/missing_secure_getenv.c
+++ b/src/basic/missing_secure_getenv.c
@@ -1,0 +1,13 @@
+#if !HAVE_SECURE_GETENV && !HAVE___SECURE_GETENV
+#include <unistd.h>
+
+#include "missing_stdlib.h"
+
+char *
+secure_getenv (char const *name)
+{
+        if (geteuid() != getuid() || getegid() != getgid())
+                return NULL;
+        return getenv(name);
+}
+#endif

--- a/src/basic/missing_stdlib.h
+++ b/src/basic/missing_stdlib.h
@@ -8,6 +8,6 @@
 #  if HAVE___SECURE_GETENV
 #    define secure_getenv __secure_getenv
 #  else
-#    error "neither secure_getenv nor __secure_getenv are available"
+     char *secure_getenv (char const *name);
 #  endif
 #endif


### PR DESCRIPTION
Copied from gnulib's secure_getenv. Here's the source: https://git.savannah.gnu.org/cgit/gnulib.git/tree/lib/secure_getenv.c
Tested on musl, it does work no warnings when compiling this source file

If any suggestions please write them