### PR TITLE
hwdb: Add sensor rule for Hometech Wi101

### DIFF
--- a/hwdb.d/60-sensor.hwdb
+++ b/hwdb.d/60-sensor.hwdb
@@ -404,6 +404,16 @@ sensor:modalias:acpi:KIOX000A*:dmi:bvnAmericanMegatrendsInc.:bvr5.11:bd05/25/201
  ACCEL_LOCATION=base
 
 #########################################
+# Hometech
+########################################
+
+# Nobody bothered to use Linux on any device of this manufacturer
+# so current marks might be too general and need fixes.
+# These values are based on Wi101 model.
+sensor:modalias:acpi:BMA250E*:dmi:*:svnInsyde*:pni101c:*
+ ACCEL_MOUNT_MATRIX=0,1,0;-1,0,0;-1,0,0
+
+#########################################
 # HP
 #########################################
 


### PR DESCRIPTION
This commit was done to add sensor rule for Hometech Wi101. Note that this rule might be too general and need fixes. I couldn't test this on any other device since this one is the only one I have.

I added @Simeonlps as co-author since he was the one to help me.

Signed-off-by: Wind/owZ <windowz414@gnuweeb.org>