### PR TITLE
core: implement Kill/Automount/Mount Context/Runtime for io.systemd.Unit.List

### DIFF
--- a/src/basic/unit-def.c
+++ b/src/basic/unit-def.c
@@ -72,6 +72,14 @@ const char* unit_dbus_interface_from_name(const char *name) {
         return unit_dbus_interface_from_type(t);
 }
 
+const char* unit_type_to_capitalized_string(UnitType t) {
+        const char *di = unit_dbus_interface_from_type(t);
+        if (!di)
+                return NULL;
+
+        return ASSERT_PTR(startswith(di, "org.freedesktop.systemd1."));
+}
+
 static const char* const unit_type_table[_UNIT_TYPE_MAX] = {
         [UNIT_SERVICE]   = "service",
         [UNIT_SOCKET]    = "socket",

--- a/src/basic/unit-def.h
+++ b/src/basic/unit-def.h
@@ -321,6 +321,7 @@ void unit_types_list(void);
 
 DECLARE_STRING_TABLE_LOOKUP(unit_load_state, UnitLoadState);
 DECLARE_STRING_TABLE_LOOKUP(unit_active_state, UnitActiveState);
+const char* unit_type_to_capitalized_string(UnitType t);
 
 DECLARE_STRING_TABLE_LOOKUP(freezer_state, FreezerState);
 FreezerState freezer_state_finish(FreezerState state) _const_;

--- a/src/core/meson.build
+++ b/src/core/meson.build
@@ -72,6 +72,7 @@ libcore_sources = files(
         'varlink-kill.c',
         'varlink-manager.c',
         'varlink-metrics.c',
+        'varlink-mount.c',
         'varlink-unit.c',
 )
 

--- a/src/core/meson.build
+++ b/src/core/meson.build
@@ -68,6 +68,7 @@ libcore_sources = files(
         'varlink-common.c',
         'varlink-dynamic-user.c',
         'varlink-execute.c',
+        'varlink-kill.c',
         'varlink-manager.c',
         'varlink-metrics.c',
         'varlink-unit.c',

--- a/src/core/meson.build
+++ b/src/core/meson.build
@@ -64,6 +64,7 @@ libcore_sources = files(
         'unit-serialize.c',
         'unit.c',
         'varlink.c',
+        'varlink-automount.c',
         'varlink-cgroup.c',
         'varlink-common.c',
         'varlink-dynamic-user.c',

--- a/src/core/varlink-automount.c
+++ b/src/core/varlink-automount.c
@@ -1,0 +1,22 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include "sd-json.h"
+
+#include "automount.h"
+#include "json-util.h"
+#include "varlink-automount.h"
+
+int automount_context_build_json(sd_json_variant **ret, const char *name, void *userdata) {
+        Automount *a = ASSERT_PTR(AUTOMOUNT(userdata));
+        return sd_json_buildo(
+                        ASSERT_PTR(ret),
+                        JSON_BUILD_PAIR_STRING_NON_EMPTY("Where", a->where),
+                        JSON_BUILD_PAIR_STRING_NON_EMPTY("ExtraOptions", a->extra_options),
+                        SD_JSON_BUILD_PAIR_UNSIGNED("DirectoryMode", a->directory_mode),
+                        JSON_BUILD_PAIR_FINITE_USEC("TimeoutIdleUSec", a->timeout_idle_usec));
+}
+
+int automount_runtime_build_json(sd_json_variant **ret, const char *name, void *userdata) {
+        Automount *a = ASSERT_PTR(AUTOMOUNT(userdata));
+        return sd_json_buildo(ASSERT_PTR(ret), JSON_BUILD_PAIR_ENUM("Result", automount_result_to_string(a->result)));
+}

--- a/src/core/varlink-automount.h
+++ b/src/core/varlink-automount.h
@@ -1,0 +1,7 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#pragma once
+
+#include "core-forward.h"
+
+int automount_context_build_json(sd_json_variant **ret, const char *name, void *userdata);
+int automount_runtime_build_json(sd_json_variant **ret, const char *name, void *userdata);

--- a/src/core/varlink-common.c
+++ b/src/core/varlink-common.c
@@ -4,6 +4,7 @@
 
 #include "bus-common-errors.h"
 #include "cpu-set-util.h"
+#include "execute.h"
 #include "json-util.h"
 #include "rlimit-util.h"
 #include "varlink-common.h"
@@ -103,4 +104,25 @@ int cpuset_build_json(sd_json_variant **ret, const char *name, void *userdata) {
 empty:
         *ret = NULL;
         return 0;
+}
+
+int exec_command_build_json(sd_json_variant **ret, const char *name, void *userdata) {
+        ExecCommand *cmd = ASSERT_PTR(userdata);
+
+        assert(ret);
+
+        if (isempty(cmd->path)) {
+                *ret = NULL;
+                return 0;
+        }
+
+        return sd_json_buildo(
+                        ret,
+                        SD_JSON_BUILD_PAIR_STRING("path", cmd->path),
+                        JSON_BUILD_PAIR_STRV_NON_EMPTY("arguments", cmd->argv),
+                        SD_JSON_BUILD_PAIR_BOOLEAN("ignoreFailure", FLAGS_SET(cmd->flags, EXEC_COMMAND_IGNORE_FAILURE)),
+                        SD_JSON_BUILD_PAIR_BOOLEAN("privileged", FLAGS_SET(cmd->flags, EXEC_COMMAND_FULLY_PRIVILEGED)),
+                        SD_JSON_BUILD_PAIR_BOOLEAN("noSetuid", FLAGS_SET(cmd->flags, EXEC_COMMAND_NO_SETUID)),
+                        SD_JSON_BUILD_PAIR_BOOLEAN("noEnvExpand", FLAGS_SET(cmd->flags, EXEC_COMMAND_NO_ENV_EXPAND)),
+                        SD_JSON_BUILD_PAIR_BOOLEAN("viaShell", FLAGS_SET(cmd->flags, EXEC_COMMAND_VIA_SHELL)));
 }

--- a/src/core/varlink-common.h
+++ b/src/core/varlink-common.h
@@ -6,5 +6,5 @@
 int rlimit_build_json(sd_json_variant **ret, const char *name, void *userdata);
 int rlimit_table_build_json(sd_json_variant **ret, const char *name, void *userdata);
 int cpuset_build_json(sd_json_variant **ret, const char *name, void *userdata);
-
 const char* varlink_error_id_from_bus_error(const sd_bus_error *e);
+int exec_command_build_json(sd_json_variant **ret, const char *name, void *userdata);

--- a/src/core/varlink-kill.c
+++ b/src/core/varlink-kill.c
@@ -1,0 +1,29 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include "sd-json.h"
+
+#include "json-util.h"
+#include "kill.h"
+#include "signal-util.h"
+#include "varlink-kill.h"
+
+int unit_kill_context_build_json(sd_json_variant **ret, const char *name, void *userdata) {
+        KillContext *c = userdata;
+
+        assert(ret);
+
+        if (!c) {
+                *ret = NULL;
+                return 0;
+        }
+
+        return sd_json_buildo(
+                        ret,
+                        JSON_BUILD_PAIR_ENUM("KillMode", kill_mode_to_string(c->kill_mode)),
+                        SD_JSON_BUILD_PAIR_STRING("KillSignal", signal_to_string(c->kill_signal)),
+                        SD_JSON_BUILD_PAIR_STRING("RestartKillSignal", signal_to_string(restart_kill_signal(c))),
+                        SD_JSON_BUILD_PAIR_BOOLEAN("SendSIGHUP", c->send_sighup),
+                        SD_JSON_BUILD_PAIR_BOOLEAN("SendSIGKILL", c->send_sigkill),
+                        SD_JSON_BUILD_PAIR_STRING("FinalKillSignal", signal_to_string(c->final_kill_signal)),
+                        SD_JSON_BUILD_PAIR_STRING("WatchdogSignal", signal_to_string(c->watchdog_signal)));
+}

--- a/src/core/varlink-kill.h
+++ b/src/core/varlink-kill.h
@@ -1,0 +1,6 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#pragma once
+
+#include "core-forward.h"
+
+int unit_kill_context_build_json(sd_json_variant **ret, const char *name, void *userdata);

--- a/src/core/varlink-mount.c
+++ b/src/core/varlink-mount.c
@@ -1,0 +1,55 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include "sd-json.h"
+
+#include "json-util.h"
+#include "mount.h"
+#include "user-util.h"
+#include "varlink-common.h"
+#include "varlink-mount.h"
+
+int mount_context_build_json(sd_json_variant **ret, const char *name, void *userdata) {
+        Mount *m = ASSERT_PTR(MOUNT(userdata));
+        _cleanup_free_ char *what = NULL, *where = NULL, *options = NULL;
+
+        what = mount_get_what_escaped(m);
+        if (!what)
+                return -ENOMEM;
+
+        where = mount_get_where_escaped(m);
+        if (!where)
+                return -ENOMEM;
+
+        options = mount_get_options_escaped(m);
+        if (!options)
+                return -ENOMEM;
+
+        return sd_json_buildo(
+                        ASSERT_PTR(ret),
+                        JSON_BUILD_PAIR_STRING_NON_EMPTY("What", what),
+                        JSON_BUILD_PAIR_STRING_NON_EMPTY("Where", where),
+                        JSON_BUILD_PAIR_STRING_NON_EMPTY("Type", mount_get_fstype(m)),
+                        JSON_BUILD_PAIR_STRING_NON_EMPTY("Options", options),
+                        SD_JSON_BUILD_PAIR_BOOLEAN("SloppyOptions", m->sloppy_options),
+                        SD_JSON_BUILD_PAIR_BOOLEAN("LazyUnmount", m->lazy_unmount),
+                        SD_JSON_BUILD_PAIR_BOOLEAN("ReadWriteOnly", m->read_write_only),
+                        SD_JSON_BUILD_PAIR_BOOLEAN("ForceUnmount", m->force_unmount),
+                        SD_JSON_BUILD_PAIR_UNSIGNED("DirectoryMode", m->directory_mode),
+                        JSON_BUILD_PAIR_FINITE_USEC("TimeoutUSec", m->timeout_usec),
+                        JSON_BUILD_PAIR_CALLBACK_NON_NULL("ExecMount", exec_command_build_json, &m->exec_command[MOUNT_EXEC_MOUNT]),
+                        JSON_BUILD_PAIR_CALLBACK_NON_NULL("ExecUnmount", exec_command_build_json, &m->exec_command[MOUNT_EXEC_UNMOUNT]),
+                        JSON_BUILD_PAIR_CALLBACK_NON_NULL("ExecRemount", exec_command_build_json, &m->exec_command[MOUNT_EXEC_REMOUNT]));
+}
+
+int mount_runtime_build_json(sd_json_variant **ret, const char *name, void *userdata) {
+        Unit *u = ASSERT_PTR(userdata);
+        Mount *m = ASSERT_PTR(MOUNT(u));
+        return sd_json_buildo(
+                        ASSERT_PTR(ret),
+                        SD_JSON_BUILD_PAIR_CONDITION(pidref_is_set(&m->control_pid), "ControlPID", JSON_BUILD_PIDREF(&m->control_pid)),
+                        JSON_BUILD_PAIR_ENUM("Result", mount_result_to_string(m->result)),
+                        JSON_BUILD_PAIR_ENUM("ReloadResult", mount_result_to_string(m->reload_result)),
+                        JSON_BUILD_PAIR_ENUM("CleanResult", mount_result_to_string(m->clean_result)),
+                        SD_JSON_BUILD_PAIR_CONDITION(uid_is_valid(u->ref_uid), "UID", SD_JSON_BUILD_UNSIGNED(u->ref_uid)),
+                        SD_JSON_BUILD_PAIR_CONDITION(gid_is_valid(u->ref_gid), "GID", SD_JSON_BUILD_UNSIGNED(u->ref_gid)));
+}

--- a/src/core/varlink-mount.h
+++ b/src/core/varlink-mount.h
@@ -1,0 +1,7 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#pragma once
+
+#include "core-forward.h"
+
+int mount_context_build_json(sd_json_variant **ret, const char *name, void *userdata);
+int mount_runtime_build_json(sd_json_variant **ret, const char *name, void *userdata);

--- a/src/core/varlink-unit.c
+++ b/src/core/varlink-unit.c
@@ -18,6 +18,7 @@
 #include "set.h"
 #include "strv.h"
 #include "unit.h"
+#include "varlink-automount.h"
 #include "varlink-cgroup.h"
 #include "varlink-execute.h"
 #include "varlink-kill.h"
@@ -113,6 +114,11 @@ static int unit_context_build_json(sd_json_variant **ret, const char *name, void
          * If it make sense to place a property into a config/unit file it belongs to Context.
          * Otherwise it's a 'Runtime'. */
 
+        /* TODO missing callbacks */
+        static const sd_json_build_callback_t unit_type_callbacks[_UNIT_TYPE_MAX] = {
+                [UNIT_AUTOMOUNT] = automount_context_build_json,
+        };
+
         return sd_json_buildo(
                         ASSERT_PTR(ret),
                         SD_JSON_BUILD_PAIR_STRING("Type", unit_type_to_string(u->type)),
@@ -191,16 +197,8 @@ static int unit_context_build_json(sd_json_variant **ret, const char *name, void
 
                         JSON_BUILD_PAIR_CALLBACK_NON_NULL("CGroup", unit_cgroup_context_build_json, u),
                         JSON_BUILD_PAIR_CALLBACK_NON_NULL("Exec", unit_exec_context_build_json, u),
-                        JSON_BUILD_PAIR_CALLBACK_NON_NULL("Kill", unit_kill_context_build_json, unit_get_kill_context(u)));
-
-        // TODO follow up PRs:
-        // Mount/Automount context
-        // Path context
-        // Scope context
-        // Swap context
-        // Timer context
-        // Service context
-        // Socket context
+                        JSON_BUILD_PAIR_CALLBACK_NON_NULL("Kill", unit_kill_context_build_json, unit_get_kill_context(u)),
+                        JSON_BUILD_PAIR_CALLBACK_NON_NULL(unit_type_to_capitalized_string(u->type), unit_type_callbacks[u->type], u));
 }
 
 static int can_clean_build_json(sd_json_variant **ret, const char *name, void *userdata) {
@@ -280,6 +278,11 @@ static int unit_runtime_build_json(sd_json_variant **ret, const char *name, void
         Unit *u = ASSERT_PTR(userdata);
         Unit *f = unit_following(u);
 
+        /* TODO missing callbacks */
+        static const sd_json_build_callback_t unit_type_callbacks[_UNIT_TYPE_MAX] = {
+                [UNIT_AUTOMOUNT] = automount_runtime_build_json,
+        };
+
         return sd_json_buildo(
                         ASSERT_PTR(ret),
                         JSON_BUILD_PAIR_STRING_NON_EMPTY("Following", f ? f->id : NULL),
@@ -309,7 +312,8 @@ static int unit_runtime_build_json(sd_json_variant **ret, const char *name, void
                         SD_JSON_BUILD_PAIR_CONDITION(!sd_id128_is_null(u->invocation_id), "InvocationID", SD_JSON_BUILD_UUID(u->invocation_id)),
                         JSON_BUILD_PAIR_CALLBACK_NON_NULL("Markers", markers_build_json, &u->markers),
                         JSON_BUILD_PAIR_CALLBACK_NON_NULL("ActivationDetails", activation_details_build_json, u->activation_details),
-                        JSON_BUILD_PAIR_CALLBACK_NON_NULL("CGroup", unit_cgroup_runtime_build_json, u));
+                        JSON_BUILD_PAIR_CALLBACK_NON_NULL("CGroup", unit_cgroup_runtime_build_json, u),
+                        JSON_BUILD_PAIR_CALLBACK_NON_NULL(unit_type_to_capitalized_string(u->type), unit_type_callbacks[u->type], u));
 }
 
 static int list_unit_one(sd_varlink *link, Unit *unit) {

--- a/src/core/varlink-unit.c
+++ b/src/core/varlink-unit.c
@@ -22,6 +22,7 @@
 #include "varlink-cgroup.h"
 #include "varlink-execute.h"
 #include "varlink-kill.h"
+#include "varlink-mount.h"
 #include "varlink-unit.h"
 #include "varlink-util.h"
 
@@ -117,6 +118,7 @@ static int unit_context_build_json(sd_json_variant **ret, const char *name, void
         /* TODO missing callbacks */
         static const sd_json_build_callback_t unit_type_callbacks[_UNIT_TYPE_MAX] = {
                 [UNIT_AUTOMOUNT] = automount_context_build_json,
+                [UNIT_MOUNT]     = mount_context_build_json,
         };
 
         return sd_json_buildo(
@@ -281,6 +283,7 @@ static int unit_runtime_build_json(sd_json_variant **ret, const char *name, void
         /* TODO missing callbacks */
         static const sd_json_build_callback_t unit_type_callbacks[_UNIT_TYPE_MAX] = {
                 [UNIT_AUTOMOUNT] = automount_runtime_build_json,
+                [UNIT_MOUNT]     = mount_runtime_build_json,
         };
 
         return sd_json_buildo(

--- a/src/core/varlink-unit.c
+++ b/src/core/varlink-unit.c
@@ -20,6 +20,7 @@
 #include "unit.h"
 #include "varlink-cgroup.h"
 #include "varlink-execute.h"
+#include "varlink-kill.h"
 #include "varlink-unit.h"
 #include "varlink-util.h"
 
@@ -189,11 +190,10 @@ static int unit_context_build_json(sd_json_variant **ret, const char *name, void
                         SD_JSON_BUILD_PAIR_BOOLEAN("DebugInvocation", u->debug_invocation),
 
                         JSON_BUILD_PAIR_CALLBACK_NON_NULL("CGroup", unit_cgroup_context_build_json, u),
-                        JSON_BUILD_PAIR_CALLBACK_NON_NULL("Exec", unit_exec_context_build_json, u));
+                        JSON_BUILD_PAIR_CALLBACK_NON_NULL("Exec", unit_exec_context_build_json, u),
+                        JSON_BUILD_PAIR_CALLBACK_NON_NULL("Kill", unit_kill_context_build_json, unit_get_kill_context(u)));
 
         // TODO follow up PRs:
-        // JSON_BUILD_PAIR_CALLBACK_NON_NULL("Exec", exec_context_build_json, u)
-        // JSON_BUILD_PAIR_CALLBACK_NON_NULL("Kill", kill_context_build_json, u)
         // Mount/Automount context
         // Path context
         // Scope context

--- a/src/shared/varlink-idl-common.c
+++ b/src/shared/varlink-idl-common.c
@@ -54,6 +54,23 @@ SD_VARLINK_DEFINE_STRUCT_TYPE(
                 SD_VARLINK_DEFINE_FIELD_BY_TYPE(RTPRIO, ResourceLimit, SD_VARLINK_NULLABLE),
                 SD_VARLINK_DEFINE_FIELD_BY_TYPE(RTTIME, ResourceLimit, SD_VARLINK_NULLABLE));
 
+SD_VARLINK_DEFINE_STRUCT_TYPE(
+                ExecCommand,
+                SD_VARLINK_FIELD_COMMENT("Path"),
+                SD_VARLINK_DEFINE_FIELD(path, SD_VARLINK_STRING, 0),
+                SD_VARLINK_FIELD_COMMENT("Arguments"),
+                SD_VARLINK_DEFINE_FIELD(arguments, SD_VARLINK_STRING, SD_VARLINK_ARRAY|SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("Ignore failure of the command"),
+                SD_VARLINK_DEFINE_FIELD(ignoreFailure, SD_VARLINK_BOOL, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("Run with full privileges"),
+                SD_VARLINK_DEFINE_FIELD(privileged, SD_VARLINK_BOOL, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("Skip setuid handling"),
+                SD_VARLINK_DEFINE_FIELD(noSetuid, SD_VARLINK_BOOL, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("Skip environment variable expansion"),
+                SD_VARLINK_DEFINE_FIELD(noEnvExpand, SD_VARLINK_BOOL, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("Run via shell"),
+                SD_VARLINK_DEFINE_FIELD(viaShell, SD_VARLINK_BOOL, SD_VARLINK_NULLABLE));
+
 SD_VARLINK_DEFINE_ENUM_TYPE(
                 ExecOutputType,
                 SD_VARLINK_DEFINE_ENUM_VALUE(inherit),

--- a/src/shared/varlink-idl-common.h
+++ b/src/shared/varlink-idl-common.h
@@ -8,6 +8,7 @@ extern const sd_varlink_symbol vl_type_ProcessId;
 extern const sd_varlink_symbol vl_type_RateLimit;
 extern const sd_varlink_symbol vl_type_ResourceLimit;
 extern const sd_varlink_symbol vl_type_ResourceLimitTable;
+extern const sd_varlink_symbol vl_type_ExecCommand;
 extern const sd_varlink_symbol vl_type_ExecOutputType;
 extern const sd_varlink_symbol vl_type_CGroupPressureWatch;
 extern const sd_varlink_symbol vl_type_ManagedOOMMode;

--- a/src/shared/varlink-io.systemd.Unit.c
+++ b/src/shared/varlink-io.systemd.Unit.c
@@ -928,6 +928,19 @@ static SD_VARLINK_DEFINE_STRUCT_TYPE(
                 SD_VARLINK_FIELD_COMMENT("https://www.freedesktop.org/software/systemd/man/"PROJECT_VERSION_STR"/systemd.kill.html#WatchdogSignal="),
                 SD_VARLINK_DEFINE_FIELD(WatchdogSignal, SD_VARLINK_STRING, SD_VARLINK_NULLABLE));
 
+/* AutomountContext
+ * https://www.freedesktop.org/software/systemd/man/latest/systemd.automount.html */
+static SD_VARLINK_DEFINE_STRUCT_TYPE(
+                AutomountContext,
+                SD_VARLINK_FIELD_COMMENT("https://www.freedesktop.org/software/systemd/man/"PROJECT_VERSION_STR"/systemd.automount.html#Where="),
+                SD_VARLINK_DEFINE_FIELD(Where, SD_VARLINK_STRING, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("https://www.freedesktop.org/software/systemd/man/"PROJECT_VERSION_STR"/systemd.automount.html#ExtraOptions="),
+                SD_VARLINK_DEFINE_FIELD(ExtraOptions, SD_VARLINK_STRING, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("https://www.freedesktop.org/software/systemd/man/"PROJECT_VERSION_STR"/systemd.automount.html#DirectoryMode="),
+                SD_VARLINK_DEFINE_FIELD(DirectoryMode, SD_VARLINK_INT, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("https://www.freedesktop.org/software/systemd/man/"PROJECT_VERSION_STR"/systemd.automount.html#TimeoutIdleSec="),
+                SD_VARLINK_DEFINE_FIELD(TimeoutIdleUSec, SD_VARLINK_INT, SD_VARLINK_NULLABLE));
+
 /* UnitContext */
 static SD_VARLINK_DEFINE_STRUCT_TYPE(
                 Condition,
@@ -1087,8 +1100,9 @@ static SD_VARLINK_DEFINE_STRUCT_TYPE(
                 SD_VARLINK_FIELD_COMMENT("The exec context of the unit"),
                 SD_VARLINK_DEFINE_FIELD_BY_TYPE(Exec, ExecContext, SD_VARLINK_NULLABLE),
                 SD_VARLINK_FIELD_COMMENT("The kill context of the unit"),
-                SD_VARLINK_DEFINE_FIELD_BY_TYPE(Kill, KillContext, SD_VARLINK_NULLABLE));
-
+                SD_VARLINK_DEFINE_FIELD_BY_TYPE(Kill, KillContext, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("The automount context of the unit"),
+                SD_VARLINK_DEFINE_FIELD_BY_TYPE(Automount, AutomountContext, SD_VARLINK_NULLABLE));
 
 static SD_VARLINK_DEFINE_STRUCT_TYPE(
                 ActivationDetails,
@@ -1162,6 +1176,19 @@ static SD_VARLINK_DEFINE_STRUCT_TYPE(
                 SD_VARLINK_FIELD_COMMENT("The number of processes of this unit killed by systemd-oomd"),
                 SD_VARLINK_DEFINE_FIELD(ManagedOOMKills, SD_VARLINK_INT, SD_VARLINK_NULLABLE));
 
+SD_VARLINK_DEFINE_ENUM_TYPE(
+                AutomountResult,
+                SD_VARLINK_DEFINE_ENUM_VALUE(success),
+                SD_VARLINK_DEFINE_ENUM_VALUE(resources),
+                SD_VARLINK_DEFINE_ENUM_VALUE(start_limit_hit),
+                SD_VARLINK_DEFINE_ENUM_VALUE(mount_start_limit_hit),
+                SD_VARLINK_DEFINE_ENUM_VALUE(unmounted));
+
+static SD_VARLINK_DEFINE_STRUCT_TYPE(
+                AutomountRuntime,
+                SD_VARLINK_FIELD_COMMENT("Result of automount operation"),
+                SD_VARLINK_DEFINE_FIELD_BY_TYPE(Result, AutomountResult, 0));
+
 static SD_VARLINK_DEFINE_STRUCT_TYPE(
                 UnitRuntime,
                 SD_VARLINK_FIELD_COMMENT("If not empty, the field contains the name of another unit that this unit follows in state"),
@@ -1219,7 +1246,9 @@ static SD_VARLINK_DEFINE_STRUCT_TYPE(
                 SD_VARLINK_FIELD_COMMENT("Provides details about why a unit was activated"),
                 SD_VARLINK_DEFINE_FIELD_BY_TYPE(ActivationDetails, ActivationDetails, SD_VARLINK_ARRAY|SD_VARLINK_NULLABLE),
                 SD_VARLINK_FIELD_COMMENT("The cgroup runtime of the unit"),
-                SD_VARLINK_DEFINE_FIELD_BY_TYPE(CGroup, CGroupRuntime, SD_VARLINK_NULLABLE));
+                SD_VARLINK_DEFINE_FIELD_BY_TYPE(CGroup, CGroupRuntime, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("The automount runtime of the unit"),
+                SD_VARLINK_DEFINE_FIELD_BY_TYPE(Automount, AutomountRuntime, SD_VARLINK_NULLABLE));
 
 static SD_VARLINK_DEFINE_METHOD_FULL(
                 List,
@@ -1350,6 +1379,9 @@ SD_VARLINK_DEFINE_INTERFACE(
                 /* other contexts */
                 &vl_type_KillMode,
                 &vl_type_KillContext,
+                &vl_type_AutomountContext,
+                &vl_type_AutomountResult,
+                &vl_type_AutomountRuntime,
 
                 /* UnitContext enums */
                 &vl_type_CollectMode,

--- a/src/shared/varlink-io.systemd.Unit.c
+++ b/src/shared/varlink-io.systemd.Unit.c
@@ -902,6 +902,32 @@ static SD_VARLINK_DEFINE_STRUCT_TYPE(
                 SD_VARLINK_FIELD_COMMENT("https://www.freedesktop.org/software/systemd/man"PROJECT_VERSION_STR"systemd.exec.html#UtmpMode="),
                 SD_VARLINK_DEFINE_FIELD_BY_TYPE(UtmpMode, ExecUtmpMode, 0));
 
+SD_VARLINK_DEFINE_ENUM_TYPE(
+                KillMode,
+                SD_VARLINK_DEFINE_ENUM_VALUE(control_group),
+                SD_VARLINK_DEFINE_ENUM_VALUE(process),
+                SD_VARLINK_DEFINE_ENUM_VALUE(mixed),
+                SD_VARLINK_DEFINE_ENUM_VALUE(none));
+
+/* KillContext
+ * https://www.freedesktop.org/software/systemd/man/latest/systemd.kill.html */
+static SD_VARLINK_DEFINE_STRUCT_TYPE(
+                KillContext,
+                SD_VARLINK_FIELD_COMMENT("https://www.freedesktop.org/software/systemd/man/"PROJECT_VERSION_STR"/systemd.kill.html#KillMode="),
+                SD_VARLINK_DEFINE_FIELD_BY_TYPE(KillMode, KillMode, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("https://www.freedesktop.org/software/systemd/man/"PROJECT_VERSION_STR"/systemd.kill.html#KillSignal="),
+                SD_VARLINK_DEFINE_FIELD(KillSignal, SD_VARLINK_STRING, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("https://www.freedesktop.org/software/systemd/man/"PROJECT_VERSION_STR"/systemd.kill.html#RestartKillSignal="),
+                SD_VARLINK_DEFINE_FIELD(RestartKillSignal, SD_VARLINK_STRING, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("https://www.freedesktop.org/software/systemd/man/"PROJECT_VERSION_STR"/systemd.kill.html#SendSIGHUP="),
+                SD_VARLINK_DEFINE_FIELD(SendSIGHUP, SD_VARLINK_BOOL, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("https://www.freedesktop.org/software/systemd/man/"PROJECT_VERSION_STR"/systemd.kill.html#SendSIGKILL="),
+                SD_VARLINK_DEFINE_FIELD(SendSIGKILL, SD_VARLINK_BOOL, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("https://www.freedesktop.org/software/systemd/man/"PROJECT_VERSION_STR"/systemd.kill.html#FinalKillSignal="),
+                SD_VARLINK_DEFINE_FIELD(FinalKillSignal, SD_VARLINK_STRING, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("https://www.freedesktop.org/software/systemd/man/"PROJECT_VERSION_STR"/systemd.kill.html#WatchdogSignal="),
+                SD_VARLINK_DEFINE_FIELD(WatchdogSignal, SD_VARLINK_STRING, SD_VARLINK_NULLABLE));
+
 /* UnitContext */
 static SD_VARLINK_DEFINE_STRUCT_TYPE(
                 Condition,
@@ -1059,7 +1085,10 @@ static SD_VARLINK_DEFINE_STRUCT_TYPE(
                 SD_VARLINK_FIELD_COMMENT("The cgroup context of the unit"),
                 SD_VARLINK_DEFINE_FIELD_BY_TYPE(CGroup, CGroupContext, SD_VARLINK_NULLABLE),
                 SD_VARLINK_FIELD_COMMENT("The exec context of the unit"),
-                SD_VARLINK_DEFINE_FIELD_BY_TYPE(Exec, ExecContext, SD_VARLINK_NULLABLE));
+                SD_VARLINK_DEFINE_FIELD_BY_TYPE(Exec, ExecContext, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("The kill context of the unit"),
+                SD_VARLINK_DEFINE_FIELD_BY_TYPE(Kill, KillContext, SD_VARLINK_NULLABLE));
+
 
 static SD_VARLINK_DEFINE_STRUCT_TYPE(
                 ActivationDetails,
@@ -1317,6 +1346,10 @@ SD_VARLINK_DEFINE_INTERFACE(
                 &vl_type_SetCredential,
                 SD_VARLINK_SYMBOL_COMMENT("Exec context of a unit"),
                 &vl_type_ExecContext,
+
+                /* other contexts */
+                &vl_type_KillMode,
+                &vl_type_KillContext,
 
                 /* UnitContext enums */
                 &vl_type_CollectMode,

--- a/src/shared/varlink-io.systemd.Unit.c
+++ b/src/shared/varlink-io.systemd.Unit.c
@@ -941,6 +941,37 @@ static SD_VARLINK_DEFINE_STRUCT_TYPE(
                 SD_VARLINK_FIELD_COMMENT("https://www.freedesktop.org/software/systemd/man/"PROJECT_VERSION_STR"/systemd.automount.html#TimeoutIdleSec="),
                 SD_VARLINK_DEFINE_FIELD(TimeoutIdleUSec, SD_VARLINK_INT, SD_VARLINK_NULLABLE));
 
+/* MountContext
+ * https://www.freedesktop.org/software/systemd/man/latest/systemd.mount.html */
+static SD_VARLINK_DEFINE_STRUCT_TYPE(
+                MountContext,
+                SD_VARLINK_FIELD_COMMENT("https://www.freedesktop.org/software/systemd/man/"PROJECT_VERSION_STR"/systemd.mount.html#What="),
+                SD_VARLINK_DEFINE_FIELD(What, SD_VARLINK_STRING, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("https://www.freedesktop.org/software/systemd/man/"PROJECT_VERSION_STR"/systemd.mount.html#Where="),
+                SD_VARLINK_DEFINE_FIELD(Where, SD_VARLINK_STRING, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("https://www.freedesktop.org/software/systemd/man/"PROJECT_VERSION_STR"/systemd.mount.html#Type="),
+                SD_VARLINK_DEFINE_FIELD(Type, SD_VARLINK_STRING, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("https://www.freedesktop.org/software/systemd/man/"PROJECT_VERSION_STR"/systemd.mount.html#Options="),
+                SD_VARLINK_DEFINE_FIELD(Options, SD_VARLINK_STRING, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("https://www.freedesktop.org/software/systemd/man/"PROJECT_VERSION_STR"/systemd.mount.html#SloppyOptions="),
+                SD_VARLINK_DEFINE_FIELD(SloppyOptions, SD_VARLINK_BOOL, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("https://www.freedesktop.org/software/systemd/man/"PROJECT_VERSION_STR"/systemd.mount.html#LazyUnmount="),
+                SD_VARLINK_DEFINE_FIELD(LazyUnmount, SD_VARLINK_BOOL, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("https://www.freedesktop.org/software/systemd/man/"PROJECT_VERSION_STR"/systemd.mount.html#ReadWriteOnly="),
+                SD_VARLINK_DEFINE_FIELD(ReadWriteOnly, SD_VARLINK_BOOL, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("https://www.freedesktop.org/software/systemd/man/"PROJECT_VERSION_STR"/systemd.mount.html#ForceUnmount="),
+                SD_VARLINK_DEFINE_FIELD(ForceUnmount, SD_VARLINK_BOOL, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("https://www.freedesktop.org/software/systemd/man/"PROJECT_VERSION_STR"/systemd.mount.html#DirectoryMode="),
+                SD_VARLINK_DEFINE_FIELD(DirectoryMode, SD_VARLINK_INT, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("https://www.freedesktop.org/software/systemd/man/"PROJECT_VERSION_STR"/systemd.mount.html#TimeoutSec="),
+                SD_VARLINK_DEFINE_FIELD(TimeoutUSec, SD_VARLINK_INT, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("Mount command"),
+                SD_VARLINK_DEFINE_FIELD_BY_TYPE(ExecMount, ExecCommand, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("Unmount command"),
+                SD_VARLINK_DEFINE_FIELD_BY_TYPE(ExecUnmount, ExecCommand, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("Remount command"),
+                SD_VARLINK_DEFINE_FIELD_BY_TYPE(ExecRemount, ExecCommand, SD_VARLINK_NULLABLE));
+
 /* UnitContext */
 static SD_VARLINK_DEFINE_STRUCT_TYPE(
                 Condition,
@@ -1102,7 +1133,9 @@ static SD_VARLINK_DEFINE_STRUCT_TYPE(
                 SD_VARLINK_FIELD_COMMENT("The kill context of the unit"),
                 SD_VARLINK_DEFINE_FIELD_BY_TYPE(Kill, KillContext, SD_VARLINK_NULLABLE),
                 SD_VARLINK_FIELD_COMMENT("The automount context of the unit"),
-                SD_VARLINK_DEFINE_FIELD_BY_TYPE(Automount, AutomountContext, SD_VARLINK_NULLABLE));
+                SD_VARLINK_DEFINE_FIELD_BY_TYPE(Automount, AutomountContext, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("The mount context of the unit"),
+                SD_VARLINK_DEFINE_FIELD_BY_TYPE(Mount, MountContext, SD_VARLINK_NULLABLE));
 
 static SD_VARLINK_DEFINE_STRUCT_TYPE(
                 ActivationDetails,
@@ -1189,6 +1222,32 @@ static SD_VARLINK_DEFINE_STRUCT_TYPE(
                 SD_VARLINK_FIELD_COMMENT("Result of automount operation"),
                 SD_VARLINK_DEFINE_FIELD_BY_TYPE(Result, AutomountResult, 0));
 
+SD_VARLINK_DEFINE_ENUM_TYPE(
+                MountResult,
+                SD_VARLINK_DEFINE_ENUM_VALUE(success),
+                SD_VARLINK_DEFINE_ENUM_VALUE(resources),
+                SD_VARLINK_DEFINE_ENUM_VALUE(timeout),
+                SD_VARLINK_DEFINE_ENUM_VALUE(exit_code),
+                SD_VARLINK_DEFINE_ENUM_VALUE(signal),
+                SD_VARLINK_DEFINE_ENUM_VALUE(core_dump),
+                SD_VARLINK_DEFINE_ENUM_VALUE(start_limit_hit),
+                SD_VARLINK_DEFINE_ENUM_VALUE(protocol));
+
+static SD_VARLINK_DEFINE_STRUCT_TYPE(
+                MountRuntime,
+                SD_VARLINK_FIELD_COMMENT("PID of the current mount/remount/etc process running"),
+                SD_VARLINK_DEFINE_FIELD_BY_TYPE(ControlPID, ProcessId, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("Result of mount operation"),
+                SD_VARLINK_DEFINE_FIELD_BY_TYPE(Result, MountResult, 0),
+                SD_VARLINK_FIELD_COMMENT("Result of remount operation"),
+                SD_VARLINK_DEFINE_FIELD_BY_TYPE(ReloadResult, MountResult, 0),
+                SD_VARLINK_FIELD_COMMENT("Result of cleaning operation"),
+                SD_VARLINK_DEFINE_FIELD_BY_TYPE(CleanResult, MountResult, 0),
+                SD_VARLINK_FIELD_COMMENT("Reference UID"),
+                SD_VARLINK_DEFINE_FIELD(UID, SD_VARLINK_INT, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("Reference GID"),
+                SD_VARLINK_DEFINE_FIELD(GID, SD_VARLINK_INT, SD_VARLINK_NULLABLE));
+
 static SD_VARLINK_DEFINE_STRUCT_TYPE(
                 UnitRuntime,
                 SD_VARLINK_FIELD_COMMENT("If not empty, the field contains the name of another unit that this unit follows in state"),
@@ -1248,7 +1307,9 @@ static SD_VARLINK_DEFINE_STRUCT_TYPE(
                 SD_VARLINK_FIELD_COMMENT("The cgroup runtime of the unit"),
                 SD_VARLINK_DEFINE_FIELD_BY_TYPE(CGroup, CGroupRuntime, SD_VARLINK_NULLABLE),
                 SD_VARLINK_FIELD_COMMENT("The automount runtime of the unit"),
-                SD_VARLINK_DEFINE_FIELD_BY_TYPE(Automount, AutomountRuntime, SD_VARLINK_NULLABLE));
+                SD_VARLINK_DEFINE_FIELD_BY_TYPE(Automount, AutomountRuntime, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("The mount runtime of the unit"),
+                SD_VARLINK_DEFINE_FIELD_BY_TYPE(Mount, MountRuntime, SD_VARLINK_NULLABLE));
 
 static SD_VARLINK_DEFINE_METHOD_FULL(
                 List,
@@ -1382,6 +1443,10 @@ SD_VARLINK_DEFINE_INTERFACE(
                 &vl_type_AutomountContext,
                 &vl_type_AutomountResult,
                 &vl_type_AutomountRuntime,
+                &vl_type_ExecCommand,
+                &vl_type_MountContext,
+                &vl_type_MountResult,
+                &vl_type_MountRuntime,
 
                 /* UnitContext enums */
                 &vl_type_CollectMode,

--- a/src/shared/varlink-io.systemd.Unit.h
+++ b/src/shared/varlink-io.systemd.Unit.h
@@ -28,5 +28,6 @@ extern const sd_varlink_symbol vl_type_IOSchedulingClass;
 extern const sd_varlink_symbol vl_type_NUMAPolicy;
 extern const sd_varlink_symbol vl_type_MountPropagationFlag;
 extern const sd_varlink_symbol vl_type_KillMode;
+extern const sd_varlink_symbol vl_type_AutomountResult;
 extern const sd_varlink_symbol vl_type_CollectMode;
 extern const sd_varlink_symbol vl_type_JobMode;

--- a/src/shared/varlink-io.systemd.Unit.h
+++ b/src/shared/varlink-io.systemd.Unit.h
@@ -27,5 +27,6 @@ extern const sd_varlink_symbol vl_type_CPUSchedulingPolicy;
 extern const sd_varlink_symbol vl_type_IOSchedulingClass;
 extern const sd_varlink_symbol vl_type_NUMAPolicy;
 extern const sd_varlink_symbol vl_type_MountPropagationFlag;
+extern const sd_varlink_symbol vl_type_KillMode;
 extern const sd_varlink_symbol vl_type_CollectMode;
 extern const sd_varlink_symbol vl_type_JobMode;

--- a/src/shared/varlink-io.systemd.Unit.h
+++ b/src/shared/varlink-io.systemd.Unit.h
@@ -29,5 +29,6 @@ extern const sd_varlink_symbol vl_type_NUMAPolicy;
 extern const sd_varlink_symbol vl_type_MountPropagationFlag;
 extern const sd_varlink_symbol vl_type_KillMode;
 extern const sd_varlink_symbol vl_type_AutomountResult;
+extern const sd_varlink_symbol vl_type_MountResult;
 extern const sd_varlink_symbol vl_type_CollectMode;
 extern const sd_varlink_symbol vl_type_JobMode;

--- a/src/test/test-varlink-idl-unit.c
+++ b/src/test/test-varlink-idl-unit.c
@@ -1,5 +1,6 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
+#include "automount.h"
 #include "cgroup.h"
 #include "ioprio-util.h"
 #include "kill.h"
@@ -50,6 +51,9 @@ TEST(unit_enums_idl) {
         TEST_IDL_ENUM(ManagedOOMPreference, managed_oom_preference, vl_type_ManagedOOMPreference);
         TEST_IDL_ENUM(CGroupPressureWatch, cgroup_pressure_watch, vl_type_CGroupPressureWatch);
         TEST_IDL_ENUM(CGroupController, cgroup_controller, vl_type_CGroupController);
+
+        /* AutomountRuntime enums */
+        TEST_IDL_ENUM(AutomountResult, automount_result, vl_type_AutomountResult);
 
         /* UnitContext enums */
         TEST_IDL_ENUM(CollectMode, collect_mode, vl_type_CollectMode);

--- a/src/test/test-varlink-idl-unit.c
+++ b/src/test/test-varlink-idl-unit.c
@@ -2,6 +2,7 @@
 
 #include "cgroup.h"
 #include "ioprio-util.h"
+#include "kill.h"
 #include "numa-util.h"
 #include "process-util.h"
 #include "tests.h"
@@ -39,6 +40,9 @@ TEST(unit_enums_idl) {
         test_enum_to_string_name("shared", &vl_type_MountPropagationFlag);
         test_enum_to_string_name("slave", &vl_type_MountPropagationFlag);
         test_enum_to_string_name("private", &vl_type_MountPropagationFlag);
+
+        /* KillContext enums */
+        TEST_IDL_ENUM(KillMode, kill_mode, vl_type_KillMode);
 
         /* CGroupContext enums */
         TEST_IDL_ENUM(CGroupDevicePolicy, cgroup_device_policy, vl_type_CGroupDevicePolicy);

--- a/src/test/test-varlink-idl-unit.c
+++ b/src/test/test-varlink-idl-unit.c
@@ -4,6 +4,7 @@
 #include "cgroup.h"
 #include "ioprio-util.h"
 #include "kill.h"
+#include "mount.h"
 #include "numa-util.h"
 #include "process-util.h"
 #include "tests.h"
@@ -54,6 +55,9 @@ TEST(unit_enums_idl) {
 
         /* AutomountRuntime enums */
         TEST_IDL_ENUM(AutomountResult, automount_result, vl_type_AutomountResult);
+
+        /* MountRuntime enums */
+        TEST_IDL_ENUM(MountResult, mount_result, vl_type_MountResult);
 
         /* UnitContext enums */
         TEST_IDL_ENUM(CollectMode, collect_mode, vl_type_CollectMode);

--- a/test/units/TEST-74-AUX-UTILS.varlinkctl.sh
+++ b/test/units/TEST-74-AUX-UTILS.varlinkctl.sh
@@ -230,6 +230,8 @@ set -o pipefail
 varlinkctl call /run/systemd/io.systemd.Manager io.systemd.Unit.List '{"cgroup": "/init.scope"}'
 invocation_id="$(systemctl show -P InvocationID systemd-journald.service)"
 varlinkctl call /run/systemd/io.systemd.Manager io.systemd.Unit.List "{\"invocationID\": \"$invocation_id\"}"
+# test for KillContext
+varlinkctl call /run/systemd/io.systemd.Manager io.systemd.Unit.List '{"pid": {"pid": 0}}' | jq -e '.context.Kill'
 
 # test io.systemd.Metrics
 varlinkctl info /run/systemd/report/io.systemd.Manager

--- a/test/units/TEST-74-AUX-UTILS.varlinkctl.sh
+++ b/test/units/TEST-74-AUX-UTILS.varlinkctl.sh
@@ -232,6 +232,11 @@ invocation_id="$(systemctl show -P InvocationID systemd-journald.service)"
 varlinkctl call /run/systemd/io.systemd.Manager io.systemd.Unit.List "{\"invocationID\": \"$invocation_id\"}"
 # test for KillContext
 varlinkctl call /run/systemd/io.systemd.Manager io.systemd.Unit.List '{"pid": {"pid": 0}}' | jq -e '.context.Kill'
+# test for AutomountContext/Runtime
+automount_id=$(varlinkctl call --collect /run/systemd/io.systemd.Manager io.systemd.Unit.List '{}' | jq -r '.[] | select(.context.Type == "automount" and .runtime.LoadState == "loaded") .context.ID' | grep -v null | tail -n 1)
+test -n "$automount_id"
+varlinkctl call /run/systemd/io.systemd.Manager io.systemd.Unit.List "{\"name\": \"$automount_id\"}" | jq -e '.context.Automount'
+varlinkctl call /run/systemd/io.systemd.Manager io.systemd.Unit.List "{\"name\": \"$automount_id\"}" | jq -e '.runtime.Automount'
 
 # test io.systemd.Metrics
 varlinkctl info /run/systemd/report/io.systemd.Manager

--- a/test/units/TEST-74-AUX-UTILS.varlinkctl.sh
+++ b/test/units/TEST-74-AUX-UTILS.varlinkctl.sh
@@ -237,6 +237,11 @@ automount_id=$(varlinkctl call --collect /run/systemd/io.systemd.Manager io.syst
 test -n "$automount_id"
 varlinkctl call /run/systemd/io.systemd.Manager io.systemd.Unit.List "{\"name\": \"$automount_id\"}" | jq -e '.context.Automount'
 varlinkctl call /run/systemd/io.systemd.Manager io.systemd.Unit.List "{\"name\": \"$automount_id\"}" | jq -e '.runtime.Automount'
+# test for MountContext/Runtime
+mount_id=$(varlinkctl call --collect /run/systemd/io.systemd.Manager io.systemd.Unit.List '{}' | jq -r '.[] | select(.context.Type == "mount" and .runtime.LoadState == "loaded") .context.ID' | grep -v null | tail -n 1)
+test -n "$mount_id"
+varlinkctl call /run/systemd/io.systemd.Manager io.systemd.Unit.List "{\"name\": \"$mount_id\"}" | jq -e '.context.Mount'
+varlinkctl call /run/systemd/io.systemd.Manager io.systemd.Unit.List "{\"name\": \"$mount_id\"}" | jq -e '.runtime.Mount'
 
 # test io.systemd.Metrics
 varlinkctl info /run/systemd/report/io.systemd.Manager


### PR DESCRIPTION
The PR implements the following objects + tests for `io.systemd.Unit.List`:
- `KillContext`
- `AutomountContext`
- `AutomountRuntime`
- `MountContext`
- `MountRuntime`

It's a continuation of the following PRs:
* https://github.com/systemd/systemd/pull/37432
* https://github.com/systemd/systemd/pull/37646
* https://github.com/systemd/systemd/pull/38032
* https://github.com/systemd/systemd/pull/38212