### PR TITLE
nss-systemd: fix off-by-one in nss_pack_group_record_shadow()

### DIFF
--- a/src/nss-systemd/userdb-glue.c
+++ b/src/nss-systemd/userdb-glue.c
@@ -475,7 +475,9 @@ int nss_pack_group_record_shadow(
 
         assert(buffer);
 
-        p = buffer + sizeof(void*) * (n + 1); /* place member strings right after the ptr array */
+        /* n already includes trailing NULL pointers from nss_count_strv(), unlike the
+         * non-shadow nss_pack_group_record() where n does not include them. */
+        p = buffer + sizeof(void*) * n;
         array = (char**) buffer; /* place ptr array at beginning of buffer, under assumption buffer is aligned */
 
         sgrp->sg_mem = array;


### PR DESCRIPTION
nss_count_strv() counts trailing NULL pointers in n. The pointer area
then used (n + 1), reserving one slot more than the size check
accounted for.

Drop the + 1 since n already includes the trailing NULLs, unlike the
non-shadow nss_pack_group_record() where n does not.

Fixes #41591