### PR TITLE
importd: harden curl file protocol handling

### DIFF
--- a/src/import/curl-util.c
+++ b/src/import/curl-util.c
@@ -291,6 +291,8 @@ int curl_glue_make(CURL **ret, const char *url, void *userdata) {
         if (curl_easy_setopt(c, CURLOPT_PROTOCOLS_STR, "HTTP,HTTPS,FILE") != CURLE_OK)
 #else
         if (curl_easy_setopt(c, CURLOPT_PROTOCOLS, CURLPROTO_HTTP|CURLPROTO_HTTPS|CURLPROTO_FILE) != CURLE_OK)
+                return -EIO;
+        if (curl_easy_setopt(c, CURLOPT_REDIR_PROTOCOLS, CURLPROTO_HTTP|CURLPROTO_HTTPS) != CURLE_OK)
 #endif
                 return -EIO;
 


### PR DESCRIPTION
With old libcurl versions file:// can get redirects which can be messy, while the new version rejects them. Set an option to explicit block them.