### PR TITLE
resolved: fix hook filter lifecycle during reconnection

### DIFF
--- a/src/resolve/resolved-hook.c
+++ b/src/resolve/resolved-hook.c
@@ -137,9 +137,11 @@ static int on_filter_reply(
                                 r = hook_acquire_filter(h);
                                 if (r < 0)
                                         goto terminate;
-                        } else
-                                log_warning("Connection terminated while querying filter of hook '%s', and reconnection attempts failed too quickly, giving up.", h->socket_path);
 
+                                return 1;
+                        }
+
+                        log_warning("Connection terminated while querying filter of hook '%s', and reconnection attempts failed too quickly, giving up.", h->socket_path);
                         goto terminate;
                 }
 
@@ -342,6 +344,7 @@ static int manager_hook_add(Manager *m, const char *p, usec_t seen_usec) {
         Hook *found = hashmap_get(m->hooks, p);
         if (found) {
                 found->seen_usec = seen_usec;
+                (void) hook_acquire_filter(found);
                 return 0;
         }
 


### PR DESCRIPTION
When the filter connection to a hook disconnects and we reconnect via hook_acquire_filter(), the newly created h->filter_link was immediately destroyed because the unconditional `goto terminate` at the end of the DISCONNECTED handler ran sd_varlink_unref(h->filter_link) on it.

Fix by returning early after a successful reconnect so the new filter connection is preserved and its reply callback can repopulate the filter domains.

Additionally, if a hook exists in the hashmap but has no active filter connection (e.g. reconnection had been ratelimited before), attempt to re-establish it in manager_hook_add() so the hook becomes active again on the next discovery scan. Otherwise filter_link will never be connected (if socket activation is used for the hook socket)