### PR TITLE
mkfs-util: Drop btrfs workaround

### DIFF
--- a/mkosi.extra/usr/lib/repart.d/usr.conf
+++ b/mkosi.extra/usr/lib/repart.d/usr.conf
@@ -1,0 +1,3 @@
+[Partition]
+Type=usr
+Format=btrfs

--- a/mkosi.repart/10-root.conf
+++ b/mkosi.repart/10-root.conf
@@ -2,7 +2,7 @@
 
 [Partition]
 Type=root
-Format=ext4
+Format=btrfs
 CopyFiles=/
 SizeMinBytes=8G
 SizeMaxBytes=8G


### PR DESCRIPTION
To reproduce the bug for which this workaround was introduced, run
the following:

```
$ git clone https://github.com/systemd/mkosi
$ ln -sf $PWD/mkosi/bin/mkosi /usr/local/bin/mkosi
$ git clone https://github.com/DaanDeMeyer/systemd --branch btrfs-bug
$ cd systemd
$ mkosi -f genkey
$ mkosi -f sandbox meson setup build
$ mkosi -f sandbox meson compile -C build mkosi
$ mkosi --runtime-size=16G boot
Failed to mount image: No such file or directory
‣ "systemd-repart --image /work/home/daandemeyer/projects/systemd/tmp/systemd/build/mkosi.output/image --no-pager --dry-run=no --offline=no --pretty=no /work/home/daandemeyer/projects/systemd/tmp/systemd/build/mkosi.output/image" returned non-zero exit code 1.
Feb 04 17:04:57 daandemeyer-fedora-PC1EV17T kernel: BTRFS error: failed to lookup block device for path /loop0p2: -2
```