### PR TITLE
More assorted coverity fixes

### DIFF
--- a/src/basic/uid-range.c
+++ b/src/basic/uid-range.c
@@ -75,6 +75,8 @@ static void uid_range_coalesce(UIDRange *range) {
                         if (range->n_entries > j + 1)
                                 memmove(y, y + 1, sizeof(UIDRangeEntry) * (range->n_entries - j - 1));
 
+                        /* Silence static analyzers, n_entries > 0 since j < n_entries holds in the loop condition */
+                        assert(range->n_entries > 0);
                         range->n_entries--;
 
                         /* Silence static analyzers, j cannot be 0 here since it starts at i + 1, i.e. >= 1 */

--- a/src/debug-generator/debug-generator.c
+++ b/src/debug-generator/debug-generator.c
@@ -101,6 +101,7 @@ static int parse_breakpoint_from_string(const char *s, uint32_t *ret_breakpoints
 
                 FOREACH_ELEMENT(i, breakpoint_info_table)
                         if (FLAGS_SET(i->validity, BREAKPOINT_DEFAULT) && breakpoint_applies(i, INT_MAX)) {
+                                assert(i->type >= 0 && i->type < _BREAKPOINT_TYPE_MAX); /* silence coverity */
                                 breakpoints |= UINT32_C(1) << i->type;
                                 found_default = true;
                                 break;

--- a/src/nss-myhostname/nss-myhostname.c
+++ b/src/nss-myhostname/nss-myhostname.c
@@ -230,7 +230,7 @@ static enum nss_status fill_in_hostent(
         if (additional) {
                 r_alias = buffer + idx;
                 memcpy(r_alias, additional, l_additional+1);
-                idx += ALIGN(l_additional+1);
+                assert_se(INC_SAFE(&idx, ALIGN(l_additional+1)));
         }
 
         /* Second, create aliases array */
@@ -258,14 +258,14 @@ static enum nss_status fill_in_hostent(
                 }
 
                 assert(i == c);
-                idx += c*ALIGN(alen);
+                assert_se(INC_SAFE(&idx, c*ALIGN(alen)));
 
         } else if (af == AF_INET) {
                 *(uint32_t*) r_addr = local_address_ipv4;
-                idx += ALIGN(alen);
+                assert_se(INC_SAFE(&idx, ALIGN(alen)));
         } else if (socket_ipv6_is_enabled()) {
                 memcpy(r_addr, LOCALADDRESS_IPV6, FAMILY_ADDRESS_SIZE(AF_INET6));
-                idx += ALIGN(alen);
+                assert_se(INC_SAFE(&idx, ALIGN(alen)));
         }
 
         /* Fourth, add address pointer array */
@@ -277,15 +277,15 @@ static enum nss_status fill_in_hostent(
                         ((char**) r_addr_list)[i] = r_addr + i*ALIGN(alen);
 
                 ((char**) r_addr_list)[i] = NULL;
-                idx += (c+1) * sizeof(char*);
+                assert_se(INC_SAFE(&idx, (c+1) * sizeof(char*)));
 
         } else if (af == AF_INET || socket_ipv6_is_enabled()) {
                 ((char**) r_addr_list)[0] = r_addr;
                 ((char**) r_addr_list)[1] = NULL;
-                idx += 2 * sizeof(char*);
+                assert_se(INC_SAFE(&idx, 2 * sizeof(char*)));
         } else {
                 ((char**) r_addr_list)[0] = NULL;
-                idx += sizeof(char*);
+                assert_se(INC_SAFE(&idx, sizeof(char*)));
         }
 
         /* Verify the size matches */

--- a/src/test/test-json.c
+++ b/src/test/test-json.c
@@ -690,7 +690,9 @@ static void test_float_match(sd_json_variant *v) {
 
         assert_se(sd_json_variant_is_array(v));
         assert_se(sd_json_variant_elements(v) == 11);
+        assert_se(!iszero_safe(sd_json_variant_real(sd_json_variant_by_index(v, 0))));
         assert_se(fabs(1.0 - (DBL_MIN / sd_json_variant_real(sd_json_variant_by_index(v, 0)))) <= delta);
+        assert_se(!iszero_safe(sd_json_variant_real(sd_json_variant_by_index(v, 1))));
         assert_se(fabs(1.0 - (DBL_MAX / sd_json_variant_real(sd_json_variant_by_index(v, 1)))) <= delta);
         assert_se(sd_json_variant_is_null(sd_json_variant_by_index(v, 2))); /* nan is not supported by json → null */
         assert_se(sd_json_variant_is_null(sd_json_variant_by_index(v, 3))); /* +inf is not supported by json → null */


### PR DESCRIPTION
One more round, this time with the help of the claudebot, especially for spelunking in git blame to find the original commit and writing commit messages from the list of warnings exported from coverity

Co-developed-by: Claude [claude@anthropic.com](mailto:claude@anthropic.com)