### PR TITLE
core-execute: Setup ExecDirectories before stdin/stdout

### DIFF
--- a/src/core/exec-invoke.c
+++ b/src/core/exec-invoke.c
@@ -4382,6 +4382,15 @@ int exec_invoke(
                 }
         }
 
+        /* Setup ExecDirectories now, as they may be targeted by stdin/stdout */
+        needs_mount_namespace = exec_needs_mount_namespace(context, params, runtime);
+
+        for (ExecDirectoryType dt = 0; dt < _EXEC_DIRECTORY_TYPE_MAX; dt++) {
+                r = setup_exec_directory(context, params, uid, gid, dt, needs_mount_namespace, exit_status);
+                if (r < 0)
+                        return log_exec_error_errno(context, params, r, "Failed to set up special execution directory in %s: %m", params->prefix[dt]);
+        }
+
         r = setup_input(context, params, socket_fd, named_iofds);
         if (r < 0) {
                 *exit_status = EXIT_STDIN;
@@ -4600,14 +4609,6 @@ int exec_invoke(
                                 }
                         }
                 }
-        }
-
-        needs_mount_namespace = exec_needs_mount_namespace(context, params, runtime);
-
-        for (ExecDirectoryType dt = 0; dt < _EXEC_DIRECTORY_TYPE_MAX; dt++) {
-                r = setup_exec_directory(context, params, uid, gid, dt, needs_mount_namespace, exit_status);
-                if (r < 0)
-                        return log_exec_error_errno(context, params, r, "Failed to set up special execution directory in %s: %m", params->prefix[dt]);
         }
 
         r = exec_setup_credentials(context, params, params->unit_id, uid, gid);

--- a/src/test/test-execute.c
+++ b/src/test/test-execute.c
@@ -1128,9 +1128,21 @@ static void test_exec_runtimedirectory(Manager *m) {
         test(m, "exec-runtimedirectory-owner-" NOBODY_GROUP_NAME ".service", MANAGER_IS_SYSTEM(m) ? 0 : EXIT_GROUP, CLD_EXITED);
 }
 
-static void test_exec_runtimedirectory_stdoutput(Manager *m) {
-        (void) rm_rf("/run/test-exec_runtimedirectory_standardoutput", REMOVE_ROOT|REMOVE_PHYSICAL);
-        test(m, "exec-runtimedirectory-stdoutput.service", 0, CLD_EXITED);
+static void test_exec_statedirectory_stdoutput(Manager *m) {
+        if (MANAGER_IS_USER(m)) {
+                log_notice("Skipping %s for user manager", __func__);
+                return;
+        }
+
+        _cleanup_free_ char *bad = private_directory_bad(m);
+        if (bad) {
+                log_warning("%s: %s has bad permissions, skipping test.", __func__, bad);
+                return;
+        }
+
+        int status = can_unshare ? 0 : EXIT_NAMESPACE;
+
+        test(m, "exec-statedirectory-stdoutput.service", status, CLD_EXITED);
 }
 
 static void test_exec_capabilityboundingset(Manager *m) {
@@ -1364,7 +1376,7 @@ static void run_tests(RuntimeScope scope, char **patterns) {
                 entry(test_exec_readwritepaths),
                 entry(test_exec_restrictnamespaces),
                 entry(test_exec_runtimedirectory),
-                entry(test_exec_runtimedirectory_stdoutput),
+                entry(test_exec_statedirectory_stdoutput),
                 entry(test_exec_specifier),
                 entry(test_exec_standardinput),
                 entry(test_exec_standardoutput),

--- a/src/test/test-execute.c
+++ b/src/test/test-execute.c
@@ -1128,6 +1128,11 @@ static void test_exec_runtimedirectory(Manager *m) {
         test(m, "exec-runtimedirectory-owner-" NOBODY_GROUP_NAME ".service", MANAGER_IS_SYSTEM(m) ? 0 : EXIT_GROUP, CLD_EXITED);
 }
 
+static void test_exec_runtimedirectory_stdoutput(Manager *m) {
+        (void) rm_rf("/run/test-exec_runtimedirectory_standardoutput", REMOVE_ROOT|REMOVE_PHYSICAL);
+        test(m, "exec-runtimedirectory-stdoutput.service", 0, CLD_EXITED);
+}
+
 static void test_exec_capabilityboundingset(Manager *m) {
         int r;
 
@@ -1359,6 +1364,7 @@ static void run_tests(RuntimeScope scope, char **patterns) {
                 entry(test_exec_readwritepaths),
                 entry(test_exec_restrictnamespaces),
                 entry(test_exec_runtimedirectory),
+                entry(test_exec_runtimedirectory_stdoutput),
                 entry(test_exec_specifier),
                 entry(test_exec_standardinput),
                 entry(test_exec_standardoutput),

--- a/test/test-execute/exec-runtimedirectory-stdoutput.service
+++ b/test/test-execute/exec-runtimedirectory-stdoutput.service
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+[Unit]
+Description=Test for RuntimeDirectory used by StandardOutput
+
+[Service]
+ExecStart=sh -c 'printf "hello\nhello\n"'
+Type=oneshot
+RuntimeDirectory=test-exec_runtimedirectory_standardoutput
+StandardOutput=file:/run/test-exec_runtimedirectory_standardoutput/test-exec-runtimedirectory_standardoutput-output

--- a/test/test-execute/exec-runtimedirectory-stdoutput.service
+++ b/test/test-execute/exec-runtimedirectory-stdoutput.service
@@ -1,9 +1,0 @@
-# SPDX-License-Identifier: LGPL-2.1-or-later
-[Unit]
-Description=Test for RuntimeDirectory used by StandardOutput
-
-[Service]
-ExecStart=sh -c 'printf "hello\nhello\n"'
-Type=oneshot
-RuntimeDirectory=test-exec_runtimedirectory_standardoutput
-StandardOutput=file:/run/test-exec_runtimedirectory_standardoutput/test-exec-runtimedirectory_standardoutput-output

--- a/test/test-execute/exec-statedirectory-stdoutput.service
+++ b/test/test-execute/exec-statedirectory-stdoutput.service
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+[Unit]
+Description=Test for StateDirectory used by StandardOutput
+
+[Service]
+ExecStart=sh -c 'printf "hello\nhello\n"'
+Type=oneshot
+DynamicUser=true
+StateDirectory=test-exec_statedirectory_standardoutput
+StandardOutput=file:/var/lib/test-exec_statedirectory_standardoutput/test-exec-statedirectory_standardoutput-output


### PR DESCRIPTION
Users may want to redirect StandardOutput=, StandardInput=, or StandardError= to one of the ExecDirectories, e.g. LogsDirectory=, RuntimeDirectory=, StateDirectory=. This moves the setup of these directories to before the setup of the standard streams.

Fixes #27591
