### PR TITLE
units: enable IgnoreOnIsolate=yes on systemd-udevd-kernel.socket

### DIFF
--- a/units/systemd-udevd-kernel.socket
+++ b/units/systemd-udevd-kernel.socket
@@ -14,6 +14,11 @@ DefaultDependencies=no
 Before=sockets.target
 ConditionPathIsReadWrite=/sys
 
+# To prevent loss of kernel events from isolate requests. This is important on
+# switching root, as otherwise the unit is stopped by initrd-cleanup.service,
+# and several early events after switching root may be lost.
+IgnoreOnIsolate=yes
+
 [Socket]
 Service=systemd-udevd.service
 ReceiveBuffer=128M


### PR DESCRIPTION
Otherwise, initrd-cleanup.service requests isolation thus the socket is stopped before switching root, and several early events after switching root may be lost.