### PR TITLE
capability-util: suppress a warning

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -467,6 +467,12 @@ if cc.get_id() == 'gcc'
         possible_common_cc_flags += '-Wno-unused-result'
 endif
 
+# Disable -Wno-stringop-overflow with gcc, see
+# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=123477
+if cc.get_id() == 'gcc' and cc.version().version_compare('>=16')
+        possible_common_cc_flags += '-Wno-stringop-overflow'
+endif
+
 # --as-needed and --no-undefined are provided by meson by default,
 # run 'meson configure' to see what is enabled
 possible_link_flags = [

--- a/src/basic/capability-util.c
+++ b/src/basic/capability-util.c
@@ -70,7 +70,9 @@ unsigned cap_last_cap(void) {
         static atomic_int saved = INT_MAX;
         int r, c;
 
-        c = saved;
+        /* Suppress a false positive from GCC 16:
+         * https://gcc.gnu.org/bugzilla/show_bug.cgi?id=123475 */
+        c = atomic_load(&saved);
         if (c != INT_MAX)
                 return c;
 


### PR DESCRIPTION
Temporary PR to workaround two compiler bugs:

1. https://gcc.gnu.org/bugzilla/show_bug.cgi?id=123475
1. https://gcc.gnu.org/bugzilla/show_bug.cgi?id=123477