### PR TITLE
Revert "mkosi: Mark minimal images as Incremental=relaxed"

### DIFF
--- a/mkosi/mkosi.images/minimal-0/mkosi.conf
+++ b/mkosi/mkosi.images/minimal-0/mkosi.conf
@@ -9,8 +9,6 @@ SplitArtifacts=yes
 
 [Build]
 Environment=SYSTEMD_REPART_OVERRIDE_FSTYPE=squashfs
-Incremental=relaxed
-CacheOnly=metadata
 
 [Content]
 BaseTrees=%O/minimal-base

--- a/mkosi/mkosi.images/minimal-1/mkosi.conf
+++ b/mkosi/mkosi.images/minimal-1/mkosi.conf
@@ -9,8 +9,6 @@ SplitArtifacts=yes
 
 [Build]
 Environment=SYSTEMD_REPART_OVERRIDE_FSTYPE=squashfs
-Incremental=relaxed
-CacheOnly=metadata
 
 [Content]
 BaseTrees=%O/minimal-base

--- a/mkosi/mkosi.images/minimal-base/mkosi.conf
+++ b/mkosi/mkosi.images/minimal-base/mkosi.conf
@@ -5,7 +5,6 @@ Format=directory
 
 [Build]
 Environment=SYSTEMD_REQUIRED_DEPS_ONLY=1
-Incremental=relaxed
 
 [Content]
 Bootable=no

--- a/mkosi/mkosi.images/minimal-base/mkosi.conf.d/arch.conf
+++ b/mkosi/mkosi.images/minimal-base/mkosi.conf.d/arch.conf
@@ -11,6 +11,9 @@ Packages=
         iproute
         nmap
 
+VolatilePackages=
+        systemd-libs
+
 RemoveFiles=
         # Arch Linux doesn't split their gcc-libs package so we manually remove
         # unneeded stuff here to make sure it doesn't end up in the image.

--- a/mkosi/mkosi.images/minimal-base/mkosi.conf.d/centos-fedora.conf
+++ b/mkosi/mkosi.images/minimal-base/mkosi.conf.d/centos-fedora.conf
@@ -12,3 +12,6 @@ Packages=
         iproute
         iproute-tc
         nmap-ncat
+
+VolatilePackages=
+        systemd-libs

--- a/mkosi/mkosi.images/minimal-base/mkosi.conf.d/debian-ubuntu.conf
+++ b/mkosi/mkosi.images/minimal-base/mkosi.conf.d/debian-ubuntu.conf
@@ -12,3 +12,7 @@ Packages=
         iproute2
         mount
         ncat
+
+VolatilePackages=
+        libsystemd0
+        libudev1

--- a/mkosi/mkosi.images/minimal-base/mkosi.conf.d/opensuse.conf
+++ b/mkosi/mkosi.images/minimal-base/mkosi.conf.d/opensuse.conf
@@ -16,3 +16,7 @@ Packages=
         patterns-base-minimal_base
         sed
         xz
+
+VolatilePackages=
+        libsystemd0
+        libudev1


### PR DESCRIPTION
The setting has fundamental flaws that can't be easily fixed (see https://github.com/systemd/mkosi/pull/4273) so revert it's use as we're dropping it in systemd. Image builds will take a bit longer again until I figure out a proper fix for this.

This reverts commit 7a70c323681b091328fcf6c9ca3104c7958a1331.