### PR TITLE
More assorted coverity fixes

### DIFF
--- a/src/basic/limits-util.c
+++ b/src/basic/limits-util.c
@@ -28,9 +28,9 @@ uint64_t physical_memory(void) {
         assert(sc > 0);
 
         ps = page_size();
-        /* Silence static analyzers */
-        assert((uint64_t) sc <= UINT64_MAX / (uint64_t) ps);
-        mem = (uint64_t) sc * (uint64_t) ps;
+        /* Physical page count times page size cannot realistically overflow uint64_t,
+         * but use MUL_SAFE to make this obvious to static analyzers. */
+        assert_se(MUL_SAFE(&mem, (uint64_t) sc, (uint64_t) ps));
 
         r = cg_get_root_path(&root);
         if (r < 0) {

--- a/src/basic/recurse-dir.c
+++ b/src/basic/recurse-dir.c
@@ -55,6 +55,8 @@ int readdir_all(int dir_fd, RecurseDirFlags flags, DirectoryEntries **ret) {
                 size_t bs;
                 ssize_t n;
 
+                /* Silence static analyzers, MALLOC_SIZEOF_SAFE is at least as large as the allocation */
+                assert(MALLOC_SIZEOF_SAFE(de) >= offsetof(DirectoryEntries, buffer));
                 bs = MIN(MALLOC_SIZEOF_SAFE(de) - offsetof(DirectoryEntries, buffer), (size_t) SSIZE_MAX);
                 assert(bs > de->buffer_size);
 

--- a/src/basic/uid-range.c
+++ b/src/basic/uid-range.c
@@ -76,6 +76,9 @@ static void uid_range_coalesce(UIDRange *range) {
                                 memmove(y, y + 1, sizeof(UIDRangeEntry) * (range->n_entries - j - 1));
 
                         range->n_entries--;
+
+                        /* Silence static analyzers, j cannot be 0 here since it starts at i + 1, i.e. >= 1 */
+                        assert(j > 0);
                         j--;
                 }
         }

--- a/src/libsystemd/sd-bus/bus-message.c
+++ b/src/libsystemd/sd-bus/bus-message.c
@@ -464,8 +464,8 @@ _public_ int sd_bus_message_new(
         /* Creation of messages with _SD_BUS_MESSAGE_TYPE_INVALID is allowed. */
         assert_return(type < _SD_BUS_MESSAGE_TYPE_MAX, -EINVAL);
 
-        /* Silence static analyzers */
-        assert_cc(sizeof(sd_bus_message) + sizeof(void*) + sizeof(BusMessageHeader) <= SIZE_MAX);
+        /* Silence static analyzers, ALIGN cannot overflow for sizeof() */
+        assert(ALIGN(sizeof(sd_bus_message)) != SIZE_MAX);
         sd_bus_message *t = malloc0(ALIGN(sizeof(sd_bus_message)) + sizeof(BusMessageHeader));
         if (!t)
                 return -ENOMEM;

--- a/src/libsystemd/sd-bus/bus-message.c
+++ b/src/libsystemd/sd-bus/bus-message.c
@@ -359,12 +359,12 @@ static int message_from_header(
         /* Note that we are happy with unknown flags in the flags header! */
 
         a = ALIGN(sizeof(sd_bus_message));
+        /* Silence static analyzers, ALIGN cannot overflow for sizeof() */
+        assert(a != SIZE_MAX);
 
         if (label) {
                 label_sz = strlen(label);
-                /* Silence static analyzers */
-                assert(label_sz <= SIZE_MAX - ALIGN(sizeof(sd_bus_message)) - 1);
-                a += label_sz + 1;
+                assert_se(INC_SAFE(&a, label_sz + 1));
         }
 
         m = malloc0(a);

--- a/src/libsystemd/sd-bus/bus-message.h
+++ b/src/libsystemd/sd-bus/bus-message.h
@@ -153,7 +153,8 @@ static inline uint64_t BUS_MESSAGE_COOKIE(sd_bus_message *m) {
 }
 
 static inline size_t BUS_MESSAGE_SIZE(sd_bus_message *m) {
-        /* Silence static analyzers */
+        /* Silence static analyzers, fields_size is validated at message creation */
+        assert(ALIGN8(m->fields_size) != SIZE_MAX);
         assert(ALIGN8(m->fields_size) <= SIZE_MAX - sizeof(BusMessageHeader));
         assert(m->body_size <= SIZE_MAX - sizeof(BusMessageHeader) - ALIGN8(m->fields_size));
         return
@@ -163,7 +164,8 @@ static inline size_t BUS_MESSAGE_SIZE(sd_bus_message *m) {
 }
 
 static inline size_t BUS_MESSAGE_BODY_BEGIN(sd_bus_message *m) {
-        /* Silence static analyzers */
+        /* Silence static analyzers, fields_size is validated at message creation */
+        assert(ALIGN8(m->fields_size) != SIZE_MAX);
         assert(ALIGN8(m->fields_size) <= SIZE_MAX - sizeof(BusMessageHeader));
         return
                 sizeof(BusMessageHeader) +

--- a/src/libsystemd/sd-event/sd-event.c
+++ b/src/libsystemd/sd-event/sd-event.c
@@ -3804,11 +3804,11 @@ static int process_signal(sd_event *e, struct signal_data *d, uint32_t events, i
                 if (_unlikely_(n != sizeof(si)))
                         return -EIO;
 
-                if (_unlikely_(!SIGNAL_VALID(si.ssi_signo)))
+                if (_unlikely_(si.ssi_signo > INT_MAX)) /* Ensure value fits in int before casting */
                         return -EIO;
 
-                /* Silence static analyzers */
-                assert(si.ssi_signo < _NSIG);
+                if (_unlikely_(!SIGNAL_VALID(si.ssi_signo)))
+                        return -EIO;
 
                 if (e->signal_sources)
                         s = e->signal_sources[si.ssi_signo];

--- a/src/nss-myhostname/nss-myhostname.c
+++ b/src/nss-myhostname/nss-myhostname.c
@@ -238,14 +238,10 @@ static enum nss_status fill_in_hostent(
         if (additional) {
                 ((char**) r_aliases)[0] = r_alias;
                 ((char**) r_aliases)[1] = NULL;
-                /* Silence static analyzers */
-                assert(idx <= buflen - 2 * sizeof(char*));
-                idx += 2*sizeof(char*);
+                assert_se(INC_SAFE(&idx, 2 * sizeof(char*)));
         } else {
                 ((char**) r_aliases)[0] = NULL;
-                /* Silence static analyzers */
-                assert(idx <= buflen - sizeof(char*));
-                idx += sizeof(char*);
+                assert_se(INC_SAFE(&idx, sizeof(char*)));
         }
 
         /* Third, add addresses */

--- a/src/test/test-path.c
+++ b/src/test/test-path.c
@@ -78,9 +78,7 @@ static int _check_states(unsigned line,
         assert_se(m);
         assert_se(service);
 
-        /* Silence static analyzers */
-        assert_cc(30 * USEC_PER_SEC <= USEC_INFINITY);
-        usec_t end = now(CLOCK_MONOTONIC) + 30 * USEC_PER_SEC;
+        usec_t end = usec_add(now(CLOCK_MONOTONIC), 30 * USEC_PER_SEC);
 
         while (path->state != path_state || service->state != service_state ||
                path->result != PATH_SUCCESS || service->result != SERVICE_SUCCESS) {

--- a/src/udev/scsi_id/scsi_serial.c
+++ b/src/udev/scsi_id/scsi_serial.c
@@ -491,9 +491,14 @@ static int check_fill_0x83_id(struct scsi_id_device *dev_scsi,
          * this differs from SCSI_ID_T10_VENDOR, where the vendor is
          * included in the identifier.
          */
-        if (id_search->id_type == SCSI_ID_VENDOR_SPECIFIC)
+        if (id_search->id_type == SCSI_ID_VENDOR_SPECIFIC) {
                 if (append_vendor_model(dev_scsi, serial + 1) < 0)
                         return 1;
+                /* append_vendor_model() uses memcpy() without null-terminating.
+                 * The buffer was zeroed by the caller, but ensure the string is
+                 * explicitly terminated for strlen() below. */
+                serial[1 + VENDOR_LENGTH + MODEL_LENGTH] = '\0';
+        }
 
         i = 4; /* offset to the start of the identifier */
         s = j = strlen(serial);


### PR DESCRIPTION
One more round, this time with the help of the claudebot, especially for spelunking in git blame to find the original commit and writing commit messages from the list of warnings exported from coverity

Co-developed-by: Claude [claude@anthropic.com](mailto:claude@anthropic.com)