### PR TITLE
networkd-wwan: handle link_get_by_name() errors in modem_simple_connect

### DIFF
--- a/src/network/networkd-wwan-bus.c
+++ b/src/network/networkd-wwan-bus.c
@@ -604,9 +604,9 @@ static void modem_simple_connect(Modem *modem) {
         if (!modem->port_name)
                 return;
 
-        (void) link_get_by_name(modem->manager, modem->port_name, &link);
-        if (!link)
-                return (void) log_debug("ModemManager: cannot find link for %s", modem->port_name);
+        r = link_get_by_name(modem->manager, modem->port_name, &link);
+        if (r < 0)
+                return (void) log_debug_errno(r, "ModemManager: cannot find link for %s: %m", modem->port_name);
 
         /* Check if .network file found at all */
         if (!link->network)


### PR DESCRIPTION
modem_simple_connect() ignored the return value of link_get_by_name() and then checked link for NULL. Since the helper only sets the output pointer on success, that could read an indeterminate value.

Check and log the return code directly with log_debug_errno().

Co-developed-by: Codex (GPT-5) <noreply@openai.com>