### PR TITLE
sd-json, ssh-proxy: two bugfixes

### DIFF
--- a/src/libsystemd/sd-json/sd-json.c
+++ b/src/libsystemd/sd-json/sd-json.c
@@ -1003,7 +1003,7 @@ _public_ uint64_t sd_json_variant_unsigned(sd_json_variant *v) {
         if (!json_variant_is_regular(v))
                 goto mismatch;
         if (v->is_reference)
-                return sd_json_variant_integer(v->reference);
+                return sd_json_variant_unsigned(v->reference);
 
         switch (v->type) {
 

--- a/src/ssh-generator/ssh-proxy.c
+++ b/src/ssh-generator/ssh-proxy.c
@@ -282,7 +282,7 @@ static int fetch_machine(const char *machine, RuntimeScope scope, sd_json_varian
         if (r < 0)
                 return log_error_errno(r, "Failed to connect to machined on %s: %m", addr);
 
-        _cleanup_(sd_json_variant_unrefp) sd_json_variant *result = NULL;
+        sd_json_variant *result = NULL;
         const char *error_id;
         r = sd_varlink_callbo(
                         vl,
@@ -303,7 +303,9 @@ static int fetch_machine(const char *machine, RuntimeScope scope, sd_json_varian
                 return log_error_errno(r, "Failed to issue io.systemd.Machine.List() varlink call: %s", error_id);
         }
 
-        *ret = TAKE_PTR(result);
+        /* result is a borrowed reference into the varlink connection's receive buffer. Take a real ref so
+         * that it survives the cleanup of vl below. */
+        *ret = sd_json_variant_ref(result);
         return 0;
 }
 


### PR DESCRIPTION
  - Fix sd_json_variant_unsigned() dispatching to the wrong accessor
    for json variant references.
  - Fix a use-after-free of a borrowed varlink reply reference in
    ssh-proxy.