### PR TITLE
hwdb.d/keyboard: revert key 76 -> touchpad_toggle mapping

### DIFF
--- a/hwdb.d/60-keyboard.hwdb
+++ b/hwdb.d/60-keyboard.hwdb
@@ -1572,6 +1572,7 @@ evdev:input:b0003v1532p0200*
 
 evdev:atkbd:dmi:bvn*:bvr*:bd*:svnMICRO-STAR*:pn*:*
 evdev:atkbd:dmi:bvn*:bvr*:bd*:svnMicro-Star*:pn*:*
+ KEYBOARD_KEY_76=touchpad_toggle                        # Toggle touchpad, sends meta+ctrl+toggle
  KEYBOARD_KEY_91=config                                 # MSIControl Center
  KEYBOARD_KEY_a0=mute                                   # Fn+F9
  KEYBOARD_KEY_ae=volumedown                             # Fn+F7
@@ -1589,10 +1590,6 @@ evdev:atkbd:dmi:bvn*:bvr*:bd*:svnMicro-Star*:pn*:*
  KEYBOARD_KEY_f7=brightnessdown                         # Fn+F4
  KEYBOARD_KEY_f8=brightnessup                           # Fn+F5
  KEYBOARD_KEY_f9=search
-
-# MSI GF63 toggles touchpad using Fn+F3 where the keyboard key is 29
-evdev:atkbd:dmi:bvn*:bvr*:bd*:svnMICRO-STAR*:pnGF63*:*
- KEYBOARD_KEY_85=touchpad_toggle                        # Toggle touchpad, sends meta+ctrl+toggle
 
 evdev:atkbd:dmi:bvn*:bvr*:bd*:svnMICRO-STAR*:pnGE60*:*
 evdev:atkbd:dmi:bvn*:bvr*:bd*:svnMICRO-STAR*:pnGE70*:*
@@ -1620,7 +1617,6 @@ evdev:atkbd:dmi:bvn*:bvr*:bd*:svnMICRO-STAR*:pnU90/U100:*
 # Keymaps MSI Prestige And MSI Modern FnKeys and Special keys
 evdev:atkbd:dmi:bvn*:bvr*:bd*:svnMicro-Star*:pn*Prestige*:*
 evdev:atkbd:dmi:bvn*:bvr*:bd*:svnMicro-Star*:pn*Modern*:*
- KEYBOARD_KEY_76=touchpad_toggle                        # Toggle touchpad, sends meta+ctrl+toggle
  KEYBOARD_KEY_91=prog1                                  # Fn+F7 Creation Center, sometime F7
  KEYBOARD_KEY_f2=rotate_display                         # Fn+F12 Screen rotation
  KEYBOARD_KEY_8d=prog3                                  # Fn+A Change True Color selections


### PR DESCRIPTION
Almost 2 years ago I created this PR, and looks like now it's not required anymore. And we can revert it, which actually fixes the regression. I tested this on Kubuntu 26.04