### PR TITLE
dissect-image: Drop blkid_probe_filter_superblocks_usage() call from probe_blkid_filter()

### DIFF
--- a/src/shared/dissect-image.c
+++ b/src/shared/dissect-image.c
@@ -207,10 +207,11 @@ static int probe_blkid_filter(blkid_probe p) {
         if (r != 0)
                 return errno_or_else(EINVAL);
 
-        errno = 0;
-        r = sym_blkid_probe_filter_superblocks_usage(p, BLKID_FLTR_NOTIN, BLKID_USAGE_RAID);
-        if (r != 0)
-                return errno_or_else(EINVAL);
+        /* Note: don't call blkid_probe_filter_superblocks_usage() here. Both filter functions share the
+         * same bitmap internally, and each call resets it before applying its own filter — so a subsequent
+         * usage filter would wipe the type filter we just set. The ONLYIN type filter above already
+         * excludes everything not in the allowed list, including RAID superblocks, so a separate usage
+         * filter is redundant anyway. */
 
         return 0;
 }

--- a/src/shared/dissect-image.c
+++ b/src/shared/dissect-image.c
@@ -195,6 +195,13 @@ static int probe_blkid_filter(blkid_probe p) {
         if (r < 0)
                 return r;
 
+        /* allowed_fstypes() returns the list of filesystem types that we are willing to mount. For the
+         * blkid probe filter we additionally need to be able to detect crypto_LUKS (so that we can set up
+         * LUKS decryption for encrypted partitions) and swap (so that we can identify swap partitions). */
+        r = strv_extend_many(&fstypes, "crypto_LUKS", "swap");
+        if (r < 0)
+                return r;
+
         errno = 0;
         r = sym_blkid_probe_filter_superblocks_type(p, BLKID_FLTR_ONLYIN, fstypes);
         if (r != 0)

--- a/test/units/TEST-50-DISSECT.dissect.sh
+++ b/test/units/TEST-50-DISSECT.dissect.sh
@@ -1203,6 +1203,47 @@ systemd-sysext unmerge
 systemctl status foo.service 2>&1 | grep -v -F "Warning" >/dev/null
 rm /var/lib/extensions/app-reload.raw
 
+# Test that GPT images with an ISO9660 El Torito boot catalog are dissected correctly. The blkid
+# superblock filter must prevent the iso9660 superblock from being detected, so dissection proceeds via
+# the GPT partition table rather than treating the whole image as a single iso9660 filesystem.
+defs="$(mktemp --directory "$IMAGE_DIR/test-50-dissect-eltorito.defs.XXXXXXXXXX")"
+imgs="$(mktemp --directory "$IMAGE_DIR/test-50-dissect-eltorito.imgs.XXXXXXXXXX")"
+
+tee "$defs/00-esp.conf" <<EOF
+[Partition]
+Type=esp
+Format=vfat
+SizeMinBytes=100M
+SizeMaxBytes=100M
+EOF
+
+tee "$defs/10-root.conf" <<EOF
+[Partition]
+Type=root
+Format=ext4
+SizeMinBytes=100M
+SizeMaxBytes=100M
+EOF
+
+systemd-repart --pretty=yes \
+               --definitions="$defs" \
+               --empty=create \
+               --size=auto \
+               --dry-run=no \
+               --offline=yes \
+               --el-torito=yes \
+               "$imgs/eltorito.img"
+
+# Verify the image has both iso9660 superblock and GPT partition table
+blkid -o value -s PTTYPE "$imgs/eltorito.img" | grep -x gpt
+blkid -o value -s TYPE "$imgs/eltorito.img" | grep -x iso9660
+
+# systemd-dissect must process the GPT partitions, not the whole-device iso9660 superblock
+systemd-dissect --json=short "$imgs/eltorito.img" | grep -F '"designator":"root"' | grep -F '"fstype":"ext4"'
+systemd-dissect --json=short "$imgs/eltorito.img" | grep -F '"designator":"esp"' | grep -F '"fstype":"vfat"'
+
+rm -rf "$defs" "$imgs"
+
 # Sneak in a couple of expected-to-fail invocations to cover
 # https://github.com/systemd/systemd/issues/29610
 (! systemd-run -P -p MountImages="/this/should/definitely/not/exist.img:/run/img2\:3:nosuid" false)


### PR DESCRIPTION
probe_blkid_filter() sets up a blkid superblock filter to restrict filesystem detection to a known-safe set of types (btrfs, erofs, ext4, f2fs, squashfs, vfat, xfs). It does so via two consecutive calls:

  1. blkid_probe_filter_superblocks_type(BLKID_FLTR_ONLYIN, ...)
  2. blkid_probe_filter_superblocks_usage(BLKID_FLTR_NOTIN, BLKID_USAGE_RAID)

However, both filter functions share the same internal bitmap in libblkid. Each call goes through blkid_probe_get_filter(), which zeroes the entire bitmap before applying the new filter. This means the second call (usage filter) silently destroys the type filter set by the first call.

The result is that only RAID superblocks end up being filtered, while all other filesystem types — including iso9660 — pass through unfiltered.

This causes ISO images (e.g. those with El Torito boot catalogs and GPT) to be incorrectly dissected: blkid detects the iso9660 superblock on the whole device (since iso9660 is marked BLKID_IDINFO_TOLERANT and can coexist with partition tables), the code enters the unpartitioned single-filesystem path, and then mounting fails because iso9660 is not in the allowed filesystem list:

  "File system type 'iso9660' is not allowed to be mounted as result
   of automatic dissection."

Fix this by dropping the blkid_probe_filter_superblocks_usage() call. The BLKID_FLTR_ONLYIN type filter already restricts probing to only the listed types, which implicitly excludes RAID superblocks as well, making the usage filter redundant.