### PR TITLE
Help users with incorrect / permission bits

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -15,6 +15,9 @@ CHANGES WITH 261 in spe:
 
         New features:
 
+        * A new tmpfiles.d/root.conf has been added that sets permissions
+          on the root directory (/) to 0555
+
         * Networking to cloud IMDS services may be locked down for recognized
           clouds. This is recommended for secure installations, but typically
           conflicts with traditional IMDS clients such as cloud-init, which

--- a/tmpfiles.d/meson.build
+++ b/tmpfiles.d/meson.build
@@ -6,6 +6,7 @@ endif
 
 files = [['README'                                  ],
          ['home.conf'                               ],
+         ['root.conf'                               ],
          ['journal-nocow.conf'                      ],
          ['portables.conf',       'ENABLE_PORTABLED'],
          ['systemd-network.conf', 'ENABLE_NETWORKD' ],

--- a/tmpfiles.d/root.conf
+++ b/tmpfiles.d/root.conf
@@ -1,0 +1,10 @@
+#  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+
+# See tmpfiles.d(5) for details.
+
+z / 555 - - -


### PR DESCRIPTION
This error causes the computer to pass the emergency.target and go to graphical.target.
    Then, your window manager will have problems because it cant access any directories, your network manager wont startup the network. In my case, the screen just goes black. Ideally, you'd get an error message explaining this edge scenario that's occuring to you, and an emergency shell that makes it easy to run the necessary chmod 0755 / to proceed with booting. IDK not sure if this is the correct way to implement this, sorry it's my first contribution.

I ran 
`meson test -C build`
and got 

Ok:                1806
Fail:              26  
Skipped:           25  
on my cloned systemd repo before any changes, and got the same result after my commit ¯\_(ツ)_/¯
So I hope I did that right. 
Thanks