### PR TITLE
core/job: retroactively start dependents blocked by dependency failure

### DIFF
--- a/src/core/job.c
+++ b/src/core/job.c
@@ -6,6 +6,7 @@
 #include "alloc-util.h"
 #include "ansi-color.h"
 #include "async.h"
+#include "bus-error.h"
 #include "cgroup.h"
 #include "condition.h"
 #include "dbus.h"
@@ -984,6 +985,34 @@ int job_run_and_invalidate(Job *j) {
         return r;
 }
 
+static void job_start_blocked_dependents(Unit *u) {
+        Unit *other;
+
+        assert(u);
+
+        /* When a unit's start job succeeds, check if any reverse dependencies (units that Requires=,
+         * Requisite=, or BindsTo= us) had their start blocked because we previously failed. If so,
+         * retroactively start them now. */
+
+        UNIT_FOREACH_DEPENDENCY_SAFE(other, u, UNIT_ATOM_PROPAGATE_START_FAILURE) {
+                if (!other->start_blocked_by_dependency)
+                        continue;
+                if (!UNIT_IS_INACTIVE_OR_FAILED(unit_active_state(other)))
+                        continue;
+
+                _cleanup_(sd_bus_error_free) sd_bus_error error = SD_BUS_ERROR_NULL;
+                int r;
+
+                log_unit_info(other, "Starting unit that was blocked by dependency on %s.", u->id);
+
+                r = manager_add_job(u->manager, JOB_START, other, JOB_REPLACE, &error, /* ret= */ NULL);
+                if (r < 0)
+                        log_unit_warning_errno(other, r,
+                                               "Failed to enqueue start job for dependency-blocked unit, ignoring: %s",
+                                               bus_error_message(&error, r));
+        }
+}
+
 static void job_fail_dependencies(Unit *u, UnitDependencyAtom match_atom) {
         Unit *other;
 
@@ -1047,6 +1076,17 @@ int job_finish_and_invalidate(Job *j, JobResult result, bool recursive, bool alr
                 else if (t == JOB_STOP)
                         job_fail_dependencies(u, UNIT_ATOM_PROPAGATE_STOP_FAILURE);
         }
+
+        /* Track units whose start was blocked by a dependency failure, so that when the dependency becomes
+         * active again, we can retroactively start them. */
+        if (IN_SET(t, JOB_START, JOB_VERIFY_ACTIVE))
+                u->start_blocked_by_dependency = (result == JOB_DEPENDENCY);
+        else if (t == JOB_STOP)
+                u->start_blocked_by_dependency = false;
+
+        /* When a start job succeeds, retroactively start any dependents that were blocked by our failure */
+        if (result == JOB_DONE && t == JOB_START)
+                job_start_blocked_dependents(u);
 
         /* A special check to make sure we take down anything RequisiteOf= if we aren't active. This is when
          * the verify-active job merges with a satisfying job type, and then loses its invalidation effect,

--- a/src/core/unit-serialize.c
+++ b/src/core/unit-serialize.c
@@ -110,6 +110,7 @@ int unit_serialize_state(Unit *u, FILE *f, FDSet *fds, bool switching_root) {
         (void) serialize_bool(f, "in-audit", u->in_audit);
 
         (void) serialize_bool(f, "debug-invocation", u->debug_invocation);
+        (void) serialize_bool(f, "start-blocked-by-dependency", u->start_blocked_by_dependency);
 
         (void) serialize_bool(f, "exported-invocation-id", u->exported_invocation_id);
         (void) serialize_bool(f, "exported-log-level-max", u->exported_log_level_max);
@@ -275,6 +276,9 @@ int unit_deserialize_state(Unit *u, FILE *f, FDSet *fds) {
                         continue;
 
                 else if (MATCH_DESERIALIZE("debug-invocation", l, v, parse_boolean, u->debug_invocation))
+                        continue;
+
+                else if (MATCH_DESERIALIZE("start-blocked-by-dependency", l, v, parse_boolean, u->start_blocked_by_dependency))
                         continue;
 
                 else if (MATCH_DESERIALIZE("exported-invocation-id", l, v, parse_boolean, u->exported_invocation_id))

--- a/src/core/unit.h
+++ b/src/core/unit.h
@@ -462,6 +462,11 @@ typedef struct Unit {
 
         bool start_limit_hit:1;
 
+        /* Set when a start job fails due to a dependency failure (JOB_DEPENDENCY result). Cleared when a
+         * start job succeeds or fails for a different reason, or when the unit is explicitly stopped. Used to
+         * retroactively start this unit when the failed dependency becomes active again. */
+        bool start_blocked_by_dependency:1;
+
         /* Did we already invoke unit_coldplug() for this unit? */
         bool coldplugged:1;
 

--- a/test/units/TEST-03-JOBS.sh
+++ b/test/units/TEST-03-JOBS.sh
@@ -218,4 +218,50 @@ assert_eq "$(systemctl show "$UNIT_NAME" -P NRestarts)" "1"
 
 rm /run/systemd/system/"$UNIT_NAME"
 
+# Test that dependent units are retroactively started when a required unit
+# auto-restarts after failure (issue #18856).
+ISSUE18856_FLAG="/tmp/test-03-issue18856-fail-once"
+
+cat >/run/systemd/system/issue18856-dep.service <<EOF
+[Service]
+Type=oneshot
+ExecStartPre=sh -c 'if [ ! -f $ISSUE18856_FLAG ]; then touch $ISSUE18856_FLAG; exit 1; fi'
+ExecStart=true
+RemainAfterExit=yes
+Restart=on-failure
+RestartSec=100ms
+EOF
+
+cat >/run/systemd/system/issue18856-dependent.service <<EOF
+[Unit]
+After=issue18856-dep.service
+Requires=issue18856-dep.service
+
+[Service]
+Type=oneshot
+ExecStart=true
+RemainAfterExit=yes
+EOF
+
+rm -f "$ISSUE18856_FLAG"
+systemctl daemon-reload
+
+# Start the dependent, which pulls in the dependency via Requires=.
+# The dependency fails on first start (ExecStartPre fails), causing the
+# dependent to fail with JOB_DEPENDENCY.
+# The dependency then auto-restarts (Restart=on-failure) and succeeds.
+# The dependent should be retroactively started as well.
+(! systemctl start issue18856-dependent.service)
+
+# Wait for the dependency to auto-restart and succeed
+timeout 10 bash -c 'while ! systemctl --quiet is-active issue18856-dep.service; do sleep .5; done'
+
+# The dependent should now also be active (retroactively started)
+timeout 10 bash -c 'while ! systemctl --quiet is-active issue18856-dependent.service; do sleep .5; done'
+
+systemctl stop issue18856-dep.service issue18856-dependent.service 2>/dev/null || :
+rm -f /run/systemd/system/issue18856-dep.service /run/systemd/system/issue18856-dependent.service
+rm -f "$ISSUE18856_FLAG"
+systemctl daemon-reload
+
 touch /testok


### PR DESCRIPTION
## Summary

- When a unit with `Restart=on-failure` fails during startup, dependent units (those with `Requires=`, `Requisite=`, or `BindsTo=`) have their start jobs failed with `JOB_DEPENDENCY` result. When the failed unit auto-restarts and succeeds, these dependent units were never retroactively started.
- Fix this by tracking a `start_blocked_by_dependency` flag on units whose start was blocked by a dependency failure. When a unit's start job succeeds, we check its reverse dependencies and enqueue `JOB_START` for any that have this flag set.
- The flag is serialized to survive daemon-reload.

## Test plan

- [x] Added integration test in `TEST-03-JOBS.sh` that reproduces the exact scenario from the issue
- [x] Run `TEST-03-JOBS` integration test in a VM/container
- [ ] Verify that existing restart propagation (manual restart, `PropagatesStopTo=`, `BindsTo=`) still works correctly

Closes #18856