### PR TITLE
network: sd-radv: allow setting the RA MTU option

### DIFF
--- a/man/systemd.network.xml
+++ b/man/systemd.network.xml
@@ -4368,6 +4368,19 @@ ServerAddress=192.168.0.1/24</programlisting>
       </varlistentry>
 
       <varlistentry>
+        <term><varname>MTUBytes=</varname></term>
+        <listitem>
+          <para>Specifies the size of the router advertisement MTU or one of the special
+          value <literal>auto</literal>. When suffixed with K, M, or G, the specified
+          size is parsed as Kilobytes, Megabytes, or Gigabytes, respectively, to the base of 1024.
+          When <literal>auto</literal>, is specified the MTU of the link is automatically taken as
+          router advertisement MTU. Defaults to <literal>auto</literal>.</para>
+
+          <xi:include href="version-info.xml" xpointer="v261"/>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
         <term><varname>UplinkInterface=</varname></term>
         <listitem><para>Specifies the name or the index of the uplink interface, or one of the special
         values <literal>:none</literal> and <literal>:auto</literal>. When emitting DNS servers or

--- a/src/network/networkd-link.c
+++ b/src/network/networkd-link.c
@@ -2499,6 +2499,9 @@ static int link_update_mtu(Link *link, sd_netlink_message *message) {
         }
 
         if (link->radv) {
+                if (link->have_router_mtu)
+                        return 0;
+
                 r = sd_radv_set_mtu(link->radv, link->mtu);
                 if (r < 0)
                         return log_link_debug_errno(link, r, "Could not set MTU for Router Advertisement: %m");

--- a/src/network/networkd-link.h
+++ b/src/network/networkd-link.h
@@ -160,6 +160,7 @@ typedef struct Link {
         bool ndisc_configured;
 
         sd_radv *radv;
+        bool have_router_mtu:1;
 
         sd_dhcp6_client *dhcp6_client;
         sd_dhcp6_lease *dhcp6_lease;

--- a/src/network/networkd-network-gperf.gperf
+++ b/src/network/networkd-network-gperf.gperf
@@ -443,6 +443,7 @@ IPv6SendRA.Managed,                              config_parse_bool,             
 IPv6SendRA.OtherInformation,                     config_parse_bool,                              0,                                      offsetof(Network, router_other_information)
 IPv6SendRA.RouterPreference,                     config_parse_router_preference,                 0,                                      offsetof(Network, router_preference)
 IPv6SendRA.HopLimit,                             config_parse_uint8,                             0,                                      offsetof(Network, router_hop_limit)
+IPv6SendRA.MTUBytes,                             config_parse_router_mtu,                        AF_INET6,                               offsetof(Network, router_mtu)
 IPv6SendRA.EmitDNS,                              config_parse_bool,                              0,                                      offsetof(Network, router_emit_dns)
 IPv6SendRA.DNS,                                  config_parse_radv_dns,                          0,                                      0
 IPv6SendRA.EmitDomains,                          config_parse_bool,                              0,                                      offsetof(Network, router_emit_domains)

--- a/src/network/networkd-network.h
+++ b/src/network/networkd-network.h
@@ -250,6 +250,8 @@ typedef struct Network {
         usec_t router_reachable_usec;
         usec_t router_retransmit_usec;
         uint8_t router_hop_limit;
+        uint32_t router_mtu;
+        bool router_mtu_auto;
         bool router_managed;
         bool router_other_information;
         bool router_emit_dns;

--- a/src/network/networkd-radv.c
+++ b/src/network/networkd-radv.c
@@ -489,6 +489,15 @@ static int radv_configure(Link *link) {
         if (r < 0)
                 return r;
 
+        if (link->network->router_mtu > 0 || link->network->router_mtu_auto) {
+                r = sd_radv_set_mtu(link->radv, link->network->router_mtu_auto ? link->network->ipv6_mtu : link->network->router_mtu);
+                if (r < 0)
+                        return r;
+
+                if (link->network->router_mtu > 0)
+                        link->have_router_mtu = true;
+        }
+
         r = sd_radv_set_preference(link->radv, link->network->router_preference);
         if (r < 0)
                 return r;
@@ -1615,5 +1624,39 @@ int config_parse_router_home_agent_lifetime(
         }
 
         *home_agent_lifetime_usec = usec;
+        return 0;
+}
+
+int config_parse_router_mtu(
+                const char *unit,
+                const char *filename,
+                unsigned line,
+                const char *section,
+                unsigned section_line,
+                const char *lvalue,
+                int ltype,
+                const char *rvalue,
+                void *data,
+                void *userdata) {
+        Network *network = userdata;
+        int r;
+
+        assert(rvalue);
+
+        if (isempty(rvalue)) {
+                network->router_mtu_auto = false;
+                return 0;
+        }
+
+        if (streq(rvalue, "auto")) {
+                network->router_mtu_auto = true;
+                return 0;
+        }
+
+        r = config_parse_mtu(unit, filename, line, section, section_line, lvalue, ltype, rvalue, data, userdata);
+        if (r <= 0)
+                return r;
+
+        network->router_mtu_auto = false;
         return 0;
 }

--- a/src/network/networkd-radv.h
+++ b/src/network/networkd-radv.h
@@ -62,6 +62,7 @@ CONFIG_PARSER_PROTOTYPE(config_parse_router_prefix_delegation);
 CONFIG_PARSER_PROTOTYPE(config_parse_router_lifetime);
 CONFIG_PARSER_PROTOTYPE(config_parse_router_uint32_msec_usec);
 CONFIG_PARSER_PROTOTYPE(config_parse_router_preference);
+CONFIG_PARSER_PROTOTYPE(config_parse_router_mtu);
 CONFIG_PARSER_PROTOTYPE(config_parse_prefix);
 CONFIG_PARSER_PROTOTYPE(config_parse_prefix_boolean);
 CONFIG_PARSER_PROTOTYPE(config_parse_prefix_lifetime);


### PR DESCRIPTION
Re-spin of #33360, which got abandoned (originally authored by @ssahani)

Addressed suggestions from @yuwata.

I did some manual testing (NetworkManager with iwd in a wifi, which the AP bridges via vxlan to a L3 router.
The L2 has an MTU smaller than 1500, causing TLS handshakes to fail, due to the bridge dropping too large packets.

With this patch (and the MTU manually set to 1430 (1500 - VXLAN over IPv6 overhead), I didn't see handshakes to fail.

Apart from tcpdumps of course, from userland, the announced MTU seems only visible in `ip -6 route show cache`, after a connection has been made. I don't see it as an attribute to `ip -6 route show`.

@yuwata If tests are required, I need some suggestions on how to extend `test/test-network/systemd-networkd-tests.py`. We mostly look at sysctl / iproute outputs there, but it doesn't seem to be exposed there.

Closes https://github.com/systemd/systemd/issues/33160