### PR TITLE
[RFC] core: add io.systemd.Unit.StartTransient() to the varlink API

### DIFF
--- a/src/core/dbus-manager.c
+++ b/src/core/dbus-manager.c
@@ -1025,7 +1025,6 @@ static int transient_unit_from_message(
                 Unit **ret_unit,
                 sd_bus_error *reterr_error) {
 
-        UnitType t;
         Unit *u;
         int r;
 
@@ -1033,27 +1032,7 @@ static int transient_unit_from_message(
         assert(message);
         assert(name);
 
-        t = unit_name_to_type(name);
-        if (t < 0)
-                return sd_bus_error_setf(reterr_error, SD_BUS_ERROR_INVALID_ARGS,
-                                         "Invalid unit name or type: %s", name);
-
-        if (!unit_vtable[t]->can_transient)
-                return sd_bus_error_setf(reterr_error, SD_BUS_ERROR_INVALID_ARGS,
-                                         "Unit type %s does not support transient units.",
-                                         unit_type_to_string(t));
-
-        r = manager_load_unit(m, name, NULL, reterr_error, &u);
-        if (r < 0)
-                return r;
-
-        if (!unit_is_pristine(u))
-                return sd_bus_error_setf(reterr_error, BUS_ERROR_UNIT_EXISTS,
-                                         "Unit %s was already loaded or has a fragment file.", name);
-
-        /* OK, the unit failed to load and is unreferenced, now let's
-         * fill in the transient data instead */
-        r = unit_make_transient(u);
+        r = manager_setup_transient_unit(m, name, &u, reterr_error);
         if (r < 0)
                 return r;
 

--- a/src/core/job.c
+++ b/src/core/job.c
@@ -24,6 +24,7 @@
 #include "string-util.h"
 #include "strv.h"
 #include "unit.h"
+#include "varlink-unit.h"
 #include "virt.h"
 
 Job* job_new_raw(Unit *unit) {
@@ -122,6 +123,7 @@ Job* job_free(Job *j) {
         job_unlink(j);
 
         sd_bus_track_unref(j->bus_track);
+        sd_varlink_unref(j->varlink);
         strv_free(j->deserialized_clients);
 
         activation_details_unref(j->activation_details);
@@ -170,8 +172,10 @@ void job_uninstall(Job *j) {
         /* Detach from next 'bigger' objects */
 
         /* daemon-reload should be transparent to job observers */
-        if (!MANAGER_IS_RELOADING(j->manager))
+        if (!MANAGER_IS_RELOADING(j->manager)) {
                 bus_job_send_removed_signal(j);
+                varlink_job_send_removed_signal(j);
+        }
 
         *pj = NULL;
 

--- a/src/core/job.h
+++ b/src/core/job.h
@@ -1,6 +1,8 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 #pragma once
 
+#include "sd-varlink.h"
+
 #include "core-forward.h"
 #include "list.h"
 
@@ -124,6 +126,9 @@ typedef struct Job {
          */
         sd_bus_track *bus_track;
         char **deserialized_clients;
+
+        /* If non-NULL, a varlink connection streaming job state updates via io.systemd.Unit.StartTransient */
+        sd_varlink *varlink;
 
         /* If the job had a specific trigger that needs to be advertised (eg: a path unit), store it. */
         ActivationDetails *activation_details;

--- a/src/core/manager.c
+++ b/src/core/manager.c
@@ -93,6 +93,7 @@
 #include "umask-util.h"
 #include "unit-name.h"
 #include "user-util.h"
+#include "varlink-unit.h"
 #include "varlink.h"
 #include "virt.h"
 #include "watchdog.h"
@@ -2625,6 +2626,7 @@ static unsigned manager_dispatch_dbus_queue(Manager *m) {
                 assert(j->in_dbus_queue);
 
                 bus_job_send_change_signal(j);
+                varlink_job_send_change_signal(j);
                 n++;
 
                 if (budget != UINT_MAX)

--- a/src/core/unit.c
+++ b/src/core/unit.c
@@ -4862,7 +4862,7 @@ int unit_make_transient(Unit *u) {
          * creating the transient, and is closed in unit_load(), as soon as we start loading the file. */
 
         WITH_UMASK(0022) {
-                f = fopen(path, "we");
+                f = fopen(path, "w+e");
                 if (!f)
                         return -errno;
         }
@@ -4886,6 +4886,40 @@ int unit_make_transient(Unit *u) {
         fputs("# This is a transient unit file, created programmatically via the systemd API. Do not edit.\n",
               u->transient_file);
 
+        return 0;
+}
+
+int manager_setup_transient_unit(Manager *m, const char *name, Unit **ret, sd_bus_error *reterr_error) {
+        Unit *u;
+        int r;
+
+        assert(m);
+        assert(name);
+        assert(ret);
+
+        UnitType t = unit_name_to_type(name);
+        if (t < 0)
+                return sd_bus_error_setf(reterr_error, SD_BUS_ERROR_INVALID_ARGS,
+                                         "Invalid unit name or type: %s", name);
+
+        if (!unit_vtable[t]->can_transient)
+                return sd_bus_error_setf(reterr_error, SD_BUS_ERROR_INVALID_ARGS,
+                                         "Unit type %s does not support transient units.",
+                                         unit_type_to_string(t));
+
+        r = manager_load_unit(m, name, /* path= */ NULL, reterr_error, &u);
+        if (r < 0)
+                return r;
+
+        if (!unit_is_pristine(u))
+                return sd_bus_error_setf(reterr_error, BUS_ERROR_UNIT_EXISTS,
+                                         "Unit %s was already loaded or has a fragment file.", name);
+
+        r = unit_make_transient(u);
+        if (r < 0)
+                return r;
+
+        *ret = u;
         return 0;
 }
 

--- a/src/core/unit.h
+++ b/src/core/unit.h
@@ -973,6 +973,7 @@ int unit_write_settingf(Unit *u, UnitWriteFlags flags, const char *name, const c
 int unit_kill_context(Unit *u, KillOperation k);
 
 int unit_make_transient(Unit *u);
+int manager_setup_transient_unit(Manager *m, const char *name, Unit **ret, sd_bus_error *reterr_error);
 
 int unit_add_mounts_for(Unit *u, const char *path, UnitDependencyMask mask, UnitMountDependencyType type);
 

--- a/src/core/varlink-common.c
+++ b/src/core/varlink-common.c
@@ -17,6 +17,8 @@ const char* varlink_error_id_from_bus_error(const sd_bus_error *e) {
                 { BUS_ERROR_NO_SUCH_UNIT,       VARLINK_ERROR_UNIT_NO_SUCH_UNIT       },
                 { BUS_ERROR_ONLY_BY_DEPENDENCY, VARLINK_ERROR_UNIT_ONLY_BY_DEPENDENCY },
                 { BUS_ERROR_SHUTTING_DOWN,      VARLINK_ERROR_UNIT_DBUS_SHUTTING_DOWN },
+                { BUS_ERROR_UNIT_EXISTS,        VARLINK_ERROR_UNIT_UNIT_EXISTS        },
+                { BUS_ERROR_BAD_UNIT_SETTING,   VARLINK_ERROR_UNIT_BAD_SETTING        },
         };
 
         if (!sd_bus_error_is_set(e))

--- a/src/core/varlink-unit.c
+++ b/src/core/varlink-unit.c
@@ -1,15 +1,23 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
+#include "sd-bus.h"
 #include "sd-json.h"
 
 #include "bitfield.h"
+#include "bus-error.h"
 #include "bus-polkit.h"
 #include "cgroup.h"
 #include "condition.h"
 #include "dbus-job.h"
+#include "conf-parser.h"
 #include "execute.h"
+#include "fd-util.h"
+#include "fileio.h"
 #include "format-util.h"
 #include "install.h"
+#include "job.h"
+#include "load-fragment.h"
+#include "locale-util.h"
 #include "json-util.h"
 #include "manager.h"
 #include "path-util.h"
@@ -18,7 +26,9 @@
 #include "set.h"
 #include "strv.h"
 #include "unit.h"
+#include "unit-name.h"
 #include "varlink-cgroup.h"
+#include "varlink-common.h"
 #include "varlink-execute.h"
 #include "varlink-unit.h"
 #include "varlink-util.h"
@@ -566,6 +576,172 @@ int varlink_error_no_such_unit(sd_varlink *v, const char *name) {
                         ASSERT_PTR(v),
                         VARLINK_ERROR_UNIT_NO_SUCH_UNIT,
                         JSON_BUILD_PAIR_STRING_NON_EMPTY("parameter", name));
+}
+
+void varlink_job_send_change_signal(Job *j) {
+        assert(j);
+
+        if (!j->varlink)
+                return;
+
+        (void) sd_varlink_notifybo(
+                        j->varlink,
+                        SD_JSON_BUILD_PAIR_INTEGER("jobId", j->id),
+                        SD_JSON_BUILD_PAIR_STRING("unit", j->unit->id),
+                        SD_JSON_BUILD_PAIR_STRING("jobType", job_type_to_string(j->type)),
+                        SD_JSON_BUILD_PAIR_STRING("state", job_state_to_string(j->state)));
+}
+
+void varlink_job_send_removed_signal(Job *j) {
+        assert(j);
+
+        if (!j->varlink)
+                return;
+
+        /* Send the final reply, which terminates the streaming connection */
+        (void) sd_varlink_replybo(
+                        j->varlink,
+                        SD_JSON_BUILD_PAIR_INTEGER("jobId", j->id),
+                        SD_JSON_BUILD_PAIR_STRING("unit", j->unit->id),
+                        SD_JSON_BUILD_PAIR_STRING("jobType", job_type_to_string(j->type)),
+                        SD_JSON_BUILD_PAIR_STRING("result", job_result_to_string(j->result)));
+
+        j->varlink = sd_varlink_unref(j->varlink);
+}
+
+int vl_method_start_transient_unit(sd_varlink *link, sd_json_variant *parameters, sd_varlink_method_flags_t flags, void *userdata) {
+        struct {
+                const char *name;
+                const char *mode;
+                const char *content;
+        } p = {};
+
+        static const sd_json_dispatch_field dispatch_table[] = {
+                { "name",    SD_JSON_VARIANT_STRING, json_dispatch_const_unit_name, offsetof(typeof(p), name),    SD_JSON_MANDATORY },
+                { "mode",    SD_JSON_VARIANT_STRING, sd_json_dispatch_const_string, offsetof(typeof(p), mode),    0                },
+                { "content", SD_JSON_VARIANT_STRING, sd_json_dispatch_const_string, offsetof(typeof(p), content), SD_JSON_MANDATORY },
+                {}
+        };
+
+        _cleanup_(sd_bus_error_free) sd_bus_error bus_error = SD_BUS_ERROR_NULL;
+        Manager *manager = ASSERT_PTR(userdata);
+        uint32_t job_id;
+        Unit *u;
+        int r;
+
+        assert(link);
+        assert(parameters);
+
+        r = mac_selinux_access_check_varlink(link, "start");
+        if (r < 0)
+                return r;
+
+        r = sd_varlink_dispatch(link, parameters, dispatch_table, &p);
+        if (r != 0)
+                return r;
+
+        JobMode job_mode;
+        if (p.mode) {
+                job_mode = job_mode_from_string(p.mode);
+                if (job_mode < 0)
+                        return sd_varlink_error_invalid_parameter_name(link, "mode");
+        } else
+                job_mode = JOB_REPLACE;
+
+        r = varlink_verify_polkit_async(
+                        link,
+                        manager->system_bus,
+                        "org.freedesktop.systemd1.manage-units",
+                        (const char**) STRV_MAKE(
+                                        "unit", p.name,
+                                        "verb", "start",
+                                        "polkit.message", N_("Authentication is required to start transient unit '$(unit)'."),
+                                        "polkit.gettext_domain", GETTEXT_PACKAGE),
+                        &manager->polkit_registry);
+        if (r <= 0)
+                return r;
+
+        r = manager_setup_transient_unit(manager, p.name, &u, &bus_error);
+        if (r < 0) {
+                const char *error_id = varlink_error_id_from_bus_error(&bus_error);
+                if (error_id)
+                        return sd_varlink_error(link, error_id, NULL);
+                return r;
+        }
+
+        /* Write the caller-provided unit file content to the transient file.
+         * Then parse it directly to populate in-memory state. This is necessary because
+         * unit_load_fragment() skips file parsing for transient units (it assumes the D-Bus
+         * property dispatch chain already populated everything in memory). Since we bypass
+         * that chain and write raw file content instead, we must parse it ourselves. */
+        fputs(p.content, u->transient_file);
+        fputc('\n', u->transient_file);
+
+        r = fflush_and_check(u->transient_file);
+        if (r < 0)
+                return r;
+
+        /* Rewind the transient file (opened read-write) so config_parse() can read it back. */
+        rewind(u->transient_file);
+
+        r = config_parse(u->id, u->fragment_path, u->transient_file,
+                         UNIT_VTABLE(u)->sections,
+                         config_item_perf_lookup, load_fragment_gperf_lookup,
+                         0,
+                         u,
+                         NULL);
+        if (r < 0)
+                return sd_varlink_error(link, VARLINK_ERROR_UNIT_BAD_SETTING, NULL);
+
+        unit_add_to_load_queue(u);
+        manager_dispatch_load_queue(manager);
+
+        if (u->load_state == UNIT_BAD_SETTING)
+                return sd_varlink_error(link, VARLINK_ERROR_UNIT_BAD_SETTING, NULL);
+        if (!UNIT_IS_LOAD_COMPLETE(u->load_state))
+                return sd_varlink_error(link, VARLINK_ERROR_UNIT_NO_SUCH_UNIT, NULL);
+
+        r = varlink_unit_queue_job_one(
+                        u,
+                        JOB_START,
+                        job_mode,
+                        /* reload_if_possible= */ false,
+                        &job_id,
+                        &bus_error);
+        if (r < 0) {
+                const char *error_id = varlink_error_id_from_bus_error(&bus_error);
+                if (error_id)
+                        return sd_varlink_error(link, error_id, NULL);
+                return r;
+        }
+
+        /* Non-streaming: just return the job ID */
+        if (!FLAGS_SET(flags, SD_VARLINK_METHOD_MORE))
+                return sd_varlink_replybo(
+                                link,
+                                SD_JSON_BUILD_PAIR_INTEGER("jobId", job_id),
+                                SD_JSON_BUILD_PAIR_STRING("unit", u->id),
+                                SD_JSON_BUILD_PAIR_STRING("jobType", job_type_to_string(JOB_START)));
+
+        /* Streaming: attach to the job and send the initial state notification */
+        Job *j = hashmap_get(manager->jobs, UINT32_TO_PTR(job_id));
+        if (!j)
+                /* Job already completed between queueing and now */
+                return sd_varlink_replybo(
+                                link,
+                                SD_JSON_BUILD_PAIR_INTEGER("jobId", job_id),
+                                SD_JSON_BUILD_PAIR_STRING("unit", u->id),
+                                SD_JSON_BUILD_PAIR_STRING("jobType", job_type_to_string(JOB_START)),
+                                SD_JSON_BUILD_PAIR_STRING("result", "done"));
+
+        j->varlink = sd_varlink_ref(link);
+
+        return sd_varlink_notifybo(
+                        link,
+                        SD_JSON_BUILD_PAIR_INTEGER("jobId", job_id),
+                        SD_JSON_BUILD_PAIR_STRING("unit", u->id),
+                        SD_JSON_BUILD_PAIR_STRING("jobType", job_type_to_string(JOB_START)),
+                        SD_JSON_BUILD_PAIR_STRING("state", job_state_to_string(j->state)));
 }
 
 typedef struct UnitSetPropertiesParameters {

--- a/src/core/varlink-unit.h
+++ b/src/core/varlink-unit.h
@@ -6,6 +6,9 @@
 #define VARLINK_ERROR_UNIT_NO_SUCH_UNIT "io.systemd.Unit.NoSuchUnit"
 #define VARLINK_ERROR_UNIT_ONLY_BY_DEPENDENCY "io.systemd.Unit.OnlyByDependency"
 #define VARLINK_ERROR_UNIT_DBUS_SHUTTING_DOWN "io.systemd.Unit.DBusShuttingDown"
+#define VARLINK_ERROR_UNIT_UNIT_EXISTS "io.systemd.Unit.UnitExists"
+#define VARLINK_ERROR_UNIT_TYPE_NOT_SUPPORTED "io.systemd.Unit.UnitTypeNotSupported"
+#define VARLINK_ERROR_UNIT_BAD_SETTING "io.systemd.Unit.BadUnitSetting"
 
 int vl_method_list_units(sd_varlink *link, sd_json_variant *parameters, sd_varlink_method_flags_t flags, void *userdata);
 
@@ -18,5 +21,10 @@ int varlink_unit_queue_job_one(
                 sd_bus_error *reterr_bus_error);
 
 int vl_method_set_unit_properties(sd_varlink *link, sd_json_variant *parameters, sd_varlink_method_flags_t flags, void *userdata);
+
+int vl_method_start_transient_unit(sd_varlink *link, sd_json_variant *parameters, sd_varlink_method_flags_t flags, void *userdata);
+
+void varlink_job_send_change_signal(Job *j);
+void varlink_job_send_removed_signal(Job *j);
 
 int varlink_error_no_such_unit(sd_varlink *v, const char *name);

--- a/src/core/varlink.c
+++ b/src/core/varlink.c
@@ -4,6 +4,7 @@
 
 #include "constants.h"
 #include "errno-util.h"
+#include "job.h"
 #include "manager.h"
 #include "metrics.h"
 #include "path-util.h"
@@ -355,6 +356,15 @@ static void vl_disconnect(sd_varlink_server *s, sd_varlink *link, void *userdata
 
         if (link == m->managed_oom_varlink)
                 m->managed_oom_varlink = sd_varlink_unref(link);
+
+        /* Drop any job varlink references for the disconnecting client.
+         * A varlink link can stream at most one job, so stop after the first match. */
+        Job *j;
+        HASHMAP_FOREACH(j, m->jobs)
+                if (j->varlink == link) {
+                        j->varlink = sd_varlink_unref(j->varlink);
+                        break;
+                }
 }
 
 int manager_setup_varlink_server(Manager *m) {
@@ -397,6 +407,7 @@ int manager_setup_varlink_server(Manager *m) {
                         "io.systemd.Manager.SoftReboot", vl_method_soft_reboot,
                         "io.systemd.Unit.List", vl_method_list_units,
                         "io.systemd.Unit.SetProperties", vl_method_set_unit_properties,
+                        "io.systemd.Unit.StartTransient", vl_method_start_transient_unit,
                         "io.systemd.service.Ping", varlink_method_ping,
                         "io.systemd.service.GetEnvironment", varlink_method_get_environment);
         if (r < 0)
@@ -418,11 +429,11 @@ int manager_setup_varlink_server(Manager *m) {
                                 "io.systemd.ManagedOOM.SubscribeManagedOOMCGroups", vl_method_subscribe_managed_oom_cgroups);
                 if (r < 0)
                         return log_debug_errno(r, "Failed to register varlink methods: %m");
-
-                r = sd_varlink_server_bind_disconnect(s, vl_disconnect);
-                if (r < 0)
-                        return log_debug_errno(r, "Failed to register varlink disconnect handler: %m");
         }
+
+        r = sd_varlink_server_bind_disconnect(s, vl_disconnect);
+        if (r < 0)
+                return log_debug_errno(r, "Failed to register varlink disconnect handler: %m");
 
         r = sd_varlink_server_attach_event(s, m->event, EVENT_PRIORITY_IPC);
         if (r < 0)

--- a/src/shared/varlink-io.systemd.Unit.c
+++ b/src/shared/varlink-io.systemd.Unit.c
@@ -1036,6 +1036,30 @@ static SD_VARLINK_DEFINE_ERROR(
                 PropertyNotSupported,
                 SD_VARLINK_DEFINE_FIELD(property, SD_VARLINK_STRING, SD_VARLINK_NULLABLE));
 
+static SD_VARLINK_DEFINE_ERROR(UnitExists);
+static SD_VARLINK_DEFINE_ERROR(UnitTypeNotSupported);
+static SD_VARLINK_DEFINE_ERROR(BadUnitSetting);
+
+static SD_VARLINK_DEFINE_METHOD_FULL(
+                StartTransient,
+                SD_VARLINK_SUPPORTS_MORE,
+                SD_VARLINK_FIELD_COMMENT("The name of the transient unit to create."),
+                SD_VARLINK_DEFINE_INPUT(name, SD_VARLINK_STRING, 0),
+                SD_VARLINK_FIELD_COMMENT("Job mode: replace, fail, isolate, etc. Defaults to replace."),
+                SD_VARLINK_DEFINE_INPUT(mode, SD_VARLINK_STRING, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("Raw unit file content including section headers."),
+                SD_VARLINK_DEFINE_INPUT(content, SD_VARLINK_STRING, 0),
+                SD_VARLINK_FIELD_COMMENT("ID of the enqueued start job."),
+                SD_VARLINK_DEFINE_OUTPUT(jobId, SD_VARLINK_INT, 0),
+                SD_VARLINK_FIELD_COMMENT("Unit name."),
+                SD_VARLINK_DEFINE_OUTPUT(unit, SD_VARLINK_STRING, 0),
+                SD_VARLINK_FIELD_COMMENT("Job type string."),
+                SD_VARLINK_DEFINE_OUTPUT(jobType, SD_VARLINK_STRING, 0),
+                SD_VARLINK_FIELD_COMMENT("Current job state: waiting, running. Set for intermediate notifications."),
+                SD_VARLINK_DEFINE_OUTPUT(state, SD_VARLINK_STRING, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("Final result: done, failed, canceled, timeout, dependency, skipped, etc. Set in the final reply."),
+                SD_VARLINK_DEFINE_OUTPUT(result, SD_VARLINK_STRING, SD_VARLINK_NULLABLE));
+
 static SD_VARLINK_DEFINE_METHOD(
                 SetProperties,
                 SD_VARLINK_FIELD_COMMENT("The name of the unit to operate on."),
@@ -1052,6 +1076,8 @@ SD_VARLINK_DEFINE_INTERFACE(
                 &vl_method_List,
                 SD_VARLINK_SYMBOL_COMMENT("Set unit properties"),
                 &vl_method_SetProperties,
+                SD_VARLINK_SYMBOL_COMMENT("Create a transient unit and start it"),
+                &vl_method_StartTransient,
                 &vl_type_RateLimit,
                 SD_VARLINK_SYMBOL_COMMENT("An object to represent a unit's conditions"),
                 &vl_type_Condition,
@@ -1121,4 +1147,10 @@ SD_VARLINK_DEFINE_INTERFACE(
                 SD_VARLINK_SYMBOL_COMMENT("Job for the unit may only be enqueued by dependencies"),
                 &vl_error_OnlyByDependency,
                 SD_VARLINK_SYMBOL_COMMENT("A unit that requires D-Bus cannot be started as D-Bus is shutting down"),
-                &vl_error_DBusShuttingDown);
+                &vl_error_DBusShuttingDown,
+                SD_VARLINK_SYMBOL_COMMENT("A unit with this name already exists"),
+                &vl_error_UnitExists,
+                SD_VARLINK_SYMBOL_COMMENT("This unit type does not support transient units"),
+                &vl_error_UnitTypeNotSupported,
+                SD_VARLINK_SYMBOL_COMMENT("The unit file content contains invalid settings"),
+                &vl_error_BadUnitSetting);

--- a/test/units/TEST-26-SYSTEMCTL.sh
+++ b/test/units/TEST-26-SYSTEMCTL.sh
@@ -519,6 +519,87 @@ systemctl show -P Markers "$UNIT_NAME" | grep needs-stop
 (! systemctl show -P Markers "$UNIT_NAME" | grep needs-reload)
 varlinkctl call /run/systemd/io.systemd.Manager io.systemd.Unit.SetProperties "{\"runtime\": true, \"name\": \"$UNIT_NAME\", \"properties\": {\"Markers\": []}}"
 
+# Test io.systemd.Unit.StartTransient
+MANAGER_SOCKET="/run/systemd/io.systemd.Manager"
+
+# Basic oneshot transient service
+result=$(varlinkctl call "$MANAGER_SOCKET" io.systemd.Unit.StartTransient \
+    '{"name":"varlink-transient-test.service","content":"[Service]\nType=oneshot\nExecStart=/bin/true\n"}')
+echo "$result" | grep -q '"jobId"'
+
+# Wait for completion
+timeout 30 bash -c 'until systemctl show -P ActiveState varlink-transient-test.service | grep -q inactive; do sleep 0.5; done'
+systemctl show -P Result varlink-transient-test.service | grep -q success
+
+# With explicit mode
+result=$(varlinkctl call "$MANAGER_SOCKET" io.systemd.Unit.StartTransient \
+    '{"name":"varlink-transient-test2.service","mode":"fail","content":"[Service]\nType=oneshot\nExecStart=/bin/true\n"}')
+echo "$result" | grep -q '"jobId"'
+
+# Streaming: should get intermediate state updates and a final result
+result=$(varlinkctl call --more "$MANAGER_SOCKET" io.systemd.Unit.StartTransient \
+    '{"name":"varlink-transient-test3.service","content":"[Service]\nType=oneshot\nExecStart=/bin/true\n"}')
+echo "$result" | grep -q '"state"'
+echo "$result" | grep -q '"result"'
+echo "$result" | grep -q '"done"'
+
+# Error: unit already exists — create a long-running service, then try to create it again while it's active
+varlinkctl call "$MANAGER_SOCKET" io.systemd.Unit.StartTransient \
+    '{"name":"varlink-transient-exists.service","content":"[Service]\nExecStart=sleep infinity\n"}'
+timeout 10 bash -c 'until systemctl is-active varlink-transient-exists.service; do sleep 0.5; done'
+(! varlinkctl call "$MANAGER_SOCKET" io.systemd.Unit.StartTransient \
+    '{"name":"varlink-transient-exists.service","content":"[Service]\nExecStart=sleep infinity\n"}')
+
+# Multiple ExecStart commands (oneshot allows multiple)
+result=$(varlinkctl call --more "$MANAGER_SOCKET" io.systemd.Unit.StartTransient \
+    '{"name":"varlink-transient-multi.service","content":"[Service]\nType=oneshot\nExecStart=/bin/true\nExecStart=/bin/true\n"}')
+echo "$result" | grep -q '"result"'
+echo "$result" | grep -q '"done"'
+
+# Transient slice
+result=$(varlinkctl call "$MANAGER_SOCKET" io.systemd.Unit.StartTransient \
+    '{"name":"varlink-transient-test.slice","content":"[Unit]\nDescription=Test transient slice\n"}')
+echo "$result" | grep -q '"jobId"'
+timeout 10 bash -c 'until systemctl is-active varlink-transient-test.slice; do sleep 0.5; done'
+systemctl show -P Description varlink-transient-test.slice | grep -q "Test transient slice"
+
+# Transient service with Description and Documentation properties
+result=$(varlinkctl call "$MANAGER_SOCKET" io.systemd.Unit.StartTransient \
+    '{"name":"varlink-transient-desc.service","content":"[Unit]\nDescription=Test description property\nDocumentation=man:test\n[Service]\nType=oneshot\nRemainAfterExit=yes\nExecStart=/bin/true\n"}')
+echo "$result" | grep -q '"jobId"'
+timeout 10 bash -c 'until systemctl is-active varlink-transient-desc.service; do sleep 0.5; done'
+systemctl show -P Description varlink-transient-desc.service | grep -q "Test description property"
+systemctl show -P Documentation varlink-transient-desc.service | grep -q "man:test"
+
+# Error: invalid mode
+(! varlinkctl call "$MANAGER_SOCKET" io.systemd.Unit.StartTransient \
+    '{"name":"varlink-transient-test4.service","mode":"bogus","content":"[Service]\nType=oneshot\nExecStart=/bin/true\n"}')
+
+# Error: unsupported unit type (target does not support transient)
+(! varlinkctl call "$MANAGER_SOCKET" io.systemd.Unit.StartTransient \
+    '{"name":"varlink-transient-test.target","content":"[Unit]\nDescription=test\n"}')
+
+# Error: bad unit content (missing ExecStart= for non-oneshot service)
+(! varlinkctl call "$MANAGER_SOCKET" io.systemd.Unit.StartTransient \
+    '{"name":"varlink-transient-bad.service","content":"[Service]\nType=simple\n"}')
+
+# Cleanup
+systemctl stop varlink-transient-test.service 2>/dev/null || true
+systemctl stop varlink-transient-test2.service 2>/dev/null || true
+systemctl stop varlink-transient-test3.service 2>/dev/null || true
+systemctl stop varlink-transient-multi.service 2>/dev/null || true
+systemctl stop varlink-transient-exists.service 2>/dev/null || true
+systemctl stop varlink-transient-desc.service 2>/dev/null || true
+systemctl stop varlink-transient-test.slice 2>/dev/null || true
+systemctl stop varlink-transient-bad.service 2>/dev/null || true
+systemctl reset-failed varlink-transient-desc.service 2>/dev/null || true
+systemctl reset-failed varlink-transient-test.service 2>/dev/null || true
+systemctl reset-failed varlink-transient-test2.service 2>/dev/null || true
+systemctl reset-failed varlink-transient-test3.service 2>/dev/null || true
+systemctl reset-failed varlink-transient-multi.service 2>/dev/null || true
+systemctl reset-failed varlink-transient-exists.service 2>/dev/null || true
+systemctl reset-failed varlink-transient-bad.service 2>/dev/null || true
+
 # --dry-run with destructive verbs
 # kexec is skipped intentionally, as it requires a bit more involved setup
 VERBS=(


### PR DESCRIPTION
This commit adds a simple version of io.systemd.Unit.StartTransient for varlink. It is similar to the dbus version, but there is a key difference:
1. Instead of building the unit from key/value properties it just takes a raw unit file as string as the "content" parameter. (Note that we could extend the API to also support key/value properties if desired and still keep "content" for simplicity).
2. No aux units (for now)
3. When called with --more the varlink socket will notify about state changes

Note that the "rewind" part is a bit ugly, I think we can fix it by changing load_fragment() but I tried to avoid touching to core core code. Feedback absolutely welcome, its different from dbus and it might be wrong direction in which case I'm of course happy to rework  it (hence the RFC :)