### PR TITLE
network: fix max MTU check for IPv6 MTU adjustments

### DIFF
--- a/src/network/networkd-sysctl.c
+++ b/src/network/networkd-sysctl.c
@@ -545,11 +545,11 @@ int link_set_ipv6_mtu(Link *link, int log_level) {
         if (mtu == 0)
                 return 0;
 
-        if (mtu > link->mtu) {
+        if (mtu > link->max_mtu) {
                 log_link_full(link, log_level,
                               "Reducing requested IPv6 MTU %"PRIu32" to the interface's maximum MTU %"PRIu32".",
-                              mtu, link->mtu);
-                mtu = link->mtu;
+                              mtu, link->max_mtu);
+                mtu = link->max_mtu;
         }
 
         r = sysctl_write_ip_property_uint32(AF_INET6, link->ifname, "mtu", mtu, manager_get_sysctl_shadow(link->manager));


### PR DESCRIPTION
When link MTU is being adjusted in an IPv6 context (e.g., according to the MTU received in an RA), the new MTU is clamped against link's current MTU than link's max MTU. This means that the link MTU can never be increased via an RA:

    systemd-networkd[10068]: eth1: Reducing requested IPv6 MTU 8900 to the interface's maximum MTU 1500.
    systemd-networkd[10068]: Setting '/proc/sys/net/ipv6/conf/eth1/mtu' to '1500'
    systemd-networkd[10068]: No change in value '1500', suppressing write

Fix this check to make logical sense, and also to match a similar check in src/network/networkd-setlink.c:link_adjust_mtu().