### PR TITLE
Revert "mountpoint-util: assume MS_NOSYMFOLLOW is available"

### DIFF
--- a/README
+++ b/README
@@ -53,13 +53,13 @@ REQUIREMENTS:
                      ≥ 5.8 for LOOP_CONFIGURE, STATX_ATTR_MOUNT_ROOT, and procfs
                                per-instance hidepid=/subset= options
                      ≥ 5.9 for close_range()
-                     ≥ 5.10 for STATX_MNT_ID and MS_NOSYMFOLLOW mount option
+                     ≥ 5.10 for STATX_MNT_ID
 
         ⛔ Kernel versions below 5.10 ("minimum baseline") are not supported at all,
            and are missing required functionality as listed above.
 
         Linux kernel ≥ 5.11 for epoll_pwait2()
-                     ≥ 5.12 for idmapped mount (mount_setattr())
+                     ≥ 5.12 for idmapped mount (mount_setattr()) and MS_NOSYMFOLLOW
                      ≥ 5.14 for cgroup.kill and quotactl_fd()
 
         ⚠️ Kernel versions below 5.14 ("recommended baseline") have significant gaps

--- a/TODO
+++ b/TODO
@@ -106,6 +106,8 @@ Deprecations and removals:
 * drop support for LOOP_CONFIGURE-less loopback block devices, once kernel
   baseline is 5.8.
 
+* Once baseline is 5.12, remove support for MS_NOSYMFOLLOW-less kernels
+
 * Remove /dev/mem ACPI FPDT parsing when /sys/firmware/acpi/fpdt is ubiquitous.
   That requires distros to enable CONFIG_ACPI_FPDT, and have kernels v5.12 for
   x86 and v6.2 for arm.

--- a/src/basic/mountpoint-util.c
+++ b/src/basic/mountpoint-util.c
@@ -629,6 +629,66 @@ bool mount_new_api_supported(void) {
         return (cache = true);
 }
 
+unsigned long ms_nosymfollow_supported(void) {
+        _cleanup_close_ int fsfd = -EBADF, mntfd = -EBADF;
+        static int cache = -1;
+
+        /* Returns MS_NOSYMFOLLOW if it is supported, zero otherwise. */
+
+        if (cache >= 0)
+                return cache ? MS_NOSYMFOLLOW : 0;
+
+        if (!mount_new_api_supported())
+                goto not_supported;
+
+        /* Checks if MS_NOSYMFOLLOW is supported (which was added in 5.10). We use the new mount API's
+         * mount_setattr() call for that, which was added in 5.12, which is close enough. */
+
+        fsfd = fsopen("tmpfs", FSOPEN_CLOEXEC);
+        if (fsfd < 0) {
+                if (ERRNO_IS_NOT_SUPPORTED(errno))
+                        goto not_supported;
+
+                log_debug_errno(errno, "Failed to open superblock context for tmpfs: %m");
+                return 0;
+        }
+
+        if (fsconfig(fsfd, FSCONFIG_CMD_CREATE, NULL, NULL, 0) < 0) {
+                if (ERRNO_IS_NOT_SUPPORTED(errno))
+                        goto not_supported;
+
+                log_debug_errno(errno, "Failed to create tmpfs superblock: %m");
+                return 0;
+        }
+
+        mntfd = fsmount(fsfd, FSMOUNT_CLOEXEC, 0);
+        if (mntfd < 0) {
+                if (ERRNO_IS_NOT_SUPPORTED(errno))
+                        goto not_supported;
+
+                log_debug_errno(errno, "Failed to turn superblock fd into mount fd: %m");
+                return 0;
+        }
+
+        if (mount_setattr(mntfd, "", AT_EMPTY_PATH|AT_RECURSIVE,
+                          &(struct mount_attr) {
+                                  .attr_set = MOUNT_ATTR_NOSYMFOLLOW,
+                          }, sizeof(struct mount_attr)) < 0) {
+                if (ERRNO_IS_NOT_SUPPORTED(errno))
+                        goto not_supported;
+
+                log_debug_errno(errno, "Failed to set MOUNT_ATTR_NOSYMFOLLOW mount attribute: %m");
+                return 0;
+        }
+
+        cache = true;
+        return MS_NOSYMFOLLOW;
+
+not_supported:
+        cache = false;
+        return 0;
+}
+
 int mount_option_supported(const char *fstype, const char *key, const char *value) {
         _cleanup_close_ int fd = -EBADF;
         int r;

--- a/src/basic/mountpoint-util.h
+++ b/src/basic/mountpoint-util.h
@@ -84,6 +84,7 @@ int mount_propagation_flag_from_string(const char *name, unsigned long *ret);
 bool mount_propagation_flag_is_valid(unsigned long flag);
 
 bool mount_new_api_supported(void);
+unsigned long ms_nosymfollow_supported(void);
 
 int mount_option_supported(const char *fstype, const char *key, const char *value);
 

--- a/src/nspawn/nspawn.c
+++ b/src/nspawn/nspawn.c
@@ -3893,7 +3893,7 @@ static int setup_unix_export_dir_outside(char **ret) {
                         "tmpfs",
                         q,
                         "tmpfs",
-                        MS_NODEV|MS_NOEXEC|MS_NOSUID|MS_NOSYMFOLLOW,
+                        MS_NODEV|MS_NOEXEC|MS_NOSUID|ms_nosymfollow_supported(),
                         "size=4M,nr_inodes=64,mode=0755");
         if (r < 0)
                 return r;
@@ -3907,7 +3907,7 @@ static int setup_unix_export_dir_outside(char **ret) {
                         /* what= */ NULL,
                         w,
                         /* fstype= */ NULL,
-                        MS_BIND|MS_REMOUNT|MS_RDONLY|MS_NODEV|MS_NOEXEC|MS_NOSUID|MS_NOSYMFOLLOW,
+                        MS_BIND|MS_REMOUNT|MS_RDONLY|MS_NODEV|MS_NOEXEC|MS_NOSUID|ms_nosymfollow_supported(),
                         /* options= */ NULL);
         if (r < 0)
                 return r;
@@ -3952,7 +3952,7 @@ static int setup_unix_export_host_inside(const char *directory, const char *unix
                         /* what= */ NULL,
                         p,
                         /* fstype= */ NULL,
-                        MS_BIND|MS_REMOUNT|MS_NODEV|MS_NOEXEC|MS_NOSUID|MS_NOSYMFOLLOW,
+                        MS_BIND|MS_REMOUNT|MS_NODEV|MS_NOEXEC|MS_NOSUID|ms_nosymfollow_supported(),
                         /* options= */ NULL);
         if (r < 0)
                 return r;

--- a/src/shared/dissect-image.c
+++ b/src/shared/dissect-image.c
@@ -2313,7 +2313,7 @@ int partition_pick_mount_options(
 
         case PARTITION_ESP:
         case PARTITION_XBOOTLDR:
-                flags |= MS_NOSUID|MS_NOEXEC|MS_NOSYMFOLLOW;
+                flags |= MS_NOSUID|MS_NOEXEC|ms_nosymfollow_supported();
 
                 /* The ESP might contain a pre-boot random seed. Let's make this unaccessible to regular
                  * userspace. ESP/XBOOTLDR is almost certainly VFAT, hence if we don't know assume it is. */

--- a/src/shared/mount-util.c
+++ b/src/shared/mount-util.c
@@ -1947,7 +1947,7 @@ int trigger_automount_at(int dir_fd, const char *path) {
 
 unsigned long credentials_fs_mount_flags(bool ro) {
         /* A tight set of mount flags for credentials mounts */
-        return MS_NODEV|MS_NOEXEC|MS_NOSUID|MS_NOSYMFOLLOW|(ro ? MS_RDONLY : 0);
+        return MS_NODEV|MS_NOEXEC|MS_NOSUID|ms_nosymfollow_supported()|(ro ? MS_RDONLY : 0);
 }
 
 int fsmount_credentials_fs(int *ret_fsfd) {

--- a/src/shared/mount-util.h
+++ b/src/shared/mount-util.h
@@ -166,7 +166,7 @@ int make_mount_point_inode_from_path(const char *source, const char *dest, mode_
 
 int trigger_automount_at(int dir_fd, const char *path);
 
-unsigned long credentials_fs_mount_flags(bool ro) _const_;
+unsigned long credentials_fs_mount_flags(bool ro);
 int fsmount_credentials_fs(int *ret_fsfd);
 int mount_credentials_fs(const char *path);
 

--- a/src/test/test-mountpoint-util.c
+++ b/src/test/test-mountpoint-util.c
@@ -359,6 +359,10 @@ TEST(is_mount_point_at) {
         ASSERT_OK(is_mount_point_at(fd, "regular", 0));
 }
 
+TEST(ms_nosymfollow_supported) {
+        log_info("MS_NOSYMFOLLOW supported: %s", yes_no(ms_nosymfollow_supported()));
+}
+
 TEST(mount_option_supported) {
         int r;
 


### PR DESCRIPTION
Turns out this is only available from kernel 5.12, not 5.10, which is above baseline, so revert this change for now, and adjust the README/TODO accordingly.

Fixes https://github.com/systemd/systemd/issues/41311

This reverts commit 6753bd8a2f38bd77a4c8b973174db6ec8bcaf3ab.