### PR TITLE
clangd: Strip GCC-only flags and silence unknown-attributes

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,4 +1,16 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+# Strip GCC-only flags from compile_commands.json before clang sees them.
+# clangd reports these as driver-level "unknown argument" errors which can't
+# be silenced via Diagnostics.Suppress, so they must be removed instead.
+#   -fwide-exec-charset:        used by EFI boot code to make L"..." literals UTF-16
+#   -maccumulate-outgoing-args: GCC x86 codegen flag, no clang equivalent
+CompileFlags:
+  Remove: [-fwide-exec-charset=*, -maccumulate-outgoing-args]
+
 Diagnostics:
   UnusedIncludes: Strict
+  # __no_reorder__ is a GCC-only attribute (see _no_reorder_ in
+  # src/fundamental/macro-fundamental.h). Meson detects it during configure
+  # with GCC and enables it unconditionally, so clangd flags every use.
+  Suppress: [unknown-attributes]


### PR DESCRIPTION
Several GCC-only options in our compile_commands.json (-fwide-exec-charset=UCS2, used by EFI boot code for UTF-16 string literals, and -maccumulate-outgoing-args) cause clangd to emit driver-level "unknown argument" errors. These can't be silenced through Diagnostics.Suppress, so remove them via CompileFlags.Remove before clang ever sees them.

Also suppress the -Wunknown-attributes warning that fires on every use of _no_reorder_, since meson unconditionally expands it to the GCC-only __no_reorder__ attribute when configured with GCC.