### PR TITLE
repart: Add support for setting a partition's UUID to zero

### DIFF
--- a/man/repart.d.xml
+++ b/man/repart.d.xml
@@ -358,8 +358,8 @@
         <listitem><para>The UUID to assign to the partition if none is assigned yet. Note that this
         setting is not used for matching. It is also not used when a UUID is already set for an existing
         partition. It is thus only used when a partition is newly created or when an existing one had a
-        all-zero UUID set. If not specified a UUID derived from the partition type is automatically
-        used.</para></listitem>
+        all-zero UUID set. If set to <literal>null</literal>, the UUID is set to all zeroes. If not specified
+        a UUID derived from the partition type is automatically used.</para></listitem>
       </varlistentry>
 
       <varlistentry>

--- a/test/units/testsuite-58.sh
+++ b/test/units/testsuite-58.sh
@@ -570,6 +570,34 @@ EOF
     assert_in "$imgs/21817.img2 : start=      104448, size=      (100319| 98304)," "$output"
 }
 
+test_zero_uuid() {
+    local defs imgs output
+
+    defs="$(mktemp --directory "/tmp/test-repart.XXXXXXXXXX")"
+    imgs="$(mktemp --directory "/var/tmp/test-repart.XXXXXXXXXX")"
+    # shellcheck disable=SC2064
+    trap "rm -rf '$defs' '$imgs'" RETURN
+
+    # Test image with zero UUID.
+
+    cat >"$defs/root.conf" <<EOF
+[Partition]
+Type=root-${architecture}
+UUID=null
+EOF
+
+    systemd-repart --definitions="$defs" \
+                   --seed="$seed" \
+                   --dry-run=no \
+                   --empty=create \
+                   --size=auto \
+                   "$imgs/zero"
+
+    output=$(sfdisk --dump "$imgs/zero")
+
+    assert_in "$imgs/zero1 : start=        2048, size=       20480, type=${root_guid}, uuid=00000000-0000-0000-0000-000000000000" "$output"
+}
+
 test_sector() {
     local defs imgs output loop
     local start size ratio
@@ -635,6 +663,7 @@ test_multiple_definitions
 test_copy_blocks
 test_unaligned_partition
 test_issue_21817
+test_zero_uuid
 
 # Valid block sizes on the Linux block layer are >= 512 and <= PAGE_SIZE, and
 # must be powers of 2. Which leaves exactly four different ones to test on


### PR DESCRIPTION
This is useful when we need to fill in the UUID later, such as when
using verity partitions.