### PR TITLE
selinux: relax error handling in permissive mode

### DIFF
--- a/src/core/service.c
+++ b/src/core/service.c
@@ -6294,17 +6294,17 @@ int service_determine_exec_selinux_label(Service *s, char **ret) {
         else
                 r = chase(c->path, s->exec_context.root_directory, CHASE_PREFIX_ROOT|CHASE_TRIGGER_AUTOFS, &path, NULL);
         if (r < 0) {
-                log_unit_debug_errno(UNIT(s), r, "Failed to resolve service binary '%s', ignoring.", c->path);
+                log_unit_debug_errno(UNIT(s), r, "Failed to resolve service binary '%s', ignoring: %m", c->path);
                 return -ENODATA;
         }
 
         r = mac_selinux_get_create_label_from_exe(path, ret);
         if (ERRNO_IS_NEG_NOT_SUPPORTED(r)) {
-                log_unit_debug_errno(UNIT(s), r, "Reading SELinux label off binary '%s' is not supported, ignoring.", path);
+                log_unit_debug_errno(UNIT(s), r, "Reading SELinux label off binary '%s' is not supported, ignoring: %m", path);
                 return -ENODATA;
         }
         if (ERRNO_IS_NEG_PRIVILEGE(r)) {
-                log_unit_debug_errno(UNIT(s), r, "Can't read SELinux label off binary '%s', due to privileges, ignoring.", path);
+                log_unit_debug_errno(UNIT(s), r, "Can't read SELinux label off binary '%s', due to privileges, ignoring: %m", path);
                 return -ENODATA;
         }
         if (r < 0) {

--- a/src/core/service.c
+++ b/src/core/service.c
@@ -6307,9 +6307,13 @@ int service_determine_exec_selinux_label(Service *s, char **ret) {
                 log_unit_debug_errno(UNIT(s), r, "Can't read SELinux label off binary '%s', due to privileges, ignoring.", path);
                 return -ENODATA;
         }
-        if (r < 0)
-                return log_unit_debug_errno(UNIT(s), r, "Failed to read SELinux label off binary '%s': %m", path);
+        if (r < 0) {
+                if (mac_selinux_enforcing())
+                        return log_unit_debug_errno(UNIT(s), r, "Failed to read SELinux label off binary '%s': %m", path);
 
+                log_unit_debug_errno(UNIT(s), r, "Failed to read SELinux label off binary '%s', SELinux in permissive mode, ignoring: %m", path);
+                return -ENODATA;
+        }
         return 0;
 }
 


### PR DESCRIPTION
Error returned from security_compute_create_raw() means that kernel couldn't compute target context. Very likely because file context is not known to the policy, i.e. security.selinux xattr contains some garbage value and we are running in permissive mode, otherwise returned context would be "unlabeled_t" instead of getting an error.

mac_selinux_get_create_label_from_exe() is used to figure out create label for socket units and we fail to start the socket if we can't figure out that label.

However, it may be necessary to start some sockets in order to get to the point when we launch the service that relabels (in permissive mode) the entire filesystem and reboots.