### PR TITLE
coredumpctl: use loop_write() for dumping inline journal coredumps

### DIFF
--- a/src/coredump/coredumpctl.c
+++ b/src/coredump/coredumpctl.c
@@ -30,6 +30,7 @@
 #include "fs-util.h"
 #include "glob-util.h"
 #include "image-policy.h"
+#include "io-util.h"
 #include "journal-internal.h"
 #include "journal-util.h"
 #include "json-util.h"
@@ -1109,8 +1110,6 @@ static int save_core(sd_journal *j, FILE *file, char **path, bool *unlink_temp) 
                 goto error;
 #endif
         } else {
-                ssize_t sz;
-
                 /* We want full data, nothing truncated. */
                 sd_journal_set_data_threshold(j, 0);
 
@@ -1122,14 +1121,9 @@ static int save_core(sd_journal *j, FILE *file, char **path, bool *unlink_temp) 
                 data += 9;
                 len -= 9;
 
-                sz = write(fd, data, len);
-                if (sz < 0) {
-                        r = log_error_errno(errno, "Failed to write output: %m");
-                        goto error;
-                }
-                if (sz != (ssize_t) len) {
-                        log_error("Short write to output.");
-                        r = -EIO;
+                r = loop_write(fd, data, len);
+                if (r < 0) {
+                        log_error_errno(r, "Failed to write output: %m");
                         goto error;
                 }
         }


### PR DESCRIPTION
save_core() used a single write() call when dumping an inline journal coredump, treating short writes as fatal (-EIO). This was correct when the code originally wrote to a temp file only, but 954d3a51af broadened the target fd to include stdout, which can be a pipe (e.g. coredumpctl dump | gdb). Pipes can short-write above PIPE_BUF, and write() can return EINTR on signal delivery.

Replace with loop_write() which handles both cases.

Co-developed-by: Claude Opus 4.6 <noreply@anthropic.com>