### PR TITLE
sleep: silence error message when homed is not installed

### DIFF
--- a/src/shared/bus-util.c
+++ b/src/shared/bus-util.c
@@ -206,8 +206,9 @@ int bus_name_has_owner(sd_bus *bus, const char *name, sd_bus_error *reterr_error
 
 bool bus_error_is_unknown_service(const sd_bus_error *error) {
         return sd_bus_error_has_names(error,
-                                      SD_BUS_ERROR_SERVICE_UNKNOWN,
                                       SD_BUS_ERROR_NAME_HAS_NO_OWNER,
+                                      SD_BUS_ERROR_SERVICE_UNKNOWN,
+                                      SD_BUS_ERROR_UNKNOWN_OBJECT,
                                       BUS_ERROR_NO_SUCH_UNIT);
 }
 


### PR DESCRIPTION
As reported in #41113, we get:
  systemd-sleep[523631]: Failed to lock home directories: Unknown object '/org/freedesktop/home1'.
when systemd-homed is not installed. We tried to suppress the message with:
   if (!bus_error_is_unknown_service(&error))
     return log_error_errno(r, "Failed to lock home directories: %s", bus_error_message(&error, r));
   log_debug("systemd-homed is not running, locking of home directories skipped.");
but the error that is returned is SD_BUS_ERROR_UNKNOWN_OBJECT a.k.a. "org.freedesktop.DBus.Error.UnknownObject". Let's add that to the filter. I think it makes sense to do this in general code, since in general if the object is unknown then the service on it would be unknown too, so that matches the intent of the filter.

Replaces #41113.