### PR TITLE
many: final final set of coccinelle check-pointer-deref tweaks

### DIFF
--- a/coccinelle/parsing_hacks.h
+++ b/coccinelle/parsing_hacks.h
@@ -99,6 +99,11 @@
 #define CMSG_BUFFER_TYPE(x) union { uint8_t align_check[(size) >= CMSG_SPACE(0) && (size) == CMSG_ALIGN(size) ? 1 : -1]; }
 #define SD_ID128_MAKE(...) ((const sd_id128) {})
 
+/* sizeof() does not evaluate its argument, so *ptr inside sizeof() is not a real dereference.
+ * The SIZEOF() macro is an alias for sizeof() that hides the argument from coccinelle to avoid
+ * false positives from check-pointer-deref.cocci. See assert-fundamental.h for the definition. */
+#define SIZEOF(x) 8
+
 /* Work around a bug in zlib.h parsing on Fedora (and possibly others)
  * See: https://github.com/coccinelle/coccinelle/issues/413 */
 #define Z_EXPORT

--- a/coccinelle/parsing_hacks.h
+++ b/coccinelle/parsing_hacks.h
@@ -61,21 +61,38 @@
 /* Coccinelle doesn't know this keyword, so just drop it, since it's not important for any of our rules. */
 #define thread_local
 
+/* Coccinelle can't handle the __attribute__((__cleanup__(x))) GCC extension used by our _cleanup_*
+ * macros. Without this, any variable declared with _cleanup_free_ or _cleanup_(foo) makes the whole
+ * function unparsable. Drop the attribute since it's not relevant for semantic checks. */
+#define _cleanup_free_
+#define _cleanup_(x)
+
 /* Coccinelle fails to parse these from the included headers, so let's just drop them. */
 #define PAM_EXTERN
 #define STACK_OF(x)
 
 /* Mark a couple of iterator explicitly as iterators, otherwise Coccinelle gets a bit confused. Coccinelle
  * can usually infer this information automagically, but in these specific cases it needs a bit of help. */
+#define FOREACH_ARGUMENT(entry, ...) YACFE_ITERATOR
 #define FOREACH_ARRAY(i, array, num) YACFE_ITERATOR
-#define FOREACH_ELEMENT(i, array) YACFE_ITERATOR
+#define FOREACH_DIRENT(de, d, on_error) YACFE_ITERATOR
 #define FOREACH_DIRENT_ALL(de, d, on_error) YACFE_ITERATOR
+#define FOREACH_DIRENT_IN_BUFFER(de, buf, sz) YACFE_ITERATOR
+#define FOREACH_ELEMENT(i, array) YACFE_ITERATOR
 #define FOREACH_STRING(x, y, ...) YACFE_ITERATOR
 #define HASHMAP_FOREACH(e, h) YACFE_ITERATOR
+#define HASHMAP_FOREACH_KEY(e, k, h) YACFE_ITERATOR
 #define LIST_FOREACH(name, i, head) YACFE_ITERATOR
+#define LIST_FOREACH_BACKWARDS(name, i, start) YACFE_ITERATOR
+#define NULSTR_FOREACH(s, l) YACFE_ITERATOR
+#define NULSTR_FOREACH_PAIR(i, j, l) YACFE_ITERATOR
 #define ORDERED_HASHMAP_FOREACH(e, h) YACFE_ITERATOR
+#define ORDERED_HASHMAP_FOREACH_KEY(e, k, h) YACFE_ITERATOR
 #define SET_FOREACH(e, s) YACFE_ITERATOR
-#define STRV_FOREACH_BACKWARDS YACFE_ITERATOR
+#define SET_FOREACH_MOVE(e, d, s) YACFE_ITERATOR
+#define STRV_FOREACH(s, l) YACFE_ITERATOR
+#define STRV_FOREACH_BACKWARDS(s, l) YACFE_ITERATOR
+#define STRV_FOREACH_PAIR(x, y, l) YACFE_ITERATOR
 
 /* Coccinelle really doesn't like multiline macros that are not in the "usual" do { ... } while(0) format, so
  * let's help it a little here by providing simplified one-line versions. */

--- a/src/analyze/analyze-plot.c
+++ b/src/analyze/analyze-plot.c
@@ -87,6 +87,8 @@ static int acquire_host_info(sd_bus *bus, HostInfo **hi) {
         _cleanup_(free_host_infop) HostInfo *host = NULL;
         int r;
 
+        assert(hi);
+
         host = new0(HostInfo, 1);
         if (!host)
                 return log_oom();

--- a/src/analyze/analyze-syscall-filter.c
+++ b/src/analyze/analyze-syscall-filter.c
@@ -21,6 +21,8 @@ static int load_kernel_syscalls(Set **ret) {
         _cleanup_fclose_ FILE *f = NULL;
         int r;
 
+        assert(ret);
+
         /* Let's read the available system calls from the list of available tracing events. Slightly dirty,
          * but good enough for analysis purposes. */
 

--- a/src/analyze/analyze-time-data.c
+++ b/src/analyze/analyze-time-data.c
@@ -172,6 +172,8 @@ int pretty_boot_time(sd_bus *bus, char **ret) {
         BootTimes *t;
         int r;
 
+        assert(ret);
+
         r = acquire_boot_times(bus, /* require_finished= */ true, &t);
         if (r < 0)
                 return r;
@@ -296,6 +298,8 @@ int acquire_time_data(sd_bus *bus, bool require_finished, UnitTimes **out) {
         size_t c = 0;
         UnitInfo u;
         int r;
+
+        assert(out);
 
         r = acquire_boot_times(bus, require_finished, &boot_times);
         if (r < 0)

--- a/src/basic/build-path.c
+++ b/src/basic/build-path.c
@@ -195,6 +195,8 @@ static int find_build_dir_binary(const char *fn, char **ret) {
 
 static int find_environment_binary(const char *fn, const char **ret) {
 
+        assert(ret);
+
         /* If a path such as /usr/lib/systemd/systemd-foobar is specified, then this will check for an
          * environment variable SYSTEMD_FOOBAR_PATH and return it if set. */
 

--- a/src/basic/cgroup-util.c
+++ b/src/basic/cgroup-util.c
@@ -1256,6 +1256,8 @@ bool cg_needs_escape(const char *p) {
 int cg_escape(const char *p, char **ret) {
         _cleanup_free_ char *n = NULL;
 
+        assert(ret);
+
         /* This implements very minimal escaping for names to be used as file names in the cgroup tree: any
          * name which might conflict with a kernel name or is prefixed with '_' is prefixed with a '_'. That
          * way, when reading cgroup names it is sufficient to remove a single prefixing underscore if there
@@ -1651,6 +1653,8 @@ int cg_mask_from_string(const char *s, CGroupMask *ret) {
 int cg_mask_supported_subtree(const char *root, CGroupMask *ret) {
         CGroupMask mask;
         int r;
+
+        assert(ret);
 
         /* Determines the mask of supported cgroup controllers. Only includes controllers we can make sense of and that
          * are actually accessible. Only covers real controllers, i.e. not the CGROUP_CONTROLLER_BPF_xyz

--- a/src/basic/fileio.c
+++ b/src/basic/fileio.c
@@ -1370,6 +1370,8 @@ int read_timestamp_file(const char *fn, usec_t *ret) {
         uint64_t t;
         int r;
 
+        assert(ret);
+
         r = read_one_line_file(fn, &ln);
         if (r < 0)
                 return r;

--- a/src/basic/hashmap.c
+++ b/src/basic/hashmap.c
@@ -1853,6 +1853,8 @@ int set_consume(Set *s, void *value) {
 int hashmap_put_strdup_full(Hashmap **h, const struct hash_ops *hash_ops, const char *k, const char *v) {
         int r;
 
+        assert(h);
+
         r = hashmap_ensure_allocated(h, hash_ops);
         if (r < 0)
                 return r;
@@ -2197,6 +2199,8 @@ int _hashmap_dump_keys_sorted(HashmapBase *h, void ***ret, size_t *ret_n) {
         size_t n;
         int r;
 
+        assert(ret);
+
         r = _hashmap_dump_entries_sorted(h, &entries, &n);
         if (r < 0)
                 return r;
@@ -2215,6 +2219,8 @@ int _hashmap_dump_sorted(HashmapBase *h, void ***ret, size_t *ret_n) {
         _cleanup_free_ void **entries = NULL;
         size_t n;
         int r;
+
+        assert(ret);
 
         r = _hashmap_dump_entries_sorted(h, &entries, &n);
         if (r < 0)

--- a/src/basic/path-util.c
+++ b/src/basic/path-util.c
@@ -1076,6 +1076,8 @@ int path_split_prefix_filename(const char *path, char **ret_dir, char **ret_file
         const char *c, *next = NULL;
         int r;
 
+        POINTER_MAY_BE_NULL(path);
+
         /* Split the path into dir prefix/filename pair. Returns:
          *
          * -EINVAL        → if the path is not valid

--- a/src/basic/string-util.c
+++ b/src/basic/string-util.c
@@ -667,6 +667,7 @@ char* strip_tab_ansi(char **ibuf, size_t *_isz, size_t highlight[2]) {
 
         assert(ibuf);
         assert(*ibuf);
+        POINTER_MAY_BE_NULL(_isz);
 
         /* This does three things:
          *

--- a/src/basic/terminal-util.c
+++ b/src/basic/terminal-util.c
@@ -1463,6 +1463,8 @@ int getttyname_harder(int fd, char **ret) {
         _cleanup_free_ char *s = NULL;
         int r;
 
+        assert(ret);
+
         r = getttyname_malloc(fd, &s);
         if (r < 0)
                 return r;

--- a/src/basic/uid-classification.c
+++ b/src/basic/uid-classification.c
@@ -39,6 +39,8 @@ static int parse_alloc_uid(const char *path, const char *name, const char *t, ui
 #endif
 
 int read_login_defs(UGIDAllocationRange *ret_defs, const char *path, const char *root) {
+        assert(ret_defs);
+
 #if ENABLE_COMPAT_MUTABLE_UID_BOUNDARIES
         _cleanup_fclose_ FILE *f = NULL;
         UGIDAllocationRange defs;

--- a/src/basic/unit-name.c
+++ b/src/basic/unit-name.c
@@ -345,6 +345,7 @@ int unit_name_unescape(const char *f, char **ret) {
         char *t;
 
         assert(f);
+        assert(ret);
 
         r = strdup(f);
         if (!r)
@@ -546,6 +547,8 @@ int unit_name_hash_long(const char *name, char **ret) {
         const char *suffix;
         le64_t h;
         size_t len;
+
+        assert(ret);
 
         if (strlen(name) < UNIT_NAME_MAX)
                 return -EMSGSIZE;

--- a/src/basic/utf8.c
+++ b/src/basic/utf8.c
@@ -284,6 +284,9 @@ int utf8_to_ascii(const char *str, char replacement_char, char **ret) {
         /* Convert to a string that has only ASCII chars, replacing anything that is not ASCII
          * by replacement_char. */
 
+        assert(str);
+        assert(ret);
+
         _cleanup_free_ char *ans = new(char, strlen(str) + 1);
         if (!ans)
                 return -ENOMEM;

--- a/src/core/bpf-firewall.c
+++ b/src/core/bpf-firewall.c
@@ -603,6 +603,8 @@ int bpf_firewall_compile(Unit *u) {
 }
 
 static int load_bpf_progs_from_fs_to_set(Unit *u, char **filter_paths, Set **set) {
+        assert(set);
+
         set_clear(*set);
 
         STRV_FOREACH(bpf_fs_path, filter_paths) {

--- a/src/core/dbus.c
+++ b/src/core/dbus.c
@@ -229,6 +229,7 @@ static int find_unit(Manager *m, sd_bus *bus, const char *path, Unit **unit, sd_
         assert(m);
         assert(bus);
         assert(path);
+        assert(unit);
 
         if (streq(path, "/org/freedesktop/systemd1/unit/self")) {
                 _cleanup_(pidref_done) PidRef pidref = PIDREF_NULL;

--- a/src/core/execute.c
+++ b/src/core/execute.c
@@ -2372,6 +2372,8 @@ static int exec_shared_runtime_add(
 
         assert(m);
         assert(id);
+        assert(tmp_dir);
+        assert(var_tmp_dir);
 
         /* tmp_dir, var_tmp_dir, {net,ipc}ns_storage_socket fds are donated on success */
 

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -2652,6 +2652,8 @@ static int do_queue_default_job(
         Unit *target;
         int r;
 
+        assert(ret_error_message);
+
         if (arg_default_unit)
                 unit = arg_default_unit;
         else if (in_initrd())

--- a/src/core/manager.c
+++ b/src/core/manager.c
@@ -2522,6 +2522,8 @@ int manager_load_startable_unit_or_warn(
         Unit *unit;
         int r;
 
+        assert(ret);
+
         r = manager_load_unit(m, name, path, &error, &unit);
         if (r < 0)
                 return log_error_errno(r, "Failed to load %s %s: %s",

--- a/src/core/socket.c
+++ b/src/core/socket.c
@@ -2026,6 +2026,7 @@ static int socket_chown(Socket *s, PidRef *ret_pid) {
         int r;
 
         assert(s);
+        assert(ret_pid);
 
         r = socket_arm_timer(s, /* relative= */ true, s->timeout_usec);
         if (r < 0)

--- a/src/core/unit-printf.c
+++ b/src/core/unit-printf.c
@@ -50,6 +50,8 @@ static int specifier_last_component(char specifier, const void *data, const char
         char *dash;
         int r;
 
+        assert(ret);
+
         r = unit_name_to_prefix(u->id, &prefix);
         if (r < 0)
                 return r;

--- a/src/core/unit.c
+++ b/src/core/unit.c
@@ -132,6 +132,8 @@ int unit_new_for_name(Manager *m, size_t size, const char *name, Unit **ret) {
         _cleanup_(unit_freep) Unit *u = NULL;
         int r;
 
+        assert(ret);
+
         u = unit_new(m, size);
         if (!u)
                 return -ENOMEM;
@@ -4300,6 +4302,9 @@ static int user_from_unit_name(Unit *u, char **ret) {
 
         _cleanup_free_ char *n = NULL;
         int r;
+
+        assert(u);
+        assert(ret);
 
         r = unit_name_to_prefix(u->id, &n);
         if (r < 0)

--- a/src/core/varlink-cgroup.c
+++ b/src/core/varlink-cgroup.c
@@ -194,6 +194,8 @@ static int device_allow_build_json(sd_json_variant **ret, const char *name, void
         CGroupDeviceAllow *allow = userdata;
         int r;
 
+        assert(ret);
+
         LIST_FOREACH(device_allow, a, allow) {
                 r = sd_json_variant_append_arraybo(
                                 &v,

--- a/src/core/varlink-execute.c
+++ b/src/core/varlink-execute.c
@@ -470,48 +470,56 @@ static int private_bpf_delegate_commands_build_json(sd_json_variant **ret, const
         ExecContext *c = ASSERT_PTR(userdata);
         _cleanup_free_ char *v = bpf_delegate_commands_to_string(c->bpf_delegate_commands);
 
+        assert(ret);
+
         if (!v) {
                 *ret = NULL;
                 return 0;
         }
 
-        return sd_json_variant_new_string(ASSERT_PTR(ret), v);
+        return sd_json_variant_new_string(ret, v);
 }
 
 static int private_bpf_delegate_maps_build_json(sd_json_variant **ret, const char *name, void *userdata) {
         ExecContext *c = ASSERT_PTR(userdata);
         _cleanup_free_ char *v = bpf_delegate_maps_to_string(c->bpf_delegate_maps);
 
+        assert(ret);
+
         if (!v) {
                 *ret = NULL;
                 return 0;
         }
 
-        return sd_json_variant_new_string(ASSERT_PTR(ret), v);
+        return sd_json_variant_new_string(ret, v);
 }
 
 static int private_bpf_delegate_programs_build_json(sd_json_variant **ret, const char *name, void *userdata) {
         ExecContext *c = ASSERT_PTR(userdata);
         _cleanup_free_ char *v = bpf_delegate_programs_to_string(c->bpf_delegate_programs);
 
+        assert(ret);
+
         if (!v) {
                 *ret = NULL;
                 return 0;
         }
 
-        return sd_json_variant_new_string(ASSERT_PTR(ret), v);
+        return sd_json_variant_new_string(ret, v);
 }
 
 static int private_bpf_delegate_attachments_build_json(sd_json_variant **ret, const char *name, void *userdata) {
         ExecContext *c = ASSERT_PTR(userdata);
         _cleanup_free_ char *v = bpf_delegate_attachments_to_string(c->bpf_delegate_attachments);
 
+        assert(ret);
+
         if (!v) {
                 *ret = NULL;
                 return 0;
         }
 
-        return sd_json_variant_new_string(ASSERT_PTR(ret), v);
+        return sd_json_variant_new_string(ret, v);
 }
 
 static int syscall_filter_build_json(sd_json_variant **ret, const char *name, void *userdata) {

--- a/src/coredump/coredump-context.c
+++ b/src/coredump/coredump-context.c
@@ -153,6 +153,7 @@ static int get_process_container_parent_cmdline(PidRef *pid, char** ret_cmdline)
 
         assert(pidref_is_set(pid));
         assert(!pidref_is_remote(pid));
+        assert(ret_cmdline);
 
         r = pidref_from_same_root_fs(pid, &PIDREF_MAKE_FROM_PID(1));
         if (r < 0)

--- a/src/cryptenroll/cryptenroll-pkcs11.c
+++ b/src/cryptenroll/cryptenroll-pkcs11.c
@@ -14,6 +14,8 @@ static int uri_set_private_class(const char *uri, char **ret_uri) {
         _cleanup_free_ char *private_uri = NULL;
         int r;
 
+        assert(ret_uri);
+
         r = uri_from_string(uri, &p11kit_uri);
         if (r < 0)
                 return log_error_errno(r, "Failed to parse PKCS#11 URI '%s': %m", uri);

--- a/src/fundamental/assert-fundamental.h
+++ b/src/fundamental/assert-fundamental.h
@@ -105,3 +105,11 @@ static inline int __coverity_check_and_return__(int condition) {
  * the coccinelle check-pointer-deref warning for parameters that are safely handled before any
  * dereference (e.g. passed to a NULL-safe helper like iovec_is_set()). */
 #define POINTER_MAY_BE_NULL(ptr) ({ (void) (ptr); })
+
+/* sizeof() does not evaluate its argument - it is a compile-time constant expression - so *ptr
+ * inside sizeof() is not a real dereference. However, coccinelle cannot distinguish this from an
+ * actual dereference, and when sizeof(*ptr) appears in a variable initializer the assert(ptr) that
+ * follows cannot come first (declarations must precede statements). Use this macro in place
+ * of sizeof() to avoid the false positive - coccinelle sees SIZEOF() as a function call (via
+ * parsing_hacks.h) and never looks inside the argument. */
+#define SIZEOF(x) sizeof(x)

--- a/src/hibernate-resume/hibernate-resume-config.c
+++ b/src/hibernate-resume/hibernate-resume-config.c
@@ -242,6 +242,8 @@ int acquire_hibernate_info(HibernateInfo *ret) {
         _cleanup_(hibernate_info_done) HibernateInfo i = {};
         int r;
 
+        assert(ret);
+
         r = get_kernel_hibernate_location(&i.cmdline);
         if (r < 0)
                 return r;

--- a/src/home/homectl.c
+++ b/src/home/homectl.c
@@ -3658,6 +3658,8 @@ static int parse_environment_field(sd_json_variant **identity, const char *field
 static int parse_language_field(char ***languages, const char *arg) {
         int r;
 
+        assert(languages);
+
         if (isempty(arg)) {
                 r = drop_from_identity("preferredLanguage", "additionalLanguages");
                 if (r < 0)

--- a/src/home/homed-home-bus.c
+++ b/src/home/homed-home-bus.c
@@ -801,6 +801,8 @@ static int bus_home_object_find(
         Home *h;
         int r;
 
+        assert(found);
+
         r = sd_bus_path_decode(path, "/org/freedesktop/home1/home", &e);
         if (r <= 0)
                 return 0;

--- a/src/home/homework-luks.c
+++ b/src/home/homework-luks.c
@@ -805,6 +805,7 @@ static int crypt_device_to_evp_cipher(struct crypt_device *cd, const EVP_CIPHER 
         int r;
 
         assert(cd);
+        assert(ret);
 
         /* Let's find the right OpenSSL EVP_CIPHER object that matches the encryption settings of the LUKS
          * device */
@@ -857,6 +858,7 @@ static int luks_validate_home_record(
 
         assert(cd);
         assert(h);
+        assert(ret_luks_home_record);
 
         for (int token = 0; token < sym_crypt_token_max(CRYPT_LUKS2); token++) {
                 _cleanup_(sd_json_variant_unrefp) sd_json_variant *v = NULL, *rr = NULL;
@@ -1918,6 +1920,7 @@ static int make_partition_table(
         assert(label);
         assert(ret_offset);
         assert(ret_size);
+        assert(ret_disk_uuid);
 
         t = fdisk_new_parttype();
         if (!t)
@@ -2786,6 +2789,7 @@ static int prepare_resize_partition(
         assert(fd >= 0);
         assert(ret_disk_uuid);
         assert(ret_table);
+        assert(ret_partition);
 
         assert((partition_offset & 511) == 0);
         assert((old_partition_size & 511) == 0);

--- a/src/home/homework.c
+++ b/src/home/homework.c
@@ -915,6 +915,7 @@ static int home_activate(UserRecord *h, UserRecord **ret_home) {
         int r;
 
         assert(h);
+        assert(ret_home);
 
         if (!h->user_name)
                 return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "User record lacks user name, refusing.");

--- a/src/home/user-record-util.c
+++ b/src/home/user-record-util.c
@@ -197,6 +197,7 @@ int user_record_reconcile(
 
         assert(host);
         assert(embedded);
+        assert(ret);
 
         /* Make sure both records are initialized */
         if (!host->json || !embedded->json)

--- a/src/hostname/hostnamed.c
+++ b/src/hostname/hostnamed.c
@@ -398,6 +398,8 @@ static int get_hardware_sku(Context *c, char **ret) {
         _cleanup_free_ char *model = NULL, *sku = NULL;
         int r;
 
+        assert(ret);
+
         r = get_dmi_property(c, "ID_SKU", &sku);
         if (r < 0)
                 return r;
@@ -418,6 +420,8 @@ static int get_hardware_sku(Context *c, char **ret) {
 static int get_hardware_version(Context *c, char **ret) {
         _cleanup_free_ char *version = NULL;
         int r;
+
+        assert(ret);
 
         r = get_dmi_property(c, "ID_HARDWARE_VERSION", &version);
         if (r < 0)

--- a/src/import/curl-util.c
+++ b/src/import/curl-util.c
@@ -207,6 +207,8 @@ int curl_glue_new(CurlGlue **glue, sd_event *event) {
         _cleanup_(sd_event_unrefp) sd_event *e = NULL;
         int r;
 
+        assert(glue);
+
         if (event)
                 e = sd_event_ref(event);
         else {

--- a/src/import/oci-util.c
+++ b/src/import/oci-util.c
@@ -153,7 +153,8 @@ int oci_ref_normalize(char **protocol, char **registry, char **image, char **tag
 
         assert(protocol);
         assert(registry);
-        assert(image && *image);
+        assert(image);
+        assert(*image);
         assert(tag);
 
         /* OCI container reference are supposed to have the form <registry>/<name>:<tag>. Except that it's
@@ -379,6 +380,7 @@ static const char *const go_arch_table[_ARCHITECTURE_MAX] = {
 DEFINE_STRING_TABLE_LOOKUP_FROM_STRING(go_arch, Architecture);
 
 char* urlescape(const char *s) {
+        POINTER_MAY_BE_NULL(s);
         size_t l = strlen_ptr(s);
 
         _cleanup_free_ char *t = new(char, l * 3 + 1);

--- a/src/import/pull-common.c
+++ b/src/import/pull-common.c
@@ -678,6 +678,7 @@ int pull_job_restart_with_signature(PullJob *j, char **ret) {
         int r;
 
         assert(j);
+        assert(ret);
 
         /* Generic implementation of a PullJobNotFound handler, that restarts the job requesting a different
          * signature file. After the initial file, additional *.sha256.gpg, SHA256SUMS.gpg and SHA256SUMS.asc

--- a/src/import/pull.c
+++ b/src/import/pull.c
@@ -46,6 +46,8 @@ static int normalize_local(const char *local, const char *url, char **ret) {
         _cleanup_free_ char *ll = NULL;
         int r;
 
+        assert(ret);
+
         if (arg_import_flags & IMPORT_DIRECT) {
 
                 if (!local)

--- a/src/journal-remote/journal-gatewayd.c
+++ b/src/journal-remote/journal-gatewayd.c
@@ -815,6 +815,8 @@ static int get_virtualization(char **v) {
         char *b = NULL;
         int r;
 
+        assert(v);
+
         r = sd_bus_default_system(&bus);
         if (r < 0)
                 return r;

--- a/src/journal/journald-manager.c
+++ b/src/journal/journald-manager.c
@@ -463,7 +463,9 @@ static int manager_find_user_journal(Manager *m, uid_t uid, JournalFile **ret) {
         _cleanup_free_ char *p = NULL;
         int r;
 
+        assert(m);
         assert(!uid_for_system_journal(uid));
+        assert(ret);
 
         f = ordered_hashmap_get(m->user_journals, UID_TO_PTR(uid));
         if (f)

--- a/src/kernel-install/kernel-install.c
+++ b/src/kernel-install/kernel-install.c
@@ -1128,6 +1128,7 @@ static int kernel_from_version(const char *version, char **ret_kernel) {
         int r;
 
         assert(version);
+        assert(ret_kernel);
 
         vmlinuz = path_join("/usr/lib/modules/", version, "/vmlinuz");
         if (!vmlinuz)

--- a/src/libsystemd/sd-bus/bus-message.c
+++ b/src/libsystemd/sd-bus/bus-message.c
@@ -418,6 +418,8 @@ int bus_message_from_malloc(
         size_t sz;
         int r;
 
+        assert(ret);
+
         r = message_from_header(
                         bus,
                         buffer, length,

--- a/src/libsystemd/sd-bus/test-bus-benchmark.c
+++ b/src/libsystemd/sd-bus/test-bus-benchmark.c
@@ -27,6 +27,8 @@ typedef enum Type {
 static void server(sd_bus *b, size_t *result) {
         int r;
 
+        assert(result);
+
         for (;;) {
                 _cleanup_(sd_bus_message_unrefp) sd_bus_message *m = NULL;
 

--- a/src/libsystemd/sd-device/test-sd-device-monitor.c
+++ b/src/libsystemd/sd-device/test-sd-device-monitor.c
@@ -20,6 +20,8 @@
 static void prepare_loopback(sd_device **ret) {
         _cleanup_(sd_device_unrefp) sd_device *dev = NULL;
 
+        assert(ret);
+
         ASSERT_OK(sd_device_new_from_syspath(&dev, "/sys/class/net/lo"));
         ASSERT_OK(device_add_property(dev, "ACTION", "add"));
         ASSERT_OK(device_add_property(dev, "SEQNUM", "10"));
@@ -31,6 +33,8 @@ static void prepare_loopback(sd_device **ret) {
 static int prepare_sda(sd_device **ret) {
         _cleanup_(sd_device_unrefp) sd_device *dev = NULL;
         int r;
+
+        assert(ret);
 
         r = sd_device_new_from_subsystem_sysname(&dev, "block", "sda");
         if (r < 0)
@@ -54,6 +58,9 @@ static int monitor_handler(sd_device_monitor *m, sd_device *d, void *userdata) {
 
 static void prepare_monitor(sd_device_monitor **ret_server, sd_device_monitor **ret_client, union sockaddr_union *ret_address) {
         _cleanup_(sd_device_monitor_unrefp) sd_device_monitor *monitor_server = NULL, *monitor_client = NULL;
+
+        assert(ret_server);
+        assert(ret_client);
 
         ASSERT_OK(device_monitor_new_full(&monitor_server, MONITOR_GROUP_NONE, -EBADF));
         ASSERT_OK(sd_device_monitor_set_description(monitor_server, "sender"));

--- a/src/libsystemd/sd-device/test-sd-device.c
+++ b/src/libsystemd/sd-device/test-sd-device.c
@@ -351,6 +351,9 @@ static void test_sd_device_enumerator_filter_subsystem_one(
         unsigned n_new_dev = 0, n_removed_dev = 0;
         sd_device *dev;
 
+        assert(ret_n_new_dev);
+        assert(ret_n_removed_dev);
+
         ASSERT_OK(sd_device_enumerator_new(&e));
         ASSERT_OK(sd_device_enumerator_add_match_subsystem(e, subsystem, true));
         exclude_problematic_devices(e);

--- a/src/libsystemd/sd-journal/test-journal-interleaving.c
+++ b/src/libsystemd/sd-journal/test-journal-interleaving.c
@@ -222,6 +222,8 @@ static void setup_unreferenced_data(void) {
 static void mkdtemp_chdir_chattr(const char *template, char **ret) {
         _cleanup_(rm_rf_physical_and_freep) char *path = NULL;
 
+        assert(ret);
+
         ASSERT_OK(mkdtemp_malloc(template, &path));
         ASSERT_OK_ERRNO(chdir(path));
 

--- a/src/libsystemd/sd-netlink/netlink-message-nfnl.c
+++ b/src/libsystemd/sd-netlink/netlink-message-nfnl.c
@@ -242,6 +242,8 @@ int sd_nfnl_nft_message_new_basechain(
         _cleanup_(sd_netlink_message_unrefp) sd_netlink_message *m = NULL;
         int r;
 
+        assert(ret);
+
         r = sd_nfnl_message_new(nfnl, &m, nfproto, NFNL_SUBSYS_NFTABLES, NFT_MSG_NEWCHAIN, NLM_F_CREATE);
         if (r < 0)
                 return r;
@@ -287,6 +289,8 @@ int sd_nfnl_nft_message_new_table(
         _cleanup_(sd_netlink_message_unrefp) sd_netlink_message *m = NULL;
         int r;
 
+        assert(ret);
+
         r = sd_nfnl_message_new(nfnl, &m, nfproto, NFNL_SUBSYS_NFTABLES, NFT_MSG_NEWTABLE, NLM_F_CREATE | NLM_F_EXCL);
         if (r < 0)
                 return r;
@@ -308,6 +312,8 @@ int sd_nfnl_nft_message_new_rule(
 
         _cleanup_(sd_netlink_message_unrefp) sd_netlink_message *m = NULL;
         int r;
+
+        assert(ret);
 
         r = sd_nfnl_message_new(nfnl, &m, nfproto, NFNL_SUBSYS_NFTABLES, NFT_MSG_NEWRULE, NLM_F_CREATE);
         if (r < 0)
@@ -336,6 +342,8 @@ int sd_nfnl_nft_message_new_set(
 
         _cleanup_(sd_netlink_message_unrefp) sd_netlink_message *m = NULL;
         int r;
+
+        assert(ret);
 
         r = sd_nfnl_message_new(nfnl, &m, nfproto, NFNL_SUBSYS_NFTABLES, NFT_MSG_NEWSET, NLM_F_CREATE);
         if (r < 0)
@@ -371,6 +379,8 @@ int sd_nfnl_nft_message_new_setelems(
 
         _cleanup_(sd_netlink_message_unrefp) sd_netlink_message *m = NULL;
         int r;
+
+        assert(ret);
 
         if (add)
                 r = sd_nfnl_message_new(nfnl, &m, nfproto, NFNL_SUBSYS_NFTABLES, NFT_MSG_NEWSETELEM, NLM_F_CREATE);

--- a/src/libsystemd/sd-netlink/test-netlink.c
+++ b/src/libsystemd/sd-netlink/test-netlink.c
@@ -608,6 +608,8 @@ static void remove_dummy_interfacep(int *ifindex) {
         _cleanup_(sd_netlink_unrefp) sd_netlink *rtnl = NULL;
         _cleanup_(sd_netlink_message_unrefp) sd_netlink_message *message = NULL;
 
+        POINTER_MAY_BE_NULL(ifindex);
+
         if (!ifindex || *ifindex <= 0)
                 return;
 

--- a/src/libsystemd/sd-varlink/sd-varlink-idl.c
+++ b/src/libsystemd/sd-varlink/sd-varlink-idl.c
@@ -840,6 +840,7 @@ static int varlink_idl_subparse_field_type(
         assert(p);
         assert(*p);
         assert(line);
+        assert(column);
         assert(field);
 
         r = varlink_idl_subparse_whitespace(p, line, column);
@@ -1171,6 +1172,9 @@ _public_ int sd_varlink_idl_parse(
 
         _cleanup_(sd_varlink_interface_freep) sd_varlink_interface *interface = NULL;
         _cleanup_(varlink_symbol_freep) sd_varlink_symbol *symbol = NULL;
+
+        assert_return(ret, -EINVAL);
+
         enum {
                 STATE_PRE_INTERFACE,
                 STATE_INTERFACE,

--- a/src/libsystemd/sd-varlink/sd-varlink-idl.c
+++ b/src/libsystemd/sd-varlink/sd-varlink-idl.c
@@ -1173,7 +1173,7 @@ _public_ int sd_varlink_idl_parse(
         _cleanup_(sd_varlink_interface_freep) sd_varlink_interface *interface = NULL;
         _cleanup_(varlink_symbol_freep) sd_varlink_symbol *symbol = NULL;
 
-        assert_return(ret, -EINVAL);
+        POINTER_MAY_BE_NULL(ret);
 
         enum {
                 STATE_PRE_INTERFACE,
@@ -1410,7 +1410,8 @@ _public_ int sd_varlink_idl_parse(
         if (r < 0)
                 return r;
 
-        *ret = TAKE_PTR(interface);
+        if (ret)
+                *ret = TAKE_PTR(interface);
         return 0;
 }
 

--- a/src/libsystemd/sd-varlink/varlink-util.c
+++ b/src/libsystemd/sd-varlink/varlink-util.c
@@ -175,6 +175,8 @@ int varlink_server_new(
         _cleanup_(sd_varlink_server_unrefp) sd_varlink_server *s = NULL;
         int r;
 
+        assert(ret);
+
         r = sd_varlink_server_new(&s, flags|SD_VARLINK_SERVER_FD_PASSING_INPUT_STRICT);
         if (r < 0)
                 return log_debug_errno(r, "Failed to allocate varlink server object: %m");

--- a/src/login/logind-dbus.c
+++ b/src/login/logind-dbus.c
@@ -90,6 +90,7 @@ static int get_sender_session(
         int r;
 
         assert(m);
+        assert(ret);
 
         /* Acquire the sender's session. This first checks if the sending process is inside a session itself,
          * and returns that. If not and 'consult_display' is true, this returns the display session of the
@@ -164,6 +165,8 @@ static int get_sender_user(Manager *m, sd_bus_message *message, sd_bus_error *er
         uid_t uid;
         User *user;
         int r;
+
+        assert(ret);
 
         /* Note that we get the owner UID of the session, not the actual client UID here! */
         r = sd_bus_query_sender_creds(message, SD_BUS_CREDS_OWNER_UID|SD_BUS_CREDS_AUGMENT, &creds);

--- a/src/machine/machinectl.c
+++ b/src/machine/machinectl.c
@@ -193,6 +193,7 @@ static int call_get_addresses(
         assert(name);
         assert(prefix);
         assert(prefix2);
+        assert(ret);
 
         r = bus_call_method(bus, bus_machine_mgr, "GetMachineAddresses", NULL, &reply, "s", name);
         if (r < 0)

--- a/src/machine/machined-dbus.c
+++ b/src/machine/machined-dbus.c
@@ -257,6 +257,8 @@ static int machine_add_from_params(
         assert(message);
         assert(name);
         assert(c == _MACHINE_CLASS_INVALID || MACHINE_CLASS_CAN_REGISTER(c));
+        assert(leader_pidref);
+        assert(supervisor_pidref);
         assert(ret);
 
         if (leader_pidref->pid == 1)

--- a/src/measure/measure-tool.c
+++ b/src/measure/measure-tool.c
@@ -639,6 +639,8 @@ static int pcr_states_allocate(PcrState **ret) {
         _cleanup_(pcr_state_free_all) PcrState *pcr_states = NULL;
         size_t n = 0;
 
+        assert(ret);
+
         pcr_states = new0(PcrState, strv_length(arg_banks) + 1);
         if (!pcr_states)
                 return log_oom();

--- a/src/mountfsd/mountfsd-manager.c
+++ b/src/mountfsd/mountfsd-manager.c
@@ -69,6 +69,8 @@ int manager_new(Manager **ret) {
         _cleanup_(manager_freep) Manager *m = NULL;
         int r;
 
+        assert(ret);
+
         m = new(Manager, 1);
         if (!m)
                 return -ENOMEM;

--- a/src/network/netdev/fou-tunnel.c
+++ b/src/network/netdev/fou-tunnel.c
@@ -86,6 +86,7 @@ static int netdev_create_fou_tunnel_message(NetDev *netdev, sd_netlink_message *
 
         assert(netdev);
         assert(netdev->manager);
+        assert(ret);
 
         r = sd_genl_message_new(netdev->manager->genl, FOU_GENL_NAME, FOU_CMD_ADD, &m);
         if (r < 0)

--- a/src/network/netdev/l2tp-tunnel.c
+++ b/src/network/netdev/l2tp-tunnel.c
@@ -104,6 +104,7 @@ static int netdev_l2tp_create_message_tunnel(NetDev *netdev, union in_addr_union
         assert(local_address);
         assert(netdev);
         assert(netdev->manager);
+        assert(ret);
 
         _cleanup_(sd_netlink_message_unrefp) sd_netlink_message *m = NULL;
         uint16_t encap_type;
@@ -200,6 +201,7 @@ static int netdev_l2tp_create_message_session(NetDev *netdev, L2tpSession *sessi
         assert(netdev->manager);
         assert(session);
         assert(session->tunnel);
+        assert(ret);
 
         r = sd_genl_message_new(netdev->manager->genl, L2TP_GENL_NAME, L2TP_CMD_SESSION_CREATE, &m);
         if (r < 0)

--- a/src/network/netdev/macsec.c
+++ b/src/network/netdev/macsec.c
@@ -239,6 +239,7 @@ static int netdev_macsec_create_message(NetDev *netdev, int command, sd_netlink_
         assert(netdev);
         assert(netdev->ifindex > 0);
         assert(netdev->manager);
+        assert(ret);
 
         r = sd_genl_message_new(netdev->manager->genl, MACSEC_GENL_NAME, command, &m);
         if (r < 0)

--- a/src/network/networkd-address.c
+++ b/src/network/networkd-address.c
@@ -173,6 +173,8 @@ DEFINE_PRIVATE_HASH_OPS_WITH_VALUE_DESTRUCTOR(
 int address_new(Address **ret) {
         _cleanup_(address_unrefp) Address *address = NULL;
 
+        assert(ret);
+
         address = new(Address, 1);
         if (!address)
                 return -ENOMEM;

--- a/src/network/networkd-dhcp-server.c
+++ b/src/network/networkd-dhcp-server.c
@@ -456,6 +456,9 @@ static int dhcp4_server_parse_dns_server_string_and_warn(
                 struct in_addr **addresses,
                 size_t *n_addresses) {
 
+        assert(addresses);
+        assert(n_addresses);
+
         for (;;) {
                 _cleanup_free_ char *word = NULL, *server_name = NULL;
                 union in_addr_union address;

--- a/src/network/networkd-dhcp6.c
+++ b/src/network/networkd-dhcp6.c
@@ -202,6 +202,10 @@ static int dhcp6_request_address(
         Address *existing;
         int r;
 
+        assert(link);
+        assert(server_address);
+        assert(ip6_addr);
+
         r = address_new(&addr);
         if (r < 0)
                 return log_oom();

--- a/src/network/networkd-manager.c
+++ b/src/network/networkd-manager.c
@@ -677,6 +677,8 @@ static int persistent_storage_open(void) {
 int manager_new(Manager **ret, bool test_mode) {
         _cleanup_(manager_freep) Manager *m = NULL;
 
+        assert(ret);
+
         m = new(Manager, 1);
         if (!m)
                 return -ENOMEM;

--- a/src/network/networkd-nexthop.c
+++ b/src/network/networkd-nexthop.c
@@ -131,6 +131,8 @@ DEFINE_PRIVATE_HASH_OPS_WITH_VALUE_DESTRUCTOR(
 int nexthop_new(NextHop **ret) {
         _cleanup_(nexthop_unrefp) NextHop *nexthop = NULL;
 
+        assert(ret);
+
         nexthop = new(NextHop, 1);
         if (!nexthop)
                 return -ENOMEM;

--- a/src/network/networkd-route.c
+++ b/src/network/networkd-route.c
@@ -245,6 +245,8 @@ DEFINE_PRIVATE_HASH_OPS_WITH_VALUE_DESTRUCTOR(
 int route_new(Route **ret) {
         _cleanup_(route_unrefp) Route *route = NULL;
 
+        assert(ret);
+
         route = new(Route, 1);
         if (!route)
                 return -ENOMEM;

--- a/src/network/tc/qdisc.c
+++ b/src/network/tc/qdisc.c
@@ -115,6 +115,8 @@ static int qdisc_new(QDiscKind kind, QDisc **ret) {
         _cleanup_(qdisc_unrefp) QDisc *qdisc = NULL;
         int r;
 
+        assert(ret);
+
         if (kind == _QDISC_KIND_INVALID) {
                 qdisc = new(QDisc, 1);
                 if (!qdisc)

--- a/src/network/tc/tclass.c
+++ b/src/network/tc/tclass.c
@@ -77,6 +77,8 @@ static int tclass_new(TClassKind kind, TClass **ret) {
         _cleanup_(tclass_unrefp) TClass *tclass = NULL;
         int r;
 
+        assert(ret);
+
         if (kind == _TCLASS_KIND_INVALID) {
                 tclass = new(TClass, 1);
                 if (!tclass)

--- a/src/nspawn/nspawn-mount.c
+++ b/src/nspawn/nspawn-mount.c
@@ -757,12 +757,13 @@ int mount_all(const char *dest,
 }
 
 static int parse_mount_bind_options(const char *options, unsigned long *open_tree_flags, char **mount_opts, RemountIdmapping *idmapping) {
-        unsigned long flags = *open_tree_flags;
+        unsigned long flags = *ASSERT_PTR(open_tree_flags);
         char *opts = NULL;
-        RemountIdmapping new_idmapping = *idmapping;
+        RemountIdmapping new_idmapping = *ASSERT_PTR(idmapping);
         int r;
 
         assert(options);
+        assert(mount_opts);
 
         for (;;) {
                 _cleanup_free_ char *word = NULL;

--- a/src/nspawn/nspawn-network.c
+++ b/src/nspawn/nspawn-network.c
@@ -177,6 +177,7 @@ int setup_veth(const char *machine_name,
         assert(machine_name);
         assert(pidref_is_set(pid));
         assert(iface_name);
+        assert(provided_mac);
 
         /* Use two different interface name prefixes depending whether
          * we are in bridge mode or not. */

--- a/src/nspawn/nspawn-oci.c
+++ b/src/nspawn/nspawn-oci.c
@@ -2082,6 +2082,7 @@ int oci_load(FILE *f, const char *bundle, Settings **ret) {
         int r;
 
         assert_se(bundle);
+        assert(ret);
 
         path = strjoina(bundle, "/config.json");
 

--- a/src/nspawn/nspawn.c
+++ b/src/nspawn/nspawn.c
@@ -445,6 +445,8 @@ static int parse_capability_spec(const char *spec, uint64_t *ret_mask) {
         uint64_t mask = 0;
         int r;
 
+        assert(ret_mask);
+
         for (;;) {
                 _cleanup_free_ char *t = NULL;
 

--- a/src/nsresourced/nsresourced-manager.c
+++ b/src/nsresourced/nsresourced-manager.c
@@ -89,6 +89,8 @@ int manager_new(Manager **ret) {
         _cleanup_(manager_freep) Manager *m = NULL;
         int r;
 
+        assert(ret);
+
         m = new(Manager, 1);
         if (!m)
                 return -ENOMEM;

--- a/src/nss-resolve/nss-resolve.c
+++ b/src/nss-resolve/nss-resolve.c
@@ -50,6 +50,8 @@ static int connect_to_resolved(sd_varlink **ret) {
         _cleanup_(sd_varlink_unrefp) sd_varlink *link = NULL;
         int r;
 
+        assert(ret);
+
         r = sd_varlink_connect_address(&link, "/run/systemd/resolve/io.systemd.Resolve");
         if (r < 0)
                 return r;

--- a/src/pcrextend/pcrextend.c
+++ b/src/pcrextend/pcrextend.c
@@ -261,6 +261,7 @@ static int escape_and_truncate_data(const void *data, size_t size, char **ret) {
         _cleanup_free_ char *safe = NULL;
 
         assert(data || size == 0);
+        assert(ret);
 
         if (size > EXTENSION_STRING_SAFE_LIMIT) {
                 safe = cescape_length(data, EXTENSION_STRING_SAFE_LIMIT);

--- a/src/pcrlock/pcrlock.c
+++ b/src/pcrlock/pcrlock.c
@@ -2456,6 +2456,8 @@ static int event_log_load_and_process(EventLog **ret) {
         _cleanup_(event_log_freep) EventLog *el = NULL;
         int r;
 
+        assert(ret);
+
         el = event_log_new();
         if (!el)
                 return log_oom();
@@ -3613,6 +3615,7 @@ static int pcrlock_file_system_path(const char *normalized_path, char **ret) {
         _cleanup_free_ char *s = NULL;
 
         assert(normalized_path);
+        assert(ret);
 
         if (path_equal(normalized_path, "/"))
                 s = strdup(PCRLOCK_ROOT_FILE_SYSTEM_PATH);

--- a/src/portable/portablectl.c
+++ b/src/portable/portablectl.c
@@ -132,6 +132,8 @@ static int extract_prefix(const char *path, char **ret) {
         size_t m;
         int r;
 
+        assert(ret);
+
         r = path_extract_filename(path, &bn);
         if (r < 0)
                 return r;

--- a/src/repart/repart.c
+++ b/src/repart/repart.c
@@ -2691,6 +2691,8 @@ static int parse_key_file(const char *filename, struct iovec *key) {
         size_t n = 0;
         int r;
 
+        assert(key);
+
         r = read_full_file_full(
                         AT_FDCWD, filename,
                         /* offset= */ UINT64_MAX,
@@ -4382,6 +4384,8 @@ static int partition_hint(const Partition *p, const char *node, char **ret) {
         _cleanup_free_ char *buf = NULL;
         const char *label;
         sd_id128_t id;
+
+        assert(ret);
 
         /* Tries really hard to find a suitable description for this partition */
 

--- a/src/report/report-cgroup.c
+++ b/src/report/report-cgroup.c
@@ -284,6 +284,9 @@ static int io_stat_parse(const char *cgroup_path, uint64_t *ret_rbytes, uint64_t
         uint64_t rbytes = 0, rios = 0;
         int r;
 
+        assert(ret_rbytes);
+        assert(ret_rios);
+
         r = cg_get_path(cgroup_path, "io.stat", &path);
         if (r < 0)
                 return r;

--- a/src/report/report.c
+++ b/src/report/report.c
@@ -337,6 +337,7 @@ static int output_collected_list(Context *context, Table **ret) {
         int r;
 
         assert(context);
+        assert(ret);
 
         _cleanup_(table_unrefp) Table *table = table_new("family", "object", "fields", "value");
         if (!table)
@@ -391,6 +392,7 @@ static int output_collected_describe(Context *context, Table **ret) {
         int r;
 
         assert(context);
+        assert(ret);
 
         _cleanup_(table_unrefp) Table *table = table_new("family", "type", "description");
         if (!table)
@@ -442,6 +444,7 @@ static int facts_output_list(Context *context, Table **ret) {
         int r;
 
         assert(context);
+        assert(ret);
 
         _cleanup_(table_unrefp) Table *table = table_new("family", "object", "value");
         if (!table)
@@ -493,6 +496,7 @@ static int facts_output_describe(Context *context, Table **ret) {
         int r;
 
         assert(context);
+        assert(ret);
 
         _cleanup_(table_unrefp) Table *table = table_new("family", "description");
         if (!table)

--- a/src/resolve/resolved-dns-dnssec.c
+++ b/src/resolve/resolved-dns-dnssec.c
@@ -2057,6 +2057,8 @@ static int dnssec_test_positive_wildcard_nsec(
         bool authenticated = true;
         int r;
 
+        assert(_authenticated);
+
         /* Run a positive NSEC wildcard proof. Specifically:
          *
          * A proof that there's neither a wildcard name nor a non-wildcard name that is a suffix of the name "name" and

--- a/src/resolve/resolved-dns-synthesize.c
+++ b/src/resolve/resolved-dns-synthesize.c
@@ -98,6 +98,8 @@ static int synthesize_localhost_rr(Manager *m, const DnsResourceKey *key, DnsAns
 static int answer_add_ptr(DnsAnswer **answer, const char *from, const char *to, int ifindex, DnsAnswerFlags flags) {
         _cleanup_(dns_resource_record_unrefp) DnsResourceRecord *rr = NULL;
 
+        assert(answer);
+
         rr = dns_resource_record_new_full(DNS_CLASS_IN, DNS_TYPE_PTR, from);
         if (!rr)
                 return -ENOMEM;

--- a/src/resolve/resolved-dns-transaction.c
+++ b/src/resolve/resolved-dns-transaction.c
@@ -3300,7 +3300,9 @@ static int dnssec_validate_records(
         DnsResourceRecord *rr;
         int r;
 
+        assert(have_nsec);
         assert(nvalidations);
+        assert(validated);
 
         /* Returns negative on error, 0 if validation failed, 1 to restart validation, 2 when finished. */
 

--- a/src/resolve/resolved-static-records.c
+++ b/src/resolve/resolved-static-records.c
@@ -50,6 +50,8 @@ DEFINE_PRIVATE_HASH_OPS_WITH_VALUE_DESTRUCTOR(
 static int load_static_record_file_item(sd_json_variant *rj, Hashmap **records) {
         int r;
 
+        assert(records);
+
         _cleanup_(dns_resource_record_unrefp) DnsResourceRecord *rr = NULL;
         r = dns_resource_record_from_json(rj, &rr);
         if (r < 0)

--- a/src/resolve/resolved-varlink.c
+++ b/src/resolve/resolved-varlink.c
@@ -211,6 +211,9 @@ static int find_addr_records(
         DnsResourceRecord *rr;
         int ifindex, r;
 
+        assert(q);
+        POINTER_MAY_BE_NULL(canonical);
+
         DNS_ANSWER_FOREACH_IFINDEX(rr, ifindex, q->answer) {
                 _cleanup_(sd_json_variant_unrefp) sd_json_variant *entry = NULL;
                 int family;

--- a/src/resolve/test-dnssec-complex.c
+++ b/src/resolve/test-dnssec-complex.c
@@ -18,6 +18,8 @@ static void prefix_random(const char *name, char **ret) {
         uint64_t i, u;
         char *m = NULL;
 
+        assert(ret);
+
         u = 1 + (random_u64() & 3);
 
         for (i = 0; i < u; i++) {

--- a/src/shared/bootspec.c
+++ b/src/shared/bootspec.c
@@ -1056,6 +1056,7 @@ static int pe_find_addon_sections(
 
         assert(fd >= 0);
         assert(path);
+        assert(ret_cmdline);
 
         r = pe_load_headers_and_sections(fd, path, &sections, &pe_header);
         if (r < 0)

--- a/src/shared/bpf-program.c
+++ b/src/shared/bpf-program.c
@@ -152,6 +152,8 @@ int bpf_program_new(uint32_t prog_type, const char *prog_name, BPFProgram **ret)
         _cleanup_(bpf_program_freep) BPFProgram *p = NULL;
         _cleanup_free_ char *name = NULL;
 
+        assert(ret);
+
         if (prog_name) {
                 if (strlen(prog_name) >= BPF_OBJ_NAME_LEN)
                         return -ENAMETOOLONG;

--- a/src/shared/bus-unit-util.c
+++ b/src/shared/bus-unit-util.c
@@ -1175,6 +1175,8 @@ static int bus_append_import_credential(sd_bus_message *m, const char *field, co
 static int bus_append_refresh_on_reload(sd_bus_message *m, const char *field, const char *eq) {
         int r;
 
+        assert(eq);
+
         r = sd_bus_message_open_container(m, 'r', "sv");
         if (r < 0)
                 return bus_log_create_error(r);

--- a/src/shared/calendarspec.c
+++ b/src/shared/calendarspec.c
@@ -1285,6 +1285,7 @@ static int find_next(const CalendarSpec *spec, struct tm *tm, usec_t *usec) {
 
         assert(spec);
         assert(tm);
+        assert(usec);
 
         c = *tm;
         tm_usec = *usec;

--- a/src/shared/cgroup-show.c
+++ b/src/shared/cgroup-show.c
@@ -413,6 +413,8 @@ int show_cgroup_get_path_and_warn(
         _cleanup_free_ char *root = NULL;
         int r;
 
+        assert(ret);
+
         if (machine) {
                 _cleanup_(sd_bus_flush_close_unrefp) sd_bus *bus = NULL;
                 _cleanup_free_ char *unit = NULL;

--- a/src/shared/conf-parser.c
+++ b/src/shared/conf-parser.c
@@ -189,6 +189,9 @@ static int parse_line(
         assert(line > 0);
         assert(lookup);
         assert(l);
+        assert(section);
+        assert(section_line);
+        assert(section_ignored);
 
         l = strstrip(l);
         if (isempty(l))

--- a/src/shared/creds-util.c
+++ b/src/shared/creds-util.c
@@ -275,6 +275,8 @@ int read_credential_strings_many_internal(
         bool all = true;
         int r, ret = 0;
 
+        assert(first_value);
+
         /* Reads a bunch of credentials into the specified buffers. If the specified buffers are already
          * non-NULL frees them if a credential is found. Only supports string-based credentials
          * (i.e. refuses embedded NUL bytes).
@@ -337,6 +339,9 @@ int get_credential_user_password(const char *username, char **ret_password, bool
         _cleanup_(erase_and_freep) char *creds_password = NULL;
         _cleanup_free_ char *cn = NULL;
         int r;
+
+        assert(ret_password);
+        assert(ret_is_hashed);
 
         /* Try to pick up the password for this account via the credentials logic */
         cn = strjoin("passwd.hashed-password.", username);

--- a/src/shared/cryptsetup-util.c
+++ b/src/shared/cryptsetup-util.c
@@ -214,6 +214,8 @@ int cryptsetup_get_volume_key_prefix(
         const char *uuid;
         char *s;
 
+        assert(ret);
+
         uuid = sym_crypt_get_uuid(cd);
         if (!uuid)
                 return log_debug_errno(SYNTHETIC_ERRNO(EINVAL), "Failed to get LUKS UUID.");
@@ -247,6 +249,8 @@ int cryptsetup_get_volume_key_id(
         uint8_t digest[SHA256_DIGEST_SIZE];
         char *hex;
         int r;
+
+        assert(ret);
 
         r = cryptsetup_get_volume_key_prefix(cd, volume_name, &prefix);
         if (r < 0)

--- a/src/shared/dissect-image.c
+++ b/src/shared/dissect-image.c
@@ -942,6 +942,7 @@ static int dissect_image_from_unpartitioned(
         assert(devname);
         assert(m);
         assert(fstype);
+        POINTER_MAY_BE_NULL(mount_node_fd);
 
         if (!image_filter_test(filter, PARTITION_ROOT, /* label= */ NULL)) /* do a filter check with an empty partition label */
                 return -ECOMM;

--- a/src/shared/dns-answer.c
+++ b/src/shared/dns-answer.c
@@ -574,6 +574,8 @@ int dns_answer_remove_by_answer_keys(DnsAnswer **a, DnsAnswer *b) {
         DnsAnswerItem *item;
         int r;
 
+        assert(a);
+
         /* Removes all items from '*a' that have a matching key in 'b' */
 
         DNS_ANSWER_FOREACH_ITEM(item, b) {

--- a/src/shared/dns-packet.c
+++ b/src/shared/dns-packet.c
@@ -1519,6 +1519,7 @@ int dns_packet_read_string(DnsPacket *p, char **ret, size_t *start) {
         int r;
 
         assert(p);
+        assert(ret);
 
         r = dns_packet_read_uint8(p, &c, NULL);
         if (r < 0)
@@ -2448,6 +2449,8 @@ static int dns_packet_extract_question(DnsPacket *p, DnsQuestion **ret_question)
         unsigned n;
         int r;
 
+        assert(ret_question);
+
         n = DNS_PACKET_QDCOUNT(p);
         if (n > 0) {
                 question = dns_question_new(n);
@@ -2500,6 +2503,8 @@ static int dns_packet_extract_answer(DnsPacket *p, DnsAnswer **ret_answer) {
         _cleanup_(dns_resource_record_unrefp) DnsResourceRecord *previous = NULL;
         bool bad_opt = false;
         int r;
+
+        assert(ret_answer);
 
         n = DNS_PACKET_RRCOUNT(p);
         if (n == 0)

--- a/src/shared/dns-rr.c
+++ b/src/shared/dns-rr.c
@@ -2012,6 +2012,7 @@ int dns_resource_record_get_cname_target(DnsResourceKey *key, DnsResourceRecord 
 
         assert(key);
         assert(cname);
+        assert(ret);
 
         /* Checks if the RR `cname` is a CNAME/DNAME RR that matches the specified `key`. If so, returns the
          * target domain. If not, returns -EUNATCH */

--- a/src/shared/extension-util.c
+++ b/src/shared/extension-util.c
@@ -140,6 +140,7 @@ int parse_env_extension_hierarchies(char ***ret_hierarchies, const char *hierarc
         _cleanup_free_ char **l = NULL;
         int r;
 
+        assert(ret_hierarchies);
         assert(hierarchy_env);
         r = getenv_path_list(hierarchy_env, &l);
         if (r == -ENXIO) {

--- a/src/shared/fido2-util.c
+++ b/src/shared/fido2-util.c
@@ -14,6 +14,8 @@ int fido2_generate_salt(struct iovec *ret_salt) {
         _cleanup_(iovec_done) struct iovec salt = {};
         int r;
 
+        assert(ret_salt);
+
         r = crypto_random_bytes_allocate_iovec(FIDO2_SALT_SIZE, &salt);
         if (r < 0)
                 return log_error_errno(r, "Failed to generate FIDO2 salt: %m");
@@ -26,6 +28,8 @@ int fido2_read_salt_file(const char *filename, uint64_t offset, const char *clie
         _cleanup_(iovec_done_erase) struct iovec salt = {};
         _cleanup_free_ char *bind_name = NULL;
         int r;
+
+        assert(ret_salt);
 
         /* If we read the salt via AF_UNIX, make the client recognizable */
         if (asprintf(&bind_name, "@%" PRIx64"/%s-fido2-salt/%s", random_u64(), client, node) < 0)

--- a/src/shared/hwdb-util.c
+++ b/src/shared/hwdb-util.c
@@ -190,6 +190,8 @@ static int trie_insert(struct trie *trie, struct trie_node *node, const char *se
                        const char *filename, uint16_t file_priority, uint32_t line_number, bool compat) {
         int r = 0;
 
+        assert(node);
+
         for (size_t i = 0;; i++) {
                 size_t p;
                 char c;

--- a/src/shared/install-printf.c
+++ b/src/shared/install-printf.c
@@ -12,6 +12,8 @@ static int specifier_prefix_and_instance(char specifier, const void *data, const
         _cleanup_free_ char *prefix = NULL;
         int r;
 
+        assert(ret);
+
         r = unit_name_to_prefix_and_instance(i->name, &prefix);
         if (r < 0)
                 return r;

--- a/src/shared/install.c
+++ b/src/shared/install.c
@@ -1861,6 +1861,8 @@ int unit_file_verify_alias(
         _cleanup_free_ char *dst_updated = NULL;
         int r;
 
+        assert(ret_dst);
+
         /* Verify that dst is a valid either a valid alias or a valid .wants/.requires symlink for the target
          * unit *i. Return negative on error or if not compatible, zero on success.
          *
@@ -2902,6 +2904,9 @@ static int do_unit_file_disable(
         _cleanup_(install_context_done) InstallContext ctx = { .scope = scope };
         bool has_install_info = false;
         int r;
+
+        assert(changes);
+        assert(n_changes);
 
         STRV_FOREACH(name, names) {
                 InstallInfo *info;

--- a/src/shared/libfido2-util.c
+++ b/src/shared/libfido2-util.c
@@ -1153,6 +1153,12 @@ static int check_device_is_fido2_with_hmac_secret(
         _cleanup_(fido_dev_free_wrapper) fido_dev_t *d = NULL;
         int r;
 
+        assert(ret_has_rk);
+        assert(ret_has_client_pin);
+        assert(ret_has_up);
+        assert(ret_has_uv);
+        assert(ret_has_always_uv);
+
         d = sym_fido_dev_new();
         if (!d)
                 return log_oom();

--- a/src/shared/libmount-util.c
+++ b/src/shared/libmount-util.c
@@ -100,6 +100,8 @@ int libmount_parse_full(
         /* Older libmount seems to require this. */
         assert(!source || path);
         assert(IN_SET(direction, MNT_ITER_FORWARD, MNT_ITER_BACKWARD));
+        assert(ret_table);
+        assert(ret_iter);
 
         r = dlopen_libmount();
         if (r < 0)

--- a/src/shared/machine-bind-user.c
+++ b/src/shared/machine-bind-user.c
@@ -107,6 +107,8 @@ static int convert_user(
         assert(u);
         assert(g);
         assert(user_record_gid(u) == g->gid);
+        assert(ret_converted_user);
+        assert(ret_converted_group);
 
         if (shell_copy)
                 shell = u->shell;

--- a/src/shared/mkfs-util.c
+++ b/src/shared/mkfs-util.c
@@ -74,10 +74,11 @@ static int mangle_linux_fs_label(const char *s, size_t max_len, char **ret) {
 }
 
 static int mangle_fat_label(const char *s, char **ret) {
-        assert(s);
-
         _cleanup_free_ char *q = NULL;
         int r;
+
+        assert(s);
+        assert(ret);
 
         r = utf8_to_ascii(s, '_', &q);
         if (r < 0)

--- a/src/shared/openssl-util.c
+++ b/src/shared/openssl-util.c
@@ -487,6 +487,9 @@ int rsa_encrypt_bytes(
         _cleanup_free_ void *b = NULL;
         size_t l;
 
+        assert(ret_encrypt_key);
+        assert(ret_encrypt_key_size);
+
         ctx = EVP_PKEY_CTX_new(pkey, NULL);
         if (!ctx)
                 return log_openssl_errors("Failed to allocate public key context");
@@ -1097,6 +1100,11 @@ static int ecc_pkey_generate_volume_keys(
                 void **ret_saved_key,
                 size_t *ret_saved_key_size) {
 
+        assert(ret_decrypted_key);
+        assert(ret_decrypted_key_size);
+        assert(ret_saved_key);
+        assert(ret_saved_key_size);
+
         _cleanup_(EVP_PKEY_freep) EVP_PKEY *pkey_new = NULL;
         _cleanup_(erase_and_freep) void *decrypted_key = NULL;
         _cleanup_free_ unsigned char *saved_key = NULL;
@@ -1149,6 +1157,11 @@ static int rsa_pkey_generate_volume_keys(
         _cleanup_free_ void *saved_key = NULL;
         size_t decrypted_key_size, saved_key_size;
         int r;
+
+        assert(ret_decrypted_key);
+        assert(ret_decrypted_key_size);
+        assert(ret_saved_key);
+        assert(ret_saved_key_size);
 
         r = rsa_pkey_to_suitable_key_size(pkey, &decrypted_key_size);
         if (r < 0)
@@ -1345,6 +1358,7 @@ static int openssl_load_private_key_from_file(const char *path, EVP_PKEY **ret) 
 }
 
 static int openssl_ask_password_ui_new(const AskPasswordRequest *request, OpenSSLAskPasswordUI **ret) {
+        assert(request);
         assert(ret);
 
 #ifndef OPENSSL_NO_UI_CONSOLE

--- a/src/shared/pcrextend-util.c
+++ b/src/shared/pcrextend-util.c
@@ -197,6 +197,7 @@ int pcrextend_verity_word(
 
         assert(name);
         assert(iovec_is_set(root_hash));
+        assert(ret);
 
         _cleanup_free_ char *name_escaped = xescape(name, ":"); /* Avoid ambiguity around ":" */
         if (!name_escaped)

--- a/src/shared/pkcs11-util.c
+++ b/src/shared/pkcs11-util.c
@@ -403,6 +403,8 @@ static int read_public_key_info(
                 CK_OBJECT_HANDLE object,
                 EVP_PKEY **ret_pkey) {
 
+        assert(ret_pkey);
+
         CK_ATTRIBUTE attribute = { CKA_PUBLIC_KEY_INFO, NULL_PTR, 0 };
         _cleanup_(EVP_PKEY_freep) EVP_PKEY *pkey = NULL;
         CK_RV rv;
@@ -444,6 +446,8 @@ int pkcs11_token_read_public_key(
         _cleanup_(EVP_PKEY_freep) EVP_PKEY *pkey = NULL;
         CK_RV rv;
         int r;
+
+        assert(ret_pkey);
 
         r = read_public_key_info(m, session, object, &pkey);
         if (r >= 0) {
@@ -667,6 +671,8 @@ int pkcs11_token_read_x509_certificate(
         _cleanup_(X509_freep) X509 *x509 = NULL;
         X509_NAME *name = NULL;
         int r;
+
+        assert(ret_cert);
 
         r = dlopen_p11kit();
         if (r < 0)
@@ -951,6 +957,9 @@ static int ecc_convert_to_compressed(
         CK_RV rv;
         int r;
 
+        assert(ret_compressed_point);
+        assert(ret_compressed_point_size);
+
         rv = m->C_GetAttributeValue(session, object, &ec_params_attr, 1);
         if (!IN_SET(rv, CKR_OK, CKR_ATTRIBUTE_TYPE_INVALID))
                 return log_error_errno(SYNTHETIC_ERRNO(EIO),
@@ -1156,6 +1165,9 @@ static int pkcs11_token_decrypt_data_rsa(
         _cleanup_(erase_and_freep) CK_BYTE *dbuffer = NULL;
         CK_ULONG dbuffer_size = 0;
         CK_RV rv;
+
+        assert(ret_decrypted_data);
+        assert(ret_decrypted_data_size);
 
         rv = m->C_DecryptInit(session, (CK_MECHANISM*) &mechanism, object);
         if (rv != CKR_OK)

--- a/src/shared/pretty-print.c
+++ b/src/shared/pretty-print.c
@@ -127,6 +127,8 @@ int file_url_from_path(const char *path, char **ret) {
         char *url = NULL;
         int r;
 
+        assert(ret);
+
         if (uname(&u) < 0)
                 return -errno;
 
@@ -389,6 +391,12 @@ static int guess_type(const char **name, char ***ret_prefixes, bool *ret_is_coll
         _cleanup_free_ char *n = NULL;
         bool run = false, coll = false;
         const char *ext = ".conf";
+
+        assert(name);
+        assert(ret_prefixes);
+        assert(ret_is_collection);
+        assert(ret_extension);
+
         /* This is static so that the array doesn't get deallocated when we exit the function */
         static const char* const std_prefixes[] = { CONF_PATHS(""), NULL };
         static const char* const run_prefixes[] = { "/run/", NULL };

--- a/src/shared/seccomp-util.c
+++ b/src/shared/seccomp-util.c
@@ -278,6 +278,8 @@ int seccomp_init_for_arch(scmp_filter_ctx *ret, uint32_t arch, uint32_t default_
         _cleanup_(seccomp_releasep) scmp_filter_ctx seccomp = NULL;
         int r;
 
+        assert(ret);
+
         /* Much like seccomp_init(), but initializes the filter for one specific architecture only, without affecting
          * any others. Also, turns off the NNP fiddling. */
 

--- a/src/shared/snapshot-util.c
+++ b/src/shared/snapshot-util.c
@@ -23,6 +23,8 @@ int create_ephemeral_snapshot(
         _cleanup_free_ char *np = NULL;
         int r;
 
+        assert(ret_new_path);
+
         /* If the specified path is a mount point we generate the new snapshot immediately
          * inside it under a random name. However if the specified is not a mount point we
          * create the new snapshot in the parent directory, just next to it. */

--- a/src/shared/socket-netlink.c
+++ b/src/shared/socket-netlink.c
@@ -372,6 +372,7 @@ int in_addr_full_new(
         _cleanup_free_ char *name = NULL;
         struct in_addr_full *x;
 
+        assert(a);
         assert(ret);
 
         if (!isempty(server_name)) {

--- a/src/shared/tar-util.c
+++ b/src/shared/tar-util.c
@@ -660,6 +660,8 @@ static int archive_entry_read_stat(
         int r;
 
         assert(entry);
+        assert(xa);
+        assert(n_xa);
 
         /* Fills in all fields that are present in the archive entry. Doesn't change the fields if the entry
          * doesn't contain the relevant data */
@@ -1160,6 +1162,7 @@ static int hardlink_lookup(
         assert(d);
         assert(inode_fd >= 0);
         assert(sx);
+        assert(ret);
 
         /* If we know the hardlink count, and it's 1, then don't bother */
         if (FLAGS_SET(sx->stx_mask, STATX_NLINK) && sx->stx_nlink == 1)

--- a/src/shared/tpm2-util.c
+++ b/src/shared/tpm2-util.c
@@ -6412,6 +6412,7 @@ int tpm2_seal_data(
         assert(c);
         assert(data);
         assert(primary_handle);
+        POINTER_MAY_BE_NULL(policy);
 
         /* This is a generic version of tpm2_seal(), that doesn't imply any policy or any specific
          * combination of the two keypairs in their marshalling. tpm2_seal() is somewhat specific to the FDE
@@ -6477,6 +6478,7 @@ int tpm2_unseal_data(
         assert(public_blob);
         assert(private_blob);
         assert(primary_handle);
+        assert(ret_data);
 
         TPM2B_PUBLIC public;
         r = tpm2_unmarshal_public(public_blob->iov_base, public_blob->iov_len, &public);
@@ -8319,6 +8321,8 @@ int tpm2_pcrlock_policy_load(
         _cleanup_free_ char *discovered_path = NULL;
         _cleanup_fclose_ FILE *f = NULL;
         int r;
+
+        assert(ret_policy);
 
         r = tpm2_pcrlock_search_file(path, &f, &discovered_path);
         if (r == -ENOENT) {

--- a/src/shared/tpm2-util.c
+++ b/src/shared/tpm2-util.c
@@ -2507,7 +2507,7 @@ static int tpm2_load_external(
 }
 
 static int tpm2_marshal_private(const TPM2B_PRIVATE *private, void **ret, size_t *ret_size) {
-        size_t max_size = sizeof(*private), blob_size = 0;
+        size_t max_size = SIZEOF(*private), blob_size = 0;
         _cleanup_free_ void *blob = NULL;
         TSS2_RC rc;
 
@@ -2550,7 +2550,7 @@ static int tpm2_unmarshal_private(const void *data, size_t size, TPM2B_PRIVATE *
 }
 
 int tpm2_marshal_public(const TPM2B_PUBLIC *public, void **ret, size_t *ret_size) {
-        size_t max_size = sizeof(*public), blob_size = 0;
+        size_t max_size = SIZEOF(*public), blob_size = 0;
         _cleanup_free_ void *blob = NULL;
         TSS2_RC rc;
 
@@ -2593,7 +2593,7 @@ static int tpm2_unmarshal_public(const void *data, size_t size, TPM2B_PUBLIC *re
 }
 
 int tpm2_marshal_nv_public(const TPM2B_NV_PUBLIC *nv_public, void **ret, size_t *ret_size) {
-        size_t max_size = sizeof(*nv_public), blob_size = 0;
+        size_t max_size = SIZEOF(*nv_public), blob_size = 0;
         _cleanup_free_ void *blob = NULL;
         TSS2_RC rc;
 

--- a/src/shared/unit-file.c
+++ b/src/shared/unit-file.c
@@ -752,6 +752,8 @@ int unit_file_find_fragment(
         _cleanup_set_free_ Set *names = NULL;
         int r;
 
+        assert(ret_fragment_path);
+
         /* Finds a fragment path, and returns the set of names:
          * if we have …/foo.service and …/foo-alias.service→foo.service,
          * and …/foo@.service and …/foo-alias@.service→foo@.service,

--- a/src/shared/volatile-util.c
+++ b/src/shared/volatile-util.c
@@ -9,6 +9,8 @@ int query_volatile_mode(VolatileMode *ret) {
         _cleanup_free_ char *mode = NULL;
         int r;
 
+        assert(ret);
+
         r = proc_cmdline_get_key("systemd.volatile", PROC_CMDLINE_VALUE_OPTIONAL, &mode);
         if (r < 0)
                 return r;

--- a/src/shared/watchdog.c
+++ b/src/shared/watchdog.c
@@ -75,6 +75,8 @@ static int watchdog_get_pretimeout_governor(char **ret_gov) {
         _cleanup_free_ char *sys_fn = NULL;
         int r;
 
+        assert(ret_gov);
+
         r = watchdog_get_sysfs_path("pretimeout_governor", &sys_fn);
         if (r < 0)
                 return r;

--- a/src/systemctl/systemctl-log-setting.c
+++ b/src/systemctl/systemctl-log-setting.c
@@ -44,6 +44,8 @@ static int service_name_to_dbus(sd_bus *bus, const char *name, char **ret_dbus_n
         _cleanup_free_ char *bus_name = NULL;
         int r;
 
+        assert(ret_dbus_name);
+
         /* First, look for the BusName= property */
         _cleanup_free_ char *dbus_path = unit_dbus_path_from_name(name);
         if (!dbus_path)

--- a/src/sysupdate/sysupdate-partition.c
+++ b/src/sysupdate/sysupdate-partition.c
@@ -158,6 +158,7 @@ int find_suitable_partition(
         int r;
 
         assert(device);
+        POINTER_MAY_BE_NULL(partition_type);
         assert(ret);
 
         r = fdisk_new_context_at(AT_FDCWD, device, /* read_only= */ true, /* sector_size= */ UINT32_MAX, &c);

--- a/src/sysupdate/sysupdate-resource.c
+++ b/src/sysupdate/sysupdate-resource.c
@@ -477,6 +477,7 @@ static int resource_load_from_web(
         int r;
 
         assert(rr);
+        POINTER_MAY_BE_NULL(web_cache);
 
         ci = web_cache ? web_cache_get_item(*web_cache, rr->path, verify) : NULL;
         if (ci) {

--- a/src/sysupdate/sysupdate-transfer.c
+++ b/src/sysupdate/sysupdate-transfer.c
@@ -1009,6 +1009,7 @@ static int callout_context_new(const Transfer *t, const Instance *i, TransferPro
         assert(t);
         assert(i);
         assert(cb);
+        assert(ret);
 
         ctx = new(CalloutContext, 1);
         if (!ctx)

--- a/src/sysusers/sysusers.c
+++ b/src/sysusers/sysusers.c
@@ -480,6 +480,8 @@ static int write_temporary_passwd(
         int r;
 
         assert(c);
+        assert(ret_tmpfile);
+        assert(ret_tmpfile_path);
 
         if (ordered_hashmap_isempty(c->todo_uids))
                 goto done;
@@ -611,6 +613,8 @@ static int write_temporary_shadow(
         int r;
 
         assert(c);
+        assert(ret_tmpfile);
+        assert(ret_tmpfile_path);
 
         if (ordered_hashmap_isempty(c->todo_uids))
                 goto done;
@@ -746,6 +750,8 @@ static int write_temporary_group(
         int r;
 
         assert(c);
+        assert(ret_tmpfile);
+        assert(ret_tmpfile_path);
 
         if (ordered_hashmap_isempty(c->todo_gids) && ordered_hashmap_isempty(c->members))
                 goto done;
@@ -863,6 +869,8 @@ static int write_temporary_gshadow(
         int r;
 
         assert(c);
+        assert(ret_tmpfile);
+        assert(ret_tmpfile_path);
 
         if (ordered_hashmap_isempty(c->todo_gids) && ordered_hashmap_isempty(c->members))
                 goto done;

--- a/src/tmpfiles/offline-passwd.c
+++ b/src/tmpfiles/offline-passwd.c
@@ -44,6 +44,8 @@ static int populate_uid_cache(const char *root, Hashmap **ret) {
         _cleanup_hashmap_free_ Hashmap *cache = NULL;
         int r;
 
+        assert(ret);
+
         cache = hashmap_new(&uid_gid_hash_ops);
         if (!cache)
                 return -ENOMEM;
@@ -84,6 +86,8 @@ static int populate_uid_cache(const char *root, Hashmap **ret) {
 static int populate_gid_cache(const char *root, Hashmap **ret) {
         _cleanup_hashmap_free_ Hashmap *cache = NULL;
         int r;
+
+        assert(ret);
 
         cache = hashmap_new(&uid_gid_hash_ops);
         if (!cache)

--- a/src/tmpfiles/tmpfiles.c
+++ b/src/tmpfiles/tmpfiles.c
@@ -289,6 +289,7 @@ static int specifier_directory(
         unsigned i;
         int r;
 
+        assert(ret);
         assert_cc(ELEMENTSOF(paths_system) == ELEMENTSOF(paths_user));
         paths = arg_runtime_scope == RUNTIME_SCOPE_USER ? paths_user : paths_system;
 

--- a/src/tpm2-setup/tpm2-swtpm.c
+++ b/src/tpm2-setup/tpm2-swtpm.c
@@ -32,6 +32,8 @@ static int load_boot_secret(struct iovec *ret) {
         _cleanup_(iovec_done_erase) struct iovec buf = {};
         int r;
 
+        assert(ret);
+
         const char *bs = in_initrd() ? "/.extra/boot-secret" : "/run/systemd/stub/boot-secret";
         r = read_full_file_full(
                         AT_FDCWD,

--- a/src/udev/udevadm-monitor.c
+++ b/src/udev/udevadm-monitor.c
@@ -65,6 +65,8 @@ static int setup_monitor(MonitorNetlinkGroup sender, sd_event *event, sd_device_
         const char *subsystem, *devtype, *tag;
         int r;
 
+        assert(ret);
+
         r = device_monitor_new_full(&monitor, sender, -EBADF);
         if (r < 0)
                 return log_error_errno(r, "Failed to create netlink socket: %m");

--- a/src/userdb/userdbd-manager.c
+++ b/src/userdb/userdbd-manager.c
@@ -79,6 +79,8 @@ int manager_new(Manager **ret) {
         _cleanup_(manager_freep) Manager *m = NULL;
         int r;
 
+        assert(ret);
+
         m = new(Manager, 1);
         if (!m)
                 return -ENOMEM;

--- a/src/xdg-autostart-generator/xdg-autostart-service.c
+++ b/src/xdg-autostart-generator/xdg-autostart-service.c
@@ -190,6 +190,9 @@ static int strv_strndup_unescape_and_push(
                 const char *start,
                 const char *end) {
 
+        assert(sv);
+        assert(n);
+
         if (end == start)
                 return 0;
 

--- a/tools/check-coccinelle.sh
+++ b/tools/check-coccinelle.sh
@@ -10,7 +10,7 @@ FOUND=0
 
 for cocci in "$COCCI_DIR"/check-*.cocci; do
     [[ -f "$cocci" ]] || continue
-    output=$(spatch --very-quiet --sp-file "$cocci" --dir "$SRC_DIR" 2>&1)
+    output=$(spatch --very-quiet --macro-file-builtins "$COCCI_DIR/parsing_hacks.h" --sp-file "$cocci" --dir "$SRC_DIR" 2>&1)
     if [[ -n "$output" ]]; then
         echo "FAIL: $(basename "$cocci") found issues in $SRC_DIR:"
         echo "$output"


### PR DESCRIPTION
I promised in https://github.com/systemd/systemd/pull/41426 that its the final update for coccinelle pointer deref checks. However it turned out there is this coccinelle/parsing_hacks.h that I wasn't aware of. The file missed some important things like _cleanup_(x) that prevented coccinelle to check a bunch of functions. 

This PR adds some missing defines to the parsing_hacks.h and fixes the missing asserts(). I apologize that its a bit long (and frankly boring) and that I missed this earlier.

The last commit contains one small behavior change (ret in sd_varlink_idl_parse() is now really optional) but the big one is very mechanical.