### PR TITLE
Add dependencies on systemd-sysext services for confext

### DIFF
--- a/units/systemd-confext-initrd.service
+++ b/units/systemd-confext-initrd.service
@@ -27,6 +27,7 @@ Conflicts=initrd-switch-root.target
 Before=initrd-switch-root.target
 Wants=modprobe@loop.service modprobe@dm_mod.service
 After=modprobe@loop.service modprobe@dm_mod.service
+After=systemd-sysext-initrd.service
 
 [Service]
 Type=oneshot

--- a/units/systemd-confext.service
+++ b/units/systemd-confext.service
@@ -20,6 +20,7 @@ ConditionPathExists=!/etc/initrd-release
 
 DefaultDependencies=no
 After=local-fs.target
+After=systemd-sysext.service
 Before=sysinit.target systemd-tmpfiles-setup.service
 Conflicts=shutdown.target
 Before=shutdown.target


### PR DESCRIPTION
Without ordering, a confext could merge before a sysext that provides binaries or data needed by services inside the confext, causing startup failures (real bug reported).
Add After=systemd-sysext.service (and initrd counterpart) to ensure sysexts are merged first.