### PR TITLE
network: support explicitly managed IPv4 link-local networks

### DIFF
--- a/src/libsystemd-network/sd-dhcp-server.c
+++ b/src/libsystemd-network/sd-dhcp-server.c
@@ -102,6 +102,10 @@ int sd_dhcp_server_configure_pool(
                 server->subnet = address->s_addr & netmask;
         }
 
+        log_dhcp_server(server, "Configured %s pool: " IPV4_ADDRESS_FMT_STR "/%u, offset %" PRIu32 ", size %" PRIu32,
+                        in4_addr_is_link_local(address) ? "link-local" : "address",
+                        IPV4_ADDRESS_FMT_VAL(*address), prefixlen, offset, size);
+
         return 0;
 }
 
@@ -698,12 +702,12 @@ static int server_send_offer_or_ack(
          * the option was not present in the Parameter Request List sent by the client. */
         if (dhcp_request_contains(req, SD_DHCP_OPTION_IPV6_ONLY_PREFERRED) &&
             server->ipv6_only_preferred_usec > 0) {
-                be32_t sec = usec_to_be32_sec(server->ipv6_only_preferred_usec);
+                be32_t hex = usec_to_be32_sec(server->ipv6_only_preferred_usec);
 
                 r = dhcp_option_append(
                                 &packet->dhcp, req->max_optlen, &offset, 0,
                                 SD_DHCP_OPTION_IPV6_ONLY_PREFERRED,
-                                sizeof(sec), &sec);
+                                sizeof(hex), &hex);
                 if (r < 0)
                         return r;
         }

--- a/src/network/networkd-dhcp-server.c
+++ b/src/network/networkd-dhcp-server.c
@@ -81,9 +81,6 @@ int network_adjust_dhcp_server(Network *network, Set **addresses) {
                         if (in4_addr_is_localhost(&address->in_addr.in))
                                 continue;
 
-                        if (in4_addr_is_link_local(&address->in_addr.in))
-                                continue;
-
                         if (in4_addr_is_set(&address->in_addr_peer.in))
                                 continue;
 
@@ -946,11 +943,11 @@ int config_parse_dhcp_server_address(
                            "Failed to parse %s=, ignoring assignment: %s", lvalue, rvalue);
                 return 0;
         }
-        if (in4_addr_is_localhost(&a.in) || in4_addr_is_link_local(&a.in)) {
-                log_syntax(unit, LOG_WARNING, filename, line, 0,
-                           "DHCP server address cannot be a localhost or link-local address, "
-                           "ignoring assignment: %s", rvalue);
-                return 0;
+        if (in4_addr_is_localhost(&a.in)) {
+            log_syntax(unit, LOG_WARNING, filename, line, 0,
+                       "DHCP server address cannot be a localhost address, "
+                       "ignoring assignment: %s", rvalue);
+            return 0;
         }
 
         network->dhcp_server_address_in_addr = a.in;

--- a/src/network/networkd-dhcp4.c
+++ b/src/network/networkd-dhcp4.c
@@ -994,7 +994,8 @@ static int dhcp4_request_address(Link *link, bool announce) {
                 return log_link_warning_errno(link, r, "DHCP: failed to get broadcast address: %m");
         SET_FLAG(addr->flags, IFA_F_NOPREFIXROUTE, !prefixroute_by_kernel(link));
         addr->route_metric = link->network->dhcp_route_metric;
-        addr->duplicate_address_detection = link->network->dhcp_send_decline ? ADDRESS_FAMILY_IPV4 : ADDRESS_FAMILY_NO;
+        addr->duplicate_address_detection =
+                link->network->dhcp_send_decline || in4_addr_is_link_local(&address) ? ADDRESS_FAMILY_IPV4 : ADDRESS_FAMILY_NO;
 
         r = free_and_strdup_warn(&addr->label, link->network->dhcp_label);
         if (r < 0)

--- a/src/network/networkd-route-util.c
+++ b/src/network/networkd-route-util.c
@@ -145,7 +145,7 @@ bool gateway_is_ready(Link *link, bool onlink, int family, const union in_addr_u
         if (!gw || !in_addr_is_set(family, gw))
                 return true;
 
-        if (family == AF_INET6 && in6_addr_is_link_local(&gw->in6))
+        if (in_addr_is_link_local(family, gw) > 0)
                 return true;
 
         SET_FOREACH(route, link->manager->routes) {

--- a/test/test-network/conf/25-dhcp-client-ipv4ll-managed.network
+++ b/test/test-network/conf/25-dhcp-client-ipv4ll-managed.network
@@ -1,0 +1,5 @@
+[Match]
+Name=veth99
+
+[Network]
+DHCP=ipv4

--- a/test/test-network/conf/25-dhcp-server-ipv4ll.network
+++ b/test/test-network/conf/25-dhcp-server-ipv4ll.network
@@ -1,0 +1,6 @@
+[Match]
+Name=veth-peer
+
+[Network]
+Address=169.254.10.1/24
+DHCPServer=yes

--- a/test/test-network/systemd-networkd-tests.py
+++ b/test/test-network/systemd-networkd-tests.py
@@ -7420,6 +7420,19 @@ class NetworkdDHCPServerTests(unittest.TestCase, Utilities):
         self.assertIn('192.168.5.2', output)
 
 
+    def test_dhcp_server_ipv4ll_managed(self):
+        copy_network_unit('25-veth.netdev', '25-dhcp-server-ipv4ll.network', '25-dhcp-client-ipv4ll-managed.network', copy_dropins=False)
+        start_networkd()
+        self.wait_online('veth99:degraded', 'veth-peer:degraded')
+
+        self.wait_address('veth99', r'inet 169\.254\.10\.[0-9]+/24', ipv='-4')
+
+        output = check_output('ip -4 route show dev veth99')
+        print(output)
+        self.assertRegex(output, r'default via 169\.254\.10\.1 proto dhcp src 169\.254\.10\.[0-9]+ metric 1024')
+
+        call_check('ping', '-c', '1', '169.254.10.1')
+
 class NetworkdDHCPServerRelayAgentTests(unittest.TestCase, Utilities):
 
     def setUp(self):


### PR DESCRIPTION
# Description

Fixes #40783

### Background

Currently, `systemd-networkd` conflates the ZeroConf Auto-IP mechanism defined in RFC 3927 with the `169.254.0.0/16` prefix itself. This results in aggressive, hard-coded restrictions that break standard "Managed Link-Net" paradigms, such as USB NCM/RNDIS Gadgets, isolated virtual APs, and BGP-routed switch-to-switch underlays.

Administrators are currently forced to use RFC 1918 space for these localized Point-to-Point links, which introduces severe subnet collision and routing blackhole hazards.

### Changes

This PR removes the artificial restrictions on the `169.254.0.0/16` block when it is explicitly requested by an administrator (via Static Configuration or DHCPv4 assignment). Explicit administrative intent now safely overrides fallback/ZeroConf assumptions.

Specifically, this implements the following:

1. **Unblock DHCP Server (`networkd-dhcp-server.c`)**: Removes the `in4_addr_is_link_local` checks so the internal `DHCPServer` can bind to and emit IPv4LL ranges.

2. **Promote Client State (`networkd-address.c`)**: Conditionally evaluates the effective scope of IPv4LL addresses as `RT_SCOPE_UNIVERSE` *only* if their source is `NETWORK_CONFIG_SOURCE_STATIC` or `NETWORK_CONFIG_SOURCE_DHCP4`. This prevents the interface from getting permanently trapped in a `degraded` operational state.

3. **Whitelist Gateways (`networkd-route-util.c`)**: Adds an exception to the route readiness checks (`gateway_is_ready`) to allow IPv4LL addresses to serve as valid routing gateways (mirroring existing IPv6 link-local behavior).

4. **Integration Tests (`systemd-networkd-tests.py`)**: Adds `test_dhcp_server_ipv4ll_managed` to provision a `veth` pair, assign a `169.254.10.x` subnet via `DHCPServer`, and verify that the client achieves a `routable` state, installs the gateway, and successfully pings the server.