### PR TITLE
Enables alternate manifest names

### DIFF
--- a/man/sysupdate.d.xml
+++ b/man/sysupdate.d.xml
@@ -595,15 +595,23 @@
 
         <para>If the source type is selected as <constant>url-file</constant> or
         <constant>url-tar</constant> this must be a HTTP/HTTPS URL. The URL is suffixed with
-        <filename>/SHA256SUMS</filename> to acquire the manifest file, with
-        <filename>/SHA256SUMS.gpg</filename> to acquire the detached signature file for it, and with the file
-        names listed in the manifest file in case an update is executed and a resource shall be
-        downloaded.</para>
+        the value assigned to the <varname>ManifestFile</varname> variable.</para>
 
         <para>For all other source resource types this must be a local path in the file system, referring to
         a local directory to find the versions of this resource in.</para>
 
         <xi:include href="version-info.xml" xpointer="v251"/></listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term><varname>ManifestFile=</varname></term>
+
+        <listitem><para>Specifies the filename of the manifest. Defaults to <filename>SHA256SUMS</filename>.
+        This is intended only as a fallback override. Extension maintainers should provide a
+        <filename>SHA256SUMS</filename> file and a corresponding <filename>SHA256SUMS.gpg</filename>
+        for verification</para>
+
+        <xi:include href="version-info.xml" xpointer="v258"/></listitem>
       </varlistentry>
 
       <varlistentry>

--- a/src/sysupdate/sysupdate-resource.c
+++ b/src/sysupdate/sysupdate-resource.c
@@ -34,6 +34,7 @@ void resource_destroy(Resource *rr) {
         assert(rr);
 
         free(rr->path);
+        free(rr->manifest);
         strv_free(rr->patterns);
 
         for (size_t i = 0; i < rr->n_instances; i++)
@@ -263,11 +264,12 @@ static int resource_load_from_blockdev(Resource *rr) {
 
 static int download_manifest(
                 const char *url,
+                const char *manifest_file,
                 bool verify_signature,
                 char **ret_buffer,
                 size_t *ret_size) {
 
-        _cleanup_free_ char *buffer = NULL, *suffixed_url = NULL;
+        _cleanup_free_ char *buffer = NULL, *suffixed_url = NULL;;
         _cleanup_close_pair_ int pfd[2] = EBADF_PAIR;
         _cleanup_fclose_ FILE *manifest = NULL;
         size_t size = 0;
@@ -278,11 +280,13 @@ static int download_manifest(
         assert(ret_buffer);
         assert(ret_size);
 
+
         /* Download a SHA256SUMS file as manifest */
 
-        r = import_url_append_component(url, "SHA256SUMS", &suffixed_url);
+        r = import_url_append_component(url, manifest_file ?: "SHA256SUMS" , &suffixed_url);
+
         if (r < 0)
-                return log_error_errno(r, "Failed to append SHA256SUMS to URL: %m");
+                return log_error_errno(r, "Failed to append manifest name to URL: %m");
 
         if (pipe2(pfd, O_CLOEXEC) < 0)
                 return log_error_errno(errno, "Failed to allocate pipe: %m");
@@ -369,7 +373,7 @@ static int resource_load_from_web(
         } else {
                 log_debug("Manifest web cache miss for %s.", rr->path);
 
-                r = download_manifest(rr->path, verify, &buf, &manifest_size);
+                r = download_manifest(rr->path, rr->manifest, verify, &buf, &manifest_size);
                 if (r < 0)
                         return r;
 

--- a/src/sysupdate/sysupdate-resource.h
+++ b/src/sysupdate/sysupdate-resource.h
@@ -85,6 +85,7 @@ struct Resource {
         char *path;
         bool path_auto; /* automatically find root path (only available if target resource, not source resource) */
         PathRelativeTo path_relative_to;
+        char *manifest; /* Manifest file name (Default: SHA256SUMS)*/
         char **patterns;
         GptPartitionType partition_type;
         bool partition_type_set;

--- a/src/sysupdate/sysupdate-transfer.c
+++ b/src/sysupdate/sysupdate-transfer.c
@@ -504,6 +504,7 @@ int transfer_read_definition(Transfer *t, const char *path, const char **dirs, H
                 { "Transfer",    "RequisiteFeatures",       config_parse_strv,                 0, &t->requisite_features      },
                 { "Source",      "Type",                    config_parse_resource_type,        0, &t->source.type             },
                 { "Source",      "Path",                    config_parse_resource_path,        0, &t->source                  },
+                { "Source",      "ManifestFile",            config_parse_string,               0, &t->source.manifest         },
                 { "Source",      "PathRelativeTo",          config_parse_resource_path_relto,  0, &t->source.path_relative_to },
                 { "Source",      "MatchPattern",            config_parse_resource_pattern,     0, &t->source.patterns         },
                 { "Target",      "Type",                    config_parse_resource_type,        0, &t->target.type             },


### PR DESCRIPTION
Allows fetching alternate manifest names with the Manifest variable. Disables verification if Manifest name is not SHA256SUMS as it is not known and accepted by systemd pull-common code. 

Fixes: #36534 