### PR TITLE
coredump: support new kernel coredump interface

### DIFF
--- a/README
+++ b/README
@@ -79,6 +79,7 @@ REQUIREMENTS:
                      ≥ 6.12 for AT_HANDLE_MNT_ID_UNIQUE
                      ≥ 6.13 for PIDFD_GET_INFO and {set,remove}xattrat()
                      ≥ 6.16 for coredump pattern '%F' (pidfd) specifier and SO_PASSRIGHTS
+                     ≥ 6.19 for PIDFD_INFO_SUPPORTED_MASK and PIDFD_INFO_COREDUMP_SIGNAL
 
         ✅ systemd utilizes several new kernel APIs, but will fall back gracefully
            when unavailable.

--- a/man/systemd-coredump.xml
+++ b/man/systemd-coredump.xml
@@ -20,14 +20,24 @@
     <refname>systemd-coredump</refname>
     <refname>systemd-coredump.socket</refname>
     <refname>systemd-coredump@.service</refname>
+    <refname>systemd-coredump-container.socket</refname>
+    <refname>systemd-coredump-container@.service</refname>
+    <refname>systemd-coredump-register.socket</refname>
+    <refname>systemd-coredump-register@.service</refname>
+    <refname>systemd-coredumpd.service</refname>
     <refpurpose>Acquire, save and process core dumps</refpurpose>
   </refnamediv>
 
   <refsynopsisdiv>
     <para><filename>/usr/lib/systemd/systemd-coredump</filename></para>
     <para><filename>/usr/lib/systemd/systemd-coredump</filename> <option>--backtrace</option></para>
-    <para><filename>systemd-coredump@.service</filename></para>
     <para><filename>systemd-coredump.socket</filename></para>
+    <para><filename>systemd-coredump@.service</filename></para>
+    <para><filename>systemd-coredump-container.socket</filename></para>
+    <para><filename>systemd-coredump-container@.service</filename></para>
+    <para><filename>systemd-coredump-register.socket</filename></para>
+    <para><filename>systemd-coredump-register@.service</filename></para>
+    <para><filename>systemd-coredumpd.service</filename></para>
   </refsynopsisdiv>
 
   <refsect1>
@@ -66,8 +76,19 @@
     <refsect2>
       <title>Invocation of <command>systemd-coredump</command></title>
 
-      <para>The <command>systemd-coredump</command> executable does the actual work. It is invoked twice:
-      once as the handler by the kernel, and the second time in the
+      <para>The <command>systemd-coredump</command> executable does the actual work. When the kernel is v6.19
+      or newer, <filename>systemd-coredumpd.service</filename> creates a unix socket, and
+      requests <filename>systemd-coredump-register@.service</filename> to write the path to the socket into
+      <filename>/proc/sys/kernel/core_pattern</filename>. When a process crashes, the kernel connects the
+      socket, and send the core of the process through the socket. Then,
+      <filename>systemd-coredumpd.service</filename> transfers the core to the corresponding container if the
+      crashed process is in a container environment, otherwise saves the core in the local storage and writes
+      information about the crashed process to journal. In container, when a core is transfered from the
+      host, <filename>systemd-coredump-client@.service</filename> is triggered, which saves the transfered
+      core into the container storage.</para>
+
+      <para>When the kernel is older than v6.19, the executable <command>systemd-coredump</command> is
+      invoked twice: once as the handler by the kernel, and the second time in the
       <filename>systemd-coredump@.service</filename> to actually write the data to the journal and process
       and save the core file.</para>
 

--- a/src/basic/pidfd-util.h
+++ b/src/basic/pidfd-util.h
@@ -8,6 +8,7 @@
 int pidfd_get_namespace(int fd, unsigned long ns_type_cmd);
 
 int pidfd_get_info(int fd, struct pidfd_info *info);
+int pidfd_info_mask_is_supported(uint64_t mask);
 
 int pidfd_get_pid(int fd, pid_t *ret);
 int pidfd_verify_pid(int pidfd, pid_t pid);

--- a/src/basic/sysctl-util.c
+++ b/src/basic/sysctl-util.c
@@ -112,6 +112,43 @@ int sysctl_writef(const char *property, const char *format, ...) {
         return sysctl_write(property, v);
 }
 
+int sysctl_write_verify(const char *property, const char *value) {
+        int r;
+
+        assert(property);
+        assert(value);
+
+        /* Some sysctl settings accept invalid values on write, but refuses on read. E.g. coredump pattern,
+         * be1e0283021ec73c2eb92839db9a471a068709d9 (v6.17) and 7d7c1fb85cba5627bbe741fb7539c709435e3848
+         * (v6.16.8), which is fixed by a779e27f24aeb679969ddd1fdd7f636e22ddbc1e (v6.18) and
+         * 304aa560385720baf3660fe8500f6dd425b63ea9 (v6.17.5). Let's first save the original value, and
+         * restore to the saved value if the new value is refused. */
+
+        _cleanup_free_ char *original = NULL;
+        r = sysctl_read(property, &original);
+        if (r >= 0 && streq(original, value))
+                return 0; /* Already set. */
+
+        r = sysctl_write(property, value);
+        if (r >= 0) {
+                _cleanup_free_ char *current = NULL;
+                r = sysctl_read(property, &current);
+                if (r >= 0) {
+                        if (streq(current, value))
+                                return 0; /* Yay! */
+
+                        /* At least for coredump pattern, this does not happen, but let's handle this as the
+                         * same as we wrote something invalid. */
+                        r = -EINVAL;
+                }
+        }
+
+        if (original)
+                (void) sysctl_write(property, original);
+
+        return r;
+}
+
 static const char* af_to_sysctl_dir(int af) {
         if (af == AF_MPLS)
                 return "mpls";

--- a/src/basic/sysctl-util.h
+++ b/src/basic/sysctl-util.h
@@ -12,6 +12,7 @@ int sysctl_writef(const char *property, const char *format, ...) _printf_(2, 3);
 static inline int sysctl_write(const char *property, const char *value) {
         return sysctl_write_full(property, value, NULL);
 }
+int sysctl_write_verify(const char *property, const char *value);
 
 int sysctl_read_ip_property(int af, const char *ifname, const char *property, char **ret);
 int sysctl_read_ip_property_int(int af, const char *ifname, const char *property, int *ret);

--- a/src/coredump/coredump-container.c
+++ b/src/coredump/coredump-container.c
@@ -1,0 +1,117 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include "sd-event.h"
+
+#include "coredump-config.h"
+#include "coredump-container.h"
+#include "coredump-context.h"
+#include "coredump-socket.h"
+#include "coredump-submit.h"
+#include "coredump-util.h"
+#include "log.h"
+#include "namespace-util.h"
+#include "time-util.h"
+#include "varlink-io.systemd.Coredump.Container.h"
+#include "varlink-util.h"
+
+static int vl_method_transfer_coredump(sd_varlink *link, sd_json_variant *parameters, sd_varlink_method_flags_t flags, void *userdata) {
+        CoredumpConfig *config = ASSERT_PTR(userdata);
+        struct {
+                unsigned coredump_fd_index;
+                usec_t timestamp;
+        } p = {
+                .timestamp = USEC_INFINITY,
+        };
+        int r;
+
+        assert(link);
+
+        static const sd_json_dispatch_field dispatch_table[] = {
+                { "coredumpFileDescriptor", _SD_JSON_VARIANT_TYPE_INVALID, sd_json_dispatch_uint,    voffsetof(p, coredump_fd_index),  SD_JSON_MANDATORY },
+                { "timestamp",              _SD_JSON_VARIANT_TYPE_INVALID, sd_json_dispatch_uint64,  voffsetof(p, timestamp),          0                 },
+                {}
+        };
+
+        r = sd_varlink_dispatch(link, parameters, dispatch_table, &p);
+        if (r != 0)
+                return r;
+
+        _cleanup_(coredump_context_done) CoredumpContext context = COREDUMP_CONTEXT_NULL;
+        context.forwarded = true;
+
+        /* If we are in a non-initial time namespace, ignore the received timestamp. */
+        if (!timestamp_is_set(p.timestamp) || namespace_is_init(NAMESPACE_TIME) == 0) {
+                r = sd_event_now(sd_varlink_get_event(link), CLOCK_REALTIME, &context.timestamp);
+                if (r < 0)
+                        return log_error_errno(r, "Failed to get the current time: %m");
+        } else
+                context.timestamp = p.timestamp;
+
+        r = sd_varlink_take_fd(link, p.coredump_fd_index);
+        if (r < 0)
+                return log_error_errno(r, "Failed to take file descriptor of the coredump socket: %m");
+        context.input_fd = r;
+
+        r = coredump_context_parse_from_peer(&context);
+        if (r < 0)
+                return r;
+
+        if (!coredump_context_is_journald(&context))
+                log_set_target_and_open(LOG_TARGET_JOURNAL_OR_KMSG);
+
+        r = coredump_process_socket(&context);
+        if (r < 0)
+                goto finalize;
+
+        r = coredump_submit(config, &context);
+        if (r < 0)
+                goto finalize;
+
+        r = sd_varlink_reply(link, /* parameters= */ NULL);
+
+finalize:
+        /* Reopen kmsg for later calls. */
+        log_set_target_and_open(LOG_TARGET_KMSG);
+
+        return r;
+}
+
+int coredump_container(int argc, char *argv[]) {
+        int r;
+
+        log_parse_environment();
+        log_set_target_and_open(LOG_TARGET_KMSG);
+
+        /* Make sure we never enter a loop. */
+        (void) set_dumpable(SUID_DUMP_DISABLE);
+
+        /* Ignore all parse errors. */
+        CoredumpConfig config = COREDUMP_CONFIG_NULL;
+        (void) coredump_parse_config(&config);
+
+        _cleanup_(sd_varlink_server_unrefp) sd_varlink_server *varlink_server = NULL;
+        r = varlink_server_new(
+                        &varlink_server,
+                        SD_VARLINK_SERVER_ROOT_ONLY |
+                        SD_VARLINK_SERVER_INHERIT_USERDATA |
+                        SD_VARLINK_SERVER_ALLOW_FD_PASSING_INPUT,
+                        &config);
+        if (r < 0)
+                return log_error_errno(r, "Failed to allocate Varlink server: %m");
+
+        r = sd_varlink_server_add_interface(varlink_server, &vl_interface_io_systemd_CoredumpContainer);
+        if (r < 0)
+                return log_error_errno(r, "Failed to add Varlink interface: %m");
+
+        r = sd_varlink_server_bind_method_many(
+                        varlink_server,
+                        "io.systemd.Coredump.Container.Transfer", vl_method_transfer_coredump);
+        if (r < 0)
+                return log_error_errno(r, "Failed to bind Varlink methods: %m");
+
+        r = sd_varlink_server_loop_auto(varlink_server);
+        if (r < 0)
+                return log_error_errno(r, "Failed to run Varlink event loop: %m");
+
+        return 0;
+}

--- a/src/coredump/coredump-container.h
+++ b/src/coredump/coredump-container.h
@@ -1,0 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#pragma once
+
+int coredump_container(int argc, char *argv[]);

--- a/src/coredump/coredump-context.c
+++ b/src/coredump/coredump-context.c
@@ -8,14 +8,18 @@
 #include "dirent-util.h"
 #include "fd-util.h"
 #include "fs-util.h"
+#include "hostname-setup.h"
 #include "hostname-util.h"
 #include "iovec-wrapper.h"
 #include "log.h"
 #include "memstream-util.h"
 #include "namespace-util.h"
 #include "parse-util.h"
+#include "pidfd-util.h"
 #include "process-util.h"
+#include "rlimit-util.h"
 #include "signal-util.h"
+#include "socket-util.h"
 #include "special.h"
 #include "string-table.h"
 #include "string-util.h"
@@ -568,6 +572,56 @@ int coredump_context_parse_from_argv(CoredumpContext *context, int argc, char **
                 if (r < 0)
                         return r;
         }
+
+        coredump_context_check_pidns(context);
+        return coredump_context_parse_from_procfs(context);
+}
+
+int coredump_context_parse_from_peer(CoredumpContext *context) {
+        int r;
+
+        assert(context);
+        assert(context->input_fd >= 0);
+
+        r = getpeerpidref(context->input_fd, &context->pidref);
+        if (r < 0)
+                return log_error_errno(r, "Failed to get peer pidref: %m");
+
+        if (context->pidref.fd < 0)
+                return log_error_errno(SYNTHETIC_ERRNO(ENOMEDIUM), "We do not have pidfd of the crashed process.");
+
+        context->got_pidfd = true;
+
+        struct pidfd_info info = {
+                .mask = PIDFD_INFO_COREDUMP | PIDFD_INFO_COREDUMP_SIGNAL,
+        };
+
+        r = pidfd_get_info(context->pidref.fd, &info);
+        if (r < 0)
+                return log_error_errno(r, "ioctl(PIDFD_GET_INFO) failed: %m");
+
+        if (!FLAGS_SET(info.coredump_mask, PIDFD_COREDUMPED))
+                return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
+                                       "The process ["PID_FMT"] did not crash.", context->pidref.pid);
+
+        if (FLAGS_SET(info.coredump_mask, PIDFD_COREDUMP_SKIP))
+                return log_error_errno(SYNTHETIC_ERRNO(ENODATA),
+                                       "Coredump generation for process ["PID_FMT"] is skipped.", context->pidref.pid);
+
+        context->uid = info.ruid;
+        context->gid = info.rgid;
+        context->dumpable = FLAGS_SET(info.coredump_mask, PIDFD_COREDUMP_USER) ? SUID_DUMP_USER : SUID_DUMP_SAFE;
+        context->signo = info.coredump_signal;
+
+        struct rlimit rl;
+        r = pid_getrlimit(info.pid, RLIMIT_CORE, &rl);
+        if (r < 0)
+                return log_error_errno(r, "Failed to get coredump size limit: %m");
+        context->rlimit = rl.rlim_cur;
+
+        r = pidref_gethostname_full(&context->pidref, GET_HOSTNAME_ALLOW_LOCALHOST | GET_HOSTNAME_FALLBACK_DEFAULT, &context->hostname);
+        if (r < 0)
+                log_warning_errno(r, "Failed to get hostname, ignoring: %m");
 
         coredump_context_check_pidns(context);
         return coredump_context_parse_from_procfs(context);

--- a/src/coredump/coredump-context.h
+++ b/src/coredump/coredump-context.h
@@ -61,6 +61,7 @@ struct CoredumpContext {
         bool got_pidfd;    /* META_ARGV_PIDFD */
         bool same_pidns;
         bool forwarded;
+        bool requested;
         int input_fd;
         int mount_tree_fd;
         struct iovec_wrapper iovw;

--- a/src/coredump/coredump-context.h
+++ b/src/coredump/coredump-context.h
@@ -82,3 +82,4 @@ bool coredump_context_is_journald(CoredumpContext *context);
 int coredump_context_build_iovw(CoredumpContext *context);
 int coredump_context_parse_iovw(CoredumpContext *context);
 int coredump_context_parse_from_argv(CoredumpContext *context, int argc, char **argv);
+int coredump_context_parse_from_peer(CoredumpContext *context);

--- a/src/coredump/coredump-manager.c
+++ b/src/coredump/coredump-manager.c
@@ -1,0 +1,644 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "sd-varlink.h"
+
+#include "alloc-util.h"
+#include "coredump-config.h"
+#include "coredump-manager.h"
+#include "coredump-util.h"
+#include "coredump-worker.h"
+#include "daemon-util.h"
+#include "errno-util.h"
+#include "event-util.h"
+#include "fd-util.h"
+#include "hashmap.h"
+#include "log.h"
+#include "namespace-util.h"
+#include "notify-recv.h"
+#include "pidfd-util.h"
+#include "pidref.h"
+#include "process-util.h"
+#include "signal-util.h"
+#include "socket-util.h"
+#include "string-util.h"
+#include "strv.h"
+#include "time-util.h"
+
+#define COREDUMP_SOCKET_PATH           "/run/systemd/coredump-kernel"
+#define COREDUMP_SOCKET_MAX_CONNECTION 16u
+
+#define WORKER_TIMEOUT_USEC (5 * USEC_PER_MINUTE)
+
+enum {
+        /* This should have the highest priority than others, to prevent accepting newer connections. */
+        EVENT_PRIORITY_SIGTERM_SIGINT  = SD_EVENT_PRIORITY_NORMAL - 5,
+        /* This must have a higher priority than the worker SIGCHLD event, to make notifications about completions of
+         * processing events received before SIGCHLD. */
+        EVENT_PRIORITY_WORKER_NOTIFY   = SD_EVENT_PRIORITY_NORMAL - 4,
+        /* This should have a higher priority than timer events about killing long running or idle worker processes. */
+        EVENT_PRIORITY_WORKER_SIGCHLD  = SD_EVENT_PRIORITY_NORMAL - 3,
+        /* As said in the above, this should have a lower proority than the SIGCHLD event source. */
+        EVENT_PRIORITY_WORKER_TIMER    = SD_EVENT_PRIORITY_NORMAL - 2,
+        /* This should have a lower priority than the events for workers. */
+        EVENT_PRIORITY_COREDUMP_SOCKET = SD_EVENT_PRIORITY_NORMAL - 1,
+        /* This should have a lower priority than other event sources. */
+        EVENT_PRIORITY_SIGHUP          = SD_EVENT_PRIORITY_NORMAL + 1,
+};
+
+typedef struct Manager Manager;
+
+typedef struct WorkerInfo {
+        Manager *manager;
+        sd_event_source *timer_event_source;
+        sd_event_source *child_event_source;
+        PidRef pidref;
+} WorkerInfo;
+
+struct Manager {
+        CoredumpConfig config;
+        sd_event *event;
+        sd_event_source *coredump_socket_event_source;
+        int coredump_socket;
+        char *worker_notify_socket_path;
+        Hashmap *workers_by_pidref;
+        bool exit;
+};
+
+static WorkerInfo* worker_info_free(WorkerInfo *worker) {
+        if (!worker)
+                return NULL;
+
+        if (pidref_is_set(&worker->pidref)) {
+                if (worker->manager)
+                        hashmap_remove(worker->manager->workers_by_pidref, &worker->pidref);
+
+                pidref_done_sigkill_wait(&worker->pidref);
+        }
+
+        sd_event_source_unref(worker->child_event_source);
+        sd_event_source_unref(worker->timer_event_source);
+
+        return mfree(worker);
+}
+
+DEFINE_TRIVIAL_CLEANUP_FUNC(WorkerInfo*, worker_info_free);
+
+static WorkerInfo* worker_info_new(void) {
+        WorkerInfo *worker = new(WorkerInfo, 1);
+        if (!worker)
+                return NULL;
+
+        *worker = (WorkerInfo) {
+                .pidref = PIDREF_NULL,
+        };
+
+        return worker;
+}
+
+static Manager* manager_free(Manager *manager) {
+        if (!manager)
+                return NULL;
+
+        sd_event_source_unref(manager->coredump_socket_event_source);
+        sd_event_unref(manager->event);
+        safe_close(manager->coredump_socket);
+        free(manager->worker_notify_socket_path);
+        hashmap_free(manager->workers_by_pidref);
+
+        return mfree(manager);
+}
+
+DEFINE_TRIVIAL_CLEANUP_FUNC(Manager*, manager_free);
+
+static Manager* manager_new(void) {
+        Manager *manager = new(Manager, 1);
+        if (!manager)
+                return NULL;
+
+        *manager = (Manager) {
+                .config = COREDUMP_CONFIG_NULL,
+                .coredump_socket = -EBADF,
+        };
+
+        return TAKE_PTR(manager);
+}
+
+static int on_worker_sigchld(sd_event_source *s, const siginfo_t *si, void *userdata) {
+        _unused_ _cleanup_(worker_info_freep) WorkerInfo *worker = ASSERT_PTR(userdata);
+
+        assert(si);
+
+        switch (si->si_code) {
+        case CLD_EXITED:
+                if (si->si_status == 0) {
+                        log_debug("Worker ["PID_FMT"] exited.", si->si_pid);
+                        return 0;
+                }
+
+                log_warning("Worker ["PID_FMT"] exited with return code %i.", si->si_pid, si->si_status);
+                break;
+
+        case CLD_KILLED:
+        case CLD_DUMPED:
+                log_warning("Worker ["PID_FMT"] terminated by signal %i (%s).",
+                            si->si_pid, si->si_status, signal_to_string(si->si_status));
+                break;
+
+        default:
+                assert_not_reached();
+        }
+
+        return 0;
+}
+
+static int on_worker_timeout(sd_event_source *s, uint64_t usec, void *userdata) {
+        WorkerInfo *worker = ASSERT_PTR(userdata);
+
+        log_warning("Worker ["PID_FMT"] is running longer than %s, killing the worker.",
+                    worker->pidref.pid, FORMAT_TIMESPAN(WORKER_TIMEOUT_USEC, USEC_PER_SEC));
+        (void) pidref_kill(&worker->pidref, SIGKILL);
+        return 0;
+}
+
+static int manager_spawn_worker(Manager *manager, int coredump_fd) {
+        int r;
+
+        assert(manager);
+        assert(coredump_fd >= 0);
+
+        _cleanup_(worker_info_freep) WorkerInfo *worker = worker_info_new();
+        if (!worker)
+                return -ENOMEM;
+
+        /* On socket mode, the kernel does not provide any timestamp of the crash. Let's use the timestamp
+         * that the socket accept the connection. */
+        usec_t timestamp;
+        r = sd_event_now(manager->event, CLOCK_REALTIME, &timestamp);
+        if (r < 0)
+                return r;
+
+        r = pidref_safe_fork_full(
+                        "(coredump-worker)",
+                        /* stdio_fds= */ NULL,
+                        (int[]) { coredump_fd }, 1,
+                        FORK_DEATHSIG_SIGTERM | FORK_CLOSE_ALL_FDS | FORK_REOPEN_LOG | FORK_LOG,
+                        &worker->pidref);
+        if (r < 0)
+                return r;
+        if (r == 0) {
+                /* Worker process */
+
+                if (setenv("NOTIFY_SOCKET", manager->worker_notify_socket_path, /* overwrite= */ true) < 0) {
+                        log_error_errno(errno, "Failed to set $NOTIFY_SOCKET: %m");
+                        _exit(EXIT_FAILURE);
+                }
+
+                r = coredump_worker(&manager->config, TAKE_FD(coredump_fd), timestamp);
+                _exit(r < 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+        }
+
+        r = event_add_child_pidref(manager->event, &worker->child_event_source, &worker->pidref, WEXITED, on_worker_sigchld, worker);
+        if (r < 0)
+                return r;
+
+        r = sd_event_source_set_priority(worker->child_event_source, EVENT_PRIORITY_WORKER_SIGCHLD);
+        if (r < 0)
+                return r;
+
+        (void) sd_event_source_set_description(worker->child_event_source, "worker-child-event");
+
+        r = sd_event_add_time_relative(manager->event, &worker->timer_event_source,
+                                       CLOCK_MONOTONIC, WORKER_TIMEOUT_USEC, USEC_PER_SEC,
+                                       on_worker_timeout, worker);
+        if (r < 0)
+                return r;
+
+        r = sd_event_source_set_priority(worker->timer_event_source, EVENT_PRIORITY_WORKER_TIMER);
+        if (r < 0)
+                return r;
+
+        (void) sd_event_source_set_description(worker->timer_event_source, "worker-timeout");
+
+        r = hashmap_ensure_put(&manager->workers_by_pidref, &pidref_hash_ops, &worker->pidref, worker);
+        if (r < 0)
+                return r;
+
+        worker->manager = manager;
+
+        TAKE_PTR(worker);
+        return 0;
+}
+
+static int on_connect(sd_event_source *s, int fd, uint32_t revents, void *userdata) {
+        Manager *manager = ASSERT_PTR(userdata);
+        int r;
+
+        assert(fd >= 0);
+
+        _cleanup_close_ int coredump_fd = accept4(fd, /* addr= */ NULL, /* addrlen= */ NULL, SOCK_CLOEXEC | SOCK_NONBLOCK);
+        if (coredump_fd < 0) {
+                if (!ERRNO_IS_ACCEPT_AGAIN(errno))
+                        log_warning_errno(errno, "Failed to accept coredump socket connection, ignoring: %m");
+
+                return 0;
+        }
+
+        r = manager_spawn_worker(manager, coredump_fd);
+        if (r < 0)
+                log_warning_errno(r, "Failed to spawn worker process, ignoring: %m");
+
+        return 0;
+}
+
+static int on_worker_notify(sd_event_source *s, int fd, uint32_t revents, void *userdata) {
+        Manager *manager = ASSERT_PTR(userdata);
+        int r;
+
+        assert(fd >= 0);
+
+        _cleanup_(pidref_done) PidRef sender = PIDREF_NULL;
+        _cleanup_strv_free_ char **l = NULL;
+        r = notify_recv_strv(fd, &l, /* ret_ucred= */ NULL, &sender);
+        if (r < 0) {
+                if (r != -EAGAIN)
+                        log_warning_errno(r, "Failed to receive worker notification, ignoring: %m");
+                return 0;
+        }
+
+        /* lookup worker who sent the signal */
+        WorkerInfo *worker = hashmap_get(manager->workers_by_pidref, &sender);
+        if (!worker) {
+                log_warning("Received notification from unknown process ["PID_FMT"], ignoring.", sender.pid);
+                return 0;
+        }
+
+        if (strv_contains(l, "READY=1")) {
+                log_debug("Received ready notification from worker process ["PID_FMT"].", sender.pid);
+                return 0;
+        }
+
+        if (strv_contains(l, "STOPPING=1")) {
+                log_debug("Received stopping notification from worker process ["PID_FMT"].", sender.pid);
+                return 0;
+        }
+
+        _cleanup_free_ char *joined = strv_join(l, ", ");
+        log_warning("Received unexpected notification from worker process ["PID_FMT"], ignoring: %s", sender.pid, strna(joined));
+        return 0;
+}
+
+static int on_post(sd_event_source *s, void *userdata) {
+        Manager *manager = ASSERT_PTR(userdata);
+
+        if (!manager->exit)
+                return 0;
+
+        if (!hashmap_isempty(manager->workers_by_pidref))
+                return 0; /* There still exist workers. */
+
+        return sd_event_exit(manager->event, 0);
+}
+
+static int on_sigterm(sd_event_source *s, const struct signalfd_siginfo *si, void *userdata) {
+        Manager *manager = ASSERT_PTR(userdata);
+
+        manager->exit = true;
+
+        (void) sd_notify(/* unset_environment= */ false, NOTIFY_STOPPING_MESSAGE);
+
+        /* Do not accept any new connections. */
+        manager->coredump_socket_event_source = sd_event_source_disable_unref(manager->coredump_socket_event_source);
+
+        return 0;
+}
+
+static int on_sighup(sd_event_source *s, const struct signalfd_siginfo *si, void *userdata) {
+        Manager *manager = ASSERT_PTR(userdata);
+        int r;
+
+        (void) notify_reloading();
+
+        manager->config = COREDUMP_CONFIG_NULL;
+        (void) coredump_parse_config(&manager->config);
+
+        r = sd_notify(/* unset_environment= */ false, NOTIFY_READY_MESSAGE);
+        if (r < 0)
+                log_warning_errno(r, "Failed to send readiness notification, ignoring: %m");
+
+        return 0;
+}
+
+static int manager_setup_signal(
+                Manager *manager,
+                sd_event *event,
+                int signal,
+                sd_event_signal_handler_t handler,
+                int64_t priority,
+                const char *description) {
+
+        int r;
+
+        assert(manager);
+        assert(event);
+
+        _cleanup_(sd_event_source_unrefp) sd_event_source *s = NULL;
+        r = sd_event_add_signal(event, &s, signal | SD_EVENT_SIGNAL_PROCMASK, handler, manager);
+        if (r < 0)
+                return r;
+
+        r = sd_event_source_set_priority(s, priority);
+        if (r < 0)
+                return r;
+
+        (void) sd_event_source_set_description(s, description);
+
+        r = sd_event_source_set_floating(s, true);
+        if (r < 0)
+                return r;
+
+        return 0;
+}
+
+static int manager_init_event(Manager *manager) {
+        int r;
+
+        assert(manager);
+
+        /* block SIGCHLD for listening child events. */
+        assert_se(sigprocmask_many(SIG_BLOCK, NULL, SIGCHLD) >= 0);
+
+        _cleanup_(sd_event_unrefp) sd_event *event = NULL;
+        r = sd_event_default(&event);
+        if (r < 0)
+                return log_error_errno(r, "Failed to allocate event loop: %m");
+
+        r = sd_event_set_watchdog(event, true);
+        if (r < 0)
+                return log_error_errno(r, "Failed to enable watchdog: %m");
+
+        r = manager_setup_signal(manager, event, SIGINT, on_sigterm, EVENT_PRIORITY_SIGTERM_SIGINT, "sigint-event-source");
+        if (r < 0)
+                return log_error_errno(r, "Failed to create SIGINT event source: %m");
+
+        r = manager_setup_signal(manager, event, SIGTERM, on_sigterm, EVENT_PRIORITY_SIGTERM_SIGINT, "sigterm-event-source");
+        if (r < 0)
+                return log_error_errno(r, "Failed to create SIGTERM event source: %m");
+
+        r = manager_setup_signal(manager, event, SIGHUP, on_sighup, EVENT_PRIORITY_SIGHUP, "sighup-event-source");
+        if (r < 0)
+                return log_error_errno(r, "Failed to create SIGHUP event source: %m");
+
+        r = sd_event_add_post(event, /* ret= */ NULL, on_post, manager);
+        if (r < 0)
+                return log_error_errno(r, "Failed to create post event source: %m");
+
+        r = notify_socket_prepare(
+                        event,
+                        EVENT_PRIORITY_WORKER_NOTIFY,
+                        on_worker_notify,
+                        manager,
+                        &manager->worker_notify_socket_path);
+        if (r < 0)
+                return log_error_errno(r, "Failed to prepare notify socket: %m");
+
+        _cleanup_(sd_event_source_unrefp) sd_event_source *s = NULL;
+        r = sd_event_add_io(event, &s, manager->coredump_socket, EPOLLIN, on_connect, manager);
+        if (r < 0)
+                return log_error_errno(r, "Failed to allocate IO event source: %m");
+
+        (void) sd_event_source_set_description(s, "coredump-socket-event");
+
+        r = sd_event_source_set_priority(s, EVENT_PRIORITY_COREDUMP_SOCKET);
+        if (r < 0)
+                return log_error_errno(r, "Failed to set priority of IO event source: %m");
+
+        manager->coredump_socket_event_source = TAKE_PTR(s);
+        manager->event = TAKE_PTR(event);
+        return 0;
+}
+
+static int manager_open_coredump_socket(Manager *manager) {
+        int r;
+
+        assert(manager);
+        assert(manager->coredump_socket < 0);
+
+        _cleanup_close_ int fd = socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC | SOCK_NONBLOCK, 0);
+        if (fd < 0)
+                return log_error_errno(errno, "Failed to create AF_UNIX socket(): %m");
+
+        union sockaddr_union sa;
+        r = sockaddr_un_set_path(&sa.un, COREDUMP_SOCKET_PATH);
+        if (r < 0)
+                return log_error_errno(r, "Failed to set path for AF_UNIX socket: %m");
+        socklen_t sa_len = r;
+
+        (void) sockaddr_un_unlink(&sa.un);
+
+        if (bind(fd, &sa.sa, sa_len) < 0)
+                return log_error_errno(errno, "Failed to bind AF_UNIX socket at %s: %m", sa.un.sun_path);
+
+        (void) chmod(sa.un.sun_path, 0600);
+
+        if (listen(fd, COREDUMP_SOCKET_MAX_CONNECTION) < 0)
+                return log_error_errno(errno, "Failed to listen AF_UNIX socket at %s: %m", sa.un.sun_path);
+
+        manager->coredump_socket = TAKE_FD(fd);
+        return 0;
+}
+
+static int manager_push_coredump_socket(Manager *manager) {
+        int r;
+
+        assert(manager);
+        assert(manager->coredump_socket >= 0);
+
+        r = notify_push_fd(manager->coredump_socket, "coredump-socket");
+        if (r < 0)
+                return log_warning_errno(r, "Failed to push coredump socket to service manager, ignoring: %m");
+
+        log_debug("Pushed coredump socket to service manager.");
+        return 0;
+}
+
+static int manager_set_coredump_socket(Manager *manager, int fd) {
+        int r;
+
+        assert(manager);
+        assert(fd >= 0);
+
+        /* This takes passed fd on success. */
+
+        if (manager->coredump_socket >= 0)
+                return log_warning_errno(SYNTHETIC_ERRNO(EALREADY),
+                                         "Received multiple coredump socket (%i), ignoring.", fd);
+
+        r = sd_is_socket_unix(fd, SOCK_STREAM, /* listening= */ true, COREDUMP_SOCKET_PATH, /* length= */ 0);
+        if (r < 0)
+                return log_warning_errno(r, "Failed to check if fd (%i) is a valid unix socket, ignoring: %m", fd);
+        if (r == 0)
+                return log_warning_errno(SYNTHETIC_ERRNO(EINVAL),
+                                         "Received invalid coredump socket (%i), ignoring.", fd);
+
+        (void) fd_nonblock(fd, true);
+
+        manager->coredump_socket = fd;
+        return 0;
+}
+
+static int manager_listen_fds(Manager *manager) {
+        int r;
+
+        assert(manager);
+
+        _cleanup_strv_free_ char **names = NULL;
+        int n = sd_listen_fds_with_names(/* unset_environment= */ false, &names);
+        if (n < 0)
+                return log_error_errno(n, "Failed to determine the number of file descriptors: %m");
+
+        for (int i = 0; i < n; i++) {
+                int fd = SD_LISTEN_FDS_START + i;
+
+                if (streq_ptr(names[i], "coredump-socket"))
+                        r = manager_set_coredump_socket(manager, fd);
+                else
+                        r = log_warning_errno(SYNTHETIC_ERRNO(EINVAL), "Received unexpected fd (%i: %s), ignoring.", fd, names[i]);
+                if (r < 0)
+                        close_and_notify_warn(fd, names[i]);
+        }
+
+        return 0;
+}
+
+static int register_coredump_socket(void) {
+        int r;
+
+        _cleanup_(sd_varlink_flush_close_unrefp) sd_varlink *vl = NULL;
+        r = sd_varlink_connect_address(&vl, "/run/systemd/io.systemd.Coredump.Register");
+        if (r < 0)
+                return log_error_errno(r, "Failed to connect to /run/systemd/io.systemd.Coredump.Register: %m");
+
+        (void) sd_varlink_set_description(vl, "varlink-coredump-register");
+
+        /* The "@@" prefix means the path is a AF_UNIX socket and it accepts the request mode protocol. The
+         * protocol is supported since kernel v6.17. We have already checked if PIDFD_INFO_COREDUMP_SIGNAL
+         * flag (since v6.19) is supported in check_requirements(). Hence, the prefix should be supported. */
+        sd_json_variant *reply;
+        const char *error_id;
+        r = sd_varlink_callbo(
+                        vl,
+                        "io.systemd.Coredump.Register.SetCorePattern",
+                        &reply,
+                        &error_id,
+                        SD_JSON_BUILD_PAIR_STRING("pattern", "@@" COREDUMP_SOCKET_PATH));
+        if (r < 0)
+                return log_error_errno(r, "Failed to issue io.systemd.Coredump.Register.SetCorePattern() varlink call: %m");
+        if (error_id) {
+                r = sd_varlink_error_to_errno(error_id, reply); /* If this is a system errno style error, output it with %m */
+                if (r != -EBADR)
+                        return log_error_errno(r, "Failed to issue io.systemd.Coredump.Register.SetCorePattern() varlink call: %m");
+
+                return log_error_errno(r, "Failed to issue io.systemd.Coredump.Register.SetCorePattern() varlink call: %s", error_id);
+        }
+
+        return 0;
+}
+
+static int check_requirements(void) {
+        int r;
+
+        /* The request mode coredump socket pattern is supported since kernel v6.17. Old kernels do not
+         * refuse the new core patterns (moreover, any strings are accepted), hence we need to check kernel
+         * version in some ways other than reading/writing core patterns. Here, we use if
+         * ioctl(PIDFD_GET_INFO) supportes necessary flags.
+         *
+         * The following flags are required for supporting kernel coredump socket feature:
+         * PIDFD_INFO_COREDUMP        : 1d8db6fd698de1f73b1a7d72aea578fdd18d9a87 (v6.16),
+         * PIDFD_INFO_COREDUMP_SIGNAL : 036375522be8425874e9e0f907c7127e315c7a52 (v6.19). */
+        r = pidfd_info_mask_is_supported(PIDFD_INFO_COREDUMP | PIDFD_INFO_COREDUMP_SIGNAL);
+        if (r == 0 || ERRNO_IS_NEG_NOT_SUPPORTED(r)) {
+                log_debug("ioctl(PIDFD_GET_INFO) does not support PIDFD_INFO_COREDUMP and/or PIDFD_INFO_COREDUMP_SIGNAL.");
+                return false;
+        }
+        if (r < 0)
+                return log_error_errno(r, "Failed to check if PIDFD_INFO_COREDUMP and PIDFD_INFO_COREDUMP_SIGNAL flags are supported by ioctl(PIDFD_GET_INFO): %m");
+
+        /* Let's check if we are in the initial PID, USER, TIME namespace. */
+        r = namespace_is_init(NAMESPACE_PID);
+        if (r < 0)
+                return log_error_errno(r, "Failed to check if we are in the initial PID namespace: %m");
+        if (r == 0) {
+                log_debug("Running in a non-initial PID namespace.");
+                return false;
+        }
+
+        r = namespace_is_init(NAMESPACE_USER);
+        if (r < 0)
+                return log_error_errno(r, "Failed to check if we are in the initial USER namespace: %m");
+        if (r == 0) {
+                log_debug("Running in a non-initial USER namespace.");
+                return false;
+        }
+
+        r = namespace_is_init(NAMESPACE_TIME);
+        if (r < 0)
+                return log_error_errno(r, "Failed to check if we are in the initial TIME namespace: %m");
+        if (r == 0) {
+                log_debug("Running in a non-initial TIME namespace.");
+                return false;
+        }
+
+        return true;
+}
+
+int coredump_manager(int argc, char *argv[]) {
+        int r;
+
+        log_setup();
+
+        _unused_ _cleanup_(notify_on_cleanup) const char *notify_message =
+                notify_start(NOTIFY_READY_MESSAGE, NOTIFY_STOPPING_MESSAGE);
+
+        /* Make sure we never enter a loop. */
+        (void) set_dumpable(SUID_DUMP_DISABLE);
+
+        r = check_requirements();
+        if (r <= 0)
+                return r;
+
+        _cleanup_(manager_freep) Manager *manager = manager_new();
+        if (!manager)
+                return log_oom();
+
+        /* Ignore all parse errors. */
+        (void) coredump_parse_config(&manager->config);
+
+        r = manager_listen_fds(manager);
+        if (r < 0)
+                return r;
+
+        if (manager->coredump_socket < 0) {
+                r = manager_open_coredump_socket(manager);
+                if (r < 0)
+                        return r;
+
+                (void) manager_push_coredump_socket(manager);
+        }
+
+        r = register_coredump_socket();
+        if (r < 0)
+                return r;
+
+        r = manager_init_event(manager);
+        if (r < 0)
+                return r;
+
+        r = sd_event_loop(manager->event);
+        if (r < 0)
+                return log_error_errno(r, "Event loop failed: %m");
+
+        return 0;
+}

--- a/src/coredump/coredump-manager.h
+++ b/src/coredump/coredump-manager.h
@@ -1,0 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#pragma once
+
+int coredump_manager(int argc, char *argv[]);

--- a/src/coredump/coredump-register.c
+++ b/src/coredump/coredump-register.c
@@ -1,0 +1,61 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include "coredump-register.h"
+#include "log.h"
+#include "sysctl-util.h"
+#include "varlink-io.systemd.Coredump.Register.h"
+#include "varlink-util.h"
+
+static int vl_method_set_core_pattern(sd_varlink *link, sd_json_variant *parameters, sd_varlink_method_flags_t flags, void *userdata) {
+        int r;
+
+        assert(link);
+
+        static const sd_json_dispatch_field dispatch_table[] = {
+                { "pattern", SD_JSON_VARIANT_STRING, sd_json_dispatch_const_string, 0, SD_JSON_STRICT | SD_JSON_MANDATORY },
+                {}
+        };
+
+        const char *pattern;
+        r = sd_varlink_dispatch(link, parameters, dispatch_table, &pattern);
+        if (r != 0)
+                return r;
+
+        r = sysctl_write_verify("kernel/core_pattern", pattern);
+        if (r == -EINVAL)
+                return sd_varlink_error(link, "io.systemd.Coredump.Register.CoredumpPatternNotSupported", NULL);
+        if (r < 0)
+                return r;
+
+        return sd_varlink_reply(link, /* parameters= */ NULL);
+}
+
+int coredump_register(int argc, char *argv[]) {
+        _cleanup_(sd_varlink_server_unrefp) sd_varlink_server *varlink_server = NULL;
+        int r;
+
+        log_setup();
+
+        r = varlink_server_new(
+                        &varlink_server,
+                        SD_VARLINK_SERVER_ROOT_ONLY,
+                        /* userdata= */ NULL);
+        if (r < 0)
+                return log_error_errno(r, "Failed to allocate Varlink server: %m");
+
+        r = sd_varlink_server_add_interface(varlink_server, &vl_interface_io_systemd_CoredumpRegister);
+        if (r < 0)
+                return log_error_errno(r, "Failed to add Varlink interface: %m");
+
+        r = sd_varlink_server_bind_method_many(
+                        varlink_server,
+                        "io.systemd.Coredump.Register.SetCorePattern", vl_method_set_core_pattern);
+        if (r < 0)
+                return log_error_errno(r, "Failed to bind Varlink methods: %m");
+
+        r = sd_varlink_server_loop_auto(varlink_server);
+        if (r < 0)
+                return log_error_errno(r, "Failed to run Varlink event loop: %m");
+
+        return 0;
+}

--- a/src/coredump/coredump-register.h
+++ b/src/coredump/coredump-register.h
@@ -1,0 +1,4 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#pragma once
+
+int coredump_register(int argc, char *argv[]);

--- a/src/coredump/coredump-send.c
+++ b/src/coredump/coredump-send.c
@@ -95,7 +95,7 @@ int coredump_send(CoredumpContext *context) {
         return 0;
 }
 
-static int can_forward_coredump(PidRef *pidref, PidRef *leader) {
+int can_forward_coredump(PidRef *pidref, PidRef *leader) {
         int r;
 
         assert(pidref_is_set(pidref));

--- a/src/coredump/coredump-send.h
+++ b/src/coredump/coredump-send.h
@@ -3,5 +3,7 @@
 
 #include "coredump-forward.h"
 
+int can_forward_coredump(PidRef *pidref, PidRef *leader);
+
 int coredump_send(CoredumpContext *context);
 int coredump_send_to_container(CoredumpContext *context);

--- a/src/coredump/coredump-socket.c
+++ b/src/coredump/coredump-socket.c
@@ -1,0 +1,224 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include <linux/coredump.h>
+
+#include "sd-event.h"
+
+#include "coredump-context.h"   /* IWYU pragma: keep */
+#include "coredump-socket.h"
+#include "errno-util.h"
+#include "fd-util.h"
+#include "log.h"
+#include "socket-util.h"
+
+#define COREDUMP_REQ_SIZE_MAX 4096u
+
+typedef enum SocketState {
+        SOCKET_WAITING_REQUEST,
+        SOCKET_SENDING_ACK,
+        SOCKET_WAITING_MARKER,
+        _SOCKET_STATE_MAX,
+        _SOCKET_STATE_INVALID = -EINVAL,
+} SocketState;
+
+typedef struct SocketContext {
+        SocketState state;
+        struct coredump_req req;
+} SocketContext;
+
+static int socket_process_request(SocketContext *socket, int fd, uint32_t revents) {
+        assert(socket);
+        assert(socket->state == SOCKET_WAITING_REQUEST);
+        assert(fd >= 0);
+
+        ssize_t n = next_datagram_size_fd(fd);
+        if (n < 0) {
+                if (ERRNO_IS_NEG_TRANSIENT(n))
+                        return 0;
+                return log_debug_errno(n, "Failed to determine coredump request size: %m");
+        }
+
+        /* Verify the acquired request size. */
+        if (n < COREDUMP_REQ_SIZE_VER0)
+                return log_debug_errno(SYNTHETIC_ERRNO(EBADMSG),
+                                       "Acquired coredump request size is too small (%zi < %i).",
+                                       n, COREDUMP_REQ_SIZE_VER0);
+        if ((size_t) n > COREDUMP_REQ_SIZE_MAX)
+                return log_debug_errno(SYNTHETIC_ERRNO(EBADMSG),
+                                       "Acquired coredump request size is too large (%zi > %u).",
+                                       n, COREDUMP_REQ_SIZE_MAX);
+
+        union coredump_req_union {
+                struct coredump_req req;
+                uint8_t buf[COREDUMP_REQ_SIZE_MAX];
+        } req = {};
+
+        n = recv(fd, &req, n, /* flags= */ 0);
+        if (n < 0) {
+                if (ERRNO_IS_TRANSIENT(errno))
+                        return 0;
+                return log_debug_errno(errno, "Failed to receive coredump request: %m");
+        }
+
+        assert((size_t) n <= sizeof(req));
+
+        /* Verify the received coredump request. */
+        if (n < COREDUMP_REQ_SIZE_VER0)
+                return log_debug_errno(SYNTHETIC_ERRNO(EBADMSG),
+                                       "Received coredump request size is too small (%zi < %i).",
+                                       n, COREDUMP_REQ_SIZE_VER0);
+        if ((size_t) n != req.req.size)
+                return log_debug_errno(SYNTHETIC_ERRNO(EBADMSG),
+                                       "Received coredump request size does not match with the size specified in the request (%zi != %"PRIu32").",
+                                       n, req.req.size);
+        if (req.req.size_ack < COREDUMP_ACK_SIZE_VER0)
+                return log_debug_errno(SYNTHETIC_ERRNO(EBADMSG),
+                                       "Received coredump request with too small ack size (%"PRIu32" < %i).",
+                                       req.req.size_ack, COREDUMP_ACK_SIZE_VER0);
+        if (!FLAGS_SET(req.req.mask, COREDUMP_KERNEL | COREDUMP_USERSPACE | COREDUMP_REJECT | COREDUMP_WAIT))
+                return log_debug_errno(SYNTHETIC_ERRNO(EBADMSG),
+                                       "Received coredump request with insufficient flags (%"PRIx64").",
+                                       (uint64_t) req.req.mask);
+
+        socket->req = req.req;
+
+        log_debug("Received coredump request, sending coredump ack.");
+        socket->state = SOCKET_SENDING_ACK;
+        return 0;
+}
+
+static int socket_send_ack(SocketContext *socket, int fd, uint32_t revents) {
+        assert(socket);
+        assert(socket->state == SOCKET_SENDING_ACK);
+        assert(fd >= 0);
+
+        struct coredump_ack ack = {
+                .size = MIN(sizeof(struct coredump_ack), socket->req.size_ack),
+                .mask = COREDUMP_KERNEL | COREDUMP_WAIT,
+        };
+
+        ssize_t n = send(fd, &ack, ack.size, MSG_NOSIGNAL);
+        if (n < 0) {
+                if (ERRNO_IS_TRANSIENT(errno))
+                        return 0;
+                return log_debug_errno(errno, "Failed to send coredump ack: %m");
+        }
+        if ((size_t) n != ack.size)
+                return log_debug_errno(SYNTHETIC_ERRNO(ESTALE),
+                                       "Sent size does not match with the size of coredump ack (%zi != %"PRIu32"): %m",
+                                       n, ack.size);
+
+        log_debug("Sent coredump ack, waiting for marker.");
+        socket->state = SOCKET_WAITING_MARKER;
+        return 0;
+}
+
+static int socket_process_marker(SocketContext *socket, int fd, uint32_t revents) {
+        assert(socket);
+        assert(socket->state == SOCKET_WAITING_MARKER);
+        assert(fd >= 0);
+
+        enum coredump_mark mark;
+        ssize_t n = recv(fd, &mark, sizeof(mark), /* flags= */ 0);
+        if (n < 0) {
+                if (ERRNO_IS_TRANSIENT(errno))
+                        return 0;
+                return log_debug_errno(errno, "Failed to receive marker: %m");
+        }
+        if ((size_t) n != sizeof(mark))
+                return log_debug_errno(SYNTHETIC_ERRNO(EBADMSG), "Received marker with invalid size (%zi).", n);
+
+        switch (mark) {
+        case COREDUMP_MARK_REQACK:
+                log_debug("Sent coredump ack message is accepted, reading coredump data.");
+                return 1;
+        case COREDUMP_MARK_MINSIZE:
+                return log_debug_errno(SYNTHETIC_ERRNO(ENOBUFS),
+                                       "Sent coredump ack message is refused as its size is too small.");
+        case COREDUMP_MARK_MAXSIZE:
+                return log_debug_errno(SYNTHETIC_ERRNO(EMSGSIZE),
+                                       "Sent coredump ack message is refused as its size is too large.");
+        case COREDUMP_MARK_UNSUPPORTED:
+                return log_debug_errno(SYNTHETIC_ERRNO(EOPNOTSUPP),
+                                       "Sent coredump ack message is refused as it contains unsupported flags.");
+        case COREDUMP_MARK_CONFLICTING:
+                return log_debug_errno(SYNTHETIC_ERRNO(EINVAL),
+                                       "Sent coredump ack message is refused as it contains conflicting flags.");
+        default:
+                return log_debug_errno(SYNTHETIC_ERRNO(EBADMSG),
+                                       "Sent coredump ack message is refused with unknown reason (%u).", mark);
+        }
+}
+
+static int on_coredump_io(sd_event_source *s, int fd, uint32_t revents, void *userdata) {
+        SocketContext *socket = ASSERT_PTR(userdata);
+        int r;
+
+        assert(s);
+        assert(fd >= 0);
+
+        switch (socket->state) {
+        case SOCKET_WAITING_REQUEST:
+                r = socket_process_request(socket, fd, revents);
+                break;
+        case SOCKET_SENDING_ACK:
+                r = socket_send_ack(socket, fd, revents);
+                break;
+        case SOCKET_WAITING_MARKER:
+                r = socket_process_marker(socket, fd, revents);
+                break;
+        default:
+                assert_not_reached();
+        }
+        if (r != 0)
+                return sd_event_exit(sd_event_source_get_event(s), r < 0 ? r : 0);
+
+        return 0;
+}
+
+static int coredump_process_request(int fd) {
+        int r;
+
+        assert(fd >= 0);
+
+        _cleanup_(sd_event_unrefp) sd_event *e = NULL;
+        r = sd_event_new(&e);
+        if (r < 0)
+                return log_error_errno(r, "Failed to allocate sd-event object: %m");
+
+        SocketContext socket = {};
+        r = sd_event_add_io(e, NULL, fd, EPOLLIN | EPOLLOUT, on_coredump_io, &socket);
+        if (r < 0)
+                return log_error_errno(r, "Failed to add IO event source for kernel coredump socket: %m");
+
+        r = sd_event_set_signal_exit(e, true);
+        if (r < 0)
+                return log_error_errno(r, "Failed to enable signal event sources: %m");
+
+        log_debug("Processing coredump request.");
+
+        r = sd_event_loop(e);
+        if (r < 0)
+                return log_error_errno(r, "Failed to process coredump request: %m");
+
+        return 0;
+}
+
+int coredump_process_socket(CoredumpContext *context) {
+        int r;
+
+        assert(context);
+        assert(context->input_fd >= 0);
+
+        if (context->requested)
+                return 0;
+
+        /* Avoid processing request again later in the case that we fail to send. */
+        context->requested = true;
+
+        (void) fd_nonblock(context->input_fd, true);
+        r = coredump_process_request(context->input_fd);
+        (void) fd_nonblock(context->input_fd, false);
+
+        return r;
+}

--- a/src/coredump/coredump-socket.h
+++ b/src/coredump/coredump-socket.h
@@ -1,0 +1,6 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#pragma once
+
+#include "coredump-forward.h"
+
+int coredump_process_socket(CoredumpContext *context);

--- a/src/coredump/coredump-worker.c
+++ b/src/coredump/coredump-worker.c
@@ -1,0 +1,209 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include <unistd.h>
+
+#include "coredump-context.h"
+#include "coredump-socket.h"
+#include "coredump-send.h"
+#include "coredump-submit.h"
+#include "coredump-worker.h"
+#include "daemon-util.h"
+#include "fd-util.h"
+#include "log.h"
+#include "namespace-util.h"
+#include "pidref.h"
+#include "process-util.h"
+#include "signal-util.h"
+#include "varlink-util.h"
+
+static int send_to_new_container(CoredumpContext *context) {
+        int r;
+
+        assert(context);
+
+        _cleanup_(sd_varlink_flush_close_unrefp) sd_varlink *vl = NULL;
+        r = sd_varlink_connect_address(&vl, "/run/systemd/io.systemd.Coredump.Container");
+        if (r < 0)
+                return log_debug_errno(r, "Failed to connect to /run/systemd/io.systemd.Coredump.Container: %m");
+
+        r = sd_varlink_set_allow_fd_passing_output(vl, true);
+        if (r < 0)
+                return log_debug_errno(r, "Failed to allow passing file descriptor through varlink: %m");
+
+        r = sd_varlink_push_dup_fd(vl, context->input_fd);
+        if (r < 0)
+                return log_debug_errno(r, "Failed to push coredump socket into varlink: %m");
+        unsigned index = r;
+
+        return varlink_callbo_and_log(
+                        vl,
+                        "io.systemd.Coredump.Container.Transfer",
+                        /* ret_parameters= */ NULL,
+                        SD_JSON_BUILD_PAIR_UNSIGNED("coredumpFileDescriptor", index),
+                        SD_JSON_BUILD_PAIR_UNSIGNED("timestamp", context->timestamp));
+}
+
+static int send_to_legacy_container(CoredumpContext *context) {
+        int r;
+
+        assert(context);
+
+        _cleanup_(coredump_context_done) CoredumpContext container_context = COREDUMP_CONTEXT_NULL;
+        container_context.input_fd = TAKE_FD(context->input_fd);
+        container_context.timestamp = context->timestamp;
+        container_context.forwarded = true;
+
+        r = coredump_context_parse_from_peer(&container_context);
+        if (r < 0)
+                return r;
+
+        r = coredump_context_build_iovw(&container_context);
+        if (r < 0)
+                return r;
+
+        return coredump_send(&container_context);
+}
+
+static int send_to_container(CoredumpContext *context) {
+        int r;
+
+        assert(context);
+        assert(pidref_is_set(&context->pidref));
+
+        if (context->same_pidns)
+                return 0;
+
+        _cleanup_(pidref_done) PidRef leader = PIDREF_NULL;
+        r = namespace_get_leader(&context->pidref, NAMESPACE_PID, &leader);
+        if (r < 0)
+                return log_debug_errno(r, "Failed to get leader of container pid namespace: %m");
+
+        r = can_forward_coredump(&context->pidref, &leader);
+        if (r <= 0)
+                return r;
+
+        _cleanup_close_ int pidns_fd = -EBADF, mntns_fd = -EBADF, userns_fd = -EBADF, root_fd = -EBADF;
+        r = pidref_namespace_open(
+                        &leader,
+                        &pidns_fd,
+                        &mntns_fd,
+                        /* ret_netns_fd= */ NULL,
+                        &userns_fd,
+                        &root_fd);
+        if (r < 0)
+                return log_debug_errno(r, "Failed to open container namespace: %m");
+
+        _cleanup_close_pair_ int errno_pipe[2] = EBADF_PAIR;
+        if (pipe2(errno_pipe, O_CLOEXEC) < 0)
+                return log_debug_errno(errno, "Failed to create pipe: %m");
+
+        /* First, try to use the new socket client interface. */
+        r = namespace_fork(
+                        "(container-outer)",
+                        "(container-inner)",
+                        FORK_RESET_SIGNALS|FORK_DEATHSIG_SIGKILL|FORK_LOG,
+                        pidns_fd,
+                        mntns_fd,
+                        /* netns_fd= */ -EBADF,
+                        userns_fd,
+                        root_fd,
+                        /* ret= */ NULL);
+        if (r < 0)
+                return r;
+        if (r == 0) {
+                /* Child process in the container namespace. */
+                errno_pipe[0] = safe_close(errno_pipe[0]);
+                r = send_to_new_container(context);
+                report_errno_and_exit(errno_pipe[1], r);
+        }
+
+        errno_pipe[1] = safe_close(errno_pipe[1]);
+        if (read_errno(errno_pipe[0]) >= 0)
+                return 1; /* sent */
+
+        /* Next, let's try to send to the legacy container interface. As it does not support the new request
+         * protocol, we need to process that here. */
+        r = coredump_process_socket(context);
+        if (r < 0)
+                return r;
+
+        errno_pipe[0] = safe_close(errno_pipe[0]);
+        if (pipe2(errno_pipe, O_CLOEXEC) < 0)
+                return log_debug_errno(errno, "Failed to create pipe: %m");
+
+        r = namespace_fork(
+                        "(container-outer)",
+                        "(container-inner)",
+                        FORK_RESET_SIGNALS|FORK_DEATHSIG_SIGKILL|FORK_LOG,
+                        pidns_fd,
+                        mntns_fd,
+                        /* netns_fd= */ -EBADF,
+                        userns_fd,
+                        root_fd,
+                        /* ret= */ NULL);
+        if (r < 0)
+                return r;
+        if (r == 0) {
+                /* Child process in the container namespace. */
+                errno_pipe[0] = safe_close(errno_pipe[0]);
+                r = send_to_legacy_container(context);
+                report_errno_and_exit(errno_pipe[1], r);
+        }
+
+        errno_pipe[1] = safe_close(errno_pipe[1]);
+        r = read_errno(errno_pipe[0]);
+        if (r < 0)
+                return r;
+
+        return 1; /* sent */
+}
+
+int coredump_worker(const CoredumpConfig *config, int coredump_fd, usec_t timestamp) {
+        int r;
+
+        assert(config);
+        assert(coredump_fd >= 0);
+
+        /* This invalidates the input file descriptor even on failure. */
+
+        LogTarget saved_target = _LOG_TARGET_INVALID;
+        if (!log_on_console()) {
+                saved_target = log_get_target();
+                log_set_target_and_open(LOG_TARGET_KMSG);
+        }
+
+        _unused_ _cleanup_(notify_on_cleanup) const char *notify_message =
+                notify_start(NOTIFY_READY_MESSAGE, NOTIFY_STOPPING_MESSAGE);
+
+        /* Set higher OOM score, we only protect the manager process. */
+        r = set_oom_score_adjust(500);
+        if (r < 0)
+                log_debug_errno(r, "Failed to reset OOM score, ignoring: %m");
+
+        _cleanup_(coredump_context_done) CoredumpContext context = COREDUMP_CONTEXT_NULL;
+        context.input_fd = TAKE_FD(coredump_fd);
+        context.timestamp = timestamp;
+
+        r = coredump_context_parse_from_peer(&context);
+        if (r < 0)
+                return r;
+
+        if (!coredump_context_is_journald(&context))
+                log_set_target_and_open(saved_target);
+
+        /* Log minimal metadata now, so it is not lost if the system is about to shut down. */
+        _cleanup_free_ char *signal_msg = NULL;
+        if (SIGNAL_VALID(context.signo))
+                (void) asprintf(&signal_msg, " with signal %i/%s", context.signo, signal_to_string(context.signo));
+        log_info("Process "PID_FMT" (%s) of user "UID_FMT" terminated abnormally%s, processing...",
+                 context.pidref.pid, context.comm, context.uid, strempty(signal_msg));
+
+        if (send_to_container(&context) > 0)
+                return 0;
+
+        r = coredump_process_socket(&context);
+        if (r < 0)
+                return r;
+
+        return coredump_submit(config, &context);
+}

--- a/src/coredump/coredump-worker.h
+++ b/src/coredump/coredump-worker.h
@@ -1,0 +1,6 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#pragma once
+
+#include "coredump-forward.h"
+
+int coredump_worker(const CoredumpConfig *config, int coredump_fd, usec_t timestamp);

--- a/src/coredump/coredump.c
+++ b/src/coredump/coredump.c
@@ -5,6 +5,7 @@
 #include "coredump-backtrace.h"
 #include "coredump-kernel-helper.h"
 #include "coredump-receive.h"
+#include "coredump-register.h"
 #include "coredump-util.h"
 #include "log.h"
 #include "main-func.h"
@@ -17,6 +18,9 @@ static int run(int argc, char *argv[]) {
          * from the command, and unexpectedly passed file descriptors can be silently ignored. */
         if (streq_ptr(argv[1], "--backtrace"))
                 return coredump_backtrace(argc, argv);
+
+        if (streq_ptr(argv[1], "--register"))
+                return coredump_register(argc, argv);
 
         /* First, log to a safe place, since we don't know what crashed and it might be journald which we'd
          * rather not log to then. */

--- a/src/coredump/coredump.c
+++ b/src/coredump/coredump.c
@@ -5,6 +5,7 @@
 #include "coredump-backtrace.h"
 #include "coredump-container.h"
 #include "coredump-kernel-helper.h"
+#include "coredump-manager.h"
 #include "coredump-receive.h"
 #include "coredump-register.h"
 #include "coredump-util.h"
@@ -22,6 +23,9 @@ static int run(int argc, char *argv[]) {
 
         if (streq_ptr(argv[1], "--container"))
                 return coredump_container(argc, argv);
+
+        if (streq_ptr(argv[1], "--manager"))
+                return coredump_manager(argc, argv);
 
         if (streq_ptr(argv[1], "--register"))
                 return coredump_register(argc, argv);

--- a/src/coredump/coredump.c
+++ b/src/coredump/coredump.c
@@ -3,6 +3,7 @@
 #include "sd-daemon.h"
 
 #include "coredump-backtrace.h"
+#include "coredump-container.h"
 #include "coredump-kernel-helper.h"
 #include "coredump-receive.h"
 #include "coredump-register.h"
@@ -18,6 +19,9 @@ static int run(int argc, char *argv[]) {
          * from the command, and unexpectedly passed file descriptors can be silently ignored. */
         if (streq_ptr(argv[1], "--backtrace"))
                 return coredump_backtrace(argc, argv);
+
+        if (streq_ptr(argv[1], "--container"))
+                return coredump_container(argc, argv);
 
         if (streq_ptr(argv[1], "--register"))
                 return coredump_register(argc, argv);

--- a/src/coredump/meson.build
+++ b/src/coredump/meson.build
@@ -8,6 +8,7 @@ systemd_coredump_sources = files(
         'coredump.c',
         'coredump-backtrace.c',
         'coredump-config.c',
+        'coredump-container.c',
         'coredump-context.c',
         'coredump-kernel-helper.c',
         'coredump-receive.c',

--- a/src/coredump/meson.build
+++ b/src/coredump/meson.build
@@ -11,11 +11,13 @@ systemd_coredump_sources = files(
         'coredump-container.c',
         'coredump-context.c',
         'coredump-kernel-helper.c',
+        'coredump-manager.c',
         'coredump-receive.c',
         'coredump-register.c',
         'coredump-send.c',
         'coredump-socket.c',
         'coredump-submit.c',
+        'coredump-worker.c',
 )
 systemd_coredump_extract_sources = files(
         'coredump-vacuum.c',

--- a/src/coredump/meson.build
+++ b/src/coredump/meson.build
@@ -13,6 +13,7 @@ systemd_coredump_sources = files(
         'coredump-receive.c',
         'coredump-register.c',
         'coredump-send.c',
+        'coredump-socket.c',
         'coredump-submit.c',
 )
 systemd_coredump_extract_sources = files(

--- a/src/coredump/meson.build
+++ b/src/coredump/meson.build
@@ -11,6 +11,7 @@ systemd_coredump_sources = files(
         'coredump-context.c',
         'coredump-kernel-helper.c',
         'coredump-receive.c',
+        'coredump-register.c',
         'coredump-send.c',
         'coredump-submit.c',
 )

--- a/src/include/override/linux/fcntl.h
+++ b/src/include/override/linux/fcntl.h
@@ -1,0 +1,6 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#pragma once
+
+/* We do not use linux/fcntl.h as it conflicts with glibc's fcntl.h. */
+
+#include <fcntl.h>

--- a/src/include/override/sys/pidfd.h
+++ b/src/include/override/sys/pidfd.h
@@ -1,113 +1,24 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 #pragma once
 
-/* since glibc-2.36 */
-#if HAVE_PIDFD_OPEN
-#include_next <sys/pidfd.h>     /* IWYU pragma: export */
-#endif
-
-#include <linux/types.h>
+/* Here, we do not use glibc's pidfd.h, as its definition of struct pidfd_info is slightly older. */
+#include <linux/pidfd.h>
 #include <signal.h>
-#include <sys/ioctl.h>
 
 /* Defined since glibc-2.36.
  * Supported since kernel v5.3 (7615d9e1780e26e0178c93c55b73309a5dc093d7). */
-#if !HAVE_PIDFD_OPEN
+#if HAVE_PIDFD_OPEN
+extern int pidfd_open(__pid_t __pid, unsigned __flags);
+#else
 int missing_pidfd_open(pid_t pid, unsigned flags);
 #  define pidfd_open missing_pidfd_open
 #endif
 
 /* Defined since glibc-2.36.
  * Supported since kernel v5.1 (3eb39f47934f9d5a3027fe00d906a45fe3a15fad). */
-#if !HAVE_PIDFD_SEND_SIGNAL
+#if HAVE_PIDFD_SEND_SIGNAL
+extern int pidfd_send_signal(int __pidfd, int __sig, siginfo_t *__info, unsigned __flags);
+#else
 int missing_pidfd_send_signal(int fd, int sig, siginfo_t *info, unsigned flags);
 #  define pidfd_send_signal missing_pidfd_send_signal
 #endif
-
-/* since glibc-2.41 */
-#ifndef PIDFS_IOCTL_MAGIC
-#  define PIDFS_IOCTL_MAGIC 0xFF
-
-#  define PIDFD_GET_CGROUP_NAMESPACE              _IO(PIDFS_IOCTL_MAGIC, 1)
-#  define PIDFD_GET_IPC_NAMESPACE                 _IO(PIDFS_IOCTL_MAGIC, 2)
-#  define PIDFD_GET_MNT_NAMESPACE                 _IO(PIDFS_IOCTL_MAGIC, 3)
-#  define PIDFD_GET_NET_NAMESPACE                 _IO(PIDFS_IOCTL_MAGIC, 4)
-#  define PIDFD_GET_PID_NAMESPACE                 _IO(PIDFS_IOCTL_MAGIC, 5)
-#  define PIDFD_GET_PID_FOR_CHILDREN_NAMESPACE    _IO(PIDFS_IOCTL_MAGIC, 6)
-#  define PIDFD_GET_TIME_NAMESPACE                _IO(PIDFS_IOCTL_MAGIC, 7)
-#  define PIDFD_GET_TIME_FOR_CHILDREN_NAMESPACE   _IO(PIDFS_IOCTL_MAGIC, 8)
-#  define PIDFD_GET_USER_NAMESPACE                _IO(PIDFS_IOCTL_MAGIC, 9)
-#  define PIDFD_GET_UTS_NAMESPACE                 _IO(PIDFS_IOCTL_MAGIC, 10)
-#endif
-
-/* defined in linux/pidfd.h */
-#ifndef PIDFD_GET_INFO
-
-/* Flags for pidfd_info. */
-#define PIDFD_INFO_PID                  (1UL << 0) /* Always returned, even if not requested */
-#define PIDFD_INFO_CREDS                (1UL << 1) /* Always returned, even if not requested */
-#define PIDFD_INFO_CGROUPID             (1UL << 2) /* Always returned if available, even if not requested */
-#define PIDFD_INFO_EXIT                 (1UL << 3) /* Only returned if requested. */
-#define PIDFD_INFO_COREDUMP             (1UL << 4) /* Only returned if requested. */
-
-#define PIDFD_INFO_SIZE_VER0            64 /* sizeof first published struct */
-
-/*
- * Values for @coredump_mask in pidfd_info.
- * Only valid if PIDFD_INFO_COREDUMP is set in @mask.
- *
- * Note, the @PIDFD_COREDUMP_ROOT flag indicates that the generated
- * coredump should be treated as sensitive and access should only be
- * granted to privileged users.
- */
-#define PIDFD_COREDUMPED        (1U << 0) /* Did crash and... */
-#define PIDFD_COREDUMP_SKIP     (1U << 1) /* coredumping generation was skipped. */
-#define PIDFD_COREDUMP_USER     (1U << 2) /* coredump was done as the user. */
-#define PIDFD_COREDUMP_ROOT     (1U << 3) /* coredump was done as root. */
-
-struct pidfd_info {
-        /*
-         * This mask is similar to the request_mask in statx(2).
-         *
-         * Userspace indicates what extensions or expensive-to-calculate fields
-         * they want by setting the corresponding bits in mask. The kernel
-         * will ignore bits that it does not know about.
-         *
-         * When filling the structure, the kernel will only set bits
-         * corresponding to the fields that were actually filled by the kernel.
-         * This also includes any future extensions that might be automatically
-         * filled. If the structure size is too small to contain a field
-         * (requested or not), to avoid confusion the mask will not
-         * contain a bit for that field.
-         *
-         * As such, userspace MUST verify that mask contains the
-         * corresponding flags after the ioctl(2) returns to ensure that it is
-         * using valid data.
-         */
-        __u64 mask;
-        /*
-         * The information contained in the following fields might be stale at the
-         * time it is received, as the target process might have exited as soon as
-         * the IOCTL was processed, and there is no way to avoid that. However, it
-         * is guaranteed that if the call was successful, then the information was
-         * correct and referred to the intended process at the time the work was
-         * performed. */
-        __u64 cgroupid;
-        __u32 pid;
-        __u32 tgid;
-        __u32 ppid;
-        __u32 ruid;
-        __u32 rgid;
-        __u32 euid;
-        __u32 egid;
-        __u32 suid;
-        __u32 sgid;
-        __u32 fsuid;
-        __u32 fsgid;
-        __s32 exit_code;     /* since kernel v6.15 (7477d7dce48a996ae4e4f0b5f7bd82de7ec9131b) */
-        __u32 coredump_mask; /* since kernel v6.16 (1d8db6fd698de1f73b1a7d72aea578fdd18d9a87) */
-        __u32 __spare1;
-};
-
-#define PIDFD_GET_INFO          _IOWR(PIDFS_IOCTL_MAGIC, 11, struct pidfd_info)
-#endif /* PIDFD_GET_INFO */

--- a/src/include/uapi/linux/ioctl.h
+++ b/src/include/uapi/linux/ioctl.h
@@ -1,0 +1,8 @@
+/* SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note */
+#ifndef _LINUX_IOCTL_H
+#define _LINUX_IOCTL_H
+
+#include <asm/ioctl.h>
+
+#endif /* _LINUX_IOCTL_H */
+

--- a/src/include/uapi/linux/pidfd.h
+++ b/src/include/uapi/linux/pidfd.h
@@ -1,0 +1,115 @@
+/* SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note */
+
+#ifndef _LINUX_PIDFD_H
+#define _LINUX_PIDFD_H
+
+#include <linux/types.h>
+#include <linux/fcntl.h>
+#include <linux/ioctl.h>
+
+/* Flags for pidfd_open().  */
+#define PIDFD_NONBLOCK	O_NONBLOCK
+#define PIDFD_THREAD	O_EXCL
+
+/* Flags for pidfd_send_signal(). */
+#define PIDFD_SIGNAL_THREAD		(1UL << 0)
+#define PIDFD_SIGNAL_THREAD_GROUP	(1UL << 1)
+#define PIDFD_SIGNAL_PROCESS_GROUP	(1UL << 2)
+
+/* Flags for pidfd_info. */
+#define PIDFD_INFO_PID			(1UL << 0) /* Always returned, even if not requested */
+#define PIDFD_INFO_CREDS		(1UL << 1) /* Always returned, even if not requested */
+#define PIDFD_INFO_CGROUPID		(1UL << 2) /* Always returned if available, even if not requested */
+#define PIDFD_INFO_EXIT			(1UL << 3) /* Only returned if requested. */
+#define PIDFD_INFO_COREDUMP		(1UL << 4) /* Only returned if requested. */
+#define PIDFD_INFO_SUPPORTED_MASK	(1UL << 5) /* Want/got supported mask flags */
+#define PIDFD_INFO_COREDUMP_SIGNAL	(1UL << 6) /* Always returned if PIDFD_INFO_COREDUMP is requested. */
+
+#define PIDFD_INFO_SIZE_VER0		64 /* sizeof first published struct */
+#define PIDFD_INFO_SIZE_VER1		72 /* sizeof second published struct */
+#define PIDFD_INFO_SIZE_VER2		80 /* sizeof third published struct */
+
+/*
+ * Values for @coredump_mask in pidfd_info.
+ * Only valid if PIDFD_INFO_COREDUMP is set in @mask.
+ *
+ * Note, the @PIDFD_COREDUMP_ROOT flag indicates that the generated
+ * coredump should be treated as sensitive and access should only be
+ * granted to privileged users.
+ */
+#define PIDFD_COREDUMPED	(1U << 0) /* Did crash and... */
+#define PIDFD_COREDUMP_SKIP	(1U << 1) /* coredumping generation was skipped. */
+#define PIDFD_COREDUMP_USER	(1U << 2) /* coredump was done as the user. */
+#define PIDFD_COREDUMP_ROOT	(1U << 3) /* coredump was done as root. */
+
+/*
+ * ...and for userland we make life simpler - PIDFD_SELF refers to the current
+ * thread, PIDFD_SELF_PROCESS refers to the process thread group leader.
+ *
+ * For nearly all practical uses, a user will want to use PIDFD_SELF.
+ */
+#define PIDFD_SELF		PIDFD_SELF_THREAD
+#define PIDFD_SELF_PROCESS	PIDFD_SELF_THREAD_GROUP
+
+struct pidfd_info {
+	/*
+	 * This mask is similar to the request_mask in statx(2).
+	 *
+	 * Userspace indicates what extensions or expensive-to-calculate fields
+	 * they want by setting the corresponding bits in mask. The kernel
+	 * will ignore bits that it does not know about.
+	 *
+	 * When filling the structure, the kernel will only set bits
+	 * corresponding to the fields that were actually filled by the kernel.
+	 * This also includes any future extensions that might be automatically
+	 * filled. If the structure size is too small to contain a field
+	 * (requested or not), to avoid confusion the mask will not
+	 * contain a bit for that field.
+	 *
+	 * As such, userspace MUST verify that mask contains the
+	 * corresponding flags after the ioctl(2) returns to ensure that it is
+	 * using valid data.
+	 */
+	__u64 mask;
+	/*
+	 * The information contained in the following fields might be stale at the
+	 * time it is received, as the target process might have exited as soon as
+	 * the IOCTL was processed, and there is no way to avoid that. However, it
+	 * is guaranteed that if the call was successful, then the information was
+	 * correct and referred to the intended process at the time the work was
+	 * performed. */
+	__u64 cgroupid;
+	__u32 pid;
+	__u32 tgid;
+	__u32 ppid;
+	__u32 ruid;
+	__u32 rgid;
+	__u32 euid;
+	__u32 egid;
+	__u32 suid;
+	__u32 sgid;
+	__u32 fsuid;
+	__u32 fsgid;
+	__s32 exit_code;
+	struct /* coredump info */ {
+		__u32 coredump_mask;
+		__u32 coredump_signal;
+	};
+	__u64 supported_mask;	/* Mask flags that this kernel supports */
+};
+
+#define PIDFS_IOCTL_MAGIC 0xFF
+
+#define PIDFD_GET_CGROUP_NAMESPACE            _IO(PIDFS_IOCTL_MAGIC, 1)
+#define PIDFD_GET_IPC_NAMESPACE               _IO(PIDFS_IOCTL_MAGIC, 2)
+#define PIDFD_GET_MNT_NAMESPACE               _IO(PIDFS_IOCTL_MAGIC, 3)
+#define PIDFD_GET_NET_NAMESPACE               _IO(PIDFS_IOCTL_MAGIC, 4)
+#define PIDFD_GET_PID_NAMESPACE               _IO(PIDFS_IOCTL_MAGIC, 5)
+#define PIDFD_GET_PID_FOR_CHILDREN_NAMESPACE  _IO(PIDFS_IOCTL_MAGIC, 6)
+#define PIDFD_GET_TIME_NAMESPACE              _IO(PIDFS_IOCTL_MAGIC, 7)
+#define PIDFD_GET_TIME_FOR_CHILDREN_NAMESPACE _IO(PIDFS_IOCTL_MAGIC, 8)
+#define PIDFD_GET_USER_NAMESPACE              _IO(PIDFS_IOCTL_MAGIC, 9)
+#define PIDFD_GET_UTS_NAMESPACE               _IO(PIDFS_IOCTL_MAGIC, 10)
+#define PIDFD_GET_INFO                        _IOWR(PIDFS_IOCTL_MAGIC, 11, struct pidfd_info)
+
+#endif /* _LINUX_PIDFD_H */

--- a/src/shared/meson.build
+++ b/src/shared/meson.build
@@ -199,6 +199,7 @@ shared_sources = files(
         'varlink-idl-common.c',
         'varlink-io.systemd.AskPassword.c',
         'varlink-io.systemd.BootControl.c',
+        'varlink-io.systemd.Coredump.Container.c',
         'varlink-io.systemd.Coredump.Register.c',
         'varlink-io.systemd.Credentials.c',
         'varlink-io.systemd.FactoryReset.c',

--- a/src/shared/meson.build
+++ b/src/shared/meson.build
@@ -199,6 +199,7 @@ shared_sources = files(
         'varlink-idl-common.c',
         'varlink-io.systemd.AskPassword.c',
         'varlink-io.systemd.BootControl.c',
+        'varlink-io.systemd.Coredump.Register.c',
         'varlink-io.systemd.Credentials.c',
         'varlink-io.systemd.FactoryReset.c',
         'varlink-io.systemd.Hostname.c',

--- a/src/shared/varlink-io.systemd.Coredump.Container.c
+++ b/src/shared/varlink-io.systemd.Coredump.Container.c
@@ -1,0 +1,17 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include "varlink-io.systemd.Coredump.Container.h"
+
+static SD_VARLINK_DEFINE_METHOD(
+                Transfer,
+                SD_VARLINK_FIELD_COMMENT("The index of the coredump socket file descriptor, which is a socket connection to the AF_UNIX socket path registered to the linux/core_pattern sysctl opened by the kernel on a process being crashed."),
+                SD_VARLINK_DEFINE_INPUT(coredumpFileDescriptor, SD_VARLINK_INT, 0),
+                SD_VARLINK_FIELD_COMMENT("The timestamp of the crash."),
+                SD_VARLINK_DEFINE_INPUT(timestamp, SD_VARLINK_INT, SD_VARLINK_NULLABLE));
+
+SD_VARLINK_DEFINE_INTERFACE(
+                io_systemd_CoredumpContainer,
+                "io.systemd.Coredump.Container",
+                SD_VARLINK_INTERFACE_COMMENT("APIs for processing coredumps inside container."),
+                SD_VARLINK_SYMBOL_COMMENT("Transfer coredump from the host to the container."),
+                &vl_method_Transfer);

--- a/src/shared/varlink-io.systemd.Coredump.Container.h
+++ b/src/shared/varlink-io.systemd.Coredump.Container.h
@@ -1,0 +1,6 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#pragma once
+
+#include "sd-varlink-idl.h"
+
+extern const sd_varlink_interface vl_interface_io_systemd_CoredumpContainer;

--- a/src/shared/varlink-io.systemd.Coredump.Register.c
+++ b/src/shared/varlink-io.systemd.Coredump.Register.c
@@ -1,0 +1,19 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include "varlink-io.systemd.Coredump.Register.h"
+
+static SD_VARLINK_DEFINE_METHOD(
+                SetCorePattern,
+                SD_VARLINK_FIELD_COMMENT("The core pattern to be written to /proc/sys/kernel/core_pattern."),
+                SD_VARLINK_DEFINE_INPUT(pattern, SD_VARLINK_STRING, 0));
+
+static SD_VARLINK_DEFINE_ERROR(CoredumpPatternNotSupported);
+
+SD_VARLINK_DEFINE_INTERFACE(
+                io_systemd_CoredumpRegister,
+                "io.systemd.Coredump.Register",
+                SD_VARLINK_INTERFACE_COMMENT("Core pattern register APIs."),
+                SD_VARLINK_SYMBOL_COMMENT("Set the specified core pattern."),
+                &vl_method_SetCorePattern,
+                SD_VARLINK_SYMBOL_COMMENT("The requested core pattern is not supported."),
+                &vl_error_CoredumpPatternNotSupported);

--- a/src/shared/varlink-io.systemd.Coredump.Register.h
+++ b/src/shared/varlink-io.systemd.Coredump.Register.h
@@ -1,0 +1,6 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#pragma once
+
+#include "sd-varlink-idl.h"
+
+extern const sd_varlink_interface vl_interface_io_systemd_CoredumpRegister;

--- a/src/test/test-varlink-idl.c
+++ b/src/test/test-varlink-idl.c
@@ -19,6 +19,7 @@
 #include "varlink-io.systemd.h"
 #include "varlink-io.systemd.AskPassword.h"
 #include "varlink-io.systemd.BootControl.h"
+#include "varlink-io.systemd.Coredump.Container.h"
 #include "varlink-io.systemd.Coredump.Register.h"
 #include "varlink-io.systemd.Credentials.h"
 #include "varlink-io.systemd.FactoryReset.h"
@@ -184,6 +185,7 @@ TEST(parse_format) {
                 &vl_interface_io_systemd,
                 &vl_interface_io_systemd_AskPassword,
                 &vl_interface_io_systemd_BootControl,
+                &vl_interface_io_systemd_CoredumpContainer,
                 &vl_interface_io_systemd_CoredumpRegister,
                 &vl_interface_io_systemd_Credentials,
                 &vl_interface_io_systemd_FactoryReset,

--- a/src/test/test-varlink-idl.c
+++ b/src/test/test-varlink-idl.c
@@ -19,6 +19,7 @@
 #include "varlink-io.systemd.h"
 #include "varlink-io.systemd.AskPassword.h"
 #include "varlink-io.systemd.BootControl.h"
+#include "varlink-io.systemd.Coredump.Register.h"
 #include "varlink-io.systemd.Credentials.h"
 #include "varlink-io.systemd.FactoryReset.h"
 #include "varlink-io.systemd.Hostname.h"
@@ -183,6 +184,7 @@ TEST(parse_format) {
                 &vl_interface_io_systemd,
                 &vl_interface_io_systemd_AskPassword,
                 &vl_interface_io_systemd_BootControl,
+                &vl_interface_io_systemd_CoredumpRegister,
                 &vl_interface_io_systemd_Credentials,
                 &vl_interface_io_systemd_FactoryReset,
                 &vl_interface_io_systemd_Hostname,

--- a/test/units/TEST-87-AUX-UTILS-VM.coredump.sh
+++ b/test/units/TEST-87-AUX-UTILS-VM.coredump.sh
@@ -26,7 +26,7 @@ journalctl --sync
 journalctl --rotate
 
 # Check that we're the ones to receive coredumps
-sysctl kernel.core_pattern | grep systemd-coredump
+sysctl kernel.core_pattern | grep -E '(systemd-coredump|@@/run/systemd/coredump-kernel)'
 
 # Prepare "fake" binaries for coredumps, so we can properly exercise
 # the matching stuff too
@@ -70,15 +70,21 @@ chmod +x "$MAKE_DUMP_SCRIPT"
 # with Storage=external as well
 mkdir -p /run/systemd/coredump.conf.d/
 printf '[Coredump]\nStorage=external' >/run/systemd/coredump.conf.d/99-external.conf
+if systemctl is-active systemd-coredumpd.service; then
+    systemctl reload systemd-coredumpd.service
+fi
 "$MAKE_DUMP_SCRIPT" "$CORE_TEST_BIN" "SIGTRAP"
 "$MAKE_DUMP_SCRIPT" "$CORE_TEST_BIN" "SIGABRT"
-rm -fv /run/systemd/coredump.conf.d/99-external.conf
 # Wait a bit for the coredumps to get processed
 timeout 30 bash -c "while [[ \$(coredumpctl list -q --no-legend $CORE_TEST_BIN | wc -l) -lt 4 ]]; do sleep 1; done"
+rm -fv /run/systemd/coredump.conf.d/99-external.conf
+if systemctl is-active systemd-coredumpd.service; then
+    systemctl reload systemd-coredumpd.service
+fi
 
-if cgroupfs_supports_user_xattrs; then
+test_container() {
     # Make sure we can forward crashes back to containers
-    CONTAINER="TEST-87-AUX-UTILS-VM-container"
+    local CONTAINER="TEST-87-AUX-UTILS-VM-container-${1:?}"
 
     mkdir -p "/var/lib/machines/$CONTAINER"
     mkdir -p "/run/systemd/system/systemd-nspawn@$CONTAINER.service.d"
@@ -92,6 +98,7 @@ ExecStart=systemd-nspawn --quiet --link-journal=try-guest --keep-unit --machine=
 EOF
     systemctl daemon-reload
 
+    local TIMEOUT
     [[ "$(systemd-detect-virt)" == "qemu" ]] && TIMEOUT=120 || TIMEOUT=60
 
     machinectl start "$CONTAINER"
@@ -106,7 +113,17 @@ EOF
 
     machinectl stop "$CONTAINER"
     rm -rf "/var/lib/machines/$CONTAINER"
-    unset CONTAINER
+}
+
+if cgroupfs_supports_user_xattrs; then
+    test_container 1
+
+    if systemctl is-active systemd-coredumpd.service; then
+        # Also test the case that the container is old by emulating that by masking the new container interface.
+        systemctl mask systemd-coredump-client.socket systemd-coredump-client@.service
+        test_container 2
+        systemctl unmask systemd-coredump-client.socket systemd-coredump-client@.service
+    fi
 fi
 
 # Sync and rotate journals (again) to make coredumps stored in archived journal. Otherwise, the main active
@@ -170,11 +187,17 @@ UNPRIV_CMD=(systemd-run --user --wait --pipe -M "testuser@.host" -E SYSTEMD_PAGE
 # with Storage=external as well
 mkdir -p /run/systemd/coredump.conf.d/
 printf '[Coredump]\nStorage=external' >/run/systemd/coredump.conf.d/99-external.conf
+if systemctl is-active systemd-coredumpd.service; then
+    systemctl reload systemd-coredumpd.service
+fi
 "${UNPRIV_CMD[@]}" "$MAKE_DUMP_SCRIPT" "$CORE_TEST_UNPRIV_BIN" "SIGTRAP"
 "${UNPRIV_CMD[@]}" "$MAKE_DUMP_SCRIPT" "$CORE_TEST_UNPRIV_BIN" "SIGABRT"
-rm -fv /run/systemd/coredump.conf.d/99-external.conf
 # Wait a bit for the coredumps to get processed
 timeout 30 bash -c "while [[ \$(coredumpctl list -q --no-legend $CORE_TEST_UNPRIV_BIN | wc -l) -lt 4 ]]; do sleep 1; done"
+rm -fv /run/systemd/coredump.conf.d/99-external.conf
+if systemctl is-active systemd-coredumpd.service; then
+    systemctl reload systemd-coredumpd.service
+fi
 
 # Sync and rotate journal again to make the coredump stored in an archived journal.
 journalctl --sync
@@ -293,6 +316,9 @@ EOF
 
     mkdir -p /run/systemd/coredump.conf.d/
     printf '[Coredump]\nEnterNamespace=no' >/run/systemd/coredump.conf.d/99-enter-namespace.conf
+    if systemctl is-active systemd-coredumpd.service; then
+        systemctl reload systemd-coredumpd.service
+    fi
 
     unshare --pid --fork --mount-proc --mount --uts --ipc --net "$MAKE_STACKTRACE_DUMP" "test-stacktrace-not-symbolized"
     timeout 30 bash -c "until coredumpctl list -q --no-legend /tmp/test-stacktrace-not-symbolized; do sleep .2; done"
@@ -303,6 +329,9 @@ EOF
     (! grep -E "#[0-9]+ .* baz " /tmp/not-symbolized.log)
 
     printf '[Coredump]\nEnterNamespace=yes' >/run/systemd/coredump.conf.d/99-enter-namespace.conf
+    if systemctl is-active systemd-coredumpd.service; then
+        systemctl reload systemd-coredumpd.service
+    fi
     unshare --pid --fork --mount-proc --mount --uts --ipc --net "$MAKE_STACKTRACE_DUMP" "test-stacktrace-symbolized"
     timeout 30 bash -c "until coredumpctl list -q --no-legend /tmp/test-stacktrace-symbolized; do sleep .2; done"
     coredumpctl info /tmp/test-stacktrace-symbolized | tee /tmp/symbolized.log
@@ -313,6 +342,9 @@ EOF
 
     test -d /usr/lib/debug/ && umount /usr/lib/debug/
     rm -f "$MAKE_STACKTRACE_DUMP" /run/systemd/coredump.conf.d/99-enter-namespace.conf /tmp/{not-,}symbolized.log
+    if systemctl is-active systemd-coredumpd.service; then
+        systemctl reload systemd-coredumpd.service
+    fi
 else
     echo "libdw doesn't not support setting sysroot, skipping EnterNamespace= test"
 fi

--- a/units/meson.build
+++ b/units/meson.build
@@ -321,6 +321,15 @@ units = [
           'conditions' : ['ENABLE_COREDUMP'],
         },
         {
+          'file' : 'systemd-coredump-container.socket',
+          'conditions' : ['ENABLE_COREDUMP'],
+          'symlinks' : ['sockets.target.wants/'],
+        },
+        {
+          'file' : 'systemd-coredump-container@.service.in',
+          'conditions' : ['ENABLE_COREDUMP'],
+        },
+        {
           'file' : 'systemd-coredump-register.socket',
           'conditions' : ['ENABLE_COREDUMP'],
           'symlinks' : ['sockets.target.wants/'],

--- a/units/meson.build
+++ b/units/meson.build
@@ -321,6 +321,15 @@ units = [
           'conditions' : ['ENABLE_COREDUMP'],
         },
         {
+          'file' : 'systemd-coredump-register.socket',
+          'conditions' : ['ENABLE_COREDUMP'],
+          'symlinks' : ['sockets.target.wants/'],
+        },
+        {
+          'file' : 'systemd-coredump-register@.service.in',
+          'conditions' : ['ENABLE_COREDUMP'],
+        },
+        {
           'file' : 'systemd-creds.socket',
           'symlinks' : ['sockets.target.wants/'],
         },

--- a/units/meson.build
+++ b/units/meson.build
@@ -339,6 +339,11 @@ units = [
           'conditions' : ['ENABLE_COREDUMP'],
         },
         {
+          'file' : 'systemd-coredumpd.service.in',
+          'conditions' : ['ENABLE_COREDUMP'],
+          'symlinks' : ['sysinit.target.wants/'],
+        },
+        {
           'file' : 'systemd-creds.socket',
           'symlinks' : ['sockets.target.wants/'],
         },

--- a/units/systemd-coredump-container.socket
+++ b/units/systemd-coredump-container.socket
@@ -1,0 +1,24 @@
+#  SPDX-License-Identifier: LGPL-2.1-or-later
+#
+#  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+
+[Unit]
+Description=Process Core Dump in Container Socket
+Documentation=man:systemd-coredump(8)
+DefaultDependencies=no
+Before=sockets.target
+Before=shutdown.target
+Conflicts=shutdown.target
+ConditionVirtualization=container
+
+[Socket]
+ListenStream=/run/systemd/io.systemd.Coredump.Container
+FileDescriptorName=varlink
+SocketMode=0600
+Accept=yes
+MaxConnections=16

--- a/units/systemd-coredump-container@.service.in
+++ b/units/systemd-coredump-container@.service.in
@@ -1,0 +1,45 @@
+#  SPDX-License-Identifier: LGPL-2.1-or-later
+#
+#  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+
+[Unit]
+Description=Process Core Dump in Container
+Documentation=man:systemd-coredump(8)
+DefaultDependencies=no
+Conflicts=shutdown.target
+After=systemd-journald.socket
+Requires=systemd-journald.socket
+Before=shutdown.target
+Conflicts=shutdown.target
+ConditionVirtualization=container
+
+[Service]
+ExecStart=-{{LIBEXECDIR}}/systemd-coredump --container
+IPAddressDeny=any
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+Nice=9
+NoNewPrivileges=yes
+OOMScoreAdjust=500
+PrivateDevices=yes
+PrivateNetwork=yes
+PrivateTmp=disconnected
+ProtectControlGroups=yes
+ProtectHome=read-only
+ProtectHostname=yes
+ProtectKernelLogs=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+ProtectSystem=strict
+RestrictAddressFamilies=AF_UNIX
+RestrictRealtime=yes
+RuntimeMaxSec=5min
+StateDirectory=systemd/coredump
+SystemCallArchitectures=native
+SystemCallErrorNumber=EPERM
+SystemCallFilter=@system-service @mount

--- a/units/systemd-coredump-register.socket
+++ b/units/systemd-coredump-register.socket
@@ -1,0 +1,24 @@
+#  SPDX-License-Identifier: LGPL-2.1-or-later
+#
+#  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+
+[Unit]
+Description=Register Coredump Pattern
+Documentation=man:systemd-coredump(8)
+DefaultDependencies=no
+Before=sockets.target
+Before=shutdown.target
+Conflicts=shutdown.target
+ConditionVirtualization=!container
+
+[Socket]
+ListenStream=/run/systemd/io.systemd.Coredump.Register
+FileDescriptorName=varlink
+SocketMode=0600
+Accept=yes
+MaxConnections=16

--- a/units/systemd-coredump-register@.service.in
+++ b/units/systemd-coredump-register@.service.in
@@ -1,0 +1,30 @@
+#  SPDX-License-Identifier: LGPL-2.1-or-later
+#
+#  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+
+[Unit]
+Description=Register Coredump Pattern
+Documentation=man:systemd-coredump(8)
+DefaultDependencies=no
+Before=shutdown.target
+Conflicts=shutdown.target
+ConditionVirtualization=!container
+
+[Service]
+ExecStart={{LIBEXECDIR}}/systemd-coredump --register
+IPAddressDeny=any
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+Nice=9
+NoNewPrivileges=yes
+RestrictAddressFamilies=AF_UNIX
+RestrictRealtime=yes
+RuntimeMaxSec=5min
+SystemCallArchitectures=native
+SystemCallErrorNumber=EPERM
+SystemCallFilter=@system-service

--- a/units/systemd-coredumpd.service.in
+++ b/units/systemd-coredumpd.service.in
@@ -1,0 +1,49 @@
+#  SPDX-License-Identifier: LGPL-2.1-or-later
+#
+#  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+
+[Unit]
+Description=Listen Kernel Core Dump Socket
+Documentation=man:systemd-coredump(8)
+DefaultDependencies=no
+After=systemd-coredump-register.socket systemd-journald.socket systemd-sysctl.service
+Requires=systemd-coredump-register.socket systemd-journald.socket
+Before=shutdown.target
+Conflicts=shutdown.target
+ConditionVirtualization=!container
+
+[Service]
+Type=notify-reload
+ExecStart={{LIBEXECDIR}}/systemd-coredump --manager
+FileDescriptorStoreMax=512
+FileDescriptorStorePreserve=yes
+IPAddressDeny=any
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+Nice=9
+NoNewPrivileges=yes
+OOMScoreAdjust=-1000
+PrivateDevices=yes
+PrivateNetwork=yes
+PrivateTmp=disconnected
+ProtectControlGroups=yes
+ProtectHome=read-only
+ProtectHostname=yes
+ProtectKernelLogs=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+ProtectSystem=strict
+Restart=on-failure
+RestartSec=0
+RestrictAddressFamilies=AF_UNIX
+RestrictRealtime=yes
+StateDirectory=systemd/coredump
+SystemCallArchitectures=native
+SystemCallErrorNumber=EPERM
+SystemCallFilter=@system-service @mount
+{{SERVICE_WATCHDOG}}


### PR DESCRIPTION
Since kernel v6.17, core pattern can take a path to unix socket. This adds support for the interface.
See also: https://lore.kernel.org/all/20250603-work-coredump-socket-protocol-v2-0-05a5f0c18ecc@kernel.org/

