### PR TITLE
Fixes & improvments for using homed-luks on 4k disks

### DIFF
--- a/src/home/homework-luks.c
+++ b/src/home/homework-luks.c
@@ -2365,9 +2365,15 @@ int home_create_luks(
                 image_sector_size = UINT32_MAX;
                 /* Let cryptsetup decide if the sector size is not specified in home record */
                 luks_sector_size = 0;
-        } else
-                luks_sector_size = image_sector_size = user_record_luks_sector_size(h);
-
+        } else {
+                if (S_ISBLK(st.st_mode)) {
+                        /* For physical block devices always use the actual device logical
+                         * sector size. Else the partition will not be discoverable by kernel. */
+                        image_sector_size = UINT32_MAX;
+                        luks_sector_size = user_record_luks_sector_size(h);
+                } else
+                        image_sector_size = luks_sector_size = user_record_luks_sector_size(h);
+        }
         r = make_partition_table(
                         setup->image_fd,
                         image_sector_size,

--- a/src/home/homework-luks.c
+++ b/src/home/homework-luks.c
@@ -1887,7 +1887,7 @@ static int make_partition_table(
         _cleanup_(fdisk_unref_parttypep) struct fdisk_parttype *t = NULL;
         _cleanup_(fdisk_unref_contextp) struct fdisk_context *c = NULL;
         _cleanup_free_ char *disk_uuid_as_string = NULL;
-        uint64_t offset, size, first_lba, start, last_lba, end;
+        uint64_t offset, size, first_lba, start, last_lba, end, fdisk_sector_size;
         sd_id128_t disk_uuid;
         int r;
 
@@ -1924,9 +1924,13 @@ static int make_partition_table(
         if (r < 0)
                 return log_error_errno(r, "Failed to place partition at first free partition index: %m");
 
+        /* Use same sector size as the fdisk context when converting to bytes */
+        fdisk_sector_size = fdisk_get_sector_size(c);
+        assert(fdisk_sector_size > 0);
+
         first_lba = fdisk_get_first_lba(c); /* Boundary where usable space starts */
-        assert(first_lba <= UINT64_MAX/512);
-        start = DISK_SIZE_ROUND_UP(first_lba * 512); /* Round up to multiple of 4K */
+        assert(first_lba <= UINT64_MAX / fdisk_sector_size);
+        start = DISK_SIZE_ROUND_UP(first_lba * fdisk_sector_size);
 
         log_debug("Starting partition at offset %" PRIu64, start);
 
@@ -1934,17 +1938,17 @@ static int make_partition_table(
                 return log_error_errno(SYNTHETIC_ERRNO(ERANGE), "Overflow while rounding up start LBA.");
 
         last_lba = fdisk_get_last_lba(c); /* One sector before boundary where usable space ends */
-        assert(last_lba < UINT64_MAX/512);
-        end = DISK_SIZE_ROUND_DOWN((last_lba + 1) * 512); /* Round down to multiple of 4K */
+        assert(last_lba < UINT64_MAX / fdisk_sector_size);
+        end = DISK_SIZE_ROUND_DOWN((last_lba + 1) * fdisk_sector_size);
 
         if (end <= start)
                 return log_error_errno(SYNTHETIC_ERRNO(ERANGE), "Resulting partition size zero or negative.");
 
-        r = fdisk_partition_set_start(p, start / 512);
+        r = fdisk_partition_set_start(p, start / fdisk_sector_size);
         if (r < 0)
                 return log_error_errno(r, "Failed to place partition at offset %" PRIu64 ": %m", start);
 
-        r = fdisk_partition_set_size(p, (end - start) / 512);
+        r = fdisk_partition_set_size(p, (end - start) / fdisk_sector_size);
         if (r < 0)
                 return log_error_errno(r, "Failed to end partition at offset %" PRIu64 ": %m", end);
 
@@ -1978,16 +1982,16 @@ static int make_partition_table(
 
         assert(fdisk_partition_has_start(q));
         offset = fdisk_partition_get_start(q);
-        if (offset > UINT64_MAX / 512U)
+        if (offset > UINT64_MAX / fdisk_sector_size)
                 return log_error_errno(SYNTHETIC_ERRNO(ERANGE), "Partition offset too large.");
 
         assert(fdisk_partition_has_size(q));
         size = fdisk_partition_get_size(q);
-        if (size > UINT64_MAX / 512U)
+        if (size > UINT64_MAX / fdisk_sector_size)
                 return log_error_errno(SYNTHETIC_ERRNO(ERANGE), "Partition size too large.");
 
-        *ret_offset = offset * 512U;
-        *ret_size = size * 512U;
+        *ret_offset = offset * fdisk_sector_size;
+        *ret_size = size * fdisk_sector_size;
         *ret_disk_uuid = disk_uuid;
 
         return 0;
@@ -2753,6 +2757,7 @@ static int prepare_resize_partition(
         n_partitions = fdisk_table_get_nents(t);
         for (size_t i = 0; i < n_partitions; i++)  {
                 struct fdisk_partition *p;
+                uint64_t fdisk_sector_size;
 
                 p = fdisk_table_get_partition(t, i);
                 if (!p)
@@ -2763,14 +2768,16 @@ static int prepare_resize_partition(
                 if (fdisk_partition_has_start(p) <= 0 || fdisk_partition_has_size(p) <= 0 || fdisk_partition_has_end(p) <= 0)
                         return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "Found partition without a size.");
 
-                if (fdisk_partition_get_start(p) == partition_offset / 512U &&
-                    fdisk_partition_get_size(p) == old_partition_size / 512U) {
+                fdisk_sector_size = fdisk_get_sector_size(c);
+                assert(fdisk_sector_size > 0);
+                if (fdisk_partition_get_start(p) == partition_offset / fdisk_sector_size &&
+                    fdisk_partition_get_size(p) == old_partition_size / fdisk_sector_size) {
 
                         if (found)
                                 return log_error_errno(SYNTHETIC_ERRNO(ENOTUNIQ), "Partition found twice, refusing.");
 
                         found = p;
-                } else if (fdisk_partition_get_end(p) > partition_offset / 512U)
+                } else if (fdisk_partition_get_end(p) > partition_offset / fdisk_sector_size)
                         return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "Can't extend, not last partition in image.");
         }
 
@@ -2790,7 +2797,7 @@ static int get_maximum_partition_size(
                 uint64_t *ret_maximum_partition_size) {
 
         _cleanup_(fdisk_unref_contextp) struct fdisk_context *c = NULL;
-        uint64_t start_lba, start, last_lba, end;
+        uint64_t start_lba, start, last_lba, end, fdisk_sector_size;
         int r;
 
         assert(fd >= 0);
@@ -2801,13 +2808,15 @@ static int get_maximum_partition_size(
         if (r < 0)
                 return log_error_errno(r, "Failed to create fdisk context: %m");
 
+        /* Get the probed sector size by fdisk */
+        fdisk_sector_size = fdisk_get_sector_size(c);
         start_lba = fdisk_partition_get_start(p);
-        assert(start_lba <= UINT64_MAX/512);
-        start = start_lba * 512;
+        assert(start_lba <= UINT64_MAX / fdisk_sector_size);
+        start = start_lba * fdisk_sector_size;
 
         last_lba = fdisk_get_last_lba(c); /* One sector before boundary where usable space ends */
-        assert(last_lba < UINT64_MAX/512);
-        end = DISK_SIZE_ROUND_DOWN((last_lba + 1) * 512); /* Round down to multiple of 4K */
+        assert(last_lba < UINT64_MAX / fdisk_sector_size);
+        end = DISK_SIZE_ROUND_DOWN((last_lba + 1) * fdisk_sector_size);
 
         if (start > end)
                 return log_error_errno(SYNTHETIC_ERRNO(EBADMSG), "Last LBA is before partition start.");
@@ -2860,15 +2869,6 @@ static int apply_resize_partition(
 
         assert(p);
 
-        /* Before writing our partition patch the final size in */
-        r = fdisk_partition_size_explicit(p, 1);
-        if (r < 0)
-                return log_error_errno(r, "Failed to enable explicit partition size: %m");
-
-        r = fdisk_partition_set_size(p, new_partition_size / 512U);
-        if (r < 0)
-                return log_error_errno(r, "Failed to change partition size: %m");
-
         r = probe_sector_size(fd, &ssz);
         if (r < 0)
                 return log_error_errno(r, "Failed to determine current sector size: %m");
@@ -2887,6 +2887,15 @@ static int apply_resize_partition(
         r = fdisk_new_context_at(fd, /* path= */ NULL, /* read_only= */ false, ssz, &c);
         if (r < 0)
                 return log_error_errno(r, "Failed to open device: %m");
+
+        /* Before writing our partition patch the final size in */
+        r = fdisk_partition_size_explicit(p, 1);
+        if (r < 0)
+                return log_error_errno(r, "Failed to enable explicit partition size: %m");
+
+        r = fdisk_partition_set_size(p, new_partition_size / ssz);
+        if (r < 0)
+                return log_error_errno(r, "Failed to change partition size: %m");
 
         r = fdisk_create_disklabel(c, "gpt");
         if (r < 0)
@@ -3472,6 +3481,7 @@ int home_resize_luks(
                         (void) reread_partition_table_fd(image_fd, /* flags= */ 0);
 
                 /* Tell LUKS about the new bigger size too */
+                /* libcrypsetup uses units of 512B sectors for size */
                 r = sym_crypt_resize(setup->crypt_device, setup->dm_name, new_fs_size / 512U);
                 if (r < 0)
                         return log_error_errno(r, "Failed to grow LUKS device: %m");
@@ -3536,7 +3546,8 @@ int home_resize_luks(
         if (new_fs_size < old_fs_size) { /* → Shrink */
 
                 /* Shrink the LUKS device now, matching the new file system size */
-                r = sym_crypt_resize(setup->crypt_device, setup->dm_name, new_fs_size / 512);
+                /* libcrypsetup uses units of 512B sectors for size */
+                r = sym_crypt_resize(setup->crypt_device, setup->dm_name, new_fs_size / 512U);
                 if (r < 0)
                         return log_error_errno(r, "Failed to shrink LUKS device: %m");
 

--- a/src/home/homework-luks.c
+++ b/src/home/homework-luks.c
@@ -1755,6 +1755,7 @@ static int luks_format(
                 const PasswordCache *cache,
                 char **effective_passwords,
                 bool discard,
+                uint64_t sector_size,
                 UserRecord *hr,
                 struct crypt_device **ret) {
 
@@ -1809,7 +1810,7 @@ static int luks_format(
                         &(struct crypt_params_luks2) {
                                 .label = label,
                                 .subsystem = "systemd-home",
-                                .sector_size = user_record_luks_sector_size(hr),
+                                .sector_size = sector_size, /* sector-size of 0 is auto for libcryptsetup */
                                 .pbkdf = &good_pbkdf,
                         });
         if (r < 0)
@@ -2166,7 +2167,7 @@ int home_create_luks(
                 UserRecord **ret_home) {
 
         _cleanup_free_ char *subdir = NULL, *disk_uuid_path = NULL;
-        uint64_t encrypted_size,
+        uint64_t encrypted_size, image_sector_size, luks_sector_size,
                 host_size = 0, partition_offset = 0, partition_size = 0; /* Unnecessary initialization to appease gcc */
         _cleanup_(user_record_unrefp) UserRecord *new_home = NULL;
         sd_id128_t partition_uuid, fs_uuid, luks_uuid, disk_uuid;
@@ -2337,9 +2338,17 @@ int home_create_luks(
                 log_info("Allocating image file completed.");
         }
 
+        if (h->luks_sector_size == UINT64_MAX) {
+                /* If sector size is not specified, select UINT32_MAX, i.e. auto-probe */
+                image_sector_size = UINT32_MAX;
+                /* Let cryptsetup decide if the sector size is not specified in home record */
+                luks_sector_size = 0;
+        } else
+                luks_sector_size = image_sector_size = user_record_luks_sector_size(h);
+
         r = make_partition_table(
                         setup->image_fd,
-                        user_record_luks_sector_size(h),
+                        image_sector_size,
                         user_record_user_name_and_realm(h),
                         partition_uuid,
                         &partition_offset,
@@ -2355,7 +2364,7 @@ int home_create_luks(
                         O_RDWR,
                         partition_offset,
                         partition_size,
-                        user_record_luks_sector_size(h),
+                        image_sector_size,
                         0,
                         LOCK_EX,
                         &setup->loop);
@@ -2375,6 +2384,7 @@ int home_create_luks(
                         cache,
                         effective_passwords,
                         user_record_luks_discard(h) || user_record_luks_offline_discard(h),
+                        luks_sector_size,
                         h,
                         &setup->crypt_device);
         if (r < 0)

--- a/src/home/homework-luks.c
+++ b/src/home/homework-luks.c
@@ -66,16 +66,16 @@
 #include "user-record.h"
 #include "user-util.h"
 
-/* Round down to the nearest 4K size. Given that newer hardware generally prefers 4K sectors, let's align our
- * partitions to that too. In the worst case we'll waste 3.5K per partition that way, but I think I can live
+/* Round down to the nearest 1 MiB size. Given that most tools generally align partitions to 1 MiB boundaries, let's align our
+ * partitions to that too. In the worst case we'll waste 1 MiB per partition that way, but I think I can live
  * with that. */
-#define DISK_SIZE_ROUND_DOWN(x) ((x) & ~UINT64_C(4095))
+#define DISK_SIZE_ROUND_DOWN(x) ((x) & ~(U64_MB - 1))
 
-/* Rounds up to the nearest 4K boundary. Returns UINT64_MAX on overflow */
+/* Rounds up to the nearest 1 MiB boundary. Returns UINT64_MAX on overflow */
 #define DISK_SIZE_ROUND_UP(x)                                           \
         ({                                                              \
                 uint64_t _x = (x);                                      \
-                _x > UINT64_MAX - 4095U ? UINT64_MAX : (_x + 4095U) & ~UINT64_C(4095); \
+                _x > UINT64_MAX - (U64_MB - 1) ? UINT64_MAX : (DISK_SIZE_ROUND_DOWN(_x + U64_MB - 1)); \
         })
 
 /* How much larger will the image on disk be than the fs inside it, i.e. the space we pay for the GPT and


### PR DESCRIPTION
Mostly consists of fixes to 

- use the same sector_size as the fdisk context we are using, when converting between sectors returned by libfdisk to bytes. Fixes #30394 , Fixes #30393 
- Use the explicit sector size if specified in the home record when are probing the image file using libblkid. Fixes #30393 

Also contains some other improvements with using physical block devices.

- Automatically probe sector size of physical block device, if user does not pass luks-sector-size explicitly.
- Assign partitions to 1 MiB boundaries, as it is the standard practice followed by all tools, fdisk, gptfdisk, gnu parted etc.
- Avoid stacking of loop device on top of physical block device in home_create_luks as it leads to degradation of discard operations, and mkfs getting stuck.