### PR TITLE
logind: set session->started before seat_read_active_vt() call

### DIFF
--- a/src/login/logind-session.c
+++ b/src/login/logind-session.c
@@ -922,10 +922,13 @@ int session_start(Session *s, sd_bus_message *properties, sd_bus_error *error) {
         if (!dual_timestamp_is_set(&s->timestamp))
                 dual_timestamp_now(&s->timestamp);
 
+        /* Must be set before seat_read_active_vt(); the activation it
+         * triggers reaches seat_triggered_uevents_done() synchronously
+         * and gates session_device_resume_all() on s->started. */
+        s->started = true;
+
         if (s->seat)
                 seat_read_active_vt(s->seat);
-
-        s->started = true;
 
         user_elect_display(s->user);
 


### PR DESCRIPTION
Fixes #41562.

`session_start()` calls `seat_read_active_vt()` before setting `s->started = true`. The activation triggered by `seat_read_active_vt()` reaches `seat_triggered_uevents_done()` synchronously:

```
seat_read_active_vt -> seat_active_vt_changed -> seat_set_active -> seat_trigger_devices -> seat_triggered_uevents_done
```

When `seat_trigger_devices()` produces no pending uevents, `seat_triggered_uevents_done()` does not return early on the empty-set check and proceeds to:

```c
if (session && session->started) {
        session_send_changed(session, "Active");
        session_device_resume_all(session);
}
```

`session->started` is still `false` because the assignment in `session_start()` runs after the call to `seat_read_active_vt()`. The gate fails, `session_device_resume_all()` is skipped, and the compositor does not receive DRM master.

Setting `s->started = true` before `seat_read_active_vt()` makes the gate see the correct value on the synchronous path. The asynchronous path (where `seat_trigger_devices()` produces N pending uevents and the udev callbacks empty the set later) is unaffected because `s->started` is also set by then.

Reproducible with greetd plus a Wayland compositor on the same VT on kernel 6.19+. Verified against `9bd72b6`.