### PR TITLE
zsh: fixup some recent zsh completers

### DIFF
--- a/shell-completion/zsh/_systemd-id128
+++ b/shell-completion/zsh/_systemd-id128
@@ -32,7 +32,7 @@ _systemd-id128_names() {
 }
 
 local ret=1
-_arguments -s "$opt_common[@]" \
+_arguments -s -A '-*' "$opt_common[@]" \
 	':command:->command' \
 	'*:: :->option-or-argument' && ret=0
 

--- a/shell-completion/zsh/_userdbctl
+++ b/shell-completion/zsh/_userdbctl
@@ -26,7 +26,7 @@ local -a opt_user_group=(
 	'-S[Equivalent to --disposition=system]'
 	'-R[Equivalent to --disposition=regular]'
 	'--uid-min=[Filter by minimum UID/GID]:uid:_numbers -t uids uid -d 0'
-	'--uid-max=[Filter by maximum UID/GID]:gid:_numbers -t gids gid -d 4294967294'
+	'--uid-max=[Filter by maximum UID/GID]:uid:_numbers -t uids uid -d 4294967294'
 	'--uuid=[Filter by UUID]:uuid'
 	'(-B)--boundaries=[Show/hide UID/GID range boundaries in output]:bool:(yes no)'
 	'(--boundaries)-B[Equivalent to --boundaries=no]'
@@ -44,7 +44,7 @@ local -a userdbctl_commands=(
 )
 
 local ret=1
-_arguments -s \
+_arguments -s -A '-*' \
 	"$opt_common[@]" \
 	':userdbctl command:->command' \
 	'*:: :->option-or-argument' && ret=0


### PR DESCRIPTION
These two completers are written in a stacked _arguments style, and some generic options are valid before or after the verb. If the toplevel _arguments is permitted to match options after the verb, it will halt completion prematurely, so stop toplevel matching after the verb.

This corrects the following error:

```
$ userdbctl --output=class user <TAB> # completes users
$ userdbctl user --output=class <TAB> # completes nothing
```