### PR TITLE
Add kernel-install plugin metadata

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1991,6 +1991,8 @@ if shared_lib_tag == ''
         shared_lib_tag = project_major_version
 endif
 
+conf.set('KERNEL_INSTALL_JSON', '{"version":"@0@"}'.format(version_tag))
+
 #####################################################################
 
 subdir('src/coverage')

--- a/src/basic/dlfcn-util.c
+++ b/src/basic/dlfcn-util.c
@@ -61,7 +61,7 @@ int dlopen_many_sym_or_warn_sentinel(void **dlp, const char *filename, int log_l
                 return -EOPNOTSUPP; /* Turn into recognizable error */
         }
 
-        log_debug("Loaded shared library '%s' via dlopen().", filename);
+        log_debug("Loaded '%s' via dlopen().", filename);
 
         va_list ap;
         va_start(ap, log_level);

--- a/src/basic/fileio.h
+++ b/src/basic/fileio.h
@@ -163,3 +163,5 @@ int safe_fgetc(FILE *f, char *ret);
 int warn_file_is_world_accessible(const char *filename, struct stat *st, const char *unit, unsigned line);
 
 int fopen_mode_to_flags(const char *mode);
+
+int file_get_marker(int fd, const char *marker, char **ret);

--- a/src/bootctl/bootctl-install.c
+++ b/src/bootctl/bootctl-install.c
@@ -202,13 +202,13 @@ static int version_check(int fd_from, const char *from, int fd_to, const char *t
         assert(fd_to >= 0);
         assert(to);
 
-        r = get_file_version(fd_from, &a);
+        r = file_get_marker(fd_from, "LoaderInfo", &a);
         if (r == -ESRCH)
                 return log_notice_errno(r, "Source file \"%s\" does not carry version information!", from);
         if (r < 0)
                 return r;
 
-        r = get_file_version(fd_to, &b);
+        r = file_get_marker(fd_to, "LoaderInfo", &b);
         if (r == -ESRCH)
                 return log_info_errno(r, "Skipping \"%s\", it's owned by another boot loader (no version info found).", to);
         if (r < 0)
@@ -1160,7 +1160,7 @@ static int remove_boot_efi(const char *esp_path) {
                 if (r == 0)
                         continue;
 
-                r = get_file_version(fd, &v);
+                r = file_get_marker(fd, "LoaderInfo", &v);
                 if (r == -ESRCH)
                         continue;  /* No version information */
                 if (r < 0)

--- a/src/bootctl/bootctl-status.c
+++ b/src/bootctl/bootctl-status.c
@@ -244,7 +244,7 @@ static int enumerate_binaries(
                 if (fd < 0)
                         return log_error_errno(errno, "Failed to open file for reading: %m");
 
-                r = get_file_version(fd, &v);
+                r = file_get_marker(fd, "LoaderInfo", &v);
                 if (r < 0 && r != -ESRCH)
                         return r;
 

--- a/src/bootctl/bootctl-util.h
+++ b/src/bootctl/bootctl-util.h
@@ -5,6 +5,4 @@ int sync_everything(void);
 
 const char* get_efi_arch(void);
 
-int get_file_version(int fd, char **ret);
-
 int settle_entry_token(void);

--- a/src/kernel-install/50-depmod.install.in
+++ b/src/kernel-install/50-depmod.install.in
@@ -17,6 +17,8 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with systemd; If not, see <https://www.gnu.org/licenses/>.
+#
+# #### install.d: {{ KERNEL_INSTALL_JSON }} ####
 
 set -e
 

--- a/src/kernel-install/60-ukify.install.in
+++ b/src/kernel-install/60-ukify.install.in
@@ -16,6 +16,8 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with systemd; If not, see <https://www.gnu.org/licenses/>.
+#
+# #### install.d: {{ KERNEL_INSTALL_JSON }} ####
 
 # pylint: disable=import-outside-toplevel,consider-using-with,disable=redefined-builtin
 

--- a/src/kernel-install/90-loaderentry.install.in
+++ b/src/kernel-install/90-loaderentry.install.in
@@ -17,6 +17,8 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with systemd; If not, see <https://www.gnu.org/licenses/>.
+#
+# #### install.d: {{ KERNEL_INSTALL_JSON }} ####
 
 set -e
 

--- a/src/kernel-install/90-uki-copy.install.in
+++ b/src/kernel-install/90-uki-copy.install.in
@@ -17,6 +17,8 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with systemd; If not, see <https://www.gnu.org/licenses/>.
+#
+# #### install.d: {{ KERNEL_INSTALL_JSON }} ####
 
 set -e
 

--- a/src/kernel-install/meson.build
+++ b/src/kernel-install/meson.build
@@ -27,17 +27,23 @@ loaderentry_install = custom_target(
         install_mode : 'rwxr-xr-x',
         install_dir : kernelinstalldir)
 
-uki_copy_install = files('90-uki-copy.install')
+uki_copy_install = custom_target(
+        input : '90-uki-copy.install.in',
+        output : '90-uki-copy.install',
+        command : [jinja2_cmdline, '@INPUT@', '@OUTPUT@'],
+        install : want_kernel_install,
+        install_mode : 'rwxr-xr-x',
+        install_dir : kernelinstalldir)
 
-kernel_install_files = uki_copy_install + files(
-        '50-depmod.install',
-)
+custom_target(
+        input : '50-depmod.install.in',
+        output : '50-depmod.install',
+        command : [jinja2_cmdline, '@INPUT@', '@OUTPUT@'],
+        install : want_kernel_install,
+        install_mode : 'rwxr-xr-x',
+        install_dir : kernelinstalldir)
 
 if want_kernel_install
-        install_data(kernel_install_files,
-                     install_mode : 'rwxr-xr-x',
-                     install_dir : kernelinstalldir)
-
         install_data('install.conf',
                      install_dir : kerneldir)
 


### PR DESCRIPTION
A small POC of how the emedding and reading of kernel-install metadata could look like. I'm marking it as draft because because the naming might need to be adjusted and this would only make sense if we want to use it the kernel-install by-root functionality.

/cc @poettering 