### PR TITLE
boot: apply PE relocations when loading inner kernels

### DIFF
--- a/src/boot/boot.c
+++ b/src/boot/boot.c
@@ -2893,7 +2893,7 @@ static EFI_STATUS call_image_start(
                 uint32_t compat_address;
 
                 err = pe_kernel_info(loaded_image->ImageBase, /* ret_entry_point= */ NULL, &compat_address,
-                                     /* ret_size_in_memory= */ NULL);
+                                     /* ret_size_in_memory= */ NULL, /* ret_headers_size= */ NULL);
                 if (err != EFI_SUCCESS) {
                         if (err != EFI_UNSUPPORTED)
                                 return log_error_status(err, "Error finding kernel compat entry address: %m");

--- a/src/boot/boot.c
+++ b/src/boot/boot.c
@@ -3116,6 +3116,7 @@ static EFI_STATUS call_image_start(
 
                 err = pe_kernel_info(loaded_image->ImageBase, loaded_image->ImageSize, /* ret_entry_point= */ NULL, &compat_address,
                                      /* ret_size_in_memory= */ NULL,
+                                     /* ret_headers_size= */ NULL,
                                      /* ret_section_alignment= */ NULL);
                 if (err != EFI_SUCCESS) {
                         if (err != EFI_UNSUPPORTED)

--- a/src/boot/linux.c
+++ b/src/boot/linux.c
@@ -159,7 +159,7 @@ EFI_STATUS linux_exec(
                 const struct iovec *kernel,
                 const struct iovec *initrd) {
 
-        size_t kernel_size_in_memory = 0;
+        size_t headers_size = 0, kernel_size_in_memory = 0;
         uint32_t compat_entry_point, entry_point;
         EFI_STATUS err;
 
@@ -167,7 +167,7 @@ EFI_STATUS linux_exec(
         assert(iovec_is_set(kernel));
         assert(iovec_is_valid(initrd));
 
-        err = pe_kernel_info(kernel->iov_base, &entry_point, &compat_entry_point, &kernel_size_in_memory);
+        err = pe_kernel_info(kernel->iov_base, &entry_point, &compat_entry_point, &kernel_size_in_memory, &headers_size);
 #if defined(__i386__) || defined(__x86_64__)
         if (err == EFI_UNSUPPORTED)
                 /* Kernel is too old to support LINUX_INITRD_MEDIA_GUID, try the deprecated EFI handover
@@ -232,10 +232,6 @@ EFI_STATUS linux_exec(
                                 initrd,
                                 kernel_file_path);
 
-        err = pe_kernel_check_no_relocation(kernel->iov_base);
-        if (err != EFI_SUCCESS)
-                return err;
-
         /* As per MSFT requirement, memory pages need to be marked W^X, so mark code pages RO+X.
          * Firmwares will start enforcing this at some point in the near-ish future.
          * The kernel needs to mark this as supported explicitly, otherwise it will crash.
@@ -259,40 +255,68 @@ EFI_STATUS linux_exec(
         const PeSectionHeader *headers;
         size_t n_headers;
 
-        /* Do we need to validate anything here? the len? */
         err = pe_section_table_from_base(kernel->iov_base, &headers, &n_headers);
         if (err != EFI_SUCCESS)
                 return log_error_status(err, "Cannot read sections: %m");
 
-        /* Do we need to ensure under 4gb address on x86? */
         _cleanup_pages_ Pages loaded_kernel_pages = xmalloc_pages(
                         AllocateAnyPages, EfiLoaderCode, EFI_SIZE_TO_PAGES(kernel_size_in_memory), 0);
 
-        uint8_t* loaded_kernel = PHYSICAL_ADDRESS_TO_POINTER(loaded_kernel_pages.addr);
+        uint8_t *loaded_kernel = PHYSICAL_ADDRESS_TO_POINTER(loaded_kernel_pages.addr);
+        memzero(loaded_kernel, kernel_size_in_memory);
+
+        /* Copy the PE headers (DOS header, PE header, section table) too. The kernel stub
+         * expects these to be present at ImageBase when it looks up its embedded sections. */
+        if (headers_size > kernel->iov_len)
+                return log_error_status(EFI_LOAD_ERROR, "PE SizeOfHeaders exceeds file size");
+        if (headers_size > kernel_size_in_memory)
+                return log_error_status(EFI_LOAD_ERROR, "PE SizeOfHeaders exceeds SizeOfImage");
+        memcpy(loaded_kernel, kernel->iov_base, headers_size);
+
+        /* First pass: copy all sections into the loaded image */
         FOREACH_ARRAY(h, headers, n_headers) {
-                if (h->PointerToRelocations != 0)
-                        return log_error_status(EFI_LOAD_ERROR, "Inner kernel image contains sections with relocations, which we do not support.");
                 if (h->SizeOfRawData == 0)
                         continue;
 
-                if (UINT32_MAX - h->VirtualAddress < h->SizeOfRawData)
-                        return log_error_status(EFI_LOAD_ERROR, "Invalid PE section, SizeOfRawData + VirtualAddress, overflows");
-                if (h->VirtualAddress + h->SizeOfRawData > kernel_size_in_memory)
+                /* SizeOfRawData is rounded up to FileAlignment per the PE spec, so it
+                 * can legitimately exceed VirtualSize. Only copy up to VirtualSize in
+                 * that case, matching pe_locate_sections_internal(). */
+                size_t copy_size = MIN(h->SizeOfRawData, h->VirtualSize);
+
+                if (UINT32_MAX - h->VirtualAddress < h->VirtualSize)
+                        return log_error_status(EFI_LOAD_ERROR, "Invalid PE section, VirtualSize + VirtualAddress overflows");
+                if (h->VirtualAddress + h->VirtualSize > kernel_size_in_memory)
                         return log_error_status(EFI_LOAD_ERROR, "Section would write outside of memory");
-                if (h->SizeOfRawData > h->VirtualSize)
-                        return log_error_status(EFI_LOAD_ERROR, "Invalid PE section, raw data size is greater than virtual size");
                 if (UINT32_MAX - h->PointerToRawData < h->SizeOfRawData)
                         return log_error_status(EFI_LOAD_ERROR, "Invalid PE section, PointerToRawData + SizeOfRawData overflows");
                 if (h->PointerToRawData + h->SizeOfRawData > kernel->iov_len)
                         return log_error_status(EFI_LOAD_ERROR, "Invalid PE section, raw data extends outside of file");
                 memcpy(loaded_kernel + h->VirtualAddress,
-                       (const uint8_t*)kernel->iov_base + h->PointerToRawData,
-                       h->SizeOfRawData);
-                memzero(loaded_kernel + h->VirtualAddress + h->SizeOfRawData,
-                        h->VirtualSize - h->SizeOfRawData);
+                       (const uint8_t *)kernel->iov_base + h->PointerToRawData,
+                       copy_size);
+                if (h->VirtualSize > copy_size)
+                        memzero(loaded_kernel + h->VirtualAddress + copy_size,
+                                h->VirtualSize - copy_size);
+        }
 
-                /* Not a code section? Nothing to do, leave as-is. */
-                if (memory_proto && (h->Characteristics & (PE_CODE|PE_EXECUTE))) {
+        /* Apply PE base relocations before marking pages RO+X. This custom loader does not go
+         * through LoadImage(), hence it must perform the fixups itself. */
+        err = pe_kernel_apply_relocations(
+                        kernel->iov_base,
+                        loaded_kernel,
+                        kernel_size_in_memory,
+                        loaded_kernel_pages.addr);
+        if (err != EFI_SUCCESS)
+                return err;
+
+        /* Second pass: mark code sections RO+X for W^X compliance */
+        if (memory_proto) {
+                FOREACH_ARRAY(h, headers, n_headers) {
+                        if (h->SizeOfRawData == 0)
+                                continue;
+                        if (!(h->Characteristics & (PE_CODE|PE_EXECUTE)))
+                                continue;
+
                         nx_sections = xrealloc(nx_sections, n_nx_sections * sizeof(struct iovec), (n_nx_sections + 1) * sizeof(struct iovec));
                         nx_sections[n_nx_sections].iov_base = loaded_kernel + h->VirtualAddress;
                         nx_sections[n_nx_sections].iov_len = h->VirtualSize;

--- a/src/boot/linux.c
+++ b/src/boot/linux.c
@@ -178,7 +178,7 @@ EFI_STATUS linux_exec(
                 const struct iovec *kernel,
                 const struct iovec *initrd) {
 
-        size_t kernel_size_in_memory = 0;
+        size_t headers_size = 0, kernel_size_in_memory = 0;
         uint32_t compat_entry_point, entry_point, section_alignment;
         EFI_STATUS err;
 
@@ -186,7 +186,14 @@ EFI_STATUS linux_exec(
         assert(iovec_is_set(kernel));
         assert(iovec_is_valid(initrd));
 
-        err = pe_kernel_info(kernel->iov_base, kernel->iov_len, &entry_point, &compat_entry_point, &kernel_size_in_memory, &section_alignment);
+        err = pe_kernel_info(
+                        kernel->iov_base,
+                        kernel->iov_len,
+                        &entry_point,
+                        &compat_entry_point,
+                        &kernel_size_in_memory,
+                        &headers_size,
+                        &section_alignment);
 #if defined(__i386__) || defined(__x86_64__)
         if (err == EFI_UNSUPPORTED)
                 /* Kernel is too old to support LINUX_INITRD_MEDIA_GUID, try the deprecated EFI handover
@@ -255,23 +262,26 @@ EFI_STATUS linux_exec(
                                 initrd,
                                 kernel_file_path);
 
-        err = pe_kernel_check_no_relocation(kernel->iov_base);
-        if (err != EFI_SUCCESS)
-                return err;
-
         /* As per MSFT requirement, memory pages need to be marked W^X, so mark code pages RO+X.
          * Firmwares will start enforcing this at some point in the near-ish future.
          * The kernel needs to mark this as supported explicitly, otherwise it will crash.
          * https://microsoft.github.io/mu/WhatAndWhy/enhancedmemoryprotection/
          * https://www.kraxel.org/blog/2023/12/uefi-nx-linux-boot/ */
         EFI_MEMORY_ATTRIBUTE_PROTOCOL *memory_proto = NULL;
+        /* Any code section marked RO+X must be reverted to RW+NX before the backing pages are freed. */
+        _cleanup_(cleanup_nx_sections) CleanupNxSections nx_restore = {};
 
         if (pe_kernel_check_nx_compat(kernel->iov_base)) {
                 /* LocateProtocol() is not quite that quick if you have many protocols, so only look for it
                  * if required for NX_COMPAT */
                 err = BS->LocateProtocol(MAKE_GUID_PTR(EFI_MEMORY_ATTRIBUTE_PROTOCOL), /* Registration= */ NULL, (void **) &memory_proto);
                 if (err != EFI_SUCCESS)
-                        log_debug_status(err, "No EFI_MEMORY_ATTRIBUTE_PROTOCOL found, skipping NX_COMPAT support.");
+                        /* Only warn if the UEFI should have support in the first place (version >= 2.10) */
+                        log_full(err,
+                                 ST->Hdr.Revision >= ((2U << 16) | 100U) ? LOG_WARNING : LOG_DEBUG,
+                                 "No EFI_MEMORY_ATTRIBUTE_PROTOCOL found, skipping NX_COMPAT support.");
+                else
+                        nx_restore.memory_proto = memory_proto;
         }
 
         const PeSectionHeader *headers;
@@ -293,43 +303,68 @@ EFI_STATUS linux_exec(
                         section_alignment,
                         /* addr= */ 0);
 
-        uint8_t* loaded_kernel = PHYSICAL_ADDRESS_TO_POINTER(loaded_kernel_pages.addr);
+        uint8_t *loaded_kernel = PHYSICAL_ADDRESS_TO_POINTER(loaded_kernel_pages.addr);
+        memzero(loaded_kernel, kernel_size_in_memory);
 
-        /* Any code section marked RO+X must be reverted to RW+NX before the backing pages are freed. */
-        _cleanup_(cleanup_nx_sections) CleanupNxSections nx_restore = {
-                .memory_proto = memory_proto,
-        };
+        /* Copy the PE headers (DOS header, PE header, section table) too. The kernel stub
+         * expects these to be present at ImageBase when it looks up its embedded sections. */
+        if (headers_size > kernel->iov_len)
+                return log_error_status(EFI_LOAD_ERROR, "PE SizeOfHeaders exceeds file size");
+        if (headers_size > kernel_size_in_memory)
+                return log_error_status(EFI_LOAD_ERROR, "PE SizeOfHeaders exceeds SizeOfImage");
+        size_t section_table_end =
+                        (const uint8_t*) (headers + n_headers) - (const uint8_t*) kernel->iov_base;
+        if (headers_size < section_table_end)
+                return log_error_status(EFI_LOAD_ERROR, "PE SizeOfHeaders does not cover the section table");
+        memcpy(loaded_kernel, kernel->iov_base, headers_size);
 
+        /* First pass: copy all sections into the loaded image. */
         FOREACH_ARRAY(h, headers, n_headers) {
                 if (h->PointerToRelocations != 0)
-                        return log_error_status(EFI_LOAD_ERROR, "Inner kernel image contains sections with relocations, which we do not support.");
+                        return log_error_status(EFI_LOAD_ERROR, "Inner kernel image contains COFF section relocations, which we do not support.");
                 if (h->SizeOfRawData == 0)
                         continue;
 
-                if (UINT32_MAX - h->VirtualAddress < h->SizeOfRawData)
-                        return log_error_status(EFI_LOAD_ERROR, "Invalid PE section, SizeOfRawData + VirtualAddress, overflows");
-                if (h->VirtualAddress + h->SizeOfRawData > kernel_size_in_memory)
-                        return log_error_status(EFI_LOAD_ERROR, "Section would write outside of memory");
-                if (h->SizeOfRawData > h->VirtualSize)
-                        return log_error_status(EFI_LOAD_ERROR, "Invalid PE section, raw data size is greater than virtual size");
+                /* SizeOfRawData is rounded up to FileAlignment per the PE spec, so it
+                 * can legitimately exceed VirtualSize. Only copy up to VirtualSize in
+                 * that case, matching pe_locate_sections_internal(). */
+                size_t copy_size = MIN(h->SizeOfRawData, h->VirtualSize);
+
                 if (UINT32_MAX - h->VirtualAddress < h->VirtualSize)
                         return log_error_status(EFI_LOAD_ERROR, "Invalid PE section, VirtualSize + VirtualAddress overflows");
                 if (h->VirtualAddress + h->VirtualSize > kernel_size_in_memory)
-                        return log_error_status(EFI_LOAD_ERROR, "Section virtual size would write outside of memory");
+                        return log_error_status(EFI_LOAD_ERROR, "Section would write outside of memory");
                 if (UINT32_MAX - h->PointerToRawData < h->SizeOfRawData)
                         return log_error_status(EFI_LOAD_ERROR, "Invalid PE section, PointerToRawData + SizeOfRawData overflows");
                 if (h->PointerToRawData + h->SizeOfRawData > kernel->iov_len)
                         return log_error_status(EFI_LOAD_ERROR, "Invalid PE section, raw data extends outside of file");
                 memcpy(loaded_kernel + h->VirtualAddress,
-                       (const uint8_t*)kernel->iov_base + h->PointerToRawData,
-                       h->SizeOfRawData);
-                memzero(loaded_kernel + h->VirtualAddress + h->SizeOfRawData,
-                        h->VirtualSize - h->SizeOfRawData);
+                       (const uint8_t*) kernel->iov_base + h->PointerToRawData,
+                       copy_size);
+                if (h->VirtualSize > copy_size)
+                        memzero(loaded_kernel + h->VirtualAddress + copy_size,
+                                h->VirtualSize - copy_size);
+        }
 
-                /* Not a code section? Nothing to do, leave as-is. */
-                if (memory_proto && (h->Characteristics & (PE_CODE|PE_EXECUTE))) {
-                        /* Record the section for cleanup before marking it RO+X: if memory_mark_ro_x()
-                         * fails after partially applying the attributes, cleanup still reverts them. */
+        /* Apply PE base relocations before marking pages RO+X. This custom loader does not go
+         * through LoadImage(), hence it must perform the fixups itself. */
+        err = pe_kernel_apply_relocations(
+                        kernel->iov_base,
+                        kernel->iov_len,
+                        loaded_kernel,
+                        kernel_size_in_memory,
+                        loaded_kernel_pages.addr);
+        if (err != EFI_SUCCESS)
+                return log_error_status(err, "Cannot apply PE relocations: %m");
+
+        /* Second pass: mark code sections RO+X for W^X compliance. */
+        if (memory_proto) {
+                FOREACH_ARRAY(h, headers, n_headers) {
+                        if (h->SizeOfRawData == 0)
+                                continue;
+                        if (!(h->Characteristics & (PE_CODE|PE_EXECUTE)))
+                                continue;
+
                         nx_restore.sections = xrealloc(nx_restore.sections, nx_restore.n_sections * sizeof(struct iovec), (nx_restore.n_sections + 1) * sizeof(struct iovec));
                         nx_restore.sections[nx_restore.n_sections++] = IOVEC_MAKE(loaded_kernel + h->VirtualAddress, h->VirtualSize);
 

--- a/src/boot/meson.build
+++ b/src/boot/meson.build
@@ -55,6 +55,12 @@ executables += [
                 'conditions' : ['ENABLE_BOOTLOADER'],
         },
         efi_test_template + {
+                'sources' : files('test-pe.c'),
+                'include_directories' : includes +
+                                        include_directories('.'),
+                'conditions' : ['ENABLE_BOOTLOADER'],
+        },
+        efi_test_template + {
                 'sources' : files('test-chid-match.c') +
                             test_hwids_section_c,
                 'conditions' : ['ENABLE_BOOTLOADER', 'ENABLE_UKIFY'],

--- a/src/boot/pe.c
+++ b/src/boot/pe.c
@@ -5,6 +5,7 @@
 #include "efi-firmware.h"
 #include "efi-log.h"
 #include "pe.h"
+#include "unaligned-fundamental.h"
 #include "util.h"
 
 #define DOS_FILE_MAGIC "MZ"
@@ -460,7 +461,12 @@ static uint32_t get_compatibility_entry_address(const DosFileHeader *dos, const 
         return 0;
 }
 
-EFI_STATUS pe_kernel_info(const void *base, uint32_t *ret_entry_point, uint32_t *ret_compat_entry_point, size_t *ret_size_in_memory) {
+EFI_STATUS pe_kernel_info(
+                const void *base,
+                uint32_t *ret_entry_point,
+                uint32_t *ret_compat_entry_point,
+                size_t *ret_size_in_memory,
+                size_t *ret_headers_size) {
         assert(base);
 
         const DosFileHeader *dos = (const DosFileHeader *) base;
@@ -474,6 +480,7 @@ EFI_STATUS pe_kernel_info(const void *base, uint32_t *ret_entry_point, uint32_t 
         /* When allocating we need to also consider the virtual/uninitialized data sections, so parse it out
          * of the SizeOfImage field in the PE header and return it */
         size_t size_in_memory = pe->OptionalHeader.SizeOfImage;
+        size_t headers_size = pe->OptionalHeader.SizeOfHeaders;
 
         /* Support for LINUX_INITRD_MEDIA_GUID was added in kernel stub 1.0. */
         if (pe->OptionalHeader.MajorImageVersion < 1)
@@ -486,6 +493,8 @@ EFI_STATUS pe_kernel_info(const void *base, uint32_t *ret_entry_point, uint32_t 
                         *ret_compat_entry_point = 0;
                 if (ret_size_in_memory)
                         *ret_size_in_memory = size_in_memory;
+                if (ret_headers_size)
+                        *ret_headers_size = headers_size;
                 return EFI_SUCCESS;
         }
 
@@ -500,6 +509,8 @@ EFI_STATUS pe_kernel_info(const void *base, uint32_t *ret_entry_point, uint32_t 
                 *ret_compat_entry_point = compat_entry_point;
         if (ret_size_in_memory)
                 *ret_size_in_memory = size_in_memory;
+        if (ret_headers_size)
+                *ret_headers_size = headers_size;
 
         return EFI_SUCCESS;
 }
@@ -507,36 +518,122 @@ EFI_STATUS pe_kernel_info(const void *base, uint32_t *ret_entry_point, uint32_t 
 /* https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#optional-header-data-directories-image-only */
 #define BASE_RELOCATION_TABLE_DATA_DIRECTORY_ENTRY 5
 
-/* We do not expect PE inner kernels to have any relocations. However that might be wrong for some
- * architectures, or it might change in the future. If the case of relocation arise, we should transform this
- * function in a function applying the relocations. However for now, since it would not be exercised and
- * would bitrot, we leave it as a check that relocations are never expected.
- */
-EFI_STATUS pe_kernel_check_no_relocation(const void *base) {
-        assert(base);
+/* https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#base-relocation-types */
+#define IMAGE_REL_BASED_ABSOLUTE 0
+#define IMAGE_REL_BASED_DIR64    10
 
-        const DosFileHeader *dos = base;
+/* Apply the subset of PE base relocations we need for 64-bit kernels.
+ *
+ * Our custom inner-kernel loader does not go through UEFI LoadImage(), hence it must
+ * apply the relocation directory itself whenever the image is loaded away from its
+ * preferred PE ImageBase. At the moment we only support IMAGE_REL_BASED_DIR64, which
+ * is sufficient for the affected 64-bit kernels.
+ *
+ * See: https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#the-reloc-section-image-only
+ */
+EFI_STATUS pe_kernel_apply_relocations(
+                const void *file_base,
+                uint8_t *loaded_base,
+                size_t loaded_size,
+                uint64_t actual_base) {
+
+        assert(file_base);
+        assert(loaded_base);
+
+        const DosFileHeader *dos = file_base;
         if (!verify_dos(dos))
                 return EFI_LOAD_ERROR;
 
-        const PeFileHeader *pe = (const PeFileHeader *) ((const uint8_t *) base + dos->ExeHeader);
+        const PeFileHeader *pe = (const PeFileHeader *) ((const uint8_t *) file_base + dos->ExeHeader);
         if (!verify_pe(dos, pe, /* allow_compatibility= */ true))
                 return EFI_LOAD_ERROR;
 
         const PeImageDataDirectory *data_directory;
+        uint32_t n_data_directory;
+        uint64_t image_base;
         switch (pe->OptionalHeader.Magic) {
         case OPTHDR32_MAGIC:
                 data_directory = pe->OptionalHeader.DataDirectory32;
+                n_data_directory = pe->OptionalHeader.NumberOfRvaAndSizes32;
+                image_base = pe->OptionalHeader.ImageBase32;
                 break;
         case OPTHDR64_MAGIC:
                 data_directory = pe->OptionalHeader.DataDirectory64;
+                n_data_directory = pe->OptionalHeader.NumberOfRvaAndSizes64;
+                image_base = pe->OptionalHeader.ImageBase64;
                 break;
         default:
-                assert_not_reached();
+                return EFI_LOAD_ERROR;
         }
 
-        if (data_directory[BASE_RELOCATION_TABLE_DATA_DIRECTORY_ENTRY].Size != 0)
-                return log_error_status(EFI_LOAD_ERROR, "Inner kernel image contains base relocations, which we do not support.");
+        if (n_data_directory <= BASE_RELOCATION_TABLE_DATA_DIRECTORY_ENTRY)
+                return EFI_SUCCESS;
+
+        uint32_t reloc_rva = data_directory[BASE_RELOCATION_TABLE_DATA_DIRECTORY_ENTRY].VirtualAddress;
+        uint32_t reloc_size = data_directory[BASE_RELOCATION_TABLE_DATA_DIRECTORY_ENTRY].Size;
+
+        if (reloc_size == 0)
+                return EFI_SUCCESS;
+
+        uint64_t delta = actual_base - image_base;
+        if (delta == 0)
+                return EFI_SUCCESS;
+
+        if (reloc_rva > loaded_size || reloc_size > loaded_size - reloc_rva)
+                return log_error_status(EFI_LOAD_ERROR, "Base relocation table extends outside loaded image");
+
+        /* Walk the relocation blocks. Each block starts with a header:
+         *   uint32_t VirtualAddress  (page RVA)
+         *   uint32_t SizeOfBlock     (total block size including header)
+         * Followed by uint16_t entries: top 4 bits = type, bottom 12 bits = offset within page */
+        const uint8_t *reloc_ptr = loaded_base + reloc_rva;
+        const uint8_t *reloc_end = reloc_ptr + reloc_size;
+
+        while (reloc_ptr < reloc_end) {
+                size_t remaining = reloc_end - reloc_ptr;
+                if (remaining < 8)
+                        return log_error_status(EFI_LOAD_ERROR, "Truncated relocation block");
+
+                uint32_t page_rva = unaligned_read_ne32(reloc_ptr);
+                uint32_t block_size = unaligned_read_ne32(reloc_ptr + 4);
+
+                if (block_size < 8 || block_size > remaining)
+                        return log_error_status(EFI_LOAD_ERROR, "Invalid relocation block");
+                if ((block_size - 8) % sizeof(uint16_t) != 0)
+                        return log_error_status(EFI_LOAD_ERROR, "Invalid relocation block size");
+
+                size_t n_entries = (block_size - 8) / sizeof(uint16_t);
+
+                for (size_t i = 0; i < n_entries; i++) {
+                        uint16_t entry = unaligned_read_ne16(reloc_ptr + 8 + i * sizeof(uint16_t));
+                        uint16_t type = entry >> 12;
+                        uint16_t offset = entry & 0xFFF;
+
+                        if (page_rva > UINT32_MAX - offset)
+                                return log_error_status(EFI_LOAD_ERROR, "Relocation fixup overflows");
+
+                        uint32_t fixup_rva = page_rva + offset;
+
+                        switch (type) {
+                        case IMAGE_REL_BASED_ABSOLUTE:
+                                /* Padding, skip */
+                                break;
+                        case IMAGE_REL_BASED_DIR64:
+                                if (fixup_rva > loaded_size || sizeof(uint64_t) > loaded_size - fixup_rva)
+                                        return log_error_status(EFI_LOAD_ERROR, "Relocation fixup outside loaded image");
+
+                                unaligned_write_ne64(
+                                                loaded_base + fixup_rva,
+                                                unaligned_read_ne64(loaded_base + fixup_rva) + delta);
+                                break;
+                        default:
+                                return log_error_status(EFI_LOAD_ERROR,
+                                                "Unsupported relocation type %u", type);
+                        }
+                }
+
+                reloc_ptr += block_size;
+        }
 
         return EFI_SUCCESS;
 }

--- a/src/boot/pe.c
+++ b/src/boot/pe.c
@@ -5,6 +5,7 @@
 #include "efi-firmware.h"
 #include "efi-log.h"
 #include "pe.h"
+#include "unaligned.h"
 #include "util.h"
 
 #define DOS_FILE_MAGIC "MZ"
@@ -142,6 +143,10 @@ typedef struct PeFileHeader {
 
 /* https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#optional-header-data-directories-image-only */
 #define BASE_RELOCATION_TABLE_DATA_DIRECTORY_ENTRY 5
+
+/* https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#base-relocation-types */
+#define IMAGE_REL_BASED_ABSOLUTE 0
+#define IMAGE_REL_BASED_DIR64    10
 
 static bool verify_dos(const DosFileHeader *dos) {
         assert(dos);
@@ -578,6 +583,7 @@ EFI_STATUS pe_kernel_info(
                 uint32_t *ret_entry_point,
                 uint32_t *ret_compat_entry_point,
                 size_t *ret_size_in_memory,
+                size_t *ret_headers_size,
                 uint32_t *ret_section_alignment) {
         assert(base);
 
@@ -590,6 +596,7 @@ EFI_STATUS pe_kernel_info(
         /* When allocating we need to also consider the virtual/uninitialized data sections, so parse it out
          * of the SizeOfImage field in the PE header and return it */
         size_t size_in_memory = pe->OptionalHeader.SizeOfImage;
+        size_t headers_size = pe->OptionalHeader.SizeOfHeaders;
 
         /* Honoring SectionAlignment lets callers place the image so the kernel's EFI stub need not relocate
          * it (SZ_64K on arm64). The PE spec requires a power of 2; for a non-conforming value fall back to
@@ -616,6 +623,8 @@ EFI_STATUS pe_kernel_info(
                         *ret_compat_entry_point = 0;
                 if (ret_size_in_memory)
                         *ret_size_in_memory = size_in_memory;
+                if (ret_headers_size)
+                        *ret_headers_size = headers_size;
                 if (ret_section_alignment)
                         *ret_section_alignment = section_alignment;
                 return EFI_SUCCESS;
@@ -635,42 +644,130 @@ EFI_STATUS pe_kernel_info(
                 *ret_compat_entry_point = compat_entry_point;
         if (ret_size_in_memory)
                 *ret_size_in_memory = size_in_memory;
+        if (ret_headers_size)
+                *ret_headers_size = headers_size;
         if (ret_section_alignment)
                 *ret_section_alignment = section_alignment;
 
         return EFI_SUCCESS;
 }
 
-/* We do not expect PE inner kernels to have any relocations. However that might be wrong for some
- * architectures, or it might change in the future. If the case of relocation arise, we should transform this
- * function in a function applying the relocations. However for now, since it would not be exercised and
- * would bitrot, we leave it as a check that relocations are never expected.
+/* Apply the subset of PE base relocations we need for 64-bit kernels.
+ *
+ * Our custom inner-kernel loader does not go through UEFI LoadImage(), hence it must
+ * apply the relocation directory itself whenever the image is loaded away from its
+ * preferred PE ImageBase. At the moment we only support IMAGE_REL_BASED_DIR64, which
+ * is sufficient for the affected 64-bit kernels.
+ *
+ * See: https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#the-reloc-section-image-only
  */
-EFI_STATUS pe_kernel_check_no_relocation(const void *base) {
-        assert(base);
+EFI_STATUS pe_kernel_apply_relocations(
+                const void *file_base,
+                size_t file_size,
+                uint8_t *loaded_base,
+                size_t loaded_size,
+                uint64_t actual_base) {
 
-        const DosFileHeader *dos = base;
-        if (!verify_dos(dos))
-                return EFI_LOAD_ERROR;
+        assert(file_base);
+        assert(loaded_base);
 
-        const PeFileHeader *pe = (const PeFileHeader *) ((const uint8_t *) base + dos->ExeHeader);
-        if (!verify_pe(dos, pe, /* allow_compatibility= */ true))
-                return EFI_LOAD_ERROR;
+        const DosFileHeader *dos;
+        const PeFileHeader *pe;
+        EFI_STATUS err = pe_headers_from_base(
+                        file_base,
+                        file_size,
+                        /* allow_compatibility= */ true,
+                        &dos,
+                        &pe);
+        if (err != EFI_SUCCESS)
+                return err;
 
         const PeImageDataDirectory *data_directory;
+        uint32_t n_data_directory;
+        uint64_t image_base;
         switch (pe->OptionalHeader.Magic) {
         case OPTHDR32_MAGIC:
                 data_directory = pe->OptionalHeader.DataDirectory32;
+                n_data_directory = pe->OptionalHeader.NumberOfRvaAndSizes32;
+                image_base = pe->OptionalHeader.ImageBase32;
                 break;
         case OPTHDR64_MAGIC:
                 data_directory = pe->OptionalHeader.DataDirectory64;
+                n_data_directory = pe->OptionalHeader.NumberOfRvaAndSizes64;
+                image_base = pe->OptionalHeader.ImageBase64;
                 break;
         default:
-                assert_not_reached();
+                return EFI_LOAD_ERROR;
         }
 
-        if (data_directory[BASE_RELOCATION_TABLE_DATA_DIRECTORY_ENTRY].Size != 0)
-                return log_error_status(EFI_LOAD_ERROR, "Inner kernel image contains base relocations, which we do not support.");
+        if (n_data_directory <= BASE_RELOCATION_TABLE_DATA_DIRECTORY_ENTRY)
+                return EFI_SUCCESS;
+
+        uint32_t reloc_rva = data_directory[BASE_RELOCATION_TABLE_DATA_DIRECTORY_ENTRY].VirtualAddress;
+        uint32_t reloc_size = data_directory[BASE_RELOCATION_TABLE_DATA_DIRECTORY_ENTRY].Size;
+
+        if (reloc_size == 0)
+                return EFI_SUCCESS;
+
+        uint64_t delta = actual_base - image_base;
+        if (delta == 0)
+                return EFI_SUCCESS;
+
+        if (reloc_rva > loaded_size || reloc_size > loaded_size - reloc_rva)
+                return log_error_status(EFI_LOAD_ERROR, "Base relocation table extends outside loaded image");
+
+        /* Walk the relocation blocks. Each block starts with a header:
+         *   uint32_t VirtualAddress  (page RVA)
+         *   uint32_t SizeOfBlock     (total block size including header)
+         * Followed by uint16_t entries: top 4 bits = type, bottom 12 bits = offset within page */
+        const uint8_t *reloc_ptr = loaded_base + reloc_rva;
+        const uint8_t *reloc_end = reloc_ptr + reloc_size;
+
+        while (reloc_ptr < reloc_end) {
+                size_t remaining = reloc_end - reloc_ptr;
+                if (remaining < 8)
+                        return log_error_status(EFI_LOAD_ERROR, "Truncated relocation block");
+
+                uint32_t page_rva = unaligned_read_ne32(reloc_ptr);
+                uint32_t block_size = unaligned_read_ne32(reloc_ptr + 4);
+
+                if (block_size < 8 || block_size > remaining)
+                        return log_error_status(EFI_LOAD_ERROR, "Invalid relocation block");
+                if ((block_size - 8) % sizeof(uint16_t) != 0)
+                        return log_error_status(EFI_LOAD_ERROR, "Invalid relocation block size");
+
+                size_t n_entries = (block_size - 8) / sizeof(uint16_t);
+
+                for (size_t i = 0; i < n_entries; i++) {
+                        uint16_t entry = unaligned_read_ne16(reloc_ptr + 8 + i * sizeof(uint16_t));
+                        uint16_t type = entry >> 12;
+                        uint16_t offset = entry & 0xFFF;
+
+                        if (page_rva > UINT32_MAX - offset)
+                                return log_error_status(EFI_LOAD_ERROR, "Relocation fixup overflows");
+
+                        uint32_t fixup_rva = page_rva + offset;
+
+                        switch (type) {
+                        case IMAGE_REL_BASED_ABSOLUTE:
+                                /* Padding, skip */
+                                break;
+                        case IMAGE_REL_BASED_DIR64:
+                                if (fixup_rva > loaded_size || sizeof(uint64_t) > loaded_size - fixup_rva)
+                                        return log_error_status(EFI_LOAD_ERROR, "Relocation fixup outside loaded image");
+
+                                unaligned_write_ne64(
+                                                loaded_base + fixup_rva,
+                                                unaligned_read_ne64(loaded_base + fixup_rva) + delta);
+                                break;
+                        default:
+                                return log_error_status(EFI_LOAD_ERROR,
+                                                "Unsupported relocation type %u", type);
+                        }
+                }
+
+                reloc_ptr += block_size;
+        }
 
         return EFI_SUCCESS;
 }

--- a/src/boot/pe.h
+++ b/src/boot/pe.h
@@ -57,8 +57,17 @@ EFI_STATUS pe_memory_locate_sections(
                 const char *const section_names[],
                 PeSectionVector sections[]);
 
-EFI_STATUS pe_kernel_info(const void *base, uint32_t *ret_entry_point, uint32_t *ret_compat_entry_point, size_t *ret_size_in_memory);
+EFI_STATUS pe_kernel_info(
+                const void *base,
+                uint32_t *ret_entry_point,
+                uint32_t *ret_compat_entry_point,
+                size_t *ret_size_in_memory,
+                size_t *ret_headers_size);
 
-EFI_STATUS pe_kernel_check_no_relocation(const void *base);
+EFI_STATUS pe_kernel_apply_relocations(
+                const void *file_base,
+                uint8_t *loaded_base,
+                size_t loaded_size,
+                uint64_t actual_base);
 
 bool pe_kernel_check_nx_compat(const void *base);

--- a/src/boot/pe.h
+++ b/src/boot/pe.h
@@ -68,8 +68,14 @@ EFI_STATUS pe_kernel_info(
                 uint32_t *ret_entry_point,
                 uint32_t *ret_compat_entry_point,
                 size_t *ret_size_in_memory,
+                size_t *ret_headers_size,
                 uint32_t *ret_section_alignment);
 
-EFI_STATUS pe_kernel_check_no_relocation(const void *base);
+EFI_STATUS pe_kernel_apply_relocations(
+                const void *file_base,
+                size_t file_size,
+                uint8_t *loaded_base,
+                size_t loaded_size,
+                uint64_t actual_base);
 
 bool pe_kernel_check_nx_compat(const void *base);

--- a/src/boot/test-pe.c
+++ b/src/boot/test-pe.c
@@ -1,0 +1,182 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include <stdlib.h>
+
+#include "alloc-util.h"
+#include "proto/file-io.h"              /* IWYU pragma: keep */
+
+#define xnew(type, n) new(type, n)
+
+/* pe.c pulls in the EFI logging API, which collides with the userspace logging API from tests.h. */
+#define LogLevel efi_LogLevel
+#define log_get_max_level efi_log_get_max_level
+#define log_set_max_level efi_log_set_max_level
+#define log_set_max_level_from_string efi_log_set_max_level_from_string
+#define log_set_max_level_from_smbios efi_log_set_max_level_from_smbios
+#define log_internal efi_log_internal
+
+/* Include the implementation directly so we can exercise the internal PE helpers. */
+#include "pe.c"
+
+#undef xnew
+
+#undef log_hexdump
+#undef log_oom
+#undef log_emergency_status
+#undef log_error_status
+#undef log_warning_status
+#undef log_notice_status
+#undef log_info_status
+#undef log_debug_status
+#undef log_emergency
+#undef log_error
+#undef log_warning
+#undef log_notice
+#undef log_info
+#undef log_debug
+#undef log_full
+
+#undef log_internal
+#undef log_set_max_level_from_smbios
+#undef log_set_max_level_from_string
+#undef log_set_max_level
+#undef log_get_max_level
+#undef LogLevel
+
+#include "tests.h"
+
+EFI_STATUS chid_match(
+                const void *hwid_buffer,
+                size_t hwid_length,
+                uint32_t match_type,
+                const Device **ret_device) {
+
+        return EFI_UNSUPPORTED;
+}
+
+bool firmware_devicetree_exists(void) {
+        return false;
+}
+
+EFI_STATUS devicetree_match(const void *uki_dtb, size_t uki_dtb_length) {
+        return EFI_UNSUPPORTED;
+}
+
+EFI_STATUS devicetree_match_by_compatible(const void *uki_dtb, size_t uki_dtb_length, const char *compat) {
+        return EFI_UNSUPPORTED;
+}
+
+EFI_STATUS efi_firmware_match_by_fwid(const void *blob, size_t blob_len, const char *fwid) {
+        return EFI_UNSUPPORTED;
+}
+
+EFI_STATUS efi_log_internal(EFI_STATUS status, efi_LogLevel log_level, const char *format, ...) {
+        return status;
+}
+
+static void make_test_kernel(
+                void *file_image,
+                void *loaded_image,
+                size_t size,
+                uint64_t image_base,
+                uint64_t fixup_value,
+                uint32_t page_rva,
+                uint16_t entry) {
+
+        ASSERT_NOT_NULL(file_image);
+        ASSERT_NOT_NULL(loaded_image);
+        ASSERT_GE(size, (size_t) 0x200);
+
+        memzero(file_image, size);
+        memzero(loaded_image, size);
+
+        DosFileHeader *dos = file_image;
+        memcpy(dos->Magic, DOS_FILE_MAGIC, STRLEN(DOS_FILE_MAGIC));
+        dos->ExeHeader = 0x40;
+
+        PeFileHeader *pe = (PeFileHeader *) ((uint8_t *) file_image + dos->ExeHeader);
+        memcpy(pe->Magic, PE_FILE_MAGIC, STRLEN(PE_FILE_MAGIC));
+        pe->FileHeader.Machine = TARGET_MACHINE_TYPE;
+        pe->FileHeader.NumberOfSections = 1;
+        pe->FileHeader.SizeOfOptionalHeader = sizeof(PeOptionalHeader);
+        pe->OptionalHeader.Magic = OPTHDR64_MAGIC;
+        pe->OptionalHeader.MajorImageVersion = 1;
+        pe->OptionalHeader.ImageBase64 = image_base;
+        pe->OptionalHeader.SizeOfImage = size;
+        pe->OptionalHeader.SizeOfHeaders = 0x80;
+        pe->OptionalHeader.NumberOfRvaAndSizes64 = IMAGE_NUMBEROF_DIRECTORY_ENTRIES;
+        pe->OptionalHeader.DataDirectory64[BASE_RELOCATION_TABLE_DATA_DIRECTORY_ENTRY] = (PeImageDataDirectory) {
+                .VirtualAddress = 0x80,
+                .Size = 10,
+        };
+
+        memcpy(loaded_image, file_image, 0x80);
+
+        unaligned_write_ne32((uint8_t *) loaded_image + 0x80, page_rva);
+        unaligned_write_ne32((uint8_t *) loaded_image + 0x84, 10);
+        unaligned_write_ne16((uint8_t *) loaded_image + 0x88, entry);
+
+        uint32_t fixup_rva = page_rva + (entry & 0x0FFF);
+        if (fixup_rva <= size && sizeof(uint64_t) <= size - fixup_rva)
+                unaligned_write_ne64((uint8_t *) loaded_image + fixup_rva, fixup_value);
+}
+
+TEST(pe_kernel_apply_relocations_add) {
+        const uint64_t image_base = UINT64_C(0x100000);
+        const uint64_t actual_base = UINT64_C(0x105000);
+        const uint64_t fixup_value = image_base + UINT64_C(0x2340);
+
+        _cleanup_free_ void *file_image = ASSERT_NOT_NULL(malloc0(0x400));
+        _cleanup_free_ void *loaded_image = ASSERT_NOT_NULL(malloc0(0x400));
+
+        make_test_kernel(
+                        file_image,
+                        loaded_image,
+                        0x400,
+                        image_base,
+                        fixup_value,
+                        0x100,
+                        (IMAGE_REL_BASED_DIR64 << 12) | 0x20);
+
+        ASSERT_EQ(pe_kernel_apply_relocations(file_image, loaded_image, 0x400, actual_base), EFI_SUCCESS);
+        ASSERT_EQ(unaligned_read_ne64((uint8_t *) loaded_image + 0x120), fixup_value + (actual_base - image_base));
+}
+
+TEST(pe_kernel_apply_relocations_subtract) {
+        const uint64_t image_base = UINT64_C(0x200000);
+        const uint64_t actual_base = UINT64_C(0x1ff000);
+        const uint64_t fixup_value = image_base + UINT64_C(0x5000);
+
+        _cleanup_free_ void *file_image = ASSERT_NOT_NULL(malloc0(0x400));
+        _cleanup_free_ void *loaded_image = ASSERT_NOT_NULL(malloc0(0x400));
+
+        make_test_kernel(
+                        file_image,
+                        loaded_image,
+                        0x400,
+                        image_base,
+                        fixup_value,
+                        0x100,
+                        (IMAGE_REL_BASED_DIR64 << 12) | 0x20);
+
+        ASSERT_EQ(pe_kernel_apply_relocations(file_image, loaded_image, 0x400, actual_base), EFI_SUCCESS);
+        ASSERT_EQ(unaligned_read_ne64((uint8_t *) loaded_image + 0x120), fixup_value + (actual_base - image_base));
+}
+
+TEST(pe_kernel_apply_relocations_fixup_overflow) {
+        _cleanup_free_ void *file_image = ASSERT_NOT_NULL(malloc0(0x400));
+        _cleanup_free_ void *loaded_image = ASSERT_NOT_NULL(malloc0(0x400));
+
+        make_test_kernel(
+                        file_image,
+                        loaded_image,
+                        0x400,
+                        UINT64_C(0x300000),
+                        UINT64_C(0x300000),
+                        UINT32_MAX,
+                        (IMAGE_REL_BASED_DIR64 << 12) | 0x0FFF);
+
+        ASSERT_EQ(pe_kernel_apply_relocations(file_image, loaded_image, 0x400, UINT64_C(0x301000)), EFI_LOAD_ERROR);
+}
+
+DEFINE_TEST_MAIN(LOG_INFO);

--- a/src/boot/test-pe.c
+++ b/src/boot/test-pe.c
@@ -1,0 +1,312 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include <stdlib.h>
+
+#include "alloc-util.h"
+#include "efi.h"
+#include "proto/file-io.h"              /* IWYU pragma: keep */
+
+#define xnew(type, n) new(type, n)
+
+/* pe.c pulls in the EFI logging API, which collides with the userspace logging API from tests.h. */
+#define LogLevel efi_LogLevel
+#define log_get_max_level efi_log_get_max_level
+#define log_set_max_level efi_log_set_max_level
+#define log_set_max_level_from_string efi_log_set_max_level_from_string
+#define log_set_max_level_from_smbios efi_log_set_max_level_from_smbios
+#define log_internal efi_log_internal
+
+/* Include the implementation directly so we can exercise the internal PE helpers. */
+#include "pe.c"
+
+#undef xnew
+
+#undef log_hexdump
+#undef log_oom
+#undef log_emergency_status
+#undef log_error_status
+#undef log_warning_status
+#undef log_notice_status
+#undef log_info_status
+#undef log_debug_status
+#undef log_emergency
+#undef log_error
+#undef log_warning
+#undef log_notice
+#undef log_info
+#undef log_debug
+#undef log_full
+
+#undef log_internal
+#undef log_set_max_level_from_smbios
+#undef log_set_max_level_from_string
+#undef log_set_max_level
+#undef log_get_max_level
+#undef LogLevel
+
+#include "tests.h"
+
+#define IMAGE_REL_BASED_HIGHLOW 3
+
+#define TEST_IMAGE_SIZE   0x800U
+#define TEST_HEADERS_SIZE 0x200U
+#define TEST_RELOC_RVA    0x200U
+#define TEST_TEXT_RVA     0x400U
+
+EFI_STATUS chid_match(
+                const void *hwid_buffer,
+                size_t hwid_length,
+                uint32_t match_type,
+                const Device **ret_device) {
+
+        return EFI_UNSUPPORTED;
+}
+
+bool firmware_devicetree_exists(void) {
+        return false;
+}
+
+EFI_STATUS devicetree_match(const void *uki_dtb, size_t uki_dtb_length) {
+        return EFI_UNSUPPORTED;
+}
+
+EFI_STATUS devicetree_match_by_compatible(const void *uki_dtb, size_t uki_dtb_length, const char *compat) {
+        return EFI_UNSUPPORTED;
+}
+
+EFI_STATUS efi_firmware_match_by_fwid(const void *blob, size_t blob_len, const char *fwid) {
+        return EFI_UNSUPPORTED;
+}
+
+EFI_STATUS efi_log_internal(EFI_STATUS status, efi_LogLevel log_level, const char *format, ...) {
+        return status;
+}
+
+static void make_test_kernel(
+                void *file_image,
+                void *loaded_image,
+                size_t size,
+                uint64_t image_base,
+                uint64_t fixup_value,
+                uint32_t page_rva,
+                uint16_t entry) {
+
+        ASSERT_NOT_NULL(file_image);
+        ASSERT_NOT_NULL(loaded_image);
+        ASSERT_GE(size, (size_t) TEST_IMAGE_SIZE);
+
+        memzero(file_image, size);
+        memzero(loaded_image, size);
+
+        DosFileHeader *dos = file_image;
+        memcpy(dos->Magic, DOS_FILE_MAGIC, STRLEN(DOS_FILE_MAGIC));
+        dos->ExeHeader = 0x80;
+
+        PeFileHeader *pe = (PeFileHeader*) ((uint8_t*) file_image + dos->ExeHeader);
+        memcpy(pe->Magic, PE_FILE_MAGIC, STRLEN(PE_FILE_MAGIC));
+        pe->FileHeader.Machine = TARGET_MACHINE_TYPE;
+        pe->FileHeader.NumberOfSections = 2;
+        pe->FileHeader.SizeOfOptionalHeader = sizeof(PeOptionalHeader);
+        pe->OptionalHeader.Magic = OPTHDR64_MAGIC;
+        pe->OptionalHeader.MajorImageVersion = 1;
+        pe->OptionalHeader.ImageBase64 = image_base;
+        pe->OptionalHeader.SizeOfImage = size;
+        pe->OptionalHeader.SizeOfHeaders = TEST_HEADERS_SIZE;
+        pe->OptionalHeader.NumberOfRvaAndSizes64 = IMAGE_NUMBEROF_DIRECTORY_ENTRIES;
+        pe->OptionalHeader.DataDirectory64[BASE_RELOCATION_TABLE_DATA_DIRECTORY_ENTRY] =
+                (PeImageDataDirectory) {
+                        .VirtualAddress = TEST_RELOC_RVA,
+                        .Size = 12,
+                };
+
+        PeSectionHeader *sections =
+                (PeSectionHeader*) ((uint8_t*) file_image + section_table_offset(dos, pe));
+        memcpy(sections[0].Name, ".reloc", STRLEN(".reloc"));
+        sections[0].VirtualSize = 0x100;
+        sections[0].VirtualAddress = TEST_RELOC_RVA;
+        sections[0].SizeOfRawData = 0x200;
+        sections[0].PointerToRawData = TEST_RELOC_RVA;
+
+        memcpy(sections[1].Name, ".text", STRLEN(".text"));
+        sections[1].VirtualSize = 0x180;
+        sections[1].VirtualAddress = TEST_TEXT_RVA;
+        sections[1].SizeOfRawData = 0x200;
+        sections[1].PointerToRawData = TEST_TEXT_RVA;
+        sections[1].Characteristics = PE_CODE | PE_EXECUTE;
+
+        ASSERT_LE(section_table_offset(dos, pe) + 2 * sizeof(PeSectionHeader), (size_t) TEST_HEADERS_SIZE);
+
+        unaligned_write_ne32((uint8_t*) file_image + TEST_RELOC_RVA, page_rva);
+        unaligned_write_ne32((uint8_t*) file_image + TEST_RELOC_RVA + 4, 12);
+        unaligned_write_ne16((uint8_t*) file_image + TEST_RELOC_RVA + 8, entry);
+        /* IMAGE_REL_BASED_ABSOLUTE pads the block to a 32-bit boundary. */
+        unaligned_write_ne16((uint8_t*) file_image + TEST_RELOC_RVA + 10, IMAGE_REL_BASED_ABSOLUTE << 12);
+
+        uint32_t fixup_rva = page_rva + (entry & 0x0FFF);
+        if (fixup_rva <= size && sizeof(uint64_t) <= size - fixup_rva)
+                unaligned_write_ne64((uint8_t*) file_image + fixup_rva, fixup_value);
+
+        memcpy(loaded_image, file_image, TEST_HEADERS_SIZE);
+        memcpy((uint8_t*) loaded_image + TEST_RELOC_RVA,
+               (uint8_t*) file_image + sections[0].PointerToRawData,
+               MIN(sections[0].SizeOfRawData, sections[0].VirtualSize));
+        memcpy((uint8_t*) loaded_image + TEST_TEXT_RVA,
+               (uint8_t*) file_image + sections[1].PointerToRawData,
+               MIN(sections[1].SizeOfRawData, sections[1].VirtualSize));
+}
+
+TEST(pe_kernel_apply_relocations_add) {
+        const uint64_t image_base = UINT64_C(0x100000);
+        const uint64_t actual_base = UINT64_C(0x105000);
+        const uint64_t fixup_value = image_base + UINT64_C(0x2340);
+
+        _cleanup_free_ void *file_image = ASSERT_NOT_NULL(malloc0(TEST_IMAGE_SIZE));
+        _cleanup_free_ void *loaded_image = ASSERT_NOT_NULL(malloc0(TEST_IMAGE_SIZE));
+
+        make_test_kernel(
+                        file_image,
+                        loaded_image,
+                        TEST_IMAGE_SIZE,
+                        image_base,
+                        fixup_value,
+                        TEST_TEXT_RVA,
+                        (IMAGE_REL_BASED_DIR64 << 12) | 0x20);
+
+        ASSERT_EQ(pe_kernel_apply_relocations(
+                          file_image, TEST_IMAGE_SIZE, loaded_image, TEST_IMAGE_SIZE, actual_base),
+                  EFI_SUCCESS);
+        ASSERT_EQ(unaligned_read_ne64((uint8_t*) loaded_image + TEST_TEXT_RVA + 0x20),
+                  fixup_value + (actual_base - image_base));
+}
+
+TEST(pe_kernel_apply_relocations_subtract) {
+        const uint64_t image_base = UINT64_C(0x200000);
+        const uint64_t actual_base = UINT64_C(0x1ff000);
+        const uint64_t fixup_value = image_base + UINT64_C(0x5000);
+
+        _cleanup_free_ void *file_image = ASSERT_NOT_NULL(malloc0(TEST_IMAGE_SIZE));
+        _cleanup_free_ void *loaded_image = ASSERT_NOT_NULL(malloc0(TEST_IMAGE_SIZE));
+
+        make_test_kernel(
+                        file_image,
+                        loaded_image,
+                        TEST_IMAGE_SIZE,
+                        image_base,
+                        fixup_value,
+                        TEST_TEXT_RVA,
+                        (IMAGE_REL_BASED_DIR64 << 12) | 0x20);
+
+        ASSERT_EQ(pe_kernel_apply_relocations(
+                          file_image, TEST_IMAGE_SIZE, loaded_image, TEST_IMAGE_SIZE, actual_base),
+                  EFI_SUCCESS);
+        ASSERT_EQ(unaligned_read_ne64((uint8_t*) loaded_image + TEST_TEXT_RVA + 0x20),
+                  fixup_value + (actual_base - image_base));
+}
+
+TEST(pe_kernel_apply_relocations_zero_delta) {
+        const uint64_t image_base = UINT64_C(0x200000);
+        const uint64_t fixup_value = image_base + UINT64_C(0x5000);
+
+        _cleanup_free_ void *file_image = ASSERT_NOT_NULL(malloc0(TEST_IMAGE_SIZE));
+        _cleanup_free_ void *loaded_image = ASSERT_NOT_NULL(malloc0(TEST_IMAGE_SIZE));
+
+        make_test_kernel(
+                        file_image,
+                        loaded_image,
+                        TEST_IMAGE_SIZE,
+                        image_base,
+                        fixup_value,
+                        TEST_TEXT_RVA,
+                        (IMAGE_REL_BASED_DIR64 << 12) | 0x20);
+
+        ASSERT_EQ(pe_kernel_apply_relocations(
+                          file_image, TEST_IMAGE_SIZE, loaded_image, TEST_IMAGE_SIZE, image_base),
+                  EFI_SUCCESS);
+        ASSERT_EQ(unaligned_read_ne64((uint8_t*) loaded_image + TEST_TEXT_RVA + 0x20), fixup_value);
+}
+
+TEST(pe_kernel_apply_relocations_unsupported_type) {
+        _cleanup_free_ void *file_image = ASSERT_NOT_NULL(malloc0(TEST_IMAGE_SIZE));
+        _cleanup_free_ void *loaded_image = ASSERT_NOT_NULL(malloc0(TEST_IMAGE_SIZE));
+
+        make_test_kernel(
+                        file_image,
+                        loaded_image,
+                        TEST_IMAGE_SIZE,
+                        UINT64_C(0x300000),
+                        UINT64_C(0x305000),
+                        TEST_TEXT_RVA,
+                        (IMAGE_REL_BASED_HIGHLOW << 12) | 0x20);
+
+        ASSERT_EQ(pe_kernel_apply_relocations(
+                          file_image, TEST_IMAGE_SIZE, loaded_image, TEST_IMAGE_SIZE, UINT64_C(0x301000)),
+                  EFI_LOAD_ERROR);
+}
+
+TEST(pe_kernel_apply_relocations_truncated_file) {
+        _cleanup_free_ void *file_image = ASSERT_NOT_NULL(malloc0(TEST_IMAGE_SIZE));
+        _cleanup_free_ void *loaded_image = ASSERT_NOT_NULL(malloc0(TEST_IMAGE_SIZE));
+
+        make_test_kernel(
+                        file_image,
+                        loaded_image,
+                        TEST_IMAGE_SIZE,
+                        UINT64_C(0x300000),
+                        UINT64_C(0x305000),
+                        TEST_TEXT_RVA,
+                        (IMAGE_REL_BASED_DIR64 << 12) | 0x20);
+
+        ASSERT_EQ(pe_kernel_apply_relocations(
+                          file_image,
+                          sizeof(DosFileHeader),
+                          loaded_image,
+                          TEST_IMAGE_SIZE,
+                          UINT64_C(0x301000)),
+                  EFI_LOAD_ERROR);
+}
+
+TEST(pe_kernel_info_headers_size) {
+        _cleanup_free_ void *file_image = ASSERT_NOT_NULL(malloc0(TEST_IMAGE_SIZE));
+        _cleanup_free_ void *loaded_image = ASSERT_NOT_NULL(malloc0(TEST_IMAGE_SIZE));
+
+        make_test_kernel(
+                        file_image,
+                        loaded_image,
+                        TEST_IMAGE_SIZE,
+                        UINT64_C(0x300000),
+                        UINT64_C(0x305000),
+                        TEST_TEXT_RVA,
+                        (IMAGE_REL_BASED_DIR64 << 12) | 0x20);
+
+        size_t headers_size;
+        ASSERT_EQ(pe_kernel_info(
+                          file_image,
+                          TEST_IMAGE_SIZE,
+                          /* ret_entry_point= */ NULL,
+                          /* ret_compat_entry_point= */ NULL,
+                          /* ret_size_in_memory= */ NULL,
+                          &headers_size,
+                          /* ret_section_alignment= */ NULL),
+                  EFI_SUCCESS);
+        ASSERT_EQ(headers_size, TEST_HEADERS_SIZE);
+}
+
+TEST(pe_kernel_apply_relocations_fixup_overflow) {
+        _cleanup_free_ void *file_image = ASSERT_NOT_NULL(malloc0(TEST_IMAGE_SIZE));
+        _cleanup_free_ void *loaded_image = ASSERT_NOT_NULL(malloc0(TEST_IMAGE_SIZE));
+
+        make_test_kernel(
+                        file_image,
+                        loaded_image,
+                        TEST_IMAGE_SIZE,
+                        UINT64_C(0x300000),
+                        UINT64_C(0x300000),
+                        UINT32_MAX,
+                        (IMAGE_REL_BASED_DIR64 << 12) | 0x0FFF);
+
+        ASSERT_EQ(pe_kernel_apply_relocations(
+                          file_image, TEST_IMAGE_SIZE, loaded_image, TEST_IMAGE_SIZE, UINT64_C(0x301000)),
+                  EFI_LOAD_ERROR);
+}
+
+DEFINE_TEST_MAIN(LOG_INFO);


### PR DESCRIPTION
This fixes inability to boot most Ubuntu arm64 kernels (eg for 26.04) with systemd-boot as they need relocations.  The existing code assumes relocations are not necessary, but this is not true for these kernels.

The custom inner-kernel loader copies the PE image into a freshly allocated buffer instead of going through UEFI LoadImage(). Some arm64 kernels rely on IMAGE_REL_BASED_DIR64 fixups in that path, and the kernel stub expects the PE headers to remain available at ImageBase when it looks up its embedded sections.

Copy SizeOfHeaders into the loaded image, copy section contents using MIN(SizeOfRawData, VirtualSize), and apply the relocation directory before marking executable sections RO+X. Harden the relocation walker against malformed inputs and add a focused PE relocation test.

This fixes booting affected Ubuntu arm64 kernels under systemd-boot.

Co-developed-by: Codex <noreply@openai.com>
Co-developed-by: Claude Opus 4.6 <noreply@anthropic.com>