### PR TITLE
journal: Add new _INITRD field

### DIFF
--- a/man/systemd.journal-fields.xml
+++ b/man/systemd.journal-fields.xml
@@ -398,6 +398,14 @@
         for details about journal namespaces.</para>
         </listitem>
       </varlistentry>
+      <varlistentry>
+        <term><varname>_SYSTEM_CONTEXT=</varname></term>
+
+        <listitem><para>A string field that specifies the context in which the message was logged. If
+        <literal>initrd</literal>, the log message was processed while systemd-journald
+        was running inside the initrd. If <literal>main</literal>, the log message was generated after
+        journald switched root to the root filesystem.</para></listitem>
+      </varlistentry>
     </variablelist>
   </refsect1>
 

--- a/src/journal/journald-server.c
+++ b/src/journal/journald-server.c
@@ -1035,6 +1035,11 @@ static void dispatch_message_real(
         if (!isempty(s->namespace_field))
                 iovec[n++] = IOVEC_MAKE_STRING(s->namespace_field);
 
+        if (in_initrd())
+                iovec[n++] = IOVEC_MAKE_STRING("_SYSTEM_CONTEXT=initrd");
+        else
+                iovec[n++] = IOVEC_MAKE_STRING("_SYSTEM_CONTEXT=main");
+
         assert(n <= m);
 
         if (s->split_mode == SPLIT_UID && c && uid_is_valid(c->uid))

--- a/src/journal/journald-server.h
+++ b/src/journal/journald-server.h
@@ -179,7 +179,7 @@ struct Server {
 #define SERVER_MACHINE_ID(s) ((s)->machine_id_field + STRLEN("_MACHINE_ID="))
 
 /* Extra fields for any log messages */
-#define N_IOVEC_META_FIELDS 23
+#define N_IOVEC_META_FIELDS 24
 
 /* Extra fields for log messages that contain OBJECT_PID= (i.e. log about another process) */
 #define N_IOVEC_OBJECT_FIELDS 18


### PR DESCRIPTION
The _INITRD field is a boolean field (0 or 1) that specifies whether
a message was processed by systemd-journald in the initrd or not.