### PR TITLE
networkd: add built-in 464XLAT/CLAT support

### DIFF
--- a/man/systemd.network.xml
+++ b/man/systemd.network.xml
@@ -981,6 +981,50 @@ DuplicateAddressDetection=none</programlisting></para>
       </varlistentry>
 
       <varlistentry>
+        <term><varname>CLAT=</varname></term>
+        <listitem>
+          <para>Takes a boolean. When enabled, <command>systemd-networkd</command> provides built-in
+          464XLAT/CLAT (Customer-side translator) support on the interface, enabling IPv4 connectivity
+          over IPv6-only networks via NAT64. IPv4 packets are translated to IPv6 using the PREF64
+          prefix, and vice versa for return traffic. When the BPF framework is available and the
+          kernel supports TCX (kernel 6.6+), translation is performed in-kernel using an eBPF program
+          attached to the interface's TC hooks for optimal performance. Otherwise, a TUN device with
+          userspace translation is used as a fallback. See
+          <ulink url="https://tools.ietf.org/html/rfc6877">RFC 6877</ulink> for further details.</para>
+
+          <para>This requires either a manually configured <varname>Pref64Prefix=</varname>, or
+          <varname>IPv6AcceptRA=</varname> to be enabled with <varname>UsePREF64=</varname> in
+          [IPv6AcceptRA] set to true, so that the NAT64 prefix is discovered from the network.
+          When multiple PREF64 prefixes are discovered via Router Advertisements, the selection
+          is non-deterministic; use <varname>Pref64Prefix=</varname> for deterministic prefix
+          selection. CLAT will only start when a PREF64 prefix is available and no native IPv4
+          default gateway exists on the link. If a native IPv4 default gateway appears while CLAT
+          is running, CLAT will be stopped automatically. Supported protocols are TCP, UDP (with
+          checksum recalculation), and ICMP Echo/Error messages. Other IP protocols (e.g. GRE,
+          SCTP, ESP) are not translated and will be silently dropped. Defaults to false.</para>
+
+          <xi:include href="version-info.xml" xpointer="v261"/>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term><varname>Pref64Prefix=</varname></term>
+        <listitem>
+          <para>Specifies the NAT64 PREF64 prefix to use for CLAT translation instead of
+          discovering it via Router Advertisements. Takes an IPv6 prefix in the format
+          <replaceable>prefix</replaceable>/<replaceable>length</replaceable>, where the prefix
+          length must be one of 32, 40, 48, 56, 64, or 96 as defined in
+          <ulink url="https://tools.ietf.org/html/rfc6052">RFC 6052</ulink>. This is useful when
+          the network gateway does not advertise the PREF64 prefix via Router Advertisements.
+          When set, <varname>CLAT=yes</varname> does not require
+          <varname>UsePREF64=</varname> to be enabled. When unset, the prefix is discovered via
+          Router Advertisements.</para>
+
+          <xi:include href="version-info.xml" xpointer="v261"/>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
         <term><varname>IPv6DuplicateAddressDetection=</varname></term>
         <listitem>
           <para>Configures the amount of IPv6 Duplicate Address Detection (DAD) probes to send. When

--- a/meson.build
+++ b/meson.build
@@ -1987,6 +1987,7 @@ endif
 conf.set10('HAVE_VMLINUX_H', use_provided_vmlinux_h or use_generated_vmlinux_h)
 
 conf.set10('ENABLE_SYSCTL_BPF', conf.get('HAVE_VMLINUX_H') == 1 and libbpf.version().version_compare('>= 0.7'))
+conf.set10('ENABLE_CLAT_BPF', conf.get('HAVE_VMLINUX_H') == 1 and libbpf.version().version_compare('>= 0.7'))
 
 #####################################################################
 

--- a/src/network/bpf/clat/clat-skel.h
+++ b/src/network/bpf/clat/clat-skel.h
@@ -1,0 +1,20 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#pragma once
+
+/* The SPDX header above is actually correct in claiming this was
+ * LGPL-2.1-or-later, because it is. Since the kernel doesn't consider that
+ * compatible with GPL we will claim this to be GPL however, which should be
+ * fine given that LGPL-2.1-or-later downgrades to GPL if needed.
+ */
+
+#include "bpf-dlopen.h"                          /* IWYU pragma: keep */
+
+/* libbpf is used via dlopen(), so rename symbols */
+#define bpf_object__destroy_skeleton sym_bpf_object__destroy_skeleton
+#define bpf_object__load_skeleton sym_bpf_object__load_skeleton
+#define bpf_object__open_skeleton sym_bpf_object__open_skeleton
+
+/* Include shared config struct before auto-generated skeleton */
+#include "bpf/clat/clat.h"
+
+#include "bpf/clat/clat.skel.h"                  /* IWYU pragma: export */

--- a/src/network/bpf/clat/clat.bpf.c
+++ b/src/network/bpf/clat/clat.bpf.c
@@ -301,7 +301,8 @@ int clat_egress(struct __sk_buff *skb) {
                 /* Incrementally update the checksum for the type byte change.
                  * Do NOT zero the checksum — it contains the payload checksum state.
                  * ICMPv6 pseudo-header contribution will be added after room adjustment. */
-                bpf_l4_csum_replace(skb, l4_off + 2, old_tc, new_tc, 2);
+                if (bpf_l4_csum_replace(skb, l4_off + 2, old_tc, new_tc, 2) < 0)
+                        return TC_ACT_OK;
         }
 
         /* Grow packet by 20 bytes for IPv6 header */
@@ -459,7 +460,8 @@ int clat_ingress(struct __sk_buff *skb) {
                 /* Incrementally update the checksum for the type byte change.
                  * Do NOT zero the checksum — it contains the payload + pseudo-header state.
                  * Pseudo-header contribution will be removed after room adjustment. */
-                bpf_l4_csum_replace(skb, l4_off + 2, old_tc, new_tc, 2);
+                if (bpf_l4_csum_replace(skb, l4_off + 2, old_tc, new_tc, 2) < 0)
+                        return TC_ACT_OK;
         }
 
         /* Shrink packet by 20 bytes */

--- a/src/network/bpf/clat/clat.bpf.c
+++ b/src/network/bpf/clat/clat.bpf.c
@@ -1,0 +1,521 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
+/* eBPF TC program for CLAT (464XLAT) IPv4↔IPv6 translation.
+ *
+ * Attached to a physical interface's TC hooks:
+ *   - Egress: translates outgoing IPv4 packets to IPv6 (CLAT → NAT64 gateway)
+ *   - Ingress: translates incoming IPv6 packets to IPv4 (NAT64 gateway → CLAT)
+ *
+ * Translation follows RFC 6145/7915 for stateless IP/ICMP translation and
+ * RFC 6052 for IPv4-embedded IPv6 address format.
+ */
+
+#include "vmlinux.h"
+
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_endian.h>
+
+#include "clat.h"
+
+/* TC action return codes — not in vmlinux.h */
+#define TC_ACT_OK 0
+
+/* Ethernet header length */
+#define ETH_H_LEN  14
+#define ETH_P_IP   0x0800
+#define ETH_P_IPV6 0x86DD
+
+/* IP header lengths */
+#define IP_H_LEN   20
+#define IP6_H_LEN  40
+#define HDR_DIFF   (IP6_H_LEN - IP_H_LEN)
+
+/* IPv4 flags */
+#define IP_DF      0x4000
+#define IP_MF      0x2000
+#define IP_OFFMASK 0x1FFF
+
+/* ICMP types */
+#define ICMP_ECHOREPLY     0
+#define ICMP_DEST_UNREACH  3
+#define ICMP_ECHO          8
+#define ICMP_TIME_EXCEEDED 11
+#define ICMP_FRAG_NEEDED   4
+
+/* ICMPv6 types */
+#define ICMPV6_DEST_UNREACH  1
+#define ICMPV6_PKT_TOOBIG    2
+#define ICMPV6_TIME_EXCEED   3
+#define ICMPV6_ECHO_REQUEST  128
+#define ICMPV6_ECHO_REPLY    129
+#define ICMPV6_NOROUTE       0
+#define ICMPV6_ADM_PROHIBITED 1
+#define ICMPV6_ADDR_UNREACH  3
+#define ICMPV6_PORT_UNREACH  4
+
+/* IPPROTO_ICMPV6 is not in all vmlinux.h versions */
+#ifndef IPPROTO_ICMPV6
+#define IPPROTO_ICMPV6 58
+#endif
+
+/* volatile to prevent compiler from optimizing out BSS data that
+ * userspace writes to before the program runs. Cast away volatile
+ * when passing to helpers via the cfg() accessor. */
+volatile struct clat_config clat_cfg = {};
+
+#define cfg() ((struct clat_config *)&clat_cfg)
+
+/* Helper: ensure we can safely read a header at the given offset */
+#define ensure_header(hdr, skb, data, data_end, offset)           \
+        ({                                                        \
+                *(hdr) = (void *)(long)(*(data)) + (offset);      \
+                (void *)(*(hdr) + 1) <= (void *)(long)(*(data_end)); \
+        })
+
+/* RFC 6052: Embed IPv4 address (4 bytes) into PREF64 prefix to form IPv6 address (16 bytes) */
+static __always_inline void v4addr_to_v6(
+                const __u8 *prefix,
+                unsigned plen,
+                const __u8 *v4,
+                __u8 *v6) {
+
+        __builtin_memcpy(v6, prefix, 16);
+
+        switch (plen) {
+        case 96:
+                v6[12] = v4[0]; v6[13] = v4[1]; v6[14] = v4[2]; v6[15] = v4[3];
+                break;
+        case 64:
+                v6[9] = v4[0]; v6[10] = v4[1]; v6[11] = v4[2]; v6[12] = v4[3];
+                v6[8] = 0;
+                break;
+        case 56:
+                v6[7] = v4[0]; v6[9] = v4[1]; v6[10] = v4[2]; v6[11] = v4[3];
+                v6[8] = 0;
+                break;
+        case 48:
+                v6[6] = v4[0]; v6[7] = v4[1]; v6[9] = v4[2]; v6[10] = v4[3];
+                v6[8] = 0;
+                break;
+        case 40:
+                v6[5] = v4[0]; v6[6] = v4[1]; v6[7] = v4[2]; v6[9] = v4[3];
+                v6[8] = 0;
+                break;
+        case 32:
+                v6[4] = v4[0]; v6[5] = v4[1]; v6[6] = v4[2]; v6[7] = v4[3];
+                v6[8] = 0;
+                break;
+        default:
+                bpf_printk("clat: unsupported pref64 length %u in v4addr_to_v6", plen);
+                break;
+        }
+}
+
+/* RFC 6052: Extract IPv4 address from PREF64-mapped IPv6 address */
+static __always_inline void v6addr_to_v4(
+                const __u8 *v6,
+                unsigned plen,
+                __u8 *v4) {
+
+        switch (plen) {
+        case 96:
+                v4[0] = v6[12]; v4[1] = v6[13]; v4[2] = v6[14]; v4[3] = v6[15];
+                break;
+        case 64:
+                v4[0] = v6[9]; v4[1] = v6[10]; v4[2] = v6[11]; v4[3] = v6[12];
+                break;
+        case 56:
+                v4[0] = v6[7]; v4[1] = v6[9]; v4[2] = v6[10]; v4[3] = v6[11];
+                break;
+        case 48:
+                v4[0] = v6[6]; v4[1] = v6[7]; v4[2] = v6[9]; v4[3] = v6[10];
+                break;
+        case 40:
+                v4[0] = v6[5]; v4[1] = v6[6]; v4[2] = v6[7]; v4[3] = v6[9];
+                break;
+        case 32:
+                v4[0] = v6[4]; v4[1] = v6[5]; v4[2] = v6[6]; v4[3] = v6[7];
+                break;
+        default:
+                bpf_printk("clat: unsupported pref64 length %u in v6addr_to_v4", plen);
+                break;
+        }
+}
+
+/* Check if IPv6 address src (16 bytes at given skb offset) matches PREF64 prefix */
+static __always_inline bool addr_in_pref64(struct __sk_buff *skb, unsigned offset) {
+        __u8 addr[16];
+
+        if (bpf_skb_load_bytes(skb, offset, addr, 16) < 0)
+                return false;
+
+        unsigned prefix_bytes = cfg()->pref64_len / 8;
+        if (prefix_bytes > 12) /* max valid: /96 = 12 bytes */
+                prefix_bytes = 12;
+        for (unsigned i = 0; i < prefix_bytes && i < 16; i++) {
+                if (addr[i] != cfg()->pref64[i])
+                        return false;
+        }
+        return true;
+}
+
+/* Check if IPv6 address at skb offset matches our local IPv6 address */
+static __always_inline bool addr_is_local_v6(struct __sk_buff *skb, unsigned offset) {
+        __u8 addr[16];
+
+        if (bpf_skb_load_bytes(skb, offset, addr, 16) < 0)
+                return false;
+
+        for (int i = 0; i < 16; i++) {
+                if (addr[i] != cfg()->local_v6[i])
+                        return false;
+        }
+        return true;
+}
+
+/* Translate ICMP Echo type to ICMPv6 Echo type (4→6).
+ * Only Echo Request/Reply are translated. ICMP error messages contain an
+ * embedded inner IP header that would also need translation (RFC 7915 Section 4.2),
+ * which is too complex for BPF. Error messages are dropped (return -1). */
+static __always_inline int translate_icmp_4to6(struct __sk_buff *skb, unsigned l4_off) {
+        __u8 type, new_type;
+
+        if (bpf_skb_load_bytes(skb, l4_off, &type, 1) < 0)
+                return -1;
+
+        switch (type) {
+        case ICMP_ECHO:
+                new_type = ICMPV6_ECHO_REQUEST;
+                break;
+        case ICMP_ECHOREPLY:
+                new_type = ICMPV6_ECHO_REPLY;
+                break;
+        default:
+                return -1;
+        }
+
+        bpf_skb_store_bytes(skb, l4_off, &new_type, 1, 0);
+        return 0;
+}
+
+/* Translate ICMPv6 Echo type to ICMP Echo type (6→4).
+ * Only Echo Request/Reply are translated. See translate_icmp_4to6 comment. */
+static __always_inline int translate_icmp_6to4(struct __sk_buff *skb, unsigned l4_off) {
+        __u8 type, new_type;
+
+        if (bpf_skb_load_bytes(skb, l4_off, &type, 1) < 0)
+                return -1;
+
+        switch (type) {
+        case ICMPV6_ECHO_REQUEST:
+                new_type = ICMP_ECHO;
+                break;
+        case ICMPV6_ECHO_REPLY:
+                new_type = ICMP_ECHOREPLY;
+                break;
+        default:
+                return -1;
+        }
+
+        bpf_skb_store_bytes(skb, l4_off, &new_type, 1, 0);
+        return 0;
+}
+
+/* Egress: IPv4 → IPv6 translation */
+SEC("tcx/egress")
+int clat_egress(struct __sk_buff *skb) {
+        void *data = (void *)(long)skb->data;
+        void *data_end = (void *)(long)skb->data_end;
+        struct ethhdr *eth;
+        struct iphdr *ip4;
+        __u8 src6[16], dst6[16];
+        __u8 protocol, tos, ttl;
+        __be16 tot_len, payload_len;
+        unsigned l4_off;
+
+        if (!ensure_header(&eth, skb, &data, &data_end, 0))
+                return TC_ACT_OK;
+        if (eth->h_proto != bpf_htons(ETH_P_IP))
+                return TC_ACT_OK;
+        if (!ensure_header(&ip4, skb, &data, &data_end, ETH_H_LEN))
+                return TC_ACT_OK;
+
+        /* Only translate packets from our CLAT IPv4 address */
+        if (__builtin_memcmp(&ip4->saddr, cfg()->local_v4, 4) != 0)
+                return TC_ACT_OK;
+
+        /* Only handle standard 20-byte IPv4 headers (no options) */
+        if (ip4->ihl != 5)
+                return TC_ACT_OK;
+
+        /* Reject fragmented packets */
+        if (bpf_ntohs(ip4->frag_off) & (IP_MF | IP_OFFMASK))
+                return TC_ACT_OK;
+
+        protocol = ip4->protocol;
+        if (protocol != IPPROTO_TCP &&
+            protocol != IPPROTO_UDP &&
+            protocol != IPPROTO_ICMP)
+                return TC_ACT_OK;
+
+        /* IPv6 requires a valid UDP checksum (RFC 8200 §8.1). If the IPv4 UDP
+         * checksum is 0 ("not computed"), we cannot do a differential update —
+         * a full recompute would be needed, which is too complex in BPF.
+         * Skip translation and let the packet pass untranslated (dropped by
+         * the network since it's IPv4 on an IPv6-only link). */
+        if (protocol == IPPROTO_UDP) {
+                __be16 udp_csum;
+                if (bpf_skb_load_bytes(skb, ETH_H_LEN + IP_H_LEN + 6, &udp_csum, 2) < 0)
+                        return TC_ACT_OK;
+                if (udp_csum == 0)
+                        return TC_ACT_OK;
+        }
+
+        tos = ip4->tos;
+        ttl = ip4->ttl;
+        tot_len = ip4->tot_len;
+        payload_len = bpf_htons(bpf_ntohs(tot_len) - IP_H_LEN);
+
+        /* Build IPv6 addresses */
+        __builtin_memcpy(src6, cfg()->local_v6, 16);
+        v4addr_to_v6(cfg()->pref64, cfg()->pref64_len,
+                     (const __u8 *)&ip4->daddr, dst6);
+
+        l4_off = ETH_H_LEN + IP_H_LEN;
+
+        /* Handle ICMP translation before header adjustment */
+        if (protocol == IPPROTO_ICMP) {
+                if (translate_icmp_4to6(skb, l4_off) < 0)
+                        return TC_ACT_OK;
+                /* Zero ICMP checksum */
+                __be16 zero = 0;
+                bpf_skb_store_bytes(skb, l4_off + 2, &zero, 2, 0);
+        }
+
+        /* Grow packet by 20 bytes for IPv6 header */
+        if (bpf_skb_adjust_room(skb, HDR_DIFF, BPF_ADJ_ROOM_MAC,
+                                BPF_F_ADJ_ROOM_FIXED_GSO) < 0)
+                return TC_ACT_OK;
+
+        data = (void *)(long)skb->data;
+        data_end = (void *)(long)skb->data_end;
+
+        /* Update Ethernet protocol */
+        if (!ensure_header(&eth, skb, &data, &data_end, 0))
+                return TC_ACT_OK;
+        eth->h_proto = bpf_htons(ETH_P_IPV6);
+
+        /* Write IPv6 header */
+        struct {
+                __be32 flow;
+                __be16 plen;
+                __u8   nxt;
+                __u8   hlim;
+        } ip6h;
+
+        ip6h.flow = bpf_htonl((__u32)6 << 28 | (__u32)tos << 20);
+        ip6h.plen = payload_len;
+        ip6h.nxt = (protocol == IPPROTO_ICMP) ? IPPROTO_ICMPV6 : protocol;
+        ip6h.hlim = ttl;
+
+        bpf_skb_store_bytes(skb, ETH_H_LEN, &ip6h, sizeof(ip6h), 0);
+        bpf_skb_store_bytes(skb, ETH_H_LEN + 8, src6, 16, 0);
+        bpf_skb_store_bytes(skb, ETH_H_LEN + 24, dst6, 16, 0);
+
+        /* Fix L4 checksums */
+        l4_off = ETH_H_LEN + IP6_H_LEN;
+
+        if (protocol == IPPROTO_TCP || protocol == IPPROTO_UDP) {
+                /* Compute pseudo-header delta: IPv4 → IPv6 */
+                struct { __be32 s; __be32 d; __u8 z; __u8 p; __be16 l; } ph4;
+                struct { __u8 s[16]; __u8 d[16]; __be32 l; __u8 z[3]; __u8 n; } ph6;
+
+                __builtin_memcpy(&ph4.s, cfg()->local_v4, 4);
+                v6addr_to_v4(dst6, cfg()->pref64_len, (__u8 *)&ph4.d);
+                ph4.z = 0;
+                ph4.p = protocol;
+                ph4.l = payload_len;
+
+                __builtin_memcpy(ph6.s, src6, 16);
+                __builtin_memcpy(ph6.d, dst6, 16);
+                ph6.l = bpf_htonl(bpf_ntohs(payload_len));
+                __builtin_memset(ph6.z, 0, 3);
+                ph6.n = protocol;
+
+                __s64 delta = bpf_csum_diff((__be32 *)&ph4, sizeof(ph4),
+                                            (__be32 *)&ph6, sizeof(ph6), 0);
+
+                unsigned coff = l4_off + (protocol == IPPROTO_TCP ? 16 : 6);
+
+                bpf_l4_csum_replace(skb, coff, 0, delta, BPF_F_PSEUDO_HDR);
+
+                /* IPv6 requires valid UDP checksum; zero means 0xFFFF (RFC 768) */
+                if (protocol == IPPROTO_UDP) {
+                        __be16 csum;
+                        if (bpf_skb_load_bytes(skb, coff, &csum, 2) == 0 && csum == 0) {
+                                csum = 0xFFFF;
+                                bpf_skb_store_bytes(skb, coff, &csum, 2, 0);
+                        }
+                }
+
+        } else if (protocol == IPPROTO_ICMP) {
+                /* ICMPv6 needs pseudo-header in checksum; ICMP doesn't.
+                 * Add the pseudo-header contribution to the zeroed checksum. */
+                struct { __u8 s[16]; __u8 d[16]; __be32 l; __u8 z[3]; __u8 n; } ph6;
+
+                __builtin_memcpy(ph6.s, src6, 16);
+                __builtin_memcpy(ph6.d, dst6, 16);
+                ph6.l = bpf_htonl(bpf_ntohs(payload_len));
+                __builtin_memset(ph6.z, 0, 3);
+                ph6.n = IPPROTO_ICMPV6;
+
+                __s64 ph_csum = bpf_csum_diff(NULL, 0, (__be32 *)&ph6, sizeof(ph6), 0);
+                bpf_l4_csum_replace(skb, l4_off + 2, 0, ph_csum, BPF_F_PSEUDO_HDR);
+        }
+
+        skb->protocol = bpf_htons(ETH_P_IPV6);
+        return bpf_redirect(skb->ifindex, 0);
+}
+
+/* Ingress: IPv6 → IPv4 translation */
+SEC("tcx/ingress")
+int clat_ingress(struct __sk_buff *skb) {
+        void *data = (void *)(long)skb->data;
+        void *data_end = (void *)(long)skb->data_end;
+        struct ethhdr *eth;
+        struct ipv6hdr *ip6;
+        __u8 nexthdr, tos, hop_limit;
+        __be16 payload_len;
+        __be32 flow;
+        __u8 src4[4], dst4[4];
+        __u8 src6_bytes[16];
+        unsigned l4_off;
+
+        if (!ensure_header(&eth, skb, &data, &data_end, 0))
+                return TC_ACT_OK;
+        if (eth->h_proto != bpf_htons(ETH_P_IPV6))
+                return TC_ACT_OK;
+        if (!ensure_header(&ip6, skb, &data, &data_end, ETH_H_LEN))
+                return TC_ACT_OK;
+
+        /* Only translate packets to our CLAT IPv6 address */
+        if (!addr_is_local_v6(skb, ETH_H_LEN + 24))
+                return TC_ACT_OK;
+
+        /* Only translate packets from PREF64 prefix */
+        if (!addr_in_pref64(skb, ETH_H_LEN + 8))
+                return TC_ACT_OK;
+
+        nexthdr = ip6->nexthdr;
+        if (nexthdr != IPPROTO_TCP &&
+            nexthdr != IPPROTO_UDP &&
+            nexthdr != IPPROTO_ICMPV6)
+                return TC_ACT_OK;
+
+        payload_len = ip6->payload_len;
+        hop_limit = ip6->hop_limit;
+
+        /* Extract traffic class using bpf_skb_load_bytes for safe access */
+        if (bpf_skb_load_bytes(skb, ETH_H_LEN, &flow, 4) < 0)
+                return TC_ACT_OK;
+        tos = (bpf_ntohl(flow) >> 20) & 0xFF;
+
+        /* Save source IPv6 for checksum and extract IPv4 addresses */
+        if (bpf_skb_load_bytes(skb, ETH_H_LEN + 8, src6_bytes, 16) < 0)
+                return TC_ACT_OK;
+        v6addr_to_v4(src6_bytes, cfg()->pref64_len, src4);
+        __builtin_memcpy(dst4, cfg()->local_v4, 4);
+
+        l4_off = ETH_H_LEN + IP6_H_LEN;
+
+        /* Handle ICMPv6 translation */
+        if (nexthdr == IPPROTO_ICMPV6) {
+                if (translate_icmp_6to4(skb, l4_off) < 0)
+                        return TC_ACT_OK;
+                __be16 zero = 0;
+                bpf_skb_store_bytes(skb, l4_off + 2, &zero, 2, 0);
+        }
+
+        /* Shrink packet by 20 bytes */
+        if (bpf_skb_adjust_room(skb, -HDR_DIFF, BPF_ADJ_ROOM_MAC,
+                                BPF_F_ADJ_ROOM_FIXED_GSO) < 0)
+                return TC_ACT_OK;
+
+        data = (void *)(long)skb->data;
+        data_end = (void *)(long)skb->data_end;
+
+        if (!ensure_header(&eth, skb, &data, &data_end, 0))
+                return TC_ACT_OK;
+        eth->h_proto = bpf_htons(ETH_P_IP);
+
+        /* Write IPv4 header */
+        struct iphdr ip4h = {
+                .version  = 4,
+                .ihl      = 5,
+                .tos      = tos,
+                .tot_len  = bpf_htons(IP_H_LEN + bpf_ntohs(payload_len)),
+                .id       = 0,
+                .frag_off = bpf_htons(IP_DF),
+                .ttl      = hop_limit,
+                .protocol = (nexthdr == IPPROTO_ICMPV6) ? IPPROTO_ICMP : nexthdr,
+                .check    = 0,
+        };
+        __builtin_memcpy(&ip4h.saddr, src4, 4);
+        __builtin_memcpy(&ip4h.daddr, dst4, 4);
+
+        /* Compute IPv4 header checksum with proper fold */
+        __s64 hdr_csum = bpf_csum_diff(NULL, 0, (__be32 *)&ip4h, sizeof(ip4h), 0);
+        __u32 sum = (__u32)(hdr_csum & 0xFFFFFFFF);
+        sum = (sum & 0xFFFF) + (sum >> 16);
+        sum = (sum & 0xFFFF) + (sum >> 16);
+        ip4h.check = (__be16)~sum;
+
+        bpf_skb_store_bytes(skb, ETH_H_LEN, &ip4h, sizeof(ip4h), 0);
+
+        /* Fix L4 checksums */
+        l4_off = ETH_H_LEN + IP_H_LEN;
+
+        if (nexthdr == IPPROTO_TCP || nexthdr == IPPROTO_UDP) {
+                /* Pseudo-header delta: IPv6 → IPv4 */
+                struct { __u8 s[16]; __u8 d[16]; __be32 l; __u8 z[3]; __u8 n; } ph6;
+                struct { __be32 s; __be32 d; __u8 z; __u8 p; __be16 l; } ph4;
+
+                /* Reconstruct original IPv6 pseudo-header */
+                __builtin_memcpy(ph6.s, src6_bytes, 16);
+                __builtin_memcpy(ph6.d, cfg()->local_v6, 16);
+                ph6.l = bpf_htonl(bpf_ntohs(payload_len));
+                __builtin_memset(ph6.z, 0, 3);
+                ph6.n = nexthdr;
+
+                __builtin_memcpy(&ph4.s, src4, 4);
+                __builtin_memcpy(&ph4.d, dst4, 4);
+                ph4.z = 0;
+                ph4.p = nexthdr;
+                ph4.l = payload_len;
+
+                __s64 delta = bpf_csum_diff((__be32 *)&ph6, sizeof(ph6),
+                                            (__be32 *)&ph4, sizeof(ph4), 0);
+
+                unsigned coff = l4_off + (nexthdr == IPPROTO_TCP ? 16 : 6);
+                __u32 flags = (nexthdr == IPPROTO_UDP) ? BPF_F_MARK_MANGLED_0 : 0;
+                bpf_l4_csum_replace(skb, coff, 0, delta, flags | BPF_F_PSEUDO_HDR);
+
+        } else if (nexthdr == IPPROTO_ICMPV6) {
+                /* Remove pseudo-header contribution from ICMPv6 → ICMP */
+                struct { __u8 s[16]; __u8 d[16]; __be32 l; __u8 z[3]; __u8 n; } ph6;
+
+                __builtin_memcpy(ph6.s, src6_bytes, 16);
+                __builtin_memcpy(ph6.d, cfg()->local_v6, 16);
+                ph6.l = bpf_htonl(bpf_ntohs(payload_len));
+                __builtin_memset(ph6.z, 0, 3);
+                ph6.n = IPPROTO_ICMPV6;
+
+                __s64 neg_ph = bpf_csum_diff((__be32 *)&ph6, sizeof(ph6), NULL, 0, 0);
+                bpf_l4_csum_replace(skb, l4_off + 2, 0, neg_ph, BPF_F_PSEUDO_HDR);
+        }
+
+        skb->protocol = bpf_htons(ETH_P_IP);
+        return bpf_redirect(skb->ifindex, BPF_F_INGRESS);
+}
+
+char _license[] SEC("license") = "GPL";

--- a/src/network/bpf/clat/clat.bpf.c
+++ b/src/network/bpf/clat/clat.bpf.c
@@ -285,11 +285,23 @@ int clat_egress(struct __sk_buff *skb) {
 
         /* Handle ICMP translation before header adjustment */
         if (protocol == IPPROTO_ICMP) {
+                /* Read original type+code as 16-bit value for checksum delta */
+                __be16 old_tc;
+                if (bpf_skb_load_bytes(skb, l4_off, &old_tc, 2) < 0)
+                        return TC_ACT_OK;
+
                 if (translate_icmp_4to6(skb, l4_off) < 0)
                         return TC_ACT_OK;
-                /* Zero ICMP checksum */
-                __be16 zero = 0;
-                bpf_skb_store_bytes(skb, l4_off + 2, &zero, 2, 0);
+
+                /* Read new type+code after translation */
+                __be16 new_tc;
+                if (bpf_skb_load_bytes(skb, l4_off, &new_tc, 2) < 0)
+                        return TC_ACT_OK;
+
+                /* Incrementally update the checksum for the type byte change.
+                 * Do NOT zero the checksum — it contains the payload checksum state.
+                 * ICMPv6 pseudo-header contribution will be added after room adjustment. */
+                bpf_l4_csum_replace(skb, l4_off + 2, old_tc, new_tc, 2);
         }
 
         /* Grow packet by 20 bytes for IPv6 header */
@@ -360,7 +372,8 @@ int clat_egress(struct __sk_buff *skb) {
 
         } else if (protocol == IPPROTO_ICMP) {
                 /* ICMPv6 needs pseudo-header in checksum; ICMP doesn't.
-                 * Add the pseudo-header contribution to the zeroed checksum. */
+                 * Add the pseudo-header contribution to the existing checksum
+                 * (which already includes payload and the updated type byte). */
                 struct { __u8 s[16]; __u8 d[16]; __be32 l; __u8 z[3]; __u8 n; } ph6;
 
                 __builtin_memcpy(ph6.s, src6, 16);
@@ -430,10 +443,23 @@ int clat_ingress(struct __sk_buff *skb) {
 
         /* Handle ICMPv6 translation */
         if (nexthdr == IPPROTO_ICMPV6) {
+                /* Read original type+code as 16-bit value for checksum delta */
+                __be16 old_tc;
+                if (bpf_skb_load_bytes(skb, l4_off, &old_tc, 2) < 0)
+                        return TC_ACT_OK;
+
                 if (translate_icmp_6to4(skb, l4_off) < 0)
                         return TC_ACT_OK;
-                __be16 zero = 0;
-                bpf_skb_store_bytes(skb, l4_off + 2, &zero, 2, 0);
+
+                /* Read new type+code after translation */
+                __be16 new_tc;
+                if (bpf_skb_load_bytes(skb, l4_off, &new_tc, 2) < 0)
+                        return TC_ACT_OK;
+
+                /* Incrementally update the checksum for the type byte change.
+                 * Do NOT zero the checksum — it contains the payload + pseudo-header state.
+                 * Pseudo-header contribution will be removed after room adjustment. */
+                bpf_l4_csum_replace(skb, l4_off + 2, old_tc, new_tc, 2);
         }
 
         /* Shrink packet by 20 bytes */

--- a/src/network/bpf/clat/clat.h
+++ b/src/network/bpf/clat/clat.h
@@ -1,0 +1,15 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#pragma once
+
+/* Configuration shared between BPF program and userspace.
+ * This struct lives in the BPF program's BSS section and is updated
+ * by userspace before the program starts processing packets.
+ *
+ * Uses raw byte arrays to avoid header conflicts between BPF context
+ * (vmlinux.h) and userspace context (netinet/in.h). */
+struct clat_config {
+        unsigned char local_v6[16];   /* CLAT IPv6 source address */
+        unsigned char pref64[16];     /* NAT64 PREF64 prefix */
+        unsigned char local_v4[4];    /* CLAT IPv4 address (192.0.0.1) */
+        unsigned int  pref64_len;     /* PREF64 prefix length (32/40/48/56/64/96) */
+};

--- a/src/network/bpf/clat/meson.build
+++ b/src/network/bpf/clat/meson.build
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+if conf.get('ENABLE_CLAT_BPF') != 1
+        subdir_done()
+endif
+
+clat_bpf_o_unstripped = custom_target(
+        input : 'clat.bpf.c',
+        output : 'clat.bpf.unstripped.o',
+        command : bpf_o_unstripped_cmd,
+        depends : vmlinux_h_dependency)
+
+clat_bpf_o = custom_target(
+        input : clat_bpf_o_unstripped,
+        output : 'clat.bpf.o',
+        command : bpf_o_cmd)
+
+clat_skel_h = custom_target(
+        input : clat_bpf_o,
+        output : 'clat.skel.h',
+        command : skel_h_cmd,
+        capture : true)
+
+generated_sources += clat_skel_h

--- a/src/network/meson.build
+++ b/src/network/meson.build
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 subdir('bpf/sysctl-monitor')
+subdir('bpf/clat')
 
 systemd_networkd_sources = files(
         'networkd.c'
@@ -93,6 +94,7 @@ systemd_networkd_extract_sources = files(
         'networkd-wiphy.c',
         'networkd-wwan.c',
         'networkd-wwan-bus.c',
+        'networkd-xlat.c',
         'tc/cake.c',
         'tc/codel.c',
         'tc/drr.c',
@@ -146,6 +148,10 @@ networkd_netdev_gperf_gperf = files('netdev/netdev-gperf.gperf')
 
 if conf.get('ENABLE_SYSCTL_BPF') == 1
         systemd_networkd_extract_sources += sysctl_monitor_skel_h
+endif
+
+if conf.get('ENABLE_CLAT_BPF') == 1
+        systemd_networkd_extract_sources += clat_skel_h
 endif
 
 networkd_gperf_c = custom_target(

--- a/src/network/networkd-address.c
+++ b/src/network/networkd-address.c
@@ -29,6 +29,7 @@
 #include "networkd-queue.h"
 #include "networkd-route.h"
 #include "networkd-route-util.h"
+#include "networkd-xlat.h"
 #include "ordered-set.h"
 #include "parse-util.h"
 #include "set.h"
@@ -809,6 +810,13 @@ static int address_update(Address *address) {
                         return r;
         }
 
+        /* Try starting CLAT when a global IPv6 address becomes ready.
+         * xlat_start() is idempotent — it returns immediately if already running. */
+        if (address_is_ready(address) &&
+            address->family == AF_INET6 &&
+            !in6_addr_is_link_local(&address->in_addr.in6))
+                (void) xlat_start(link);
+
         if (IN_SET(link->state, LINK_STATE_FAILED, LINK_STATE_LINGER))
                 return 0;
 
@@ -888,6 +896,10 @@ static int address_drop(Address *in, bool removed_by_us) {
         if (address->family == AF_INET6 &&
             in6_addr_equal(&address->in_addr.in6, &link->ipv6ll_address))
                 link->ipv6ll_address = (const struct in6_addr) {};
+
+        /* Restart CLAT if its cached source address was removed */
+        if (address->family == AF_INET6)
+                (void) xlat_check_address(link);
 
         ipv4acd_detach(link, address);
 
@@ -2033,6 +2045,9 @@ finalize:
                         log_link_warning_errno(link, r, "Failed to notify IPv6 connectivity to DHCPv4 client: %m");
                         link_enter_failed(link);
                 }
+
+                /* Try starting CLAT if it was deferred waiting for an IPv6 address */
+                (void) xlat_start(link);
         }
 
         return 1;

--- a/src/network/networkd-link.c
+++ b/src/network/networkd-link.c
@@ -65,6 +65,7 @@
 #include "networkd-sysctl.h"
 #include "networkd-wifi.h"
 #include "networkd-wwan-bus.h"
+#include "networkd-xlat.h"
 #include "ordered-set.h"
 #include "parse-util.h"
 #include "set.h"
@@ -261,6 +262,8 @@ static void link_free_engines(Link *link) {
         ndisc_flush(link);
 
         link->radv = sd_radv_unref(link->radv);
+
+        xlat_done(link);
 }
 
 static Link* link_free(Link *link) {
@@ -423,6 +426,10 @@ int link_stop_engines(Link *link, bool may_keep_dynamic) {
                         RET_GATHER(ret, log_link_warning_errno(link, r, "Could not stop IPv6 Router Discovery: %m"));
 
                 ndisc_flush(link);
+
+                r = xlat_stop(link);
+                if (r < 0)
+                        RET_GATHER(ret, log_link_warning_errno(link, r, "Could not stop CLAT: %m"));
         }
 
         r = sd_dhcp_server_stop(link->dhcp_server);
@@ -2770,6 +2777,14 @@ static int link_new(Manager *manager, sd_netlink_message *message, Link **ret) {
                 .kind = TAKE_PTR(kind),
 
                 .bridge_vlan_pvid = UINT16_MAX,
+
+                .clat_tun_fd = -EBADF,
+                .clat_send_fd = -EBADF,
+                .clat_recv_fd = -EBADF,
+#if ENABLE_CLAT_BPF
+                .clat_bpf_ingress_fd = -EBADF,
+                .clat_bpf_egress_fd = -EBADF,
+#endif
 
                 .ipv6ll_address_gen_mode = _IPV6_LINK_LOCAL_ADDRESS_GEN_MODE_INVALID,
 

--- a/src/network/networkd-link.h
+++ b/src/network/networkd-link.h
@@ -159,6 +159,28 @@ typedef struct Link {
         unsigned ndisc_messages;
         bool ndisc_configured;
 
+        /* CLAT (464XLAT) — common state */
+        struct in6_addr clat_pref64_prefix;
+        uint8_t clat_pref64_prefix_len;
+        struct in6_addr clat_ipv6_src;
+        bool clat_running;
+
+        /* CLAT BPF path */
+#if ENABLE_CLAT_BPF
+        bool clat_bpf_active;
+        struct clat_bpf *clat_bpf_obj;
+        int clat_bpf_ingress_fd;
+        int clat_bpf_egress_fd;
+#endif
+
+        /* CLAT TUN fallback path */
+        int clat_tun_fd;
+        int clat_send_fd;
+        int clat_recv_fd;
+        sd_event_source *clat_tun_event_source;
+        sd_event_source *clat_recv_event_source;
+        int clat_ifindex;
+
         sd_radv *radv;
 
         sd_dhcp6_client *dhcp6_client;

--- a/src/network/networkd-ndisc.c
+++ b/src/network/networkd-ndisc.c
@@ -25,6 +25,7 @@
 #include "networkd-route.h"
 #include "networkd-state-file.h"
 #include "networkd-sysctl.h"
+#include "networkd-xlat.h"
 #include "ordered-set.h"
 #include "set.h"
 #include "siphash24.h"
@@ -2139,6 +2140,13 @@ static int ndisc_router_process_pref64(Link *link, sd_ndisc_router *rt, bool zer
                                         .prefix = a,
                                         .prefix_len = prefix_len
                                 }));
+
+                /* Only stop CLAT on PREF64 expiry if we depend on NDisc for the prefix.
+                 * If Pref64Prefix= is manually configured, CLAT doesn't need NDisc entries. */
+                if (set_isempty(link->ndisc_pref64) &&
+                    link->network && link->network->clat_pref64_prefix_len == 0)
+                        (void) xlat_stop(link);
+
                 return 0;
         }
 
@@ -2151,6 +2159,9 @@ static int ndisc_router_process_pref64(Link *link, sd_ndisc_router *rt, bool zer
                 /* update existing entry */
                 exist->router = router;
                 exist->lifetime_usec = lifetime_usec;
+
+                /* Retry CLAT start - it may have been deferred if no IPv6 address was available */
+                (void) xlat_start(link);
                 return 0;
         }
 
@@ -2176,6 +2187,8 @@ static int ndisc_router_process_pref64(Link *link, sd_ndisc_router *rt, bool zer
 
         assert(r > 0);
         TAKE_PTR(new_entry);
+
+        (void) xlat_start(link);
 
         return 0;
 }
@@ -2494,6 +2507,10 @@ static int ndisc_drop_outdated(Link *link, const struct in6_addr *router, usec_t
                 free(set_remove(link->ndisc_pref64, p64));
                 /* The pref64 prefix is not exported through the state file, hence it is not necessary to set
                  * the 'updated' flag. */
+
+                if (set_isempty(link->ndisc_pref64) &&
+                    link->network && link->network->clat_pref64_prefix_len == 0)
+                        (void) xlat_stop(link);
         }
 
         SET_FOREACH(dnr, link->ndisc_dnr) {

--- a/src/network/networkd-network-gperf.gperf
+++ b/src/network/networkd-network-gperf.gperf
@@ -41,6 +41,7 @@ _Pragma("GCC diagnostic ignored \"-Wzero-as-null-pointer-constant\"")
 #include "networkd-route.h"
 #include "networkd-routing-policy-rule.h"
 #include "networkd-wwan.h"
+#include "networkd-xlat.h"
 #include "qdisc.h"
 #include "socket-util.h"
 #include "tclass.h"
@@ -138,6 +139,8 @@ Network.IPv6LinkLocalAddressGenerationMode,      config_parse_ipv6_link_local_ad
 Network.IPv6StableSecretAddress,                 config_parse_in_addr_non_null,                  AF_INET6,                               offsetof(Network, ipv6ll_stable_secret)
 Network.IPv4LLStartAddress,                      config_parse_ipv4ll_address,                    0,                                      offsetof(Network, ipv4ll_start_address)
 Network.IPv4LLRoute,                             config_parse_bool,                              0,                                      offsetof(Network, ipv4ll_route)
+Network.CLAT,                                    config_parse_bool,                              0,                                      offsetof(Network, clat)
+Network.Pref64Prefix,                            config_parse_clat_pref64_prefix,                0,                                      0
 Network.DefaultRouteOnDevice,                    config_parse_bool,                              0,                                      offsetof(Network, default_route_on_device)
 Network.LLDP,                                    config_parse_lldp_mode,                         0,                                      offsetof(Network, lldp_mode)
 Network.EmitLLDP,                                config_parse_lldp_multicast_mode,               0,                                      offsetof(Network, lldp_multicast_mode)

--- a/src/network/networkd-network.c
+++ b/src/network/networkd-network.c
@@ -317,6 +317,25 @@ int network_verify(Network *network) {
                 return r; /* sr_iov_drop_invalid_sections() logs internally. */
         network_drop_invalid_static_leases(network);
 
+        if (network->clat && network->clat_pref64_prefix_len == 0) {
+                if (!network->ndisc_use_pref64) {
+                        log_warning("%s: CLAT=yes requires either [IPv6AcceptRA] UsePREF64=yes or "
+                                    "[Network] Pref64Prefix= to be configured. "
+                                    "CLAT will not start without a PREF64 prefix. Disabling CLAT.",
+                                    network->filename);
+                        network->clat = false;
+                } else if (network->ndisc < 0) {
+                        /* ndisc is tristate: -1 = unset (default), 0 = no, 1 = yes.
+                         * When unset, RA acceptance depends on other factors. Only warn
+                         * when explicitly disabled. */
+                } else if (network->ndisc == 0) {
+                        log_warning("%s: CLAT=yes with UsePREF64=yes requires IPv6AcceptRA=yes. "
+                                    "Disabling CLAT.",
+                                    network->filename);
+                        network->clat = false;
+                }
+        }
+
         return 0;
 }
 

--- a/src/network/networkd-network.c
+++ b/src/network/networkd-network.c
@@ -324,11 +324,10 @@ int network_verify(Network *network) {
                                     "CLAT will not start without a PREF64 prefix. Disabling CLAT.",
                                     network->filename);
                         network->clat = false;
-                } else if (network->ndisc < 0) {
-                        /* ndisc is tristate: -1 = unset (default), 0 = no, 1 = yes.
-                         * When unset, RA acceptance depends on other factors. Only warn
-                         * when explicitly disabled. */
                 } else if (network->ndisc == 0) {
+                        /* ndisc is tristate: -1 = unset (default), 0 = no, 1 = yes.
+                         * Only warn when explicitly disabled; when unset, RA acceptance
+                         * depends on other factors and may still work. */
                         log_warning("%s: CLAT=yes with UsePREF64=yes requires IPv6AcceptRA=yes. "
                                     "Disabling CLAT.",
                                     network->filename);

--- a/src/network/networkd-network.h
+++ b/src/network/networkd-network.h
@@ -361,6 +361,9 @@ typedef struct Network {
         bool ndisc_quickack;
         bool ndisc_use_captive_portal;
         bool ndisc_use_pref64;
+        bool clat;
+        struct in6_addr clat_pref64_prefix;
+        uint8_t clat_pref64_prefix_len;
         bool active_slave;
         bool primary_slave;
         UseDomains ndisc_use_domains;

--- a/src/network/networkd-route.c
+++ b/src/network/networkd-route.c
@@ -21,6 +21,7 @@
 #include "networkd-queue.h"
 #include "networkd-route.h"
 #include "networkd-route-util.h"
+#include "networkd-xlat.h"
 #include "ordered-set.h"
 #include "parse-util.h"
 #include "set.h"
@@ -1216,6 +1217,11 @@ static int process_route_one(
                         link_enter_failed(link);
                 }
         }
+
+        /* Stop CLAT if a native IPv4 default gateway appeared in the main table */
+        if (link && type == RTM_NEWROUTE && tmp->family == AF_INET && tmp->dst_prefixlen == 0 &&
+            tmp->table == RT_TABLE_MAIN)
+                (void) xlat_check_route(link);
 
         return 1;
 }

--- a/src/network/networkd-xlat.c
+++ b/src/network/networkd-xlat.c
@@ -895,13 +895,14 @@ static int xlat_set_tun_up(Link *link) {
         return 0;
 }
 
-static int xlat_configure_address_handler(Link *link, int ifindex) {
+static int xlat_configure_address_handler(Link *link, int ifindex, const char *description) {
         _cleanup_(sd_netlink_message_unrefp) sd_netlink_message *m = NULL;
         struct in_addr addr = { .s_addr = htobe32(CLAT_V4_ADDR_U32) };
         int r;
 
         assert(link);
         assert(ifindex > 0);
+        assert(description);
 
         r = sd_rtnl_message_new_addr_update(link->manager->rtnl, &m, ifindex, AF_INET);
         if (r < 0)
@@ -929,12 +930,12 @@ static int xlat_configure_address_handler(Link *link, int ifindex) {
                 return log_link_error_errno(link, r,
                                             "CLAT: failed to configure address 192.0.0.1/32: %m");
 
-        log_link_debug(link, "CLAT: assigned 192.0.0.1/32 to ifindex %d.", ifindex);
+        log_link_debug(link, "CLAT: assigned 192.0.0.1/32 to %s.", description);
         return 0;
 }
 
 static int xlat_configure_address(Link *link) {
-        return xlat_configure_address_handler(link, link->clat_ifindex);
+        return xlat_configure_address_handler(link, link->clat_ifindex, "TUN device");
 }
 
 static int xlat_configure_route(Link *link) {
@@ -1076,7 +1077,7 @@ static int xlat_bpf_attach_tcx(int prog_fd, int ifindex, enum bpf_attach_type at
 }
 
 static int xlat_configure_address_on_link(Link *link) {
-        return xlat_configure_address_handler(link, link->ifindex);
+        return xlat_configure_address_handler(link, link->ifindex, "physical interface");
 }
 
 static int xlat_configure_route_on_link(Link *link) {

--- a/src/network/networkd-xlat.c
+++ b/src/network/networkd-xlat.c
@@ -266,27 +266,27 @@ static void xlat_update_transport_checksum_4to6(
                 const struct in6_addr *src6,
                 const struct in6_addr *dst6) {
 
-        uint16_t *csum_field;
+        size_t csum_offset;
         uint32_t sum;
-        uint16_t csum;
+        uint16_t csum, zero = 0;
 
         if (protocol == IPPROTO_TCP && payload_len >= sizeof(struct tcphdr))
-                csum_field = &((struct tcphdr *) payload)->th_sum;
+                csum_offset = offsetof(struct tcphdr, th_sum);
         else if (protocol == IPPROTO_UDP && payload_len >= sizeof(struct udphdr))
-                csum_field = &((struct udphdr *) payload)->uh_sum;
+                csum_offset = offsetof(struct udphdr, uh_sum);
         else
                 return;
 
         /* UDP checksum is mandatory in IPv6 - must compute if it was zero */
         sum = xlat_pseudo_header_checksum(src6, dst6, payload_len, protocol);
-        *csum_field = 0;
+        memcpy(payload + csum_offset, &zero, sizeof(zero));
         csum = xlat_compute_full_checksum(sum, payload, payload_len);
 
         /* Per RFC 768, a computed zero UDP checksum is transmitted as 0xFFFF */
         if (csum == 0 && protocol == IPPROTO_UDP)
                 csum = 0xFFFF;
 
-        *csum_field = csum;
+        memcpy(payload + csum_offset, &csum, sizeof(csum));
 }
 
 /* Adjust TCP/UDP checksum when translating IPv6->IPv4 */
@@ -297,14 +297,14 @@ static void xlat_update_transport_checksum_6to4(
                 const struct in_addr *src4,
                 const struct in_addr *dst4) {
 
-        uint16_t *csum_field;
+        size_t csum_offset;
         uint32_t sum = 0;
-        uint16_t v, csum;
+        uint16_t v, csum, zero = 0;
 
         if (protocol == IPPROTO_TCP && payload_len >= sizeof(struct tcphdr))
-                csum_field = &((struct tcphdr *) payload)->th_sum;
+                csum_offset = offsetof(struct tcphdr, th_sum);
         else if (protocol == IPPROTO_UDP && payload_len >= sizeof(struct udphdr))
-                csum_field = &((struct udphdr *) payload)->uh_sum;
+                csum_offset = offsetof(struct udphdr, uh_sum);
         else
                 return;
 
@@ -320,13 +320,13 @@ static void xlat_update_transport_checksum_6to4(
         sum += htobe16((uint16_t) protocol);
         sum += htobe16((uint16_t) payload_len);
 
-        *csum_field = 0;
+        memcpy(payload + csum_offset, &zero, sizeof(zero));
         csum = xlat_compute_full_checksum(sum, payload, payload_len);
 
         if (csum == 0 && protocol == IPPROTO_UDP)
                 csum = 0xFFFF;
 
-        *csum_field = csum;
+        memcpy(payload + csum_offset, &csum, sizeof(csum));
 }
 
 /* Translate ICMP Echo to ICMPv6 Echo (outbound) */
@@ -895,15 +895,15 @@ static int xlat_set_tun_up(Link *link) {
         return 0;
 }
 
-static int xlat_configure_address(Link *link) {
+static int xlat_configure_address_handler(Link *link, int ifindex) {
         _cleanup_(sd_netlink_message_unrefp) sd_netlink_message *m = NULL;
         struct in_addr addr = { .s_addr = htobe32(CLAT_V4_ADDR_U32) };
         int r;
 
         assert(link);
-        assert(link->clat_ifindex > 0);
+        assert(ifindex > 0);
 
-        r = sd_rtnl_message_new_addr_update(link->manager->rtnl, &m, link->clat_ifindex, AF_INET);
+        r = sd_rtnl_message_new_addr_update(link->manager->rtnl, &m, ifindex, AF_INET);
         if (r < 0)
                 return log_link_error_errno(link, r,
                                             "CLAT: failed to create RTM_NEWADDR message: %m");
@@ -929,8 +929,12 @@ static int xlat_configure_address(Link *link) {
                 return log_link_error_errno(link, r,
                                             "CLAT: failed to configure address 192.0.0.1/32: %m");
 
-        log_link_debug(link, "CLAT: assigned 192.0.0.1/32 to TUN device.");
+        log_link_debug(link, "CLAT: assigned 192.0.0.1/32 to ifindex %d.", ifindex);
         return 0;
+}
+
+static int xlat_configure_address(Link *link) {
+        return xlat_configure_address_handler(link, link->clat_ifindex);
 }
 
 static int xlat_configure_route(Link *link) {
@@ -1072,40 +1076,7 @@ static int xlat_bpf_attach_tcx(int prog_fd, int ifindex, enum bpf_attach_type at
 }
 
 static int xlat_configure_address_on_link(Link *link) {
-        _cleanup_(sd_netlink_message_unrefp) sd_netlink_message *m = NULL;
-        struct in_addr addr = { .s_addr = htobe32(CLAT_V4_ADDR_U32) };
-        int r;
-
-        assert(link);
-
-        r = sd_rtnl_message_new_addr_update(link->manager->rtnl, &m, link->ifindex, AF_INET);
-        if (r < 0)
-                return log_link_error_errno(link, r,
-                                            "CLAT: failed to create RTM_NEWADDR message: %m");
-
-        r = sd_rtnl_message_addr_set_prefixlen(m, 32);
-        if (r < 0)
-                return log_link_error_errno(link, r, "CLAT: failed to set prefix length: %m");
-
-        r = sd_rtnl_message_addr_set_scope(m, RT_SCOPE_UNIVERSE);
-        if (r < 0)
-                return log_link_error_errno(link, r, "CLAT: failed to set address scope: %m");
-
-        r = sd_netlink_message_append_in_addr(m, IFA_LOCAL, &addr);
-        if (r < 0)
-                return log_link_error_errno(link, r, "CLAT: failed to append IFA_LOCAL: %m");
-
-        r = sd_netlink_message_append_in_addr(m, IFA_ADDRESS, &addr);
-        if (r < 0)
-                return log_link_error_errno(link, r, "CLAT: failed to append IFA_ADDRESS: %m");
-
-        r = sd_netlink_call(link->manager->rtnl, m, 0, NULL);
-        if (r < 0)
-                return log_link_error_errno(link, r,
-                                            "CLAT: failed to configure address 192.0.0.1/32 on link: %m");
-
-        log_link_debug(link, "CLAT: assigned 192.0.0.1/32 to physical interface.");
-        return 0;
+        return xlat_configure_address_handler(link, link->ifindex);
 }
 
 static int xlat_configure_route_on_link(Link *link) {
@@ -1467,7 +1438,9 @@ int xlat_check_address(Link *link) {
                 xlat_stop(link);
                 r = xlat_start(link);
                 if (r < 0)
-                        log_link_warning_errno(link, r, "CLAT: failed to restart after source address change.");
+                        log_link_warning_errno(link, r,
+                                               "CLAT: failed to restart after source address change, "
+                                               "CLAT will remain stopped until next address change.");
                 return r;
         }
 

--- a/src/network/networkd-xlat.c
+++ b/src/network/networkd-xlat.c
@@ -1,0 +1,1545 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include <endian.h>
+#include <fcntl.h>
+#include <linux/filter.h>
+#include <linux/if_ether.h>
+#include <linux/if_packet.h>
+#include <linux/if_tun.h>
+#include <net/if.h>
+#include <netinet/icmp6.h>
+#include <netinet/ip.h>
+#include <netinet/ip6.h>
+#include <netinet/ip_icmp.h>
+#include <netinet/tcp.h>
+#include <netinet/udp.h>
+#include <sys/ioctl.h>
+
+#include "sd-event.h"
+#include "sd-netlink.h"
+
+#if ENABLE_CLAT_BPF
+#include <linux/bpf.h>
+#include <sys/syscall.h>
+
+#include "bpf/clat/clat-skel.h"
+#endif
+
+#include "conf-parser.h"
+#include "errno-util.h"
+#include "fd-util.h"
+#include "in-addr-util.h"
+#include "networkd-address.h"
+#include "networkd-link.h"
+#include "networkd-manager.h"
+#include "networkd-ndisc.h"
+#include "networkd-network.h"
+#include "networkd-route-util.h"
+#include "networkd-xlat.h"
+#include "set.h"
+#include "string-util.h"
+
+#define TUN_DEV "/dev/net/tun"
+
+/* RFC 7335: IPv4 address used for CLAT local endpoint */
+#define CLAT_V4_ADDR_U32 UINT32_C(0xC0000001) /* 192.0.0.1 in host byte order */
+
+/* Route metric for the CLAT default route (high enough to not conflict with normal routes) */
+#define CLAT_ROUTE_METRIC UINT32_C(2048)
+
+/* MTU for CLAT default route. IPv6 minimum MTU (1280) minus IPv4 header (20) = 1260.
+ * TCP MSS = MTU - 40 (IPv4 header + TCP header) = 1220. */
+#define CLAT_ROUTE_MTU UINT32_C(1260)
+#define CLAT_ROUTE_ADVMSS UINT32_C(1220)
+
+/* Max packet buffer size */
+#define CLAT_BUFSIZE 2048
+
+bool link_xlat_enabled(Link *link) {
+        assert(link);
+
+        return link->network && link->network->clat;
+}
+
+/* RFC 6052 Section 2.2: Embed IPv4 address into IPv6 PREF64 prefix.
+ * Supports all valid NAT64 prefix lengths: /32, /40, /48, /56, /64, /96. */
+static void xlat_embed_ipv4_in_pref64(
+                const struct in6_addr *prefix,
+                uint8_t prefix_len,
+                const struct in_addr *v4,
+                struct in6_addr *ret) {
+
+        const uint8_t *v4b = (const uint8_t *) &v4->s_addr;
+
+        assert(prefix);
+        assert(v4);
+        assert(ret);
+
+        *ret = *prefix;
+
+        switch (prefix_len) {
+        case 96:
+                ret->s6_addr[12] = v4b[0];
+                ret->s6_addr[13] = v4b[1];
+                ret->s6_addr[14] = v4b[2];
+                ret->s6_addr[15] = v4b[3];
+                break;
+        case 64:
+                ret->s6_addr[9]  = v4b[0];
+                ret->s6_addr[10] = v4b[1];
+                ret->s6_addr[11] = v4b[2];
+                ret->s6_addr[12] = v4b[3];
+                ret->s6_addr[8]  = 0; /* "u" byte must be zero */
+                break;
+        case 56:
+                ret->s6_addr[7]  = v4b[0];
+                ret->s6_addr[9]  = v4b[1];
+                ret->s6_addr[10] = v4b[2];
+                ret->s6_addr[11] = v4b[3];
+                ret->s6_addr[8]  = 0;
+                break;
+        case 48:
+                ret->s6_addr[6]  = v4b[0];
+                ret->s6_addr[7]  = v4b[1];
+                ret->s6_addr[9]  = v4b[2];
+                ret->s6_addr[10] = v4b[3];
+                ret->s6_addr[8]  = 0;
+                break;
+        case 40:
+                ret->s6_addr[5]  = v4b[0];
+                ret->s6_addr[6]  = v4b[1];
+                ret->s6_addr[7]  = v4b[2];
+                ret->s6_addr[9]  = v4b[3];
+                ret->s6_addr[8]  = 0;
+                break;
+        case 32:
+                ret->s6_addr[4]  = v4b[0];
+                ret->s6_addr[5]  = v4b[1];
+                ret->s6_addr[6]  = v4b[2];
+                ret->s6_addr[7]  = v4b[3];
+                ret->s6_addr[8]  = 0;
+                break;
+        default:
+                assert_not_reached();
+        }
+}
+
+/* Reverse of xlat_embed_ipv4_in_pref64: extract IPv4 from PREF64-mapped IPv6 address */
+static void xlat_extract_ipv4_from_pref64(
+                const struct in6_addr *v6,
+                uint8_t prefix_len,
+                struct in_addr *ret) {
+
+        uint8_t *v4b = (uint8_t *) &ret->s_addr;
+
+        assert(v6);
+        assert(ret);
+
+        switch (prefix_len) {
+        case 96:
+                v4b[0] = v6->s6_addr[12];
+                v4b[1] = v6->s6_addr[13];
+                v4b[2] = v6->s6_addr[14];
+                v4b[3] = v6->s6_addr[15];
+                break;
+        case 64:
+                v4b[0] = v6->s6_addr[9];
+                v4b[1] = v6->s6_addr[10];
+                v4b[2] = v6->s6_addr[11];
+                v4b[3] = v6->s6_addr[12];
+                break;
+        case 56:
+                v4b[0] = v6->s6_addr[7];
+                v4b[1] = v6->s6_addr[9];
+                v4b[2] = v6->s6_addr[10];
+                v4b[3] = v6->s6_addr[11];
+                break;
+        case 48:
+                v4b[0] = v6->s6_addr[6];
+                v4b[1] = v6->s6_addr[7];
+                v4b[2] = v6->s6_addr[9];
+                v4b[3] = v6->s6_addr[10];
+                break;
+        case 40:
+                v4b[0] = v6->s6_addr[5];
+                v4b[1] = v6->s6_addr[6];
+                v4b[2] = v6->s6_addr[7];
+                v4b[3] = v6->s6_addr[9];
+                break;
+        case 32:
+                v4b[0] = v6->s6_addr[4];
+                v4b[1] = v6->s6_addr[5];
+                v4b[2] = v6->s6_addr[6];
+                v4b[3] = v6->s6_addr[7];
+                break;
+        default:
+                assert_not_reached();
+        }
+}
+
+/* Compute one's complement checksum over a buffer */
+static uint16_t xlat_checksum(const void *buf, size_t len) {
+        const uint8_t *p = buf;
+        uint32_t sum = 0;
+
+        while (len > 1) {
+                uint16_t v;
+                memcpy(&v, p, sizeof(v));
+                sum += v;
+                p += 2;
+                len -= 2;
+        }
+
+        if (len == 1) {
+                uint16_t v = 0;
+                memcpy(&v, p, 1);
+                sum += v;
+        }
+
+        while (sum >> 16)
+                sum = (sum & 0xFFFF) + (sum >> 16);
+
+        return (uint16_t) ~sum;
+}
+
+/* Compute IPv6 pseudo-header checksum contribution */
+static uint32_t xlat_pseudo_header_checksum(
+                const struct in6_addr *src,
+                const struct in6_addr *dst,
+                size_t payload_len,
+                uint8_t next_header) {
+
+        uint32_t sum = 0;
+
+        for (size_t i = 0; i < 16; i += 2) {
+                uint16_t v;
+                memcpy(&v, &src->s6_addr[i], sizeof(v));
+                sum += v;
+        }
+
+        for (size_t i = 0; i < 16; i += 2) {
+                uint16_t v;
+                memcpy(&v, &dst->s6_addr[i], sizeof(v));
+                sum += v;
+        }
+
+        /* payload_len fits in 16 bits since IPv6 payload length field is 16-bit */
+        sum += htobe16((uint16_t) payload_len);
+        sum += htobe16((uint16_t) next_header);
+
+        return sum;
+}
+
+/* Recompute checksum from pseudo-header + payload */
+static uint16_t xlat_compute_full_checksum(
+                uint32_t pseudo_sum,
+                const uint8_t *payload,
+                size_t payload_len) {
+
+        uint32_t sum = pseudo_sum;
+        const uint8_t *p = payload;
+
+        while (payload_len > 1) {
+                uint16_t v;
+                memcpy(&v, p, sizeof(v));
+                sum += v;
+                p += 2;
+                payload_len -= 2;
+        }
+        if (payload_len == 1) {
+                uint16_t v = 0;
+                memcpy(&v, p, 1);
+                sum += v;
+        }
+
+        while (sum >> 16)
+                sum = (sum & 0xFFFF) + (sum >> 16);
+
+        return (uint16_t) ~sum;
+}
+
+/* Adjust TCP/UDP checksum when translating IPv4->IPv6 */
+static void xlat_update_transport_checksum_4to6(
+                uint8_t *payload,
+                size_t payload_len,
+                uint8_t protocol,
+                const struct in6_addr *src6,
+                const struct in6_addr *dst6) {
+
+        uint16_t *csum_field;
+        uint32_t sum;
+        uint16_t csum;
+
+        if (protocol == IPPROTO_TCP && payload_len >= sizeof(struct tcphdr))
+                csum_field = &((struct tcphdr *) payload)->th_sum;
+        else if (protocol == IPPROTO_UDP && payload_len >= sizeof(struct udphdr))
+                csum_field = &((struct udphdr *) payload)->uh_sum;
+        else
+                return;
+
+        /* UDP checksum is mandatory in IPv6 - must compute if it was zero */
+        sum = xlat_pseudo_header_checksum(src6, dst6, payload_len, protocol);
+        *csum_field = 0;
+        csum = xlat_compute_full_checksum(sum, payload, payload_len);
+
+        /* Per RFC 768, a computed zero UDP checksum is transmitted as 0xFFFF */
+        if (csum == 0 && protocol == IPPROTO_UDP)
+                csum = 0xFFFF;
+
+        *csum_field = csum;
+}
+
+/* Adjust TCP/UDP checksum when translating IPv6->IPv4 */
+static void xlat_update_transport_checksum_6to4(
+                uint8_t *payload,
+                size_t payload_len,
+                uint8_t protocol,
+                const struct in_addr *src4,
+                const struct in_addr *dst4) {
+
+        uint16_t *csum_field;
+        uint32_t sum = 0;
+        uint16_t v, csum;
+
+        if (protocol == IPPROTO_TCP && payload_len >= sizeof(struct tcphdr))
+                csum_field = &((struct tcphdr *) payload)->th_sum;
+        else if (protocol == IPPROTO_UDP && payload_len >= sizeof(struct udphdr))
+                csum_field = &((struct udphdr *) payload)->uh_sum;
+        else
+                return;
+
+        /* IPv4 pseudo-header */
+        memcpy(&v, (const uint8_t *) &src4->s_addr, sizeof(v));
+        sum += v;
+        memcpy(&v, (const uint8_t *) &src4->s_addr + 2, sizeof(v));
+        sum += v;
+        memcpy(&v, (const uint8_t *) &dst4->s_addr, sizeof(v));
+        sum += v;
+        memcpy(&v, (const uint8_t *) &dst4->s_addr + 2, sizeof(v));
+        sum += v;
+        sum += htobe16((uint16_t) protocol);
+        sum += htobe16((uint16_t) payload_len);
+
+        *csum_field = 0;
+        csum = xlat_compute_full_checksum(sum, payload, payload_len);
+
+        if (csum == 0 && protocol == IPPROTO_UDP)
+                csum = 0xFFFF;
+
+        *csum_field = csum;
+}
+
+/* Translate ICMP Echo to ICMPv6 Echo (outbound) */
+static int xlat_translate_icmp_4to6(
+                uint8_t *payload,
+                size_t payload_len,
+                const struct in6_addr *src6,
+                const struct in6_addr *dst6) {
+
+        struct icmphdr *icmp4;
+        uint32_t sum;
+
+        if (payload_len < sizeof(struct icmphdr))
+                return -EINVAL;
+
+        icmp4 = (struct icmphdr *) payload;
+
+        /* Only translate Echo Request/Reply for now */
+        switch (icmp4->type) {
+        case ICMP_ECHO:
+                icmp4->type = ICMP6_ECHO_REQUEST;
+                icmp4->code = 0;
+                break;
+        case ICMP_ECHOREPLY:
+                icmp4->type = ICMP6_ECHO_REPLY;
+                icmp4->code = 0;
+                break;
+        default:
+                return -EOPNOTSUPP;
+        }
+
+        /* ICMPv6 checksum uses pseudo-header (unlike ICMP which doesn't) */
+        icmp4->checksum = 0;
+        sum = xlat_pseudo_header_checksum(src6, dst6, payload_len, IPPROTO_ICMPV6);
+        icmp4->checksum = xlat_compute_full_checksum(sum, payload, payload_len);
+
+        return 0;
+}
+
+/* Translate ICMPv6 Echo to ICMP Echo (inbound) */
+static int xlat_translate_icmp_6to4(uint8_t *payload, size_t payload_len) {
+        struct icmp6_hdr *icmp6;
+
+        if (payload_len < sizeof(struct icmp6_hdr))
+                return -EINVAL;
+
+        icmp6 = (struct icmp6_hdr *) payload;
+
+        switch (icmp6->icmp6_type) {
+        case ICMP6_ECHO_REQUEST:
+                icmp6->icmp6_type = ICMP_ECHO;
+                break;
+        case ICMP6_ECHO_REPLY:
+                icmp6->icmp6_type = ICMP_ECHOREPLY;
+                break;
+        default:
+                return -EOPNOTSUPP;
+        }
+
+        /* ICMP checksum does not use pseudo-header */
+        icmp6->icmp6_cksum = 0;
+        icmp6->icmp6_cksum = xlat_checksum(payload, payload_len);
+
+        return 0;
+}
+
+/* Select a global unicast IPv6 address from the link for CLAT source */
+static int xlat_select_ipv6_source(Link *link, struct in6_addr *ret) {
+        Address *a;
+
+        assert(link);
+        assert(ret);
+
+        /* First pass: prefer ready addresses */
+        SET_FOREACH(a, link->addresses) {
+                if (a->family != AF_INET6)
+                        continue;
+
+                if (in6_addr_is_link_local(&a->in_addr.in6))
+                        continue;
+
+                if (!address_is_ready(a))
+                        continue;
+
+                *ret = a->in_addr.in6;
+                return 0;
+        }
+
+        /* Second pass: accept any non-link-local IPv6 address */
+        SET_FOREACH(a, link->addresses) {
+                if (a->family != AF_INET6)
+                        continue;
+
+                if (in6_addr_is_link_local(&a->in_addr.in6))
+                        continue;
+
+                *ret = a->in_addr.in6;
+                return 0;
+        }
+
+        return -ENOENT;
+}
+
+/* IPv4->IPv6 translation and send */
+static int xlat_translate_and_send_4to6(Link *link, const uint8_t *pkt4, size_t len4) {
+        uint8_t pkt6[CLAT_BUFSIZE];
+        const struct iphdr *ip4;
+        struct ip6_hdr *ip6;
+        size_t ip4_hlen, payload_len;
+        struct in6_addr dst6;
+        struct in_addr dst4;
+        uint8_t protocol;
+        int r;
+
+        assert(link);
+        assert(pkt4);
+
+        if (len4 < sizeof(struct iphdr))
+                return -EINVAL;
+
+        ip4 = (const struct iphdr *) pkt4;
+
+        if (ip4->version != 4)
+                return -EINVAL;
+
+        ip4_hlen = (size_t) ip4->ihl * 4;
+        if (ip4_hlen < sizeof(struct iphdr) || ip4_hlen > len4)
+                return -EINVAL;
+
+        if (be16toh(ip4->tot_len) < ip4_hlen)
+                return -EINVAL;
+
+        payload_len = be16toh(ip4->tot_len) - ip4_hlen;
+        if (ip4_hlen + payload_len > len4)
+                return -EINVAL;
+
+        if (sizeof(struct ip6_hdr) + payload_len > sizeof(pkt6))
+                return -EMSGSIZE;
+
+        /* Reject fragmented IPv4 packets - we cannot correctly translate non-first fragments
+         * as they lack transport headers needed for checksum recalculation (RFC 7915 Section 4.1) */
+        if (be16toh(ip4->frag_off) & (IP_MF | IP_OFFMASK))
+                return -EOPNOTSUPP;
+
+        protocol = ip4->protocol;
+        dst4.s_addr = ip4->daddr;
+
+        /* Destination: embed IPv4 dst into PREF64 prefix (RFC 6052) */
+        xlat_embed_ipv4_in_pref64(&link->clat_pref64_prefix, link->clat_pref64_prefix_len,
+                                  &dst4, &dst6);
+
+        /* Build IPv6 header */
+        ip6 = (struct ip6_hdr *) pkt6;
+        memset(ip6, 0, sizeof(*ip6));
+        ip6->ip6_flow = htobe32(UINT32_C(6) << 28 | ((uint32_t) ip4->tos << 20));
+        ip6->ip6_plen = htobe16((uint16_t) payload_len);
+        ip6->ip6_hlim = ip4->ttl;
+        /* Source: cached global IPv6 address (per RFC 6877 Section 4.4) */
+        ip6->ip6_src = link->clat_ipv6_src;
+        ip6->ip6_dst = dst6;
+
+        /* Copy payload after IPv6 header */
+        memcpy(pkt6 + sizeof(struct ip6_hdr), pkt4 + ip4_hlen, payload_len);
+        uint8_t *payload = pkt6 + sizeof(struct ip6_hdr);
+
+        /* Protocol-specific translation */
+        if (protocol == IPPROTO_ICMP) {
+                r = xlat_translate_icmp_4to6(payload, payload_len, &link->clat_ipv6_src, &dst6);
+                if (r < 0)
+                        return r;
+                ip6->ip6_nxt = IPPROTO_ICMPV6;
+        } else if (protocol == IPPROTO_TCP || protocol == IPPROTO_UDP) {
+                ip6->ip6_nxt = protocol;
+                xlat_update_transport_checksum_4to6(payload, payload_len, protocol, &link->clat_ipv6_src, &dst6);
+        } else {
+                return -EOPNOTSUPP;
+        }
+
+        /* Send via raw IPv6 socket */
+        struct sockaddr_in6 sa = {
+                .sin6_family = AF_INET6,
+                .sin6_addr = dst6,
+        };
+
+        if (sendto(link->clat_send_fd, pkt6, sizeof(struct ip6_hdr) + payload_len, 0,
+                   (struct sockaddr *) &sa, sizeof(sa)) < 0)
+                return -errno;
+
+        return 0;
+}
+
+/* IPv6->IPv4 translation and write to TUN */
+static int xlat_translate_and_send_6to4(Link *link, const uint8_t *pkt6, size_t len6) {
+        uint8_t pkt4[CLAT_BUFSIZE];
+        const struct ip6_hdr *ip6;
+        struct iphdr *ip4;
+        size_t payload_len;
+        struct in_addr src4, dst4;
+        uint8_t protocol;
+        int r;
+
+        assert(link);
+        assert(pkt6);
+
+        if (len6 < sizeof(struct ip6_hdr))
+                return -EINVAL;
+
+        ip6 = (const struct ip6_hdr *) pkt6;
+
+        if ((be32toh(ip6->ip6_flow) >> 28) != 6)
+                return -EINVAL;
+
+        payload_len = be16toh(ip6->ip6_plen);
+        if (sizeof(struct ip6_hdr) + payload_len > len6)
+                return -EINVAL;
+
+        if (sizeof(struct iphdr) + payload_len > sizeof(pkt4))
+                return -EMSGSIZE;
+
+        protocol = ip6->ip6_nxt;
+
+        /* Source: extract IPv4 from PREF64-mapped source address */
+        xlat_extract_ipv4_from_pref64(&ip6->ip6_src, link->clat_pref64_prefix_len, &src4);
+
+        /* Destination: 192.0.0.1 (our CLAT address) */
+        dst4.s_addr = htobe32(CLAT_V4_ADDR_U32);
+
+        /* Build IPv4 header */
+        ip4 = (struct iphdr *) pkt4;
+        memset(ip4, 0, sizeof(*ip4));
+        ip4->version = 4;
+        ip4->ihl = 5;
+        ip4->tos = (be32toh(ip6->ip6_flow) >> 20) & 0xFF;
+        ip4->tot_len = htobe16((uint16_t) (sizeof(struct iphdr) + payload_len));
+        ip4->id = 0;
+        ip4->frag_off = htobe16(IP_DF); /* Don't Fragment, per RFC 7915 */
+        ip4->ttl = ip6->ip6_hlim;
+        ip4->saddr = src4.s_addr;
+        ip4->daddr = dst4.s_addr;
+
+        /* Copy payload after IPv4 header */
+        memcpy(pkt4 + sizeof(struct iphdr), pkt6 + sizeof(struct ip6_hdr), payload_len);
+        uint8_t *payload = pkt4 + sizeof(struct iphdr);
+
+        /* Protocol-specific translation */
+        if (protocol == IPPROTO_ICMPV6) {
+                r = xlat_translate_icmp_6to4(payload, payload_len);
+                if (r < 0)
+                        return r;
+                ip4->protocol = IPPROTO_ICMP;
+        } else if (protocol == IPPROTO_TCP || protocol == IPPROTO_UDP) {
+                ip4->protocol = protocol;
+                xlat_update_transport_checksum_6to4(payload, payload_len, protocol, &src4, &dst4);
+        } else {
+                return -EOPNOTSUPP;
+        }
+
+        /* Compute IPv4 header checksum */
+        ip4->check = 0;
+        ip4->check = xlat_checksum(ip4, sizeof(struct iphdr));
+
+        /* Write to TUN */
+        if (write(link->clat_tun_fd, pkt4, sizeof(struct iphdr) + payload_len) < 0)
+                return -errno;
+
+        return 0;
+}
+
+static int xlat_tun_handler(sd_event_source *s, int fd, uint32_t revents, void *userdata) {
+        Link *link = ASSERT_PTR(userdata);
+        uint8_t buf[CLAT_BUFSIZE];
+        ssize_t n;
+
+        n = read(fd, buf, sizeof(buf));
+        if (n < 0) {
+                if (ERRNO_IS_TRANSIENT(errno))
+                        return 0;
+                log_link_warning_errno(link, errno, "CLAT: failed to read from TUN: %m");
+                return 0;
+        }
+        if (n == 0)
+                return 0;
+
+        (void) xlat_translate_and_send_4to6(link, buf, (size_t) n);
+        return 0;
+}
+
+static int xlat_recv_handler(sd_event_source *s, int fd, uint32_t revents, void *userdata) {
+        Link *link = ASSERT_PTR(userdata);
+        uint8_t buf[CLAT_BUFSIZE];
+        ssize_t n;
+
+        /* The BPF socket filter already ensures we only receive IPv6 packets with:
+         *   - next header = TCP, UDP, or ICMPv6
+         *   - source address matching our PREF64 prefix
+         *   - destination address = our cached IPv6 source address
+         * So no further filtering is needed here. */
+
+        n = recv(fd, buf, sizeof(buf), MSG_TRUNC);
+        if (n < 0) {
+                if (ERRNO_IS_TRANSIENT(errno))
+                        return 0;
+                log_link_warning_errno(link, errno, "CLAT: failed to read from packet socket: %m");
+                return 0;
+        }
+        if ((size_t) n > sizeof(buf))
+                return 0; /* Packet was truncated, skip */
+        if (n < (ssize_t) sizeof(struct ip6_hdr))
+                return 0;
+
+        (void) xlat_translate_and_send_6to4(link, buf, (size_t) n);
+        return 0;
+}
+
+static int xlat_create_tun(Link *link) {
+        _cleanup_close_ int fd = -EBADF;
+        struct ifreq ifr = {};
+        const char *tun_name;
+        int r;
+
+        assert(link);
+        assert(link->ifname);
+
+        tun_name = strjoina("cl-", link->ifname);
+        if (strlen(tun_name) >= IFNAMSIZ)
+                return log_link_error_errno(link, SYNTHETIC_ERRNO(ENAMETOOLONG),
+                                            "CLAT TUN name '%s' is too long.", tun_name);
+
+        fd = open(TUN_DEV, O_RDWR|O_CLOEXEC|O_NONBLOCK);
+        if (fd < 0)
+                return log_link_error_errno(link, errno, "Failed to open " TUN_DEV ": %m");
+
+        ifr.ifr_flags = IFF_TUN | IFF_NO_PI;
+        strncpy(ifr.ifr_name, tun_name, IFNAMSIZ - 1);
+
+        if (ioctl(fd, TUNSETIFF, &ifr) < 0)
+                return log_link_error_errno(link, errno,
+                                            "Failed to create CLAT TUN device '%s': %m", tun_name);
+
+        /* Do NOT set TUNSETPERSIST - TUN is automatically removed when fd is closed */
+
+        link->clat_ifindex = (int) if_nametoindex(ifr.ifr_name);
+        if (link->clat_ifindex <= 0)
+                return log_link_error_errno(link, SYNTHETIC_ERRNO(ENODEV),
+                                            "Failed to get ifindex for CLAT TUN '%s'", ifr.ifr_name);
+
+        r = sd_event_add_io(link->manager->event, &link->clat_tun_event_source,
+                                fd, EPOLLIN, xlat_tun_handler, link);
+        if (r < 0)
+                return log_link_error_errno(link, r, "Failed to add CLAT TUN event source: %m");
+
+        (void) sd_event_source_set_description(link->clat_tun_event_source, "network-clat-tun");
+
+        link->clat_tun_fd = TAKE_FD(fd);
+
+        log_link_info(link, "CLAT: TUN device '%s' created (ifindex=%d).",
+                      ifr.ifr_name, link->clat_ifindex);
+        return 0;
+}
+
+static int xlat_create_send_socket(Link *link) {
+        _cleanup_close_ int fd = -EBADF;
+        int r, one = 1;
+
+        assert(link);
+
+        fd = socket(AF_INET6, SOCK_RAW|SOCK_CLOEXEC|SOCK_NONBLOCK, IPPROTO_RAW);
+        if (fd < 0)
+                return log_link_error_errno(link, errno,
+                                            "CLAT: failed to create raw IPv6 send socket: %m");
+
+        r = setsockopt(fd, IPPROTO_IPV6, IPV6_HDRINCL, &one, sizeof(one));
+        if (r < 0)
+                return log_link_error_errno(link, errno, "CLAT: failed to set IPV6_HDRINCL: %m");
+
+        /* Bind to the outgoing physical interface */
+        r = setsockopt(fd, SOL_SOCKET, SO_BINDTOIFINDEX, &link->ifindex, sizeof(link->ifindex));
+        if (r < 0)
+                return log_link_error_errno(link, errno,
+                                            "CLAT: failed to bind send socket to interface: %m");
+
+        link->clat_send_fd = TAKE_FD(fd);
+
+        log_link_debug(link, "CLAT: raw IPv6 send socket created.");
+        return 0;
+}
+
+/* Build and attach a classic BPF socket filter to the receive socket.
+ *
+ * With SOCK_DGRAM on AF_PACKET, we receive IPv6 packets with L2 headers stripped,
+ * so the data starts at the IPv6 header. The filter matches:
+ *   - IPv6 next header = TCP (6), UDP (17), or ICMPv6 (58)
+ *   - Source address starts with the PREF64 prefix
+ *   - Destination address = our cached CLAT IPv6 source address
+ *
+ * IPv6 header layout (offsets from start of packet data):
+ *   Byte 6:     Next Header
+ *   Bytes 8-23: Source Address (16 bytes)
+ *   Bytes 24-39: Destination Address (16 bytes)
+ */
+static int xlat_attach_bpf_filter(Link *link, int fd) {
+        size_t prefix_words = link->clat_pref64_prefix_len / 32;
+        size_t prefix_remainder = (link->clat_pref64_prefix_len % 32) / 8;
+        const uint8_t *prefix = link->clat_pref64_prefix.s6_addr;
+        const uint8_t *dst = link->clat_ipv6_src.s6_addr;
+
+        /* Max filter size: next_header(4) + prefix(3*3 worst case /32) + dst(4*2) + accept/reject(2) = 21
+         * Worst case is /32 prefix: 4 + 1*2 + 0 + 4*2 + 2 = 16. /96: 4 + 3*2 + 0 + 4*2 + 2 = 20 */
+        struct sock_filter insns[32];
+        assert_cc(20 <= ELEMENTSOF(insns));
+        size_t i = 0;
+
+        /* Load next header field (byte 6) */
+        insns[i++] = (struct sock_filter) BPF_STMT(BPF_LD | BPF_B | BPF_ABS, 6);
+
+        /* Accept if next header is TCP, UDP, or ICMPv6 */
+        insns[i++] = (struct sock_filter) BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, IPPROTO_TCP, 2, 0);
+        insns[i++] = (struct sock_filter) BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, IPPROTO_UDP, 1, 0);
+        insns[i++] = (struct sock_filter) BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, IPPROTO_ICMPV6, 0, /* reject */ 0);
+        /* The reject jump offset in insns[3] will be patched at the end */
+
+        /* Check source address against PREF64 prefix (starts at offset 8).
+         * Compare 32-bit words for the full-word portion of the prefix. */
+        for (size_t w = 0; w < prefix_words; w++) {
+                uint32_t word;
+                memcpy(&word, prefix + w * 4, sizeof(word));
+
+                insns[i++] = (struct sock_filter) BPF_STMT(BPF_LD | BPF_W | BPF_ABS, 8 + w * 4);
+                insns[i++] = (struct sock_filter) BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, be32toh(word), 0, /* reject */ 0);
+        }
+
+        /* Handle remaining bytes of the prefix (if prefix_len is not a multiple of 32) */
+        if (prefix_remainder > 0) {
+                uint32_t word = 0, mask = 0;
+
+                memcpy(&word, prefix + prefix_words * 4, prefix_remainder);
+                memset(&mask, 0xFF, prefix_remainder);
+
+                insns[i++] = (struct sock_filter) BPF_STMT(BPF_LD | BPF_W | BPF_ABS, 8 + prefix_words * 4);
+                insns[i++] = (struct sock_filter) BPF_STMT(BPF_ALU | BPF_AND | BPF_K, be32toh(mask));
+                insns[i++] = (struct sock_filter) BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, be32toh(word), 0, /* reject */ 0);
+        }
+
+        /* Check destination address = our IPv6 source (16 bytes at offset 24), 4 words */
+        for (size_t w = 0; w < 4; w++) {
+                uint32_t word;
+                memcpy(&word, dst + w * 4, sizeof(word));
+
+                insns[i++] = (struct sock_filter) BPF_STMT(BPF_LD | BPF_W | BPF_ABS, 24 + w * 4);
+                insns[i++] = (struct sock_filter) BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, be32toh(word), 0, /* reject */ 0);
+        }
+
+        /* Accept: return full packet length */
+        size_t accept_idx = i;
+        insns[i++] = (struct sock_filter) BPF_STMT(BPF_RET | BPF_K, UINT32_MAX);
+
+        /* Reject: return 0 (drop packet) */
+        size_t reject_idx = i;
+        insns[i++] = (struct sock_filter) BPF_STMT(BPF_RET | BPF_K, 0);
+
+        assert(i <= ELEMENTSOF(insns));
+
+        /* Patch all reject jump offsets. BPF jump targets are relative to the NEXT instruction.
+         * Instructions with jf=0 that are JEQ comparisons (not the first three next-header checks)
+         * need their false branch pointed to the reject instruction. */
+        for (size_t j = 4; j < accept_idx; j++) {
+                if (BPF_CLASS(insns[j].code) == BPF_JMP &&
+                    BPF_OP(insns[j].code) == BPF_JEQ &&
+                    insns[j].jf == 0)
+                        insns[j].jf = (uint8_t) (reject_idx - j - 1);
+        }
+
+        /* Patch the ICMPv6 check (insns[3]): on mismatch, jump to reject */
+        insns[3].jf = (uint8_t) (reject_idx - 3 - 1);
+
+        struct sock_fprog prog = {
+                .len = (unsigned short) i,
+                .filter = insns,
+        };
+
+        if (setsockopt(fd, SOL_SOCKET, SO_ATTACH_FILTER, &prog, sizeof(prog)) < 0)
+                return log_link_error_errno(link, errno,
+                                            "CLAT: failed to attach BPF filter to receive socket: %m");
+
+        log_link_debug(link, "CLAT: attached BPF filter (%zu instructions) to receive socket.", i);
+        return 0;
+}
+
+static int xlat_create_recv_socket(Link *link) {
+        _cleanup_close_ int fd = -EBADF;
+        int r;
+
+        assert(link);
+
+        /* AF_PACKET SOCK_DGRAM receives IPv6 packets with L2 headers stripped.
+         * A BPF socket filter ensures only relevant CLAT reply packets are delivered
+         * to userspace, avoiding unnecessary context switches and copies. */
+        fd = socket(AF_PACKET, SOCK_DGRAM|SOCK_CLOEXEC|SOCK_NONBLOCK, htobe16(ETH_P_IPV6));
+        if (fd < 0)
+                return log_link_error_errno(link, errno,
+                                            "CLAT: failed to create packet receive socket: %m");
+
+        /* Bind to the physical interface */
+        struct sockaddr_ll sll = {
+                .sll_family = AF_PACKET,
+                .sll_protocol = htobe16(ETH_P_IPV6),
+                .sll_ifindex = link->ifindex,
+        };
+
+        r = bind(fd, (struct sockaddr *) &sll, sizeof(sll));
+        if (r < 0)
+                return log_link_error_errno(link, errno,
+                                            "CLAT: failed to bind packet socket to interface: %m");
+
+        /* Attach BPF filter to reduce userspace packet processing */
+        r = xlat_attach_bpf_filter(link, fd);
+        if (r < 0)
+                return r;
+
+        r = sd_event_add_io(link->manager->event, &link->clat_recv_event_source,
+                            fd, EPOLLIN, xlat_recv_handler, link);
+        if (r < 0)
+                return log_link_error_errno(link, r,
+                                            "CLAT: failed to add receive event source: %m");
+
+        (void) sd_event_source_set_description(link->clat_recv_event_source, "network-clat-recv");
+
+        link->clat_recv_fd = TAKE_FD(fd);
+
+        log_link_debug(link, "CLAT: packet receive socket created.");
+        return 0;
+}
+
+static int xlat_set_tun_up(Link *link) {
+        _cleanup_(sd_netlink_message_unrefp) sd_netlink_message *m = NULL;
+        int r;
+
+        assert(link);
+        assert(link->clat_ifindex > 0);
+
+        r = sd_rtnl_message_new_link(link->manager->rtnl, &m, RTM_SETLINK, link->clat_ifindex);
+        if (r < 0)
+                return log_link_error_errno(link, r,
+                                            "CLAT: failed to create RTM_SETLINK message: %m");
+
+        r = sd_rtnl_message_link_set_flags(m, IFF_UP, IFF_UP);
+        if (r < 0)
+                return log_link_error_errno(link, r, "CLAT: failed to set IFF_UP flag: %m");
+
+        /* IPv6 header is 40 bytes vs IPv4's 20 bytes = 20 bytes overhead.
+         * Cap TUN MTU so packets always fit in the translation buffer. */
+        {
+                /* Cap TUN MTU so translated IPv6 packets fit within the physical link MTU.
+                 * Default to 1280 (IPv6 minimum) when link MTU is unknown. */
+                uint32_t base_mtu = link->mtu > 20 ? link->mtu : 1280;
+                uint32_t tun_mtu = MIN(base_mtu - 20, CLAT_BUFSIZE - sizeof(struct ip6_hdr));
+                r = sd_netlink_message_append_u32(m, IFLA_MTU, tun_mtu);
+                if (r < 0)
+                        return log_link_error_errno(link, r, "CLAT: failed to set MTU: %m");
+        }
+
+        r = sd_netlink_call(link->manager->rtnl, m, 0, NULL);
+        if (r < 0)
+                return log_link_error_errno(link, r, "CLAT: failed to bring TUN up: %m");
+
+        return 0;
+}
+
+static int xlat_configure_address(Link *link) {
+        _cleanup_(sd_netlink_message_unrefp) sd_netlink_message *m = NULL;
+        struct in_addr addr = { .s_addr = htobe32(CLAT_V4_ADDR_U32) };
+        int r;
+
+        assert(link);
+        assert(link->clat_ifindex > 0);
+
+        r = sd_rtnl_message_new_addr_update(link->manager->rtnl, &m, link->clat_ifindex, AF_INET);
+        if (r < 0)
+                return log_link_error_errno(link, r,
+                                            "CLAT: failed to create RTM_NEWADDR message: %m");
+
+        r = sd_rtnl_message_addr_set_prefixlen(m, 32);
+        if (r < 0)
+                return log_link_error_errno(link, r, "CLAT: failed to set prefix length: %m");
+
+        r = sd_rtnl_message_addr_set_scope(m, RT_SCOPE_UNIVERSE);
+        if (r < 0)
+                return log_link_error_errno(link, r, "CLAT: failed to set address scope: %m");
+
+        r = sd_netlink_message_append_in_addr(m, IFA_LOCAL, &addr);
+        if (r < 0)
+                return log_link_error_errno(link, r, "CLAT: failed to append IFA_LOCAL: %m");
+
+        r = sd_netlink_message_append_in_addr(m, IFA_ADDRESS, &addr);
+        if (r < 0)
+                return log_link_error_errno(link, r, "CLAT: failed to append IFA_ADDRESS: %m");
+
+        r = sd_netlink_call(link->manager->rtnl, m, 0, NULL);
+        if (r < 0)
+                return log_link_error_errno(link, r,
+                                            "CLAT: failed to configure address 192.0.0.1/32: %m");
+
+        log_link_debug(link, "CLAT: assigned 192.0.0.1/32 to TUN device.");
+        return 0;
+}
+
+static int xlat_configure_route(Link *link) {
+        _cleanup_(sd_netlink_message_unrefp) sd_netlink_message *m = NULL;
+        int r;
+
+        assert(link);
+        assert(link->clat_ifindex > 0);
+
+        r = sd_rtnl_message_new_route(link->manager->rtnl, &m, RTM_NEWROUTE, AF_INET, RTPROT_STATIC);
+        if (r < 0)
+                return log_link_error_errno(link, r,
+                                            "CLAT: failed to create RTM_NEWROUTE message: %m");
+
+        r = sd_rtnl_message_route_set_type(m, RTN_UNICAST);
+        if (r < 0)
+                return log_link_error_errno(link, r, "CLAT: failed to set route type: %m");
+
+        r = sd_rtnl_message_route_set_scope(m, RT_SCOPE_UNIVERSE);
+        if (r < 0)
+                return log_link_error_errno(link, r, "CLAT: failed to set route scope: %m");
+
+        /* Default route: 0.0.0.0/0 */
+        r = sd_rtnl_message_route_set_dst_prefixlen(m, 0);
+        if (r < 0)
+                return log_link_error_errno(link, r, "CLAT: failed to set dst prefixlen: %m");
+
+        r = sd_netlink_message_append_u32(m, RTA_OIF, (uint32_t) link->clat_ifindex);
+        if (r < 0)
+                return log_link_error_errno(link, r,
+                                            "CLAT: failed to set output interface: %m");
+
+        r = sd_netlink_message_append_u32(m, RTA_PRIORITY, CLAT_ROUTE_METRIC);
+        if (r < 0)
+                return log_link_error_errno(link, r, "CLAT: failed to set route metric: %m");
+
+        /* Set route MTU and TCP MSS to avoid fragmentation issues.
+         * IPv6 minimum MTU is 1280; translated packets gain 20 bytes of IPv6 header overhead,
+         * so the effective IPv4 path MTU is 1260. TCP MSS = 1260 - 40 = 1220. */
+        r = sd_netlink_message_open_container(m, RTA_METRICS);
+        if (r < 0)
+                return log_link_error_errno(link, r, "CLAT: failed to open RTA_METRICS: %m");
+
+        r = sd_netlink_message_append_u32(m, RTAX_MTU, CLAT_ROUTE_MTU);
+        if (r < 0)
+                return log_link_error_errno(link, r, "CLAT: failed to set route MTU: %m");
+
+        r = sd_netlink_message_append_u32(m, RTAX_ADVMSS, CLAT_ROUTE_ADVMSS);
+        if (r < 0)
+                return log_link_error_errno(link, r, "CLAT: failed to set route advmss: %m");
+
+        r = sd_netlink_message_close_container(m);
+        if (r < 0)
+                return log_link_error_errno(link, r, "CLAT: failed to close RTA_METRICS: %m");
+
+        r = sd_netlink_call(link->manager->rtnl, m, 0, NULL);
+        if (r < 0)
+                return log_link_error_errno(link, r,
+                                            "CLAT: failed to add default route via TUN: %m");
+
+        log_link_debug(link, "CLAT: added default IPv4 route via TUN (metric %" PRIu32 ", mtu %" PRIu32 ").",
+                       CLAT_ROUTE_METRIC, CLAT_ROUTE_MTU);
+        return 0;
+}
+
+/* Add an IPv6 route for the PREF64 prefix via the TUN device.
+ * This prevents the kernel's TCP/IPv6 stack from processing translated return
+ * traffic (which would generate spurious RSTs), because reverse path filtering
+ * drops packets arriving on the physical interface whose source address is
+ * routable only through the TUN device. */
+static int xlat_configure_pref64_route(Link *link) {
+        _cleanup_(sd_netlink_message_unrefp) sd_netlink_message *m = NULL;
+        int r;
+
+        assert(link);
+        assert(link->clat_ifindex > 0);
+
+        r = sd_rtnl_message_new_route(link->manager->rtnl, &m, RTM_NEWROUTE, AF_INET6, RTPROT_STATIC);
+        if (r < 0)
+                return log_link_error_errno(link, r,
+                                            "CLAT: failed to create PREF64 route message: %m");
+
+        r = sd_rtnl_message_route_set_type(m, RTN_UNICAST);
+        if (r < 0)
+                return log_link_error_errno(link, r, "CLAT: failed to set route type: %m");
+
+        r = sd_rtnl_message_route_set_dst_prefixlen(m, link->clat_pref64_prefix_len);
+        if (r < 0)
+                return log_link_error_errno(link, r, "CLAT: failed to set dst prefixlen: %m");
+
+        r = sd_netlink_message_append_in6_addr(m, RTA_DST, &link->clat_pref64_prefix);
+        if (r < 0)
+                return log_link_error_errno(link, r, "CLAT: failed to set route destination: %m");
+
+        r = sd_netlink_message_append_u32(m, RTA_OIF, (uint32_t) link->clat_ifindex);
+        if (r < 0)
+                return log_link_error_errno(link, r, "CLAT: failed to set output interface: %m");
+
+        r = sd_netlink_message_append_u32(m, RTA_PRIORITY, CLAT_ROUTE_METRIC);
+        if (r < 0)
+                return log_link_error_errno(link, r, "CLAT: failed to set route metric: %m");
+
+        r = sd_netlink_call(link->manager->rtnl, m, 0, NULL);
+        if (r < 0)
+                return log_link_warning_errno(link, r,
+                                              "CLAT: failed to add PREF64 route via TUN: %m");
+
+        log_link_debug(link, "CLAT: added %s/%u route via TUN for reverse path filtering.",
+                       IN6_ADDR_TO_STRING(&link->clat_pref64_prefix),
+                       link->clat_pref64_prefix_len);
+        return 0;
+}
+
+#if ENABLE_CLAT_BPF
+
+static struct clat_bpf* clat_bpf_free(struct clat_bpf *obj) {
+        clat_bpf__destroy(obj);
+        return NULL;
+}
+
+DEFINE_TRIVIAL_CLEANUP_FUNC(struct clat_bpf *, clat_bpf_free);
+
+/* Attach a BPF program to a TC hook using the raw BPF syscall.
+ * This avoids requiring bpf_program__attach_tcx from libbpf >= 1.3. */
+static int xlat_bpf_attach_tcx(int prog_fd, int ifindex, enum bpf_attach_type attach_type) {
+        union bpf_attr attr = {
+                .link_create = {
+                        .prog_fd        = (__u32) prog_fd,
+                        .target_ifindex = (__u32) ifindex,
+                        .attach_type    = attach_type,
+                },
+        };
+
+        int fd = (int) syscall(__NR_bpf, BPF_LINK_CREATE, &attr, sizeof(attr));
+        if (fd < 0)
+                return -errno;
+
+        return fd;
+}
+
+static int xlat_configure_address_on_link(Link *link) {
+        _cleanup_(sd_netlink_message_unrefp) sd_netlink_message *m = NULL;
+        struct in_addr addr = { .s_addr = htobe32(CLAT_V4_ADDR_U32) };
+        int r;
+
+        assert(link);
+
+        r = sd_rtnl_message_new_addr_update(link->manager->rtnl, &m, link->ifindex, AF_INET);
+        if (r < 0)
+                return log_link_error_errno(link, r,
+                                            "CLAT: failed to create RTM_NEWADDR message: %m");
+
+        r = sd_rtnl_message_addr_set_prefixlen(m, 32);
+        if (r < 0)
+                return log_link_error_errno(link, r, "CLAT: failed to set prefix length: %m");
+
+        r = sd_rtnl_message_addr_set_scope(m, RT_SCOPE_UNIVERSE);
+        if (r < 0)
+                return log_link_error_errno(link, r, "CLAT: failed to set address scope: %m");
+
+        r = sd_netlink_message_append_in_addr(m, IFA_LOCAL, &addr);
+        if (r < 0)
+                return log_link_error_errno(link, r, "CLAT: failed to append IFA_LOCAL: %m");
+
+        r = sd_netlink_message_append_in_addr(m, IFA_ADDRESS, &addr);
+        if (r < 0)
+                return log_link_error_errno(link, r, "CLAT: failed to append IFA_ADDRESS: %m");
+
+        r = sd_netlink_call(link->manager->rtnl, m, 0, NULL);
+        if (r < 0)
+                return log_link_error_errno(link, r,
+                                            "CLAT: failed to configure address 192.0.0.1/32 on link: %m");
+
+        log_link_debug(link, "CLAT: assigned 192.0.0.1/32 to physical interface.");
+        return 0;
+}
+
+static int xlat_configure_route_on_link(Link *link) {
+        _cleanup_(sd_netlink_message_unrefp) sd_netlink_message *m = NULL;
+        uint32_t mtu;
+        int r;
+
+        assert(link);
+
+        r = sd_rtnl_message_new_route(link->manager->rtnl, &m, RTM_NEWROUTE, AF_INET, RTPROT_STATIC);
+        if (r < 0)
+                return log_link_error_errno(link, r,
+                                            "CLAT: failed to create RTM_NEWROUTE message: %m");
+
+        r = sd_rtnl_message_route_set_type(m, RTN_UNICAST);
+        if (r < 0)
+                return log_link_error_errno(link, r, "CLAT: failed to set route type: %m");
+
+        r = sd_rtnl_message_route_set_scope(m, RT_SCOPE_UNIVERSE);
+        if (r < 0)
+                return log_link_error_errno(link, r, "CLAT: failed to set route scope: %m");
+
+        r = sd_rtnl_message_route_set_dst_prefixlen(m, 0);
+        if (r < 0)
+                return log_link_error_errno(link, r, "CLAT: failed to set dst prefixlen: %m");
+
+        r = sd_netlink_message_append_u32(m, RTA_OIF, (uint32_t) link->ifindex);
+        if (r < 0)
+                return log_link_error_errno(link, r,
+                                            "CLAT: failed to set output interface: %m");
+
+        r = sd_netlink_message_append_u32(m, RTA_PRIORITY, CLAT_ROUTE_METRIC);
+        if (r < 0)
+                return log_link_error_errno(link, r, "CLAT: failed to set route metric: %m");
+
+        /* Dynamic MTU: link MTU minus 20 bytes for IPv4→IPv6 header size difference
+         * (IPv6 header is 40 bytes vs IPv4's 20 bytes). Consistent with TUN path. */
+        mtu = link->mtu > 0 ? link->mtu : 1500;
+        if (mtu < 1280)
+                mtu = 1280;
+        mtu -= 20;
+
+        r = sd_netlink_message_open_container(m, RTA_METRICS);
+        if (r < 0)
+                return log_link_error_errno(link, r, "CLAT: failed to open RTA_METRICS: %m");
+
+        r = sd_netlink_message_append_u32(m, RTAX_MTU, mtu);
+        if (r < 0)
+                return log_link_error_errno(link, r, "CLAT: failed to set route MTU: %m");
+
+        uint32_t advmss = mtu > 40 ? mtu - 40 : 0;
+        r = sd_netlink_message_append_u32(m, RTAX_ADVMSS, advmss);
+        if (r < 0)
+                return log_link_error_errno(link, r, "CLAT: failed to set route advmss: %m");
+
+        r = sd_netlink_message_close_container(m);
+        if (r < 0)
+                return log_link_error_errno(link, r, "CLAT: failed to close RTA_METRICS: %m");
+
+        r = sd_netlink_call(link->manager->rtnl, m, 0, NULL);
+        if (r < 0)
+                return log_link_error_errno(link, r,
+                                            "CLAT: failed to add default route via physical interface: %m");
+
+        log_link_debug(link, "CLAT: added default IPv4 route (metric %" PRIu32 ", mtu %" PRIu32 ").",
+                       CLAT_ROUTE_METRIC, mtu);
+        return 0;
+}
+
+static int xlat_remove_address_from_link(Link *link) {
+        _cleanup_(sd_netlink_message_unrefp) sd_netlink_message *m = NULL;
+        struct in_addr addr = { .s_addr = htobe32(CLAT_V4_ADDR_U32) };
+        int r;
+
+        assert(link);
+
+        r = sd_rtnl_message_new_addr(link->manager->rtnl, &m, RTM_DELADDR, link->ifindex, AF_INET);
+        if (r < 0)
+                return r;
+
+        r = sd_rtnl_message_addr_set_prefixlen(m, 32);
+        if (r < 0)
+                return r;
+
+        r = sd_netlink_message_append_in_addr(m, IFA_LOCAL, &addr);
+        if (r < 0)
+                return r;
+
+        return sd_netlink_call(link->manager->rtnl, m, 0, NULL);
+}
+
+static int xlat_remove_route_from_link(Link *link) {
+        _cleanup_(sd_netlink_message_unrefp) sd_netlink_message *m = NULL;
+        int r;
+
+        assert(link);
+
+        r = sd_rtnl_message_new_route(link->manager->rtnl, &m, RTM_DELROUTE, AF_INET, RTPROT_STATIC);
+        if (r < 0)
+                return r;
+
+        r = sd_rtnl_message_route_set_dst_prefixlen(m, 0);
+        if (r < 0)
+                return r;
+
+        r = sd_netlink_message_append_u32(m, RTA_OIF, (uint32_t) link->ifindex);
+        if (r < 0)
+                return r;
+
+        r = sd_netlink_message_append_u32(m, RTA_PRIORITY, CLAT_ROUTE_METRIC);
+        if (r < 0)
+                return r;
+
+        return sd_netlink_call(link->manager->rtnl, m, 0, NULL);
+}
+
+static void xlat_close_bpf(Link *link) {
+        assert(link);
+
+        /* Remove address and route from the physical interface.
+         * Ignore errors — the interface may already be gone. */
+        (void) xlat_remove_route_from_link(link);
+        (void) xlat_remove_address_from_link(link);
+
+        link->clat_bpf_ingress_fd = safe_close(link->clat_bpf_ingress_fd);
+        link->clat_bpf_egress_fd = safe_close(link->clat_bpf_egress_fd);
+
+        if (link->clat_bpf_obj) {
+                clat_bpf__destroy(link->clat_bpf_obj);
+                link->clat_bpf_obj = NULL;
+        }
+
+        link->clat_bpf_active = false;
+}
+
+static int xlat_start_bpf(Link *link) {
+        _cleanup_(clat_bpf_freep) struct clat_bpf *obj = NULL;
+        int r, egress_fd = -EBADF, ingress_fd = -EBADF;
+
+        assert(link);
+
+        r = dlopen_bpf();
+        if (r < 0)
+                return log_link_debug_errno(link, r,
+                                            "CLAT: BPF support not available, will try TUN fallback.");
+
+        obj = clat_bpf__open();
+        if (!obj)
+                return log_link_debug_errno(link, SYNTHETIC_ERRNO(EOPNOTSUPP),
+                                            "CLAT: failed to open BPF program, will try TUN fallback.");
+
+        /* Configure BPF program via BSS section before loading */
+        struct in_addr v4 = { .s_addr = htobe32(CLAT_V4_ADDR_U32) };
+        memcpy(obj->bss->clat_cfg.local_v6, &link->clat_ipv6_src, 16);
+        memcpy(obj->bss->clat_cfg.pref64, &link->clat_pref64_prefix, 16);
+        memcpy(obj->bss->clat_cfg.local_v4, &v4, 4);
+        obj->bss->clat_cfg.pref64_len = link->clat_pref64_prefix_len;
+
+        r = clat_bpf__load(obj);
+        if (r < 0)
+                return log_link_debug_errno(link, r,
+                                            "CLAT: failed to load BPF program, will try TUN fallback.");
+
+        /* Attach egress program (IPv4→IPv6) */
+        egress_fd = xlat_bpf_attach_tcx(
+                        sym_bpf_program__fd(obj->progs.clat_egress),
+                        link->ifindex,
+                        BPF_TCX_EGRESS);
+        if (egress_fd < 0)
+                return log_link_debug_errno(link, egress_fd,
+                                            "CLAT: failed to attach BPF egress program, will try TUN fallback.");
+
+        /* Attach ingress program (IPv6→IPv4) */
+        ingress_fd = xlat_bpf_attach_tcx(
+                        sym_bpf_program__fd(obj->progs.clat_ingress),
+                        link->ifindex,
+                        BPF_TCX_INGRESS);
+        if (ingress_fd < 0) {
+                safe_close(egress_fd);
+                return log_link_debug_errno(link, ingress_fd,
+                                            "CLAT: failed to attach BPF ingress program, will try TUN fallback.");
+        }
+
+        /* Commit BPF state to link before configuring address/route,
+         * so xlat_close_bpf() can clean up everything on failure. */
+        link->clat_bpf_obj = TAKE_PTR(obj);
+        link->clat_bpf_egress_fd = egress_fd;
+        link->clat_bpf_ingress_fd = ingress_fd;
+        link->clat_bpf_active = true;
+
+        /* Configure IPv4 address on physical interface */
+        r = xlat_configure_address_on_link(link);
+        if (r < 0) {
+                xlat_close_bpf(link);
+                return r;
+        }
+
+        /* Configure default IPv4 route */
+        r = xlat_configure_route_on_link(link);
+        if (r < 0) {
+                xlat_close_bpf(link);
+                return r;
+        }
+
+        log_link_info(link, "CLAT: started using BPF TC translation.");
+        return 0;
+}
+
+#endif /* ENABLE_CLAT_BPF */
+
+/* Clean up all CLAT resources unconditionally (does not check clat_running) */
+static void xlat_close(Link *link) {
+        assert(link);
+
+#if ENABLE_CLAT_BPF
+        if (link->clat_bpf_active)
+                xlat_close_bpf(link);
+        else
+#endif
+        {
+                /* TUN fallback cleanup */
+                link->clat_tun_event_source = sd_event_source_disable_unref(link->clat_tun_event_source);
+                link->clat_recv_event_source = sd_event_source_disable_unref(link->clat_recv_event_source);
+
+                link->clat_tun_fd = safe_close(link->clat_tun_fd);
+                link->clat_send_fd = safe_close(link->clat_send_fd);
+                link->clat_recv_fd = safe_close(link->clat_recv_fd);
+
+                link->clat_ifindex = 0;
+        }
+
+        link->clat_running = false;
+}
+
+int xlat_start(Link *link) {
+        NDiscPREF64 *p64;
+        int r;
+
+        assert(link);
+
+        if (!link_xlat_enabled(link))
+                return 0;
+
+        if (link->clat_running)
+                return 0;
+
+        /* Skip CLAT if the link already has native IPv4 connectivity */
+        if (link_has_default_gateway(link, AF_INET)) {
+                log_link_debug(link, "CLAT: link already has IPv4 default gateway, skipping.");
+                return 0;
+        }
+
+        /* Use manually configured PREF64 prefix if available, otherwise use NDisc-discovered one */
+        if (link->network->clat_pref64_prefix_len > 0) {
+                link->clat_pref64_prefix = link->network->clat_pref64_prefix;
+                link->clat_pref64_prefix_len = link->network->clat_pref64_prefix_len;
+        } else {
+                if (set_isempty(link->ndisc_pref64))
+                        return 0;
+
+                /* Pick an arbitrary PREF64 entry. When multiple entries exist (e.g., from
+                 * different routers), the choice is non-deterministic. Use Pref64Prefix= for
+                 * deterministic prefix selection. */
+                p64 = set_first(link->ndisc_pref64);
+                if (!p64)
+                        return 0;
+
+                link->clat_pref64_prefix = p64->prefix;
+                link->clat_pref64_prefix_len = p64->prefix_len;
+        }
+
+        /* Select and cache the global IPv6 source address for translation */
+        r = xlat_select_ipv6_source(link, &link->clat_ipv6_src);
+        if (r < 0)
+                return log_link_debug_errno(link, r,
+                                            "CLAT: no global IPv6 address available, deferring.");
+
+        log_link_info(link, "CLAT: starting with PREF64 %s/%u, source %s.",
+                      IN6_ADDR_TO_STRING(&link->clat_pref64_prefix),
+                      link->clat_pref64_prefix_len,
+                      IN6_ADDR_TO_STRING(&link->clat_ipv6_src));
+
+#if ENABLE_CLAT_BPF
+        /* Try BPF TC translation first (in-kernel, zero context switches per packet) */
+        r = xlat_start_bpf(link);
+        if (r >= 0) {
+                link->clat_running = true;
+                return 0;
+        }
+
+        /* BPF failed, fall through to TUN */
+        log_link_info(link, "CLAT: falling back to TUN device translation.");
+#endif
+
+        /* TUN fallback: userspace packet translation */
+        r = xlat_create_tun(link);
+        if (r < 0)
+                goto fail;
+
+        r = xlat_set_tun_up(link);
+        if (r < 0)
+                goto fail;
+
+        r = xlat_configure_address(link);
+        if (r < 0)
+                goto fail;
+
+        r = xlat_configure_route(link);
+        if (r < 0)
+                goto fail;
+
+        r = xlat_create_send_socket(link);
+        if (r < 0)
+                goto fail;
+
+        r = xlat_create_recv_socket(link);
+        if (r < 0)
+                goto fail;
+
+        /* Add PREF64 route via TUN to prevent kernel TCP stack from processing
+         * CLAT return traffic and generating spurious RSTs (non-fatal if it fails) */
+        (void) xlat_configure_pref64_route(link);
+
+        log_link_info(link, "CLAT: started using TUN device translation.");
+        link->clat_running = true;
+        return 0;
+
+fail:
+        xlat_close(link);
+        return r;
+}
+
+int xlat_stop(Link *link) {
+        assert(link);
+
+        if (!link->clat_running)
+                return 0;
+
+        xlat_close(link);
+
+        log_link_info(link, "CLAT stopped.");
+        return 0;
+}
+
+int xlat_check_address(Link *link) {
+        struct in6_addr current_src;
+
+        assert(link);
+
+        if (!link->clat_running)
+                return 0;
+
+        /* Check if the cached IPv6 source address is still valid */
+        if (xlat_select_ipv6_source(link, &current_src) < 0 ||
+            !in6_addr_equal(&current_src, &link->clat_ipv6_src)) {
+                int r;
+
+                log_link_info(link, "CLAT: IPv6 source address changed or removed, restarting.");
+                xlat_stop(link);
+                r = xlat_start(link);
+                if (r < 0)
+                        log_link_warning_errno(link, r, "CLAT: failed to restart after source address change.");
+                return r;
+        }
+
+        return 0;
+}
+
+int xlat_check_route(Link *link) {
+        assert(link);
+
+        if (!link->clat_running)
+                return 0;
+
+        /* Stop CLAT if a native IPv4 default gateway has appeared */
+        if (link_has_default_gateway(link, AF_INET)) {
+                log_link_info(link, "CLAT: native IPv4 default gateway appeared, stopping.");
+                return xlat_stop(link);
+        }
+
+        return 0;
+}
+
+void xlat_done(Link *link) {
+        if (!link)
+                return;
+
+        xlat_stop(link);
+}
+
+int config_parse_clat_pref64_prefix(
+                const char *unit,
+                const char *filename,
+                unsigned line,
+                const char *section,
+                unsigned section_line,
+                const char *lvalue,
+                int ltype,
+                const char *rvalue,
+                void *data,
+                void *userdata) {
+
+        Network *network = ASSERT_PTR(userdata);
+        union in_addr_union a;
+        uint8_t prefixlen;
+        int r;
+
+        assert(filename);
+        assert(lvalue);
+        assert(rvalue);
+
+        if (isempty(rvalue)) {
+                network->clat_pref64_prefix = (struct in6_addr) {};
+                network->clat_pref64_prefix_len = 0;
+                return 0;
+        }
+
+        r = in_addr_prefix_from_string(rvalue, AF_INET6, &a, &prefixlen);
+        if (r < 0) {
+                log_syntax(unit, LOG_WARNING, filename, line, r,
+                           "CLAT PREF64 prefix is invalid, ignoring assignment: %s", rvalue);
+                return 0;
+        }
+
+        if (!IN_SET(prefixlen, 96, 64, 56, 48, 40, 32)) {
+                log_syntax(unit, LOG_WARNING, filename, line, 0,
+                           "CLAT PREF64 prefix length must be 32, 40, 48, 56, 64, or 96, "
+                           "ignoring assignment: %s", rvalue);
+                return 0;
+        }
+
+        (void) in6_addr_mask(&a.in6, prefixlen);
+        network->clat_pref64_prefix = a.in6;
+        network->clat_pref64_prefix_len = prefixlen;
+
+        return 0;
+}

--- a/src/network/networkd-xlat.h
+++ b/src/network/networkd-xlat.h
@@ -1,0 +1,13 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#pragma once
+
+#include "networkd-forward.h"
+
+bool link_xlat_enabled(Link *link);
+int xlat_start(Link *link);
+int xlat_stop(Link *link);
+void xlat_done(Link *link);
+int xlat_check_address(Link *link);
+int xlat_check_route(Link *link);
+
+CONFIG_PARSER_PROTOTYPE(config_parse_clat_pref64_prefix);

--- a/src/shared/bpf-dlopen.c
+++ b/src/shared/bpf-dlopen.c
@@ -48,6 +48,7 @@ DLSYM_PROTOTYPE(bpf_object__pin_maps) = NULL;
 DLSYM_PROTOTYPE(bpf_program__attach) = NULL;
 DLSYM_PROTOTYPE(bpf_program__attach_cgroup) = NULL;
 DLSYM_PROTOTYPE(bpf_program__attach_lsm) = NULL;
+DLSYM_PROTOTYPE(bpf_program__fd) = NULL;
 DLSYM_PROTOTYPE(bpf_program__name) = NULL;
 DLSYM_PROTOTYPE(libbpf_set_print) = NULL;
 DLSYM_PROTOTYPE(ring_buffer__epoll_fd) = NULL;
@@ -171,6 +172,7 @@ int dlopen_bpf_full(int log_level) {
                         DLSYM_ARG_FORCE(bpf_program__attach_cgroup),
                         DLSYM_ARG_FORCE(bpf_program__attach_lsm),
 #endif
+                        DLSYM_ARG(bpf_program__fd),
                         DLSYM_ARG(bpf_program__name),
                         DLSYM_ARG(libbpf_get_error),
                         DLSYM_ARG(libbpf_set_print),

--- a/src/shared/bpf-dlopen.h
+++ b/src/shared/bpf-dlopen.h
@@ -37,6 +37,7 @@ extern DLSYM_PROTOTYPE(bpf_object__pin_maps);
 extern DLSYM_PROTOTYPE(bpf_program__attach);
 extern DLSYM_PROTOTYPE(bpf_program__attach_cgroup);
 extern DLSYM_PROTOTYPE(bpf_program__attach_lsm);
+extern DLSYM_PROTOTYPE(bpf_program__fd);
 extern DLSYM_PROTOTYPE(bpf_program__name);
 extern DLSYM_PROTOTYPE(libbpf_set_print);
 extern DLSYM_PROTOTYPE(ring_buffer__epoll_fd);

--- a/test/test-network/conf/25-ipv6ra-prefix-client-clat.network
+++ b/test/test-network/conf/25-ipv6ra-prefix-client-clat.network
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+[Match]
+Name=veth-peer
+
+[Network]
+DHCP=no
+IPv6AcceptRA=yes
+CLAT=yes
+
+[IPv6AcceptRA]
+PrefixAllowList=2001:db8:0:1::/64
+UsePREF64=yes

--- a/test/test-network/systemd-networkd-tests.py
+++ b/test/test-network/systemd-networkd-tests.py
@@ -9471,7 +9471,7 @@ class NetworkdIPv6PrefixTests(unittest.TestCase, Utilities):
         self.assertEqual(pref64['PrefixLength'], 96)
 
         # Verify CLAT started by checking the log
-        self.check_networkd_log('veth-peer: Starting CLAT with PREF64 64:ff9b::/96')
+        self.check_networkd_log('veth-peer: CLAT: starting with PREF64 64:ff9b::/96')
 
         # Determine which CLAT backend is active (BPF TC or TUN fallback)
         log = read_networkd_log()

--- a/test/test-network/systemd-networkd-tests.py
+++ b/test/test-network/systemd-networkd-tests.py
@@ -9455,6 +9455,76 @@ class NetworkdIPv6PrefixTests(unittest.TestCase, Utilities):
         print(output)
         self.assertIn('example.com', output)
 
+    def test_clat(self):
+        copy_network_unit('25-veth.netdev', '25-ipv6ra-prefix-client-clat.network', '25-ipv6ra-prefix.network',
+                          '12-dummy.netdev', '25-ipv6ra-uplink.network')
+
+        start_networkd()
+        self.wait_online('veth99:routable', 'veth-peer:routable', 'dummy98:routable')
+
+        # Verify PREF64 was discovered
+        output = networkctl_json('veth-peer')
+        check_json(output)
+        pref64 = json.loads(output)['NDisc']['PREF64'][0]
+        prefix = socket.inet_ntop(socket.AF_INET6, bytearray(pref64['Prefix']))
+        self.assertEqual(prefix, '64:ff9b::')
+        self.assertEqual(pref64['PrefixLength'], 96)
+
+        # Verify CLAT started by checking the log
+        self.check_networkd_log('veth-peer: Starting CLAT with PREF64 64:ff9b::/96')
+
+        # Determine which CLAT backend is active (BPF TC or TUN fallback)
+        log = read_networkd_log()
+        use_bpf = 'started using BPF TC translation' in log
+
+        if use_bpf:
+            print('### CLAT using BPF TC path')
+
+            # BPF path: address and route are on the physical interface
+            output = check_output('ip -4 address show dev veth-peer')
+            print(output)
+            self.assertIn('192.0.0.1/32', output)
+
+            output = check_output('ip -4 route show dev veth-peer')
+            print(output)
+            self.assertIn('default', output)
+            self.assertIn('metric 2048', output)
+
+            # No TUN device should exist
+            self.assertFalse(link_exists('cl-veth-peer'), 'TUN device should not exist in BPF mode')
+        else:
+            print('### CLAT using TUN fallback path')
+
+            # TUN path: verify TUN device was created
+            self.wait_links('cl-veth-peer')
+
+            output = check_output('ip link show cl-veth-peer')
+            print(output)
+            self.assertIn('UP', output)
+
+            # Verify CLAT IPv4 address (192.0.0.1/32 per RFC 7335)
+            output = check_output('ip -4 address show dev cl-veth-peer')
+            print(output)
+            self.assertIn('192.0.0.1/32', output)
+
+            # Verify default IPv4 route through CLAT TUN
+            output = check_output('ip -4 route show dev cl-veth-peer')
+            print(output)
+            self.assertIn('default', output)
+            self.assertIn('metric 2048', output)
+
+        # Verify CLAT is cleaned up after stopping networkd
+        stop_networkd()
+        self.assertFalse(link_exists('cl-veth-peer'), 'CLAT TUN device should be removed after stop')
+
+        if use_bpf:
+            # Verify BPF-path resources are cleaned up
+            output = check_output('ip -4 address show dev veth-peer')
+            self.assertNotIn('192.0.0.1', output, 'CLAT address should be removed after stop')
+            output = check_output('ip -4 route show dev veth-peer')
+            self.assertNotIn('default', output, 'CLAT route should be removed after stop')
+
+
 class NetworkdMTUTests(unittest.TestCase, Utilities):
 
     def setUp(self):


### PR DESCRIPTION
Add a TUN-based userspace CLAT (Customer-side LAT) implementation to systemd-networkd, providing IPv4 connectivity over IPv6-only networks using NAT64 translation (RFC 6877).

When CLAT=yes is set in the [Network] section and a PREF64 prefix is discovered via Router Advertisements (NDISC), networkd automatically:

- Creates a non-persistent TUN device (cl-<ifname>)
- Assigns 192.0.0.1/32 (RFC 7335) to the TUN
- Adds a default IPv4 route through the TUN (metric 2048)
- Translates IPv4 packets to IPv6 using the PREF64 prefix (RFC 6052)
- Translates IPv6 replies back to IPv4

A classic BPF socket filter on the receive socket ensures only relevant NAT64 reply packets reach userspace.

Supported protocols: TCP, UDP (with checksum recalculation), and ICMP Echo <-> ICMPv6 Echo. All valid NAT64 prefix lengths are supported (/32, /40, /48, /56, /64, /96).

The CLAT lifecycle is fully managed: it starts when PREF64 appears (retrying if no IPv6 address is available yet), stops when the last PREF64 expires, and cleans up on link teardown.

Closes: https://github.com/systemd/systemd/issues/23674