### PR TITLE
vmspawn: Drop --sandbox=chroot from virtiofsd command line

### DIFF
--- a/src/vmspawn/vmspawn.c
+++ b/src/vmspawn/vmspawn.c
@@ -1558,7 +1558,6 @@ static int start_virtiofsd(
                         "--shared-dir", source_uid == FOREIGN_UID_MIN ? "/run/systemd/mount-rootfs" : directory,
                         "--xattr",
                         "--fd", sockstr,
-                        "--sandbox=chroot",
                         "--no-announce-submounts");
         if (!argv)
                 return log_oom();


### PR DESCRIPTION
It's unclear why I added this in fd05c6c7593c5e36864d8784df91b878bbf991ab,
but it breaks bind mounting regular directories via --bind,
so drop it again since it's not actually required to make virtiofsd
work with the foreign UID range.
