### PR TITLE
networkd: fix WWAN uninitialized pointer use and lease parser cleanup

### DIFF
--- a/src/network/networkd-dhcp-server-static-lease.c
+++ b/src/network/networkd-dhcp-server-static-lease.c
@@ -188,6 +188,7 @@ int config_parse_dhcp_static_lease_hwaddr(
         if (isempty(rvalue)) {
                 lease->client_id = mfree(lease->client_id);
                 lease->client_id_size = 0;
+                TAKE_PTR(lease);
                 return 0;
         }
 

--- a/src/network/networkd-wwan-bus.c
+++ b/src/network/networkd-wwan-bus.c
@@ -604,9 +604,9 @@ static void modem_simple_connect(Modem *modem) {
         if (!modem->port_name)
                 return;
 
-        (void) link_get_by_name(modem->manager, modem->port_name, &link);
-        if (!link)
-                return (void) log_debug("ModemManager: cannot find link for %s", modem->port_name);
+        r = link_get_by_name(modem->manager, modem->port_name, &link);
+        if (r < 0)
+                return (void) log_debug_errno(r, "ModemManager: cannot find link for %s: %m", modem->port_name);
 
         /* Check if .network file found at all */
         if (!link->network)
@@ -798,8 +798,8 @@ static int bearer_properties_changed_handler(
 
         Manager *manager = ASSERT_PTR(userdata);
         const char *path;
-        Modem *modem;
-        Bearer *b;
+        Modem *modem = NULL;
+        Bearer *b = NULL;
 
         assert(message);
 
@@ -807,15 +807,10 @@ static int bearer_properties_changed_handler(
         if (!path)
                 return 0;
 
-        if (bearer_get_by_path(manager, path, &modem, &b) < 0) {
-                /*
-                 * Have new bearer: check if we have the corresponding modem
-                 * for it which we might not during initialization.
-                 */
-                if (modem)
-                        (void) bearer_new_and_initialize(modem, path);
+        if (bearer_get_by_path(manager, path, &modem, &b) < 0)
+                /* Unknown bearer, nothing to do. Modem-bearer association is handled
+                 * by modem_map_bearers() during modem property initialization. */
                 return 0;
-        }
 
         if (b->slot_getall) {
                 /* Not initialized yet. Re-initialize it. */


### PR DESCRIPTION
Fix three related issues:

modem_simple_connect() declared Link *link without initialization and discarded the return value of link_get_by_name() with (void), then checked if (!link). link_get_by_name() only writes *ret on success, so on lookup failure the check read an indeterminate value, which is undefined behavior. Check the return code instead and log it with log_debug_errno() to match the dominant pattern across the codebase.

bearer_properties_changed_handler() declared Modem *modem and Bearer *b without initialization. bearer_get_by_path() only writes its output parameters when both modem and bearer are found; on failure (-ENOENT) neither was written. The subsequent if (modem) check on the failure path read uninitialized memory. Initialize both variables to NULL and remove the dead fallback branch that attempted to call bearer_new_and_initialize(modem, path) — since bearer_get_by_path() never writes ret_modem on failure, modem is always NULL on this path, making the branch unreachable. Modem-bearer association is handled by modem_map_bearers() during modem property initialization.

config_parse_dhcp_static_lease_hwaddr() was missing TAKE_PTR(lease) on the empty-rvalue (reset) path. The variable uses the _cleanup_(dhcp_static_lease_free_or_set_invalidp) attribute, so without TAKE_PTR the cleanup marks section->invalid = true on scope exit. This causes network_drop_invalid_static_leases() to later discard the entire [DHCPServerStaticLease] section even when a subsequent MACAddress= line provides a valid value. Add the missing TAKE_PTR(lease) to match the pattern already used in config_parse_dhcp_static_lease_address().

Co-developed-by: Codex (GPT-5) <noreply@openai.com>