### PR TITLE
networkctl: display DHCP client state and lease timestamps in status output

### DIFF
--- a/src/libsystemd/sd-network/sd-network.c
+++ b/src/libsystemd/sd-network/sd-network.c
@@ -219,12 +219,42 @@ int sd_network_link_get_online_state(int ifindex, char **ret) {
         return network_link_get_string(ifindex, "ONLINE_STATE", ret);
 }
 
+int sd_network_link_get_dhcp_client_state(int ifindex, char **ret) {
+        return network_link_get_string(ifindex, "DHCP_CLIENT_STATE", ret);
+}
+
+int sd_network_link_get_dhcp_lease_timestamp(int ifindex, uint64_t *ret) {
+        _cleanup_free_ char *s = NULL;
+        int r;
+
+        r = network_link_get_string(ifindex, "DHCP_LEASE_TIMESTAMP", &s);
+        if (r < 0)
+                return r;
+
+        return safe_atou64(s, ret);
+}
+
+int sd_network_link_get_dhcp6_client_state(int ifindex, char **ret) {
+        return network_link_get_string(ifindex, "DHCP6_CLIENT_STATE", ret);
+}
+
 int sd_network_link_get_dhcp6_client_iaid_string(int ifindex, char **ret) {
         return network_link_get_string(ifindex, "DHCP6_CLIENT_IAID", ret);
 }
 
 int sd_network_link_get_dhcp6_client_duid_string(int ifindex, char **ret) {
         return network_link_get_string(ifindex, "DHCP6_CLIENT_DUID", ret);
+}
+
+int sd_network_link_get_dhcp6_lease_timestamp(int ifindex, uint64_t *ret) {
+        _cleanup_free_ char *s = NULL;
+        int r;
+
+        r = network_link_get_string(ifindex, "DHCP6_LEASE_TIMESTAMP", &s);
+        if (r < 0)
+                return r;
+
+        return safe_atou64(s, ret);
 }
 
 int sd_network_link_get_required_for_online(int ifindex) {

--- a/src/network/networkctl-link-info-json.c
+++ b/src/network/networkctl-link-info-json.c
@@ -8,6 +8,7 @@
 #include "networkctl-link-info.h"
 #include "networkctl-link-info-json.h"
 #include "networkctl-util.h"
+#include "time-util.h"
 
 static int acquire_link_bitrates(LinkInfo *link) {
         int r;
@@ -57,6 +58,75 @@ static int acquire_link_dhcp_client(LinkInfo *link) {
         return sd_dhcp_client_id_set_raw(&link->dhcp_client_id, iov.iov_base, iov.iov_len);
 }
 
+static int acquire_link_dhcp_states(LinkInfo *link) {
+        int r;
+
+        assert(link);
+
+        static const sd_json_dispatch_field dhcp4_dispatch_table[] = {
+                { "State", SD_JSON_VARIANT_STRING, sd_json_dispatch_const_string, offsetof(LinkInfo, dhcp4_client_state), 0 },
+                {}
+        }, dhcp6_dispatch_table[] = {
+                { "State", SD_JSON_VARIANT_STRING, sd_json_dispatch_const_string, offsetof(LinkInfo, dhcp6_client_state), 0 },
+                {}
+        };
+
+        sd_json_variant *v;
+        r = json_variant_find_object(link->description, STRV_MAKE("Interface", "DHCPv4Client"), &v);
+        if (r < 0 && r != -ENODATA)
+                return r;
+        if (r >= 0)
+                (void) sd_json_dispatch(v, dhcp4_dispatch_table, SD_JSON_LOG | SD_JSON_WARNING | SD_JSON_ALLOW_EXTENSIONS, link);
+
+        r = json_variant_find_object(link->description, STRV_MAKE("Interface", "DHCPv6Client"), &v);
+        if (r < 0 && r != -ENODATA)
+                return r;
+        if (r >= 0)
+                (void) sd_json_dispatch(v, dhcp6_dispatch_table, SD_JSON_LOG | SD_JSON_WARNING | SD_JSON_ALLOW_EXTENSIONS, link);
+
+        return 0;
+}
+
+static int acquire_link_dhcp_lease_timestamps(LinkInfo *link) {
+        int r;
+
+        assert(link);
+
+        static const sd_json_dispatch_field dhcp4_dispatch_table[] = {
+                { "LeaseTimestampUSec", _SD_JSON_VARIANT_TYPE_INVALID, sd_json_dispatch_uint64, offsetof(LinkInfo, dhcp4_lease_timestamp), 0 },
+                {}
+        }, dhcp6_dispatch_table[] = {
+                { "LeaseTimestampUSec", _SD_JSON_VARIANT_TYPE_INVALID, sd_json_dispatch_uint64, offsetof(LinkInfo, dhcp6_lease_timestamp), 0 },
+                {}
+        };
+
+        link->dhcp4_lease_timestamp = USEC_INFINITY;
+        link->dhcp6_lease_timestamp = USEC_INFINITY;
+
+        sd_json_variant *v;
+        r = json_variant_find_object(link->description, STRV_MAKE("Interface", "DHCPv4Client", "Lease"), &v);
+        if (r < 0 && r != -ENODATA)
+                return r;
+        if (r >= 0)
+                (void) sd_json_dispatch(v, dhcp4_dispatch_table, SD_JSON_LOG | SD_JSON_WARNING | SD_JSON_ALLOW_EXTENSIONS, link);
+
+        r = json_variant_find_object(link->description, STRV_MAKE("Interface", "DHCPv6Client", "Lease"), &v);
+        if (r < 0 && r != -ENODATA)
+                return r;
+        if (r >= 0)
+                (void) sd_json_dispatch(v, dhcp6_dispatch_table, SD_JSON_LOG | SD_JSON_WARNING | SD_JSON_ALLOW_EXTENSIONS, link);
+
+        /* The timestamps in the JSON data are based on CLOCK_BOOTTIME, but the table display needs
+         * wallclock time. */
+        if (link->dhcp4_lease_timestamp != USEC_INFINITY)
+                link->dhcp4_lease_timestamp = map_clock_usec(link->dhcp4_lease_timestamp, CLOCK_BOOTTIME, CLOCK_REALTIME);
+
+        if (link->dhcp6_lease_timestamp != USEC_INFINITY)
+                link->dhcp6_lease_timestamp = map_clock_usec(link->dhcp6_lease_timestamp, CLOCK_BOOTTIME, CLOCK_REALTIME);
+
+        return 0;
+}
+
 static int acquire_link_dhcp_message(LinkInfo *link) {
         int r;
 
@@ -87,6 +157,8 @@ int link_info_parse_description(LinkInfo *link, sd_varlink *vl) {
         (void) acquire_link_bitrates(link);
         (void) acquire_link_dhcp_client(link);
         (void) acquire_link_dhcp_message(link);
+        (void) acquire_link_dhcp_states(link);
+        (void) acquire_link_dhcp_lease_timestamps(link);
 
         return 0;
 }

--- a/src/network/networkctl-link-info.h
+++ b/src/network/networkctl-link-info.h
@@ -63,6 +63,12 @@ typedef struct LinkInfo {
         /* DHCPv4 */
         sd_dhcp_message *dhcp_message;
         sd_dhcp_client_id dhcp_client_id;
+        const char *dhcp4_client_state;
+        usec_t dhcp4_lease_timestamp;
+
+        /* DHCPv6 */
+        const char *dhcp6_client_state;
+        usec_t dhcp6_lease_timestamp;
 
         /* bridge info */
         uint32_t forward_delay;

--- a/src/network/networkctl-status-link.c
+++ b/src/network/networkctl-status-link.c
@@ -268,7 +268,8 @@ static int link_status_one(
         _cleanup_strv_free_ char **dns = NULL, **ntp = NULL, **sip = NULL, **search_domains = NULL,
                 **route_domains = NULL, **link_dropins = NULL, **network_dropins = NULL, **netdev_dropins = NULL;
         _cleanup_free_ char *t = NULL, *network = NULL, *netdev = NULL, *iaid = NULL, *duid = NULL, *captive_portal = NULL,
-                *setup_state = NULL, *operational_state = NULL, *online_state = NULL, *activation_policy = NULL;
+                *setup_state = NULL, *operational_state = NULL, *online_state = NULL, *activation_policy = NULL,
+                *dhcp_state = NULL, *dhcp6_state = NULL;
         const char *driver = NULL, *path = NULL, *vendor = NULL, *model = NULL, *link = NULL,
                 *on_color_operational, *off_color_operational, *on_color_setup, *off_color_setup, *on_color_online;
         _cleanup_free_ int *carrier_bound_to = NULL, *carrier_bound_by = NULL;
@@ -870,7 +871,6 @@ static int link_status_one(
         }
 
         if (lease) {
-                const sd_dhcp_client_id *client_id;
                 const char *tz;
 
                 r = sd_dhcp_lease_get_timezone(lease, &tz);
@@ -881,6 +881,19 @@ static int link_status_one(
                         if (r < 0)
                                 return table_log_add_error(r);
                 }
+        }
+
+        (void) sd_network_link_get_dhcp_client_state(info->ifindex, &dhcp_state);
+        if (dhcp_state) {
+                r = table_add_many(table,
+                                   TABLE_FIELD, "DHCPv4 Client State",
+                                   TABLE_STRING, dhcp_state);
+                if (r < 0)
+                        return table_log_add_error(r);
+        }
+
+        if (lease) {
+                const sd_dhcp_client_id *client_id;
 
                 r = sd_dhcp_lease_get_client_id(lease, &client_id);
                 if (r >= 0) {
@@ -897,6 +910,25 @@ static int link_status_one(
                 }
         }
 
+        uint64_t dhcp4_ts;
+        r = sd_network_link_get_dhcp_lease_timestamp(info->ifindex, &dhcp4_ts);
+        if (r >= 0) {
+                r = table_add_many(table,
+                                   TABLE_FIELD, "DHCPv4 Lease Timestamp",
+                                   TABLE_TIMESTAMP, dhcp4_ts);
+                if (r < 0)
+                        return table_log_add_error(r);
+        }
+
+        (void) sd_network_link_get_dhcp6_client_state(info->ifindex, &dhcp6_state);
+        if (dhcp6_state) {
+                r = table_add_many(table,
+                                   TABLE_FIELD, "DHCPv6 Client State",
+                                   TABLE_STRING, dhcp6_state);
+                if (r < 0)
+                        return table_log_add_error(r);
+        }
+
         r = sd_network_link_get_dhcp6_client_iaid_string(info->ifindex, &iaid);
         if (r >= 0) {
                 r = table_add_many(table,
@@ -911,6 +943,16 @@ static int link_status_one(
                 r = table_add_many(table,
                                    TABLE_FIELD, "DHCPv6 Client DUID",
                                    TABLE_STRING, duid);
+                if (r < 0)
+                        return table_log_add_error(r);
+        }
+
+        uint64_t dhcp6_ts;
+        r = sd_network_link_get_dhcp6_lease_timestamp(info->ifindex, &dhcp6_ts);
+        if (r >= 0) {
+                r = table_add_many(table,
+                                   TABLE_FIELD, "DHCPv6 Lease Timestamp",
+                                   TABLE_TIMESTAMP, dhcp6_ts);
                 if (r < 0)
                         return table_log_add_error(r);
         }

--- a/src/network/networkctl-status-link.c
+++ b/src/network/networkctl-status-link.c
@@ -843,6 +843,14 @@ static int link_status_one(
                 }
         }
 
+        if (info->dhcp4_client_state) {
+                r = table_add_many(table,
+                                   TABLE_FIELD, "DHCPv4 Client State",
+                                   TABLE_STRING, info->dhcp4_client_state);
+                if (r < 0)
+                        return table_log_add_error(r);
+        }
+
         if (sd_dhcp_client_id_is_set(&info->dhcp_client_id)) {
                 _cleanup_free_ char *id = NULL;
 
@@ -854,6 +862,22 @@ static int link_status_one(
                         if (r < 0)
                                 return table_log_add_error(r);
                 }
+        }
+
+        if (info->dhcp4_lease_timestamp != USEC_INFINITY) {
+                r = table_add_many(table,
+                                   TABLE_FIELD, "DHCPv4 Lease Timestamp",
+                                   TABLE_TIMESTAMP, info->dhcp4_lease_timestamp);
+                if (r < 0)
+                        return table_log_add_error(r);
+        }
+
+        if (info->dhcp6_client_state) {
+                r = table_add_many(table,
+                                   TABLE_FIELD, "DHCPv6 Client State",
+                                   TABLE_STRING, info->dhcp6_client_state);
+                if (r < 0)
+                        return table_log_add_error(r);
         }
 
         r = sd_network_link_get_dhcp6_client_iaid_string(info->ifindex, &iaid);
@@ -870,6 +894,14 @@ static int link_status_one(
                 r = table_add_many(table,
                                    TABLE_FIELD, "DHCPv6 Client DUID",
                                    TABLE_STRING, duid);
+                if (r < 0)
+                        return table_log_add_error(r);
+        }
+
+        if (info->dhcp6_lease_timestamp != USEC_INFINITY) {
+                r = table_add_many(table,
+                                   TABLE_FIELD, "DHCPv6 Lease Timestamp",
+                                   TABLE_TIMESTAMP, info->dhcp6_lease_timestamp);
                 if (r < 0)
                         return table_log_add_error(r);
         }

--- a/src/network/networkd-dhcp6.c
+++ b/src/network/networkd-dhcp6.c
@@ -11,6 +11,7 @@
 #include "conf-parser.h"
 #include "dhcp6-client-internal.h"
 #include "dhcp6-lease-internal.h"
+#include "dhcp6-protocol.h"
 #include "errno-util.h"
 #include "hashmap.h"
 #include "hostname-setup.h"
@@ -28,6 +29,7 @@
 #include "set.h"
 #include "string-table.h"
 #include "string-util.h"
+#include "time-util.h"
 
 bool link_dhcp6_with_address_enabled(Link *link) {
         if (!link_dhcp6_enabled(link))
@@ -889,6 +891,10 @@ int link_serialize_dhcp6_client(Link *link, FILE *f) {
         if (!link->dhcp6_client)
                 return 0;
 
+        const char *state = dhcp6_state_to_string(dhcp6_client_get_state(link->dhcp6_client));
+        if (state)
+                fprintf(f, "DHCP6_CLIENT_STATE=%s\n", state);
+
         r = sd_dhcp6_client_get_iaid(link->dhcp6_client, &iaid);
         if (r >= 0)
                 fprintf(f, "DHCP6_CLIENT_IAID=0x%x\n", iaid);
@@ -896,6 +902,14 @@ int link_serialize_dhcp6_client(Link *link, FILE *f) {
         r = sd_dhcp6_client_get_duid_as_string(link->dhcp6_client, &duid);
         if (r >= 0)
                 fprintf(f, "DHCP6_CLIENT_DUID=%s\n", duid);
+
+        if (link->dhcp6_lease) {
+                usec_t ts;
+
+                r = sd_dhcp6_lease_get_timestamp(link->dhcp6_lease, CLOCK_REALTIME, &ts);
+                if (r >= 0)
+                        fprintf(f, "DHCP6_LEASE_TIMESTAMP=" USEC_FMT "\n", ts);
+        }
 
         return 0;
 }

--- a/src/network/networkd-json.c
+++ b/src/network/networkd-json.c
@@ -6,9 +6,11 @@
 #include "sd-dhcp-client.h"
 #include "sd-dhcp6-client.h"
 
+#include "dhcp-client-internal.h"
 #include "dhcp-lease-internal.h"         /* IWYU pragma: keep */
 #include "dhcp-server-internal.h"
 #include "dhcp-server-lease-internal.h"
+#include "dhcp6-client-internal.h"
 #include "dhcp6-lease-internal.h"
 #include "extract-word.h"
 #include "in-addr-util.h"
@@ -1297,6 +1299,26 @@ static int dhcp6_client_duid_append_json(Link *link, sd_json_variant **v) {
         return sd_json_variant_merge_objectbo(v, SD_JSON_BUILD_PAIR_BYTE_ARRAY("DUID", data, data_size));
 }
 
+static int dhcp6_client_state_append_json(Link *link, sd_json_variant **v) {
+        int state;
+
+        assert(link);
+        assert(v);
+
+        if (!link->dhcp6_client)
+                return 0;
+
+        state = dhcp6_client_get_state(link->dhcp6_client);
+        if (state < 0)
+                return 0;
+
+        const char *s = dhcp6_state_to_string(state);
+        if (!s)
+                return 0;
+
+        return sd_json_variant_merge_objectbo(v, SD_JSON_BUILD_PAIR_STRING("State", s));
+}
+
 static int dhcp6_client_append_json(Link *link, sd_json_variant **v) {
         _cleanup_(sd_json_variant_unrefp) sd_json_variant *w = NULL;
         int r;
@@ -1320,6 +1342,10 @@ static int dhcp6_client_append_json(Link *link, sd_json_variant **v) {
                 return r;
 
         r = dhcp6_client_duid_append_json(link, &w);
+        if (r < 0)
+                return r;
+
+        r = dhcp6_client_state_append_json(link, &w);
         if (r < 0)
                 return r;
 
@@ -1465,6 +1491,26 @@ static int dhcp_client_id_append_json(Link *link, sd_json_variant **v) {
         return sd_json_variant_merge_objectbo(v, SD_JSON_BUILD_PAIR_BYTE_ARRAY("ClientIdentifier", data, l));
 }
 
+static int dhcp_client_state_append_json(Link *link, sd_json_variant **v) {
+        int state;
+
+        assert(link);
+        assert(v);
+
+        if (!link->dhcp_client)
+                return 0;
+
+        state = dhcp_client_get_state(link->dhcp_client);
+        if (state < 0)
+                return 0;
+
+        const char *s = dhcp_state_to_string(state);
+        if (!s)
+                return 0;
+
+        return sd_json_variant_merge_objectbo(v, SD_JSON_BUILD_PAIR_STRING("State", s));
+}
+
 static int dhcp_client_append_json(Link *link, sd_json_variant **v) {
         _cleanup_(sd_json_variant_unrefp) sd_json_variant *w = NULL;
         int r;
@@ -1488,6 +1534,10 @@ static int dhcp_client_append_json(Link *link, sd_json_variant **v) {
                 return r;
 
         r = dhcp_client_id_append_json(link, &w);
+        if (r < 0)
+                return r;
+
+        r = dhcp_client_state_append_json(link, &w);
         if (r < 0)
                 return r;
 

--- a/src/network/networkd-state-file.c
+++ b/src/network/networkd-state-file.c
@@ -5,9 +5,11 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#include "sd-dhcp-lease.h"
 #include "sd-dhcp6-lease.h"
 
 #include "alloc-util.h"
+#include "dhcp-client-internal.h"
 #include "dns-domain.h"
 #include "dns-resolver-internal.h"
 #include "errno-util.h"
@@ -959,7 +961,19 @@ static int link_save(Link *link) {
         print_link_hashmap(f, "CARRIER_BOUND_TO=", link->bound_to_links);
         print_link_hashmap(f, "CARRIER_BOUND_BY=", link->bound_by_links);
 
+        if (link->dhcp_client) {
+                const char *state = dhcp_state_to_string(dhcp_client_get_state(link->dhcp_client));
+                if (state)
+                        fprintf(f, "DHCP_CLIENT_STATE=%s\n", state);
+        }
+
         if (link->dhcp_lease) {
+                usec_t ts;
+
+                r = sd_dhcp_lease_get_timestamp(link->dhcp_lease, CLOCK_REALTIME, &ts);
+                if (r >= 0)
+                        fprintf(f, "DHCP_LEASE_TIMESTAMP=" USEC_FMT "\n", ts);
+
                 r = dhcp_lease_save(link->dhcp_lease, link->lease_file);
                 if (r < 0)
                         return r;

--- a/src/shared/varlink-io.systemd.Network.c
+++ b/src/shared/varlink-io.systemd.Network.c
@@ -374,6 +374,8 @@ SD_VARLINK_DEFINE_STRUCT_TYPE(
 
 SD_VARLINK_DEFINE_STRUCT_TYPE(
                 DHCPv6Client,
+                SD_VARLINK_FIELD_COMMENT("State of the DHCPv6 client (information-request, solicitation, request, bound, renew, rebind, stopping, etc.)"),
+                SD_VARLINK_DEFINE_FIELD(State, SD_VARLINK_STRING, SD_VARLINK_NULLABLE),
                 SD_VARLINK_FIELD_COMMENT("DHCPv6 lease information including timestamps and timeouts"),
                 SD_VARLINK_DEFINE_FIELD_BY_TYPE(Lease, DHCPLease, SD_VARLINK_NULLABLE),
                 SD_VARLINK_FIELD_COMMENT("Delegated prefixes received from DHCPv6 server"),

--- a/src/systemd/sd-network.h
+++ b/src/systemd/sd-network.h
@@ -192,11 +192,23 @@ int sd_network_link_get_carrier_bound_to(int ifindex, int **ret);
 /* Get the CARRIERS that are bound to current link. */
 int sd_network_link_get_carrier_bound_by(int ifindex, int **ret);
 
+/* Get DHCPv4 client state for a given link. */
+int sd_network_link_get_dhcp_client_state(int ifindex, char **ret);
+
+/* Get DHCPv4 lease timestamp for a given link. */
+int sd_network_link_get_dhcp_lease_timestamp(int ifindex, uint64_t *ret);
+
+/* Get DHCPv6 client state for a given link. */
+int sd_network_link_get_dhcp6_client_state(int ifindex, char **ret);
+
 /* Get DHCPv6 client IAID for a given link. */
 int sd_network_link_get_dhcp6_client_iaid_string(int ifindex, char **ret);
 
 /* Get DHCPv6 client DUID for a given link. */
 int sd_network_link_get_dhcp6_client_duid_string(int ifindex, char **ret);
+
+/* Get DHCPv6 lease timestamp for a given link. */
+int sd_network_link_get_dhcp6_lease_timestamp(int ifindex, uint64_t *ret);
 
 int sd_network_link_get_stat(int ifindex, struct stat *ret);
 

--- a/test/test-network/systemd-networkd-tests.py
+++ b/test/test-network/systemd-networkd-tests.py
@@ -7408,6 +7408,8 @@ class NetworkdDHCPServerTests(unittest.TestCase, Utilities):
         output = networkctl_status('veth99')
         print(output)
         self.assertIn('Address: 10.1.1.200 (DHCPv4 via 10.1.1.1)', output)
+        self.assertIn('DHCPv4 Client State: bound', output)
+        self.assertRegex(output, r'DHCPv4 Lease Timestamp: .+')
         self.assertIn('DHCPv4 Client ID: 12:34:56:78:9a:bc', output)
 
     def test_dhcp_server_static_lease_mac_by_global(self):
@@ -7686,6 +7688,12 @@ class NetworkdDHCPClientTests(unittest.TestCase, Utilities):
         print(f"DHCPv6 client state = {state}")
         self.assertEqual(state, 'bound')
 
+        # Also verify DHCP client state is written to the link state file
+        output = read_link_state_file('veth99')
+        print(output)
+        self.assertIn('DHCP6_CLIENT_STATE=bound', output)
+        self.assertRegex(output, r'DHCP6_LEASE_TIMESTAMP=\d+')
+
         # DHCPv4 client will stop after an DHCPOFFER message received, so we need to wait for a while.
         for _ in range(100):
             state = get_dhcp4_client_state('veth99')
@@ -7816,6 +7824,7 @@ class NetworkdDHCPClientTests(unittest.TestCase, Utilities):
         self.assertIn('DNS=192.168.5.6 192.168.5.7', output)
         self.assertIn('SIP=192.168.5.21 192.168.5.22', output)
         self.assertIn('DOMAINS=example.com', output)
+        self.assertIn('DHCP_CLIENT_STATE=bound', output)
 
         print('## json')
         j = json.loads(networkctl_json('veth99'))
@@ -7923,6 +7932,7 @@ class NetworkdDHCPClientTests(unittest.TestCase, Utilities):
         self.assertIn('DNS=192.168.5.1 192.168.5.7 192.168.5.8', output)
         self.assertIn('SIP=192.168.5.23 192.168.5.24', output)
         self.assertIn('DOMAINS=foo.example.com', output)
+        self.assertIn('DHCP_CLIENT_STATE=bound', output)
 
         print('## json')
         j = json.loads(networkctl_json('veth99'))

--- a/test/test-network/systemd-networkd-tests.py
+++ b/test/test-network/systemd-networkd-tests.py
@@ -8388,6 +8388,8 @@ class NetworkdDHCPServerTests(unittest.TestCase, Utilities):
         output = networkctl_status('veth99')
         print(output)
         self.assertIn('Address: 10.1.1.200 (DHCPv4 via 10.1.1.1)', output)
+        self.assertIn('DHCPv4 Client State: bound', output)
+        self.assertRegex(output, r'DHCPv4 Lease Timestamp: \w{3} \d{4}-\d{2}-\d{2}')
         self.assertIn('DHCPv4 Client ID: 12:34:56:78:9a:bc', output)
 
     def test_dhcp_server_static_lease_mac_by_global(self):
@@ -8813,6 +8815,12 @@ class NetworkdDHCPClientTests(unittest.TestCase, Utilities):
         print(f'DHCPv6 client state = {state}')
         self.assertEqual(state, 'bound')
 
+        # Also verify the DHCP client states are exposed via the varlink Describe() interface
+        j = json.loads(networkctl_json('veth99'))
+        self.assertEqual(j['DHCPv6Client']['State'], 'bound')
+        self.assertIn('LeaseTimestampUSec', j['DHCPv6Client']['Lease'])
+        self.assertEqual(j['DHCPv4Client']['State'], 'selecting')
+
         # DHCPv4 client will stop after an DHCPOFFER message received, so we need to wait for a while.
         for _ in range(100):
             state = get_dhcp4_client_state('veth99')
@@ -8956,6 +8964,7 @@ class NetworkdDHCPClientTests(unittest.TestCase, Utilities):
 
         print('## json')
         j = json.loads(networkctl_json('veth99'))
+        self.assertEqual(j['DHCPv4Client']['State'], 'bound')
 
         self.assertEqual(len(j['DNS']), 2)
         for i in j['DNS']:
@@ -9102,6 +9111,7 @@ class NetworkdDHCPClientTests(unittest.TestCase, Utilities):
 
         print('## json')
         j = json.loads(networkctl_json('veth99'))
+        self.assertEqual(j['DHCPv4Client']['State'], 'bound')
 
         self.assertEqual(len(j['DNS']), 3)
         for i in j['DNS']:


### PR DESCRIPTION
Show DHCPv4/v6 client state (e.g. "bound", "renewing") and lease receipt timestamps in `networkctl status` output, giving users visibility into DHCP lease lifecycle without having to grep journal logs.

Displayed as:

```
         DHCPv6 Client State: bound
          DHCPv6 Client IAID: 0xb7b09587
          DHCPv6 Client DUID: DUID-EN/Vendor:0000ab11313fabc68e638457
      DHCPv6 Lease Timestamp: Mon 2026-03-16 01:39:22 UTC
```


Fixes: https://github.com/systemd/systemd/issues/39054

Developed with Claude Code.