### PR TITLE
udev: fix bounds check in dev_if_packed_info()

### DIFF
--- a/src/udev/udev-builtin-usb_id.c
+++ b/src/udev/udev-builtin-usb_id.c
@@ -168,7 +168,7 @@ static int dev_if_packed_info(sd_device *dev, char *ifs_str, size_t len) {
                 desc = (struct usb_interface_descriptor *) (buf + pos);
                 if (desc->bLength < 3)
                         break;
-                if (desc->bLength > size - sizeof(struct usb_interface_descriptor))
+                if (desc->bLength > (size_t) size - pos)
                         return log_device_debug_errno(dev, SYNTHETIC_ERRNO(EIO),
                                                       "Corrupt data read from \"%s\"", filename);
                 pos += desc->bLength;


### PR DESCRIPTION
The check compared bLength against (size - sizeof(descriptor)), which is an
absolute limit unrelated to the current buffer position. Since bLength is
uint8_t (max 255), this can never exceed size - 9 for any realistic input,
making the check dead code. Use (size - pos) instead.

Fixes #41570