### PR TITLE
repart: Add support for formatting verity partitions

### DIFF
--- a/TODO
+++ b/TODO
@@ -117,6 +117,8 @@ Deprecations and removals:
 
 Features:
 
+* Add support for extra verity configuration options to systemd-reart (FEC, hash type, etc)
+
 * measure credentials picked up from SMBIOS to some suitable PCR
 
 * measure GPT and LUKS headers somewhere when we use them (i.e. in

--- a/man/repart.d.xml
+++ b/man/repart.d.xml
@@ -581,6 +581,38 @@
       </varlistentry>
 
       <varlistentry>
+        <term><varname>Verity=</varname></term>
+
+        <listitem><para>Takes one of <literal>off</literal>, <literal>data</literal> or
+        <literal>hash</literal>. Defaults to <literal>off</literal>. If set to <literal>off</literal> or
+        <literal>data</literal>, the partition is populated with content as specified by
+        <varname>CopyBlocks=</varname> or <varname>CopyFiles=</varname>. If set to <literal>hash</literal>,
+        the partition will be populated with verity hashes from a matching verity data partition. A matching
+        data partition is a partition with <varname>Verity=</varname> set to <literal>data</literal> and the
+        same verity match key (as configured with <varname>VerityMatchKey=</varname>). If not explicitly
+        configured, the data partition's UUID will be set to the first 128 bits of the verity root hash.
+        Similarly, if not configured, the hash partition's UUID will be set to the final 128 bits of the
+        verity root hash. The verity root hash itself will be included in the output of
+        <command>systemd-repart</command>.</para>
+
+        <para>This option has no effect if the partition already exists.</para>
+
+        <para>Usage of this option in combination with <varname>Encrypt=</varname> is not supported.</para>
+
+        <para>For each unique <varname>VerityMatchKey=</varname> value, a single verity data partition
+        (<literal>Verity=data</literal>) and a single verity hash partition (<literal>Verity=hash</literal>)
+        must be defined.</para></listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term><varname>VerityMatchKey=</varname></term>
+
+        <listitem><para>Takes a short, user-chosen identifier string. This setting is used to find sibling
+        verity partitions for the current verity partition. See the description for
+        <varname>Verity=</varname>.</para></listitem>
+      </varlistentry>
+
+      <varlistentry>
         <term><varname>FactoryReset=</varname></term>
 
         <listitem><para>Takes a boolean argument. If specified the partition is marked for removal during a
@@ -746,6 +778,28 @@ SizeMaxBytes=64M
 
 <para><programlisting># ln -s 50-root.conf /usr/lib/repart.d/70-root-b.conf
 # ln -s 60-root-verity.conf /usr/lib/repart.d/80-root-verity-b.conf
+</programlisting></para>
+    </example>
+
+     <example>
+      <title>Create a data and verity partition from a OS tree</title>
+
+      <para>Assuming we have an OS tree at /var/tmp/os-tree that we want to package in a root partition
+      together with a matching verity partition, we can do so as follows:</para>
+
+      <para><programlisting># 50-root.conf
+[Partition]
+Type=root
+CopyFiles=/var/tmp/os-tree
+Verity=data
+VerityMatchKey=root
+</programlisting></para>
+
+      <para><programlisting># 60-root-verity.conf
+[Partition]
+Type=root-verity
+Verity=hash
+VerityMatchKey=root
 </programlisting></para>
     </example>
 

--- a/src/partition/repart.c
+++ b/src/partition/repart.c
@@ -2043,7 +2043,7 @@ static int context_dump_partitions(Context *context, const char *node) {
         uint64_t sum_padding = 0, sum_size = 0;
         int r;
         const size_t dropin_files_col = 13;
-        bool no_dropin_files = true;
+        bool has_dropin_files = false;
 
         if ((arg_json_format_flags & JSON_FORMAT_OFF) && context->n_partitions == 0) {
                 log_info("Empty partition table.");
@@ -2120,7 +2120,7 @@ static int context_dump_partitions(Context *context, const char *node) {
                 if (r < 0)
                         return table_log_add_error(r);
 
-                no_dropin_files = no_dropin_files && strv_isempty(p->drop_in_files);
+                has_dropin_files = has_dropin_files || !strv_isempty(p->drop_in_files);
         }
 
         if ((arg_json_format_flags & JSON_FORMAT_OFF) && (sum_padding > 0 || sum_size > 0)) {
@@ -2149,7 +2149,7 @@ static int context_dump_partitions(Context *context, const char *node) {
                         return table_log_add_error(r);
         }
 
-        if (no_dropin_files) {
+        if (!has_dropin_files) {
                 r = table_hide_column_from_display(t, dropin_files_col);
                 if (r < 0)
                         return log_error_errno(r, "Failed to set columns to display: %m");

--- a/test/TEST-58-REPART/test.sh
+++ b/test/TEST-58-REPART/test.sh
@@ -10,6 +10,8 @@ TEST_DESCRIPTION="test systemd-repart"
 test_append_files() {
     if ! get_bool "${TEST_NO_QEMU:=}"; then
         install_dmevent
+        image_install jq
+        instmods dm_verity =md
         generate_module_dependencies
     fi
 }


### PR DESCRIPTION
This commit adds a new Verity= setting to repart definition files
with two possible values: "data" and "hash".

If Verity= is set to "data", repart works as before, and populates
the partition with the content from CopyBlocks= or CopyFiles=.

If Verity= is set to "hash", repart will try to find a matching
data partition with Verity=data and equal values for CopyBlocks=
or CopyFiles=, Format= and MakeDirectories=. If a matching data
partition is found, repart will generate verity hashes for that
data partition in the verity partition. The UUID of the data
partition is set to the first 128 bits of the verity root hash. The
UUID of the hashes partition is set to the final 128 bits of the
verity root hash.

Fixes https://github.com/systemd/systemd/issues/24559