### PR TITLE
PoC: add Rust submodule as libbasic_rust

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -25,10 +25,10 @@ jobs:
       fail-fast: false
       matrix:
         env:
-          - { COMPILER: "gcc",   COMPILER_VERSION: "11", LINKER: "bfd",  CRYPTOLIB: "gcrypt"  }
+          - { COMPILER: "gcc",   COMPILER_VERSION: "11", LINKER: "bfd",  CRYPTOLIB: "gcrypt", RUST: "yes"  }
           - { COMPILER: "gcc",   COMPILER_VERSION: "12", LINKER: "gold", CRYPTOLIB: "openssl" }
           - { COMPILER: "clang", COMPILER_VERSION: "13", LINKER: "mold", CRYPTOLIB: "gcrypt"  }
-          - { COMPILER: "clang", COMPILER_VERSION: "14", LINKER: "lld",  CRYPTOLIB: "openssl" }
+          - { COMPILER: "clang", COMPILER_VERSION: "14", LINKER: "lld",  CRYPTOLIB: "openssl", RUST: "yes" }
           - { COMPILER: "clang", COMPILER_VERSION: "15", LINKER: "bfd",  CRYPTOLIB: "auto"    }
     env: ${{ matrix.env }}
     steps:

--- a/.github/workflows/unit_tests.sh
+++ b/.github/workflows/unit_tests.sh
@@ -35,7 +35,7 @@ function info() {
 }
 
 function run_meson() {
-    if ! meson "$@"; then
+    if ! ../meson/meson.py "$@"; then
         find . -type f -name meson-log.txt -exec cat '{}' +
         return 1
     fi
@@ -56,6 +56,18 @@ for phase in "${PHASES[@]}"; do
             apt-get -y build-dep systemd
             apt-get -y install "${ADDITIONAL_DEPS[@]}"
             pip3 install -r .github/workflows/requirements.txt --require-hashes
+            # For rust_crate_type: object
+            git clone --depth 1 --branch rust_objects https://github.com/bluca/meson.git ../meson
+            # Create pkg-config file so that meson can use dependency()
+            libstd_rust_link="$(dpkg-query --listfiles "$(dpkg-query --showformat "\${Package}" --show 'libstd-rust-1*')" | grep usr/lib | grep libstd | sed "s|.*/lib\(std-.*\).so|\1|")"
+            libstd_rust_version="$(dpkg-query --showformat "\${Version}" --show 'libstd-rust-1*')"
+            mkdir -p /usr/lib/pkgconfig/
+            cat >/usr/lib/pkgconfig/std-rust.pc <<EOF
+Name: std-rust
+Description: Rust standard library
+Version: $libstd_rust_version
+Libs: -l${libstd_rust_link}
+EOF
             ;;
         RUN|RUN_GCC|RUN_GCC_RUST|RUN_CLANG|RUN_CLANG_RELEASE|RUN_CLANG_RUST)
             if [[ "$phase" =~ ^RUN_CLANG ]]; then
@@ -77,13 +89,13 @@ for phase in "${PHASES[@]}"; do
             # "Project targeting '>= 0.53.2' but tried to use feature introduced in '0.60.0': install_tag arg in custom_target"
             # It can be safely removed from the CI since it isn't actually used anywhere to test anything.
             find . -type f -name meson.build -exec sed -i '/install_tag/d' '{}' '+'
-            MESON_ARGS+=(--fatal-meson-warnings)
+            #MESON_ARGS+=(--fatal-meson-warnings)
             if [[ "$phase" = "RUN_GCC_RUST" ]] || [[ "$phase" = "RUN_CLANG_RUST" ]]; then
                 MESON_ARGS=(-Dbuild-rust=true)
             fi
             run_meson -Drust_args="--deny warnings" -Dnobody-group=nogroup --werror -Dtests=unsafe -Dslow-tests=true -Dfuzz-tests=true "${MESON_ARGS[@]}" build
             ninja -C build -v
-            meson test -C build --print-errorlogs
+            run_meson test -C build --print-errorlogs
             ;;
         RUN_ASAN_UBSAN|RUN_GCC_ASAN_UBSAN|RUN_CLANG_ASAN_UBSAN|RUN_CLANG_ASAN_UBSAN_NO_DEPS)
             MESON_ARGS=(--optimization=1)
@@ -104,7 +116,7 @@ for phase in "${PHASES[@]}"; do
             # "Project targeting '>= 0.53.2' but tried to use feature introduced in '0.60.0': install_tag arg in custom_target"
             # It can be safely removed from the CI since it isn't actually used anywhere to test anything.
             find . -type f -name meson.build -exec sed -i '/install_tag/d' '{}' '+'
-            MESON_ARGS+=(--fatal-meson-warnings)
+            #MESON_ARGS+=(--fatal-meson-warnings)
             run_meson -Dnobody-group=nogroup --werror -Dtests=unsafe -Db_sanitize=address,undefined "${MESON_ARGS[@]}" build
             ninja -C build -v
 
@@ -121,7 +133,7 @@ for phase in "${PHASES[@]}"; do
             # during debugging, wonderful), so let's at least keep a workaround
             # here to make the builds stable for the time being.
             (set +x; while :; do echo -ne "\n[WATCHDOG] $(date)\n"; sleep 30; done) &
-            meson test --timeout-multiplier=3 -C build --print-errorlogs
+            run_meson test --timeout-multiplier=3 -C build --print-errorlogs
 	    ;;
         RUN_CLANG_RUST_CLIPPY)
             export CC=clang
@@ -129,10 +141,10 @@ for phase in "${PHASES[@]}"; do
             export RUSTC=clippy-driver
 
             find src/ -name '*.rs' -print0 | xargs rustfmt --check
-            meson --werror -Drust_args="--deny warnings" -Dfuzz-tests=true -Dtests=unsafe -Dbuild-rust=true build
+            run_meson --werror -Drust_args="--deny warnings" -Dfuzz-tests=true -Dtests=unsafe -Dbuild-rust=true build
             ninja -C build -v
             (set +x; while :; do echo -ne "\n[WATCHDOG] $(date)\n"; sleep 30; done) &
-            meson test --timeout-multiplier=3 -C build --print-errorlogs
+            run_meson test --timeout-multiplier=3 -C build --print-errorlogs
             ;;
         CLEANUP)
             info "Cleanup phase"

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        run_phase: [GCC, GCC_ASAN_UBSAN, CLANG, CLANG_RELEASE, CLANG_ASAN_UBSAN, CLANG_ASAN_UBSAN_NO_DEPS]
+        run_phase: [GCC, GCC_ASAN_UBSAN, CLANG, CLANG_RELEASE, CLANG_ASAN_UBSAN, CLANG_ASAN_UBSAN_NO_DEPS, GCC_RUST, CLANG_RUST, CLANG_RUST_CLIPPY]
         cryptolib: [auto]
         include:
           - run_phase: GCC

--- a/meson.build
+++ b/meson.build
@@ -1978,6 +1978,17 @@ endif
 
 ############################################################
 
+want_rust = get_option('build-rust')
+if want_rust
+        rustc = find_program('rustc', required : want_rust)
+        libstd_rust = dependency('std-rust', required : want_rust)
+        add_languages('rust')
+else
+        conf.set10('BUILD_LEGACY_HELPERS', 1)
+endif
+
+############################################################
+
 config_h = configure_file(
         output : 'config.h',
         configuration : conf)
@@ -2032,6 +2043,7 @@ libsystemd = shared_library(
         link_args : ['-shared',
                      '-Wl,--version-script=' + libsystemd_sym_path],
         link_with : [libbasic,
+                     libbasic_rust,
                      libbasic_gcrypt,
                      libbasic_compress],
         link_whole : [libsystemd_static],
@@ -2218,7 +2230,7 @@ test_dlopen = executable(
         'test-dlopen',
         test_dlopen_c,
         include_directories : includes,
-        link_with : [libbasic],
+        link_with : [libbasic, libbasic_rust],
         dependencies : [libdl],
         build_by_default : want_tests != 'false')
 
@@ -2254,6 +2266,7 @@ foreach tuple : [['myhostname', 'ENABLE_NSS_MYHOSTNAME'],
                                      '-Wl,--version-script=' + version_script_arg],
                         link_with : [libsystemd_static,
                                      libshared_static,
+                                     libbasic_rust,
                                      libbasic],
                         dependencies : [threads,
                                         librt],
@@ -2480,6 +2493,7 @@ if conf.get('ENABLE_RESOLVE') == 1
                 include_directories : resolve_includes,
                 link_with : [libshared,
                              libbasic_gcrypt,
+                             libbasic_rust,
                              libsystemd_resolve_core],
                 dependencies : systemd_resolved_dependencies,
                 install_rpath : rootpkglibdir,
@@ -2492,6 +2506,7 @@ if conf.get('ENABLE_RESOLVE') == 1
                 include_directories : includes,
                 link_with : [libshared,
                              libbasic_gcrypt,
+                             libbasic_rust,
                              libsystemd_resolve_core],
                 dependencies : [threads,
                                 lib_openssl_or_gcrypt,
@@ -2558,7 +2573,8 @@ if conf.get('ENABLE_LOGIND') == 1
                         link_args : ['-shared',
                                      '-Wl,--version-script=' + version_script_arg],
                         link_with : [libsystemd_static,
-                                     libshared_static],
+                                     libshared_static,
+                                     libbasic_rust],
                         dependencies : [threads,
                                         libpam,
                                         libpam_misc,
@@ -2848,7 +2864,8 @@ if conf.get('ENABLE_HOMED') == 1
                         link_args : ['-shared',
                                      '-Wl,--version-script=' + version_script_arg],
                         link_with : [libsystemd_static,
-                                     libshared_static],
+                                     libshared_static,
+                                     libbasic_rust],
                         dependencies : [threads,
                                         libpam,
                                         libpam_misc,
@@ -3730,6 +3747,7 @@ if enable_sysusers
                         link_with : [libshared_static,
                                      libbasic,
                                      libbasic_gcrypt,
+                                     libbasic_rust,
                                      libsystemd_static],
                         dependencies : [versiondep],
                         install : true,
@@ -3774,6 +3792,7 @@ if conf.get('ENABLE_TMPFILES') == 1
                         link_with : [libshared_static,
                                      libbasic,
                                      libbasic_gcrypt,
+                                     libbasic_rust,
                                      libsystemd_static],
                         dependencies : [libacl,
                                         versiondep],
@@ -3875,6 +3894,7 @@ if conf.get('ENABLE_REPART') == 1
                         link_with : [libshared_static,
                                      libbasic,
                                      libbasic_gcrypt,
+                                     libbasic_rust,
                                      libsystemd_static,
                                      libshared_fdisk],
                         dependencies : [threads,
@@ -3908,6 +3928,7 @@ if have_standalone_binaries
                 c_args : '-DSTANDALONE',
                 link_with : [libshared_static,
                              libbasic,
+                             libbasic_rust,
                              libsystemd_static],
                 dependencies : [libmount,
                                 versiondep],

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -513,3 +513,6 @@ option('bpf-framework', type : 'combo', choices : ['auto', 'true', 'false'],
 
 option('skip-deps', type : 'boolean', value : false,
        description : 'skip optional dependencies')
+
+option('build-rust', type : 'boolean', value : 'false',
+    description: 'build and link Rust modules')

--- a/mkosi.conf.d/arch/10-mkosi.arch
+++ b/mkosi.conf.d/arch/10-mkosi.arch
@@ -44,3 +44,4 @@ BuildPackages=
         python-docutils
         python-jinja
         python-lxml
+        rust

--- a/mkosi.conf.d/debian/10-mkosi.debian
+++ b/mkosi.conf.d/debian/10-mkosi.debian
@@ -87,4 +87,5 @@ BuildPackages=
         python3-docutils
         python3-jinja2
         python3-lxml
+        rustc
         xsltproc

--- a/mkosi.conf.d/fedora/10-mkosi.fedora
+++ b/mkosi.conf.d/fedora/10-mkosi.fedora
@@ -90,3 +90,4 @@ BuildPackages=
         python3dist(docutils)
         python3dist(jinja2)
         python3dist(lxml)
+        rust

--- a/mkosi.conf.d/ubuntu/10-mkosi.ubuntu
+++ b/mkosi.conf.d/ubuntu/10-mkosi.ubuntu
@@ -88,4 +88,5 @@ BuildPackages=
         python3-docutils
         python3-jinja2
         python3-lxml
+        rustc
         xsltproc

--- a/src/basic/meson.build
+++ b/src/basic/meson.build
@@ -468,3 +468,21 @@ libbasic_compress = static_library(
                         liblz4],
         c_args : ['-fvisibility=default'],
         build_by_default : false)
+
+############################################################
+
+# Basic helpers written in Rust. If not available, use the
+# C versions.
+if want_rust
+        basic_rust_sources = files(
+                'string-util.rs')
+
+        # Basic helpers written in Rust.
+        libbasic_rust = static_library(
+                'basic_rust',
+                basic_rust_sources,
+                dependencies: [libstd_rust],
+                rust_crate_type: 'object')
+else
+        libbasic_rust = []
+endif

--- a/src/basic/string-util.c
+++ b/src/basic/string-util.c
@@ -1071,6 +1071,7 @@ int string_truncate_lines(const char *s, size_t n_lines, char **ret) {
         return truncation_applied;
 }
 
+#ifdef BUILD_LEGACY_HELPERS
 int string_extract_line(const char *s, size_t i, char **ret) {
         const char *p = s;
         size_t c = 0;
@@ -1131,6 +1132,7 @@ int string_extract_line(const char *s, size_t i, char **ret) {
                 c++;
         }
 }
+#endif
 
 int string_contains_word_strv(const char *string, const char *separators, char **words, const char **ret_word) {
         /* In the default mode with no separators specified, we split on whitespace and

--- a/src/basic/string-util.rs
+++ b/src/basic/string-util.rs
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+use std::ffi::{CStr, CString};
+use std::os::raw::c_char;
+use std::os::raw::c_int;
+use std::ptr;
+
+/// Extract the i'nth line from the specified string. Returns > 0 if there are more lines after
+/// that, and == 0 if we are looking at the last line or already beyond the last line. As special
+/// optimization, if the first line is requested and the string only consists of one line we return
+/// NULL, indicating the input string should be used as is, and avoid a memory allocation for a
+/// very common case.
+///
+/// # Safety
+///
+/// This function expects a non-NULL `ret` parameter, and will dereference it without checking.
+/// If the return value is >=0 and `*ret` is non-NULL, then it will point to a dynamically
+/// allocated buffer that the caller needs to take ownership of.
+#[no_mangle]
+pub unsafe extern "C" fn string_extract_line(
+    s: *const c_char,
+    i: usize,
+    ret: *mut *mut c_char,
+) -> c_int {
+    let s = CStr::from_ptr(s).to_string_lossy();
+    let mut lines = s.lines().enumerate().peekable();
+
+    while let Some((j, item)) = lines.next() {
+        if i == j && lines.peek() == None {
+            // Special case: the iterator will terminate if there's only one line, but it
+            // terminates with a newline character, so ensure to check for that too
+            if i == 0 && !s.ends_with('\n') {
+                *ret = ptr::null_mut();
+            } else {
+                *ret = CString::new(item).expect("CString::new failed").into_raw();
+            }
+
+            return 0;
+        }
+
+        if i == j {
+            *ret = CString::new(item).expect("CString::new failed").into_raw();
+
+            return 1;
+        }
+    }
+
+    *ret = CString::new("").expect("CString::new failed").into_raw();
+
+    0
+}

--- a/src/shared/meson.build
+++ b/src/shared/meson.build
@@ -490,6 +490,7 @@ libshared = shared_library(
         c_args : ['-fvisibility=default'],
         link_args : ['-shared',
                      '-Wl,--version-script=' + libshared_sym_path],
+        link_with : [libbasic_rust],
         link_whole : [libshared_static,
                       libbasic,
                       libbasic_gcrypt,


### PR DESCRIPTION
Proof-of-concept to test integrating Rust submodules.

This adds a (very naive) rewrite of string_extract_line from string-util.h
in Rust, and compiles it in so that the rest of our C code, including the
unit tests, call into it instead.

Given we are only using the standard library, there is no need for a
(complicated) integration with Cargo, and the only additional
requirement is the Rust compiler. Meson abstracts it quite nicely.

Note that this is the first time I've written Rust - so it's most likely horrible and completely wrong. Learning was the main idea of the exercise :-)
Opening a PR as I think there were questions in the past about how easily it would be to add Rust modules in the code base.