### PR TITLE
error-fundamental: add error pointer encoding

### DIFF
--- a/src/basic/alloc-util.h
+++ b/src/basic/alloc-util.h
@@ -76,7 +76,8 @@ static inline void unsetp(void *p) {
 }
 
 static inline void freep(void *p) {
-        *(void**)p = mfree(*(void**) p);
+        if (!PTR_IS_DIRTY(*(void**)p))
+                *(void**)p = mfree(*(void**)p);
 }
 
 #define _cleanup_free_ _cleanup_(freep)

--- a/src/basic/basic-forward.h
+++ b/src/basic/basic-forward.h
@@ -140,6 +140,3 @@ typedef struct SocketAddress SocketAddress;
 
 #define USEC_INFINITY           ((usec_t) UINT64_MAX)
 #define NSEC_INFINITY           ((nsec_t) UINT64_MAX)
-
-/* MAX_ERRNO is defined as 4095 in linux/err.h. We use the same value here. */
-#define ERRNO_MAX               4095

--- a/src/basic/btrfs.c
+++ b/src/basic/btrfs.c
@@ -22,23 +22,21 @@ int btrfs_validate_subvolume_name(const char *name) {
         return 0;
 }
 
-static int extract_subvolume_name(const char *path, char **ret) {
+static char *extract_subvolume_name(const char *path) {
         _cleanup_free_ char *fn = NULL;
         int r;
 
         assert(path);
-        assert(ret);
 
         r = path_extract_filename(path, &fn);
         if (r < 0)
-                return r;
+                return ERR_TO_PTR(r);
 
         r = btrfs_validate_subvolume_name(fn);
         if (r < 0)
-                return r;
+                return ERR_TO_PTR(r);
 
-        *ret = TAKE_PTR(fn);
-        return 0;
+        return TAKE_PTR(fn);
 }
 
 int btrfs_subvol_make(int dir_fd, const char *path) {
@@ -50,9 +48,9 @@ int btrfs_subvol_make(int dir_fd, const char *path) {
         assert(dir_fd >= 0 || dir_fd == AT_FDCWD);
         assert(!isempty(path));
 
-        r = extract_subvolume_name(path, &subvolume);
-        if (r < 0)
-                return r;
+        subvolume = extract_subvolume_name(path);
+        if (PTR_IS_ERR(subvolume))
+                return PTR_TO_ERR(subvolume);
 
         r = path_extract_directory(path, &parent);
         if (r < 0) {

--- a/src/core/bpf-foreign.c
+++ b/src/core/bpf-foreign.c
@@ -19,25 +19,19 @@ typedef struct BPFForeignKey {
         uint32_t attach_type;
 } BPFForeignKey;
 
-static int bpf_foreign_key_new(uint32_t prog_id,
-                enum bpf_attach_type attach_type,
-                BPFForeignKey **ret) {
-        _cleanup_free_ BPFForeignKey *p = NULL;
-
-        assert(ret);
+static BPFForeignKey *bpf_foreign_key_new(uint32_t prog_id, enum bpf_attach_type attach_type) {
+        BPFForeignKey *p;
 
         p = new(BPFForeignKey, 1);
         if (!p)
-                return -ENOMEM;
+                return ERR_TO_PTR(ENOMEM);
 
         *p = (BPFForeignKey) {
                 .prog_id = prog_id,
                 .attach_type = attach_type,
         };
 
-        *ret = TAKE_PTR(p);
-
-        return 0;
+        return p;
 }
 
 static int bpf_foreign_key_compare_func(const BPFForeignKey *a, const BPFForeignKey *b) {
@@ -116,9 +110,9 @@ static int bpf_foreign_prepare(
         if (r < 0)
                 return log_unit_error_errno(u, r, "bpf-foreign: Failed to get BPF program id from fd: %m");
 
-        r = bpf_foreign_key_new(prog_id, attach_type, &key);
-        if (r < 0)
-                return log_unit_error_errno(u, r,
+        key = bpf_foreign_key_new(prog_id, attach_type);
+        if (PTR_IS_ERR(key))
+                return log_unit_error_errno(u, PTR_TO_ERR(key),
                                 "bpf-foreign: Failed to create foreign BPF program key from path '%s': %m", bpffs_path);
 
         r = hashmap_ensure_put(&crt->bpf_foreign_by_key, &bpf_foreign_by_key_hash_ops, key, prog);

--- a/src/core/dbus-execute.c
+++ b/src/core/dbus-execute.c
@@ -4302,7 +4302,7 @@ int bus_exec_context_set_transient_property(
                                                 exec_directory_type_to_string(i),
                                                 source_escaped,
                                                 destination_escaped || FLAGS_SET(symlink_flags, EXEC_DIRECTORY_READ_ONLY) ? ":" : "",
-                                                destination_escaped,
+                                                strempty(destination_escaped),
                                                 FLAGS_SET(symlink_flags, EXEC_DIRECTORY_READ_ONLY) ? ":ro" : "");
                         }
                 }

--- a/src/core/dynamic-user.c
+++ b/src/core/dynamic-user.c
@@ -711,21 +711,18 @@ int dynamic_user_lookup_name(Manager *m, const char *name, uid_t *ret) {
         return 0;
 }
 
-int dynamic_creds_make(Manager *m, const char *user, const char *group, DynamicCreds **ret) {
+DynamicCreds *dynamic_creds_make(Manager *m, const char *user, const char *group) {
         _cleanup_(dynamic_creds_unrefp) DynamicCreds *creds = NULL;
         int r;
 
         assert(m);
-        assert(ret);
 
-        if (!user && !group) {
-                *ret = NULL;
-                return 0;
-        }
+        if (!user && !group)
+                return NULL;
 
         creds = new0(DynamicCreds, 1);
         if (!creds)
-                return -ENOMEM;
+                return ERR_TO_PTR(ENOMEM);
 
         /* A DynamicUser object encapsulates an allocation of both a UID and a GID for a specific name. However, some
          * services use different user and groups. For cases like that there's DynamicCreds containing a pair of user
@@ -734,19 +731,17 @@ int dynamic_creds_make(Manager *m, const char *user, const char *group, DynamicC
         if (user) {
                 r = dynamic_user_acquire(m, user, &creds->user);
                 if (r < 0)
-                        return r;
+                        return ERR_TO_PTR(r);
         }
 
         if (group && !streq_ptr(user, group)) {
                 r = dynamic_user_acquire(m, group, &creds->group);
                 if (r < 0)
-                        return r;
+                        return ERR_TO_PTR(r);
         } else
                 creds->group = ASSERT_PTR(dynamic_user_ref(creds->user));
 
-        *ret = TAKE_PTR(creds);
-
-        return 0;
+        return TAKE_PTR(creds);
 }
 
 int dynamic_creds_realize(DynamicCreds *creds, char **suggested_paths, uid_t *uid, gid_t *gid) {

--- a/src/core/dynamic-user.h
+++ b/src/core/dynamic-user.h
@@ -33,7 +33,7 @@ int dynamic_user_current(DynamicUser *d, uid_t *ret);
 int dynamic_user_lookup_uid(Manager *m, uid_t uid, char **ret);
 int dynamic_user_lookup_name(Manager *m, const char *name, uid_t *ret);
 
-int dynamic_creds_make(Manager *m, const char *user, const char *group, DynamicCreds **ret);
+DynamicCreds *dynamic_creds_make(Manager *m, const char *user, const char *group);
 int dynamic_creds_realize(DynamicCreds *creds, char **suggested_paths, uid_t *uid, gid_t *gid);
 
 DynamicCreds *dynamic_creds_unref(DynamicCreds *creds);

--- a/src/core/execute.c
+++ b/src/core/execute.c
@@ -2806,12 +2806,11 @@ void exec_shared_runtime_vacuum(Manager *m) {
         }
 }
 
-int exec_runtime_make(
+ExecRuntime *exec_runtime_make(
                 const Unit *unit,
                 const ExecContext *context,
                 ExecSharedRuntime *shared,
-                DynamicCreds *creds,
-                ExecRuntime **ret) {
+                DynamicCreds *creds) {
         _cleanup_close_pair_ int ephemeral_storage_socket[2] = EBADF_PAIR;
         _cleanup_free_ char *ephemeral = NULL;
         _cleanup_(exec_runtime_freep) ExecRuntime *rt = NULL;
@@ -2819,29 +2818,26 @@ int exec_runtime_make(
 
         assert(unit);
         assert(context);
-        assert(ret);
 
-        if (!shared && !creds && !exec_needs_ephemeral(context)) {
-                *ret = NULL;
-                return 0;
-        }
+        if (!shared && !creds && !exec_needs_ephemeral(context))
+                return NULL;
 
         if (exec_needs_ephemeral(context)) {
                 r = mkdir_p("/var/lib/systemd/ephemeral-trees", 0755);
                 if (r < 0)
-                        return r;
+                        return ERR_TO_PTR(r);
 
                 r = tempfn_random_child("/var/lib/systemd/ephemeral-trees", unit->id, &ephemeral);
                 if (r < 0)
-                        return r;
+                        return ERR_TO_PTR(r);
 
                 if (socketpair(AF_UNIX, SOCK_DGRAM|SOCK_CLOEXEC, 0, ephemeral_storage_socket) < 0)
-                        return -errno;
+                        return ERR_TO_PTR(errno);
         }
 
         rt = new(ExecRuntime, 1);
         if (!rt)
-                return -ENOMEM;
+                return ERR_TO_PTR(ENOMEM);
 
         *rt = (ExecRuntime) {
                 .shared = shared,
@@ -2851,8 +2847,7 @@ int exec_runtime_make(
                 .ephemeral_storage_socket[1] = TAKE_FD(ephemeral_storage_socket[1]),
         };
 
-        *ret = TAKE_PTR(rt);
-        return 1;
+        return TAKE_PTR(rt);
 }
 
 ExecRuntime* exec_runtime_free(ExecRuntime *rt) {

--- a/src/core/execute.h
+++ b/src/core/execute.h
@@ -601,7 +601,7 @@ int exec_shared_runtime_deserialize_one(Manager *m, const char *value, FDSet *fd
 void exec_shared_runtime_done(ExecSharedRuntime *rt);
 void exec_shared_runtime_vacuum(Manager *m);
 
-int exec_runtime_make(const Unit *unit, const ExecContext *context, ExecSharedRuntime *shared, DynamicCreds *creds, ExecRuntime **ret);
+ExecRuntime *exec_runtime_make(const Unit *unit, const ExecContext *context, ExecSharedRuntime *shared, DynamicCreds *creds);
 ExecRuntime* exec_runtime_free(ExecRuntime *rt);
 DEFINE_TRIVIAL_CLEANUP_FUNC(ExecRuntime*, exec_runtime_free);
 ExecRuntime* exec_runtime_destroy(ExecRuntime *rt);

--- a/src/core/unit.c
+++ b/src/core/unit.c
@@ -5185,19 +5185,20 @@ int unit_setup_exec_runtime(Unit *u) {
         }
 
         if (ec->dynamic_user) {
-                r = dynamic_creds_make(u->manager, ec->user, ec->group, &dcreds);
-                if (r < 0)
-                        return r;
+                dcreds = dynamic_creds_make(u->manager, ec->user, ec->group);
+                if (PTR_IS_ERR(dcreds))
+                        return PTR_TO_ERR(dcreds);
         }
 
-        r = exec_runtime_make(u, ec, esr, dcreds, rt);
-        if (r < 0)
-                return r;
+        ExecRuntime *ert = exec_runtime_make(u, ec, esr, dcreds);
+        if (PTR_IS_ERR(ert))
+                return PTR_TO_ERR(ert);
 
+        *rt = ert;
         TAKE_PTR(esr);
         TAKE_PTR(dcreds);
 
-        return r;
+        return 0;
 }
 
 CGroupRuntime* unit_setup_cgroup_runtime(Unit *u) {

--- a/src/fundamental/cleanup-fundamental.h
+++ b/src/fundamental/cleanup-fundamental.h
@@ -2,6 +2,19 @@
 #pragma once
 
 #include "assert-fundamental.h"
+#include "error-fundamental.h"
+
+DISABLE_WARNING_REDUNDANT_DECLS;
+void free(void *p); /* NOLINT (readability-redundant-declaration) */
+REENABLE_WARNING;
+
+#define mfree(memory)                           \
+        ({                                      \
+                typeof(memory) _mfree_ = (memory); \
+                assert_se(!PTR_IS_DIRTY(_mfree_)); \
+                free(_mfree_);                  \
+                (typeof(memory)) NULL;          \
+        })
 
 /* A wrapper for 'func' to return void.
  * Only useful when a void-returning function is required by some API. */
@@ -13,7 +26,7 @@
 /* When func() returns the void value (NULL, -1, …) of the appropriate type */
 #define DEFINE_TRIVIAL_CLEANUP_FUNC(type, func)         \
         static inline void func##p(type *p) {           \
-                if (*p)                                 \
+                if (*p && !PTR_IS_DIRTY(*p))            \
                         *p = func(*p);                  \
         }
 
@@ -21,7 +34,7 @@
  * provided by a dynamically loaded (dlopen()) shared library, hence add an assertion. */
 #define DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_RENAME(type, func, name, empty) \
         static inline void name(type *p) {                              \
-                if (*p != (empty)) {                                    \
+                if (*p != (empty) && !PTR_IS_DIRTY(*p)) {               \
                         DISABLE_WARNING_ADDRESS;                        \
                         assert(func);                                   \
                         REENABLE_WARNING;                               \
@@ -36,7 +49,7 @@
 /* When func() doesn't return the appropriate type, and is also a macro, set variable to empty afterwards. */
 #define DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_MACRO_RENAME(type, macro, name, empty) \
         static inline void name(type *p) {                              \
-                if (*p != (empty)) {                                    \
+                if (*p != (empty) && !PTR_IS_DIRTY(*p)) {               \
                         macro(*p);                                      \
                         *p = (empty);                                   \
                 }                                                       \

--- a/src/fundamental/error-fundamental.h
+++ b/src/fundamental/error-fundamental.h
@@ -1,0 +1,43 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#pragma once
+
+#include "assert-fundamental.h"
+
+/* MAX_ERRNO is defined as 4095 in linux/err.h. We use the same value here. */
+#define ERRNO_MAX 4095
+
+/* Error pointer functions — inspired by Linux kernel's ERR_PTR.
+ *
+ * Encode errno values into pointers in [UINTPTR_MAX - ERRNO_MAX, UINTPTR_MAX - 1]. UINTPTR_MAX itself is
+ * excluded (used as sentinel: STRV_IGNORE, variadic terminators, etc.). Accepts both positive and negative
+ * errno values. */
+
+/* Single-comparison guard for cleanup macros and mfree(). Unlike PTR_IS_ERR() this also covers UINTPTR_MAX
+ * (== POINTER_MAX). We need this because PTR_IS_ERR() deliberately excludes UINTPTR_MAX from the error range
+ * causing -Wfree-nonheap-object to complain about error pointers being able to reach cleanup macros. */
+#define PTR_IS_DIRTY(ptr) ((uintptr_t) (ptr) >= UINTPTR_MAX - ERRNO_MAX)
+
+static inline _warn_unused_result_ void *ERR_TO_PTR(int error) {
+        error = ABS(error);
+        assert_se(error > 0 && error <= ERRNO_MAX);
+        return (void *) (UINTPTR_MAX - (uintptr_t) error);
+}
+
+static inline _warn_unused_result_ bool PTR_IS_ERR(const void *ptr) {
+        return PTR_IS_DIRTY(ptr) && (uintptr_t) ptr < UINTPTR_MAX;
+}
+
+static inline _warn_unused_result_ int PTR_TO_ERR(const void *ptr) {
+        assert_se(PTR_IS_ERR(ptr));
+        return -(int) (UINTPTR_MAX - (uintptr_t) ptr);
+}
+
+static inline _warn_unused_result_ bool PTR_IS_ERR_OR_NULL(const void *ptr) {
+        return !ptr || PTR_IS_ERR(ptr);
+}
+
+static inline _warn_unused_result_ int PTR_TO_ERR_OR_ZERO(const void *ptr) {
+        if (PTR_IS_ERR(ptr))
+                return PTR_TO_ERR(ptr);
+        return 0;
+}

--- a/src/fundamental/iovec-util-fundamental.h
+++ b/src/fundamental/iovec-util-fundamental.h
@@ -6,6 +6,7 @@
 #endif
 
 #include "assert-fundamental.h"         /* IWYU pragma: keep */
+#include "cleanup-fundamental.h"
 #include "macro-fundamental.h"
 
 #if SD_BOOT

--- a/src/fundamental/macro-fundamental.h
+++ b/src/fundamental/macro-fundamental.h
@@ -415,16 +415,6 @@ assert_cc(sizeof(long long) == sizeof(intmax_t));
  */
 #define STRLEN(x) (sizeof(""x"") - sizeof(typeof(x[0])))
 
-DISABLE_WARNING_REDUNDANT_DECLS;
-void free(void *p); /* NOLINT (readability-redundant-declaration) */
-REENABLE_WARNING;
-
-#define mfree(memory)                           \
-        ({                                      \
-                free(memory);                   \
-                (typeof(memory)) NULL;          \
-        })
-
 #define UPDATE_FLAG(orig, flag, b)                      \
         ((b) ? ((orig) | (flag)) : ((orig) & ~(flag)))
 #define SET_FLAG(v, flag, b) \

--- a/src/libsystemd/sd-journal/sd-journal.c
+++ b/src/libsystemd/sd-journal/sd-journal.c
@@ -81,7 +81,7 @@ static int journal_put_error(sd_journal *j, int r, const char *path) {
                         return -ENOMEM;
         }
 
-        r = hashmap_ensure_put(&j->errors, &trivial_hash_ops_value_free, INT_TO_PTR(r), copy);
+        r = hashmap_ensure_put(&j->errors, &trivial_hash_ops_value_free, ERR_TO_PTR(r), copy);
         if (r == -EEXIST)
                 return 0;
         if (r < 0)

--- a/src/shared/discover-image.c
+++ b/src/shared/discover-image.c
@@ -249,7 +249,7 @@ static int image_auxiliary_path(Image *image, const char *suffix, char **ret) {
         return file_in_same_dir(image->path, fn, ret);
 }
 
-static int image_new(
+static Image *image_new(
                 ImageType t,
                 ImageClass c,
                 const char *pretty,
@@ -259,8 +259,7 @@ static int image_new(
                 usec_t mtime,
                 struct file_handle *fh,
                 uint64_t on_mount_id,
-                uint64_t inode,
-                Image **ret) {
+                uint64_t inode) {
 
         _cleanup_(image_unrefp) Image *i = NULL;
 
@@ -268,11 +267,10 @@ static int image_new(
         assert(t < _IMAGE_TYPE_MAX);
         assert(pretty);
         assert(path);
-        assert(ret);
 
         i = new(Image, 1);
         if (!i)
-                return -ENOMEM;
+                return ERR_TO_PTR(ENOMEM);
 
         *i = (Image) {
                 .n_ref = 1,
@@ -292,22 +290,20 @@ static int image_new(
         if (fh) {
                 i->fh = file_handle_dup(fh);
                 if (!i->fh)
-                        return -ENOMEM;
+                        return ERR_TO_PTR(ENOMEM);
         }
 
         i->name = strdup(pretty);
         if (!i->name)
-                return -ENOMEM;
+                return ERR_TO_PTR(ENOMEM);
 
         i->path = strdup(path);
         if (!i->path)
-                return -ENOMEM;
+                return ERR_TO_PTR(ENOMEM);
 
         path_simplify(i->path);
 
-        *ret = TAKE_PTR(i);
-
-        return 0;
+        return TAKE_PTR(i);
 }
 
 static int extract_image_basename(
@@ -519,28 +515,28 @@ static int image_make(
                                 read_only = r != 0;
                         }
 
-                        r = image_new(IMAGE_MSTACK,
-                                      c,
-                                      pretty,
-                                      path,
-                                      read_only,
-                                      crtime,
-                                      /* mtime= */ 0,
-                                      fh,
-                                      on_mount_id,
-                                      (uint64_t) st->st_ino,
-                                      ret);
-                        if (r < 0)
-                                return r;
+                        Image *img = image_new(IMAGE_MSTACK,
+                                               c,
+                                               pretty,
+                                               path,
+                                               read_only,
+                                               crtime,
+                                               /* mtime= */ 0,
+                                               fh,
+                                               on_mount_id,
+                                               (uint64_t) st->st_ino);
+                        if (PTR_IS_ERR(img))
+                                return PTR_TO_ERR(img);
 
                         if (mstack) {
                                 r = mstack_is_foreign_uid_owned(mstack);
                                 if (r < 0)
                                         log_debug_errno(r, "Failed to determine if mstack '%s' is foreign UID owned, assuming it is not: %m", path);
                                 if (r > 0)
-                                        (*ret)->foreign_uid_owned = true;
+                                        img->foreign_uid_owned = true;
                         }
 
+                        *ret = img;
                         return 0;
                 }
 
@@ -571,22 +567,22 @@ static int image_make(
                                 if (r < 0)
                                         return r;
 
-                                r = image_new(IMAGE_SUBVOLUME,
-                                              c,
-                                              pretty,
-                                              path,
-                                              info.read_only || read_only,
-                                              info.otime,
-                                              info.ctime,
-                                              fh,
-                                              on_mount_id,
-                                              (uint64_t) st->st_ino,
-                                              ret);
-                                if (r < 0)
-                                        return r;
+                                Image *img = image_new(IMAGE_SUBVOLUME,
+                                                       c,
+                                                       pretty,
+                                                       path,
+                                                       info.read_only || read_only,
+                                                       info.otime,
+                                                       info.ctime,
+                                                       fh,
+                                                       on_mount_id,
+                                                       (uint64_t) st->st_ino);
+                                if (PTR_IS_ERR(img))
+                                        return PTR_TO_ERR(img);
 
-                                (*ret)->foreign_uid_owned = uid_is_foreign(st->st_uid);
-                                (void) image_update_quota(*ret, fd);
+                                img->foreign_uid_owned = uid_is_foreign(st->st_uid);
+                                (void) image_update_quota(img, fd);
+                                *ret = img;
                                 return 0;
                         }
                 }
@@ -601,21 +597,21 @@ static int image_make(
                 (void) read_attr_fd(fd, &file_attr);
 
                 /* It's just a normal directory. */
-                r = image_new(IMAGE_DIRECTORY,
-                              c,
-                              pretty,
-                              path,
-                              read_only || (file_attr & FS_IMMUTABLE_FL),
-                              crtime,
-                              0, /* we don't use mtime of stat() here, since it's not the time of last change of the tree, but only of the top-level dir */
-                              fh,
-                              on_mount_id,
-                              (uint64_t) st->st_ino,
-                              ret);
-                if (r < 0)
-                        return r;
+                Image *img = image_new(IMAGE_DIRECTORY,
+                                       c,
+                                       pretty,
+                                       path,
+                                       read_only || (file_attr & FS_IMMUTABLE_FL),
+                                       crtime,
+                                       0, /* we don't use mtime of stat() here, since it's not the time of last change of the tree, but only of the top-level dir */
+                                       fh,
+                                       on_mount_id,
+                                       (uint64_t) st->st_ino);
+                if (PTR_IS_ERR(img))
+                        return PTR_TO_ERR(img);
 
-                (*ret)->foreign_uid_owned = uid_is_foreign(st->st_uid);
+                img->foreign_uid_owned = uid_is_foreign(st->st_uid);
+                *ret = img;
                 return 0;
 
         } else if (S_ISREG(st->st_mode) && endswith(path, ".raw")) {
@@ -641,23 +637,23 @@ static int image_make(
                         pretty = pretty_buffer;
                 }
 
-                r = image_new(IMAGE_RAW,
-                              c,
-                              pretty,
-                              path,
-                              !(st->st_mode & 0222) || read_only,
-                              crtime,
-                              timespec_load(&st->st_mtim),
-                              fh,
-                              on_mount_id,
-                              (uint64_t) st->st_ino,
-                              ret);
-                if (r < 0)
-                        return r;
+                Image *img = image_new(IMAGE_RAW,
+                                       c,
+                                       pretty,
+                                       path,
+                                       !(st->st_mode & 0222) || read_only,
+                                       crtime,
+                                       timespec_load(&st->st_mtim),
+                                       fh,
+                                       on_mount_id,
+                                       (uint64_t) st->st_ino);
+                if (PTR_IS_ERR(img))
+                        return PTR_TO_ERR(img);
 
-                (*ret)->usage = (*ret)->usage_exclusive = st->st_blocks * 512;
-                (*ret)->limit = (*ret)->limit_exclusive = st->st_size;
+                img->usage = img->usage_exclusive = st->st_blocks * 512;
+                img->limit = img->limit_exclusive = st->st_size;
 
+                *ret = img;
                 return 0;
 
         } else if (S_ISBLK(st->st_mode)) {
@@ -701,23 +697,23 @@ static int image_make(
                         block_fd = safe_close(block_fd);
                 }
 
-                r = image_new(IMAGE_BLOCK,
-                              c,
-                              pretty,
-                              path,
-                              !(st->st_mode & 0222) || read_only,
-                              0,
-                              0,
-                              fh,
-                              on_mount_id,
-                              (uint64_t) st->st_ino,
-                              ret);
-                if (r < 0)
-                        return r;
+                Image *img = image_new(IMAGE_BLOCK,
+                                       c,
+                                       pretty,
+                                       path,
+                                       !(st->st_mode & 0222) || read_only,
+                                       0,
+                                       0,
+                                       fh,
+                                       on_mount_id,
+                                       (uint64_t) st->st_ino);
+                if (PTR_IS_ERR(img))
+                        return PTR_TO_ERR(img);
 
                 if (!IN_SET(size, 0, UINT64_MAX))
-                        (*ret)->usage = (*ret)->usage_exclusive = (*ret)->limit = (*ret)->limit_exclusive = size;
+                        img->usage = img->usage_exclusive = img->limit = img->limit_exclusive = size;
 
+                *ret = img;
                 return 0;
         }
 

--- a/src/shared/dissect-image.c
+++ b/src/shared/dissect-image.c
@@ -81,11 +81,9 @@
 /* how many times to wait for the device nodes to appear */
 #define N_DEVICE_NODE_LIST_ATTEMPTS 10
 
-static int allowed_fstypes(char ***ret_strv) {
-        _cleanup_strv_free_ char **l = NULL;
+static char **allowed_fstypes(void) {
+        char **l;
         const char *e;
-
-        assert(ret_strv);
 
         e = secure_getenv("SYSTEMD_DISSECT_FILE_SYSTEMS");
         if (e)
@@ -99,23 +97,21 @@ static int allowed_fstypes(char ***ret_strv) {
                              "vfat",
                              "xfs");
         if (!l)
-                return -ENOMEM;
+                return ERR_TO_PTR(ENOMEM);
 
-        *ret_strv = TAKE_PTR(l);
-        return 0;
+        return l;
 }
 
 int dissect_fstype_ok(const char *fstype) {
         _cleanup_strv_free_ char **l = NULL;
-        int r;
 
         /* When we automatically mount file systems, be a bit conservative by default what we are willing to
          * mount, just as an extra safety net to not mount with badly maintained legacy file system
          * drivers. */
 
-        r = allowed_fstypes(&l);
-        if (r < 0)
-                return r;
+        l = allowed_fstypes();
+        if (PTR_IS_ERR(l))
+                return PTR_TO_ERR(l);
 
         if (strv_contains(l, fstype))
                 return true;
@@ -191,9 +187,9 @@ static int probe_blkid_filter(blkid_probe p) {
 
         assert(p);
 
-        r = allowed_fstypes(&fstypes);
-        if (r < 0)
-                return r;
+        fstypes = allowed_fstypes();
+        if (PTR_IS_ERR(fstypes))
+                return PTR_TO_ERR(fstypes);
 
         /* allowed_fstypes() returns the list of filesystem types that we are willing to mount. For the
          * blkid probe filter we additionally need to be able to detect crypto_LUKS (so that we can set up
@@ -648,22 +644,20 @@ int dissected_image_name_from_path(const char *path, char **ret) {
 }
 
 #if HAVE_BLKID
-static int dissected_image_new(const char *path, DissectedImage **ret) {
+static DissectedImage *dissected_image_new(const char *path) {
         _cleanup_(dissected_image_unrefp) DissectedImage *m = NULL;
         _cleanup_free_ char *name = NULL;
         int r;
 
-        assert(ret);
-
         if (path) {
                 r = dissected_image_name_from_path(path, &name);
                 if (r < 0)
-                        return r;
+                        return ERR_TO_PTR(r);
         }
 
         m = new(DissectedImage, 1);
         if (!m)
-                return -ENOMEM;
+                return ERR_TO_PTR(ENOMEM);
 
         *m = (DissectedImage) {
                 .has_init_system = -1,
@@ -673,8 +667,7 @@ static int dissected_image_new(const char *path, DissectedImage **ret) {
         for (PartitionDesignator i = 0; i < _PARTITION_DESIGNATOR_MAX; i++)
                 m->partitions[i] = DISSECTED_PARTITION_NULL;
 
-        *ret = TAKE_PTR(m);
-        return 0;
+        return TAKE_PTR(m);
 }
 #endif
 
@@ -1942,9 +1935,9 @@ int dissected_image_new_from_existing_verity(
         if (!node)
                 return -ENOMEM;
 
-        r = dissected_image_new(src, &dissected_image);
-        if (r < 0)
-                return r;
+        dissected_image = dissected_image_new(src);
+        if (PTR_IS_ERR(dissected_image))
+                return PTR_TO_ERR(dissected_image);
 
         mount_node_fd = open_partition(node, /* is_partition= */ false, /* loop= */ NULL);
         if (mount_node_fd < 0)
@@ -2003,9 +1996,9 @@ int dissect_image_file(
         if (r < 0)
                 return r;
 
-        r = dissected_image_new(path, &m);
-        if (r < 0)
-                return r;
+        m = dissected_image_new(path);
+        if (PTR_IS_ERR(m))
+                return PTR_TO_ERR(m);
 
         m->image_size = st.st_size;
 
@@ -2839,21 +2832,18 @@ static DecryptedImage* decrypted_image_free(DecryptedImage *d) {
 DEFINE_TRIVIAL_REF_UNREF_FUNC(DecryptedImage, decrypted_image, decrypted_image_free);
 
 #if HAVE_LIBCRYPTSETUP
-static int decrypted_image_new(DecryptedImage **ret) {
+static DecryptedImage *decrypted_image_new(void) {
         _cleanup_(decrypted_image_unrefp) DecryptedImage *d = NULL;
-
-        assert(ret);
 
         d = new(DecryptedImage, 1);
         if (!d)
-                return -ENOMEM;
+                return ERR_TO_PTR(ENOMEM);
 
         *d = (DecryptedImage) {
                 .n_ref = 1,
         };
 
-        *ret = TAKE_PTR(d);
-        return 0;
+        return TAKE_PTR(d);
 }
 
 static uint64_t dissected_image_diskseq(const DissectedImage *di) {
@@ -3522,9 +3512,9 @@ int dissected_image_decrypt(
                 SET_FLAG(flags, DISSECT_IMAGE_VERITY_SHARE, r);
 
 #if HAVE_LIBCRYPTSETUP
-        r = decrypted_image_new(&d);
-        if (r < 0)
-                return r;
+        d = decrypted_image_new();
+        if (PTR_IS_ERR(d))
+                return PTR_TO_ERR(d);
 
         for (PartitionDesignator i = 0; i < _PARTITION_DESIGNATOR_MAX; i++) {
                 DissectedPartition *p = m->partitions + i;
@@ -4495,9 +4485,9 @@ int dissect_loop_device(
 
         assert(loop);
 
-        r = dissected_image_new(loop->backing_file ?: loop->node, &m);
-        if (r < 0)
-                return r;
+        m = dissected_image_new(loop->backing_file ?: loop->node);
+        if (PTR_IS_ERR(m))
+                return PTR_TO_ERR(m);
 
         m->loop = loop_device_ref(loop);
         m->image_size = m->loop->device_size;
@@ -5266,9 +5256,9 @@ int mountfsd_mount_image_fd(
                 assert(pp.designator >= 0);
 
                 if (!di) {
-                        r = dissected_image_new(/* path= */ NULL, &di);
-                        if (r < 0)
-                                return log_debug_errno(r, "Failed to allocated new dissected image structure: %m");
+                        di = dissected_image_new(/* path= */ NULL);
+                        if (PTR_IS_ERR(di))
+                                return log_debug_errno(PTR_TO_ERR(di), "Failed to allocate new dissected image structure: %m");
                 }
 
                 if (di->partitions[pp.designator].found)

--- a/src/shared/fdset.c
+++ b/src/shared/fdset.c
@@ -29,25 +29,23 @@ static void fdset_shallow_freep(FDSet **s) {
         set_free(MAKE_SET(*ASSERT_PTR(s)));
 }
 
-int fdset_new_array(FDSet **ret, const int fds[], size_t n_fds) {
+FDSet *fdset_new_array(const int fds[], size_t n_fds) {
         _cleanup_(fdset_shallow_freep) FDSet *s = NULL;
         int r;
 
-        assert(ret);
         assert(fds || n_fds == 0);
 
         s = fdset_new();
         if (!s)
-                return -ENOMEM;
+                return ERR_TO_PTR(ENOMEM);
 
         FOREACH_ARRAY(fd, fds, n_fds) {
                 r = fdset_put(s, *fd);
                 if (r < 0)
-                        return r;
+                        return ERR_TO_PTR(r);
         }
 
-        *ret = TAKE_PTR(s);
-        return 0;
+        return TAKE_PTR(s);
 }
 
 int fdset_steal_first(FDSet *fds) {

--- a/src/shared/fdset.h
+++ b/src/shared/fdset.h
@@ -15,7 +15,7 @@ int fdset_put_dup(FDSet *s, int fd);
 bool fdset_contains(FDSet *s, int fd);
 int fdset_remove(FDSet *s, int fd);
 
-int fdset_new_array(FDSet **ret, const int *fds, size_t n_fds);
+FDSet *fdset_new_array(const int *fds, size_t n_fds);
 int fdset_new_fill(int filter_cloexec, FDSet **ret);
 int fdset_new_listen_fds(FDSet **ret, bool unset);
 

--- a/src/shared/journal-util.c
+++ b/src/shared/journal-util.c
@@ -89,7 +89,7 @@ static int access_check_var_log_journal(sd_journal *j, bool want_other_users) {
 }
 
 int journal_access_blocked(sd_journal *j) {
-        return hashmap_contains(j->errors, INT_TO_PTR(-EACCES));
+        return hashmap_contains(j->errors, ERR_TO_PTR(EACCES));
 }
 
 int journal_access_check_and_warn(sd_journal *j, bool quiet, bool want_other_users) {
@@ -117,7 +117,7 @@ int journal_access_check_and_warn(sd_journal *j, bool quiet, bool want_other_use
         HASHMAP_FOREACH_KEY(path, code, j->errors) {
                 int err;
 
-                err = ABS(PTR_TO_INT(code));
+                err = ABS(PTR_TO_ERR(code));
 
                 switch (err) {
                 case EACCES:

--- a/src/shared/netif-sriov.c
+++ b/src/shared/netif-sriov.c
@@ -34,14 +34,12 @@ DEFINE_PRIVATE_HASH_OPS_WITH_VALUE_DESTRUCTOR(
                 ConfigSection, config_section_hash_func, config_section_compare_func,
                 SRIOV, sr_iov_free);
 
-static int sr_iov_new(SRIOV **ret) {
+static SRIOV *sr_iov_new(void) {
         SRIOV *sr_iov;
-
-        assert(ret);
 
         sr_iov = new(SRIOV, 1);
         if (!sr_iov)
-                return -ENOMEM;
+                return ERR_TO_PTR(ENOMEM);
 
         *sr_iov = (SRIOV) {
                   .vf = UINT32_MAX,
@@ -52,9 +50,7 @@ static int sr_iov_new(SRIOV **ret) {
                   .link_state = _SR_IOV_LINK_STATE_INVALID,
         };
 
-        *ret = TAKE_PTR(sr_iov);
-
-        return 0;
+        return sr_iov;
 }
 
 static int sr_iov_new_static(OrderedHashmap **sr_iov_by_section, const char *filename, unsigned section_line, SRIOV **ret) {
@@ -78,9 +74,9 @@ static int sr_iov_new_static(OrderedHashmap **sr_iov_by_section, const char *fil
                 return 0;
         }
 
-        r = sr_iov_new(&sr_iov);
-        if (r < 0)
-                return r;
+        sr_iov = sr_iov_new();
+        if (PTR_IS_ERR(sr_iov))
+                return PTR_TO_ERR(sr_iov);
 
         r = ordered_hashmap_ensure_put(sr_iov_by_section, &sr_iov_hash_ops_by_section, n, sr_iov);
         if (r < 0)

--- a/src/shared/notify-recv.c
+++ b/src/shared/notify-recv.c
@@ -108,7 +108,6 @@ int notify_recv_with_fds(
                 .msg_controllen = sizeof(control),
         };
         ssize_t n;
-        int r;
 
         assert(fd >= 0);
 
@@ -175,10 +174,10 @@ int notify_recv_with_fds(
                         log_debug("Received fds via notification while none is expected, closing all.");
                         asynchronous_close_many(fd_array, n_fds);
                 } else {
-                        r = fdset_new_array(&fds, fd_array, n_fds);
-                        if (r < 0) {
+                        fds = fdset_new_array(fd_array, n_fds);
+                        if (PTR_IS_ERR(fds)) {
                                 asynchronous_close_many(fd_array, n_fds);
-                                log_warning_errno(r, "Failed to collect fds from notification, ignoring message: %m");
+                                log_warning_errno(PTR_TO_ERR(fds), "Failed to collect fds from notification, ignoring message: %m");
                                 return -EAGAIN;
                         }
                 }

--- a/src/test/test-errno-util.c
+++ b/src/test/test-errno-util.c
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
 #include "errno-util.h"
+#include "macro.h"
 #include "stdio-util.h"
 #include "tests.h"
 
@@ -106,6 +107,53 @@ TEST(ERRNO_IS_TRANSIENT) {
         ASSERT_FALSE(ERRNO_IS_NEG_TRANSIENT(INT_MIN));
         ASSERT_FALSE(ERRNO_IS_NEG_TRANSIENT(INTMAX_MAX));
         ASSERT_FALSE(ERRNO_IS_NEG_TRANSIENT(INTMAX_MIN));
+}
+
+TEST(ERR_TO_PTR) {
+        /* Basic roundtrip with positive errno values */
+        ASSERT_EQ(PTR_TO_ERR(ERR_TO_PTR(EINVAL)), -EINVAL);
+        ASSERT_EQ(PTR_TO_ERR(ERR_TO_PTR(ENOMEM)), -ENOMEM);
+        ASSERT_EQ(PTR_TO_ERR(ERR_TO_PTR(ENOENT)), -ENOENT);
+
+        /* ABS() handles negative values too */
+        ASSERT_EQ(PTR_TO_ERR(ERR_TO_PTR(-EINVAL)), -EINVAL);
+        ASSERT_EQ(PTR_TO_ERR(ERR_TO_PTR(-ENOMEM)), -ENOMEM);
+
+        /* Edge cases */
+        ASSERT_EQ(PTR_TO_ERR(ERR_TO_PTR(1)), -1);
+        ASSERT_EQ(PTR_TO_ERR(ERR_TO_PTR(ERRNO_MAX)), -ERRNO_MAX);
+
+        /* PTR_IS_ERR detection */
+        ASSERT_TRUE(PTR_IS_ERR(ERR_TO_PTR(EINVAL)));
+        ASSERT_TRUE(PTR_IS_ERR(ERR_TO_PTR(1)));
+        ASSERT_TRUE(PTR_IS_ERR(ERR_TO_PTR(ERRNO_MAX)));
+
+        /* PTR_IS_ERR rejects non-errors */
+        ASSERT_FALSE(PTR_IS_ERR(NULL));
+        ASSERT_FALSE(PTR_IS_ERR(POINTER_MAX));
+        ASSERT_FALSE(PTR_IS_ERR(INT_TO_PTR(1)));
+        ASSERT_FALSE(PTR_IS_ERR(INT_TO_PTR(4096)));
+
+        /* PTR_IS_ERR_OR_NULL */
+        ASSERT_TRUE(PTR_IS_ERR_OR_NULL(NULL));
+        ASSERT_TRUE(PTR_IS_ERR_OR_NULL(ERR_TO_PTR(EINVAL)));
+        ASSERT_FALSE(PTR_IS_ERR_OR_NULL(INT_TO_PTR(1)));
+        ASSERT_FALSE(PTR_IS_ERR_OR_NULL(POINTER_MAX));
+
+        /* PTR_TO_ERR_OR_ZERO */
+        ASSERT_EQ(PTR_TO_ERR_OR_ZERO(ERR_TO_PTR(EINVAL)), -EINVAL);
+        ASSERT_EQ(PTR_TO_ERR_OR_ZERO(INT_TO_PTR(1)), 0);
+
+        /* Does not conflict with POINTER_MAX sentinel */
+        ASSERT_TRUE(ERR_TO_PTR(1) != POINTER_MAX);
+
+        /* PTR_IS_DIRTY covers both error pointers and POINTER_MAX sentinel */
+        ASSERT_TRUE(PTR_IS_DIRTY(ERR_TO_PTR(EINVAL)));
+        ASSERT_TRUE(PTR_IS_DIRTY(ERR_TO_PTR(1)));
+        ASSERT_TRUE(PTR_IS_DIRTY(ERR_TO_PTR(ERRNO_MAX)));
+        ASSERT_TRUE(PTR_IS_DIRTY(POINTER_MAX));
+        ASSERT_FALSE(PTR_IS_DIRTY(NULL));
+        ASSERT_FALSE(PTR_IS_DIRTY(INT_TO_PTR(1)));
 }
 
 DEFINE_TEST_MAIN(LOG_INFO);

--- a/src/test/test-fdset.c
+++ b/src/test/test-fdset.c
@@ -200,7 +200,8 @@ TEST(fdset_new_array) {
         int fds[] = {10, 11, 12, 13};
         _cleanup_fdset_free_ FDSet *fdset = NULL;
 
-        assert_se(fdset_new_array(&fdset, fds, 4) >= 0);
+        fdset = fdset_new_array(fds, 4);
+        assert_se(!PTR_IS_ERR(fdset));
         assert_se(fdset_size(fdset) == 4);
         assert_se(fdset_contains(fdset, 10));
         assert_se(fdset_contains(fdset, 11));

--- a/src/udev/udev-builtin-path_id.c
+++ b/src/udev/udev-builtin-path_id.c
@@ -112,7 +112,8 @@ static sd_device* handle_scsi_fibre_channel(sd_device *parent, char **path) {
         if (sd_device_get_sysattr_value(fcdev, "port_name", &port) < 0)
                 return NULL;
 
-        format_lun_number(parent, &lun);
+        if (format_lun_number(parent, &lun) < 0)
+                return NULL;
         path_prepend(path, "fc-%s-%s", port, lun);
         return parent;
 }
@@ -137,7 +138,8 @@ static sd_device* handle_scsi_sas_wide_port(sd_device *parent, char **path) {
         if (sd_device_get_sysattr_value(sasdev, "sas_address", &sas_address) < 0)
                 return NULL;
 
-        format_lun_number(parent, &lun);
+        if (format_lun_number(parent, &lun) < 0)
+                return NULL;
         path_prepend(path, "sas-%s-%s", sas_address, lun);
         return parent;
 }
@@ -192,7 +194,8 @@ static sd_device* handle_scsi_sas(sd_device *parent, char **path) {
                         return NULL;
         }
 
-        format_lun_number(parent, &lun);
+        if (format_lun_number(parent, &lun) < 0)
+                return NULL;
         if (sas_address)
                  path_prepend(path, "sas-exp%s-phy%s-%s", sas_address, phy_id, lun);
         else
@@ -239,7 +242,8 @@ static sd_device* handle_scsi_iscsi(sd_device *parent, char **path) {
         if (sd_device_get_sysattr_value(conndev, "persistent_port", &port) < 0)
                 return NULL;
 
-        format_lun_number(parent, &lun);
+        if (format_lun_number(parent, &lun) < 0)
+                return NULL;
         path_prepend(path, "ip-%s:%s-iscsi-%s-%s", addr, port, target, lun);
         return parent;
 }
@@ -390,7 +394,8 @@ static sd_device* handle_scsi_hyperv(sd_device *parent, char **path, size_t guid
         }
         guid[k] = '\0';
 
-        format_lun_number(parent, &lun);
+        if (format_lun_number(parent, &lun) < 0)
+                return NULL;
         path_prepend(path, "vmbus-%s-%s", guid, lun);
         return parent;
 }


### PR DESCRIPTION
Add kernel-inspired error pointer macros that encode negative errno values into the upper pointer range [UINTPTR_MAX - ERRNO_MAX, UINTPTR_MAX - 1]. The encoding is shifted by one position compared to the kernel's so that UINTPTR_MAX itself (POINTER_MAX) remains available as a sentinel value for e.g. STRV_IGNORE and sd_varlink.

This is nothing new as we already use `INT_TO_PTR()` in a lot of places:

```
src/cryptsetup/cryptsetup.c:        r = sd_event_add_time_relative(event, NULL, CLOCK_MONOTONIC, arg_token_timeout_usec, USEC_PER_SEC, NULL, INT_TO_PTR(-ETIMEDOUT));
src/cryptsetup/cryptsetup.c:        r = sd_event_add_time_relative(event, NULL, CLOCK_MONOTONIC, arg_token_timeout_usec, USEC_PER_SEC, NULL, INT_TO_PTR(-ETIMEDOUT));
src/libsystemd-network/test-dhcp-client.c:                                             NULL, INT_TO_PTR(-ETIMEDOUT)));
src/libsystemd-network/test-dhcp-client.c:                                             NULL, INT_TO_PTR(-ETIMEDOUT)));
src/libsystemd-network/test-dhcp6-client.c:                                             NULL, INT_TO_PTR(-ETIMEDOUT)) >= 0);
src/libsystemd-network/test-ndisc-ra.c:                                             NULL, INT_TO_PTR(-ETIMEDOUT)) >= 0);
src/libsystemd-network/test-ndisc-rs.c:                                             NULL, INT_TO_PTR(-ETIMEDOUT)) >= 0);
src/libsystemd-network/test-ndisc-rs.c:                                             NULL, INT_TO_PTR(-ETIMEDOUT)) >= 0);
src/libsystemd-network/test-ndisc-rs.c:                                             NULL, INT_TO_PTR(-ETIMEDOUT)) >= 0);
src/libsystemd-network/test-ndisc-rs.c:                                             NULL, INT_TO_PTR(-ETIMEDOUT)) >= 0);
src/libsystemd/sd-event/test-event.c:        ASSERT_OK(sd_event_add_io(e, &s, pfd_a[0], EPOLLIN, NULL, INT_TO_PTR(-ENOANO)));
src/network/wait-online/wait-online-manager.c:                r = sd_event_add_time_relative(m->event, NULL, CLOCK_BOOTTIME, timeout, 0, NULL, INT_TO_PTR(-ETIMEDOUT));
src/shared/journal-util.c:        return hashmap_contains(j->errors, INT_TO_PTR(-EACCES));
src/shared/seccomp-util.c:                return hashmap_put(filter, INT_TO_PTR(id + 1), INT_TO_PTR(-1));
src/shared/udev-util.c:                                NULL, INT_TO_PTR(-ETIMEDOUT));
src/sysupdate/sysupdate-transfer.c:        r = sd_event_add_signal(event, NULL, SIGINT | SD_EVENT_SIGNAL_PROCMASK, NULL, INT_TO_PTR(-ECANCELED));
src/sysupdate/sysupdate-transfer.c:        r = sd_event_add_signal(event, NULL, SIGTERM | SD_EVENT_SIGNAL_PROCMASK, NULL, INT_TO_PTR(-ECANCELED));
src/sysupdate/updatectl.c:        r = ordered_hashmap_replace(map, op->target_id, INT_TO_PTR(-ECANCELED));
src/test/test-execute.c:                ASSERT_OK(hashmap_ensure_put(&s, NULL, UINT32_TO_PTR(r + 1), INT_TO_PTR(-1)));
src/test/test-macro.c:        assert_se(PTR_TO_INT(INT_TO_PTR(-1)) == -1);
src/test/test-seccomp.c:                assert_se(hashmap_put(s, UINT32_TO_PTR(__NR_access + 1), INT_TO_PTR(-1)) >= 0);
src/test/test-seccomp.c:                assert_se(hashmap_put(s, UINT32_TO_PTR(__NR_faccessat + 1), INT_TO_PTR(-1)) >= 0);
src/test/test-seccomp.c:                assert_se(hashmap_put(s, UINT32_TO_PTR(__NR_faccessat2 + 1), INT_TO_PTR(-1)) >= 0);
src/test/test-seccomp.c:                assert_se(hashmap_put(s, UINT32_TO_PTR(__NR_poll + 1), INT_TO_PTR(-1)) >= 0);
src/test/test-seccomp.c:                assert_se(hashmap_put(s, UINT32_TO_PTR(__NR_ppoll + 1), INT_TO_PTR(-1)) >= 0);
src/test/test-seccomp.c:                assert_se(hashmap_put(s, UINT32_TO_PTR(__NR_ppoll_time64 + 1), INT_TO_PTR(-1)) >= 0);
src/test/test-seccomp.c:                assert_se(hashmap_put(s, UINT32_TO_PTR(__NR_access + 1), INT_TO_PTR(-1)) >= 0);
src/test/test-seccomp.c:                assert_se(hashmap_put(s, UINT32_TO_PTR(__NR_faccessat + 1), INT_TO_PTR(-1)) >= 0);
src/test/test-seccomp.c:                assert_se(hashmap_put(s, UINT32_TO_PTR(__NR_faccessat2 + 1), INT_TO_PTR(-1)) >= 0);
src/udev/udev-ctrl.c:                                0, NULL, INT_TO_PTR(-ETIMEDOUT));
src/udev/udevadm-settle.c:                                               NULL, INT_TO_PTR(-ETIMEDOUT));
src/udev/udevadm-wait.c:                                       NULL, INT_TO_PTR(-ETIMEDOUT));
```

to pass error pointers around. This just makes the concept explicit.