### PR TITLE
boot: respect menu-hidden and menu-disabled for one-shot timeout

### DIFF
--- a/src/boot/boot.c
+++ b/src/boot/boot.c
@@ -1558,7 +1558,7 @@ static void boot_entry_add_type1(
         TAKE_PTR(entry);
 }
 
-static EFI_STATUS efivar_get_timeout(const char16_t *var, uint64_t *ret_value) {
+static EFI_STATUS efivar_get_timeout(const char16_t *var, uint64_t *ret_value, bool *ret_is_numeric) {
         _cleanup_free_ char16_t *value = NULL;
         EFI_STATUS err;
 
@@ -1571,14 +1571,20 @@ static EFI_STATUS efivar_get_timeout(const char16_t *var, uint64_t *ret_value) {
 
         if (streq16(value, u"menu-disabled")) {
                 *ret_value = TIMEOUT_MENU_DISABLED;
+                if (ret_is_numeric)
+                        *ret_is_numeric = false;
                 return EFI_SUCCESS;
         }
         if (streq16(value, u"menu-force")) {
                 *ret_value = TIMEOUT_MENU_FORCE;
+                if (ret_is_numeric)
+                        *ret_is_numeric = false;
                 return EFI_SUCCESS;
         }
         if (streq16(value, u"menu-hidden")) {
                 *ret_value = TIMEOUT_MENU_HIDDEN;
+                if (ret_is_numeric)
+                        *ret_is_numeric = false;
                 return EFI_SUCCESS;
         }
 
@@ -1587,6 +1593,8 @@ static EFI_STATUS efivar_get_timeout(const char16_t *var, uint64_t *ret_value) {
                 return EFI_INVALID_PARAMETER;
 
         *ret_value = MIN(timeout, TIMEOUT_TYPE_MAX);
+        if (ret_is_numeric)
+                *ret_is_numeric = true;
         return EFI_SUCCESS;
 }
 
@@ -1631,20 +1639,22 @@ static void config_load_defaults(Config *config, EFI_FILE *root_dir) {
                 config_defaults_load_from_file(config, content);
         }
 
-        err = efivar_get_timeout(u"LoaderConfigTimeout", &config->timeout_sec_efivar);
+        err = efivar_get_timeout(
+                        u"LoaderConfigTimeout",
+                        &config->timeout_sec_efivar,
+                        /* ret_is_numeric= */ NULL);
         if (err == EFI_SUCCESS)
                 config->timeout_sec = config->timeout_sec_efivar;
         else if (err != EFI_NOT_FOUND)
                 log_warning_status(err, "Error reading LoaderConfigTimeout EFI variable, ignoring: %m");
         config_timeout_load_from_smbios(config);
 
-        err = efivar_get_timeout(u"LoaderConfigTimeoutOneShot", &config->timeout_sec);
-        if (err == EFI_SUCCESS) {
+        /* Numeric oneshot values get the menu even when set to 0, as per the BLI */
+        err = efivar_get_timeout(u"LoaderConfigTimeoutOneShot", &config->timeout_sec, &config->force_menu);
+        if (err == EFI_SUCCESS)
                 /* Unset variable now, after all it's "one shot". */
                 (void) efivar_unset(MAKE_GUID_PTR(LOADER), u"LoaderConfigTimeoutOneShot", EFI_VARIABLE_NON_VOLATILE);
-
-                config->force_menu = true; /* force the menu when this is set */
-        } else if (err != EFI_NOT_FOUND)
+        else if (err != EFI_NOT_FOUND)
                 log_warning_status(err, "Error reading LoaderConfigTimeoutOneShot EFI variable, ignoring: %m");
 
         uint64_t value;

--- a/src/login/logind-dbus.c
+++ b/src/login/logind-dbus.c
@@ -3202,11 +3202,13 @@ static int property_get_reboot_to_boot_loader_menu(
 
         r = getenv_bool("SYSTEMD_REBOOT_TO_BOOT_LOADER_MENU");
         if (r == -ENXIO) {
-                /* EFI case: returns the current value of LoaderConfigTimeoutOneShot. Three cases are distinguished:
+                /* EFI case: returns the current value of LoaderConfigTimeoutOneShot. Four cases are
+                 * distinguished:
                  *
-                 *     1. Variable not set, boot into boot loader menu is not enabled (we return UINT64_MAX to the user)
-                 *     2. Variable set to "0", boot into boot loader menu is enabled with no timeout (we return 0 to the user)
-                 *     3. Variable set to numeric value formatted in ASCII, boot into boot loader menu with the specified timeout in seconds
+                 *     1. Variable not set: boot into boot loader menu is not enabled (return UINT64_MAX)
+                 *     2. Set to "0" or "menu-force": menu enabled without a timeout (return 0)
+                 *     3. Set to a positive number: menu enabled (return its timeout converted to μs)
+                 *     4. Set to "menu-hidden" or "menu-disabled": menu not enabled (return UINT64_MAX)
                  */
 
                 r = efi_loader_get_config_timeout_one_shot(&x);

--- a/src/shared/efi-loader.c
+++ b/src/shared/efi-loader.c
@@ -361,14 +361,22 @@ int efi_loader_get_config_timeout_one_shot(usec_t *ret) {
         if (r < 0)
                 return r;
 
-        r = safe_atou64(v, &sec);
-        if (r < 0)
-                return r;
-        if (sec > USEC_INFINITY / USEC_PER_SEC)
-                return -ERANGE;
+        if (streq(v, "menu-force"))
+                sec = 0;
+        else if (STR_IN_SET(v, "menu-hidden", "menu-disabled"))
+                sec = USEC_INFINITY;
+        else {
+                r = safe_atou64(v, &sec);
+                if (r < 0)
+                        return r;
+                if (sec > USEC_INFINITY / USEC_PER_SEC)
+                        return -ERANGE;
+
+                sec *= USEC_PER_SEC; /* return in μs */
+        }
 
         cache_stat = new_stat;
-        *ret = cache = sec * USEC_PER_SEC; /* return in μs */
+        *ret = cache = sec;
         return 0;
 #else
         return -EOPNOTSUPP;


### PR DESCRIPTION
Keep the documented LoaderConfigTimeoutOneShot=0 behavior, which shows the
menu indefinitely. However, don't force the menu to appear when the
variable is explicitly set to menu-hidden or menu-disabled.
    
Get the userspace EFI variable reader to understand these values as well,
so logind can read RebootToBootLoaderMenu without throwing parse warnings.

The problem this fixes is a bit of a quirk that prevents some useful functionality, e.g. automatically hiding systemd-boot on next boot if the previous boot was blessed, which I had to work around to implement in KDE Linux.

Fixes https://github.com/systemd/systemd/issues/38254 (see the issue for more information)