### PR TITLE
network/radv: fade out announced prefixes

### DIFF
--- a/src/libsystemd-network/sd-radv.c
+++ b/src/libsystemd-network/sd-radv.c
@@ -714,6 +714,10 @@ void sd_radv_remove_prefix(
                          addr_p,
                          FORMAT_TIMESPAN(p->lifetime_preferred_usec, USEC_PER_SEC),
                          FORMAT_TIMESPAN(p->lifetime_valid_usec, USEC_PER_SEC));
+
+                log_radv(ra, "Trigger advertisement now");
+                sd_radv_send(ra);
+                // TODO error handling for this method?
                 return;
         }
 }

--- a/src/libsystemd-network/sd-radv.c
+++ b/src/libsystemd-network/sd-radv.c
@@ -679,6 +679,8 @@ void sd_radv_remove_prefix(
         if (!prefix)
                 return;
 
+        const char *addr_p = IN6_ADDR_PREFIX_TO_STRING(prefix, prefixlen);
+
         LIST_FOREACH(prefix, cur, ra->prefixes) {
                 if (prefixlen != cur->opt.prefixlen)
                         continue;
@@ -686,9 +688,32 @@ void sd_radv_remove_prefix(
                 if (!in6_addr_equal(prefix, &cur->opt.in6_addr))
                         continue;
 
+                /* "Fade out" IPv6 prefix, i.e. informing clients about its sudden invalidity.
+                 * Realized by announcing the prefix with preferred=0 & valid=2h.
+                 * This makes clients rotating to a newer prefix if some is already defined.
+                */
+
+                // TODO is copying required here? (& does it do anything at all?)
+                sd_radv_prefix *p = cur;
+
+                // TODO replace hacky way to get current time
+                uint64_t current_time = cur->valid_until - cur->lifetime_valid_usec;
+                // TODO replace constant with setting (valid lifetime) ?
+                uint64_t two_hours_usec = (uint64_t) 2 * 60 * 60 * 1000000;
+                sd_radv_prefix_set_preferred_lifetime(p, 0, current_time);
+                sd_radv_prefix_set_valid_lifetime(p, two_hours_usec, current_time + two_hours_usec);
+
+                // TODO is full replacement procedure required or can we just edit the stored prefix without this?
+                // procedure cloned from sd_radv_add_prefix, if found. I do not call this here because of the duplicated search in the list & because of the different logging message
+                sd_radv_prefix_ref(p);
                 LIST_REMOVE(prefix, ra->prefixes, cur);
-                ra->n_prefixes--;
                 sd_radv_prefix_unref(cur);
+                LIST_APPEND(prefix, ra->prefixes, p);
+
+                log_radv(ra, "Fade out IPv6 prefix %s (preferred: %s, valid: %s)",
+                         addr_p,
+                         FORMAT_TIMESPAN(p->lifetime_preferred_usec, USEC_PER_SEC),
+                         FORMAT_TIMESPAN(p->lifetime_valid_usec, USEC_PER_SEC));
                 return;
         }
 }


### PR DESCRIPTION
Fixes #29651

## Open TODOs

I know this code has a few problems left. Help is appreciated, that’s why I intended to open this as a draft (*sorry for pings which were already sent out, I misclicked*).

The points which are still open are marked as TODOs in the code (I plan to remove those with force pushes), as this is mainly a rather small "proof of concept"-alike.

Further, the compiler does not seem to like the function call `sd_radv_send(ra);` for immediately sending router advertisements out to the clients. This is not per se required for fixing #29651, but it would speed up the process a lot, because otherwise clients might have no Internet connection until the next normally scheduled advertisement, which might take several minutes.

However, when removing the offending `sd_radv_send(ra);` by reverting commit 2e2f498, the code compiles, all tests are still working. Further, with a NixOS test implementing a router with systemd-network, I can verify that everything else still seems to work (e.g. delegating prefixes from DHCP-PD to clients via RA) and after waiting for the next advertisement, a client also based on systemd-network correctly ditches the old prefix in favor for a new one.