### PR TITLE
Adding an explanation for CONFIG_NET requirement

### DIFF
--- a/README
+++ b/README
@@ -44,7 +44,7 @@ REQUIREMENTS:
           CONFIG_SIGNALFD
           CONFIG_TIMERFD
           CONFIG_EPOLL
-          CONFIG_NET
+          CONFIG_NET (the only other flag required is CONFIG_UNIX to include support for Unix domain sockets)
           CONFIG_SYSFS
           CONFIG_PROC_FS
           CONFIG_FHANDLE (libudev, mount and bind mount handling)

--- a/README
+++ b/README
@@ -44,7 +44,7 @@ REQUIREMENTS:
           CONFIG_SIGNALFD
           CONFIG_TIMERFD
           CONFIG_EPOLL
-          CONFIG_NET (the only other flag required is CONFIG_UNIX to include support for Unix domain sockets)
+          CONFIG_UNIX (it requires CONFIG_NET, but every other flag in it is not necessary)
           CONFIG_SYSFS
           CONFIG_PROC_FS
           CONFIG_FHANDLE (libudev, mount and bind mount handling)


### PR DESCRIPTION
I added an explanation for the CONFIG_NET requirement stating that the only other flag required is CONFIG_UNIX that adds support for Unix domain sockets.