### PR TITLE
fix build failure on Fedora

### DIFF
--- a/src/network/bpf/sysctl-monitor/sysctl-monitor.bpf.c
+++ b/src/network/bpf/sysctl-monitor/sysctl-monitor.bpf.c
@@ -3,7 +3,13 @@
 #include "vmlinux.h"
 
 #include <errno.h>
+
+/* Prevent conflicting declarations of bpf_stream_vprintk between vmlinux.h
+ * (from kernel BTF) and bpf/bpf_helpers.h (from libbpf), which may have
+ * different signatures depending on kernel and libbpf versions. */
+#define bpf_stream_vprintk __libbpf_bpf_stream_vprintk
 #include <bpf/bpf_helpers.h>
+#undef bpf_stream_vprintk
 
 #include "sysctl-write-event.h"
 

--- a/src/nsresourced/bpf/userns-restrict/userns-restrict.bpf.c
+++ b/src/nsresourced/bpf/userns-restrict/userns-restrict.bpf.c
@@ -16,9 +16,15 @@
 #include "vmlinux.h"
 
 #include <errno.h>
+
+/* Prevent conflicting declarations of bpf_stream_vprintk between vmlinux.h
+ * (from kernel BTF) and bpf/bpf_helpers.h (from libbpf), which may have
+ * different signatures depending on kernel and libbpf versions. */
+#define bpf_stream_vprintk __libbpf_bpf_stream_vprintk
 #include <bpf/bpf_core_read.h>
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_tracing.h>
+#undef bpf_stream_vprintk
 
 #ifndef bpf_core_cast
 /* bpf_rdonly_cast() was introduced in libbpf commit 688879f together with


### PR DESCRIPTION
I noticed `mkosi` build on Fedora was failing with a bpf error. I used Claude to help fix it to unblock testing https://github.com/systemd/systemd/pull/40619.

```
In file included from ../src/src/network/bpf/sysctl-monitor/sysctl-monitor.bpf.c:6:
/usr/include/bpf/bpf_helpers.h:318:12: error: conflicting types for 'bpf_stream_vprintk'
  318 | extern int bpf_stream_vprintk(int stream_id, const char *fmt__str, const void *args,
      |            ^
/usr/src/kernels/6.20.0-0.rc0.260216g0f2acd3148e0e.8.fc45.x86_64/vmlinux.h:167429:12: note: previous declaration is here
 167429 | extern int bpf_stream_vprintk(int stream_id, const char *fmt__str, const void *args, u32 len__sz) __weak __ksym;
        |            ^
1 error generated.
```