### PR TITLE
journal: Add "format" output mode

### DIFF
--- a/src/journal-remote/fuzz-journal-remote.c
+++ b/src/journal-remote/fuzz-journal-remote.c
@@ -80,7 +80,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
         for (OutputMode mode = 0; mode < _OUTPUT_MODE_MAX; mode++) {
                 if (!dev_null)
                         log_info("/* %s */", output_mode_to_string(mode));
-                r = show_journal(dev_null ?: stdout, j, mode, 0, 0, -1, 0, NULL);
+                r = show_journal(dev_null ?: stdout, j, mode, 0, 0, -1, 0, "%m", NULL);
                 assert_se(r >= 0);
 
                 r = sd_journal_seek_head(j);

--- a/src/journal-remote/journal-gatewayd.c
+++ b/src/journal-remote/journal-gatewayd.c
@@ -223,7 +223,7 @@ static ssize_t request_reader_entries(
                 }
 
                 r = show_journal_entry(m->tmp, m->journal, m->mode, 0, OUTPUT_FULL_WIDTH,
-                                   NULL, NULL, NULL);
+                                   NULL, NULL, NULL, NULL);
                 if (r < 0) {
                         log_error_errno(r, "Failed to serialize item: %m");
                         return MHD_CONTENT_READER_END_WITH_ERROR;

--- a/src/machine/machinectl.c
+++ b/src/machine/machinectl.c
@@ -78,6 +78,7 @@ static bool arg_quiet = false;
 static bool arg_ask_password = true;
 static unsigned arg_lines = 10;
 static OutputMode arg_output = OUTPUT_SHORT;
+static char *arg_output_format = NULL;
 static bool arg_force = false;
 static ImportVerify arg_verify = IMPORT_VERIFY_SIGNATURE;
 static const char* arg_format = NULL;
@@ -86,6 +87,7 @@ static char **arg_setenv = NULL;
 static int arg_max_addresses = 1;
 
 STATIC_DESTRUCTOR_REGISTER(arg_property, strv_freep);
+STATIC_DESTRUCTOR_REGISTER(arg_output_format, freep);
 STATIC_DESTRUCTOR_REGISTER(arg_setenv, strv_freep);
 
 static OutputFlags get_output_flags(void) {
@@ -599,6 +601,7 @@ static void print_machine_status_info(sd_bus *bus, MachineStatusInfo *i) {
                                         get_output_flags() | OUTPUT_BEGIN_NEWLINE,
                                         SD_JOURNAL_LOCAL_ONLY,
                                         true,
+                                        arg_output_format,
                                         NULL);
         }
 }
@@ -2543,6 +2546,7 @@ static int parse_argv(int argc, char *argv[]) {
                 ARG_FORMAT,
                 ARG_UID,
                 ARG_MAX_ADDRESSES,
+                ARG_OUTPUT_FORMAT,
         };
 
         static const struct option options[] = {
@@ -2563,6 +2567,7 @@ static int parse_argv(int argc, char *argv[]) {
                 { "quiet",           no_argument,       NULL, 'q'                 },
                 { "lines",           required_argument, NULL, 'n'                 },
                 { "output",          required_argument, NULL, 'o'                 },
+                { "output-format",   required_argument, NULL, ARG_OUTPUT_FORMAT   },
                 { "no-ask-password", no_argument,       NULL, ARG_NO_ASK_PASSWORD },
                 { "verify",          required_argument, NULL, ARG_VERIFY          },
                 { "force",           no_argument,       NULL, ARG_FORCE           },
@@ -2685,6 +2690,15 @@ static int parse_argv(int argc, char *argv[]) {
                                 arg_legend = false;
                         break;
 
+                case ARG_OUTPUT_FORMAT:
+                        arg_output = OUTPUT_FORMAT;
+
+                        r = free_and_strdup(&arg_output_format, optarg);
+                        if (r < 0)
+                                return log_oom();
+
+                        break;
+
                 case ARG_NO_PAGER:
                         arg_pager_flags |= PAGER_DISABLE;
                         break;
@@ -2781,6 +2795,11 @@ static int parse_argv(int argc, char *argv[]) {
                         assert_not_reached();
                 }
         }
+
+        if (arg_output_format && arg_output != OUTPUT_FORMAT)
+                return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
+                                       "--output-format cannot be used with output mode \"%s\"",
+                                       output_mode_to_string(arg_output));
 
 done:
         if (shell >= 0) {

--- a/src/network/networkctl.c
+++ b/src/network/networkctl.c
@@ -1516,6 +1516,7 @@ static int show_logs(const LinkInfo *info) {
                         0,
                         arg_lines,
                         get_output_flags() | OUTPUT_BEGIN_NEWLINE,
+                        NULL,
                         NULL);
 }
 

--- a/src/shared/logs-show.c
+++ b/src/shared/logs-show.c
@@ -5,6 +5,7 @@
 #include <signal.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sys/socket.h>
 #include <syslog.h>
 #include <unistd.h>
@@ -13,6 +14,8 @@
 #include "sd-journal.h"
 
 #include "alloc-util.h"
+#include "env-util.h"
+#include "errno-util.h"
 #include "fd-util.h"
 #include "format-util.h"
 #include "glyph-util.h"
@@ -48,6 +51,9 @@
 #define PRINT_CHAR_THRESHOLD 300
 
 #define JSON_THRESHOLD 4096U
+
+#define VALID_FORMAT_SPECIFIER_CHARS LETTERS
+#define VALID_FORMAT_FIELD_CHARS DIGITS UPPERCASE_LETTERS "_"
 
 static int print_catalog(FILE *f, sd_journal *j) {
         _cleanup_free_ char *t = NULL, *z = NULL;
@@ -432,7 +438,8 @@ static int output_short(
                 unsigned n_columns,
                 OutputFlags flags,
                 const Set *output_fields,
-                const size_t highlight[2]) {
+                const size_t highlight[2],
+                const char *format) {
 
         int r;
         const void *data;
@@ -633,7 +640,8 @@ static int output_verbose(
                 unsigned n_columns,
                 OutputFlags flags,
                 const Set *output_fields,
-                const size_t highlight[2]) {
+                const size_t highlight[2],
+                const char *format) {
 
         const void *data;
         size_t length;
@@ -751,7 +759,8 @@ static int output_export(
                 unsigned n_columns,
                 OutputFlags flags,
                 const Set *output_fields,
-                const size_t highlight[2]) {
+                const size_t highlight[2],
+                const char *format) {
 
         _cleanup_free_ char *cursor = NULL;
         usec_t realtime, monotonic;
@@ -986,7 +995,8 @@ static int output_json(
                 unsigned n_columns,
                 OutputFlags flags,
                 const Set *output_fields,
-                const size_t highlight[2]) {
+                const size_t highlight[2],
+                const char *format) {
 
         char sid[SD_ID128_STRING_MAX], usecbuf[DECIMAL_STR_MAX(usec_t)];
         _cleanup_(json_variant_unrefp) JsonVariant *object = NULL;
@@ -1118,6 +1128,26 @@ finish:
         return r;
 }
 
+static int get_field_datan(sd_journal *j, const char *field, size_t field_length, const void **ret_data, size_t *ret_length) {
+        int r;
+
+        r = sd_journal_get_data_n(j, field, field_length, ret_data, ret_length);
+        if (r < 0)
+                return r;
+
+        assert(*ret_length >= field_length + 1);
+        assert(((char*) *ret_data)[field_length] == '=');
+
+        *ret_data = (const char *) *ret_data + field_length + 1;
+        *ret_length -= field_length + 1;
+
+        return 0;
+}
+
+static int get_field_data(sd_journal *j, const char *field, const void **ret_data, size_t *ret_length) {
+        return get_field_datan(j, field, strlen(field), ret_data, ret_length);
+}
+
 static int output_cat_field(
                 FILE *f,
                 sd_journal *j,
@@ -1128,13 +1158,13 @@ static int output_cat_field(
 
         const char *color_on = "", *color_off = "", *highlight_on = "";
         const void *data;
-        size_t l, fl;
+        size_t l;
         int r;
 
         if (FLAGS_SET(flags, OUTPUT_COLOR))
                 get_log_colors(prio, &color_on, &color_off, &highlight_on);
 
-        r = sd_journal_get_data(j, field, &data, &l);
+        r = get_field_data(j, field, &data, &l);
         if (r == -EBADMSG) {
                 log_debug_errno(r, "Skipping message we can't read: %m");
                 return 0;
@@ -1143,13 +1173,6 @@ static int output_cat_field(
                 return 0;
         if (r < 0)
                 return log_error_errno(r, "Failed to get data: %m");
-
-        fl = strlen(field);
-        assert(l >= fl + 1);
-        assert(((char*) data)[fl] == '=');
-
-        data = (const uint8_t*) data + fl + 1;
-        l -= fl + 1;
 
         if (FLAGS_SET(flags, OUTPUT_COLOR)) {
                 if (highlight) {
@@ -1175,6 +1198,33 @@ static int output_cat_field(
         return 0;
 }
 
+static int get_priority(sd_journal *j, OutputFlags flags) {
+        const void *data;
+        size_t l;
+        int r;
+
+        /* Determine priority of this entry, so that we can color it nicely */
+
+        r = sd_journal_get_data(j, "PRIORITY", &data, &l);
+        if (r == -EBADMSG) {
+                log_debug_errno(r, "Skipping message we can't read: %m");
+                return 0;
+        }
+        if (r < 0) {
+                if (r != -ENOENT)
+                        return log_error_errno(r, "Failed to get data: %m");
+
+                /* An entry without PRIORITY */
+        } else if (l == 10 && memcmp(data, "PRIORITY=", 9) == 0) {
+                char c = ((char*) data)[9];
+
+                if (c >= '0' && c <= '7')
+                        r = c - '0';
+        }
+
+        return r;
+}
+
 static int output_cat(
                 FILE *f,
                 sd_journal *j,
@@ -1182,7 +1232,8 @@ static int output_cat(
                 unsigned n_columns,
                 OutputFlags flags,
                 const Set *output_fields,
-                const size_t highlight[2]) {
+                const size_t highlight[2],
+                const char *format) {
 
         int r, prio = LOG_INFO;
         const char *field;
@@ -1192,29 +1243,8 @@ static int output_cat(
 
         (void) sd_journal_set_data_threshold(j, 0);
 
-        if (FLAGS_SET(flags, OUTPUT_COLOR)) {
-                const void *data;
-                size_t l;
-
-                /* Determine priority of this entry, so that we can color it nicely */
-
-                r = sd_journal_get_data(j, "PRIORITY", &data, &l);
-                if (r == -EBADMSG) {
-                        log_debug_errno(r, "Skipping message we can't read: %m");
-                        return 0;
-                }
-                if (r < 0) {
-                        if (r != -ENOENT)
-                                return log_error_errno(r, "Failed to get data: %m");
-
-                        /* An entry without PRIORITY */
-                } else if (l == 10 && memcmp(data, "PRIORITY=", 9) == 0) {
-                        char c = ((char*) data)[9];
-
-                        if (c >= '0' && c <= '7')
-                                prio = c - '0';
-                }
-        }
+        if (FLAGS_SET(flags, OUTPUT_COLOR))
+                prio = get_priority(j, flags);
 
         if (set_isempty(output_fields))
                 return output_cat_field(f, j, flags, prio, "MESSAGE", highlight);
@@ -1228,6 +1258,202 @@ static int output_cat(
         return 0;
 }
 
+
+typedef int (*FormatSpecifierCallback)(char specifier, FILE *f, sd_journal *j);
+
+typedef struct FormatSpecifier {
+        const char specifier;
+        const FormatSpecifierCallback lookup;
+} FormatSpecifier;
+
+// TODO: Implement the timestamp formatting functions.
+const FormatSpecifier format_specifier_table[] = {
+        { 's', format_timestamp_short },
+        { 'f', format_timestamp_full },
+        { 'i', format_timestamp_iso },
+        { 'j', format_timestamp_iso_precise },
+        { 'p', format_timestamp_precise },
+        { 'm', format_timestamp_monotonic },
+        { 'u', format_timestamp_unix },
+};
+
+static int output_format_field(
+                        const char *field,
+                        size_t field_length,
+                        FILE *f,
+                        sd_journal *j,
+                        OutputFlags flags,
+                        const size_t highlight[2]) {
+
+        const void *d = NULL;
+        size_t l = 0;
+        int r;
+
+        r = get_field_datan(j, field, field_length, &d, &l);
+        if (IN_SET(r, -EBADMSG, -ENOENT))
+                return 0;
+        if (r < 0)
+                return r;
+
+        if (FLAGS_SET(flags, OUTPUT_COLOR) && strneq(field, "MESSAGE", field_length)) {
+                const char *color_on = "", *color_off = "", *highlight_on = "";
+
+                get_log_colors(get_priority(j, flags), &color_on, &color_off, &highlight_on);
+
+                if (highlight) {
+                        assert(highlight[0] <= highlight[1]);
+                        assert(highlight[1] <= l);
+
+                        fputs(color_on, f);
+                        fwrite((const char*) d, 1, highlight[0], f);
+                        fputs(highlight_on, f);
+                        fwrite((const char*) d + highlight[0], 1, highlight[1] - highlight[0], f);
+                        fputs(color_on, f);
+                        fwrite((const char*) d + highlight[1], 1, l - highlight[1], f);
+                        fputs(color_off, f);
+                } else {
+                        fputs(color_on, f);
+                        fwrite((const char*) d, 1, l, f);
+                        fputs(color_off, f);
+                }
+        } else
+                fwrite((const char*) d, 1, l, f);
+
+        return 0;
+}
+
+static int output_format(
+                FILE *f,
+                sd_journal *j,
+                OutputMode mode,
+                unsigned n_columns,
+                OutputFlags flags,
+                const Set *output_fields,
+                const size_t highlight[2],
+                const char *format) {
+
+        enum {
+                WORD,
+                CURLY,
+                SPECIFIER,
+                VARIABLE,
+                VARIABLE_RAW,
+        } state = WORD;
+
+        const char *e, *word = format;
+        size_t i, n;
+        int r;
+
+        assert(f);
+        assert(j);
+        assert(mode == OUTPUT_FORMAT);
+        assert(format);
+
+        for (e = format, i = 0, n = strlen(format); *e && i < n; e++, i++)
+                switch (state) {
+
+                case WORD:
+                        if (*e == '@')
+                                state = CURLY;
+                        else if (*e == '%')
+                                state = SPECIFIER;
+                        break;
+
+                case CURLY:
+                        if (*e == '{') {
+                                fwrite(word, 1, e-word-1, f);
+
+                                word = e-1;
+                                state = VARIABLE;
+                        } else if (*e == '@') {
+                                fwrite(word, 1, e-word, f);
+
+                                word = e+1;
+                                state = WORD;
+                        } else if (strchr(VALID_FORMAT_FIELD_CHARS, *e)) {
+                                fwrite(word, 1, e-word-1, f);
+
+                                word = e-1;
+                                state = VARIABLE_RAW;
+                        } else
+                                state = WORD;
+                        break;
+
+                case SPECIFIER: {
+                        const FormatSpecifier *s;
+
+                        fwrite(word, 1, e-word-1, f);
+
+                        if (!strchr(VALID_FORMAT_SPECIFIER_CHARS, *e))
+                                return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
+                                                       "Invalid specifier '%c', ignoring.",
+                                                       *e);
+
+                        for (s = format_specifier_table; s->specifier; s++)
+                                if (s->specifier == *e)
+                                        break;
+
+                        if (!s->specifier)
+                                return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
+                                                       "Unknown specifier '%c', ignoring.",
+                                                       *e);
+
+                        r = s->lookup(*e, f, j);
+                        if (r < 0)
+                                return r;
+
+                        word = e + 1;
+                        state = WORD;
+
+                        break;
+                }
+
+                case VARIABLE:
+                        if (*e == '}') {
+                                r = output_format_field(word+2, e-word-2, f, j, flags, highlight);
+                                if (r < 0)
+                                        return log_error_errno(r, "Failed to write field: %m");
+
+                                word = e+1;
+                                state = WORD;
+                        }
+                        break;
+
+                case VARIABLE_RAW:
+                        if (!strchr(VALID_FORMAT_FIELD_CHARS, *e)) {
+                                const void *data = NULL;
+                                size_t l = 0;
+
+                                r = get_field_datan(j, word+1, e-word-1, &data, &l);
+                                if (r < 0 && !IN_SET(r, -EBADMSG, -ENOENT))
+                                        return r;
+
+                                fwrite(data, 1, l, f);
+
+                                word = e--;
+                                i--;
+                                state = WORD;
+                        }
+                        break;
+                }
+
+        if (state == VARIABLE_RAW) {
+                const void *data = NULL;
+                size_t l = 0;
+
+                r = get_field_datan(j, word+1, e-word-1, &data, &l);
+                if (r < 0 && !IN_SET(r, -EBADMSG, -ENOENT))
+                        return r;
+
+                fwrite(data, 1, l, f);
+        } else
+                fwrite(word, 1, e-word, f);
+
+        fputc('\n', f);
+
+        return 0;
+}
+
 static int (*output_funcs[_OUTPUT_MODE_MAX])(
                 FILE *f,
                 sd_journal *j,
@@ -1235,7 +1461,8 @@ static int (*output_funcs[_OUTPUT_MODE_MAX])(
                 unsigned n_columns,
                 OutputFlags flags,
                 const Set *output_fields,
-                const size_t highlight[2]) = {
+                const size_t highlight[2],
+                const char *format) = {
 
         [OUTPUT_SHORT]             = output_short,
         [OUTPUT_SHORT_ISO]         = output_short,
@@ -1252,6 +1479,7 @@ static int (*output_funcs[_OUTPUT_MODE_MAX])(
         [OUTPUT_JSON_SEQ]          = output_json,
         [OUTPUT_CAT]               = output_cat,
         [OUTPUT_WITH_UNIT]         = output_short,
+        [OUTPUT_FORMAT]            = output_format,
 };
 
 int show_journal_entry(
@@ -1262,6 +1490,7 @@ int show_journal_entry(
                 OutputFlags flags,
                 char **output_fields,
                 const size_t highlight[2],
+                const char *format,
                 bool *ellipsized) {
 
         _cleanup_set_free_ Set *fields = NULL;
@@ -1277,7 +1506,7 @@ int show_journal_entry(
         if (r < 0)
                 return r;
 
-        r = output_funcs[mode](f, j, mode, n_columns, flags, fields, highlight);
+        r = output_funcs[mode](f, j, mode, n_columns, flags, fields, highlight, format);
 
         if (ellipsized && r > 0)
                 *ellipsized = true;
@@ -1308,6 +1537,7 @@ int show_journal(
                 usec_t not_before,
                 unsigned how_many,
                 OutputFlags flags,
+                const char *format,
                 bool *ellipsized) {
 
         int r;
@@ -1362,7 +1592,7 @@ int show_journal(
                 line++;
                 maybe_print_begin_newline(f, &flags);
 
-                r = show_journal_entry(f, j, mode, n_columns, flags, NULL, NULL, ellipsized);
+                r = show_journal_entry(f, j, mode, n_columns, flags, NULL, NULL, format, ellipsized);
                 if (r < 0)
                         return r;
         }
@@ -1615,6 +1845,7 @@ int show_journal_by_unit(
                 OutputFlags flags,
                 int journal_open_flags,
                 bool system_unit,
+                const char *format,
                 bool *ellipsized) {
 
         _cleanup_(sd_journal_closep) sd_journal *j = NULL;
@@ -1656,5 +1887,5 @@ int show_journal_by_unit(
                 log_debug("Journal filter: %s", filter);
         }
 
-        return show_journal(f, j, mode, n_columns, not_before, how_many, flags, ellipsized);
+        return show_journal(f, j, mode, n_columns, not_before, how_many, flags, format, ellipsized);
 }

--- a/src/shared/logs-show.h
+++ b/src/shared/logs-show.h
@@ -21,6 +21,7 @@ int show_journal_entry(
                 OutputFlags flags,
                 char **output_fields,
                 const size_t highlight[2],
+                const char *format,
                 bool *ellipsized);
 int show_journal(
                 FILE *f,
@@ -30,6 +31,7 @@ int show_journal(
                 usec_t not_before,
                 unsigned how_many,
                 OutputFlags flags,
+                const char *format,
                 bool *ellipsized);
 
 int add_match_this_boot(sd_journal *j, const char *machine);
@@ -55,6 +57,7 @@ int show_journal_by_unit(
                 OutputFlags flags,
                 int journal_open_flags,
                 bool system_unit,
+                const char *format,
                 bool *ellipsized);
 
 void json_escape(

--- a/src/shared/output-mode.c
+++ b/src/shared/output-mode.c
@@ -37,6 +37,7 @@ static const char *const output_mode_table[_OUTPUT_MODE_MAX] = {
         [OUTPUT_JSON_SEQ] = "json-seq",
         [OUTPUT_CAT] = "cat",
         [OUTPUT_WITH_UNIT] = "with-unit",
+        [OUTPUT_FORMAT] = "format",
 };
 
 DEFINE_STRING_TABLE_LOOKUP(output_mode, OutputMode);

--- a/src/shared/output-mode.h
+++ b/src/shared/output-mode.h
@@ -20,6 +20,7 @@ typedef enum OutputMode {
         OUTPUT_JSON_SEQ,
         OUTPUT_CAT,
         OUTPUT_WITH_UNIT,
+        OUTPUT_FORMAT,
         _OUTPUT_MODE_MAX,
         _OUTPUT_MODE_INVALID = -EINVAL,
 } OutputMode;

--- a/src/systemctl/systemctl-show.c
+++ b/src/systemctl/systemctl-show.c
@@ -780,6 +780,7 @@ static void print_status_info(
                                 get_output_flags() | OUTPUT_BEGIN_NEWLINE,
                                 SD_JOURNAL_LOCAL_ONLY,
                                 arg_scope == LOOKUP_SCOPE_SYSTEM,
+                                arg_output_format,
                                 ellipsized);
 
         if (i->need_daemon_reload)

--- a/src/systemctl/systemctl.c
+++ b/src/systemctl/systemctl.c
@@ -99,6 +99,7 @@ BusTransport arg_transport = BUS_TRANSPORT_LOCAL;
 const char *arg_host = NULL;
 unsigned arg_lines = 10;
 OutputMode arg_output = OUTPUT_SHORT;
+char *arg_output_format = NULL;
 bool arg_plain = false;
 bool arg_firmware_setup = false;
 usec_t arg_boot_loader_menu = USEC_INFINITY;
@@ -121,6 +122,7 @@ STATIC_DESTRUCTOR_REGISTER(arg_kill_who, unsetp);
 STATIC_DESTRUCTOR_REGISTER(arg_root, freep);
 STATIC_DESTRUCTOR_REGISTER(arg_reboot_argument, unsetp);
 STATIC_DESTRUCTOR_REGISTER(arg_host, unsetp);
+STATIC_DESTRUCTOR_REGISTER(arg_output_format, freep);
 STATIC_DESTRUCTOR_REGISTER(arg_boot_loader_entry, unsetp);
 STATIC_DESTRUCTOR_REGISTER(arg_clean_what, strv_freep);
 
@@ -424,6 +426,7 @@ static int systemctl_parse_argv(int argc, char *argv[]) {
                 ARG_READ_ONLY,
                 ARG_MKDIR,
                 ARG_MARKED,
+                ARG_OUTPUT_FORMAT,
         };
 
         static const struct option options[] = {
@@ -467,6 +470,7 @@ static int systemctl_parse_argv(int argc, char *argv[]) {
                 { "runtime",             no_argument,       NULL, ARG_RUNTIME             },
                 { "lines",               required_argument, NULL, 'n'                     },
                 { "output",              required_argument, NULL, 'o'                     },
+                { "output-format",       required_argument, NULL, ARG_OUTPUT_FORMAT       },
                 { "plain",               no_argument,       NULL, ARG_PLAIN               },
                 { "state",               required_argument, NULL, ARG_STATE               },
                 { "recursive",           no_argument,       NULL, 'r'                     },
@@ -746,6 +750,14 @@ static int systemctl_parse_argv(int argc, char *argv[]) {
                         }
                         break;
 
+                case ARG_OUTPUT_FORMAT:
+                        arg_output = OUTPUT_FORMAT;
+
+                        r = free_and_strdup(&arg_output_format, optarg);
+                        if (r < 0)
+                                return log_oom();
+
+                        break;
                 case 'i':
                         arg_check_inhibitors = 0;
                         break;
@@ -958,6 +970,11 @@ static int systemctl_parse_argv(int argc, char *argv[]) {
                         return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
                                                "List of units to restart/reload is required.");
         }
+
+        if (arg_output_format && arg_output != OUTPUT_FORMAT)
+                return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
+                                       "--output-format cannot be used with output mode \"%s\"",
+                                       output_mode_to_string(arg_output));
 
         return 1;
 }

--- a/src/systemctl/systemctl.h
+++ b/src/systemctl/systemctl.h
@@ -84,6 +84,7 @@ extern BusTransport arg_transport;
 extern const char *arg_host;
 extern unsigned arg_lines;
 extern OutputMode arg_output;
+extern char *arg_output_format;
 extern bool arg_plain;
 extern bool arg_firmware_setup;
 extern usec_t arg_boot_loader_menu;

--- a/src/systemd/sd-journal.h
+++ b/src/systemd/sd-journal.h
@@ -104,6 +104,7 @@ int sd_journal_set_data_threshold(sd_journal *j, size_t sz);
 int sd_journal_get_data_threshold(sd_journal *j, size_t *sz);
 
 int sd_journal_get_data(sd_journal *j, const char *field, const void **data, size_t *l);
+int sd_journal_get_data_n(sd_journal *j, const char *field, size_t field_length, const void **data, size_t *l);
 int sd_journal_enumerate_data(sd_journal *j, const void **data, size_t *l);
 int sd_journal_enumerate_available_data(sd_journal *j, const void **data, size_t *l);
 void sd_journal_restart_data(sd_journal *j);


### PR DESCRIPTION
Draft since I still need to add specifiers for timestamps and documentation, etc. I'm slightly unsure on the best way to do specifiers for timestamps though, since there's many different ways to output the time. Should we reuse a bunch of the remaining specifier variables to each represent a different time output or do we need something more clever.

See commit messages for more details on the feature.