### PR TITLE
hwdb: gpd micropc2 sensor

### DIFF
--- a/hwdb.d/60-sensor.hwdb
+++ b/hwdb.d/60-sensor.hwdb
@@ -599,7 +599,11 @@ sensor:modalias:acpi:MXC6655*:dmi:*:svnGPD:pnG1628-04:*
 
 # GPD WinMax2
 sensor:modalias:acpi:BMI0160*:dmi:*:svnGPD:pnG1619*:*
- ACCEL_MOUNT_MATRIX=0, -1, 0; -1, 0, 0; 0, 0, 1
+ ACCEL_MOUNT_MATRIX=0, -1, 0; -1, 0, 0; 0, 0,
+
+# GPD MicroPC 2
+sensor:modalias:acpi:MXC6655*:dmi:*:svnGPD:pnG1688-*:*
+ ACCEL_MOUNT_MATRIX=0, -1, 0; -1, 0, 0; 0, 0, -1
 
 #########################################
 # Hometech

--- a/hwdb.d/60-sensor.hwdb
+++ b/hwdb.d/60-sensor.hwdb
@@ -599,7 +599,7 @@ sensor:modalias:acpi:MXC6655*:dmi:*:svnGPD:pnG1628-04:*
 
 # GPD WinMax2
 sensor:modalias:acpi:BMI0160*:dmi:*:svnGPD:pnG1619*:*
- ACCEL_MOUNT_MATRIX=0, -1, 0; -1, 0, 0; 0, 0,
+ ACCEL_MOUNT_MATRIX=0, -1, 0; -1, 0, 0; 0, 0, 1
 
 # GPD MicroPC 2
 sensor:modalias:acpi:MXC6655*:dmi:*:svnGPD:pnG1688-*:*


### PR DESCRIPTION
This rule calibrates rotation of the screen display by adjusting matrix of sensor for the GPD MicroPC 2

udevadm info --export-db output: https://justpaste.it/cmr2z

I'm not well-versed with Github so hopefully I did this right with the pull request thing


(Also accidentally removed 1 at the end but readded it after noticing.)