### PR TITLE
pcrlock: don't accept PCRs > 23 from firmware event log

### DIFF
--- a/src/boot/measure.c
+++ b/src/boot/measure.c
@@ -309,7 +309,7 @@ EFI_STATUS tpm_log_tagged_event(
         }
 
         err = tpm2_measure_to_pcr_and_tagged_event_log(tpm2, pcrindex, buffer, buffer_size, event_id, description);
-        if (!err)
+        if (err != EFI_SUCCESS)
                 return err;
 
         *ret_measured = true;

--- a/src/pcrlock/pcrlock.c
+++ b/src/pcrlock/pcrlock.c
@@ -949,6 +949,11 @@ static int event_log_load_firmware(EventLog *el) {
                         continue;
                 }
 
+                if (event->pcrIndex >= TPM2_PCRS_MAX) {
+                        log_debug("Skipping event on PCR %" PRIu32 " (out of range).", event->pcrIndex);
+                        continue;
+                }
+
                 r = event_log_add_record(el, &record);
                 if (r < 0)
                         return log_error_errno(r, "Failed to add record to event log: %m");


### PR DESCRIPTION
Let's harden ourselves against shitty firmware which might report an invalid PCR.

(This is not really a security issue, more a robustness issue, after all firmware generally comes with highest privileges and trust, even though it might just be shit)

Fixes an issue found with Claude code review