### PR TITLE
meson: Check if files returned by git ls-files actually exist

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2896,7 +2896,13 @@ if git.found()
                      'ls-files', ':/*.[ch]', ':/*.cc',
                 check : false)
         if all_files.returncode() == 0
-                all_files = files(all_files.stdout().split())
+                existing_files = []
+                foreach f : all_files.stdout().split()
+                        if fs.exists(f)
+                                existing_files += f
+                        endif
+                endforeach
+                all_files = files(existing_files)
 
                 custom_target(
                         output : 'tags',

--- a/test/fuzz/meson.build
+++ b/test/fuzz/meson.build
@@ -51,7 +51,7 @@ foreach p : out.stdout().split()
         #
         # Also, backslashes get mangled, so skip test. See
         # https://github.com/mesonbuild/meson/issues/1564.
-        if p.contains('\\')
+        if p.contains('\\') or not fs.exists(p)
                 continue
         endif
         fuzzer = fs.name(fs.parent(p))


### PR DESCRIPTION
Otherwise you run into errors such as:

"""
../meson.build:2899:28: ERROR: File src/test/test-loop-util.c does not exist. """

when deleting a file in git without staging the deletion.