### PR TITLE
resolved: allow cache size to be tunable

### DIFF
--- a/man/resolved.conf.xml
+++ b/man/resolved.conf.xml
@@ -302,6 +302,15 @@
       </varlistentry>
 
       <varlistentry>
+        <term><varname>CacheSize=</varname></term>
+        <listitem><para>Takes an unsigned integer as argument. Specifies the maximum number of DNS resource records that
+        can be stored in the cache. Note that each scope maintains its own independent cache. The default value is 4096
+        entries per cache.</para>
+
+        <xi:include href="version-info.xml" xpointer="v258"/></listitem>
+      </varlistentry>
+
+      <varlistentry>
         <term><varname>DNSStubListener=</varname></term>
         <listitem><para>Takes a boolean argument or one of <literal>udp</literal> and
         <literal>tcp</literal>. If <literal>udp</literal>, a DNS stub resolver will listen for UDP requests
@@ -373,7 +382,7 @@ DNSStubListenerExtra=udp:[2001:db8:0:f102::13]:9953</programlisting>
         <xi:include href="version-info.xml" xpointer="v246"/></listitem>
       </varlistentry>
       <varlistentry>
-        <term>StaleRetentionSec=<replaceable>SECONDS</replaceable></term>
+        <term><varname>StaleRetentionSec=</varname><replaceable>SECONDS</replaceable></term>
         <listitem><para>Takes a duration value, which determines the length of time DNS resource records can
         be retained in the cache beyond their Time To Live (TTL). This allows these records to be returned as
         stale records. By default, this value is set to zero, meaning that DNS resource records are not

--- a/src/resolve/resolved-dns-cache.h
+++ b/src/resolve/resolved-dns-cache.h
@@ -8,9 +8,14 @@
 #include "resolved-dns-dnssec.h"
 #include "time-util.h"
 
+/* RFC 1536, Section 5 suggests to leave DNS caches unbounded,
+ * but that's crazy. */
+#define DEFAULT_CACHE_SIZE 4096
+
 typedef struct DnsCache {
         Hashmap *by_key;
         Prioq *by_expiry;
+        unsigned max_size;
         unsigned n_hit;
         unsigned n_miss;
 } DnsCache;

--- a/src/resolve/resolved-dns-scope.c
+++ b/src/resolve/resolved-dns-scope.c
@@ -44,6 +44,10 @@ int dns_scope_new(Manager *m, DnsScope **ret, Link *l, DnsProtocol protocol, int
                 .family = family,
                 .resend_timeout = MULTICAST_RESEND_TIMEOUT_MIN_USEC,
 
+                .cache = {
+                        .max_size = m->cache_size_per_scope,
+                },
+
                 /* Enforce ratelimiting for the multicast protocols */
                 .ratelimit = { MULTICAST_RATELIMIT_INTERVAL_USEC, MULTICAST_RATELIMIT_BURST },
         };

--- a/src/resolve/resolved-gperf.gperf
+++ b/src/resolve/resolved-gperf.gperf
@@ -34,3 +34,4 @@ Resolve.ResolveUnicastSingleLabel, config_parse_bool,                    0,     
 Resolve.DNSStubListenerExtra,      config_parse_dns_stub_listener_extra, 0,                   offsetof(Manager, dns_extra_stub_listeners)
 Resolve.CacheFromLocalhost,        config_parse_bool,                    0,                   offsetof(Manager, cache_from_localhost)
 Resolve.StaleRetentionSec,         config_parse_sec,                     0,                   offsetof(Manager, stale_retention_usec)
+Resolve.CacheSize,                 config_parse_unsigned,                DEFAULT_CACHE_SIZE,  offsetof(Manager, cache_size_per_scope)

--- a/src/resolve/resolved-manager.c
+++ b/src/resolve/resolved-manager.c
@@ -584,6 +584,7 @@ static void manager_set_defaults(Manager *m) {
         m->resolve_unicast_single_label = false;
         m->cache_from_localhost = false;
         m->stale_retention_usec = 0;
+        m->cache_size_per_scope = DEFAULT_CACHE_SIZE;
 }
 
 static int manager_dispatch_reload_signal(sd_event_source *s, const struct signalfd_siginfo *si, void *userdata) {

--- a/src/resolve/resolved-manager.h
+++ b/src/resolve/resolved-manager.h
@@ -42,6 +42,7 @@ struct Manager {
         DnsOverTlsMode dns_over_tls_mode;
         DnsCacheMode enable_cache;
         bool cache_from_localhost;
+        unsigned cache_size_per_scope;
         DnsStubListenerMode dns_stub_listener_mode;
         usec_t stale_retention_usec;
 

--- a/src/resolve/resolved.conf.in
+++ b/src/resolve/resolved.conf.in
@@ -29,6 +29,7 @@
 #MulticastDNS={{DEFAULT_MDNS_MODE_STR}}
 #LLMNR={{DEFAULT_LLMNR_MODE_STR}}
 #Cache=yes
+#CacheSize=4096
 #CacheFromLocalhost=no
 #DNSStubListener=yes
 #DNSStubListenerExtra=

--- a/src/resolve/test-dns-cache.c
+++ b/src/resolve/test-dns-cache.c
@@ -18,7 +18,9 @@
 #include "tmpfile-util.h"
 
 static DnsCache new_cache(void) {
-        return (DnsCache) {};
+        return (DnsCache) {
+                .max_size = DEFAULT_CACHE_SIZE,
+        };
 }
 
 typedef struct PutArgs {

--- a/test/fuzz/fuzz-unit-file/directives-all.service
+++ b/test/fuzz/fuzz-unit-file/directives-all.service
@@ -408,6 +408,7 @@ Bridge=
 Broadcast=
 Cache=
 CacheFromLocalhost=
+CacheSize=
 ClientIdentifier=
 ConfigureWithoutCarrier=
 CopyDSCP=


### PR DESCRIPTION
This change adds CacheSize= option to resolved.conf that allows adjusting systemd-resolved DNS cache size.

Supersedes #26078