### PR TITLE
Add cryptsetup-token-systemd-empty

### DIFF
--- a/man/systemd-cryptenroll.xml
+++ b/man/systemd-cryptenroll.xml
@@ -287,6 +287,19 @@
       </varlistentry>
 
       <varlistentry>
+        <term><option>--empty</option></term>
+
+        <listitem><para>Enroll an empty key. This allows the volume to be unlocked without a key,
+        which effectively disables the confidentiality protections of encryption. The encryption is not
+        removed, however, so confidentiality protections can be reenabled by removing the empty
+        key enrollment (i.e. via <option>--wipe-key=empty</option>). Unlike a blank <option>--password</option>,
+        a key enrolled via this option will automatically unlock the volume with no user input and no
+        performance penalty.</para>
+
+        <xi:include href="version-info.xml" xpointer="v256"/></listitem>
+      </varlistentry>
+
+      <varlistentry>
         <term><option>--unlock-key-file=</option><replaceable>PATH</replaceable></term>
 
         <listitem><para>Use a file instead of a password/passphrase read from stdin to unlock the volume.
@@ -590,7 +603,8 @@
 
         <listitem><para>Wipes one or more LUKS2 key slots. Takes a comma separated list of numeric slot
         indexes, or the special strings <literal>all</literal> (for wiping all key slots),
-        <literal>empty</literal> (for wiping all key slots that are unlocked by an empty passphrase),
+        <literal>empty</literal> (for wiping all key slots that are unlocked by an empty passphrase; not
+        just those enrolled via <option>--empty</option>),
         <literal>password</literal> (for wiping all key slots that are unlocked by a traditional passphrase),
         <literal>recovery</literal> (for wiping all key slots that are unlocked by a recovery key),
         <literal>pkcs11</literal> (for wiping all key slots that are unlocked by a PKCS#11 token),

--- a/src/cryptenroll/cryptenroll-empty.c
+++ b/src/cryptenroll/cryptenroll-empty.c
@@ -1,0 +1,61 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include "cryptenroll-empty.h"
+#include "json.h"
+
+int enroll_empty(
+                struct crypt_device *cd,
+                const void *volume_key,
+                size_t volume_key_size) {
+        _cleanup_(json_variant_unrefp) JsonVariant *v = NULL;
+        const char *node;
+        int keyslot, r, q;
+        char keyslot_str[DECIMAL_STR_MAX(keyslot)];
+
+        assert_se(cd);
+        assert_se(volume_key);
+        assert_se(volume_key_size > 0);
+
+        assert_se(node = crypt_get_device_name(cd));
+
+        /* No need to robustly protect against brute-force attacks... */
+        r = cryptsetup_set_minimal_pbkdf(cd);
+        if (r < 0)
+                return log_error_errno(r, "Failed to set minimal PBKDF: %m");
+
+        keyslot = crypt_keyslot_add_by_volume_key(
+                        cd,
+                        CRYPT_ANY_SLOT,
+                        volume_key,
+                        volume_key_size,
+                        /* passphrase= */ "",
+                        /* passphrase_size= */ 0);
+        if (keyslot < 0)
+                return log_error_errno(keyslot, "Failed to add empty key to %s: %m", node);
+        xsprintf(keyslot_str, "%i", keyslot);
+
+        r = json_build(&v,
+                       JSON_BUILD_OBJECT(
+                                       JSON_BUILD_PAIR("type", JSON_BUILD_CONST_STRING("systemd-empty")),
+                                       JSON_BUILD_PAIR("keyslots", JSON_BUILD_ARRAY(JSON_BUILD_STRING(keyslot_str)))));
+        if (r < 0) {
+                log_error_errno(r, "Failed to prepare systemd-empty JSON token object: %m");
+                goto rollback;
+        }
+
+        r = cryptsetup_add_token_json(cd, v);
+        if (r < 0) {
+                log_error_errno(r, "Failed to add systemd-empty JSON token to LUKS2 header: %m");
+                goto rollback;
+        }
+
+        log_info("Empty key enrolled as key slot %i.", keyslot);
+        return keyslot;
+
+rollback:
+        q = crypt_keyslot_destroy(cd, keyslot);
+        if (q < 0)
+                log_error_errno(q, "Unable to remove key slot we just added, can't rollback, sorry: %m");
+
+        return r;
+}

--- a/src/cryptenroll/cryptenroll-empty.h
+++ b/src/cryptenroll/cryptenroll-empty.h
@@ -1,0 +1,8 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#pragma once
+
+#include <sys/types.h>
+
+#include "cryptsetup-util.h"
+
+int enroll_empty(struct crypt_device *cd, const void *volume_key, size_t volume_key_size);

--- a/src/cryptenroll/cryptenroll.h
+++ b/src/cryptenroll/cryptenroll.h
@@ -9,6 +9,7 @@ typedef enum EnrollType {
         ENROLL_PKCS11,
         ENROLL_FIDO2,
         ENROLL_TPM2,
+        ENROLL_EMPTY,
         _ENROLL_TYPE_MAX,
         _ENROLL_TYPE_INVALID = -EINVAL,
 } EnrollType;

--- a/src/cryptenroll/meson.build
+++ b/src/cryptenroll/meson.build
@@ -4,6 +4,7 @@ systemd_cryptenroll_sources = files(
         'cryptenroll-list.c',
         'cryptenroll-password.c',
         'cryptenroll-recovery.c',
+        'cryptenroll-empty.c',
         'cryptenroll-wipe.c',
         'cryptenroll.c',
 )

--- a/src/cryptsetup/cryptsetup-tokens/cryptsetup-token-systemd-empty.c
+++ b/src/cryptsetup/cryptsetup-tokens/cryptsetup-token-systemd-empty.c
@@ -1,0 +1,73 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include <errno.h>
+#include <libcryptsetup.h>
+
+#include "cryptsetup-token.h"
+#include "cryptsetup-token-util.h"
+#include "memory-util.h"
+#include "version.h"
+
+#define TOKEN_VERSION_MAJOR "1"
+#define TOKEN_VERSION_MINOR "0"
+
+/* for libcryptsetup debug purpose */
+_public_ const char *cryptsetup_token_version(void) {
+        return TOKEN_VERSION_MAJOR "." TOKEN_VERSION_MINOR " systemd-v" STRINGIFY(PROJECT_VERSION) " (" GIT_VERSION ")";
+}
+
+_public_ int cryptsetup_token_open_pin(
+                struct crypt_device *cd, /* is always LUKS2 context */
+                int token /* is always >= 0 */,
+                const char *pin,
+                size_t pin_size,
+                char **ret_password, /* freed by cryptsetup_token_buffer_free */
+                size_t *ret_password_len,
+                void *usrptr /* plugin defined parameter passed to crypt_activate_by_token*() API */) {
+
+        _cleanup_free_ char *p = NULL;
+
+        assert(token >= 0);
+        assert(!pin || pin_size > 0);
+        assert(ret_password);
+        assert(ret_password_len);
+
+        p = strdup("");
+        if (!p)
+                return crypt_log_oom(cd);
+
+        *ret_password = TAKE_PTR(p);
+        *ret_password_len = 0;
+        return 0;
+}
+
+/*
+ * This function is called from within following libcryptsetup calls
+ * provided conditions further below are met:
+ *
+ * crypt_activate_by_token(), crypt_activate_by_token_type(type == 'systemd-empty'):
+ *
+ * - token is assigned to at least one luks2 keyslot eligible to activate LUKS2 device
+ *   (alternatively: name is set to null, flags contains CRYPT_ACTIVATE_ALLOW_UNBOUND_KEY
+ *   and token is assigned to at least single keyslot).
+ *
+ * - if plugin defines validate function (systemd-empty does not) it must have passed the
+ *   check (aka return 0)
+ */
+_public_ int cryptsetup_token_open(
+                struct crypt_device *cd, /* is always LUKS2 context */
+                int token /* is always >= 0 */,
+                char **ret_password, /* freed by cryptsetup_token_buffer_free */
+                size_t *ret_password_len,
+                void *usrptr /* plugin defined parameter passed to crypt_activate_by_token*() API */) {
+
+        return cryptsetup_token_open_pin(cd, token, NULL, 0, ret_password, ret_password_len, usrptr);
+}
+
+/*
+ * libcryptsetup callback for memory deallocation of 'password' parameter passed in
+ * any crypt_token_open_* plugin function
+ */
+_public_ void cryptsetup_token_buffer_free(void *buffer, size_t buffer_len) {
+        free(buffer);
+}

--- a/src/cryptsetup/cryptsetup-tokens/cryptsetup-token-systemd-empty.c
+++ b/src/cryptsetup/cryptsetup-tokens/cryptsetup-token-systemd-empty.c
@@ -51,8 +51,8 @@ _public_ int cryptsetup_token_open_pin(
  *   (alternatively: name is set to null, flags contains CRYPT_ACTIVATE_ALLOW_UNBOUND_KEY
  *   and token is assigned to at least single keyslot).
  *
- * - if plugin defines validate function (systemd-empty does not) it must have passed the
- *   check (aka return 0)
+ * - if plugin defines validate function (see cryptsetup_token_validate below) it must have
+ *   passed the check (aka return 0)
  */
 _public_ int cryptsetup_token_open(
                 struct crypt_device *cd, /* is always LUKS2 context */
@@ -70,4 +70,28 @@ _public_ int cryptsetup_token_open(
  */
 _public_ void cryptsetup_token_buffer_free(void *buffer, size_t buffer_len) {
         free(buffer);
+}
+
+/*
+ * Note:
+ *   If plugin is available in library path, it's called in before following libcryptsetup calls:
+ *
+ *   crypt_token_json_set, crypt_dump, any crypt_activate_by_token_* flavour
+ */
+ _public_ int cryptsetup_token_validate(
+                struct crypt_device *cd, /* is always LUKS2 context */
+                const char *json /* contains valid 'type' and 'keyslots' fields. 'type' is 'systemd-empty' */) {
+
+        return 0; /* Nothing to validate */
+}
+
+/*
+ * prints systemd-empty token content in crypt_dump().
+ * 'type' and 'keyslots' fields are printed by libcryptsetup
+ */
+_public_ void cryptsetup_token_dump(
+                struct crypt_device *cd /* is always LUKS2 context */,
+                const char *json /* validated 'systemd-empty' token if cryptsetup_token_validate is defined */) {
+
+        /* Nothing to dump */
 }

--- a/src/cryptsetup/cryptsetup-tokens/meson.build
+++ b/src/cryptsetup/cryptsetup-tokens/meson.build
@@ -8,6 +8,10 @@ lib_cryptsetup_token_common = static_library(
         link_with : libshared,
         build_by_default : false)
 
+cryptsetup_token_systemd_empty_sources = files(
+        'cryptsetup-token-systemd-empty.c'
+)
+
 cryptsetup_token_systemd_tpm2_sources = files(
         'cryptsetup-token-systemd-tpm2.c',
         'luks2-tpm2.c',
@@ -36,6 +40,16 @@ template = {
 }
 
 modules += [
+        template + {
+                'name' : 'cryptsetup-token-systemd-empty',
+                'conditions' : [
+                        'HAVE_LIBCRYPTSETUP_PLUGINS',
+                ],
+                'sources' : cryptsetup_token_systemd_empty_sources,
+                'dependencies' : [
+                        libcryptsetup,
+                ],
+        },
         template + {
                 'name' : 'cryptsetup-token-systemd-tpm2',
                 'conditions' : [

--- a/test/units/testsuite-24.sh
+++ b/test/units/testsuite-24.sh
@@ -81,26 +81,37 @@ WORKDIR="$(mktemp -d)"
 
 # Prepare a couple of LUKS2-encrypted disk images
 #
-# 1) Image with an empty password
-IMAGE_EMPTY="$WORKDIR/empty.img)"
-IMAGE_EMPTY_KEYFILE="$WORKDIR/empty.keyfile"
-IMAGE_EMPTY_KEYFILE_ERASE="$WORKDIR/empty-erase.keyfile"
-IMAGE_EMPTY_KEYFILE_ERASE_FAIL="$WORKDIR/empty-erase-fail.keyfile)"
-truncate -s 32M "$IMAGE_EMPTY"
-echo -n passphrase >"$IMAGE_EMPTY_KEYFILE"
-chmod 0600 "$IMAGE_EMPTY_KEYFILE"
+# 1) Image with both a password and an empty password
+IMAGE_PASS="$WORKDIR/password.img"
+IMAGE_PASS_KEYFILE="$WORKDIR/password.keyfile"
+IMAGE_PASS_KEYFILE_ERASE="$WORKDIR/password-erase.keyfile"
+IMAGE_PASS_KEYFILE_ERASE_FAIL="$WORKDIR/password-erase-fail.keyfile)"
+truncate -s 32M "$IMAGE_PASS"
+echo -n passphrase >"$IMAGE_PASS_KEYFILE"
+chmod 0600 "$IMAGE_PASS_KEYFILE"
 cryptsetup luksFormat --batch-mode \
                       --pbkdf pbkdf2 \
                       --pbkdf-force-iterations 1000 \
                       --use-urandom \
-                      "$IMAGE_EMPTY" "$IMAGE_EMPTY_KEYFILE"
-PASSWORD=passphrase NEWPASSWORD="" systemd-cryptenroll --password "$IMAGE_EMPTY"
+                      "$IMAGE_PASS" "$IMAGE_PASS_KEYFILE"
+# Enroll an empty passphrase as well
+PASSWORD=passphrase NEWPASSWORD="" systemd-cryptenroll --password "$IMAGE_PASS"
 # Duplicate the key file to test keyfile-erase as well
-cp -v "$IMAGE_EMPTY_KEYFILE" "$IMAGE_EMPTY_KEYFILE_ERASE"
+cp -v "$IMAGE_PASS_KEYFILE" "$IMAGE_PASS_KEYFILE_ERASE"
 # The key should get erased even on a failed attempt, so test that too
-cp -v "$IMAGE_EMPTY_KEYFILE" "$IMAGE_EMPTY_KEYFILE_ERASE_FAIL"
+cp -v "$IMAGE_PASS_KEYFILE" "$IMAGE_PASS_KEYFILE_ERASE_FAIL"
 
-# 2) Image with a detached header and a key file offset + size
+# 2) Image with a systemd-empty slot
+IMAGE_EMPTY="$WORKDIR/empty.img"
+truncate -s 32M "$IMAGE_EMPTY"
+cryptsetup luksFormat --batch-mode \
+                      --pbkdf pbkdf2 \
+                      --pbkdf-force-iterations 1000 \
+                      --use-urandom \
+                      "$IMAGE_EMPTY" "$IMAGE_PASS_KEYFILE"
+PASSWORD=passphrase systemd-cryptenroll --wipe-slot=password --empty "$IMAGE_EMPTY"
+
+# 3) Image with a detached header and a key file offset + size
 IMAGE_DETACHED="$WORKDIR/detached.img"
 IMAGE_DETACHED_KEYFILE="$WORKDIR/detached.keyfile"
 IMAGE_DETACHED_KEYFILE2="$WORKDIR/detached.keyfile2"
@@ -154,16 +165,19 @@ udevadm settle --timeout=30
 [[ -e /etc/crypttab ]] && cp -fv /etc/crypttab /tmp/crypttab.bak
 cat >/etc/crypttab <<EOF
 # headless should translate to headless=1
-empty_key            $IMAGE_EMPTY    $IMAGE_EMPTY_KEYFILE            headless,x-systemd.device-timeout=1m
-empty_key_erase      $IMAGE_EMPTY    $IMAGE_EMPTY_KEYFILE_ERASE      headless=1,keyfile-erase=1
-empty_key_erase_fail $IMAGE_EMPTY    $IMAGE_EMPTY_KEYFILE_ERASE_FAIL headless=1,keyfile-erase=1,keyfile-offset=4
+pass_key             $IMAGE_PASS     $IMAGE_PASS_KEYFILE             headless,x-systemd.device-timeout=1m
+pass_key_erase       $IMAGE_PASS     $IMAGE_PASS_KEYFILE_ERASE       headless=1,keyfile-erase=1
+pass_key_erase_fail  $IMAGE_PASS     $IMAGE_PASS_KEYFILE_ERASE_FAIL  headless=1,keyfile-erase=1,keyfile-offset=4
 # Empty passphrase without try-empty-password(=yes) shouldn't work
-empty_fail0          $IMAGE_EMPTY    -                               headless=1
-empty_fail1          $IMAGE_EMPTY    -                               headless=1,try-empty-password=0
-empty0               $IMAGE_EMPTY    -                               headless=1,try-empty-password
-empty1               $IMAGE_EMPTY    -                               headless=1,try-empty-password=1
-# This one expects the key to be under /{etc,run}/cryptsetup-keys.d/empty_nokey.key
-empty_nokey          $IMAGE_EMPTY    -                               headless=1
+pass_empty_fail0     $IMAGE_PASS     -                               headless=1
+pass_empty_fail1     $IMAGE_PASS     -                               headless=1,try-empty-password=0
+pass_empty0          $IMAGE_PASS     -                               headless=1,try-empty-password
+pass_empty1          $IMAGE_PASS     -                               headless=1,try-empty-password=1
+# This one expects the key to be under /{etc,run}/cryptsetup-keys.d/pass_nokey.key
+pass_nokey           $IMAGE_PASS     -                               headless=1
+
+# Unlike the empty passphrase, an image with an empty slot should automatically unlock w/o try-empty-password
+empty                $IMAGE_EMPTY    -                               headless=1
 
 detached             $IMAGE_DETACHED $IMAGE_DETACHED_KEYFILE         headless=1,header=$IMAGE_DETACHED_HEADER,keyfile-offset=32,keyfile-size=16
 detached_store0      $IMAGE_DETACHED $IMAGE_DETACHED_KEYFILE         headless=1,header=/header:LABEL=header_store,keyfile-offset=32,keyfile-size=16
@@ -191,21 +205,23 @@ mkdir -p /tmp/systemd-cryptsetup-generator.out
 systemctl daemon-reload
 systemctl list-unit-files "systemd-cryptsetup@*"
 
-cryptsetup_start_and_check empty_key
-test -e "$IMAGE_EMPTY_KEYFILE_ERASE"
-cryptsetup_start_and_check empty_key_erase
-test ! -e "$IMAGE_EMPTY_KEYFILE_ERASE"
-test -e "$IMAGE_EMPTY_KEYFILE_ERASE_FAIL"
-cryptsetup_start_and_check -f empty_key_erase_fail
-test ! -e "$IMAGE_EMPTY_KEYFILE_ERASE_FAIL"
-cryptsetup_start_and_check -f empty_fail{0..1}
-cryptsetup_start_and_check empty{0..1}
+cryptsetup_start_and_check pass_key
+test -e "$IMAGE_PASS_KEYFILE_ERASE"
+cryptsetup_start_and_check pass_key_erase
+test ! -e "$IMAGE_PASS_KEYFILE_ERASE"
+test -e "$IMAGE_PASS_KEYFILE_ERASE_FAIL"
+cryptsetup_start_and_check -f pass_key_erase_fail
+test ! -e "$IMAGE_PASS_KEYFILE_ERASE_FAIL"
+cryptsetup_start_and_check -f pass_empty_fail{0..1}
+cryptsetup_start_and_check pass_empty{0..1}
 # First, check if we correctly fail without any key
-cryptsetup_start_and_check -f empty_nokey
+cryptsetup_start_and_check -f pass_nokey
 # And now provide the key via /{etc,run}/cryptsetup-keys.d/
 mkdir -p /run/cryptsetup-keys.d
-cp "$IMAGE_EMPTY_KEYFILE" /run/cryptsetup-keys.d/empty_nokey.key
-cryptsetup_start_and_check empty_nokey
+cp "$IMAGE_PASS_KEYFILE" /run/cryptsetup-keys.d/pass_nokey.key
+cryptsetup_start_and_check pass_nokey
+
+cryptsetup_start_and_check empty
 
 cryptsetup_start_and_check detached
 cryptsetup_start_and_check detached_store{0..2}


### PR DESCRIPTION
Replaces https://github.com/systemd/systemd/pull/28052

This creates a new `systemd-empty` token type, which cryptsetup can then automatically unlock.

Enrolling an empty password behaves exactly as before: nothing is automatically unlocked unless `try-empty-password` is enabled on that volume.

<!-- devel-freezer = {"comment-id":"1795630675","freezing-tag":"v255-rc2"} -->