### PR TITLE
Allow to get the current udevd log level from command line

### DIFF
--- a/man/udevadm.xml
+++ b/man/udevadm.xml
@@ -730,6 +730,15 @@
           </listitem>
         </varlistentry>
         <varlistentry>
+          <term><option>--get-log-level</term>
+          <listitem>
+            <para>Print textual representation of the current log level of
+            <filename>systemd-udevd</filename>.</para>
+
+            <xi:include href="version-info.xml" xpointer="v263"/>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
           <term><option>-s</option></term>
           <term><option>--stop-exec-queue</option></term>
           <listitem>

--- a/src/udev/udevadm-control.c
+++ b/src/udev/udevadm-control.c
@@ -4,6 +4,7 @@
 
 #include "sd-json.h"
 
+#include "alloc-util.h"
 #include "build.h"
 #include "creds-util.h"
 #include "log.h"
@@ -26,6 +27,7 @@ static bool arg_ping = false;
 static bool arg_reload = false;
 static bool arg_exit = false;
 static int arg_max_children = -1;
+static bool arg_get_log_level = false;
 static int arg_log_level = -1;
 static int arg_start_exec_queue = -1;
 static int arg_trace = -1;
@@ -75,6 +77,10 @@ static int parse_argv(int argc, char *argv[]) {
                         arg_log_level = log_level_from_string(opts.arg);
                         if (arg_log_level < 0)
                                 return log_error_errno(arg_log_level, "Failed to parse log level '%s': %m", opts.arg);
+                        break;
+
+                OPTION_LONG("get-log-level", NULL, "Get the udev log level for the daemon"):
+                        arg_get_log_level = true;
                         break;
 
                 OPTION('s', "stop-exec-queue", NULL, "Do not execute events, queue only"):
@@ -169,6 +175,31 @@ static int send_control_commands(void) {
                 r = varlink_call_and_log(link, "io.systemd.Udev.Revert", /* parameters= */ NULL, /* reply= */ NULL);
                 if (r < 0)
                         return r;
+        }
+
+        if (arg_get_log_level) {
+                static const sd_json_dispatch_field dispatch_table[] = {
+                        {"level", SD_JSON_VARIANT_INTEGER, sd_json_dispatch_int64, 0, SD_JSON_MANDATORY},
+                        {}
+                };
+
+                _cleanup_(sd_json_variant_unrefp) sd_json_variant *v = NULL;
+                _cleanup_free_ char *level_str = NULL;
+                int64_t level;
+
+                r = varlink_call_and_log(link, "io.systemd.service.GetLogLevel", /* parameters = */ NULL, &v);
+                if (r < 0)
+                        return r;
+
+                r = sd_varlink_dispatch(link, v, dispatch_table, &level);
+                if (r < 0)
+                        return log_error_errno(r, "Failed to dispatch server response: %m");
+
+                r = log_level_to_string_alloc(r, &level_str);
+                if (r < 0)
+                        return log_error_errno(r, "Failed to convert log level to string: %m");
+
+                printf("%s\n", level_str);
         }
 
         if (arg_log_level >= 0) {

--- a/test/units/TEST-13-NSPAWN.importctl.sh
+++ b/test/units/TEST-13-NSPAWN.importctl.sh
@@ -91,4 +91,5 @@ varlinkctl call --more /run/systemd/io.systemd.Import io.systemd.service.Ping '{
 varlinkctl call --more /run/systemd/io.systemd.Import io.systemd.service.SetLogLevel '{"level":"7"}'
 varlinkctl call --more /run/systemd/io.systemd.Import io.systemd.service.SetLogLevel '{"level":"1"}'
 varlinkctl call --more /run/systemd/io.systemd.Import io.systemd.service.SetLogLevel '{"level":"7"}'
+varlinkctl call --more /run/systemd/io.systemd.Import io.systemd.service.GetLogLevel '{}'
 varlinkctl call --more /run/systemd/io.systemd.Import io.systemd.service.GetEnvironment '{}'

--- a/test/units/TEST-17-UDEV.sanity-check.sh
+++ b/test/units/TEST-17-UDEV.sanity-check.sh
@@ -55,6 +55,7 @@ udevadm control -l notice
 udevadm control --log-level info
 udevadm control --log-level debug
 (! udevadm control -l hello)
+udevadm control --get-log-level
 (! udevadm control -m 2147483648)
 
 # Check if processing queued events has been stopped.


### PR DESCRIPTION
`udevadm control` allows to change `systemd-udevd`'s log level from command line, but there's no way to get the current level. This PR remedies that.

This builds upon #25523 .