### PR TITLE
Revert "resolve: refuse traffic from the local host only for queries"

### DIFF
--- a/src/resolve/resolved-mdns.c
+++ b/src/resolve/resolved-mdns.c
@@ -413,6 +413,14 @@ static int on_mdns_packet(sd_event_source *s, int fd, uint32_t revents, void *us
         if (r <= 0)
                 return r;
 
+        /* Refuse traffic from the local host, to avoid query loops. However, allow legacy mDNS
+         * unicast queries through anyway (we never send those ourselves, hence no risk).
+         * i.e. check for the source port nr. */
+        if (p->sender_port == MDNS_PORT && manager_packet_from_local_address(m, p)) {
+                log_debug("Got mDNS UDP packet from local host, ignoring.");
+                return 0;
+        }
+
         scope = manager_find_scope(m, p);
         if (!scope) {
                 log_debug("Got mDNS UDP packet on unknown scope. Ignoring.");
@@ -529,14 +537,6 @@ static int on_mdns_packet(sd_event_source *s, int fd, uint32_t revents, void *us
                 if (unsolicited_packet)
                         mdns_notify_browsers_unsolicited_updates(m, p->answer, p->family);
         } else if (dns_packet_validate_query(p) > 0)  {
-                /* Refuse traffic from the local host, to avoid query loops. However, allow legacy mDNS
-                 * unicast queries through anyway (we never send those ourselves, hence no risk).
-                 * i.e. check for the source port nr. */
-                if (p->sender_port == MDNS_PORT && manager_packet_from_local_address(m, p)) {
-                        log_debug("Got mDNS UDP packet from local host, ignoring.");
-                        return 0;
-                }
-
                 log_debug("Got mDNS query packet for id %u", DNS_PACKET_ID(p));
 
                 r = mdns_scope_process_query(scope, p);


### PR DESCRIPTION
This reverts commit e6fd7a3f50 because it breaks mDNS hostname stability any time a DNS-SD service calls `UnregisterService`. When a service unregisters (e.g. on process restart), systemd-resolved re-probes the hostname via mDNS. Due to this change, resolved now processes its own looped-back multicast response, misidentifies it as a conflict from another host, and renames the hostname (e.g. `hostname.local` -> `hostname4.local`). This happens reliably on every restart of any service that uses `RegisterService`/`UnregisterService` (homebridge, avahi-compat wrappers, etc.).

On the original issue (#40636): running avahi and resolved side-by-side in a configuration where both are actively responding to mDNS queries is already problematic and generally unsupported. The two conflict at a deeper level. It's unclear what realistic scenario produces the reported symptom without also having other breakage.

@poettering's PR #37754, which introduced the top-level local-packet check, appeared deliberate: suppressing all loopback traffic prevents resolved from acting on its own multicast reflections and is consistent with the overall design of resolved. This revert restores that behavior.

@carlospeon not trying to dismiss the original issue, but the fix causes a significant regression for any mDNS service that does normal cleanup via `UnregisterService`. After this working correctly for years, the rename behavior is clearly a bug/unintended.

Is there a way to get both? The distinction needed is between a loopback of resolved's own probe (should be suppressed) vs. a reply from another local process like avahi (should be allowed through). Both have the same source IP, so `manager_packet_from_local_address()` alone can't distinguish them. That might be worth solving separately in the conflict-detection layer rather than at packet ingestion.