### PR TITLE
kernel-install: silence output in plugins if VERBOSE is not set

### DIFF
--- a/src/kernel-install/50-depmod.install
+++ b/src/kernel-install/50-depmod.install
@@ -30,12 +30,12 @@ case "$COMMAND" in
         [ -d "/lib/modules/$KERNEL_VERSION/kernel" ] || exit 0
         command -v depmod >/dev/null || exit 0
         [ "$KERNEL_INSTALL_VERBOSE" -gt 0 ] && echo "+depmod -a $KERNEL_VERSION"
-        exec depmod -a "$KERNEL_VERSION"
+        depmod -a "$KERNEL_VERSION"
         ;;
     remove)
         [ "$KERNEL_INSTALL_VERBOSE" -gt 0 ] && \
             echo "Removing /lib/modules/${KERNEL_VERSION}/modules.dep and associated files"
-        exec rm -f \
+        rm -f \
             "/lib/modules/$KERNEL_VERSION/modules.alias" \
             "/lib/modules/$KERNEL_VERSION/modules.alias.bin" \
             "/lib/modules/$KERNEL_VERSION/modules.builtin.bin" \
@@ -52,3 +52,5 @@ case "$COMMAND" in
         exit 0
         ;;
 esac
+
+printf "+ kernel-install plugin '%s' completed successfully\n" "$0"

--- a/src/kernel-install/60-ukify.install.in
+++ b/src/kernel-install/60-ukify.install.in
@@ -22,7 +22,10 @@
 import argparse
 import os
 import shlex
+import sys
 import types
+
+from contextlib import contextmanager, nullcontext
 from shutil import which
 from pathlib import Path
 from typing import Optional
@@ -256,6 +259,23 @@ def call_ukify(opts) -> None:
     log(f'{opts2.output} has been created')
 
 
+@contextmanager
+# Silence output when VERBOSE is not set
+def silence_fd():
+    with open(os.devnull, 'w') as devnull:
+        old_stdout_fd = os.dup(1)
+        old_stderr_fd = os.dup(2)
+        try:
+            os.dup2(devnull.fileno(), 1)
+            os.dup2(devnull.fileno(), 2)
+            yield
+        finally:
+            os.dup2(old_stdout_fd, 1)
+            os.dup2(old_stderr_fd, 2)
+            os.close(old_stdout_fd)
+            os.close(old_stderr_fd)
+
+
 def main():
     opts = parse_args()
     if opts.command != 'add':
@@ -263,7 +283,12 @@ def main():
     if not we_are_wanted():
         return
 
-    call_ukify(opts)
+    context = silence_fd() if not VERBOSE else nullcontext()
+    
+    with context:
+        call_ukify(opts)
+
+    print(f"+ kernel-install plugin '{__file__}' completed successfully")
 
 
 if __name__ == '__main__':

--- a/src/kernel-install/90-loaderentry.install.in
+++ b/src/kernel-install/90-loaderentry.install.in
@@ -51,7 +51,7 @@ case "$COMMAND" in
     remove)
         [ "$KERNEL_INSTALL_VERBOSE" -gt 0 ] && \
             echo "Removing ${LOADER_ENTRY%.conf}*.conf"
-        exec rm -f \
+        rm -f \
             "$LOADER_ENTRY" \
             "${LOADER_ENTRY%.conf}"*".conf"
         ;;
@@ -228,4 +228,7 @@ mkdir -p "${LOADER_ENTRY%/*}" || {
     echo "Error: could not create loader entry '$LOADER_ENTRY'." >&2
     exit 1
 }
+
+printf "+ kernel-install plugin '%s' completed successfully\n" "$0"
+
 exit 0

--- a/src/kernel-install/90-uki-copy.install
+++ b/src/kernel-install/90-uki-copy.install
@@ -35,7 +35,7 @@ case "$COMMAND" in
     remove)
         [ "$KERNEL_INSTALL_VERBOSE" -gt 0 ] && \
             echo "Removing $UKI_DIR/$ENTRY_TOKEN-$KERNEL_VERSION*.efi and extras"
-        exec rm -rf \
+        rm -rf \
             "$UKI_DIR/$ENTRY_TOKEN-$KERNEL_VERSION.efi" \
             "$UKI_DIR/$ENTRY_TOKEN-$KERNEL_VERSION.efi.extra.d/" \
             "$UKI_DIR/$ENTRY_TOKEN-$KERNEL_VERSION+"*".efi"
@@ -118,5 +118,7 @@ else
     exit 0
 fi
 chown root:root "$UKI_FILE" || :
+
+printf "+ kernel-install plugin '%s' completed successfully\n" "$0"
 
 exit 0


### PR DESCRIPTION
For those of us _still_ building UKIs locally, quick draft for cleaner kernel-install output. See #30382 and #33976

```
# kernel-install add 6.12.33-1-lts /lib/modules/6.12.33-1-lts/vmlinuz
+ kernel-install plugin '/etc/kernel/install.d/50-depmod.install' completed successfully
+ kernel-install plugin '/etc/kernel/install.d/50-mkinitcpio.install' completed successfully
+ kernel-install plugin '/etc/kernel/install.d/60-ukify.install' completed successfully
+ kernel-install plugin '/etc/kernel/install.d/90-uki-copy.install' completed successfully
```

However I feel like the silencing logic should probably belong in the main kernel-install logic rather than hoping all plugins behave correctly.... 

If cleaner output is desired, the above example requires changes in other plugins, something like: 

```
# diff /etc/kernel/install.d/50-mkosi.install /usr/lib/kernel/install.d/50-mkosi.install 
6d5
< import subprocess
9d7
< 
51a50
> 
96,99c95
<     run(cmdline, stdin=sys.stdin,
<         stdout=None if context.verbose else subprocess.DEVNULL,
<         stderr=None if context.verbose else subprocess.DEVNULL,
<         env=os.environ)
---
>     run(cmdline, stdin=sys.stdin, stdout=sys.stdout, env=os.environ)
103,104d98
< 
<     print(f"+ kernel-install plugin '{__file__}' completed successfully")
```

```
# diff /etc/kernel/install.d/50-mkinitcpio.install /usr/lib/kernel/install.d/50-mkinitcpio.install
38,45c38
< 
< if (( KERNEL_INSTALL_VERBOSE )); then
<     "${GENERATOR_CMD[@]}"
< else
<     "${GENERATOR_CMD[@]}" &>/dev/null
< fi
< 
< printf "+ kernel-install plugin '%s' completed successfully\n" "$0"
---
> "${GENERATOR_CMD[@]}"
```

Thoughts ?