### PR TITLE
Add varlink API to cryptenroll

### DIFF
--- a/src/cryptenroll/cryptenroll-custom.c
+++ b/src/cryptenroll/cryptenroll-custom.c
@@ -1,0 +1,133 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ * Copyright © 2024 GNOME Foundation Inc
+ *      Original Author: Adrian Vovk
+ */
+
+#include "bus-polkit.h"
+#include "cryptenroll-custom.h"
+#include "cryptenroll-wipe.h"
+#include "cryptenroll.h"
+
+int enroll_slot_and_token(
+                struct crypt_device *cd,
+                void *volume_key,
+                size_t volume_key_size,
+                const char *passphrase,
+                size_t passphrase_size,
+                JsonVariant *token) {
+        _cleanup_(json_variant_unrefp) JsonVariant *v = NULL;
+        _cleanup_free_ char *keyslot_as_string = NULL;
+        const char *node = NULL;
+        int r, q, keyslot;
+
+        assert(cd);
+        assert(volume_key);
+        assert(passphrase);
+        assert(token);
+
+        assert_se(node = crypt_get_device_name(cd));
+
+        v = json_variant_ref(token);
+
+        keyslot = crypt_keyslot_add_by_volume_key(
+                        cd,
+                        CRYPT_ANY_SLOT,
+                        volume_key,
+                        volume_key_size,
+                        passphrase,
+                        passphrase_size);
+        if (keyslot < 0)
+                return log_error_errno(keyslot, "Failed to add new key to %s: %m", node);
+
+        if (asprintf(&keyslot_as_string, "%i", keyslot) < 0) {
+                log_oom();
+                goto rollback;
+        }
+
+        r = json_variant_set_fieldb(&v, "keyslots",
+                                    JSON_BUILD_ARRAY(JSON_BUILD_STRING(keyslot_as_string)));
+        if (r < 0) {
+                log_error_errno(r, "Failed to insert keyslot into JSON token object: %m");
+                goto rollback;
+        }
+
+        r = cryptsetup_add_token_json(cd, v);
+        if (r < 0) {
+                log_error_errno(r, "Failed to add JSON token to LUKS2 header: %m");
+                goto rollback;
+        }
+
+        return 0;
+
+rollback:
+        q = crypt_keyslot_destroy(cd, keyslot);
+        if (q < 0)
+                log_warning_errno(q, "Unable to remove key slot we just added again, can't rollback, sorry: %m");
+        return r;
+}
+
+int enroll_slot_and_tokenb(struct crypt_device *cd,
+                           void *volume_key,
+                           size_t volume_key_size,
+                           const char *passphrase,
+                           size_t passphrase_size,
+                           ...) {
+        _cleanup_(json_variant_unrefp) JsonVariant *token = NULL;
+        va_list ap;
+        int r;
+
+        assert(cd);
+        assert(volume_key);
+        assert(passphrase);
+
+        va_start(ap, passphrase_size);
+        r = json_buildv(&token, ap);
+        va_end(ap);
+
+        if (r < 0)
+                return log_error_errno(r, "Failed to build JSON token: %m");
+
+        return enroll_slot_and_token(cd, volume_key, volume_key_size,
+                                     passphrase, passphrase_size, token);
+}
+
+int vl_method_enroll_custom(Varlink *link,
+                            JsonVariant *params,
+                            VarlinkMethodFlags flags,
+                            void *userdata) {
+        static const JsonDispatch dispatch_table[] = {
+                VARLINK_DISPATCH_UNLOCK_FIELDS,
+                VARLINK_DISPATCH_WIPE_FIELDS,
+                VARLINK_DISPATCH_POLKIT_FIELD,
+                {}
+        };
+        Hashmap **polkit_registry = ASSERT_PTR(userdata);
+        _cleanup_(crypt_freep) struct crypt_device *cd = NULL;
+        _cleanup_(erase_and_freep) void *vk = NULL;
+        size_t vks;
+        int r;
+
+        r = varlink_dispatch(link, params, dispatch_table, NULL);
+        if (r != 0)
+                return r;
+
+        r = varlink_verify_polkit_async(
+                        link,
+                        /* bus= */ NULL,
+                        "io.systemd.cryptenroll.enroll-custom",
+                        /* details= */ NULL,
+                        /* good_user= */ UID_INVALID,
+                        polkit_registry);
+        if (r <= 0)
+                return r;
+
+        r = vl_luks_setup(link, params, &cd, &vk, &vks);
+        if (r != 0)
+                return r;
+
+        return varlink_errorb(
+                        link,
+                        VARLINK_ERROR_METHOD_NOT_IMPLEMENTED,
+                        JSON_BUILD_OBJECT(JSON_BUILD_PAIR("method", "io.systemd.CryptEnroll.EnrollCustom")));
+}

--- a/src/cryptenroll/cryptenroll-custom.h
+++ b/src/cryptenroll/cryptenroll-custom.h
@@ -1,0 +1,24 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#pragma once
+
+#include "cryptsetup-util.h"
+#include "varlink.h"
+
+int enroll_slot_and_token(struct crypt_device *cd,
+                          void *volume_key,
+                          size_t volume_key_size,
+                          const char *passpharse,
+                          size_t passphrase_size,
+                          JsonVariant *token);
+
+int enroll_slot_and_tokenb(struct crypt_device *cd,
+                           void *volume_key,
+                           size_t volume_key_size,
+                           const char *passpharse,
+                           size_t passphrase_size,
+                           ...);
+
+int vl_method_enroll_custom(Varlink *link,
+                            JsonVariant *params,
+                            VarlinkMethodFlags flags,
+                            void *userdata);

--- a/src/cryptenroll/cryptenroll-fido2.c
+++ b/src/cryptenroll/cryptenroll-fido2.c
@@ -1,7 +1,14 @@
-/* SPDX-License-Identifier: LGPL-2.1-or-later */
+/* SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ * Copyright © 2024 GNOME Foundation Inc
+ *      Original Author: Adrian Vovk
+ */
 
 #include "ask-password-api.h"
+#include "bus-polkit.h"
 #include "cryptenroll-fido2.h"
+#include "cryptenroll-wipe.h"
+#include "cryptenroll.h"
 #include "cryptsetup-fido2.h"
 #include "hexdecoct.h"
 #include "json.h"
@@ -148,4 +155,41 @@ int enroll_fido2(
 
         log_info("New FIDO2 token enrolled as key slot %i.", keyslot);
         return keyslot;
+}
+
+int vl_method_enroll_fido2(Varlink *link, JsonVariant *params, VarlinkMethodFlags flags, void *userdata) {
+        static const JsonDispatch dispatch_table[] = {
+                VARLINK_DISPATCH_UNLOCK_FIELDS,
+                VARLINK_DISPATCH_WIPE_FIELDS,
+                VARLINK_DISPATCH_POLKIT_FIELD,
+                {}
+        };
+        Hashmap **polkit_registry = ASSERT_PTR(userdata);
+        _cleanup_(crypt_freep) struct crypt_device *cd = NULL;
+        _cleanup_(erase_and_freep) void *vk = NULL;
+        size_t vks;
+        int r;
+
+        r = varlink_dispatch(link, params, dispatch_table, NULL);
+        if (r != 0)
+                return r;
+
+        r = varlink_verify_polkit_async(
+                        link,
+                        /* bus= */ NULL,
+                        "io.systemd.cryptenroll.enroll",
+                        /* details= */ NULL,
+                        /* good_user= */ UID_INVALID,
+                        polkit_registry);
+        if (r <= 0)
+                return r;
+
+        r = vl_luks_setup(link, params, &cd, &vk, &vks);
+        if (r != 0)
+                return r;
+
+        return varlink_errorb(
+                        link,
+                        VARLINK_ERROR_METHOD_NOT_IMPLEMENTED,
+                        JSON_BUILD_OBJECT(JSON_BUILD_PAIR("method", "io.systemd.CryptEnroll.EnrollFIDO2")));
 }

--- a/src/cryptenroll/cryptenroll-fido2.h
+++ b/src/cryptenroll/cryptenroll-fido2.h
@@ -6,10 +6,12 @@
 #include "cryptsetup-util.h"
 #include "libfido2-util.h"
 #include "log.h"
+#include "varlink.h"
 
 #if HAVE_LIBFIDO2
 int load_volume_key_fido2(struct crypt_device *cd, const char *cd_node, const char *device, void *ret_vk, size_t *ret_vks);
 int enroll_fido2(struct crypt_device *cd, const void *volume_key, size_t volume_key_size, const char *device, Fido2EnrollFlags lock_with, int cred_alg);
+int vl_method_enroll_fido2(Varlink *link, JsonVariant *params, VarlinkMethodFlags flags, void *userdata);
 
 #else
 static inline int load_volume_key_fido2(struct crypt_device *cd, const char *cd_node, const char *device, void *ret_vk, size_t *ret_vks) {
@@ -20,5 +22,12 @@ static inline int load_volume_key_fido2(struct crypt_device *cd, const char *cd_
 static inline int enroll_fido2(struct crypt_device *cd, const void *volume_key, size_t volume_key_size, const char *device, Fido2EnrollFlags lock_with, int cred_alg) {
         return log_debug_errno(SYNTHETIC_ERRNO(EOPNOTSUPP),
                                "FIDO2 key enrollment not supported.");
+}
+
+static inline int vl_method_enroll_fido2(Varlink *link, JsonVariant *params, VarlinkMethodFlags flags, void *userdata) {
+        return varlink_errorb(
+                        link,
+                        VARLINK_ERROR_METHOD_NOT_IMPLEMENTED,
+                        JSON_BUILD_OBJECT(JSON_BUILD_PAIR("method", "io.systemd.CryptEnroll.EnrollFIDO2")));
 }
 #endif

--- a/src/cryptenroll/cryptenroll-password.h
+++ b/src/cryptenroll/cryptenroll-password.h
@@ -4,6 +4,9 @@
 #include <sys/types.h>
 
 #include "cryptsetup-util.h"
+#include "varlink.h"
 
 int load_volume_key_password(struct crypt_device *cd, const char* cd_node, void *ret_vk, size_t *ret_vks);
 int enroll_password(struct crypt_device *cd, const void *volume_key, size_t volume_key_size);
+
+int vl_method_enroll_password(Varlink *link, JsonVariant *params, VarlinkMethodFlags flags, void *userdata);

--- a/src/cryptenroll/cryptenroll-pkcs11.h
+++ b/src/cryptenroll/cryptenroll-pkcs11.h
@@ -5,12 +5,25 @@
 
 #include "cryptsetup-util.h"
 #include "log.h"
+#include "varlink.h"
 
 #if HAVE_P11KIT && HAVE_OPENSSL
+
 int enroll_pkcs11(struct crypt_device *cd, const void *volume_key, size_t volume_key_size, const char *uri);
+int vl_method_enroll_pkcs11(Varlink *link, JsonVariant *params, VarlinkMethodFlags flags, void *userdata);
+
 #else
+
 static inline int enroll_pkcs11(struct crypt_device *cd, const void *volume_key, size_t volume_key_size, const char *uri) {
         return log_debug_errno(SYNTHETIC_ERRNO(EOPNOTSUPP),
                                "PKCS#11 key enrollment not supported.");
 }
+
+static inline int vl_method_enroll_pkcs11(Varlink *link, JsonVariant *params, VarlinkMethodFlags flags, void *userdata) {
+        return varlink_errorb(
+                        link,
+                        VARLINK_ERROR_METHOD_NOT_IMPLEMENTED,
+                        JSON_BUILD_OBJECT(JSON_BUILD_PAIR("method", "io.systemd.CryptEnroll.EnrollPKCS11")));
+}
+
 #endif

--- a/src/cryptenroll/cryptenroll-recovery.c
+++ b/src/cryptenroll/cryptenroll-recovery.c
@@ -1,6 +1,13 @@
-/* SPDX-License-Identifier: LGPL-2.1-or-later */
+/* SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ * Copyright © 2024 GNOME Foundation Inc
+ *      Original Author: Adrian Vovk
+ */
 
+#include "bus-polkit.h"
 #include "cryptenroll-recovery.h"
+#include "cryptenroll-wipe.h"
+#include "cryptenroll.h"
 #include "glyph-util.h"
 #include "json.h"
 #include "memory-util.h"
@@ -98,4 +105,41 @@ rollback:
                 log_debug_errno(q, "Unable to remove key slot we just added again, can't rollback, sorry: %m");
 
         return r;
+}
+
+int vl_method_enroll_recovery(Varlink *link, JsonVariant *params, VarlinkMethodFlags flags, void *userdata) {
+        static const JsonDispatch dispatch_table[] = {
+                VARLINK_DISPATCH_UNLOCK_FIELDS,
+                VARLINK_DISPATCH_WIPE_FIELDS,
+                VARLINK_DISPATCH_POLKIT_FIELD,
+                {}
+        };
+        Hashmap **polkit_registry = ASSERT_PTR(userdata);
+        _cleanup_(crypt_freep) struct crypt_device *cd = NULL;
+        _cleanup_(erase_and_freep) void *vk = NULL;
+        size_t vks;
+        int r;
+
+        r = varlink_dispatch(link, params, dispatch_table, NULL);
+        if (r != 0)
+                return r;
+
+        r = varlink_verify_polkit_async(
+                        link,
+                        /* bus= */ NULL,
+                        "io.systemd.cryptenroll.enroll",
+                        /* details= */ NULL,
+                        /* good_user= */ UID_INVALID,
+                        polkit_registry);
+        if (r <= 0)
+                return r;
+
+        r = vl_luks_setup(link, params, &cd, &vk, &vks);
+        if (r != 0)
+                return r;
+
+        return varlink_errorb(
+                        link,
+                        VARLINK_ERROR_METHOD_NOT_IMPLEMENTED,
+                        JSON_BUILD_OBJECT(JSON_BUILD_PAIR("method", "io.systemd.CryptEnroll.EnrollRecoveryKey")));
 }

--- a/src/cryptenroll/cryptenroll-recovery.h
+++ b/src/cryptenroll/cryptenroll-recovery.h
@@ -4,5 +4,7 @@
 #include <sys/types.h>
 
 #include "cryptsetup-util.h"
+#include "varlink.h"
 
 int enroll_recovery(struct crypt_device *cd, const void *volume_key, size_t volume_key_size);
+int vl_method_enroll_recovery(Varlink *link, JsonVariant *params, VarlinkMethodFlags flags, void *userdata);

--- a/src/cryptenroll/cryptenroll-tpm2.c
+++ b/src/cryptenroll/cryptenroll-tpm2.c
@@ -1,8 +1,15 @@
-/* SPDX-License-Identifier: LGPL-2.1-or-later */
+/* SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ * Copyright © 2024 GNOME Foundation Inc
+ *      Original Author: Adrian Vovk
+ */
 
 #include "alloc-util.h"
 #include "ask-password-api.h"
+#include "bus-polkit.h"
 #include "cryptenroll-tpm2.h"
+#include "cryptenroll-wipe.h"
+#include "cryptenroll.h"
 #include "env-util.h"
 #include "fileio.h"
 #include "hexdecoct.h"
@@ -377,4 +384,41 @@ int enroll_tpm2(struct crypt_device *cd,
 
         log_info("New TPM2 token enrolled as key slot %i.", keyslot);
         return keyslot;
+}
+
+int vl_method_enroll_tpm2(Varlink *link, JsonVariant *params, VarlinkMethodFlags flags, void *userdata) {
+        static const JsonDispatch dispatch_table[] = {
+                VARLINK_DISPATCH_UNLOCK_FIELDS,
+                VARLINK_DISPATCH_WIPE_FIELDS,
+                VARLINK_DISPATCH_POLKIT_FIELD,
+                {}
+        };
+        Hashmap **polkit_registry = ASSERT_PTR(userdata);
+        _cleanup_(crypt_freep) struct crypt_device *cd = NULL;
+        _cleanup_(erase_and_freep) void *vk = NULL;
+        size_t vks;
+        int r;
+
+        r = varlink_dispatch(link, params, dispatch_table, NULL);
+        if (r != 0)
+                return r;
+
+        r = varlink_verify_polkit_async(
+                        link,
+                        /* bus= */ NULL,
+                        "io.systemd.cryptenroll.enroll",
+                        /* details= */ NULL,
+                        /* good_user= */ UID_INVALID,
+                        polkit_registry);
+        if (r <= 0)
+                return r;
+
+        r = vl_luks_setup(link, params, &cd, &vk, &vks);
+        if (r != 0)
+                return r;
+
+        return varlink_errorb(
+                        link,
+                        VARLINK_ERROR_METHOD_NOT_IMPLEMENTED,
+                        JSON_BUILD_OBJECT(JSON_BUILD_PAIR("method", "io.systemd.CryptEnroll.EnrollTPM2")));
 }

--- a/src/cryptenroll/cryptenroll-tpm2.h
+++ b/src/cryptenroll/cryptenroll-tpm2.h
@@ -6,12 +6,25 @@
 #include "cryptsetup-util.h"
 #include "log.h"
 #include "tpm2-util.h"
+#include "varlink.h"
 
 #if HAVE_TPM2
+
 int enroll_tpm2(struct crypt_device *cd, const void *volume_key, size_t volume_key_size, const char *device, uint32_t seal_key_handle, const char *device_key, Tpm2PCRValue *hash_pcrs, size_t n_hash_pcrs, const char *pubkey_path, uint32_t pubkey_pcr_mask, const char *signature_path, bool use_pin, const char *pcrlock_path);
+int vl_method_enroll_tpm2(Varlink *link, JsonVariant *params, VarlinkMethodFlags flags, void *userdata);
+
 #else
+
 static inline int enroll_tpm2(struct crypt_device *cd, const void *volume_key, size_t volume_key_size, const char *device, uint32_t seal_key_handle, const char *device_key, Tpm2PCRValue *hash_pcrs, size_t n_hash_pcrs, const char *pubkey_path, uint32_t pubkey_pcr_mask, const char *signature_path, bool use_pin, const char *pcrlock_path) {
         return log_debug_errno(SYNTHETIC_ERRNO(EOPNOTSUPP),
                                "TPM2 key enrollment not supported.");
 }
+
+static inline int vl_method_enroll_tpm2(Varlink *link, JsonVariant *params, VarlinkMethodFlags flags, void *userdata) {
+        return varlink_errorb(
+                        link,
+                        VARLINK_ERROR_METHOD_NOT_IMPLEMENTED,
+                        JSON_BUILD_OBJECT(JSON_BUILD_PAIR("method", "io.systemd.CryptEnroll.EnrollTPM2")));
+}
+
 #endif

--- a/src/cryptenroll/cryptenroll-wipe.h
+++ b/src/cryptenroll/cryptenroll-wipe.h
@@ -3,6 +3,7 @@
 
 #include "cryptenroll.h"
 #include "cryptsetup-util.h"
+#include "varlink.h"
 
 int wipe_slots(struct crypt_device *cd,
                const int explicit_slots[],
@@ -10,3 +11,21 @@ int wipe_slots(struct crypt_device *cd,
                WipeScope by_scope,
                unsigned by_mask,
                int except_slot);
+
+int vl_wipe_slots(Varlink *link,
+                  JsonVariant *params,
+                  struct crypt_device *cd,
+                  int except_slot);
+
+int vl_method_wipe(Varlink *link,
+                   JsonVariant *params,
+                   VarlinkMethodFlags flags,
+                   void *userdata);
+
+/* A set of JsonDispatch initializers that ignore fields used by vl_wipe_slots, to
+ * avoid complaints about unexpected fields */
+#define VARLINK_DISPATCH_WIPE_FIELDS                            \
+        { .name = "wipeAll",   .type = JSON_VARIANT_BOOLEAN },  \
+        { .name = "wipeEmpty", .type = JSON_VARIANT_BOOLEAN },  \
+        { .name = "wipeType",  .type = JSON_VARIANT_STRING  },  \
+        { .name = "wipeSlots", .type = JSON_VARIANT_ARRAY   }

--- a/src/cryptenroll/cryptenroll.h
+++ b/src/cryptenroll/cryptenroll.h
@@ -3,6 +3,9 @@
 
 #include <errno.h>
 
+#include "cryptsetup-util.h"
+#include "varlink.h"
+
 typedef enum EnrollType {
         ENROLL_PASSWORD,
         ENROLL_RECOVERY,
@@ -34,3 +37,13 @@ EnrollType enroll_type_from_string(const char *s);
 
 const char* luks2_token_type_to_string(EnrollType t);
 EnrollType luks2_token_type_from_string(const char *s);
+
+int vl_luks_setup(Varlink *link, JsonVariant *params, struct crypt_device **ret_cd, void **ret_vk, size_t *ret_vks);
+
+/* A set of JsonDispatch initializers that ignore fields used by vl_luks_setup, to avoid complaints
+ * about unexpected fields */
+#define VARLINK_DISPATCH_UNLOCK_FIELDS                                \
+        { .name = "node",           .type = JSON_VARIANT_STRING },    \
+        { .name = "unlockPassword", .type = JSON_VARIANT_STRING },    \
+        { .name = "unlockKey",      .type = JSON_VARIANT_STRING },    \
+        { .name = "unlockFido2",    .type = JSON_VARIANT_STRING }

--- a/src/cryptenroll/io.systemd.cryptenroll.policy
+++ b/src/cryptenroll/io.systemd.cryptenroll.policy
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?> <!--*-nxml-*-->
+<!DOCTYPE policyconfig PUBLIC "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
+        "https://www.freedesktop.org/standards/PolicyKit/1/policyconfig.dtd">
+
+<!--
+  SPDX-License-Identifier: LGPL-2.1-or-later
+
+  This file is part of systemd.
+
+  systemd is free software; you can redistribute it and/or modify it
+  under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation; either version 2.1 of the License, or
+  (at your option) any later version.
+-->
+
+<policyconfig>
+
+        <vendor>The systemd Project</vendor>
+        <vendor_url>https://systemd.io</vendor_url>
+
+        <action id="io.systemd.cryptenroll.enroll">
+                <description gettext-domain="systemd">Allow enrolling new credentials into encrypted volume.</description>
+                <message gettext-domain="systemd">Authentication is required for an application to enroll a new credential into an encrypted volume.</message>
+                <defaults>
+                        <allow_any>auth_admin_keep</allow_any>
+                        <allow_inactive>auth_admin_keep</allow_inactive>
+                        <allow_active>auth_admin_keep</allow_active>
+                </defaults>
+        </action>
+
+        <action id="io.systemd.cryptenroll.enroll-custom">
+                <description gettext-domain="systemd">Allow enrolling new custom credentials into encrypted volume.</description>
+                <message gettext-domain="systemd">Authentication is required for an application to enroll a new custom credential into an encrypted volume.</message>
+                <defaults>
+                        <allow_any>auth_admin_keep</allow_any>
+                        <allow_inactive>auth_admin_keep</allow_inactive>
+                        <allow_active>auth_admin_keep</allow_active>
+                </defaults>
+        </action>
+
+        <action id="io.systemd.cryptenroll.wipe">
+                <description gettext-domain="systemd">Allow removing credentials from an encrypted volume.</description>
+                <message gettext-domain="systemd">Authentication is required for an application to remove credentials from an encrypted volume.</message>
+                <defaults>
+                        <allow_any>auth_admin_keep</allow_any>
+                        <allow_inactive>auth_admin_keep</allow_inactive>
+                        <allow_active>auth_admin_keep</allow_active>
+                </defaults>
+        </action>
+</policyconfig>

--- a/src/cryptenroll/meson.build
+++ b/src/cryptenroll/meson.build
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 systemd_cryptenroll_sources = files(
+        'cryptenroll-custom.c',
         'cryptenroll-list.c',
         'cryptenroll-password.c',
         'cryptenroll-recovery.c',
@@ -34,3 +35,6 @@ executables += [
                 ],
         },
 ]
+
+install_data('io.systemd.cryptenroll.policy',
+             install_dir : polkitpolicydir)

--- a/src/shared/json.c
+++ b/src/shared/json.c
@@ -23,6 +23,7 @@
 #include "math-util.h"
 #include "memory-util.h"
 #include "memstream-util.h"
+#include "path-util.h"
 #include "set.h"
 #include "string-table.h"
 #include "string-util.h"
@@ -5065,6 +5066,32 @@ int json_dispatch_in_addr(const char *name, JsonVariant *variant, JsonDispatchFl
                 return json_log(variant, flags, SYNTHETIC_ERRNO(EINVAL), "JSON field '%s' is array of unexpected size.", strna(name));
 
         memcpy(address, iov.iov_base, iov.iov_len);
+        return 0;
+}
+
+int json_dispatch_path(const char *name, JsonVariant *variant, JsonDispatchFlags flags, void *userdata) {
+        char **s = userdata;
+        const char *n;
+        int r;
+
+        if (json_variant_is_null(variant)) {
+                *s = mfree(*s);
+                return 0;
+        }
+
+        if (!json_variant_is_string(variant))
+                return json_log(variant, flags, SYNTHETIC_ERRNO(EINVAL), "JSON field '%s' is not a string.", strna(name));
+
+        n = json_variant_string(variant);
+        if (!path_is_normalized(n))
+                return json_log(variant, flags, SYNTHETIC_ERRNO(EINVAL), "JSON field '%s' is not a normalized file system path.", strna(name));
+        if (!path_is_absolute(n))
+                return json_log(variant, flags, SYNTHETIC_ERRNO(EINVAL), "JSON field '%s' is not an absolute file system path.", strna(name));
+
+        r = free_and_strdup(s, n);
+        if (r < 0)
+                return json_log(variant, flags, r, "Failed to allocate string: %m");
+
         return 0;
 }
 

--- a/src/shared/json.h
+++ b/src/shared/json.h
@@ -428,6 +428,7 @@ int json_dispatch_unsupported(const char *name, JsonVariant *variant, JsonDispat
 int json_dispatch_unbase64_iovec(const char *name, JsonVariant *variant, JsonDispatchFlags flags, void *userdata);
 int json_dispatch_byte_array_iovec(const char *name, JsonVariant *variant, JsonDispatchFlags flags, void *userdata);
 int json_dispatch_in_addr(const char *name, JsonVariant *variant, JsonDispatchFlags flags, void *userdata);
+int json_dispatch_path(const char *name, JsonVariant *variant, JsonDispatchFlags flags, void *userdata);
 
 assert_cc(sizeof(uint32_t) == sizeof(unsigned));
 #define json_dispatch_uint json_dispatch_uint32

--- a/src/shared/meson.build
+++ b/src/shared/meson.build
@@ -174,6 +174,7 @@ shared_sources = files(
         'varlink-idl.c',
         'varlink-io.systemd.c',
         'varlink-io.systemd.Credentials.c',
+        'varlink-io.systemd.CryptEnroll.c',
         'varlink-io.systemd.Hostname.c',
         'varlink-io.systemd.Journal.c',
         'varlink-io.systemd.ManagedOOM.c',

--- a/src/shared/user-record.c
+++ b/src/shared/user-record.c
@@ -383,32 +383,6 @@ static int json_dispatch_filename_or_path(const char *name, JsonVariant *variant
         return 0;
 }
 
-static int json_dispatch_path(const char *name, JsonVariant *variant, JsonDispatchFlags flags, void *userdata) {
-        char **s = userdata;
-        const char *n;
-        int r;
-
-        if (json_variant_is_null(variant)) {
-                *s = mfree(*s);
-                return 0;
-        }
-
-        if (!json_variant_is_string(variant))
-                return json_log(variant, flags, SYNTHETIC_ERRNO(EINVAL), "JSON field '%s' is not a string.", strna(name));
-
-        n = json_variant_string(variant);
-        if (!path_is_normalized(n))
-                return json_log(variant, flags, SYNTHETIC_ERRNO(EINVAL), "JSON field '%s' is not a normalized file system path.", strna(name));
-        if (!path_is_absolute(n))
-                return json_log(variant, flags, SYNTHETIC_ERRNO(EINVAL), "JSON field '%s' is not an absolute file system path.", strna(name));
-
-        r = free_and_strdup(s, n);
-        if (r < 0)
-                return json_log(variant, flags, r, "Failed to allocate string: %m");
-
-        return 0;
-}
-
 static int json_dispatch_home_directory(const char *name, JsonVariant *variant, JsonDispatchFlags flags, void *userdata) {
         char **s = userdata;
         const char *n;

--- a/src/shared/varlink-idl.h
+++ b/src/shared/varlink-idl.h
@@ -88,17 +88,44 @@ struct VarlinkInterface {
 #define VARLINK_DEFINE_FIELD_BY_TYPE(_name, _named_type, _field_flags) \
         { .name = #_name, .field_type = VARLINK_NAMED_TYPE, .named_type = #_named_type, .symbol = &vl_type_ ## _named_type, .field_flags = (_field_flags) }
 
-#define VARLINK_DEFINE_INPUT(_name, _field_type, _field_flags)        \
+#define VARLINK_DEFINE_FIELD_BY_ANON_TYPE(_name, _field_type, _anon_type, _field_flags) \
+        { .name = #_name, .field_type = (_field_type), .symbol = &vl_anon_type_ ## _anon_type, .field_flags = (_field_flags) }
+
+#define VARLINK_DEFINE_FIELD_STRUCT(_name, _anon_struct, _field_flags) \
+        VARLINK_DEFINE_FIELD_BY_ANON_TYPE(_name, VARLINK_STRUCT, _anon_struct, _field_flags)
+
+#define VARLINK_DEFINE_FIELD_ENUM(_name, _anon_struct, _field_flags) \
+        VARLINK_DEFINE_FIELD_BY_ANON_TYPE(_name, VARLINK_ENUM, _anon_struct, _field_flags)
+
+#define VARLINK_DEFINE_INPUT(_name, _field_type, _field_flags) \
         { .name = #_name, .field_type = (_field_type), .field_flags = (_field_flags), .field_direction = VARLINK_INPUT }
 
 #define VARLINK_DEFINE_INPUT_BY_TYPE(_name, _named_type, _field_flags) \
         { .name = #_name, .field_type = VARLINK_NAMED_TYPE, .named_type = #_named_type, .symbol = &vl_type_ ## _named_type, .field_flags = (_field_flags), .field_direction = VARLINK_INPUT }
 
-#define VARLINK_DEFINE_OUTPUT(_name, _field_type, _field_flags)        \
+#define VARLINK_DEFINE_INPUT_BY_ANON_TYPE(_name, _field_type, _anon_type, _field_flags) \
+        { .name = #_name, .field_type = (_field_type), .symbol = &vl_anon_type_ ## _anon_type, .field_flags = (_field_flags), .field_direction = VARLINK_INPUT }
+
+#define VARLINK_DEFINE_INPUT_STRUCT(_name, _anon_struct, _field_flags) \
+        VARLINK_DEFINE_INPUT_BY_ANON_TYPE(_name, VARLINK_STRUCT, _anon_struct, _field_flags)
+
+#define VARLINK_DEFINE_INPUT_ENUM(_name, _anon_struct, _field_flags) \
+        VARLINK_DEFINE_INPUT_BY_ANON_TYPE(_name, VARLINK_ENUM, _anon_struct, _field_flags)
+
+#define VARLINK_DEFINE_OUTPUT(_name, _field_type, _field_flags) \
         { .name = #_name, .field_type = (_field_type), .field_flags = (_field_flags), .field_direction = VARLINK_OUTPUT }
 
 #define VARLINK_DEFINE_OUTPUT_BY_TYPE(_name, _named_type, _field_flags) \
         { .name = #_name, .field_type = VARLINK_NAMED_TYPE, .named_type = #_named_type, .symbol = &vl_type_ ## _named_type, .field_flags = (_field_flags), .field_direction = VARLINK_OUTPUT }
+
+#define VARLINK_DEFINE_OUTPUT_BY_ANON_TYPE(_name, _field_type, _anon_type, _field_flags) \
+        { .name = #_name, .field_type = (_field_type), .symbol = &vl_anon_type_ ## _anon_type, .field_flags = (_field_flags), .field_direction = VARLINK_OUTPUT }
+
+#define VARLINK_DEFINE_OUTPUT_STRUCT(_name, _anon_struct, _field_flags) \
+        VARLINK_DEFINE_OUTPUT_BY_ANON_TYPE(_name, VARLINK_STRUCT, _anon_struct, _field_flags)
+
+#define VARLINK_DEFINE_OUTPUT_ENUM(_name, _anon_struct, _field_flags) \
+        VARLINK_DEFINE_OUTPUT_BY_ANON_TYPE(_name, VARLINK_ENUM, _anon_struct, _field_flags)
 
 #define VARLINK_DEFINE_ENUM_VALUE(_name) \
         { .name = #_name, .field_type = VARLINK_ENUM_VALUE }
@@ -124,9 +151,21 @@ struct VarlinkInterface {
                 .fields = { __VA_ARGS__ __VA_OPT__(,) {}},              \
         }
 
+#define VARLINK_DEFINE_ANON_STRUCT(_name, ...)                          \
+        const VarlinkSymbol vl_anon_type_ ## _name = {                  \
+                .symbol_type = VARLINK_STRUCT_TYPE,                     \
+                .fields = { __VA_ARGS__ __VA_OPT__(,) {}},              \
+        }
+
 #define VARLINK_DEFINE_ENUM_TYPE(_name, ...)                            \
         const VarlinkSymbol vl_type_ ## _name = {                       \
                 .name = #_name,                                         \
+                .symbol_type = VARLINK_ENUM_TYPE,                       \
+                .fields = { __VA_ARGS__ __VA_OPT__(,) {}},              \
+        }
+
+#define VARLINK_DEFINE_ANON_ENUM(_name, ...)                            \
+        const VarlinkSymbol vl_anon_type_ ## _name = {                  \
                 .symbol_type = VARLINK_ENUM_TYPE,                       \
                 .fields = { __VA_ARGS__ __VA_OPT__(,) {}},              \
         }

--- a/src/shared/varlink-io.systemd.CryptEnroll.c
+++ b/src/shared/varlink-io.systemd.CryptEnroll.c
@@ -1,0 +1,106 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include "varlink-io.systemd.Credentials.h"
+
+#define UNLOCK_FIELDS                                                           \
+        VARLINK_DEFINE_INPUT(node, VARLINK_STRING, VARLINK_NULLABLE),           \
+        VARLINK_DEFINE_INPUT(unlockPassword, VARLINK_STRING, VARLINK_NULLABLE), \
+        VARLINK_DEFINE_INPUT(unlockKey, VARLINK_STRING, VARLINK_NULLABLE),      \
+        VARLINK_DEFINE_INPUT(unlockFido2, VARLINK_STRING, VARLINK_NULLABLE)
+
+static VARLINK_DEFINE_ANON_ENUM(
+                TokenType,
+                VARLINK_DEFINE_ENUM_VALUE(password),
+                VARLINK_DEFINE_ENUM_VALUE(recovery),
+                VARLINK_DEFINE_ENUM_VALUE(pkcs11),
+                VARLINK_DEFINE_ENUM_VALUE(fido2),
+                VARLINK_DEFINE_ENUM_VALUE(tpm2));
+
+#define WIPE_FIELDS                                                                     \
+        VARLINK_DEFINE_INPUT(wipeAll, VARLINK_BOOL, VARLINK_NULLABLE),                  \
+        VARLINK_DEFINE_INPUT(wipeEmpty, VARLINK_BOOL, VARLINK_NULLABLE),                \
+        VARLINK_DEFINE_INPUT_ENUM(wipeType, TokenType, VARLINK_ARRAY|VARLINK_NULLABLE), \
+        VARLINK_DEFINE_INPUT(wipeSlots, VARLINK_INT, VARLINK_ARRAY|VARLINK_NULLABLE)
+
+static VARLINK_DEFINE_METHOD(
+                EnrollCustom,
+                VARLINK_DEFINE_INPUT(key, VARLINK_STRING, 0),
+                VARLINK_DEFINE_INPUT(token, VARLINK_OBJECT, 0),
+                UNLOCK_FIELDS,
+                WIPE_FIELDS,
+                VARLINK_DEFINE_OUTPUT(slot, VARLINK_INT, 0));
+
+static VARLINK_DEFINE_METHOD(
+                EnrollPassword,
+                VARLINK_DEFINE_INPUT(password, VARLINK_STRING, 0),
+                UNLOCK_FIELDS,
+                WIPE_FIELDS,
+                VARLINK_DEFINE_OUTPUT(slot, VARLINK_INT, 0));
+
+static VARLINK_DEFINE_METHOD(
+                EnrollRecoveryKey,
+                VARLINK_DEFINE_INPUT(recoveryKey, VARLINK_STRING, VARLINK_NULLABLE),
+                UNLOCK_FIELDS,
+                WIPE_FIELDS,
+                VARLINK_DEFINE_OUTPUT(recoveryKey, VARLINK_STRING, 0),
+                VARLINK_DEFINE_OUTPUT(slot, VARLINK_INT, 0));
+
+static VARLINK_DEFINE_METHOD(
+                EnrollPKCS11,
+                VARLINK_DEFINE_INPUT(tokenUri, VARLINK_STRING, VARLINK_NULLABLE),
+                VARLINK_DEFINE_INPUT(pin, VARLINK_STRING, VARLINK_NULLABLE),
+                UNLOCK_FIELDS,
+                WIPE_FIELDS,
+                VARLINK_DEFINE_OUTPUT(slot, VARLINK_INT, 0));
+
+static VARLINK_DEFINE_METHOD(
+                EnrollFIDO2,
+                VARLINK_DEFINE_INPUT(device, VARLINK_STRING, VARLINK_NULLABLE),
+                VARLINK_DEFINE_INPUT(credentialAlgorithm, VARLINK_STRING, VARLINK_NULLABLE),
+                VARLINK_DEFINE_INPUT(withClientPin, VARLINK_BOOL, VARLINK_NULLABLE),
+                VARLINK_DEFINE_INPUT(withUserPresence, VARLINK_BOOL, VARLINK_NULLABLE),
+                VARLINK_DEFINE_INPUT(withUserVerification, VARLINK_BOOL, VARLINK_NULLABLE),
+                VARLINK_DEFINE_INPUT(pin, VARLINK_STRING, VARLINK_NULLABLE),
+                UNLOCK_FIELDS,
+                WIPE_FIELDS,
+                VARLINK_DEFINE_OUTPUT(slot, VARLINK_INT, 0));
+
+static VARLINK_DEFINE_ANON_STRUCT(
+                TpmPcr,
+                VARLINK_DEFINE_FIELD(index, VARLINK_INT, 0),
+                VARLINK_DEFINE_FIELD(algorithm, VARLINK_STRING, VARLINK_NULLABLE),
+                VARLINK_DEFINE_FIELD(value, VARLINK_STRING, VARLINK_NULLABLE));
+
+static VARLINK_DEFINE_METHOD(
+                EnrollTPM2,
+                VARLINK_DEFINE_INPUT(device, VARLINK_STRING, VARLINK_NULLABLE),
+                VARLINK_DEFINE_INPUT(deviceKey, VARLINK_STRING, VARLINK_NULLABLE),
+                VARLINK_DEFINE_INPUT(sealKeyHandle, VARLINK_INT, VARLINK_NULLABLE),
+                VARLINK_DEFINE_INPUT_STRUCT(pcrs, TpmPcr, VARLINK_ARRAY|VARLINK_NULLABLE),
+                VARLINK_DEFINE_INPUT(withPin, VARLINK_BOOL, VARLINK_NULLABLE),
+                VARLINK_DEFINE_INPUT(publicKey, VARLINK_STRING, VARLINK_NULLABLE),
+                VARLINK_DEFINE_INPUT(publicKeyPcrs, VARLINK_INT, VARLINK_ARRAY|VARLINK_NULLABLE),
+                VARLINK_DEFINE_INPUT(signature, VARLINK_OBJECT, VARLINK_NULLABLE),
+                VARLINK_DEFINE_INPUT(pcrlockPolicy, VARLINK_OBJECT, VARLINK_NULLABLE),
+                VARLINK_DEFINE_INPUT(pin, VARLINK_STRING, VARLINK_NULLABLE),
+                UNLOCK_FIELDS,
+                WIPE_FIELDS,
+                VARLINK_DEFINE_OUTPUT(slot, VARLINK_INT, 0));
+
+static VARLINK_DEFINE_METHOD(Wipe, UNLOCK_FIELDS, WIPE_FIELDS);
+
+static VARLINK_DEFINE_ERROR(NoDevice);
+static VARLINK_DEFINE_ERROR(BadKey);
+
+VARLINK_DEFINE_INTERFACE(
+                io_systemd_CryptEnroll,
+                "io.systemd.CryptEnroll",
+                &vl_method_EnrollCustom,
+                &vl_method_EnrollPassword,
+                &vl_method_EnrollRecoveryKey,
+                &vl_method_EnrollPKCS11,
+                &vl_method_EnrollFIDO2,
+                &vl_method_EnrollTPM2,
+                &vl_method_Wipe,
+                &vl_error_NoDevice,
+                &vl_error_BadKey);

--- a/src/shared/varlink-io.systemd.CryptEnroll.h
+++ b/src/shared/varlink-io.systemd.CryptEnroll.h
@@ -1,0 +1,6 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#pragma once
+
+#include "varlink-idl.h"
+
+extern const VarlinkInterface vl_interface_io_systemd_CryptEnroll;

--- a/src/shared/varlink.h
+++ b/src/shared/varlink.h
@@ -47,7 +47,7 @@ typedef enum VarlinkServerFlags {
         VARLINK_SERVER_MYSELF_ONLY      = 1 << 1, /* Only accessible by our own UID */
         VARLINK_SERVER_ACCOUNT_UID      = 1 << 2, /* Do per user accounting */
         VARLINK_SERVER_INHERIT_USERDATA = 1 << 3, /* Initialize Varlink connection userdata from VarlinkServer userdata */
-        VARLINK_SERVER_INPUT_SENSITIVE  = 1 << 4, /* Automatically mark al connection input as sensitive */
+        VARLINK_SERVER_INPUT_SENSITIVE  = 1 << 4, /* Automatically mark all connection input as sensitive */
         _VARLINK_SERVER_FLAGS_ALL = (1 << 5) - 1,
 } VarlinkServerFlags;
 

--- a/units/meson.build
+++ b/units/meson.build
@@ -285,6 +285,15 @@ units = [
           'symlinks' : ['sockets.target.wants/'],
         },
         { 'file' : 'systemd-creds@.service' },
+        {
+          'file' : 'systemd-cryptenroll.socket',
+          'conditions' : ['HAVE_LIBCRYPTSETUP'],
+          'symlinks' : ['sockets.target.wants/'],
+        },
+        {
+          'file' : 'systemd-cryptenroll@.service',
+          'conditions' : ['HAVE_LIBCRYPTSETUP'],
+        },
         { 'file' : 'systemd-exit.service' },
         {
           'file' : 'systemd-firstboot.service',

--- a/units/systemd-cryptenroll.socket
+++ b/units/systemd-cryptenroll.socket
@@ -1,0 +1,18 @@
+#  SPDX-License-Identifier: LGPL-2.1-or-later
+#
+#  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+
+[Unit]
+Description=LUKS Key Management (Varlink)
+Documentation=man:systemd-cryptenroll(1)
+
+[Socket]
+ListenStream=/run/systemd/io.systemd.CryptEnroll
+FileDescriptorName=varlink
+SocketMode=0666
+Accept=yes

--- a/units/systemd-cryptenroll@.service
+++ b/units/systemd-cryptenroll@.service
@@ -1,0 +1,16 @@
+#  SPDX-License-Identifier: LGPL-2.1-or-later
+#
+#  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+
+[Unit]
+Description=LUKS Key Management (Varlink)
+Documentation=man:systemd-cryptenroll(1)
+
+[Service]
+Environment=LISTEN_FDNAMES=varlink
+ExecStart=-systemd-cryptenroll


### PR DESCRIPTION
This allows unprivileged clients to manage the keyslots via systemd-cryptenroll over varlink

The motivation is that clients will use this to synchronize the system recovery key with the recovery key of systemd-homed users