### PR TITLE
terminal-util: improve terminal_get_size_by_dsr, avoid hangs

### DIFF
--- a/src/basic/fd-util.c
+++ b/src/basic/fd-util.c
@@ -167,6 +167,13 @@ int fd_nonblock(int fd, bool nonblock) {
         return 1;
 }
 
+void nonblock_resetp(int *fd) {
+        PROTECT_ERRNO;
+
+        if (*fd >= 0)
+                (void) fd_nonblock(*fd, false);
+}
+
 int stdio_disable_nonblock(void) {
         int ret = 0;
 

--- a/src/basic/fd-util.h
+++ b/src/basic/fd-util.h
@@ -105,6 +105,8 @@ DEFINE_TRIVIAL_CLEANUP_FUNC_FULL(DIR*, closedir, NULL);
 int fd_nonblock(int fd, bool nonblock);
 int stdio_disable_nonblock(void);
 
+void nonblock_resetp(int *fd);
+
 int fd_cloexec(int fd, bool cloexec);
 int fd_cloexec_many(const int fds[], size_t n_fds, bool cloexec);
 

--- a/src/basic/terminal-util.c
+++ b/src/basic/terminal-util.c
@@ -2422,12 +2422,16 @@ int terminal_get_size_by_dsr(
         if (tcsetattr(nonblock_input_fd, TCSANOW, &new_termios) < 0)
                 return log_debug_errno(errno, "Failed to set new terminal settings: %m");
 
-        unsigned saved_row = 0, saved_column = 0;
+        /* Flush any stale input that might confuse the response parser. */
+        (void) tcflush(nonblock_input_fd, TCIFLUSH);
 
+        /* Use DECSC/DECRC to save/restore cursor instead of querying position via DSR. This way the cursor
+         * is always restored — even on timeout — and we only need one DSR response instead of two. */
         r = loop_write(output_fd,
-                       "\x1B[6n"           /* Request cursor position (DSR/CPR) */
-                       "\x1B[32766;32766H" /* Position cursor really far to the right and to the bottom, but let's stay within the 16bit signed range */
-                       "\x1B[6n",          /* Request cursor position again */
+                       "\x1B" "7"              /* DECSC: save cursor position */
+                       "\x1B[32766;32766H"     /* CUP: position cursor far to the right and to the bottom, staying within 16bit signed range */
+                       "\x1B[6n"               /* DSR: request cursor position (CPR) */
+                       "\x1B" "8",             /* DECRC: restore cursor position */
                        SIZE_MAX);
         if (r < 0)
                 goto finish;
@@ -2479,52 +2483,25 @@ int terminal_get_size_by_dsr(
                 memmove(buf, buf + processed, buf_full);
 
                 if (r > 0) {
-                        if (saved_row == 0) {
-                                assert(saved_column == 0);
-
-                                /* First sequence, this is the cursor position before we set it somewhere
-                                 * into the void at the bottom right. Let's save where we are so that we can
-                                 * return later. */
-
-                                /* Superficial validity checks */
-                                if (context.row <= 0 || context.column <= 0 || context.row >= 32766 || context.column >= 32766) {
-                                        r = -ENODATA;
-                                        goto finish;
-                                }
-
-                                saved_row = context.row;
-                                saved_column = context.column;
-
-                                /* Reset state */
-                                context = (CursorPositionContext) {};
-                        } else {
-                                /* Second sequence, this is the cursor position after we set it somewhere
-                                 * into the void at the bottom right. */
-
-                                /* Superficial validity checks (no particular reason to check for < 4, it's
-                                 * just a way to look for unreasonably small values) */
-                                if (context.row < 4 || context.column < 4 || context.row >= 32766 || context.column >= 32766) {
-                                        r = -ENODATA;
-                                        goto finish;
-                                }
-
-                                if (ret_rows)
-                                        *ret_rows = context.row;
-                                if (ret_columns)
-                                        *ret_columns = context.column;
-
-                                r = 0;
+                        /* Superficial validity checks (no particular reason to check for < 4, it's
+                         * just a way to look for unreasonably small values) */
+                        if (context.row < 4 || context.column < 4 || context.row >= 32766 || context.column >= 32766) {
+                                r = -ENODATA;
                                 goto finish;
                         }
+
+                        if (ret_rows)
+                                *ret_rows = context.row;
+                        if (ret_columns)
+                                *ret_columns = context.column;
+
+                        r = 0;
+                        goto finish;
                 }
         }
 
 finish:
-        /* Restore cursor position */
-        if (saved_row > 0 && saved_column > 0)
-                (void) terminal_set_cursor_position(output_fd, saved_row, saved_column);
         (void) tcsetattr(nonblock_input_fd, TCSANOW, &old_termios);
-
         return r;
 }
 

--- a/src/basic/terminal-util.c
+++ b/src/basic/terminal-util.c
@@ -1985,7 +1985,7 @@ int terminal_get_cursor_position(
         assert(input_fd >= 0);
         assert(output_fd >= 0);
 
-        if (terminal_is_dumb())
+        if (getenv_terminal_is_dumb())
                 return -EOPNOTSUPP;
 
         r = terminal_verify_same(input_fd, output_fd);
@@ -2397,7 +2397,11 @@ int terminal_get_size_by_dsr(
          * recognized as a "niche" value. (Note that the dimension fields in "struct winsize" are 16bit only,
          * too). */
 
-        if (terminal_is_dumb())
+        /* Use getenv_terminal_is_dumb() instead of terminal_is_dumb() here since we operate on an
+         * explicitly passed fd, not on stdio. terminal_is_dumb() additionally checks on_tty() which
+         * tests whether *stderr* is a tty — that's irrelevant when we're querying a directly opened
+         * terminal such as /dev/console. */
+        if (getenv_terminal_is_dumb())
                 return -EOPNOTSUPP;
 
         r = terminal_verify_same(input_fd, output_fd);

--- a/src/basic/terminal-util.c
+++ b/src/basic/terminal-util.c
@@ -44,8 +44,8 @@
 #include "time-util.h"
 #include "utf8.h"
 
-/* How much to wait for a reply to a terminal sequence */
-#define CONSOLE_REPLY_WAIT_USEC  (333 * USEC_PER_MSEC)
+/* How much to wait when reading/writing ANSI sequences from/to the console */
+#define CONSOLE_ANSI_SEQUENCE_TIMEOUT_USEC (333 * USEC_PER_MSEC)
 
 static volatile unsigned cached_columns = 0;
 static volatile unsigned cached_lines = 0;
@@ -858,7 +858,7 @@ int vt_disallocate(const char *tty_path) {
                                "\033[3J"  /* clear screen including scrollback, requires Linux 2.6.40 */
                                "\033c",   /* reset to initial state */
                                SIZE_MAX,
-                               100 * USEC_PER_MSEC);
+                               CONSOLE_ANSI_SEQUENCE_TIMEOUT_USEC);
 }
 
 static int vt_default_utf8(void) {
@@ -957,7 +957,8 @@ finish:
 }
 
 int terminal_reset_ansi_seq(int fd) {
-        int r, k;
+        _cleanup_(nonblock_resetp) int nonblock_reset = -EBADF;
+        int r;
 
         assert(fd >= 0);
 
@@ -967,8 +968,10 @@ int terminal_reset_ansi_seq(int fd) {
         r = fd_nonblock(fd, true);
         if (r < 0)
                 return log_debug_errno(r, "Failed to set terminal to non-blocking mode: %m");
+        if (r > 0)
+                nonblock_reset = fd;
 
-        k = loop_write_full(fd,
+        r = loop_write_full(fd,
                             "\033[!p"              /* soft terminal reset */
                             ANSI_OSC "104" ANSI_ST /* reset color palette via OSC 104 */
                             ANSI_NORMAL            /* reset colors */
@@ -976,17 +979,11 @@ int terminal_reset_ansi_seq(int fd) {
                             "\033[1G"              /* place cursor at beginning of current line */
                             "\033[0J",             /* erase till end of screen */
                             SIZE_MAX,
-                            100 * USEC_PER_MSEC);
-        if (k < 0)
-                log_debug_errno(k, "Failed to reset terminal through ANSI sequences: %m");
+                            CONSOLE_ANSI_SEQUENCE_TIMEOUT_USEC);
+        if (r < 0)
+                log_debug_errno(r, "Failed to reset terminal through ANSI sequences: %m");
 
-        if (r > 0) {
-                r = fd_nonblock(fd, false);
-                if (r < 0)
-                        log_debug_errno(r, "Failed to set terminal back to blocking mode: %m");
-        }
-
-        return k < 0 ? k : r;
+        return r;
 }
 
 void reset_dev_console_fd(int fd, bool switch_to_text) {
@@ -2017,7 +2014,7 @@ int terminal_get_cursor_position(
         if (r < 0)
                 goto finish;
 
-        usec_t end = usec_add(now(CLOCK_MONOTONIC), CONSOLE_REPLY_WAIT_USEC);
+        usec_t end = usec_add(now(CLOCK_MONOTONIC), CONSOLE_ANSI_SEQUENCE_TIMEOUT_USEC);
         char buf[STRLEN("\x1B[1;1R")]; /* The shortest valid reply possible */
         size_t buf_full = 0;
         CursorPositionContext context = {};
@@ -2311,7 +2308,7 @@ int get_default_background_color(double *ret_red, double *ret_green, double *ret
         if (r < 0)
                 goto finish;
 
-        usec_t end = usec_add(now(CLOCK_MONOTONIC), CONSOLE_REPLY_WAIT_USEC);
+        usec_t end = usec_add(now(CLOCK_MONOTONIC), CONSOLE_ANSI_SEQUENCE_TIMEOUT_USEC);
         char buf[STRLEN(ANSI_OSC "11;rgb:0/0/0" ANSI_ST)]; /* shortest possible reply */
         size_t buf_full = 0;
         BackgroundColorContext context = {};
@@ -2379,6 +2376,7 @@ int terminal_get_size_by_dsr(
                 unsigned *ret_rows,
                 unsigned *ret_columns) {
 
+        _cleanup_(nonblock_resetp) int nonblock_reset = -EBADF;
         int r;
 
         assert(input_fd >= 0);
@@ -2412,6 +2410,12 @@ int terminal_get_size_by_dsr(
         if (r < 0)
                 return r;
 
+        r = fd_nonblock(output_fd, true);
+        if (r < 0)
+                return log_debug_errno(r, "Failed to set terminal to non-blocking mode: %m");
+        if (r > 0)
+                nonblock_reset = output_fd;
+
         struct termios old_termios;
         if (tcgetattr(nonblock_input_fd, &old_termios) < 0)
                 return log_debug_errno(errno, "Failed to get terminal settings: %m");
@@ -2427,16 +2431,17 @@ int terminal_get_size_by_dsr(
 
         /* Use DECSC/DECRC to save/restore cursor instead of querying position via DSR. This way the cursor
          * is always restored — even on timeout — and we only need one DSR response instead of two. */
-        r = loop_write(output_fd,
+        r = loop_write_full(output_fd,
                        "\x1B" "7"              /* DECSC: save cursor position */
                        "\x1B[32766;32766H"     /* CUP: position cursor far to the right and to the bottom, staying within 16bit signed range */
                        "\x1B[6n"               /* DSR: request cursor position (CPR) */
                        "\x1B" "8",             /* DECRC: restore cursor position */
-                       SIZE_MAX);
+                       SIZE_MAX,
+                       CONSOLE_ANSI_SEQUENCE_TIMEOUT_USEC);
         if (r < 0)
                 goto finish;
 
-        usec_t end = usec_add(now(CLOCK_MONOTONIC), CONSOLE_REPLY_WAIT_USEC);
+        usec_t end = usec_add(now(CLOCK_MONOTONIC), CONSOLE_ANSI_SEQUENCE_TIMEOUT_USEC);
         char buf[STRLEN("\x1B[1;1R")]; /* The shortest valid reply possible */
         size_t buf_full = 0;
         CursorPositionContext context = {};
@@ -2607,7 +2612,7 @@ int terminal_get_terminfo_by_dcs(int fd, char **ret_name) {
         if (r < 0)
                 goto finish;
 
-        usec_t end = usec_add(now(CLOCK_MONOTONIC), CONSOLE_REPLY_WAIT_USEC);
+        usec_t end = usec_add(now(CLOCK_MONOTONIC), CONSOLE_ANSI_SEQUENCE_TIMEOUT_USEC);
         char buf[STRLEN(DCS_TERMINFO_R1) + MAX_TERMINFO_LENGTH + STRLEN(ANSI_ST)];
         size_t bytes = 0;
 


### PR DESCRIPTION
This is a backport of only the DSR method improvement from da69848. 259 does not have the CSI 18 method or the plumbing for trying CSI 18 then falling back to DSR.

This backport was done by Cursor 2.6.11 using claude-4.6-opus-high. I've eyeballed it and it looks plausible as far as I can see.

Assisted-by: Cursor 2.6.11 | claude-4.6-opus-high