### PR TITLE
WIP: Mitigate TPM+Passphrase being less secure than Passphrase if TPM is pwned

### DIFF
--- a/src/cryptenroll/cryptenroll-tpm2.c
+++ b/src/cryptenroll/cryptenroll-tpm2.c
@@ -75,7 +75,7 @@ static int get_pin(char **ret_pin_str, TPM2Flags *ret_flags) {
         if (r < 0)
                 return log_error_errno(r, "Failed to acquire PIN from environment: %m");
         if (r > 0)
-                flags |= TPM2_FLAGS_USE_PIN;
+                flags |= TPM2_FLAGS_USE_PIN | TPM2_FLAGS_APPEND_SALT;
         else {
                 for (size_t i = 5;; i--) {
                         _cleanup_strv_free_erase_ char **pin = NULL, **pin2 = NULL;
@@ -115,7 +115,7 @@ static int get_pin(char **ret_pin_str, TPM2Flags *ret_flags) {
                                 pin_str = strdup(*pin);
                                 if (!pin_str)
                                         return log_oom();
-                                flags |= TPM2_FLAGS_USE_PIN;
+                                flags |= TPM2_FLAGS_USE_PIN | TPM2_FLAGS_APPEND_SALT;
                                 break;
                         }
 
@@ -141,9 +141,9 @@ int enroll_tpm2(struct crypt_device *cd,
 
         _cleanup_(erase_and_freep) void *secret = NULL;
         _cleanup_(json_variant_unrefp) JsonVariant *v = NULL, *signature_json = NULL;
-        _cleanup_(erase_and_freep) char *base64_encoded = NULL;
+        _cleanup_(erase_and_freep) char *base64_encoded = NULL, *secret_and_salt = NULL;
         _cleanup_free_ void *srk_buf = NULL;
-        size_t secret_size, blob_size, hash_size, pubkey_size = 0, srk_buf_size = 0;
+        size_t secret_size, blob_size, hash_size, pubkey_size = 0, srk_buf_size = 0, secret_and_salt_size = 0;
         _cleanup_free_ void *blob = NULL, *hash = NULL, *pubkey = NULL;
         uint16_t pcr_bank, primary_alg;
         const char *node;
@@ -152,6 +152,7 @@ int enroll_tpm2(struct crypt_device *cd,
         int r, keyslot;
         TPM2Flags flags = 0;
         uint8_t binary_salt[SHA256_DIGEST_SIZE] = {};
+        uint8_t salted_pin[SHA256_DIGEST_SIZE] = {};
         /*
          * erase the salt, we'd rather attempt to not have this in a coredump
          * as an attacker would have all the parameters but pin used to create
@@ -159,6 +160,7 @@ int enroll_tpm2(struct crypt_device *cd,
          * primary key, aka the SRK.
          */
         CLEANUP_ERASE(binary_salt);
+        CLEANUP_ERASE(salted_pin);
 
         assert(cd);
         assert(volume_key);
@@ -177,8 +179,6 @@ int enroll_tpm2(struct crypt_device *cd,
                 if (r < 0)
                         return log_error_errno(r, "Failed to acquire random salt: %m");
 
-                uint8_t salted_pin[SHA256_DIGEST_SIZE] = {};
-                CLEANUP_ERASE(salted_pin);
                 r = tpm2_util_pbkdf2_hmac_sha256(pin_str, strlen(pin_str), binary_salt, sizeof(binary_salt), salted_pin);
                 if (r < 0)
                         return log_error_errno(r, "Failed to perform PBKDF2: %m");
@@ -257,8 +257,19 @@ int enroll_tpm2(struct crypt_device *cd,
                         return log_error_errno(SYNTHETIC_ERRNO(ENOTRECOVERABLE), "TPM2 seal/unseal verification failed.");
         }
 
+        if (use_pin) {
+                /* To prevent using a secret from a compromised TPM without the pin, append salted pin.
+                 * See following attack on AMD's fTPMs: https://arxiv.org/abs/2304.14717 */
+                secret_and_salt_size = secret_size + sizeof(salted_pin);
+                secret_and_salt = malloc(secret_and_salt_size);
+                if (!secret_and_salt)
+                        return log_oom();
+                memcpy(secret_and_salt, secret, secret_size);
+                memcpy(secret_and_salt + secret_size, salted_pin, sizeof(salted_pin));
+        }
+
         /* let's base64 encode the key to use, for compat with homed (and it's easier to every type it in by keyboard, if that might end up being necessary. */
-        base64_encoded_size = base64mem(secret, secret_size, &base64_encoded);
+        base64_encoded_size = base64mem(secret_and_salt ?: secret, secret_and_salt_size ?: secret_size, &base64_encoded);
         if (base64_encoded_size < 0)
                 return log_error_errno(base64_encoded_size, "Failed to base64 encode secret key: %m");
 

--- a/src/cryptsetup/cryptsetup-tpm2.c
+++ b/src/cryptsetup/cryptsetup-tpm2.c
@@ -84,11 +84,13 @@ int acquire_tpm2_key(
         _cleanup_(json_variant_unrefp) JsonVariant *signature_json = NULL;
         _cleanup_free_ void *loaded_blob = NULL;
         _cleanup_free_ char *auto_device = NULL;
-        size_t blob_size;
+        _cleanup_(erase_and_freep) void *secret = NULL;
+        size_t blob_size, secret_size = 0;
         const void *blob;
         int r;
 
         assert(salt || salt_size == 0);
+        assert(salt || !(flags & TPM2_FLAGS_APPEND_SALT));
 
         if (!device) {
                 r = tpm2_find_device_auto(LOG_DEBUG, &auto_device);
@@ -150,6 +152,8 @@ int acquire_tpm2_key(
 
         for (int i = 5;; i--) {
                 _cleanup_(erase_and_freep) char *pin_str = NULL, *b64_salted_pin = NULL;
+                uint8_t salted_pin[SHA256_DIGEST_SIZE] = {};
+                CLEANUP_ERASE(salted_pin);
 
                 if (i <= 0)
                         return -EACCES;
@@ -159,9 +163,6 @@ int acquire_tpm2_key(
                         return r;
 
                 if (salt_size > 0) {
-                        uint8_t salted_pin[SHA256_DIGEST_SIZE] = {};
-                        CLEANUP_ERASE(salted_pin);
-
                         r = tpm2_util_pbkdf2_hmac_sha256(pin_str, strlen(pin_str), salt, salt_size, salted_pin);
                         if (r < 0)
                                 return log_error_errno(r, "Failed to perform PBKDF2: %m");
@@ -187,14 +188,29 @@ int acquire_tpm2_key(
                                 policy_hash_size,
                                 srk_buf,
                                 srk_buf_size,
-                                ret_decrypted_key,
-                                ret_decrypted_key_size);
+                                &secret,
+                                &secret_size);
                 /* We get this error in case there is an authentication policy mismatch. This should
                  * not happen, but this avoids confusing behavior, just in case. */
                 if (IN_SET(r, -EPERM, -ENOLCK))
                         return r;
                 if (r < 0)
                         continue;
+
+                if (flags & TPM2_FLAGS_APPEND_SALT) {
+                        /* Append salted pin to unsealed secret if there is a salt */
+                        _cleanup_(erase_and_freep) uint8_t * decrypted_key = malloc(secret_size + sizeof(salted_pin));
+                        if (!decrypted_key)
+                                return log_oom();
+                        memcpy(decrypted_key, secret, secret_size);
+                        memcpy(decrypted_key + secret_size, salted_pin, sizeof(salted_pin));
+                        *ret_decrypted_key = (void*) TAKE_PTR(decrypted_key);
+                        *ret_decrypted_key_size = secret_size + sizeof(salted_pin);
+                } else {
+                        /* for backwards compatibility with salted pin/secret only setups */
+                        *ret_decrypted_key = TAKE_PTR(secret);
+                        *ret_decrypted_key_size = secret_size;
+                }
 
                 return r;
         }
@@ -264,6 +280,11 @@ int find_tpm2_auto_data(
 
                         if (start_token <= 0)
                                 log_info("Automatically discovered security TPM2 token unlocks volume.");
+
+                        if ((flags & TPM2_FLAGS_APPEND_SALT) && !salt) {
+                                log_error("'tpm2_append_salted_pin_to_key' is set, but no salt given.");
+                                continue;
+                        }
 
                         *ret_hash_pcr_mask = hash_pcr_mask;
                         *ret_pcr_bank = pcr_bank;

--- a/src/shared/tpm2-util.c
+++ b/src/shared/tpm2-util.c
@@ -2755,6 +2755,7 @@ int tpm2_make_luks2_json(
                                        JSON_BUILD_PAIR_CONDITION(pubkey_pcr_mask != 0, "tpm2_pubkey_pcrs", JSON_BUILD_VARIANT(pkmj)),
                                        JSON_BUILD_PAIR_CONDITION(pubkey_pcr_mask != 0, "tpm2_pubkey", JSON_BUILD_BASE64(pubkey, pubkey_size)),
                                        JSON_BUILD_PAIR_CONDITION(salt, "tpm2_salt", JSON_BUILD_BASE64(salt, salt_size)),
+                                       JSON_BUILD_PAIR_CONDITION(salt, "tpm2_append_salted_pin_to_key", JSON_BUILD_BOOLEAN(flags & TPM2_FLAGS_APPEND_SALT)),
                                        JSON_BUILD_PAIR_CONDITION(srk_buf, "tpm2_srk", JSON_BUILD_BASE64(srk_buf, srk_buf_size))));
         if (r < 0)
                 return r;
@@ -2875,6 +2876,14 @@ int tpm2_parse_luks2_json(
                 r = json_variant_unbase64(w, &salt, &salt_size);
                 if (r < 0)
                         return log_debug_errno(r, "Invalid base64 data in 'tpm2_salt' field.");
+        }
+
+        w = json_variant_by_key(v, "tpm2_append_salted_pin_to_key");
+        if (w) {
+                if (!json_variant_is_boolean(w))
+                        return log_debug_errno(SYNTHETIC_ERRNO(EINVAL), "'tpm2_append_salted_pin_to_key' field is not a boolean.");
+
+                SET_FLAG(flags, TPM2_FLAGS_APPEND_SALT, json_variant_boolean(w));
         }
 
         w = json_variant_by_key(v, "tpm2_pubkey_pcrs");

--- a/src/shared/tpm2-util.h
+++ b/src/shared/tpm2-util.h
@@ -9,7 +9,8 @@
 #include "sha256.h"
 
 typedef enum TPM2Flags {
-        TPM2_FLAGS_USE_PIN = 1 << 0,
+        TPM2_FLAGS_USE_PIN      = 1 << 0,
+        TPM2_FLAGS_APPEND_SALT  = 1 << 1,
 } TPM2Flags;
 
 


### PR DESCRIPTION
If an attacker gets hold of the TPM-sealed secret, they currently are able to decrypt the volume without access to the pin. This is counter intuitive, as TPM+Passphrase should be at least as secure as Passphrase only, even if the TPM is compromised.

This scenario is a real threat on systems with an AMD fTPM: https://arxiv.org/abs/2304.14717

To prevent using a secret from a compromised TPM without the pin, append salted pin to the luks keyslot passphrase.
If an attack knows the sealed secret, they still need to brute-force the pin to unlock the volume.