### PR TITLE
Backport #41401 terminal-util: fix boot hang from ANSI terminal size queries to v260-stable

### DIFF
--- a/src/basic/fd-util.c
+++ b/src/basic/fd-util.c
@@ -166,6 +166,13 @@ int fd_nonblock(int fd, bool nonblock) {
         return 1;
 }
 
+void nonblock_resetp(int *fd) {
+        PROTECT_ERRNO;
+
+        if (*fd >= 0)
+                (void) fd_nonblock(*fd, false);
+}
+
 int stdio_disable_nonblock(void) {
         int ret = 0;
 

--- a/src/basic/fd-util.h
+++ b/src/basic/fd-util.h
@@ -112,6 +112,8 @@ DEFINE_TRIVIAL_CLEANUP_FUNC_FULL(DIR*, closedir, NULL);
 int fd_nonblock(int fd, bool nonblock);
 int stdio_disable_nonblock(void);
 
+void nonblock_resetp(int *fd);
+
 int fd_cloexec(int fd, bool cloexec);
 int fd_cloexec_many(const int fds[], size_t n_fds, bool cloexec);
 

--- a/src/basic/terminal-util.c
+++ b/src/basic/terminal-util.c
@@ -311,13 +311,17 @@ int ask_string_full(
          * swapping out stdin/stdout. */
         int fd_input = fileno(stdin);
         int fd_output = fileno(stdout);
+        struct termios old_termios = TERMIOS_NULL;
+        CLEANUP_TERMIOS_RESET(fd_input, old_termios);
+
         if (fd_input < 0 || fd_output < 0 || same_fd(fd_input, fd_output) <= 0)
                 goto fallback;
 
         /* Try to disable echo, which also tells us if this even is a terminal */
-        struct termios old_termios;
-        if (tcgetattr(fd_input, &old_termios) < 0)
+        if (tcgetattr(fd_input, &old_termios) < 0) {
+                old_termios = TERMIOS_NULL;
                 goto fallback;
+        }
 
         struct termios new_termios = old_termios;
         termios_disable_echo(&new_termios);
@@ -344,15 +348,13 @@ int ask_string_full(
                         if (get_completions) {
                                 r = get_completions(string, &completions, userdata);
                                 if (r < 0)
-                                        goto fail;
+                                        return r;
                         }
 
                         _cleanup_free_ char *new_string = NULL;
                         CompletionResult cr = pick_completion(string, completions, &new_string);
-                        if (cr < 0) {
-                                r = cr;
-                                goto fail;
-                        }
+                        if (cr < 0)
+                                return cr;
                         if (IN_SET(cr, COMPLETION_PARTIAL, COMPLETION_FULL)) {
                                 /* Output the new suffix we learned */
                                 fputs(ASSERT_PTR(startswith(new_string, strempty(string))), stdout);
@@ -371,10 +373,8 @@ int ask_string_full(
                                 fputc('\n', stdout);
 
                                 _cleanup_strv_free_ char **filtered = strv_filter_prefix(completions, string);
-                                if (!filtered) {
-                                        r = -ENOMEM;
-                                        goto fail;
-                                }
+                                if (!filtered)
+                                        return -ENOMEM;
 
                                 r = show_menu(filtered,
                                               /* n_columns= */ SIZE_MAX,
@@ -383,7 +383,7 @@ int ask_string_full(
                                               /* grey_prefix= */ string,
                                               /* with_numbers= */ false);
                                 if (r < 0)
-                                        goto fail;
+                                        return r;
 
                                 /* Show the prompt again */
                                 fputs(ansi_highlight(), stdout);
@@ -421,8 +421,7 @@ int ask_string_full(
                 } else if (c == 4) {
                         /* Ctrl-d → cancel this field input */
 
-                        r = -ECANCELED;
-                        goto fail;
+                        return -ECANCELED;
 
                 } else if (char_is_cc(c) || n >= LINE_MAX)
                         /* refuse control characters and too long strings */
@@ -430,10 +429,8 @@ int ask_string_full(
                 else {
                         /* Regular char */
 
-                        if (!GREEDY_REALLOC(string, n+2)) {
-                                r = -ENOMEM;
-                                goto fail;
-                        }
+                        if (!GREEDY_REALLOC(string, n+2))
+                                return -ENOMEM;
 
                         string[n++] = (char) c;
                         string[n] = 0;
@@ -444,9 +441,6 @@ int ask_string_full(
                 fflush(stdout);
         }
 
-        if (tcsetattr(fd_input, TCSANOW, &old_termios) < 0)
-                return -errno;
-
         if (!string) {
                 string = strdup("");
                 if (!string)
@@ -455,10 +449,6 @@ int ask_string_full(
 
         *ret = TAKE_PTR(string);
         return 0;
-
-fail:
-        (void) tcsetattr(fd_input, TCSANOW, &old_termios);
-        return r;
 
 fallback:
         /* A simple fallback without TTY magic */
@@ -2000,7 +1990,11 @@ int terminal_get_cursor_position(
         if (r < 0)
                 return log_debug_errno(r, "Called with distinct input/output fds: %m");
 
-        struct termios old_termios;
+        /* Failure to reset the terminal is ignored here and in similar cases below.
+         * We already have our result; if cleanup fails it doesn't change the validity of the result. */
+        struct termios old_termios = TERMIOS_NULL;
+        CLEANUP_TERMIOS_RESET(input_fd, old_termios);
+
         if (tcgetattr(input_fd, &old_termios) < 0)
                 return log_debug_errno(errno, "Failed to get terminal settings: %m");
 
@@ -2013,14 +2007,14 @@ int terminal_get_cursor_position(
         /* Request cursor position (DSR/CPR) */
         r = loop_write(output_fd, "\x1B[6n", SIZE_MAX);
         if (r < 0)
-                goto finish;
+                return r;
 
         /* Open a 2nd input fd, in non-blocking mode, so that we won't ever hang in read() should someone
          * else process the POLLIN. */
 
         nonblock_input_fd = r = fd_reopen(input_fd, O_RDONLY|O_CLOEXEC|O_NONBLOCK|O_NOCTTY);
         if (r < 0)
-                goto finish;
+                return r;
 
         usec_t end = usec_add(now(CLOCK_MONOTONIC), CONSOLE_REPLY_WAIT_USEC);
         char buf[STRLEN("\x1B[1;1R")]; /* The shortest valid reply possible */
@@ -2030,18 +2024,14 @@ int terminal_get_cursor_position(
         for (bool first = true;; first = false) {
                 if (buf_full == 0) {
                         usec_t n = now(CLOCK_MONOTONIC);
-                        if (n >= end) {
-                                r = -EOPNOTSUPP;
-                                goto finish;
-                        }
+                        if (n >= end)
+                                return -EOPNOTSUPP;
 
                         r = fd_wait_for_event(nonblock_input_fd, POLLIN, usec_sub_unsigned(end, n));
                         if (r < 0)
-                                goto finish;
-                        if (r == 0) {
-                                r = -EOPNOTSUPP;
-                                goto finish;
-                        }
+                                return r;
+                        if (r == 0)
+                                return -EOPNOTSUPP;
 
                         /* On the first try, read multiple characters, i.e. the shortest valid
                          * reply. Afterwards read byte-wise, since we don't want to read too much, and
@@ -2051,8 +2041,7 @@ int terminal_get_cursor_position(
                                 if (errno == EAGAIN)
                                         continue;
 
-                                r = -errno;
-                                goto finish;
+                                return -errno;
                         }
 
                         assert((size_t) l <= sizeof(buf));
@@ -2062,7 +2051,7 @@ int terminal_get_cursor_position(
                 size_t processed;
                 r = scan_cursor_position_response(&context, buf, buf_full, &processed);
                 if (r < 0)
-                        goto finish;
+                        return r;
 
                 assert(processed <= buf_full);
                 buf_full -= processed;
@@ -2070,26 +2059,17 @@ int terminal_get_cursor_position(
 
                 if (r > 0) {
                         /* Superficial validity check */
-                        if (context.row >= 32766 || context.column >= 32766) {
-                                r = -ENODATA;
-                                goto finish;
-                        }
+                        if (context.row >= 32766 || context.column >= 32766)
+                                return -ENODATA;
 
                         if (ret_row)
                                 *ret_row = context.row;
                         if (ret_column)
                                 *ret_column = context.column;
 
-                        r = 0;
-                        goto finish;
+                        return 0;
                 }
         }
-
-finish:
-        /* We ignore failure here and in similar cases below. We already got a reply and if cleanup fails,
-         * this doesn't change the validity of the result. */
-        (void) tcsetattr(input_fd, TCSANOW, &old_termios);
-        return r;
 }
 
 int terminal_reset_defensive(int fd, TerminalResetFlags flags) {
@@ -2129,6 +2109,23 @@ void termios_disable_echo(struct termios *termios) {
         termios->c_lflag &= ~(ICANON|ECHO);
         termios->c_cc[VMIN] = 1;
         termios->c_cc[VTIME] = 0;
+}
+
+static bool termios_is_null(const struct termios *t) {
+        if (!t)
+                return true;
+
+        return t->c_iflag == UINT_MAX &&
+               t->c_oflag == UINT_MAX &&
+               t->c_cflag == UINT_MAX &&
+               t->c_lflag == UINT_MAX;
+}
+
+void termios_reset(const TermiosResetContext *c) {
+        assert(c);
+
+        if (c->fd && *c->fd >= 0 && !termios_is_null(c->termios))
+                (void) tcsetattr(*c->fd, TCSANOW, c->termios);
 }
 
 typedef enum BackgroundColorState {
@@ -2302,7 +2299,9 @@ int get_default_background_color(double *ret_red, double *ret_green, double *ret
         if (r < 0)
                 return r;
 
-        struct termios old_termios;
+        struct termios old_termios = TERMIOS_NULL;
+        CLEANUP_TERMIOS_RESET(nonblock_input_fd, old_termios);
+
         if (tcgetattr(nonblock_input_fd, &old_termios) < 0)
                 return -errno;
 
@@ -2314,7 +2313,7 @@ int get_default_background_color(double *ret_red, double *ret_green, double *ret
 
         r = loop_write(STDOUT_FILENO, ANSI_OSC "11;?" ANSI_ST, SIZE_MAX);
         if (r < 0)
-                goto finish;
+                return r;
 
         usec_t end = usec_add(now(CLOCK_MONOTONIC), CONSOLE_REPLY_WAIT_USEC);
         char buf[STRLEN(ANSI_OSC "11;rgb:0/0/0" ANSI_ST)]; /* shortest possible reply */
@@ -2324,18 +2323,14 @@ int get_default_background_color(double *ret_red, double *ret_green, double *ret
         for (bool first = true;; first = false) {
                 if (buf_full == 0) {
                         usec_t n = now(CLOCK_MONOTONIC);
-                        if (n >= end) {
-                                r = -EOPNOTSUPP;
-                                goto finish;
-                        }
+                        if (n >= end)
+                                return -EOPNOTSUPP;
 
                         r = fd_wait_for_event(nonblock_input_fd, POLLIN, usec_sub_unsigned(end, n));
                         if (r < 0)
-                                goto finish;
-                        if (r == 0) {
-                                r = -EOPNOTSUPP;
-                                goto finish;
-                        }
+                                return r;
+                        if (r == 0)
+                                return -EOPNOTSUPP;
 
                         /* On the first try, read multiple characters, i.e. the shortest valid
                          * reply. Afterwards read byte-wise, since we don't want to read too much, and
@@ -2344,8 +2339,7 @@ int get_default_background_color(double *ret_red, double *ret_green, double *ret
                         if (l < 0) {
                                 if (errno == EAGAIN)
                                         continue;
-                                r = -errno;
-                                goto finish;
+                                return -errno;
                         }
 
                         assert((size_t) l <= sizeof(buf));
@@ -2355,7 +2349,7 @@ int get_default_background_color(double *ret_red, double *ret_green, double *ret
                 size_t processed;
                 r = scan_background_color_response(&context, buf, buf_full, &processed);
                 if (r < 0)
-                        goto finish;
+                        return r;
 
                 assert(processed <= buf_full);
                 buf_full -= processed;
@@ -2368,14 +2362,9 @@ int get_default_background_color(double *ret_red, double *ret_green, double *ret
                         *ret_green = (double) context.green / ((UINT64_C(1) << context.green_bits) - 1);
                         assert(context.blue_bits > 0);
                         *ret_blue = (double) context.blue / ((UINT64_C(1) << context.blue_bits) - 1);
-                        r = 0;
-                        goto finish;
+                        return 0;
                 }
         }
-
-finish:
-        (void) tcsetattr(nonblock_input_fd, TCSANOW, &old_termios);
-        return r;
 }
 
 int terminal_get_size_by_dsr(
@@ -2412,7 +2401,9 @@ int terminal_get_size_by_dsr(
         if (r < 0)
                 return r;
 
-        struct termios old_termios;
+        struct termios old_termios = TERMIOS_NULL;
+        CLEANUP_TERMIOS_RESET(nonblock_input_fd, old_termios);
+
         if (tcgetattr(nonblock_input_fd, &old_termios) < 0)
                 return log_debug_errno(errno, "Failed to get terminal settings: %m");
 
@@ -2523,7 +2514,6 @@ finish:
         /* Restore cursor position */
         if (saved_row > 0 && saved_column > 0)
                 (void) terminal_set_cursor_position(output_fd, saved_row, saved_column);
-        (void) tcsetattr(nonblock_input_fd, TCSANOW, &old_termios);
 
         return r;
 }
@@ -2589,7 +2579,9 @@ int terminal_get_size_by_csi18(
         if (r < 0)
                 return r;
 
-        struct termios old_termios;
+        struct termios old_termios = TERMIOS_NULL;
+        CLEANUP_TERMIOS_RESET(nonblock_input_fd, old_termios);
+
         if (tcgetattr(nonblock_input_fd, &old_termios) < 0)
                 return log_debug_errno(errno, "Failed to get terminal settings: %m");
 
@@ -2601,7 +2593,7 @@ int terminal_get_size_by_csi18(
 
         r = loop_write(output_fd, CSI18_Q, SIZE_MAX);
         if (r < 0)
-                goto finish;
+                return r;
 
         usec_t end = usec_add(now(CLOCK_MONOTONIC), CONSOLE_REPLY_WAIT_USEC);
         char buf[STRLEN(CSI18_R1)];
@@ -2609,18 +2601,14 @@ int terminal_get_size_by_csi18(
 
         for (;;) {
                 usec_t n = now(CLOCK_MONOTONIC);
-                if (n >= end) {
-                        r = -EOPNOTSUPP;
-                        break;
-                }
+                if (n >= end)
+                        return -EOPNOTSUPP;
 
                 r = fd_wait_for_event(nonblock_input_fd, POLLIN, usec_sub_unsigned(end, n));
                 if (r < 0)
-                        break;
-                if (r == 0) {
-                        r = -EOPNOTSUPP;
-                        break;
-                }
+                        return r;
+                if (r == 0)
+                        return -EOPNOTSUPP;
 
                 /* On the first read, read multiple characters, i.e. the shortest valid reply. Afterwards
                  * read byte by byte, since we don't want to read too much and drop characters from the input
@@ -2629,8 +2617,7 @@ int terminal_get_size_by_csi18(
                 if (l < 0) {
                         if (errno == EAGAIN)
                                 continue;
-                        r = -errno;
-                        break;
+                        return -errno;
                 }
 
                 assert((size_t) l <= sizeof(buf) - bytes);
@@ -2638,20 +2625,14 @@ int terminal_get_size_by_csi18(
 
                 r = scan_text_area_size_response(buf, bytes, ret_rows, ret_columns);
                 if (r != -EAGAIN)
-                        break;
+                        return r;
 
-                if (bytes == sizeof(buf)) {
-                        r = -EOPNOTSUPP; /* The response has the right prefix, but we didn't find a valid
-                                          * answer with a terminator in the allotted space. Something is
-                                          * wrong, possibly some unrelated bytes got injected into the
-                                          * answer. */
-                        break;
-                }
+                if (bytes == sizeof(buf))
+                        return -EOPNOTSUPP; /* The response has the right prefix, but we didn't find a valid
+                                             * answer with a terminator in the allotted space. Something is
+                                             * wrong, possibly some unrelated bytes got injected into the
+                                             * answer. */
         }
-
-finish:
-        (void) tcsetattr(nonblock_input_fd, TCSANOW, &old_termios);
-        return r;
 }
 
 int terminal_fix_size(int input_fd, int output_fd) {
@@ -2752,7 +2733,9 @@ int terminal_get_terminfo_by_dcs(int fd, char **ret_name) {
 
         /* Note: fd must be in non-blocking read-write mode! */
 
-        struct termios old_termios;
+        struct termios old_termios = TERMIOS_NULL;
+        CLEANUP_TERMIOS_RESET(fd, old_termios);
+
         if (tcgetattr(fd, &old_termios) < 0)
                 return -errno;
 
@@ -2764,7 +2747,7 @@ int terminal_get_terminfo_by_dcs(int fd, char **ret_name) {
 
         r = loop_write(fd, DCS_TERMINFO_Q, SIZE_MAX);
         if (r < 0)
-                goto finish;
+                return r;
 
         usec_t end = usec_add(now(CLOCK_MONOTONIC), CONSOLE_REPLY_WAIT_USEC);
         char buf[STRLEN(DCS_TERMINFO_R1) + MAX_TERMINFO_LENGTH + STRLEN(ANSI_ST)];
@@ -2772,18 +2755,14 @@ int terminal_get_terminfo_by_dcs(int fd, char **ret_name) {
 
         for (;;) {
                 usec_t n = now(CLOCK_MONOTONIC);
-                if (n >= end) {
-                        r = -EOPNOTSUPP;
-                        break;
-                }
+                if (n >= end)
+                        return -EOPNOTSUPP;
 
                 r = fd_wait_for_event(fd, POLLIN, usec_sub_unsigned(end, n));
                 if (r < 0)
-                        break;
-                if (r == 0) {
-                        r = -EOPNOTSUPP;
-                        break;
-                }
+                        return r;
+                if (r == 0)
+                        return -EOPNOTSUPP;
 
                 /* On the first read, read multiple characters, i.e. the shortest valid reply. Afterwards
                  * read byte by byte, since we don't want to read too much and drop characters from the input
@@ -2792,8 +2771,7 @@ int terminal_get_terminfo_by_dcs(int fd, char **ret_name) {
                 if (l < 0) {
                         if (errno == EAGAIN)
                                 continue;
-                        r = -errno;
-                        break;
+                        return -errno;
                 }
 
                 assert((size_t) l <= sizeof(buf) - bytes);
@@ -2801,20 +2779,14 @@ int terminal_get_terminfo_by_dcs(int fd, char **ret_name) {
 
                 r = scan_terminfo_response(buf, bytes, ret_name);
                 if (r != -EAGAIN)
-                        break;
+                        return r;
 
-                if (bytes == sizeof(buf)) {
-                        r = -EOPNOTSUPP; /* The response has the right prefix, but we didn't find a valid
-                                          * answer with a terminator in the allotted space. Something is
-                                          * wrong, possibly some unrelated bytes got injected into the
-                                          * answer. */
-                        break;
-                }
+                if (bytes == sizeof(buf))
+                        return -EOPNOTSUPP; /* The response has the right prefix, but we didn't find a valid
+                                             * answer with a terminator in the allotted space. Something is
+                                             * wrong, possibly some unrelated bytes got injected into the
+                                             * answer. */
         }
-
-finish:
-        (void) tcsetattr(fd, TCSANOW, &old_termios);
-        return r;
 }
 
 int have_terminfo_file(const char *name) {

--- a/src/basic/terminal-util.c
+++ b/src/basic/terminal-util.c
@@ -44,8 +44,8 @@
 #include "time-util.h"
 #include "utf8.h"
 
-/* How much to wait for a reply to a terminal sequence */
-#define CONSOLE_REPLY_WAIT_USEC  (333 * USEC_PER_MSEC)
+/* How much to wait when reading/writing ANSI sequences from/to the console */
+#define CONSOLE_ANSI_SEQUENCE_TIMEOUT_USEC (333 * USEC_PER_MSEC)
 
 static volatile unsigned cached_columns = 0;
 static volatile unsigned cached_lines = 0;
@@ -853,7 +853,7 @@ int vt_disallocate(const char *tty_path) {
                                "\033[3J"  /* clear screen including scrollback, requires Linux 2.6.40 */
                                "\033c",   /* reset to initial state */
                                SIZE_MAX,
-                               100 * USEC_PER_MSEC);
+                               CONSOLE_ANSI_SEQUENCE_TIMEOUT_USEC);
 }
 
 static int vt_default_utf8(void) {
@@ -952,7 +952,8 @@ finish:
 }
 
 int terminal_reset_ansi_seq(int fd) {
-        int r, k;
+        _cleanup_(nonblock_resetp) int nonblock_reset = -EBADF;
+        int r;
 
         assert(fd >= 0);
 
@@ -962,8 +963,10 @@ int terminal_reset_ansi_seq(int fd) {
         r = fd_nonblock(fd, true);
         if (r < 0)
                 return log_debug_errno(r, "Failed to set terminal to non-blocking mode: %m");
+        if (r > 0)
+                nonblock_reset = fd;
 
-        k = loop_write_full(fd,
+        r = loop_write_full(fd,
                             "\033[!p"              /* soft terminal reset */
                             ANSI_OSC "104" ANSI_ST /* reset color palette via OSC 104 */
                             ANSI_NORMAL            /* reset colors */
@@ -971,17 +974,11 @@ int terminal_reset_ansi_seq(int fd) {
                             "\033[1G"              /* place cursor at beginning of current line */
                             "\033[0J",             /* erase till end of screen */
                             SIZE_MAX,
-                            100 * USEC_PER_MSEC);
-        if (k < 0)
-                log_debug_errno(k, "Failed to reset terminal through ANSI sequences: %m");
+                            CONSOLE_ANSI_SEQUENCE_TIMEOUT_USEC);
+        if (r < 0)
+                log_debug_errno(r, "Failed to reset terminal through ANSI sequences: %m");
 
-        if (r > 0) {
-                r = fd_nonblock(fd, false);
-                if (r < 0)
-                        log_debug_errno(r, "Failed to set terminal back to blocking mode: %m");
-        }
-
-        return k < 0 ? k : r;
+        return r;
 }
 
 void reset_dev_console_fd(int fd, bool switch_to_text) {
@@ -2016,7 +2013,7 @@ int terminal_get_cursor_position(
         if (r < 0)
                 return r;
 
-        usec_t end = usec_add(now(CLOCK_MONOTONIC), CONSOLE_REPLY_WAIT_USEC);
+        usec_t end = usec_add(now(CLOCK_MONOTONIC), CONSOLE_ANSI_SEQUENCE_TIMEOUT_USEC);
         char buf[STRLEN("\x1B[1;1R")]; /* The shortest valid reply possible */
         size_t buf_full = 0;
         CursorPositionContext context = {};
@@ -2315,7 +2312,7 @@ int get_default_background_color(double *ret_red, double *ret_green, double *ret
         if (r < 0)
                 return r;
 
-        usec_t end = usec_add(now(CLOCK_MONOTONIC), CONSOLE_REPLY_WAIT_USEC);
+        usec_t end = usec_add(now(CLOCK_MONOTONIC), CONSOLE_ANSI_SEQUENCE_TIMEOUT_USEC);
         char buf[STRLEN(ANSI_OSC "11;rgb:0/0/0" ANSI_ST)]; /* shortest possible reply */
         size_t buf_full = 0;
         BackgroundColorContext context = {};
@@ -2386,16 +2383,17 @@ static int terminal_query_size_by_dsr(
 
         /* Use DECSC/DECRC to save/restore cursor instead of querying position via DSR. This way the cursor
          * is always restored — even on timeout — and we only need one DSR response instead of two. */
-        r = loop_write(output_fd,
-                       "\x1B" "7"              /* DECSC: save cursor position */
-                       "\x1B[32766;32766H"     /* CUP: position cursor far to the right and to the bottom, staying within 16bit signed range */
-                       "\x1B[6n"               /* DSR: request cursor position (CPR) */
-                       "\x1B" "8",             /* DECRC: restore cursor position */
-                       SIZE_MAX);
+        r = loop_write_full(output_fd,
+                            "\x1B" "7"              /* DECSC: save cursor position */
+                            "\x1B[32766;32766H"     /* CUP: position cursor far to the right and to the bottom, staying within 16bit signed range */
+                            "\x1B[6n"               /* DSR: request cursor position (CPR) */
+                            "\x1B" "8",             /* DECRC: restore cursor position */
+                            SIZE_MAX,
+                            CONSOLE_ANSI_SEQUENCE_TIMEOUT_USEC);
         if (r < 0)
                 return r;
 
-        usec_t end = usec_add(now(CLOCK_MONOTONIC), CONSOLE_REPLY_WAIT_USEC);
+        usec_t end = usec_add(now(CLOCK_MONOTONIC), CONSOLE_ANSI_SEQUENCE_TIMEOUT_USEC);
         char buf[STRLEN("\x1B[1;1R")]; /* The shortest valid reply possible */
         size_t buf_full = 0;
         CursorPositionContext context = {};
@@ -2543,11 +2541,11 @@ static int terminal_query_size_by_csi18(
         assert(nonblock_input_fd >= 0);
         assert(output_fd >= 0);
 
-        r = loop_write(output_fd, CSI18_Q, SIZE_MAX);
+        r = loop_write_full(output_fd, CSI18_Q, SIZE_MAX, CONSOLE_ANSI_SEQUENCE_TIMEOUT_USEC);
         if (r < 0)
                 return r;
 
-        usec_t end = usec_add(now(CLOCK_MONOTONIC), CONSOLE_REPLY_WAIT_USEC);
+        usec_t end = usec_add(now(CLOCK_MONOTONIC), CONSOLE_ANSI_SEQUENCE_TIMEOUT_USEC);
         char buf[STRLEN(CSI18_R1)];
         size_t bytes = 0;
 
@@ -2598,6 +2596,7 @@ int terminal_get_size(
         _cleanup_close_ int nonblock_input_fd = -EBADF;
         struct termios old_termios = TERMIOS_NULL;
         CLEANUP_TERMIOS_RESET(nonblock_input_fd, old_termios);
+        _cleanup_(nonblock_resetp) int nonblock_reset = -EBADF;
         int r;
 
         assert(try_dsr || try_csi18);
@@ -2605,6 +2604,14 @@ int terminal_get_size(
         r = terminal_prepare_query(input_fd, output_fd, &nonblock_input_fd, &old_termios);
         if (r < 0)
                 return r;
+
+        /* Put the output fd in non-blocking mode with a write timeout, to avoid blocking indefinitely on
+         * write if the terminal is not consuming data (e.g. serial console with flow control). */
+        r = fd_nonblock(output_fd, true);
+        if (r < 0)
+                return log_debug_errno(r, "Failed to set terminal to non-blocking mode: %m");
+        if (r > 0)
+                nonblock_reset = output_fd;
 
         /* Flush any stale input that might confuse the response parsers. */
         (void) tcflush(nonblock_input_fd, TCIFLUSH);
@@ -2731,7 +2738,7 @@ int terminal_get_terminfo_by_dcs(int fd, char **ret_name) {
         if (r < 0)
                 return r;
 
-        usec_t end = usec_add(now(CLOCK_MONOTONIC), CONSOLE_REPLY_WAIT_USEC);
+        usec_t end = usec_add(now(CLOCK_MONOTONIC), CONSOLE_ANSI_SEQUENCE_TIMEOUT_USEC);
         char buf[STRLEN(DCS_TERMINFO_R1) + MAX_TERMINFO_LENGTH + STRLEN(ANSI_ST)];
         size_t bytes = 0;
 

--- a/src/basic/terminal-util.c
+++ b/src/basic/terminal-util.c
@@ -2367,26 +2367,105 @@ int get_default_background_color(double *ret_red, double *ret_green, double *ret
         }
 }
 
-int terminal_get_size_by_dsr(
-                int input_fd,
+/* Determine terminal dimensions by means of ANSI sequences: save the cursor via DECSC, position it far
+ * to the bottom right (clamped to actual terminal dimensions), read back via DSR where we ended up, and
+ * restore cursor via DECRC. Only needs a single DSR round-trip, and always restores the cursor regardless
+ * of whether the response is received.
+ *
+ * Caller must have already opened a non-blocking input fd and configured termios (echo/icanon off). */
+static int terminal_query_size_by_dsr(
+                int nonblock_input_fd,
                 int output_fd,
                 unsigned *ret_rows,
                 unsigned *ret_columns) {
 
         int r;
 
-        assert(input_fd >= 0);
+        assert(nonblock_input_fd >= 0);
         assert(output_fd >= 0);
 
-        /* Tries to determine the terminal dimension by means of ANSI sequences.
-         *
-         * We position the cursor briefly at an absolute location very far down and very far to the right,
-         * and then read back where we actually ended up. Because cursor locations are capped at the terminal
-         * width/height we should then see the right values. In order to not risk integer overflows in
-         * terminal applications we'll use INT16_MAX-1 as location to jump to — hopefully a value that is
-         * large enough for any real-life terminals, but small enough to not overflow anything or be
-         * recognized as a "niche" value. (Note that the dimension fields in "struct winsize" are 16bit only,
-         * too). */
+        /* Use DECSC/DECRC to save/restore cursor instead of querying position via DSR. This way the cursor
+         * is always restored — even on timeout — and we only need one DSR response instead of two. */
+        r = loop_write(output_fd,
+                       "\x1B" "7"              /* DECSC: save cursor position */
+                       "\x1B[32766;32766H"     /* CUP: position cursor far to the right and to the bottom, staying within 16bit signed range */
+                       "\x1B[6n"               /* DSR: request cursor position (CPR) */
+                       "\x1B" "8",             /* DECRC: restore cursor position */
+                       SIZE_MAX);
+        if (r < 0)
+                return r;
+
+        usec_t end = usec_add(now(CLOCK_MONOTONIC), CONSOLE_REPLY_WAIT_USEC);
+        char buf[STRLEN("\x1B[1;1R")]; /* The shortest valid reply possible */
+        size_t buf_full = 0;
+        CursorPositionContext context = {};
+
+        for (bool first = true;; first = false) {
+                if (buf_full == 0) {
+                        usec_t n = now(CLOCK_MONOTONIC);
+                        if (n >= end)
+                                return -EOPNOTSUPP;
+
+                        r = fd_wait_for_event(nonblock_input_fd, POLLIN, usec_sub_unsigned(end, n));
+                        if (r < 0)
+                                return r;
+                        if (r == 0)
+                                return -EOPNOTSUPP;
+
+                        /* On the first try, read multiple characters, i.e. the shortest valid
+                         * reply. Afterwards read byte-wise, since we don't want to read too much, and
+                         * unnecessarily drop too many characters from the input queue. */
+                        ssize_t l = read(nonblock_input_fd, buf, first ? sizeof(buf) : 1);
+                        if (l < 0) {
+                                if (errno == EAGAIN)
+                                        continue;
+
+                                return -errno;
+                        }
+
+                        assert((size_t) l <= sizeof(buf));
+                        buf_full = l;
+                }
+
+                size_t processed;
+                r = scan_cursor_position_response(&context, buf, buf_full, &processed);
+                if (r < 0)
+                        return r;
+
+                assert(processed <= buf_full);
+                buf_full -= processed;
+                memmove(buf, buf + processed, buf_full);
+
+                if (r > 0) {
+                        /* Superficial validity checks (no particular reason to check for < 4, it's
+                         * just a way to look for unreasonably small values) */
+                        if (context.row < 4 || context.column < 4 || context.row >= 32766 || context.column >= 32766)
+                                return -ENODATA;
+
+                        if (ret_rows)
+                                *ret_rows = context.row;
+                        if (ret_columns)
+                                *ret_columns = context.column;
+
+                        return 0;
+                }
+        }
+}
+
+/* Common setup for ANSI terminal queries: validate the fds, open a non-blocking input fd, and configure
+ * termios with echo and canonical mode disabled. Caller must restore termios and close the fd when done. */
+static int terminal_prepare_query(
+                int input_fd,
+                int output_fd,
+                int *ret_nonblock_fd,
+                struct termios *ret_saved_termios) {
+
+        int r;
+
+        assert(input_fd >= 0);
+        assert(output_fd >= 0);
+        assert(ret_nonblock_fd);
+        assert(ret_saved_termios);
 
         if (terminal_is_dumb())
                 return -EOPNOTSUPP;
@@ -2401,121 +2480,17 @@ int terminal_get_size_by_dsr(
         if (r < 0)
                 return r;
 
-        struct termios old_termios = TERMIOS_NULL;
-        CLEANUP_TERMIOS_RESET(nonblock_input_fd, old_termios);
-
-        if (tcgetattr(nonblock_input_fd, &old_termios) < 0)
+        if (tcgetattr(nonblock_input_fd, ret_saved_termios) < 0)
                 return log_debug_errno(errno, "Failed to get terminal settings: %m");
 
-        struct termios new_termios = old_termios;
+        struct termios new_termios = *ret_saved_termios;
         termios_disable_echo(&new_termios);
 
         if (tcsetattr(nonblock_input_fd, TCSANOW, &new_termios) < 0)
                 return log_debug_errno(errno, "Failed to set new terminal settings: %m");
 
-        unsigned saved_row = 0, saved_column = 0;
-
-        r = loop_write(output_fd,
-                       "\x1B[6n"           /* Request cursor position (DSR/CPR) */
-                       "\x1B[32766;32766H" /* Position cursor really far to the right and to the bottom, but let's stay within the 16bit signed range */
-                       "\x1B[6n",          /* Request cursor position again */
-                       SIZE_MAX);
-        if (r < 0)
-                goto finish;
-
-        usec_t end = usec_add(now(CLOCK_MONOTONIC), CONSOLE_REPLY_WAIT_USEC);
-        char buf[STRLEN("\x1B[1;1R")]; /* The shortest valid reply possible */
-        size_t buf_full = 0;
-        CursorPositionContext context = {};
-
-        for (bool first = true;; first = false) {
-                if (buf_full == 0) {
-                        usec_t n = now(CLOCK_MONOTONIC);
-                        if (n >= end) {
-                                r = -EOPNOTSUPP;
-                                goto finish;
-                        }
-
-                        r = fd_wait_for_event(nonblock_input_fd, POLLIN, usec_sub_unsigned(end, n));
-                        if (r < 0)
-                                goto finish;
-                        if (r == 0) {
-                                r = -EOPNOTSUPP;
-                                goto finish;
-                        }
-
-                        /* On the first try, read multiple characters, i.e. the shortest valid
-                         * reply. Afterwards read byte-wise, since we don't want to read too much, and
-                         * unnecessarily drop too many characters from the input queue. */
-                        ssize_t l = read(nonblock_input_fd, buf, first ? sizeof(buf) : 1);
-                        if (l < 0) {
-                                if (errno == EAGAIN)
-                                        continue;
-
-                                r = -errno;
-                                goto finish;
-                        }
-
-                        assert((size_t) l <= sizeof(buf));
-                        buf_full = l;
-                }
-
-                size_t processed;
-                r = scan_cursor_position_response(&context, buf, buf_full, &processed);
-                if (r < 0)
-                        goto finish;
-
-                assert(processed <= buf_full);
-                buf_full -= processed;
-                memmove(buf, buf + processed, buf_full);
-
-                if (r > 0) {
-                        if (saved_row == 0) {
-                                assert(saved_column == 0);
-
-                                /* First sequence, this is the cursor position before we set it somewhere
-                                 * into the void at the bottom right. Let's save where we are so that we can
-                                 * return later. */
-
-                                /* Superficial validity checks */
-                                if (context.row <= 0 || context.column <= 0 || context.row >= 32766 || context.column >= 32766) {
-                                        r = -ENODATA;
-                                        goto finish;
-                                }
-
-                                saved_row = context.row;
-                                saved_column = context.column;
-
-                                /* Reset state */
-                                context = (CursorPositionContext) {};
-                        } else {
-                                /* Second sequence, this is the cursor position after we set it somewhere
-                                 * into the void at the bottom right. */
-
-                                /* Superficial validity checks (no particular reason to check for < 4, it's
-                                 * just a way to look for unreasonably small values) */
-                                if (context.row < 4 || context.column < 4 || context.row >= 32766 || context.column >= 32766) {
-                                        r = -ENODATA;
-                                        goto finish;
-                                }
-
-                                if (ret_rows)
-                                        *ret_rows = context.row;
-                                if (ret_columns)
-                                        *ret_columns = context.column;
-
-                                r = 0;
-                                goto finish;
-                        }
-                }
-        }
-
-finish:
-        /* Restore cursor position */
-        if (saved_row > 0 && saved_column > 0)
-                (void) terminal_set_cursor_position(output_fd, saved_row, saved_column);
-
-        return r;
+        *ret_nonblock_fd = TAKE_FD(nonblock_input_fd);
+        return 0;
 }
 
 /*
@@ -2554,42 +2529,19 @@ static int scan_text_area_size_response(
         return 0;
 }
 
-int terminal_get_size_by_csi18(
-                int input_fd,
+/* Determine terminal dimensions by means of an ANSI CSI 18 sequence.
+ *
+ * Caller must have already opened a non-blocking input fd and configured termios (echo/icanon off). */
+static int terminal_query_size_by_csi18(
+                int nonblock_input_fd,
                 int output_fd,
                 unsigned *ret_rows,
                 unsigned *ret_columns) {
+
         int r;
 
-        assert(input_fd >= 0);
+        assert(nonblock_input_fd >= 0);
         assert(output_fd >= 0);
-
-        /* Tries to determine the terminal dimension by means of an ANSI sequence CSI 18. */
-
-        if (terminal_is_dumb())
-                return -EOPNOTSUPP;
-
-        r = terminal_verify_same(input_fd, output_fd);
-        if (r < 0)
-                return log_debug_errno(r, "Called with distinct input/output fds: %m");
-
-        /* Open a 2nd input fd, in non-blocking mode, so that we won't ever hang in read()
-         * should someone else process the POLLIN. Do all subsequent operations on the new fd. */
-        _cleanup_close_ int nonblock_input_fd = r = fd_reopen(input_fd, O_RDONLY|O_CLOEXEC|O_NONBLOCK|O_NOCTTY);
-        if (r < 0)
-                return r;
-
-        struct termios old_termios = TERMIOS_NULL;
-        CLEANUP_TERMIOS_RESET(nonblock_input_fd, old_termios);
-
-        if (tcgetattr(nonblock_input_fd, &old_termios) < 0)
-                return log_debug_errno(errno, "Failed to get terminal settings: %m");
-
-        struct termios new_termios = old_termios;
-        termios_disable_echo(&new_termios);
-
-        if (tcsetattr(nonblock_input_fd, TCSANOW, &new_termios) < 0)
-                return log_debug_errno(errno, "Failed to set new terminal settings: %m");
 
         r = loop_write(output_fd, CSI18_Q, SIZE_MAX);
         if (r < 0)
@@ -2635,6 +2587,44 @@ int terminal_get_size_by_csi18(
         }
 }
 
+int terminal_get_size(
+                int input_fd,
+                int output_fd,
+                unsigned *ret_rows,
+                unsigned *ret_columns,
+                bool try_dsr,
+                bool try_csi18) {
+
+        _cleanup_close_ int nonblock_input_fd = -EBADF;
+        struct termios old_termios = TERMIOS_NULL;
+        CLEANUP_TERMIOS_RESET(nonblock_input_fd, old_termios);
+        int r;
+
+        assert(try_dsr || try_csi18);
+
+        r = terminal_prepare_query(input_fd, output_fd, &nonblock_input_fd, &old_termios);
+        if (r < 0)
+                return r;
+
+        /* Flush any stale input that might confuse the response parsers. */
+        (void) tcflush(nonblock_input_fd, TCIFLUSH);
+
+        if (try_csi18) {
+                r = terminal_query_size_by_csi18(nonblock_input_fd, output_fd, ret_rows, ret_columns);
+                if (!IN_SET(r, -EOPNOTSUPP, -EINVAL) || !try_dsr)
+                        return r;
+
+                /* CSI 18 query failed. Flush input before trying the DSR fallback — a late CSI 18 response
+                 * may have landed in the input queue and would confuse the DSR response parser. */
+                (void) tcflush(nonblock_input_fd, TCIFLUSH);
+        }
+
+        if (try_dsr)
+                r = terminal_query_size_by_dsr(nonblock_input_fd, output_fd, ret_rows, ret_columns);
+
+        return r;
+}
+
 int terminal_fix_size(int input_fd, int output_fd) {
         unsigned rows, columns;
         int r;
@@ -2646,20 +2636,12 @@ int terminal_fix_size(int input_fd, int output_fd) {
          * sequences are interpreted by the final terminal instead of an intermediary tty driver they should
          * be more accurate.
          */
-        r = terminal_verify_same(input_fd, output_fd);
-        if (r < 0)
-                return r;
 
         struct winsize ws = {};
         if (ioctl(output_fd, TIOCGWINSZ, &ws) < 0)
                 return log_debug_errno(errno, "Failed to query terminal dimensions, ignoring: %m");
 
-        r = terminal_get_size_by_csi18(input_fd, output_fd, &rows, &columns);
-        if (IN_SET(r, -EOPNOTSUPP, -EINVAL))
-                /* We get -EOPNOTSUPP if the query fails and -EINVAL when the received answer is invalid.
-                 * Try the fallback method. It is more involved and moves the cursor, but seems to have wider
-                 * support. */
-                r = terminal_get_size_by_dsr(input_fd, output_fd, &rows, &columns);
+        r = terminal_get_size(input_fd, output_fd, &rows, &columns, /* try_dsr= */ true, /* try_csi18= */ true);
         if (r < 0)
                 return log_debug_errno(r, "Failed to acquire terminal dimensions via ANSI sequences, not adjusting terminal dimensions: %m");
 

--- a/src/basic/terminal-util.h
+++ b/src/basic/terminal-util.h
@@ -145,6 +145,29 @@ assert_cc((TTY_MODE & 0711) == 0600);
 
 void termios_disable_echo(struct termios *termios);
 
+/* A termios sentinel with all flag fields set to all-ones-bits. No real tcgetattr() result will ever
+ * match this because the multi-bit sub-fields (CSIZE, CBAUD, …) can't validly have every bit set. */
+#define TERMIOS_NULL (struct termios) {         \
+        .c_iflag = UINT_MAX,                    \
+        .c_oflag = UINT_MAX,                    \
+        .c_cflag = UINT_MAX,                    \
+        .c_lflag = UINT_MAX,                    \
+}
+
+typedef struct TermiosResetContext {
+        int *fd;
+        struct termios *termios;
+} TermiosResetContext;
+
+void termios_reset(const TermiosResetContext *c);
+
+#define CLEANUP_TERMIOS_RESET(_fd, _termios)                                   \
+        _cleanup_(termios_reset) _unused_ const TermiosResetContext            \
+                CONCATENATE(_cleanup_termios_, UNIQ) = {                       \
+                        .fd = &(_fd),                                          \
+                        .termios = &(_termios),                                \
+                }
+
 /* The $TERM value we use for terminals other than the Linux console */
 #define FALLBACK_TERM "vt220"
 

--- a/src/basic/terminal-util.h
+++ b/src/basic/terminal-util.h
@@ -146,7 +146,7 @@ assert_cc((TTY_MODE & 0711) == 0600);
 void termios_disable_echo(struct termios *termios);
 
 /* A termios sentinel with all flag fields set to all-ones-bits. No real tcgetattr() result will ever
- * match this because the multi-bit sub-fields (CSIZE, CBAUD, …) can't validly have every bit set. */
+ * match this because no real terminal configuration uses all-ones in every flag field simultaneously. */
 #define TERMIOS_NULL (struct termios) {         \
         .c_iflag = UINT_MAX,                    \
         .c_oflag = UINT_MAX,                    \
@@ -172,8 +172,7 @@ void termios_reset(const TermiosResetContext *c);
 #define FALLBACK_TERM "vt220"
 
 int get_default_background_color(double *ret_red, double *ret_green, double *ret_blue);
-int terminal_get_size_by_dsr(int input_fd, int output_fd, unsigned *ret_rows, unsigned *ret_columns);
-int terminal_get_size_by_csi18(int input_fd, int output_fd, unsigned *ret_rows, unsigned *ret_columns);
+int terminal_get_size(int input_fd, int output_fd, unsigned *ret_rows, unsigned *ret_columns, bool try_dsr, bool try_csi18);
 int terminal_fix_size(int input_fd, int output_fd);
 
 int terminal_get_terminfo_by_dcs(int fd, char **ret_name);

--- a/src/core/execute.c
+++ b/src/core/execute.c
@@ -113,7 +113,7 @@ int exec_context_apply_tty_size(
         if (rows == UINT_MAX && cols == UINT_MAX &&
             exec_context_shall_ansi_seq_reset(context) &&
             isatty_safe(input_fd)) {
-                r = terminal_get_size_by_dsr(input_fd, output_fd, &rows, &cols);
+                r = terminal_get_size(input_fd, output_fd, &rows, &cols, /* try_dsr= */ true, /* try_csi18= */ false);
                 if (r < 0)
                         log_debug_errno(r, "Failed to get terminal size by DSR, ignoring: %m");
         }

--- a/src/test/test-terminal-util.c
+++ b/src/test/test-terminal-util.c
@@ -175,12 +175,12 @@ TEST(get_default_background_color) {
                 log_notice("R=%g G=%g B=%g", red, green, blue);
 }
 
-TEST(terminal_get_size_by_csi18) {
+TEST(terminal_get_size_csi18) {
         unsigned rows, columns;
         int r;
 
         usec_t n = now(CLOCK_MONOTONIC);
-        r = terminal_get_size_by_csi18(STDIN_FILENO, STDOUT_FILENO, &rows, &columns);
+        r = terminal_get_size(STDIN_FILENO, STDOUT_FILENO, &rows, &columns, /* try_dsr= */ false, /* try_csi18= */ true);
         log_info("%s took %s", __func__+5,
                  FORMAT_TIMESPAN(usec_sub_unsigned(now(CLOCK_MONOTONIC), n), USEC_PER_MSEC));
         if (r < 0)
@@ -196,12 +196,12 @@ TEST(terminal_get_size_by_csi18) {
                 log_notice("terminal size via ioctl: rows=%u columns=%u", ws.ws_row, ws.ws_col);
 }
 
-TEST(terminal_get_size_by_dsr) {
+TEST(terminal_get_size_dsr) {
         unsigned rows, columns;
         int r;
 
         usec_t n = now(CLOCK_MONOTONIC);
-        r = terminal_get_size_by_dsr(STDIN_FILENO, STDOUT_FILENO, &rows, &columns);
+        r = terminal_get_size(STDIN_FILENO, STDOUT_FILENO, &rows, &columns, /* try_dsr= */ true, /* try_csi18= */ false);
         log_info("%s took %s", __func__+5,
                  FORMAT_TIMESPAN(usec_sub_unsigned(now(CLOCK_MONOTONIC), n), USEC_PER_MSEC));
         if (r < 0)


### PR DESCRIPTION
This backports #41401 to v260-stable. These changes are intended to fix hangs on boot, which definitely seems like something we want to fix in stable releases.