### PR TITLE
mkosi: Install clang-tidy package instead of clang-tools

### DIFF
--- a/mkosi/mkosi.tools.conf/mkosi.conf.d/debian-ubuntu.conf
+++ b/mkosi/mkosi.tools.conf/mkosi.conf.d/debian-ubuntu.conf
@@ -7,7 +7,7 @@ Distribution=|ubuntu
 [Content]
 PrepareScripts=%D/mkosi/mkosi.images/build/mkosi.conf.d/debian-ubuntu/mkosi.prepare
 Packages=
-        clang-tools
+        clang-tidy
         lcov
         mypy
         shellcheck


### PR DESCRIPTION
clang-tools surprisingly enough doesn't provide clang-tidy