### PR TITLE
systemctl: add --no-state flag for switch-root

### DIFF
--- a/man/systemctl.xml
+++ b/man/systemctl.xml
@@ -1855,6 +1855,13 @@ Jan 12 10:46:45 example.com bluetoothd[8900]: gatt-time-server: Input/output err
             the initrd's system manager process is passed to the main system manager, which allows later
             introspection of the state of the services involved in the initrd boot phase.</para>
 
+            <para>If <option>--no-state</option> is specified, the initrd's system manager will not pass
+            its state (such as serialized units, file descriptors, and other runtime data) to the new system
+            manager. The new system manager will start fresh, as if booting directly into the new root
+            filesystem. This is useful when the initrd and root filesystem use different systemd versions
+            that may be incompatible, or when a clean separation between initrd and root filesystem boot
+            phases is desired.</para>
+
             <xi:include href="version-info.xml" xpointer="v209"/>
           </listitem>
         </varlistentry>
@@ -2477,6 +2484,19 @@ Jan 12 10:46:45 example.com bluetoothd[8900]: gatt-time-server: Input/output err
 
         <listitem>
           <para>Do not send wall message before halt, power-off and reboot.</para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term><option>--no-state</option></term>
+
+        <listitem>
+          <para>When used with <command>switch-root</command>, do not pass the initrd system manager's
+          state to the new root's system manager. The new system manager instance will start fresh without
+          any state carried over from the initrd. See <command>switch-root</command> above for details.
+          This option has no effect with other commands.</para>
+
+          <xi:include href="version-info.xml" xpointer="v261"/>
         </listitem>
       </varlistentry>
 

--- a/mkosi/mkosi.initrd.conf/mkosi.extra/usr/lib/systemd/system/initrd-switch-root-no-state.service
+++ b/mkosi/mkosi.initrd.conf/mkosi.extra/usr/lib/systemd/system/initrd-switch-root-no-state.service
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Unit]
+Description=Override switch-root to use --no-state
+DefaultDependencies=no
+Before=initrd-switch-root.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=mkdir -p /run/systemd/system/initrd-switch-root.service.d
+ExecStart=sh -c 'printf "[Service]\nExecStart=\nExecStart=systemctl --no-block --no-state switch-root\n" >/run/systemd/system/initrd-switch-root.service.d/no-state.conf'
+ExecStart=systemctl daemon-reload
+# Remove initrd credentials so the new PID 1 imports them fresh from SMBIOS.
+# Without this, the existing credential files cause import_credentials() to
+# skip all entries (O_EXCL → EEXIST), leaving $CREDENTIALS_DIRECTORY unset.
+# That breaks $NOTIFY_SOCKET propagation and thus VM exit code reporting.
+# The credentials directory is a read-only mount, so we must unmount it first.
+ExecStart=sh -c 'mountpoint -q /run/credentials/@system && umount /run/credentials/@system; rm -rf /run/credentials/@system'

--- a/shell-completion/bash/systemctl.in
+++ b/shell-completion/bash/systemctl.in
@@ -134,7 +134,7 @@ _systemctl () {
                       --help -h --no-ask-password --no-block --legend=no --no-pager --no-reload --no-wall --now
                       --quiet -q --system --user --version --runtime --recursive -r --firmware-setup
                       --show-types --plain --failed --value --fail --dry-run --wait --no-warn --with-dependencies
-                      --show-transaction -T --mkdir --read-only'
+                      --show-transaction -T --mkdir --read-only --no-state'
         [ARG]='--host -H --kill-whom --property -p -P --signal -s --type -t --state --job-mode --root
                --preset-mode -n --lines -o --output -M --machine --message --timestamp --check-inhibitors --what
                --image --boot-loader-menu --boot-loader-entry --reboot-argument --drop-in'

--- a/shell-completion/zsh/_systemctl.in
+++ b/shell-completion/zsh/_systemctl.in
@@ -526,6 +526,7 @@ _arguments -s \
     '--system[Connect to system manager]' \
     '--user[Connect to user service manager]' \
     "--no-wall[Don't send wall message before halt/power-off/reboot]" \
+    "--no-state[Don't pass state to the new system manager when switching root]" \
     '--global[Enable/disable/mask default user unit files globally]' \
     "--no-reload[When enabling/disabling unit files, don't reload daemon configuration]" \
     '--no-ask-password[Do not ask for system passwords]' \

--- a/src/systemctl/systemctl-switch-root.c
+++ b/src/systemctl/systemctl-switch-root.c
@@ -82,7 +82,16 @@ int verb_switch_root(int argc, char *argv[], uintptr_t _data, void *userdata) {
         }
 
         init = empty_to_null(init);
-        if (init) {
+        if (arg_no_state) {
+                if (init)
+                        return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
+                                               "--no-state is incompatible with an explicit init argument.");
+
+                /* When --no-state is requested, force init to the systemd binary path. This causes PID 1
+                 * to take the switch-root fallback path which skips serialization, cleans up /run/systemd,
+                 * and starts the new systemd fresh without any state from the initrd. */
+                init = SYSTEMD_BINARY_PATH;
+        } else if (init) {
                 if (!path_is_valid(init))
                         return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "Invalid path to init binary: %s", init);
                 if (!path_is_absolute(init))

--- a/src/systemctl/systemctl.c
+++ b/src/systemctl/systemctl.c
@@ -88,6 +88,7 @@ bool arg_marked = false;
 const char *arg_drop_in = NULL;
 ImagePolicy *arg_image_policy = NULL;
 char *arg_kill_subgroup = NULL;
+bool arg_no_state = false;
 
 STATIC_DESTRUCTOR_REGISTER(arg_types, strv_freep);
 STATIC_DESTRUCTOR_REGISTER(arg_states, strv_freep);
@@ -443,6 +444,7 @@ static int systemctl_parse_argv(int argc, char *argv[]) {
                 ARG_WHEN,
                 ARG_STDIN,
                 ARG_KILL_SUBGROUP,
+                ARG_NO_STATE,
         };
 
         static const struct option options[] = {
@@ -513,6 +515,7 @@ static int systemctl_parse_argv(int argc, char *argv[]) {
                 { "when",                required_argument, NULL, ARG_WHEN                },
                 { "stdin",               no_argument,       NULL, ARG_STDIN               },
                 { "kill-subgroup",       required_argument, NULL, ARG_KILL_SUBGROUP       },
+                { "no-state",            no_argument,       NULL, ARG_NO_STATE            },
                 {}
         };
 
@@ -1037,6 +1040,10 @@ static int systemctl_parse_argv(int argc, char *argv[]) {
                         free_and_replace(arg_kill_subgroup, p);
                         break;
                 }
+
+                case ARG_NO_STATE:
+                        arg_no_state = true;
+                        break;
 
                 case '.':
                         /* Output an error mimicking getopt, and print a hint afterwards */

--- a/src/systemctl/systemctl.h
+++ b/src/systemctl/systemctl.h
@@ -96,6 +96,7 @@ extern bool arg_marked;
 extern const char *arg_drop_in;
 extern ImagePolicy *arg_image_policy;
 extern char *arg_kill_subgroup;
+extern bool arg_no_state;
 
 static inline const char* arg_job_mode(void) {
         return _arg_job_mode ?: "replace";

--- a/test/integration-tests/TEST-08-INITRD/meson.build
+++ b/test/integration-tests/TEST-08-INITRD/meson.build
@@ -1,12 +1,43 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+name = fs.name(meson.current_source_dir())
+
 integration_tests += [
         integration_test_template + {
-                'name' : fs.name(meson.current_source_dir()),
+                'name' : name,
                 'cmdline' : integration_test_template['cmdline'] + [
                         'rd.systemd.wants=initrd-run-mount.service',
                 ],
                 'exit-code' : 124,
+                'vm' : true,
+                'firmware' : 'linux',
+        },
+        # --no-state drops all initrd state including credentials. The test wrapper
+        # normally injects SuccessAction=, FailureAction=, and StandardOutput= via
+        # credential-based drop-ins, but those are lost after a stateless switch-root.
+        # However, the new PID 1 re-imports credentials from SMBIOS since it starts
+        # fresh (skip_setup=false), so vmm.notify_socket is restored and exit codes
+        # work. Bake the remaining settings into the service file. Drop
+        # user@4711.service dependency since its credentials are also lost.
+        integration_test_template + {
+                'name' : '@0@-no-state'.format(name),
+                'configuration' : integration_test_template['configuration'] + {
+                        'wants' : 'multi-user.target',
+                        'after' : '',  # Drop user@4711.service ordering — its credentials are lost
+
+                        'unit' : integration_test_template['configuration']['unit'] + {
+                                'SuccessAction' : 'exit',
+                                'SuccessActionExitStatus' : '123',
+                                'FailureAction' : 'exit',
+                                'FailureActionExitStatus' : '1',
+                        },
+                        'service' : integration_test_template['configuration']['service'] + {
+                                'StandardOutput' : 'journal+console',
+                        },
+                },
+                'cmdline' : integration_test_template['cmdline'] + [
+                        'rd.systemd.wants=initrd-switch-root-no-state.service',
+                ],
                 'vm' : true,
                 'firmware' : 'linux',
         },

--- a/test/units/TEST-08-INITRD-no-state.sh
+++ b/test/units/TEST-08-INITRD-no-state.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: LGPL-2.1-or-later
+set -eux
+set -o pipefail
+
+if systemd-detect-virt -qc; then
+    echo >&2 "This test can't run in a container"
+    exit 1
+fi
+
+# When --no-state is used for switch-root, the new system manager starts fresh
+# without --switched-root and --deserialize. Verify that no initrd state was
+# carried over.
+
+# InitRDTimestampMonotonic is normally serialized from the initrd PID 1 and
+# deserialized by the real-root PID 1. With --no-state there is no
+# deserialization, so the timestamp must be 0.
+if [[ "$(systemctl show -P InitRDTimestampMonotonic)" -ne 0 ]]; then
+    echo >&2 "InitRDTimestampMonotonic is set, but --no-state should have prevented state transfer"
+    exit 1
+fi
+
+# The fallback path in PID 1 moves /run/systemd to /run/systemd.pre-switch-root
+# before exec'ing the new systemd. Verify that happened.
+test -d /run/systemd.pre-switch-root
+
+# Verify that initrd-originating units were not deserialized into the real-root
+# manager. initrd-switch-root-no-state.service was active in the initrd; after a
+# stateless switch-root the new manager should know nothing about it.
+state=$(systemctl show -P LoadState initrd-switch-root-no-state.service 2>/dev/null)
+if [[ "$state" != "not-found" ]]; then
+    echo >&2 "initrd-switch-root-no-state.service should not be known to the new manager (LoadState=$state)"
+    exit 1
+fi
+
+touch /testok


### PR DESCRIPTION
Add a `--no-state` option to `systemctl switch-root` that starts the new root's system manager fresh, without carrying over any state from the initrd.

When the initrd and root filesystem are built and shipped separately, the serialized state passed from the initrd's PID 1 (`--switched-root --deserialize <fd>`) ties the two systemd instances together. This creates two problems:
  1. The two systemd versions must always be compatible with each other's serialization format, which is hard to guarantee when initrd and rootfs are built independently.
  2. Changes in the initrd systemd can corrupt dependency ordering in the rootfs systemd, causing hard-to-debug failures.

Currently the workaround is to specify a custom init binary — a shim script that simply does `exec /usr/lib/systemd/systemd` — to trick PID 1 into taking the fallback path that skips deserialization. `systemctl switch-root --no-state` forces the init parameter to the systemd binary path, bypassing the `same_file_in_root()` suppression that would normally clear it. This causes PID 1 to take its existing fallback path: skip serialization, move /run/systemd to /run/systemd.pre-switch-root, and exec the new systemd without `--switched-root` or `--deserialize`.