### PR TITLE
boot: load addons from systemd-boot Type 1 entries

### DIFF
--- a/src/boot/bootctl-status.c
+++ b/src/boot/bootctl-status.c
@@ -634,6 +634,11 @@ static int count_known_files(const BootConfig *config, const char* root, Hashmap
                         if (r < 0)
                                 return r;
                 }
+                STRV_FOREACH(s, e->addons) {
+                        r = ref_file(known_files, *s, +1);
+                        if (r < 0)
+                                return r;
+                }
                 r = ref_file(known_files, e->device_tree, +1);
                 if (r < 0)
                         return r;

--- a/src/boot/efi/addon-util.c
+++ b/src/boot/efi/addon-util.c
@@ -1,0 +1,48 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include "addon-util.h"
+#include "proto/device-path.h"
+#include "util.h"
+#include "log.h"
+
+EFI_STATUS addons_install_proto(EFI_LOADED_IMAGE_PROTOCOL *stub_image, char16_t * const *addons) {
+        EFI_STATUS err;
+        EFI_DEVICE_PATH **dps;
+
+        assert(stub_image);
+
+        err = make_multiple_file_device_path(stub_image->DeviceHandle, addons, &dps);
+        if (err != EFI_SUCCESS || dps == NULL)
+                return err;
+
+        return BS->InstallMultipleProtocolInterfaces(&stub_image->DeviceHandle,
+                                            MAKE_GUID_PTR(SYSTEMD_ADDON_MEDIA),
+                                            dps, NULL);
+}
+
+EFI_STATUS addons_unload_proto(EFI_HANDLE *addons)
+{
+        EFI_STATUS err;
+        EFI_DEVICE_PATH *dps;
+
+        assert(addons);
+
+        if (!*addons)
+                return EFI_SUCCESS;
+
+        /* get the EFI_DEVICE_PATH* interface that we allocated earlier */
+        err = BS->HandleProtocol(*addons, MAKE_GUID_PTR(SYSTEMD_ADDON_MEDIA),
+                        (void **) &dps);
+        if (err != EFI_SUCCESS)
+                return err;
+
+        err = BS->UninstallMultipleProtocolInterfaces(*addons,
+                        MAKE_GUID_PTR(SYSTEMD_ADDON_MEDIA),
+                        &dps, NULL);
+
+        if (err != EFI_SUCCESS)
+                return err;
+
+        *addons = NULL;
+        return EFI_SUCCESS;
+}

--- a/src/boot/efi/addon-util.h
+++ b/src/boot/efi/addon-util.h
@@ -1,0 +1,12 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#pragma once
+
+#include "proto/loaded-image.h"
+#include "device-path-util.h"
+#include "util.h"
+
+#define SYSTEMD_ADDON_MEDIA_GUID \
+        GUID_DEF(0x97ac68bf, 0xc741, 0x4bbb, 0xb7, 0xbf, 0x7f, 0x6c, 0xcc, 0x00, 0x8a, 0x7e)
+
+EFI_STATUS addons_install_proto(EFI_LOADED_IMAGE_PROTOCOL *loaded_image, char16_t * const *addons);
+EFI_STATUS addons_unload_proto(EFI_HANDLE *addons);

--- a/src/boot/efi/addon-util.h
+++ b/src/boot/efi/addon-util.h
@@ -8,5 +8,7 @@
 #define SYSTEMD_ADDON_MEDIA_GUID \
         GUID_DEF(0x97ac68bf, 0xc741, 0x4bbb, 0xb7, 0xbf, 0x7f, 0x6c, 0xcc, 0x00, 0x8a, 0x7e)
 
+#define ADDON_FILENAME "sd-addon"
+
 EFI_STATUS addons_install_proto(EFI_LOADED_IMAGE_PROTOCOL *loaded_image, char16_t * const *addons);
 EFI_STATUS addons_unload_proto(EFI_HANDLE *addons);

--- a/src/boot/efi/addon.c
+++ b/src/boot/efi/addon.c
@@ -5,6 +5,10 @@
 
 /* Magic string for recognizing our own binaries */
 DECLARE_NOALLOC_SECTION(".sdmagic", "#### LoaderInfo: systemd-addon " GIT_VERSION " ####");
+_used_ _section_(".binrel") static const struct pe_metadata metadata = {
+        .fname = ADDON_FILENAME
+};
+
 
 /* This is intended to carry data, not to be executed */
 

--- a/src/boot/efi/boot.c
+++ b/src/boot/efi/boot.c
@@ -1,5 +1,6 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
+#include "addon-util.h"
 #include "bcd.h"
 #include "bootspec-fundamental.h"
 #include "console.h"
@@ -63,6 +64,7 @@ typedef struct {
         char16_t *options;
         bool options_implied; /* If true, these options are implied if we invoke the PE binary without any parameters (as in: UKI). If false we must specify these options explicitly. */
         char16_t **initrd;
+        char16_t **addons; /* systemd-addons for this entry */
         char16_t key;
         EFI_STATUS (*call)(void);
         int tries_done;
@@ -599,6 +601,8 @@ static void print_status(Config *config, char16_t *loaded_image_path) {
                         printf("        loader: %ls\n", entry->loader);
                 STRV_FOREACH(initrd, entry->initrd)
                         printf("        initrd: %ls\n", *initrd);
+                STRV_FOREACH(addon, entry->addons)
+                        printf("         addon: %ls\n", *addon);
                 if (entry->devicetree)
                         printf("    devicetree: %ls\n", entry->devicetree);
                 if (entry->options)
@@ -1176,6 +1180,7 @@ static BootEntry* boot_entry_free(BootEntry *entry) {
         free(entry->devicetree);
         free(entry->options);
         strv_free(entry->initrd);
+        strv_free(entry->addons);
         free(entry->path);
         free(entry->current_name);
         free(entry->next_name);
@@ -1412,7 +1417,7 @@ static void boot_entry_add_type1(
 
         _cleanup_(boot_entry_freep) BootEntry *entry = NULL;
         char *line;
-        size_t pos = 0, n_initrd = 0;
+        size_t pos = 0, n_initrd = 0, n_addons = 0;
         char *key, *value;
         EFI_STATUS err;
 
@@ -1481,7 +1486,14 @@ static void boot_entry_add_type1(
                                 (n_initrd + 2) * sizeof(uint16_t *));
                         entry->initrd[n_initrd++] = xstr8_to_path(value);
                         entry->initrd[n_initrd] = NULL;
-
+                } else if (streq8(key, "add-on")) {
+                        entry->addons = xrealloc(
+                                entry->addons,
+                                n_addons == 0 ? 0 : (n_addons + 1) * sizeof(uint16_t *),
+                                (n_addons + 2) * sizeof(uint16_t *));
+                        entry->addons[n_addons++] = xstr8_to_path(value);
+                        entry->addons[n_addons] = NULL;
+                        continue;
                 } else if (streq8(key, "options")) {
                         _cleanup_free_ char16_t *new = NULL;
 
@@ -2309,6 +2321,13 @@ static EFI_STATUS initrd_prepare(
         return EFI_SUCCESS;
 }
 
+static void cleanup_loaded_image(EFI_LOADED_IMAGE_PROTOCOL **loaded_image) {
+        assert(loaded_image);
+
+        (void) addons_unload_proto((EFI_HANDLE *)*loaded_image);
+        *loaded_image = NULL;
+}
+
 static EFI_STATUS image_start(
                 EFI_HANDLE parent_image,
                 const BootEntry *entry) {
@@ -2358,7 +2377,7 @@ static EFI_STATUS image_start(
         if (err != EFI_SUCCESS)
                 return log_error_status(err, "Error registering initrd: %m");
 
-        EFI_LOADED_IMAGE_PROTOCOL *loaded_image;
+        _cleanup_(cleanup_loaded_image) EFI_LOADED_IMAGE_PROTOCOL *loaded_image = NULL;
         err = BS->HandleProtocol(image, MAKE_GUID_PTR(EFI_LOADED_IMAGE_PROTOCOL), (void **) &loaded_image);
         if (err != EFI_SUCCESS)
                 return log_error_status(err, "Error getting LoadedImageProtocol handle: %m");
@@ -2373,6 +2392,12 @@ static EFI_STATUS image_start(
 
                 /* Try to log any options to the TPM, especially to catch manually edited options */
                 (void) tpm_log_load_options(options, NULL);
+        }
+
+        if (entry->addons) {
+                err = addons_install_proto(loaded_image, entry->addons);
+                if (err != EFI_SUCCESS)
+                        return log_error_status(err, "Error installing addons protocol: %m");
         }
 
         efivar_set_time_usec(MAKE_GUID_PTR(LOADER), u"LoaderTimeExecUSec", 0);

--- a/src/boot/efi/boot.c
+++ b/src/boot/efi/boot.c
@@ -2554,6 +2554,7 @@ static void export_variables(
                 EFI_LOADER_FEATURE_SECUREBOOT_ENROLL |
                 EFI_LOADER_FEATURE_RETAIN_SHIM |
                 EFI_LOADER_FEATURE_MENU_DISABLE |
+                EFI_LOADER_FEATURE_OFFER_ADDONS |
                 0;
 
         _cleanup_free_ char16_t *infostr = NULL, *typestr = NULL;

--- a/src/boot/efi/boot.c
+++ b/src/boot/efi/boot.c
@@ -1480,17 +1480,19 @@ static void boot_entry_add_type1(
                         entry->devicetree = xstr8_to_path(value);
 
                 } else if (streq8(key, "initrd")) {
-                        entry->initrd = xrealloc(
+                        entry->initrd = xrealloc_extra_item(
+                                uint16_t,
                                 entry->initrd,
-                                n_initrd == 0 ? 0 : (n_initrd + 1) * sizeof(uint16_t *),
-                                (n_initrd + 2) * sizeof(uint16_t *));
+                                n_initrd
+                        );
                         entry->initrd[n_initrd++] = xstr8_to_path(value);
                         entry->initrd[n_initrd] = NULL;
                 } else if (streq8(key, "add-on")) {
-                        entry->addons = xrealloc(
+                        entry->addons = xrealloc_extra_item(
+                                uint16_t,
                                 entry->addons,
-                                n_addons == 0 ? 0 : (n_addons + 1) * sizeof(uint16_t *),
-                                (n_addons + 2) * sizeof(uint16_t *));
+                                n_addons
+                        );
                         entry->addons[n_addons++] = xstr8_to_path(value);
                         entry->addons[n_addons] = NULL;
                         continue;

--- a/src/boot/efi/device-path-util.c
+++ b/src/boot/efi/device-path-util.c
@@ -4,11 +4,14 @@
 #include "util.h"
 
 EFI_STATUS make_multiple_file_device_path(
-                EFI_HANDLE device, const char16_t **files, EFI_DEVICE_PATH ***ret_dp) {
+                EFI_HANDLE device,
+                char16_t * const *files,
+                EFI_DEVICE_PATH ***ret_dp) {
+
         EFI_STATUS err;
         EFI_DEVICE_PATH *cur_dp = NULL, **iterator_dp = NULL;
         EFI_DEVICE_PATH *original_device_path = NULL;
-        size_t n_files = strv_length((const void**)files);
+        size_t n_files = strv_length(files);
 
         assert(files);
         assert(ret_dp);

--- a/src/boot/efi/device-path-util.h
+++ b/src/boot/efi/device-path-util.h
@@ -3,7 +3,7 @@
 
 #include "proto/device-path.h"
 
-EFI_STATUS make_multiple_file_device_path(EFI_HANDLE device, const char16_t **files, EFI_DEVICE_PATH
+EFI_STATUS make_multiple_file_device_path(EFI_HANDLE device, char16_t * const *files, EFI_DEVICE_PATH
                 ***ret_dp);
 EFI_STATUS make_file_device_path(EFI_HANDLE device, const char16_t *file, EFI_DEVICE_PATH **ret_dp);
 EFI_STATUS device_path_to_str(const EFI_DEVICE_PATH *dp, char16_t **ret);

--- a/src/boot/efi/device-path-util.h
+++ b/src/boot/efi/device-path-util.h
@@ -3,6 +3,8 @@
 
 #include "proto/device-path.h"
 
+EFI_STATUS make_multiple_file_device_path(EFI_HANDLE device, const char16_t **files, EFI_DEVICE_PATH
+                ***ret_dp);
 EFI_STATUS make_file_device_path(EFI_HANDLE device, const char16_t *file, EFI_DEVICE_PATH **ret_dp);
 EFI_STATUS device_path_to_str(const EFI_DEVICE_PATH *dp, char16_t **ret);
 bool device_path_startswith(const EFI_DEVICE_PATH *dp, const EFI_DEVICE_PATH *start);
@@ -19,9 +21,21 @@ static inline bool device_path_is_end(const EFI_DEVICE_PATH *dp) {
         return dp->Type == END_DEVICE_PATH_TYPE && dp->SubType == END_ENTIRE_DEVICE_PATH_SUBTYPE;
 }
 
+static inline bool device_path_is_end_instance(const EFI_DEVICE_PATH *dp) {
+        assert(dp);
+        return dp->Type == END_DEVICE_PATH_TYPE && dp->SubType == END_INSTANCE_DEVICE_PATH_SUBTYPE;
+}
+
 #define DEVICE_PATH_END_NODE                               \
         (EFI_DEVICE_PATH) {                                \
                 .Type = END_DEVICE_PATH_TYPE,              \
                 .SubType = END_ENTIRE_DEVICE_PATH_SUBTYPE, \
                 .Length = sizeof(EFI_DEVICE_PATH)          \
+        }
+
+#define DEVICE_PATH_END_INSTANCE                             \
+        (EFI_DEVICE_PATH) {                                  \
+                .Type = END_DEVICE_PATH_TYPE,                \
+                .SubType = END_INSTANCE_DEVICE_PATH_SUBTYPE, \
+                .Length = sizeof(EFI_DEVICE_PATH)            \
         }

--- a/src/boot/efi/meson.build
+++ b/src/boot/efi/meson.build
@@ -250,6 +250,7 @@ endif
 ############################################################
 
 libefi_sources = files(
+        'addon-util.c',
         'console.c',
         'device-path-util.c',
         'devicetree.c',

--- a/src/boot/efi/pe.h
+++ b/src/boot/efi/pe.h
@@ -3,6 +3,12 @@
 
 #include "efi.h"
 
+/* This is used to hold PE-specific metadata
+ * under the section `.sdmeta`               */
+struct pe_metadata {
+        const char *fname;
+};
+
 EFI_STATUS pe_memory_locate_sections(
                 const void *base,
                 const char * const sections[],

--- a/src/boot/efi/stub.c
+++ b/src/boot/efi/stub.c
@@ -1,5 +1,7 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
+#include "addon-util.h"
+#include "stub.h"
 #include "cpio.h"
 #include "device-path-util.h"
 #include "devicetree.h"
@@ -23,8 +25,10 @@
 
 /* magic string to find in the binary image */
 DECLARE_NOALLOC_SECTION(".sdmagic", "#### LoaderInfo: systemd-stub " GIT_VERSION " ####");
-
 DECLARE_SBAT(SBAT_STUB_SECTION_TEXT);
+_used_ _section_(".binrel") static const struct pe_metadata metadata = {
+        .fname = STUB_FILENAME
+};
 
 struct addon_entry {
         char16_t *source_path;

--- a/src/boot/efi/stub.c
+++ b/src/boot/efi/stub.c
@@ -26,6 +26,18 @@ DECLARE_NOALLOC_SECTION(".sdmagic", "#### LoaderInfo: systemd-stub " GIT_VERSION
 
 DECLARE_SBAT(SBAT_STUB_SECTION_TEXT);
 
+struct addon_entry {
+        char16_t *source_path;
+        const EFI_DEVICE_PATH *device_path;
+};
+
+static int cmp_addon_entry(const struct addon_entry *s1, const struct addon_entry *s2) {
+        assert(s1);
+        assert(s2);
+
+        return strcmp16((const char16_t*)&s1->source_path, (const char16_t*)&s2->source_path);
+}
+
 static EFI_STATUS combine_initrd(
                 EFI_PHYSICAL_ADDRESS initrd_base, size_t initrd_size,
                 const void * const extra_initrds[], const size_t extra_initrd_sizes[], size_t n_extra_initrds,
@@ -191,20 +203,23 @@ static bool use_load_options(
 }
 
 static EFI_STATUS load_addons_from_dir(
+                EFI_LOADED_IMAGE_PROTOCOL *current_image,
                 EFI_FILE *root,
                 const char16_t *prefix,
-                char16_t ***items,
+                struct addon_entry **addons,
                 size_t *n_items,
                 size_t *n_allocated) {
 
         _cleanup_(file_closep) EFI_FILE *extra_dir = NULL;
         _cleanup_free_ EFI_FILE_INFO *dirent = NULL;
+        char16_t *addon_spath = NULL;
+        EFI_DEVICE_PATH *addon_path = NULL;
         size_t dirent_size = 0;
         EFI_STATUS err;
 
         assert(root);
         assert(prefix);
-        assert(items);
+        assert(addons);
         assert(n_items);
         assert(n_allocated);
 
@@ -237,18 +252,76 @@ static EFI_STATUS load_addons_from_dir(
 
                 d = xstrdup16(dirent->FileName);
 
+
                 if (*n_items + 2 > *n_allocated) {
                         /* We allocate 16 entries at a time, as a matter of optimization */
-                        if (*n_items > (SIZE_MAX / sizeof(uint16_t)) - 16) /* Overflow check, just in case */
+                        if (*n_items > (SIZE_MAX / sizeof(struct addon_entry)) - 16) /* Overflow check, just in case */
                                 return log_oom();
 
                         size_t m = *n_items + 16;
-                        *items = xrealloc(*items, *n_allocated * sizeof(uint16_t *), m * sizeof(uint16_t *));
+                        *addons = xrealloc(*addons, *n_allocated + sizeof(struct addon_entry), m *
+                                          sizeof(struct addon_entry));
                         *n_allocated = m;
                 }
 
-                (*items)[(*n_items)++] = TAKE_PTR(d);
-                (*items)[*n_items] = NULL; /* Let's always NUL terminate, to make freeing via strv_free() easy */
+                addon_spath = xasprintf("%ls\\%ls", prefix, d);
+                err = make_file_device_path(current_image, addon_spath, &addon_path);
+                if (err != EFI_SUCCESS)
+                        return log_error_status(err, "Error making device path for %ls: %m", addon_spath);
+
+                (*addons)[*n_items] = (struct addon_entry) {
+                        .source_path = TAKE_PTR(d),
+                        .device_path = TAKE_PTR(addon_path)
+                };
+                *n_items = *n_items + 1;
+        }
+
+        return EFI_SUCCESS;
+}
+
+static EFI_STATUS load_addons_from_efi(
+                EFI_LOADED_IMAGE_PROTOCOL *image,
+                struct addon_entry **addons,
+                size_t *n_items,
+                size_t *n_allocated) {
+
+        EFI_STATUS err;
+        EFI_DEVICE_PATH **addon_paths = NULL;
+
+        err = BS->HandleProtocol(image->DeviceHandle, MAKE_GUID_PTR(SYSTEMD_ADDON_MEDIA), (void **) &addon_paths);
+
+        if (err == EFI_NOT_FOUND)
+                /* No addons from EFI, that's OK */
+                return EFI_SUCCESS;
+        if (err != EFI_SUCCESS)
+                return log_error_status(err, "Failed to load addons from EFI protocol: %m");
+
+        while (*addon_paths) {
+                char16_t *spath = NULL;
+                /* If we increment this pointer instead of addon_paths_split, we will arrive on a end node
+                 * marker */
+                const EFI_DEVICE_PATH *addon_dpath = *addon_paths;
+                err = device_path_to_str(addon_dpath, &spath);
+                if (err != EFI_SUCCESS)
+                        return err;
+
+                if (*n_items + 2 > *n_allocated) {
+                        /* We allocate 16 entries at a time, as a matter of optimization */
+                        if (*n_items > (SIZE_MAX / sizeof(struct addon_entry)) - 16) /* Overflow check, just in case */
+                                return log_oom();
+
+                        size_t m = *n_items + 16;
+                        *addons = xrealloc(*addons, *n_allocated + sizeof(struct addon_entry), m *
+                                          sizeof(struct addon_entry));
+                        *n_allocated = m;
+                }
+
+                (*addons)[*n_items] = (struct addon_entry) {
+                        .source_path = TAKE_PTR(spath),
+                        .device_path = TAKE_PTR(addon_dpath)
+                };
+                *n_items = *n_items + 1;
+                addon_paths++;
         }
 
         return EFI_SUCCESS;
@@ -358,13 +431,14 @@ static EFI_STATUS load_addons(
                 char16_t ***ret_dt_filenames,
                 size_t *ret_n_dt) {
 
+        _cleanup_free_ struct addon_entry *addons = NULL;
         _cleanup_free_ size_t *dt_sizes = NULL;
-        _cleanup_(strv_freep) char16_t **items = NULL;
         _cleanup_(file_closep) EFI_FILE *root = NULL;
         _cleanup_free_ char16_t *cmdline = NULL;
         size_t n_items = 0, n_allocated = 0, n_dt = 0;
         char16_t **dt_filenames = NULL;
         void **dt_bases = NULL;
+        char16_t **items = NULL;
         EFI_STATUS err;
 
         assert(stub_image);
@@ -379,6 +453,7 @@ static EFI_STATUS load_addons(
 
         CLEANUP_ARRAY(dt_bases, n_dt, dt_bases_free);
         CLEANUP_ARRAY(dt_filenames, n_dt, dt_filenames_free);
+        CLEANUP_ARRAY(items, n_items, strv_free);
 
         err = open_volume(loaded_image->DeviceHandle, &root);
         if (err == EFI_UNSUPPORTED)
@@ -388,7 +463,11 @@ static EFI_STATUS load_addons(
         if (err != EFI_SUCCESS)
                 return log_error_status(err, "Unable to open root directory: %m");
 
-        err = load_addons_from_dir(root, prefix, &items, &n_items, &n_allocated);
+        err = load_addons_from_dir(loaded_image, root, prefix, &addons, &n_items, &n_allocated);
+        if (err != EFI_SUCCESS)
+                return err;
+
+        err = load_addons_from_efi(loaded_image, &addons, &n_items, &n_allocated);
         if (err != EFI_SUCCESS)
                 return err;
 
@@ -397,28 +476,19 @@ static EFI_STATUS load_addons(
 
         /* Now, sort the files we found, to make this uniform and stable (and to ensure the TPM measurements
          * are not dependent on read order) */
-        sort_pointer_array((void**) items, n_items, (compare_pointer_func_t) strcmp16);
+        sort_pointer_array((void**) addons, n_items, (compare_pointer_func_t) cmp_addon_entry);
 
         for (size_t i = 0; i < n_items; i++) {
                 size_t addrs[_UNIFIED_SECTION_MAX] = {}, szs[_UNIFIED_SECTION_MAX] = {};
-                _cleanup_free_ EFI_DEVICE_PATH *addon_path = NULL;
                 _cleanup_(unload_imagep) EFI_HANDLE addon = NULL;
                 EFI_LOADED_IMAGE_PROTOCOL *loaded_addon = NULL;
-                _cleanup_free_ char16_t *addon_spath = NULL;
-
-                addon_spath = xasprintf("%ls\\%ls", prefix, items[i]);
-                err = make_file_device_path(loaded_image->DeviceHandle, addon_spath, &addon_path);
-                if (err != EFI_SUCCESS)
-                        return log_error_status(err, "Error making device path for %ls: %m", addon_spath);
 
                 /* By using shim_load_image, we cover both the case where the PE files are signed with MoK
                  * and with DB, and running with or without shim. */
-                err = shim_load_image(stub_image, addon_path, &addon);
+                err = shim_load_image(stub_image, addons[i].device_path, &addon);
                 if (err != EFI_SUCCESS) {
                         log_error_status(err,
-                                         "Failed to read '%ls' from '%ls', ignoring: %m",
-                                         items[i],
-                                         addon_spath);
+                                         "Failed to read '%ls', ignoring: %m", addons[i].source_path);
                         continue;
                 }
 
@@ -426,7 +496,8 @@ static EFI_STATUS load_addons(
                                          MAKE_GUID_PTR(EFI_LOADED_IMAGE_PROTOCOL),
                                          (void **) &loaded_addon);
                 if (err != EFI_SUCCESS)
-                        return log_error_status(err, "Failed to find protocol in %ls: %m", items[i]);
+                        return log_error_status(err, "Failed to find protocol in %ls: %m",
+                                                addons[i].source_path);
 
                 err = pe_memory_locate_sections(loaded_addon->ImageBase, unified_sections, addrs, szs);
                 if (err != EFI_SUCCESS ||
@@ -434,14 +505,15 @@ static EFI_STATUS load_addons(
                         if (err == EFI_SUCCESS)
                                 err = EFI_NOT_FOUND;
                         log_error_status(err,
-                                         "Unable to locate embedded .cmdline/.dtb sections in %ls, ignoring: %m",
-                                         items[i]);
+                                         "Unable to locate embedded .cmdline/.dtb section in %ls, ignoring: %m",
+                                         addons[i].source_path);
                         continue;
                 }
 
                 /* We want to enforce that addons are not UKIs, i.e.: they must not embed a kernel. */
                 if (szs[UNIFIED_SECTION_LINUX] > 0) {
-                        log_error_status(EFI_INVALID_PARAMETER, "%ls is a UKI, not an addon, ignoring: %m", items[i]);
+                        log_error_status(EFI_INVALID_PARAMETER, "%ls is a UKI, not an addon, ignoring: %m",
+                                         addons[i].source_path);
                         continue;
                 }
 
@@ -451,7 +523,7 @@ static EFI_STATUS load_addons(
                                 !strneq8(uname,
                                          (char *)loaded_addon->ImageBase + addrs[UNIFIED_SECTION_UNAME],
                                          szs[UNIFIED_SECTION_UNAME])) {
-                        log_error(".uname mismatch between %ls and UKI, ignoring", items[i]);
+                        log_error(".uname mismatch between %ls and UKI, ignoring", addons[i].source_path);
                         continue;
                 }
 
@@ -529,10 +601,13 @@ static EFI_STATUS run(EFI_HANDLE image) {
         }
 
         err = pe_memory_locate_sections(loaded_image->ImageBase, unified_sections, addrs, szs);
-        if (err != EFI_SUCCESS || szs[UNIFIED_SECTION_LINUX] == 0) {
-                if (err == EFI_SUCCESS)
-                        err = EFI_NOT_FOUND;
-                return log_error_status(err, "Unable to locate embedded .linux section: %m");
+        if (err != EFI_SUCCESS)
+                return log_error_status(err, "Unable to locate embedded sections in the current binary: %m");
+
+        if (szs[UNIFIED_SECTION_LINUX] == 0) {
+                err = EFI_NOT_FOUND;
+                log_error_status(err, "Unable to locate embedded .linux section: %m, will skip...");
+                err = EFI_SUCCESS;
         }
 
         CLEANUP_ARRAY(dt_bases_addons_global, n_dts_addons_global, dt_bases_free);

--- a/src/boot/efi/stub.h
+++ b/src/boot/efi/stub.h
@@ -1,0 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#pragma once
+
+#define STUB_FILENAME "sd-stub"

--- a/src/boot/efi/util.h
+++ b/src/boot/efi/util.h
@@ -57,6 +57,15 @@ static inline void* xmemdup(const void *p, size_t l) {
         return memcpy(xmalloc(l), p, l);
 }
 
+static inline void **xrealloc_extra_k_items(void *p, size_t item_size, size_t current_size, size_t extra_elements) {
+        size_t new_size = (current_size + extra_elements + 1) * item_size;
+        if (current_size == 0)
+                return (void**)xrealloc(p, 0, new_size);
+        else
+                return (void**)xrealloc(p, (current_size + 1) * item_size, new_size);
+}
+
+#define xrealloc_extra_item(type, p, current_size) ((type **) xrealloc_extra_k_items(p, current_size, sizeof(type), 1))
 #define xnew(type, n) ((type *) xmalloc_multiply(sizeof(type), (n)))
 
 typedef struct {

--- a/src/fundamental/efivars-fundamental.h
+++ b/src/fundamental/efivars-fundamental.h
@@ -23,6 +23,7 @@
 #define EFI_LOADER_FEATURE_SECUREBOOT_ENROLL       (UINT64_C(1) << 11)
 #define EFI_LOADER_FEATURE_RETAIN_SHIM             (UINT64_C(1) << 12)
 #define EFI_LOADER_FEATURE_MENU_DISABLE            (UINT64_C(1) << 13)
+#define EFI_LOADER_FEATURE_OFFER_ADDONS            (UINT64_C(1) << 14)
 
 /* Features of the stub, i.e. systemd-stub */
 #define EFI_STUB_FEATURE_REPORT_BOOT_PARTITION     (UINT64_C(1) << 0)

--- a/src/fundamental/string-util-fundamental.h
+++ b/src/fundamental/string-util-fundamental.h
@@ -102,6 +102,21 @@ static inline void *memory_startswith(const void *p, size_t sz, const sd_char *t
 #define STRV_FOREACH(s, l)                      \
         _STRV_FOREACH(s, l, UNIQ_T(i, UNIQ))
 
+#if SD_BOOT
+static inline size_t strv_length(char16_t * const *l) {
+        size_t n = 0;
+
+        if (l == NULL)
+                return 0;
+
+        STRV_FOREACH(i, l)
+                n++;
+
+        return n;
+}
+#endif
+
+
 static inline bool ascii_isdigit(sd_char a) {
         /* A pure ASCII, locale independent version of isdigit() */
         return a >= '0' && a <= '9';

--- a/src/shared/bootspec.h
+++ b/src/shared/bootspec.h
@@ -37,6 +37,7 @@ typedef struct BootEntry {
         char *kernel;        /* linux is #defined to 1, yikes! */
         char *efi;
         char **initrd;
+        char **addons;
         char *device_tree;
         char **device_tree_overlay;
         unsigned tries_left;


### PR DESCRIPTION
This PR introduces a way to load addons from systemd-boot Type 1 entries using the `addon` stanza (which can be repeated as much time as you want and is **sensitive** to **order**).

It also pick up those addons in systemd-stub and load them as part of the addon loading procedure.

<!-- devel-freezer = {"comment-id":"1627439012","freezing-tag":"v254-rc1"} -->

<!-- devel-freezer = {"comment-id":"1627445767","freezing-tag":"v254-rc2"} -->
