### PR TITLE
test: drop assert for TTY_GID

### DIFF
--- a/src/test/test-user-util.c
+++ b/src/test/test-user-util.c
@@ -410,7 +410,6 @@ TEST(in_gid) {
         assert_se(in_gid(getgid()) >= 0);
         assert_se(in_gid(getegid()) >= 0);
         assert_se(in_gid(GID_INVALID) < 0);
-        assert_se(in_gid(TTY_GID) == 0); /* The TTY gid is for owning ttys, it would be really really weird if we were in it. */
 }
 
 TEST(gid_lists_ops) {


### PR DESCRIPTION
The comment says that this shouldn't happen, but unfortunately it can, on a debian build server:

```
/* test_in_gid */
Assertion 'in_gid(TTY_GID) == 0' failed at src/test/test-user-util.c:413, function test_in_gid(). Aborting.
```

https://buildd.debian.org/status/fetch.php?pkg=systemd&arch=sparc64&ver=259-1&stamp=1766088457&raw=0