### PR TITLE
pcrlock: error out if requested PCR was dropped

### DIFF
--- a/man/systemd-pcrlock.xml
+++ b/man/systemd-pcrlock.xml
@@ -430,6 +430,14 @@
 
     <variablelist>
       <varlistentry>
+        <term><option>--full</option></term>
+
+        <listitem><para>Show full hash value instead of abbreviating to 7 characters.</para>
+
+        <xi:include href="version-info.xml" xpointer="v256"/></listitem>
+      </varlistentry>
+
+      <varlistentry>
         <term><option>--raw-description</option></term>
 
         <listitem><para>When displaying the TPM2 event log do not attempt to decode the records to provide a

--- a/man/systemd-pcrlock.xml
+++ b/man/systemd-pcrlock.xml
@@ -138,6 +138,16 @@
       </varlistentry>
 
       <varlistentry>
+        <term><command>is-supported</command></term>
+
+        <listitem><para>Checks whether a TPM is present has has the necessary features to support creating a
+        pcrlock policy</para>
+
+        <xi:include href="version-info.xml" xpointer="v256"/>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
         <term><command>make-policy</command></term>
 
         <listitem><para>This predicts the PCR state for future boots, much like the

--- a/man/systemd-pcrlock.xml
+++ b/man/systemd-pcrlock.xml
@@ -578,6 +578,15 @@
         <xi:include href="version-info.xml" xpointer="v256"/></listitem>
       </varlistentry>
 
+      <varlistentry>
+        <term><option>--strict=</option></term>
+
+        <listitem><para>Takes a boolean. Defaults to false. Honoured by <command>make-policy</command>. If
+        true all specified PCRs must be included in the policy otherwise the command returns failure.</para>
+
+        <xi:include href="version-info.xml" xpointer="v256"/></listitem>
+      </varlistentry>
+
       <xi:include href="standard-options.xml" xpointer="json" />
       <xi:include href="standard-options.xml" xpointer="no-pager" />
       <xi:include href="standard-options.xml" xpointer="help" />

--- a/src/pcrlock/pcrlock.c
+++ b/src/pcrlock/pcrlock.c
@@ -232,6 +232,9 @@ struct EventLog {
 
         /* PCRs mask indicating all PCRs touched by unrecognized components */
         uint32_t missing_component_pcrs;
+
+        /* PCRs mask indicating component found for the pcr */
+        uint32_t has_component_pcrs;
 };
 
 static EventLogRecordBank *event_log_record_bank_free(EventLogRecordBank *bank) {
@@ -1936,6 +1939,8 @@ static int event_log_map_components(EventLog *el) {
                                 continue;
                         }
 
+                        el->has_component_pcrs |= event_log_component_variant_pcrs(*ii);
+
                         r = event_log_match_component_variant(el, 0, i, 0, n_matching + n_empty == 0);
                         if (r < 0)
                                 return r;
@@ -2271,14 +2276,23 @@ static int show_pcr_table(EventLog *el, JsonVariant **ret_variant) {
                 /* Whether all records in this PCR have a matching component */
                 bool fully_recognized = el->registers[pcr].fully_recognized;
 
+                bool seen = el->registers[pcr].n_measurements > 0;
+
                 /* Whether any unmatched components touch this PCR */
                 bool missing_components = FLAGS_SET(el->missing_component_pcrs, UINT32_C(1) << pcr);
+                bool has_components = FLAGS_SET(el->has_component_pcrs, UINT32_C(1) << pcr);
 
-                const char *emoji = special_glyph(
-                                !hash_match ? SPECIAL_GLYPH_DEPRESSED_SMILEY :
-                                !fully_recognized ? SPECIAL_GLYPH_UNHAPPY_SMILEY :
-                                missing_components ?  SPECIAL_GLYPH_SLIGHTLY_HAPPY_SMILEY :
-                                SPECIAL_GLYPH_HAPPY_SMILEY);
+                const char *emoji = "";
+                if (seen || has_components) {
+                        if (!hash_match)
+                                emoji = special_glyph(SPECIAL_GLYPH_DEPRESSED_SMILEY);
+                        else if (!fully_recognized)
+                                emoji = special_glyph(SPECIAL_GLYPH_UNHAPPY_SMILEY);
+                        else if (!missing_components)
+                                emoji = special_glyph(SPECIAL_GLYPH_HAPPY_SMILEY);
+                        else
+                                emoji = special_glyph(SPECIAL_GLYPH_SLIGHTLY_HAPPY_SMILEY);
+                }
 
                 r = table_add_many(table,
                                    TABLE_UINT32, pcr,
@@ -2297,11 +2311,11 @@ static int show_pcr_table(EventLog *el, JsonVariant **ret_variant) {
                         return table_log_add_error(r);
 
                 r = table_add_many(table,
-                                   TABLE_BOOLEAN_CHECKMARK, hash_match,
+                                   TABLE_STRING, seen ? special_glyph_check_mark(hash_match) : " ",
                                    TABLE_SET_COLOR, ansi_highlight_green_red(hash_match),
-                                   TABLE_BOOLEAN_CHECKMARK, fully_recognized,
+                                   TABLE_STRING, seen ? special_glyph_check_mark(fully_recognized) : " ",
                                    TABLE_SET_COLOR, ansi_highlight_green_red(fully_recognized),
-                                   TABLE_BOOLEAN_CHECKMARK, !missing_components,
+                                   TABLE_STRING, has_components ? special_glyph_check_mark(!missing_components) : " ",
                                    TABLE_SET_COLOR, ansi_highlight_green_red(!missing_components));
                 if (r < 0)
                         return table_log_add_error(r);
@@ -2368,7 +2382,7 @@ static int show_pcr_table(EventLog *el, JsonVariant **ret_variant) {
                 printf("\n"
                        "%sLegend: H → PCR hash value matches event log%s\n"
                        "%s        R → All event log records for this PCR have a matching component%s\n"
-                       "%s        C → No components that couldn't be matched with log records affect this PCR%s\n",
+                       "%s        C → Component exists and found in event log%s\n",
                        ansi_grey(), ansi_normal(), /* less on small screens automatically resets the color after long lines, hence we set it anew for each line */
                        ansi_grey(), ansi_normal(),
                        ansi_grey(), ansi_normal());

--- a/src/pcrlock/pcrlock.c
+++ b/src/pcrlock/pcrlock.c
@@ -791,6 +791,16 @@ static int event_log_record_extract_firmware_description(EventLogRecord *rec) {
                         goto invalid;
                 }
 
+                /* device path could be empty. Don't mark that as invalid but leave as don't know.
+                 * Happens eg with shim https://github.com/rhboot/shim/issues/642 */
+                if (load->lengthOfDevicePath == 0) {
+                        rec->description = strdup("File: <unspecified>");
+                        if (!rec->description)
+                                return log_oom();
+
+                        return 1;
+                }
+
                 const packed_EFI_DEVICE_PATH *dp = (const packed_EFI_DEVICE_PATH*) load->devicePath;
                 size_t left = load->lengthOfDevicePath;
 

--- a/src/pcrlock/pcrlock.c
+++ b/src/pcrlock/pcrlock.c
@@ -1973,6 +1973,19 @@ static const char *ansi_true_color(uint8_t r, uint8_t g, uint8_t b, char ret[sta
         return ret;
 }
 
+/* red and green colors usually have good/bad meaning. So exclude color ranges that look too red- or
+ * greenish. See https://en.wikipedia.org/wiki/Hue */
+static double map_pcr_to_hue(uint32_t pcr) {
+        double exclude_red_range = 60.0;
+        double exclude_green_range = 60.0;
+        double h = (360.0 - exclude_red_range - exclude_green_range) / (TPM2_PCRS_MAX - 1) * pcr;
+        h += exclude_red_range/2;
+        if (h > 120-exclude_green_range/2)
+                h += exclude_green_range;
+        assert(h <= 360-exclude_red_range/2);
+        return h;
+}
+
 static char *color_for_pcr(EventLog *el, uint32_t pcr) {
         char color[ANSI_TRUE_COLOR_MAX];
         uint8_t r, g, b;
@@ -1983,7 +1996,7 @@ static char *color_for_pcr(EventLog *el, uint32_t pcr) {
         if (el->registers[pcr].color)
                 return el->registers[pcr].color;
 
-        hsv_to_rgb(360.0 / (TPM2_PCRS_MAX - 1) * pcr, 100, 90, &r, &g, &b);
+        hsv_to_rgb(map_pcr_to_hue(pcr), 100, 90, &r, &g, &b);
         ansi_true_color(r, g, b, color);
 
         el->registers[pcr].color = strdup(color);

--- a/src/pcrlock/pcrlock.c
+++ b/src/pcrlock/pcrlock.c
@@ -77,6 +77,8 @@ static bool arg_force = false;
 static BootEntryTokenType arg_entry_token_type = BOOT_ENTRY_TOKEN_AUTO;
 static char *arg_entry_token = NULL;
 static bool arg_varlink = false;
+/* abbreviate to 7 chars, just like git */
+static size_t arg_abbreviate_hash = 7;
 
 STATIC_DESTRUCTOR_REGISTER(arg_components, strv_freep);
 STATIC_DESTRUCTOR_REGISTER(arg_pcrlock_path, freep);
@@ -2166,6 +2168,8 @@ static int show_log_table(EventLog *el, JsonVariant **ret_variant) {
                                 if (!hex)
                                         return log_oom();
 
+                                strshorten(hex, arg_abbreviate_hash);
+
                                 r = table_add_cell(table, NULL, TABLE_STRING, hex);
                         } else
                                 r = table_add_cell(table, NULL, TABLE_EMPTY, NULL);
@@ -2314,6 +2318,8 @@ static int show_pcr_table(EventLog *el, JsonVariant **ret_variant) {
                                 if (!hex)
                                         return log_oom();
 
+                                strshorten(hex, arg_abbreviate_hash);
+
                                 r = table_add_many(table,
                                                    TABLE_STRING, hex,
                                                    TABLE_SET_COLOR, color);
@@ -2332,6 +2338,8 @@ static int show_pcr_table(EventLog *el, JsonVariant **ret_variant) {
                         hex = hexmem(el->registers[pcr].banks[i].observed.buffer, el->registers[pcr].banks[i].observed.size);
                         if (!hex)
                                 return log_oom();
+
+                        strshorten(hex, arg_abbreviate_hash);
 
                         color = !hash_match ? ANSI_HIGHLIGHT_RED :
                                 is_unset_pcr(el->registers[pcr].banks[i].observed.buffer, el->registers[pcr].banks[i].observed.size) ? ANSI_GREY : NULL;
@@ -5003,6 +5011,7 @@ static int help(int argc, char *argv[], void *userdata) {
                "  -h --help                   Show this help\n"
                "     --version                Print version\n"
                "     --no-pager               Do not pipe output into a pager\n"
+               "     --full                   Print full hash in measurement log\n"
                "     --json=pretty|short|off  Generate JSON output\n"
                "     --raw-description        Show raw firmware record data as description in table\n"
                "     --pcr=NR                 Generate .pcrlock for specified PCR\n"
@@ -5048,6 +5057,7 @@ static int parse_argv(int argc, char *argv[]) {
                 { "help",            no_argument,       NULL, 'h'                 },
                 { "version",         no_argument,       NULL, ARG_VERSION         },
                 { "no-pager",        no_argument,       NULL, ARG_NO_PAGER        },
+                { "full",            no_argument,       NULL, 'f'                 },
                 { "json",            required_argument, NULL, ARG_JSON            },
                 { "raw-description", no_argument,       NULL, ARG_RAW_DESCRIPTION },
                 { "pcr",             required_argument, NULL, ARG_PCR             },
@@ -5080,6 +5090,10 @@ static int parse_argv(int argc, char *argv[]) {
 
                 case ARG_NO_PAGER:
                         arg_pager_flags |= PAGER_DISABLE;
+                        break;
+
+                case 'f':
+                        arg_abbreviate_hash = SIZE_MAX;
                         break;
 
                 case ARG_JSON:

--- a/src/pcrlock/pcrlock.c
+++ b/src/pcrlock/pcrlock.c
@@ -2652,6 +2652,9 @@ static int verb_list_components(int argc, char *argv[], void *userdata) {
 
         FOREACH_ARRAY(c, el->components, el->n_components) {
 
+                if (arg_pcr_mask != 0 && (arg_pcr_mask & event_log_component_pcrs(*c)) == 0)
+                        continue;
+
                 if (FLAGS_SET(arg_json_format_flags, JSON_FORMAT_OFF)) {
                         _cleanup_free_ char *marker = NULL;
 

--- a/src/pcrlock/pcrlock.c
+++ b/src/pcrlock/pcrlock.c
@@ -1827,7 +1827,7 @@ static int event_log_validate_fully_recognized(EventLog *el) {
                                 continue;
 
                         if (rec->n_mapped == 0) {
-                                log_notice("Event log record %zu (PCR %" PRIu32 ", \"%s\") not matching any component.",
+                                log_info("Event log record %zu (PCR %" PRIu32 ", \"%s\") not matching any component.",
                                            (size_t) (rr - el->records), rec->pcr, strna(rec->description));
                                 fully_recognized = false;
                                 break;
@@ -1958,7 +1958,7 @@ static int event_log_map_components(EventLog *el) {
                         if (arg_location_start && strcmp(c->id, arg_location_start) >= 0)
                                 log_info("Didn't find component '%s' in event log, assuming system hasn't reached it yet.", c->id);
                         else {
-                                log_notice("Couldn't find component '%s' in event log.", c->id);
+                                log_info("Couldn't find component '%s' in event log.", c->id);
                                 el->n_missing_components++;
                                 el->missing_component_pcrs |= event_log_component_pcrs(c);
                         }
@@ -1967,9 +1967,9 @@ static int event_log_map_components(EventLog *el) {
         }
 
         if (n_skipped > 0)
-                log_notice("Skipped %u components after location '%s' (%s).", n_skipped, arg_location_end, skipped_ids);
+                log_info("Skipped %u components after location '%s' (%s).", n_skipped, arg_location_end, skipped_ids);
         if (el->n_missing_components > 0)
-                log_notice("Unable to recognize %zu components in event log.", el->n_missing_components);
+                log_debug("Unable to recognize %zu components in event log.", el->n_missing_components);
 
         return event_log_validate_fully_recognized(el);
 }
@@ -2907,7 +2907,7 @@ static int write_pcrlock(JsonVariant *array, const char *default_pcrlock_path) {
                 return log_error_errno(r, "Failed to output JSON object: %m");
 
         if (p)
-                log_info("%s written.", p);
+                log_debug("%s written.", p);
 
         return 0;
 }
@@ -3890,7 +3890,7 @@ static int event_log_reduce_to_safe_pcrs(EventLog *el, uint32_t *pcrs) {
                         goto drop;
                 }
 
-                log_info("PCR %" PRIu32 " (%s) matches event log and fully consists of recognized measurements. Including in set of PCRs.", pcr, strna(tpm2_pcr_index_to_string(pcr)));
+                log_debug("PCR %" PRIu32 " (%s) matches event log and fully consists of recognized measurements. Including in set of PCRs.", pcr, strna(tpm2_pcr_index_to_string(pcr)));
 
                 if (strextendf_with_separator(&kept, ", ", "%" PRIu32 " (%s)", pcr, tpm2_pcr_index_to_string(pcr)) < 0)
                         return log_oom();
@@ -4527,7 +4527,7 @@ static int make_policy(bool force, RecoveryPinMode recovery_pin_mode) {
         if (r < 0)
                 return r;
 
-        log_info("Predicted future PCRs in %s.", FORMAT_TIMESPAN(usec_sub_unsigned(now(CLOCK_MONOTONIC), predict_start_usec), 1));
+        log_debug("Predicted future PCRs in %s.", FORMAT_TIMESPAN(usec_sub_unsigned(now(CLOCK_MONOTONIC), predict_start_usec), 1));
 
         _cleanup_(json_variant_unrefp) JsonVariant *new_prediction_json = NULL;
         r = tpm2_pcr_prediction_to_json(&new_prediction, el->primary_algorithm, &new_prediction_json);

--- a/src/pcrlock/pcrlock.c
+++ b/src/pcrlock/pcrlock.c
@@ -2131,6 +2131,9 @@ static int show_log_table(EventLog *el, JsonVariant **ret_variant) {
         FOREACH_ARRAY(rr, el->records, el->n_records) {
                 EventLogRecord *record = *rr;
 
+                if (arg_pcr_mask != 0 && !FLAGS_SET(arg_pcr_mask, UINT32_C(1) << record->pcr))
+                        continue;
+
                 r = table_add_many(table,
                                    TABLE_UINT32, record->pcr,
                                    TABLE_STRING, special_glyph(SPECIAL_GLYPH_FULL_BLOCK),
@@ -2271,6 +2274,10 @@ static int show_pcr_table(EventLog *el, JsonVariant **ret_variant) {
         (void) table_set_json_field_name(table, 7, "noMissingComponents");
 
         for (uint32_t pcr = 0; pcr < TPM2_PCRS_MAX; pcr++) {
+
+                if (arg_pcr_mask != 0 && !FLAGS_SET(arg_pcr_mask, UINT32_C(1) << pcr))
+                        continue;
+
                 /* Check if the PCR hash value matches the event log data */
                 bool hash_match = event_log_pcr_checks_out(el, el->registers + pcr);
 

--- a/src/pcrlock/pcrlock.c
+++ b/src/pcrlock/pcrlock.c
@@ -1966,6 +1966,30 @@ static int event_log_map_components(EventLog *el) {
         return event_log_validate_fully_recognized(el);
 }
 
+static int tpm2_check_and_allocate(Tpm2Context** ret_tc) {
+        _cleanup_(tpm2_context_unrefp) Tpm2Context *tc = NULL;
+        int r;
+
+        if (tpm2_support() != TPM2_SUPPORT_FULL)
+                return log_error_errno(SYNTHETIC_ERRNO(EOPNOTSUPP), "Sorry, system lacks full TPM2 support.");
+
+        r = tpm2_context_new_or_warn(/* device= */ NULL, &tc);
+        if (r < 0)
+                return log_error_errno(r, "Failed to create TPM2 context: %m");
+
+        if (!tpm2_supports_command(tc, TPM2_CC_PolicyAuthorizeNV))
+                return log_error_errno(SYNTHETIC_ERRNO(EOPNOTSUPP), "TPM2 does not support PolicyAuthorizeNV command, refusing.");
+
+        if (ret_tc)
+                *ret_tc = TAKE_PTR(tc);
+
+        return 0;
+}
+
+static int verb_is_supported(int argc, char *argv[], void *userdata) {
+        return tpm2_check_and_allocate(NULL);
+}
+
 #define ANSI_TRUE_COLOR_MAX (7U + 3U + 1U + 3U + 1U + 3U + 2U)
 
 static const char *ansi_true_color(uint8_t r, uint8_t g, uint8_t b, char ret[static ANSI_TRUE_COLOR_MAX]) {
@@ -4420,7 +4444,12 @@ static int write_boot_policy_file(const char *json_text) {
 }
 
 static int make_policy(bool force, RecoveryPinMode recovery_pin_mode) {
+        _cleanup_(tpm2_context_unrefp) Tpm2Context *tc = NULL;
         int r;
+
+        r = tpm2_check_and_allocate(&tc);
+        if (r < 0)
+                return r;
 
         /* Here's how this all works: after predicting all possible PCR values for next boot (with
          * alternatives) we'll calculate a policy from it as a combination of PolicyPCR + PolicyOR
@@ -4501,14 +4530,6 @@ static int make_policy(bool force, RecoveryPinMode recovery_pin_mode) {
                         return 0; /* NOP */
                 }
         }
-
-        _cleanup_(tpm2_context_unrefp) Tpm2Context *tc = NULL;
-        r = tpm2_context_new_or_warn(/* device= */ NULL, &tc);
-        if (r < 0)
-                return r;
-
-        if (!tpm2_supports_command(tc, TPM2_CC_PolicyAuthorizeNV))
-                return log_error_errno(SYNTHETIC_ERRNO(EOPNOTSUPP), "TPM2 does not support PolicyAuthorizeNV command, refusing.");
 
         _cleanup_(tpm2_handle_freep) Tpm2Handle *srk_handle = NULL;
 
@@ -4951,6 +4972,7 @@ static int help(int argc, char *argv[], void *userdata) {
                "  list-components             List defined .pcrlock components\n"
                "  predict                     Predict PCR values\n"
                "  make-policy                 Predict PCR values and generate TPM2 policy from it\n"
+               "  is-supported                Check whether there's sufficient TPM supports PolicyAuthorizeNV\n"
                "  remove-policy               Remove TPM2 policy\n"
                "\n%3$sProtections:%4$s\n"
                "  lock-firmware-code          Generate a .pcrlock file from current firmware code\n"
@@ -5253,6 +5275,7 @@ static int pcrlock_main(int argc, char *argv[]) {
                 { "lock-raw",                    VERB_ANY, 2,        0,            verb_lock_raw                    },
                 { "unlock-raw",                  VERB_ANY, 1,        0,            verb_unlock_simple               },
                 { "make-policy",                 VERB_ANY, 1,        0,            verb_make_policy                 },
+                { "is-supported",                VERB_ANY, 1,        0,            verb_is_supported                },
                 { "remove-policy",               VERB_ANY, 1,        0,            verb_remove_policy               },
                 {}
         };

--- a/src/pcrlock/pcrlock.c
+++ b/src/pcrlock/pcrlock.c
@@ -75,6 +75,7 @@ static RecoveryPinMode arg_recovery_pin = RECOVERY_PIN_HIDE;
 static char *arg_policy_path = NULL;
 static bool arg_force = false;
 static BootEntryTokenType arg_entry_token_type = BOOT_ENTRY_TOKEN_AUTO;
+static bool arg_strict = false;
 static char *arg_entry_token = NULL;
 static bool arg_varlink = false;
 /* abbreviate to 7 chars, just like git */
@@ -3847,6 +3848,7 @@ static int verb_lock_uki(int argc, char *argv[], void *userdata) {
 
 static int event_log_reduce_to_safe_pcrs(EventLog *el, uint32_t *pcrs) {
         _cleanup_free_ char *dropped = NULL, *kept = NULL;
+        uint32_t dropped_relevant_pcr = 0;
 
         assert(el);
         assert(pcrs);
@@ -3889,6 +3891,9 @@ static int event_log_reduce_to_safe_pcrs(EventLog *el, uint32_t *pcrs) {
                 continue;
 
         drop:
+                if (arg_strict && FLAGS_SET(*pcrs, UINT32_C(1) << pcr))
+                        dropped_relevant_pcr |= pcr;
+
                 *pcrs &= ~(UINT32_C(1) << pcr);
 
                 if (strextendf_with_separator(&dropped, ", ", "%" PRIu32 " (%s)", pcr, tpm2_pcr_index_to_string(pcr)) < 0)
@@ -3896,7 +3901,7 @@ static int event_log_reduce_to_safe_pcrs(EventLog *el, uint32_t *pcrs) {
         }
 
         if (dropped)
-                log_notice("PCRs dropped from protection mask: %s", dropped);
+                log_full(dropped_relevant_pcr != 0 ? LOG_ERR : LOG_NOTICE, "PCRs dropped from protection mask: %s", dropped);
         else
                 log_debug("No PCRs dropped from protection mask.");
 
@@ -3905,7 +3910,7 @@ static int event_log_reduce_to_safe_pcrs(EventLog *el, uint32_t *pcrs) {
         else
                 log_notice("No PCRs kept in protection mask.");
 
-        return 0;
+        return arg_strict && dropped_relevant_pcr != 0 ? -ENOEXEC : 0;
 }
 
 static int verb_lock_kernel_cmdline(int argc, char *argv[], void *userdata) {
@@ -5039,6 +5044,7 @@ static int help(int argc, char *argv[], void *userdata) {
                "     --force                  Write policy even if it matches existing policy\n"
                "     --entry-token=machine-id|os-id|os-image-id|auto|literal:…\n"
                "                              Boot entry token to use for this installation\n"
+               "     --strict                 Require all PCRs configured via --pcr= included in policy\n"
                "\nSee the %2$s for details.\n",
                program_invocation_short_name,
                link,
@@ -5065,6 +5071,7 @@ static int parse_argv(int argc, char *argv[]) {
                 ARG_POLICY,
                 ARG_FORCE,
                 ARG_ENTRY_TOKEN,
+                ARG_STRICT,
         };
 
         static const struct option options[] = {
@@ -5083,6 +5090,7 @@ static int parse_argv(int argc, char *argv[]) {
                 { "policy",          required_argument, NULL, ARG_POLICY          },
                 { "force",           no_argument,       NULL, ARG_FORCE           },
                 { "entry-token",     required_argument, NULL, ARG_ENTRY_TOKEN     },
+                { "strict",          required_argument, NULL, ARG_STRICT          },
                 {}
         };
 
@@ -5236,6 +5244,12 @@ static int parse_argv(int argc, char *argv[]) {
 
                 case ARG_ENTRY_TOKEN:
                         r = parse_boot_entry_token_type(optarg, &arg_entry_token_type, &arg_entry_token);
+                        if (r < 0)
+                                return r;
+                        break;
+
+                case ARG_STRICT:
+                        r = parse_boolean_argument("--strict", optarg, &arg_strict);
                         if (r < 0)
                                 return r;
                         break;

--- a/test/units/testsuite-70.pcrlock.sh
+++ b/test/units/testsuite-70.pcrlock.sh
@@ -74,10 +74,12 @@ if [[ -n "$SD_STUB" ]]; then
     "$SD_PCRLOCK" lock-uki <"$SD_STUB"
 fi
 
-PIN=huhu "$SD_PCRLOCK" make-policy --pcr="$PCRS" --recovery-pin=query
-# Repeat immediately (this call will have to reuse the nvindex, rather than create it)
-"$SD_PCRLOCK" make-policy --pcr="$PCRS"
-"$SD_PCRLOCK" make-policy --pcr="$PCRS" --force
+if "$SD_PCRLOCK" is-supported; then
+	PIN=huhu "$SD_PCRLOCK" make-policy --pcr="$PCRS" --recovery-pin=query
+	# Repeat immediately (this call will have to reuse the nvindex, rather than create it)
+	"$SD_PCRLOCK" make-policy --pcr="$PCRS"
+	"$SD_PCRLOCK" make-policy --pcr="$PCRS" --force
+fi
 
 img="/tmp/pcrlock.img"
 truncate -s 20M "$img"


### PR DESCRIPTION
If certain PCRs were explicitly requested, don't silently drop them from the generated policy. Instead throw an error. Avoids creating a policy less secure than requested.



<!-- devel-freezer = {"comment-id":"2082797734","freezing-tag":"v256-rc1"} -->