### PR TITLE
core: Use LOG_CONTEXT_PUSH_UNIT() more

### DIFF
--- a/src/core/cgroup.c
+++ b/src/core/cgroup.c
@@ -2559,6 +2559,8 @@ static int unit_realize_cgroup_now(Unit *u, ManagerState state) {
 
         assert(u);
 
+        LOG_CONTEXT_PUSH_UNIT(u);
+
         unit_remove_from_cgroup_realize_queue(u);
 
         target_mask = unit_get_target_mask(u);

--- a/src/core/dbus-manager.c
+++ b/src/core/dbus-manager.c
@@ -1000,6 +1000,8 @@ static int transient_unit_from_message(
         if (r < 0)
                 return r;
 
+        LOG_CONTEXT_PUSH_UNIT(u);
+
         if (!unit_is_pristine(u))
                 return sd_bus_error_setf(error, BUS_ERROR_UNIT_EXISTS,
                                          "Unit %s was already loaded or has a fragment file.", name);
@@ -1107,6 +1109,8 @@ static int method_start_transient_unit(sd_bus_message *message, void *userdata, 
         r = transient_unit_from_message(m, message, name, &u, error);
         if (r < 0)
                 return r;
+
+        LOG_CONTEXT_PUSH_UNIT(u);
 
         r = transient_aux_units_from_message(m, message, error);
         if (r < 0)
@@ -2772,6 +2776,8 @@ static int method_abandon_scope(sd_bus_message *message, void *userdata, sd_bus_
         r = bus_get_unit_by_name(m, message, name, &u, error);
         if (r < 0)
                 return r;
+
+        LOG_CONTEXT_PUSH_UNIT(u);
 
         if (u->type != UNIT_SCOPE)
                 return sd_bus_error_setf(error, SD_BUS_ERROR_INVALID_ARGS,

--- a/src/core/dbus-unit.c
+++ b/src/core/dbus-unit.c
@@ -389,6 +389,8 @@ int bus_unit_method_start_generic(
         assert(u);
         assert(job_type >= 0 && job_type < _JOB_TYPE_MAX);
 
+        LOG_CONTEXT_PUSH_UNIT(u);
+
         r = mac_selinux_unit_access_check(
                         u, message,
                         job_type_to_access_method(job_type),
@@ -474,6 +476,8 @@ int bus_unit_method_enqueue_job(sd_bus_message *message, void *userdata, sd_bus_
 
         assert(message);
 
+        LOG_CONTEXT_PUSH_UNIT(u);
+
         r = sd_bus_message_read(message, "ss", &jtype, &smode);
         if (r < 0)
                 return r;
@@ -526,6 +530,8 @@ int bus_unit_method_kill(sd_bus_message *message, void *userdata, sd_bus_error *
         int r, code;
 
         assert(message);
+
+        LOG_CONTEXT_PUSH_UNIT(u);
 
         r = mac_selinux_unit_access_check(u, message, "stop", error);
         if (r < 0)
@@ -583,6 +589,8 @@ int bus_unit_method_reset_failed(sd_bus_message *message, void *userdata, sd_bus
 
         assert(message);
 
+        LOG_CONTEXT_PUSH_UNIT(u);
+
         r = mac_selinux_unit_access_check(u, message, "reload", error);
         if (r < 0)
                 return r;
@@ -608,6 +616,8 @@ int bus_unit_method_set_properties(sd_bus_message *message, void *userdata, sd_b
         int runtime, r;
 
         assert(message);
+
+        LOG_CONTEXT_PUSH_UNIT(u);
 
         r = mac_selinux_unit_access_check(u, message, "start", error);
         if (r < 0)
@@ -641,6 +651,8 @@ int bus_unit_method_ref(sd_bus_message *message, void *userdata, sd_bus_error *e
 
         assert(message);
 
+        LOG_CONTEXT_PUSH_UNIT(u);
+
         r = mac_selinux_unit_access_check(u, message, "start", error);
         if (r < 0)
                 return r;
@@ -669,6 +681,8 @@ int bus_unit_method_unref(sd_bus_message *message, void *userdata, sd_bus_error 
 
         assert(message);
 
+        LOG_CONTEXT_PUSH_UNIT(u);
+
         r = bus_unit_track_remove_sender(u, message);
         if (r == -EUNATCH)
                 return sd_bus_error_set(error, BUS_ERROR_NOT_REFERENCED, "Unit has not been referenced yet.");
@@ -684,6 +698,8 @@ int bus_unit_method_clean(sd_bus_message *message, void *userdata, sd_bus_error 
         int r;
 
         assert(message);
+
+        LOG_CONTEXT_PUSH_UNIT(u);
 
         r = mac_selinux_unit_access_check(u, message, "stop", error);
         if (r < 0)
@@ -744,6 +760,8 @@ static int bus_unit_method_freezer_generic(sd_bus_message *message, void *userda
 
         assert(message);
         assert(IN_SET(action, FREEZER_FREEZE, FREEZER_THAW));
+
+        LOG_CONTEXT_PUSH_UNIT(u);
 
         const char *perm = action == FREEZER_FREEZE ? "stop" : "start";
 
@@ -1342,10 +1360,12 @@ static int append_cgroup(sd_bus_message *reply, const char *p, Set *pids) {
 int bus_unit_method_get_processes(sd_bus_message *message, void *userdata, sd_bus_error *error) {
         _cleanup_(sd_bus_message_unrefp) sd_bus_message *reply = NULL;
         _cleanup_set_free_ Set *pids = NULL;
-        Unit *u = userdata;
+        Unit *u = ASSERT_PTR(userdata);
         int r;
 
         assert(message);
+
+        LOG_CONTEXT_PUSH_UNIT(u);
 
         r = mac_selinux_unit_access_check(u, message, "status", error);
         if (r < 0)
@@ -1461,11 +1481,13 @@ static int property_get_effective_limit(
 int bus_unit_method_attach_processes(sd_bus_message *message, void *userdata, sd_bus_error *error) {
         _cleanup_(sd_bus_creds_unrefp) sd_bus_creds *creds = NULL;
         _cleanup_set_free_ Set *pids = NULL;
-        Unit *u = userdata;
+        Unit *u = ASSERT_PTR(userdata);
         const char *path;
         int r;
 
         assert(message);
+
+        LOG_CONTEXT_PUSH_UNIT(u);
 
         /* This migrates the processes with the specified PIDs into the cgroup of this unit, optionally below a
          * specified cgroup path. Obviously this only works for units that actually maintain a cgroup
@@ -1578,6 +1600,8 @@ int bus_unit_method_remove_subgroup(sd_bus_message *message, void *userdata, sd_
         int r;
 
         assert(message);
+
+        LOG_CONTEXT_PUSH_UNIT(u);
 
         /* This removes a subcgroup of the unit, regardless which user owns the subcgroup. This is useful
          * when cgroup delegation is enabled for a unit, and the unit subdelegates the cgroup further */

--- a/src/core/job.c
+++ b/src/core/job.c
@@ -1016,6 +1016,8 @@ int job_finish_and_invalidate(Job *j, JobResult result, bool recursive, bool alr
 
         j->result = result;
 
+        LOG_CONTEXT_PUSH_UNIT(u);
+
         log_unit_debug(u, "Job %" PRIu32 " %s/%s finished, result=%s",
                        j->id, u->id, job_type_to_string(t), job_result_to_string(result));
 

--- a/src/core/manager.c
+++ b/src/core/manager.c
@@ -2099,6 +2099,8 @@ int manager_add_job_full(
         assert(mode >= 0 && mode < _JOB_MODE_MAX);
         assert((extra_flags & ~_TRANSACTION_FLAGS_MASK_PUBLIC) == 0);
 
+        LOG_CONTEXT_PUSH_UNIT(unit);
+
         if (mode == JOB_ISOLATE && type != JOB_START)
                 return sd_bus_error_set(error, SD_BUS_ERROR_INVALID_ARGS, "Isolate is only valid for start.");
 

--- a/src/core/unit.c
+++ b/src/core/unit.c
@@ -397,6 +397,8 @@ void unit_release_resources(Unit *u) {
         if (u->perpetual)
                 return;
 
+        LOG_CONTEXT_PUSH_UNIT(u);
+
         state = unit_active_state(u);
         if (!UNIT_IS_INACTIVE_OR_FAILED(state))
                 return;


### PR DESCRIPTION
Let's make sure the log context is populated with the fields of the unit we're currently operating on in various key functions so that all log messages, even those from library code have the unit's log fields attached to them.