### PR TITLE
journald-native: fix field-count limit off-by-one

### DIFF
--- a/src/journal/journald-native.c
+++ b/src/journal/journald-native.c
@@ -146,7 +146,7 @@ static int manager_process_entry(
                 }
 
                 /* A property follows */
-                if (n > ENTRY_FIELD_COUNT_MAX) {
+                if (n >= ENTRY_FIELD_COUNT_MAX) {
                         log_debug("Received an entry that has more than " STRINGIFY(ENTRY_FIELD_COUNT_MAX) " fields, ignoring entry.");
                         goto finish;
                 }


### PR DESCRIPTION
Reject entries once the configured maximum field count is reached.

The previous check used n > ENTRY_FIELD_COUNT_MAX before appending a new field, which let one extra field through in boundary cases. (n starts from 0)
Switch the check to n >= ENTRY_FIELD_COUNT_MAX so an entry at the limit is rejected before adding another property.

Co-developed-by: Codex (GPT-5) <noreply@openai.com>