### PR TITLE
docs: beef up SECURITY.md rules for reporting

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -18,3 +18,12 @@ Subscription to the Security Advisories and/or systemd-security mailing list is 
 Those conditions should be backed by publicly accessible information (ideally, a track of posts and commits from the mail address in question).
 If you fall into one of those categories and wish to be subscribed,
 contact the maintainers or submit a **[subscription request](https://www.redhat.com/mailman/listinfo/systemd-security)**.
+
+# Requirements for a Valid Report
+
+- Please ensure the issue is reproducible on main.
+- Please ensure a fully working, end-to-end reproducer is provided.
+- Please ensure the reproducer is real-world and not simulated or abstracted.
+- Please ensure the reproducer demonstrably violates a security boundary.
+- Please understand that most of our maintainers are volunteers and already have a heavy review burden. While we will try to triage and fix issues in a timely manner, we cannot guarantee any fixed timeline for issue resolution.
+- While modern industry practices around coordinated disclosures encourage public disclosure to avoid vendors stonewalling researchers, we are an open source project that would gain little from needlessly stonewalling researchers. We thus kindly request that reporters do not publicly disclose issues they have reported to us before an agreed-to disclosure date.


### PR DESCRIPTION
With yeswehack.com suspended due to funding issues for triagers being worked out, reports on GH are starting to pile up. Explicitly define some ground rules to avoid noise and time wasting.