### PR TITLE
udev: Save/restore the LEDs for the ROG Ally

### DIFF
--- a/rules.d/99-systemd.rules.in
+++ b/rules.d/99-systemd.rules.in
@@ -73,10 +73,10 @@ SUBSYSTEM=="udc", TAG+="systemd", ENV{SYSTEMD_WANTS}+="usb-gadget.target"
 ACTION=="add", SUBSYSTEM=="net", KERNEL!="lo", RUN+="{{LIBEXECDIR}}/systemd-sysctl --prefix=/net/ipv4/conf/$name --prefix=/net/ipv4/neigh/$name --prefix=/net/ipv6/conf/$name --prefix=/net/ipv6/neigh/$name"
 
 {% if ENABLE_BACKLIGHT %}
-# Pull in backlight save/restore for all backlight devices and
-# keyboard backlights
+# Pull in backlight save/restore for all backlight devices,
+# keyboard backlights, and handheld joystick rings
 SUBSYSTEM=="backlight", TAG+="systemd", IMPORT{builtin}="path_id", ENV{SYSTEMD_WANTS}+="systemd-backlight@backlight:$name.service"
-SUBSYSTEM=="leds", KERNEL=="*kbd_backlight*", TAG+="systemd", IMPORT{builtin}="path_id", ENV{SYSTEMD_WANTS}+="systemd-backlight@leds:$name.service"
+SUBSYSTEM=="leds", KERNEL=="*kbd_backlight*|*joystick_rings*", TAG+="systemd", IMPORT{builtin}="path_id", ENV{SYSTEMD_WANTS}+="systemd-backlight@leds:$name.service"
 {% endif %}
 
 # Pull in rfkill save/restore for all rfkill devices


### PR DESCRIPTION
The kernel has a driver for the LEDs around the joystick rings. BIOS defaults to these LEDs enabled from a cold boot. If user set them off, systemd should restore that.

```
P: /devices/pci0000:00/0000:00:08.1/0000:09:00.3/usb1/1-3/1-3:1.2/0003:0B05:1ABE.0003/leds/ally:rgb:joystick_rings
M: ally:rgb:joystick_rings
U: leds
E: DEVPATH=/devices/pci0000:00/0000:00:08.1/0000:09:00.3/usb1/1-3/1-3:1.2/0003:0B05:1ABE.0003/leds/ally:rgb:joystick_rings
E: SUBSYSTEM=leds
E: USEC_INITIALIZED=9275537
E: ID_PATH_WITH_USB_REVISION=pci-0000:09:00.3-usbv2-0:3:1.2
E: ID_PATH=pci-0000:09:00.3-usb-0:3:1.2
E: ID_PATH_TAG=pci-0000_09_00_3-usb-0_3_1_2
E: ID_FOR_SEAT=leds-pci-0000_09_00_3-usb-0_3_1_2
E: TAGS=:seat:
E: CURRENT_TAGS=:seat:
```

Fixes: https://github.com/systemd/systemd/issues/35436
Suggested-by: Yu Watanabe <watanabe.yu+github@gmail.com>