### PR TITLE
Fixes for vscode/intellisense parsing

### DIFF
--- a/src/fundamental/macro-fundamental.h
+++ b/src/fundamental/macro-fundamental.h
@@ -472,7 +472,7 @@ assert_cc(STRLEN(__FILE__) > STRLEN(RELATIVE_SOURCE_PATH) + 1);
 #define PROJECT_FILE (&__FILE__[STRLEN(RELATIVE_SOURCE_PATH) + 1])
 
 /* In GCC 14 (C23) we can force enums to have the right types, and not solely rely on language extensions anymore */
-#if __GNUC__ >= 14 || __STDC_VERSION__ >= 202311L
+#if (__GNUC__ >= 14 || __STDC_VERSION__ >= 202311L) && !defined(__EDG__)
 #  define ENUM_TYPE_S64(id) id : int64_t
 #else
 #  define ENUM_TYPE_S64(id) id

--- a/src/systemd/_sd-common.h
+++ b/src/systemd/_sd-common.h
@@ -26,7 +26,7 @@
 
 /* This is a private header; never even think of including this directly! */
 
-#if defined(__INCLUDE_LEVEL__) && __INCLUDE_LEVEL__ <= 1 && !defined(__COVERITY__) && !defined(__clang_analyzer__)
+#if defined(__INCLUDE_LEVEL__) && __INCLUDE_LEVEL__ <= 1 && !defined(__COVERITY__) && !defined(__clang_analyzer__) && !defined(__INTELLISENSE__)
 #  error "Do not include _sd-common.h directly; it is a private header."
 #endif
 

--- a/src/systemd/_sd-common.h
+++ b/src/systemd/_sd-common.h
@@ -117,7 +117,7 @@ typedef void (*_sd_destroy_t)(void *userdata);
         _SD_##id##_INT64_MAX = INT64_MAX
 
 /* In GCC 14 (C23) we can force enums to have the right types, and not solely rely on language extensions anymore */
-#if ((__GNUC__ >= 14) || (__STDC_VERSION__ >= 202311L)) && !defined(__cplusplus)
+#if ((__GNUC__ >= 14) || (__STDC_VERSION__ >= 202311L)) && !defined(__cplusplus) && !defined(__EDG__)
 #  define _SD_ENUM_TYPE_S64(id) id : int64_t
 #else
 #  define _SD_ENUM_TYPE_S64(id) id


### PR DESCRIPTION
With these two changes the vscode parser works nicely again. Once the EDG frontend adds support for this feature I'll fix it to check for the fixed version like for GCC.