### PR TITLE
mount: make sys-kernel-debug.mount optional

### DIFF
--- a/units/meson.build
+++ b/units/meson.build
@@ -230,10 +230,7 @@ units = [
           'file' : 'sys-kernel-config.mount',
           'symlinks' : ['sysinit.target.wants/'],
         },
-        {
-          'file' : 'sys-kernel-debug.mount',
-          'symlinks' : ['sysinit.target.wants/'],
-        },
+        { 'file' : 'sys-kernel-debug.mount' },
         {
           'file' : 'sys-kernel-tracing.mount',
           'symlinks' : ['sysinit.target.wants/'],

--- a/units/sys-kernel-debug.mount
+++ b/units/sys-kernel-debug.mount
@@ -21,3 +21,6 @@ What=debugfs
 Where=/sys/kernel/debug
 Type=debugfs
 Options=nosuid,nodev,noexec
+
+[Install]
+WantedBy=sysinit.target


### PR DESCRIPTION
debugfs exposes sensitive kernel internals and has been the subject of multiple CVEs. Most regular users do not need it mounted, so make it opt-in rather than unconditionally started at boot.