### PR TITLE
resolve: Verify insecure delegations per RFC 6840 Section 4.4

### DIFF
--- a/src/resolve/resolved-dns-dnssec.c
+++ b/src/resolve/resolved-dns-dnssec.c
@@ -1367,7 +1367,7 @@ static int nsec3_hashed_domain_make(DnsResourceRecord *nsec3, const char *domain
  * that there is no proof either way. The latter is the case if a proof of non-existence of a given
  * name uses an NSEC3 record with the opt-out bit set. Lastly, if we are given insufficient NSEC3 records
  * to conclude anything we indicate this by returning NO_RR. */
-static int dnssec_test_nsec3(DnsAnswer *answer, DnsResourceKey *key, DnssecNsecResult *result, bool *authenticated, uint32_t *ttl) {
+static int dnssec_test_nsec3(DnsAnswer *answer, DnsResourceKey *key, DnssecNsecResult *result, bool *authenticated, uint32_t *ttl, bool find_glue) {
         _cleanup_free_ char *next_closer_domain = NULL, *wildcard_domain = NULL;
         const char *zone, *p, *pp = NULL, *wildcard;
         DnsResourceRecord *rr, *enclosure_rr, *zone_rr, *wildcard_rr = NULL;
@@ -1473,8 +1473,8 @@ found_closest_encloser:
                         if (bitmap_isset(enclosure_rr->nsec3.types, DNS_TYPE_SOA))
                                 return -EBADMSG;
                 } else {
-                        if (bitmap_isset(enclosure_rr->nsec3.types, DNS_TYPE_NS) &&
-                            !bitmap_isset(enclosure_rr->nsec3.types, DNS_TYPE_SOA))
+                        if ((bitmap_isset(enclosure_rr->nsec3.types, DNS_TYPE_NS) &&
+                             !bitmap_isset(enclosure_rr->nsec3.types, DNS_TYPE_SOA)) != find_glue)
                                 return -EBADMSG;
                 }
 
@@ -1771,7 +1771,7 @@ static int dnssec_nsec_generate_wildcard(DnsResourceRecord *rr, const char *name
         return 0;
 }
 
-int dnssec_nsec_test(DnsAnswer *answer, DnsResourceKey *key, DnssecNsecResult *result, bool *authenticated, uint32_t *ttl) {
+int dnssec_nsec_test(DnsAnswer *answer, DnsResourceKey *key, DnssecNsecResult *result, bool *authenticated, uint32_t *ttl, bool find_glue) {
         bool have_nsec3 = false, covering_rr_authenticated = false, wildcard_rr_authenticated = false;
         DnsResourceRecord *rr, *covering_rr = NULL, *wildcard_rr = NULL;
         DnsAnswerFlags flags;
@@ -1823,8 +1823,8 @@ int dnssec_nsec_test(DnsAnswer *answer, DnsResourceKey *key, DnssecNsecResult *r
                         } else {
                                 /* For all RR types, ensure that if NS is set SOA is set too, so that we know
                                  * we got the child's NSEC. */
-                                if (bitmap_isset(rr->nsec.types, DNS_TYPE_NS) &&
-                                    !bitmap_isset(rr->nsec.types, DNS_TYPE_SOA))
+                                if ((bitmap_isset(rr->nsec.types, DNS_TYPE_NS) &&
+                                     !bitmap_isset(rr->nsec.types, DNS_TYPE_SOA)) != find_glue)
                                         continue;
                         }
 
@@ -1916,7 +1916,7 @@ int dnssec_nsec_test(DnsAnswer *answer, DnsResourceKey *key, DnssecNsecResult *r
 
         /* OK, this was not sufficient. Let's see if NSEC3 can help. */
         if (have_nsec3)
-                return dnssec_test_nsec3(answer, key, result, authenticated, ttl);
+                return dnssec_test_nsec3(answer, key, result, authenticated, ttl, find_glue);
 
         /* No appropriate NSEC RR found, report this. */
         *result = DNSSEC_NSEC_NO_RR;
@@ -2206,7 +2206,7 @@ int dnssec_nsec3_hash(DnsResourceRecord *nsec3, const char *name, void *ret) {
         return -EOPNOTSUPP;
 }
 
-int dnssec_nsec_test(DnsAnswer *answer, DnsResourceKey *key, DnssecNsecResult *result, bool *authenticated, uint32_t *ttl) {
+int dnssec_nsec_test(DnsAnswer *answer, DnsResourceKey *key, DnssecNsecResult *result, bool *authenticated, uint32_t *ttl, bool find_glue) {
 
         return -EOPNOTSUPP;
 }

--- a/src/resolve/resolved-dns-dnssec.h
+++ b/src/resolve/resolved-dns-dnssec.h
@@ -73,7 +73,7 @@ typedef enum DnssecNsecResult {
         DNSSEC_NSEC_OPTOUT,
 } DnssecNsecResult;
 
-int dnssec_nsec_test(DnsAnswer *answer, DnsResourceKey *key, DnssecNsecResult *result, bool *authenticated, uint32_t *ttl);
+int dnssec_nsec_test(DnsAnswer *answer, DnsResourceKey *key, DnssecNsecResult *result, bool *authenticated, uint32_t *ttl, bool find_glue);
 
 int dnssec_test_positive_wildcard(DnsAnswer *a, const char *name, const char *source, const char *zone, bool *authenticated);
 

--- a/src/resolve/resolved-dns-transaction.c
+++ b/src/resolve/resolved-dns-transaction.c
@@ -2850,6 +2850,39 @@ static int dns_transaction_validate_dnskey_by_ds(DnsTransaction *t) {
         return 0;
 }
 
+/* Evaluate the delegation type expressed in a transaction */
+static int dns_delegation_is_secure(DnsTransaction *t) {
+        int r;
+
+        assert(t);
+
+        /* Check that this is an answer to a query for a DS record */
+        if (dns_transaction_key(t)->type != DNS_TYPE_DS)
+                return -EBADMSG;
+
+        r = dns_answer_match_key(t->answer, dns_transaction_key(t), /* ret_flags = */ NULL);
+        if (r < 0)
+                return r;
+        if (r > 0)
+                return true; /* Secure as DS record present */
+
+        /* The answer didn't contain a DS record, check for proof of an NS record */
+        _cleanup_(dns_resource_key_unrefp) DnsResourceKey *ns =
+                dns_resource_key_new(dns_transaction_key(t)->class, DNS_TYPE_NS, dns_resource_key_name(dns_transaction_key(t)));
+        if (!ns)
+                return -ENOMEM;
+
+        DnssecNsecResult nsec_result;
+        r = dnssec_nsec_test(t->answer, ns, &nsec_result, /* authenticated = */ NULL, /* ttl = */ NULL, /* find_glue = */ true);
+        if (r < 0)
+                return r;
+
+        if (IN_SET(nsec_result, DNSSEC_NSEC_FOUND, DNSSEC_NSEC_OPTOUT))
+                return false; /* Insecure as NS records are present */
+
+        return -EBADMSG; /* Not a delegation as neither DS or NS records are present */
+}
+
 static int dns_transaction_requires_rrsig(DnsTransaction *t, DnsResourceRecord *rr) {
         int r;
 
@@ -2902,7 +2935,11 @@ static int dns_transaction_requires_rrsig(DnsTransaction *t, DnsResourceRecord *
                         if (!FLAGS_SET(dt->answer_query_flags, SD_RESOLVED_AUTHENTICATED))
                                 return false;
 
-                        return dns_answer_match_key(dt->answer, dns_transaction_key(dt), NULL);
+                        r = dns_delegation_is_secure(dt);
+                        if (r < 0)
+                                return r;
+
+                        return r;
                 }
 
                 /* We found nothing that proves this is safe to leave
@@ -2956,7 +2993,11 @@ static int dns_transaction_requires_rrsig(DnsTransaction *t, DnsResourceRecord *
 
                         /* We expect this to be signed when the DS record exists, and don't expect it to be
                          * signed when the DS record is proven not to exist. */
-                        return dns_answer_match_key(dt->answer, dns_transaction_key(dt), NULL);
+                        r = dns_delegation_is_secure(dt);
+                        if (r < 0)
+                                return r;
+
+                        return r;
                 }
 
                 return true;
@@ -2984,7 +3025,11 @@ static int dns_transaction_requires_rrsig(DnsTransaction *t, DnsResourceRecord *
 
                         /* We expect this to be signed when the DS record exists, and don't expect it to be
                          * signed when the DS record is proven not to exist. */
-                        return dns_answer_match_key(dt->answer, dns_transaction_key(dt), NULL);
+                        r = dns_delegation_is_secure(dt);
+                        if (r < 0)
+                                return r;
+
+                        return r;
                 }
 
                 return true;
@@ -3108,7 +3153,10 @@ static int dns_transaction_requires_nsec(DnsTransaction *t) {
 
                 /* We expect this to be signed when the DS record exists, and don't expect it to be signed
                  * when the DS record is proven not to exist. */
-                return dns_answer_match_key(dt->answer, dns_transaction_key(dt), NULL);
+                r = dns_delegation_is_secure(dt);
+                if (r < 0)
+                        return r;
+                return r;
         }
 
         /* If in doubt, require NSEC/NSEC3 */
@@ -3686,7 +3734,7 @@ int dns_transaction_validate_dnssec(DnsTransaction *t) {
                 bool authenticated = false;
 
                 /* Bummer! Let's check NSEC/NSEC3 */
-                r = dnssec_nsec_test(t->answer, dns_transaction_key(t), &nr, &authenticated, &t->answer_nsec_ttl);
+                r = dnssec_nsec_test(t->answer, dns_transaction_key(t), &nr, &authenticated, &t->answer_nsec_ttl, /* find_glue = */ false);
                 if (r < 0)
                         return r;
 


### PR DESCRIPTION
This checks whether a DNSSEC delegation actually has an (unsigned) NS record in the parent zone when verifing an insecure delegation (one where the child is unsigned).

Without this check systemd-resolved could serve bogus records for non apex signed domains.

Fixes https://github.com/systemd/systemd/issues/23955