### PR TITLE
boot: fix loop bound in devicetree_get_compatible()

### DIFF
--- a/src/boot/devicetree.c
+++ b/src/boot/devicetree.c
@@ -141,10 +141,10 @@ static const char* devicetree_get_compatible(const void *dtb) {
         size_t size_words = struct_size / sizeof(uint32_t);
         size_t len, name_off, len_words, s;
 
-        for (size_t i = 0; i < end; i++) {
+        for (size_t i = 0; i < size_words; i++) {
                 switch (be32toh(cursor[i])) {
                 case FDT_BEGIN_NODE:
-                        if (i >= size_words || cursor[++i] != 0)
+                        if (i + 1 >= size_words || cursor[++i] != 0)
                                 return NULL;
                         break;
                 case FDT_NOP:


### PR DESCRIPTION
The loop used end (struct_off + struct_size, a byte offset) as the
limit, but cursor[i] indexes uint32_t words. Use size_words instead.

Fixes #41590