### PR TITLE
shared/pager: add support for more(1) pager in secure mode

### DIFF
--- a/README
+++ b/README
@@ -264,9 +264,9 @@ REQUIREMENTS:
         During runtime, you need the following additional
         dependencies:
 
-        util-linux >= v2.27.1 required (including but not limited to: mount,
-                                        umount, swapon, swapoff, sulogin,
-                                        agetty, fsck)
+        util-linux >= v2.42 required (including but not limited to: mount,
+                                      umount, swapon, swapoff, sulogin,
+                                      agetty, fsck, more)
         dbus >= 1.4.0 (strictly speaking optional, but recommended)
                 NOTE: If using dbus < 1.9.18, you should override the default
                 policy directory (--with-dbuspolicydir=/etc/dbus-1/system.d).

--- a/man/common-variables.xml
+++ b/man/common-variables.xml
@@ -190,11 +190,14 @@
       allowing untrusted users to execute commands with elevated privileges.</para>
 
       <para>This option takes a boolean argument. When set to true, the "secure mode" of the pager is
-      enabled. In "secure mode", <option>LESSSECURE=1</option> will be set when invoking the pager, which
-      instructs the pager to disable commands that open or create new files or start new subprocesses.
+      enabled. In "secure mode", <option>LESSSECURE=1</option> and <option>PAGERSECURE=1</option> will be set
+      when invoking the pager, which instructs the pager to disable commands that open or create new files or
+      start new subprocesses.
       Currently only <citerefentry
-      project='man-pages'><refentrytitle>less</refentrytitle><manvolnum>1</manvolnum></citerefentry> is known
-      to understand this variable and implement "secure mode".</para>
+      project='man-pages'><refentrytitle>less</refentrytitle><manvolnum>1</manvolnum></citerefentry> and
+      <citerefentry
+      project='man-pages'><refentrytitle>more</refentrytitle><manvolnum>1</manvolnum></citerefentry> are known
+      to understand these variables, respectively, and implement "secure mode".</para>
 
       <para>When set to false, no limitation is placed on the pager. Setting
       <varname>SYSTEMD_PAGERSECURE=0</varname> or not removing it from the inherited environment may allow

--- a/src/shared/pager.c
+++ b/src/shared/pager.c
@@ -206,6 +206,13 @@ void pager_open(PagerFlags flags) {
                         _exit(EXIT_FAILURE);
                 }
 
+                /* Some pager implementations support the PAGERSECURE environment variable, e.g. more(1) */
+                r = set_unset_env("PAGERSECURE", use_secure_mode ? "1" : NULL, true);
+                if (r < 0) {
+                        log_error_errno(r, "Failed to adjust environment variable PAGERSECURE: %m");
+                        _exit(EXIT_FAILURE);
+                }
+
                 if (trust_pager && pager_args) { /* The pager config might be set globally, and we cannot
                                                   * know if the user adjusted it to be appropriate for the
                                                   * secure mode. Thus, start the pager specified through
@@ -228,8 +235,8 @@ void pager_open(PagerFlags flags) {
                 static const char* pagers[] = { "pager", "less", "more", "(built-in)" };
 
                 for (unsigned i = 0; i < ELEMENTSOF(pagers); i++) {
-                        /* Only less (and our trivial fallback) implement secure mode right now. */
-                        if (use_secure_mode && !STR_IN_SET(pagers[i], "less", "(built-in)"))
+                        /* Only less, more (and our trivial fallback) implement secure mode right now. */
+                        if (use_secure_mode && !STR_IN_SET(pagers[i], "less", "more", "(built-in)"))
                                 continue;
 
                         r = loop_write(exe_name_pipe[1], pagers[i], strlen(pagers[i]) + 1);


### PR DESCRIPTION
The more(1) pager (part of util-linux) now supports secure mode,
which can be enabled with the MORESECURE environment variable.

Adding support for more(1) in secure mode serves as an alternative
for systems that do not have less installed or for users who prefer
it.

Commit d2fce960f9cac740 introduced secure mode in more(1) and the
new feature is available in version 2.42 of util-linux.