### PR TITLE
networkd: keep static lease section valid on MACAddress= reset

### DIFF
--- a/src/network/networkd-dhcp-server-static-lease.c
+++ b/src/network/networkd-dhcp-server-static-lease.c
@@ -188,6 +188,7 @@ int config_parse_dhcp_static_lease_hwaddr(
         if (isempty(rvalue)) {
                 lease->client_id = mfree(lease->client_id);
                 lease->client_id_size = 0;
+                TAKE_PTR(lease);
                 return 0;
         }
 


### PR DESCRIPTION
config_parse_dhcp_static_lease_hwaddr() uses a cleanup helper that marks a lease section invalid unless ownership is taken.

Add TAKE_PTR(lease) on the empty-rvalue reset path so subsequent valid MACAddress= assignments in the same section are not dropped.

Co-developed-by: Codex (GPT-5) <noreply@openai.com>