### PR TITLE
run: allow setting output format

### DIFF
--- a/man/systemd-run.xml
+++ b/man/systemd-run.xml
@@ -435,6 +435,16 @@
       </varlistentry>
 
       <varlistentry>
+        <term><option>--output=</option></term>
+
+        <listitem>
+          <para>Controls the formatting of verbose unit log output, see <citerefentry><refentrytitle>journalctl</refentrytitle><manvolnum>1</manvolnum></citerefentry> for possible values.</para>
+
+          <xi:include href="version-info.xml" xpointer="v261"/>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
         <term><option>--on-active=</option></term>
         <term><option>--on-boot=</option></term>
         <term><option>--on-startup=</option></term>

--- a/src/run/run.c
+++ b/src/run/run.c
@@ -105,6 +105,7 @@ static char **arg_timer_property = NULL;
 static bool arg_with_timer = false;
 static bool arg_quiet = false;
 static bool arg_verbose = false;
+static OutputMode arg_output = _OUTPUT_MODE_INVALID;
 static bool arg_aggressive_gc = false;
 static char *arg_working_directory = NULL;
 static char *arg_root_directory = NULL;
@@ -182,6 +183,8 @@ static int help(void) {
                "  -P --pipe                       Pass STDIN/STDOUT/STDERR directly to service\n"
                "  -q --quiet                      Suppress information messages during runtime\n"
                "  -v --verbose                    Show unit logs while executing operation\n"
+               "     --output=STRING              Controls formatting of verbose logs, see\n"
+               "                                  journalctl for valid values\n"
                "     --json=pretty|short|off      Print unit name and invocation id as JSON\n"
                "  -G --collect                    Unload unit after it ran, even when failed\n"
                "  -S --shell                      Invoke a $SHELL interactively\n"
@@ -318,6 +321,7 @@ static int parse_argv(int argc, char *argv[]) {
                 ARG_EXEC_USER,
                 ARG_EXEC_GROUP,
                 ARG_NICE,
+                ARG_OUTPUT,
                 ARG_ON_ACTIVE,
                 ARG_ON_BOOT,
                 ARG_ON_STARTUP,
@@ -370,6 +374,7 @@ static int parse_argv(int argc, char *argv[]) {
                 { "pipe",               no_argument,       NULL, 'P'                    },
                 { "quiet",              no_argument,       NULL, 'q'                    },
                 { "verbose",            no_argument,       NULL, 'v'                    },
+                { "output",             required_argument, NULL, ARG_OUTPUT             },
                 { "on-active",          required_argument, NULL, ARG_ON_ACTIVE          },
                 { "on-boot",            required_argument, NULL, ARG_ON_BOOT            },
                 { "on-startup",         required_argument, NULL, ARG_ON_STARTUP         },
@@ -540,6 +545,15 @@ static int parse_argv(int argc, char *argv[]) {
 
                 case 'v':
                         arg_verbose = true;
+                        break;
+
+                case ARG_OUTPUT:
+                        if (streq(optarg, "help"))
+                                return DUMP_STRING_TABLE(output_mode, OutputMode, _OUTPUT_MODE_MAX);
+
+                        arg_output = output_mode_from_string(optarg);
+                        if (arg_output < 0)
+                                return log_error_errno(arg_output, "Unknown output format '%s'.", optarg);
                         break;
 
                 case ARG_ON_ACTIVE:
@@ -2569,7 +2583,7 @@ static int start_transient_service(sd_bus *bus) {
 
         _cleanup_(fork_notify_terminate) PidRef journal_pid = PIDREF_NULL;
         if (arg_verbose)
-                (void) journal_fork(arg_runtime_scope, STRV_MAKE(c.unit), &journal_pid);
+                (void) journal_fork(arg_runtime_scope, STRV_MAKE(c.unit), arg_output, &journal_pid);
 
         r = bus_call_with_hint(bus, m, "service", &reply);
         if (r < 0)

--- a/src/shared/fork-notify.c
+++ b/src/shared/fork-notify.c
@@ -205,7 +205,7 @@ void fork_notify_terminate_many(sd_event_source **array, size_t n) {
         free(array);
 }
 
-int journal_fork(RuntimeScope scope, char * const* units, PidRef *ret_pidref) {
+int journal_fork(RuntimeScope scope, char * const* units, OutputMode output, PidRef *ret_pidref) {
         assert(scope >= 0);
         assert(scope < _RUNTIME_SCOPE_MAX);
 
@@ -226,6 +226,10 @@ int journal_fork(RuntimeScope scope, char * const* units, PidRef *ret_pidref) {
                 if (strv_extendf(&argv,
                                  scope == RUNTIME_SCOPE_SYSTEM ? "--unit=%s" : "--user-unit=%s",
                                  *u) < 0)
+                        return log_oom_debug();
+
+        if (output >= 0)
+                if (strv_extendf(&argv, "--output=%s", output_mode_to_string(output)) < 0)
                         return log_oom_debug();
 
         return fork_notify(argv, ret_pidref);

--- a/src/shared/fork-notify.h
+++ b/src/shared/fork-notify.h
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 #pragma once
 
+#include "output-mode.h"
 #include "shared-forward.h"
 
 int fork_notify(char * const *argv, PidRef *ret_pidref);
@@ -9,4 +10,4 @@ void fork_notify_terminate(PidRef *pidref);
 
 void fork_notify_terminate_many(sd_event_source **array, size_t n);
 
-int journal_fork(RuntimeScope scope, char * const *units, PidRef *ret_pidref);
+int journal_fork(RuntimeScope scope, char * const *units, OutputMode output, PidRef *ret_pidref);

--- a/src/systemctl/systemctl-start-unit.c
+++ b/src/systemctl/systemctl-start-unit.c
@@ -402,7 +402,7 @@ int verb_start(int argc, char *argv[], uintptr_t _data, void *userdata) {
                 ret = enqueue_marked_jobs(bus, w);
         else {
                 if (arg_verbose)
-                        (void) journal_fork(arg_runtime_scope, names, &journal_pid);
+                        (void) journal_fork(arg_runtime_scope, names, arg_output, &journal_pid);
 
                 STRV_FOREACH(name, names) {
                         _cleanup_(sd_bus_error_free) sd_bus_error error = SD_BUS_ERROR_NULL;


### PR DESCRIPTION
This is useful when moving from `--pty` or `--pipe` to using `--verbose`: you can use `--verbose-output=cat` to get similar output on stdout while still having all of the advantages of `--verbose` over the other options.