### PR TITLE
sd-varlink: fix a potential connection count leak

### DIFF
--- a/src/libsystemd/sd-varlink/sd-varlink.c
+++ b/src/libsystemd/sd-varlink/sd-varlink.c
@@ -3727,8 +3727,6 @@ static int count_connection(sd_varlink_server *server, const struct ucred *ucred
         assert(server);
         assert(ucred);
 
-        server->n_connections++;
-
         if (FLAGS_SET(server->flags, SD_VARLINK_SERVER_ACCOUNT_UID)) {
                 assert(uid_is_valid(ucred->uid));
 
@@ -3745,6 +3743,8 @@ static int count_connection(sd_varlink_server *server, const struct ucred *ucred
                 if (r < 0)
                         return varlink_server_log_errno(server, r, "Failed to increment counter in UID hash table: %m");
         }
+
+        server->n_connections++;
 
         return 0;
 }


### PR DESCRIPTION
With the old version there was a potential connection count leak if either of the two hashmap operations in `count_connection()` failed. In that case we'd return from `sd_varlink_server_add_connection_pair()` _before_ attached the `sd_varlink_server` object to an `sd_varlink` object, and since `varlink_detach_server()` is the only place where the connection counter is decremented (called through `sd_varlink_close()` in various error paths later _if_ the "server" object is not null, i.e. attached to the `sd_varlink` object) we'd "leak" a connection every time this happened. However, the potential of abusing this is very theoretical, as one would need to hit OOM every time either of the hashmap operations was executed for a while before exhausting the connection limit.

Let's just increment the connection counter after any potential error path, so we don't have to deal with potential rollbacks.