### PR TITLE
update-helper: fix action with users units

### DIFF
--- a/src/rpm/systemd-update-helper.in
+++ b/src/rpm/systemd-update-helper.in
@@ -30,7 +30,8 @@ case "$command" in
         [ -d /run/systemd/system ] || exit 0
 
         users=$(systemctl list-units 'user@*' --legend=no | sed -n -r 's/.*user@([0-9]+).service.*/\1/p')
-        for user in $users; do
+        for id in $users; do
+            user=$(id -nu "$id")
             SYSTEMD_BUS_TIMEOUT={{UPDATE_HELPER_USER_TIMEOUT}} \
                     systemctl --user -M "$user@" disable --now "$@" &
         done
@@ -50,7 +51,8 @@ case "$command" in
         [ -d /run/systemd/system ] || exit 0
 
         users=$(systemctl list-units 'user@*' --legend=no | sed -n -r 's/.*user@([0-9]+).service.*/\1/p')
-        for user in $users; do
+        for id in $users; do
+            user=$(id -nu "$id")
             SYSTEMD_BUS_TIMEOUT={{UPDATE_HELPER_USER_TIMEOUT}} \
                     systemctl --user -M "$user@" set-property "$unit" Markers=+needs-restart &
         done
@@ -85,7 +87,8 @@ case "$command" in
         users=$(systemctl list-units 'user@*' --legend=no | sed -n -r 's/.*user@([0-9]+).service.*/\1/p')
 
         if [[ "$command" =~ reexec ]]; then
-            for user in $users; do
+            for id in $users; do
+                user=$(id -nu "$id")
                 SYSTEMD_BUS_TIMEOUT={{UPDATE_HELPER_USER_TIMEOUT}} \
                         systemctl --user -M "$user@" daemon-reexec &
             done
@@ -93,7 +96,8 @@ case "$command" in
         fi
 
         if [[ "$command" =~ reload ]]; then
-            for user in $users; do
+            for id in $users; do
+                user=$(id -nu "$id")
                 SYSTEMD_BUS_TIMEOUT={{UPDATE_HELPER_USER_TIMEOUT}} \
                         systemctl --user -M "$user@" daemon-reload &
             done
@@ -101,7 +105,8 @@ case "$command" in
         fi
 
         if [[ "$command" =~ restart ]]; then
-            for user in $users; do
+            for id in $users; do
+                user=$(id -nu "$id")
                 SYSTEMD_BUS_TIMEOUT={{UPDATE_HELPER_USER_TIMEOUT}} \
                         systemctl --user -M "$user@" reload-or-restart --marked &
             done


### PR DESCRIPTION
/lib/systemd/systemd-update-helper user-reload-restart
Failed to connect to bus: Invalid argument
Failed to connect to bus: Invalid argument

Because:
systemctl --user -M "500@" daemon-reexec
Failed to connect to bus: Invalid argument

True:
systemctl --user -M "username@" daemon-reexec

fixes #20687