### PR TITLE
boot: add bootloader config for colors

### DIFF
--- a/src/boot/boot.c
+++ b/src/boot/boot.c
@@ -18,6 +18,7 @@
 #include "measure.h"
 #include "memory-util-fundamental.h"
 #include "part-discovery.h"
+#include "palette.h"
 #include "pe.h"
 #include "proto/block-io.h"
 #include "proto/disk-io.h"
@@ -104,6 +105,9 @@ static const char *reboot_on_error_table[_REBOOT_ON_ERROR_MAX] = {
 
 DEFINE_PRIVATE_STRING_TABLE_LOOKUP_TO_STRING(reboot_on_error, RebootOnError);
 
+#define CONFIG_PALETTE(config, type) ((config)->efi_palettes[(EFI_PALETTE_##type)])
+#define CONFIG_COLOR(config, type, color) (CONFIG_PALETTE(config, type)[(EFI_PALETTE_COLORS_##color)])
+
 typedef struct BootEntry {
         char16_t *id;         /* The unique identifier for this entry (typically the filename of the file defining the entry, possibly suffixed with a profile id) */
         char16_t *id_without_profile; /* same, but without any profile id suffixed */
@@ -165,6 +169,7 @@ typedef struct {
         bool sysfail_occurred;
         int64_t console_mode;
         int64_t console_mode_efivar;
+        EfiPalettes efi_palettes;
 } Config;
 
 /* These values have been chosen so that the transitions the user sees could employ unsigned over-/underflow
@@ -304,7 +309,7 @@ static void print_status(Config *config, char16_t *loaded_image_path) {
 
         assert(config);
 
-        clear_screen(COLOR_NORMAL);
+        clear_screen(CONFIG_COLOR(config, NORMAL, TEXT));
         console_query_mode(&x_max, &y_max);
         query_screen_resolution(&screen_width, &screen_height);
 
@@ -386,6 +391,21 @@ static void print_status(Config *config, char16_t *loaded_image_path) {
                 printf("        console-mode (EFI var): %" PRIi64 "\n", config->console_mode_efivar);
 
         printf("                     log-level: %s\n", log_level_to_string(log_get_max_level()));
+
+        for (size_t i = 0; i < _EFI_PALETTE_TYPE_MAX; i++) {
+                const char *name = efi_color_to_string(i);
+                for (size_t j = strlen8(name); j < 18; j++)
+                        printf(" ");
+                printf("efi-palette-%s: ", name);
+                for (size_t j = 0; j < _EFI_PALETTE_COLORS_MAX; j++) {
+                        if (j > 0)
+                                printf(", ");
+                        size_t color = config->efi_palettes[i][j];
+                        printf("%s, %s", efi_color_to_string(EFI_TEXT_ATTR_FG(color)),
+                               efi_color_to_string(EFI_TEXT_ATTR_BG(color)));
+                }
+                printf("\n");
+        }
 
         if (!ps_continue())
                 return;
@@ -524,7 +544,7 @@ static bool menu_run(
         err = console_set_mode(config->console_mode_efivar != CONSOLE_MODE_KEEP ?
                                config->console_mode_efivar : config->console_mode);
         if (err != EFI_SUCCESS) {
-                clear_screen(COLOR_NORMAL);
+                clear_screen(CONFIG_COLOR(config, NORMAL, TEXT));
                 log_error_status(err, "Error switching console mode: %m");
         }
 
@@ -610,7 +630,7 @@ static bool menu_run(
                 }
 
                 if (clear) {
-                        clear_screen(COLOR_NORMAL);
+                        clear_screen(CONFIG_COLOR(config, NORMAL, TEXT));
                         clear = false;
                         refresh = true;
                 }
@@ -618,27 +638,27 @@ static bool menu_run(
                 if (refresh) {
                         for (size_t i = idx_first; i <= idx_last && i < config->n_entries; i++) {
                                 print_at(x_start, y_start + i - idx_first,
-                                         i == idx_highlight ? COLOR_HIGHLIGHT : COLOR_ENTRY,
+                                         i == idx_highlight ? CONFIG_COLOR(config, ENTRY, CURSOR) : CONFIG_COLOR(config, ENTRY, TEXT),
                                          lines[i]);
                                 if (i == config->idx_default_efivar)
                                         print_at(x_start,
                                                  y_start + i - idx_first,
-                                                 i == idx_highlight ? COLOR_HIGHLIGHT : COLOR_ENTRY,
+                                                 i == idx_highlight ? CONFIG_COLOR(config, ENTRY, CURSOR) : CONFIG_COLOR(config, ENTRY, TEXT),
                                                  unicode_supported() ? u" ►" : u"=>");
                         }
                         refresh = false;
                 } else if (highlight) {
-                        print_at(x_start, y_start + idx_highlight_prev - idx_first, COLOR_ENTRY, lines[idx_highlight_prev]);
-                        print_at(x_start, y_start + idx_highlight - idx_first, COLOR_HIGHLIGHT, lines[idx_highlight]);
+                        print_at(x_start, y_start + idx_highlight_prev - idx_first, CONFIG_COLOR(config, ENTRY, TEXT), lines[idx_highlight_prev]);
+                        print_at(x_start, y_start + idx_highlight - idx_first, CONFIG_COLOR(config, ENTRY, CURSOR), lines[idx_highlight]);
                         if (idx_highlight_prev == config->idx_default_efivar)
                                 print_at(x_start,
                                          y_start + idx_highlight_prev - idx_first,
-                                         COLOR_ENTRY,
+                                         CONFIG_COLOR(config, ENTRY, TEXT),
                                          unicode_supported() ? u" ►" : u"=>");
                         if (idx_highlight == config->idx_default_efivar)
                                 print_at(x_start,
                                          y_start + idx_highlight - idx_first,
-                                         COLOR_HIGHLIGHT,
+                                         CONFIG_COLOR(config, ENTRY, CURSOR),
                                          unicode_supported() ? u" ►" : u"=>");
                         highlight = false;
                 }
@@ -656,16 +676,16 @@ static bool menu_run(
                         size_t len = strnlen16(status, x_max - 1);
                         size_t x = (x_max - len) / 2;
                         status[len] = '\0';
-                        print_at(0, y_status, COLOR_NORMAL, clearline + x_max - x);
+                        print_at(0, y_status, CONFIG_COLOR(config, NORMAL, TEXT), clearline + x_max - x);
                         ST->ConOut->OutputString(ST->ConOut, status);
                         ST->ConOut->OutputString(ST->ConOut, clearline + 1 + x + len);
 
                         len = MIN(MAX(len, line_width) + 2 * entry_padding, x_max);
                         x = (x_max - len) / 2;
-                        print_at(x, y_status - 1, COLOR_NORMAL, separator + x_max - len);
+                        print_at(x, y_status - 1, CONFIG_COLOR(config, NORMAL, TEXT), separator + x_max - len);
                 } else {
-                        print_at(0, y_status - 1, COLOR_NORMAL, clearline);
-                        print_at(0, y_status, COLOR_NORMAL, clearline + 1); /* See comment above. */
+                        print_at(0, y_status - 1, CONFIG_COLOR(config, NORMAL, TEXT), clearline);
+                        print_at(0, y_status, CONFIG_COLOR(config, NORMAL, TEXT), clearline + 1); /* See comment above. */
                 }
 
                 /* Beep several times so that the selected entry can be distinguished. */
@@ -849,10 +869,10 @@ static bool menu_run(
                          * causing a scroll to happen that screws with our beautiful boot loader output.
                          * Since we cannot paint the last character of the edit line, we simply start
                          * at x-offset 1 for symmetry. */
-                        print_at(1, y_status, COLOR_EDIT, clearline + 2);
-                        if (line_edit(&config->entries[idx_highlight]->options, x_max - 2, y_status))
+                        print_at(1, y_status, CONFIG_COLOR(config, EDIT, TEXT), clearline + 2);
+                        if (line_edit(&config->entries[idx_highlight]->options, x_max - 2, y_status, &CONFIG_PALETTE(config, EDIT)))
                                 action = ACTION_RUN;
-                        print_at(1, y_status, COLOR_NORMAL, clearline + 2);
+                        print_at(1, y_status, CONFIG_COLOR(config, NORMAL, TEXT), clearline + 2);
 
                         /* The options string was now edited, hence we have to pass it to the invoked
                          * binary. */
@@ -1012,7 +1032,7 @@ static bool menu_run(
         }
 
         *chosen_entry = config->entries[idx_highlight];
-        clear_screen(COLOR_NORMAL);
+        clear_screen(CONFIG_COLOR(config, NORMAL, TEXT));
         return action == ACTION_RUN;
 }
 
@@ -1220,6 +1240,14 @@ static void config_defaults_load_from_file(Config *config, char *content) {
                 } else if (streq8(key, "log-level")) {
                         if (log_set_max_level_from_string(value) < 0)
                                 log_warning("Error parsing 'log-level' config option, ignoring: %s", value);
+                } else {
+                        const char *palete_string = startswith8(key, "efi-palette-");
+                        if (!palete_string)
+                                continue;
+                        EfiPaletteType palette_type = efi_palette_type_from_string(palete_string);
+                        if (palette_type < 0)
+                                continue;
+                        parse_palette(palette_type, value, &config->efi_palettes[palette_type]);
                 }
 }
 
@@ -1585,6 +1613,8 @@ static void config_load_defaults(Config *config, EFI_FILE *root_dir) {
                 .timeout_sec_efivar = TIMEOUT_UNSET,
                 .timeout_sec_smbios = TIMEOUT_UNSET,
         };
+
+        init_palettes(&config->efi_palettes);
 
         err = file_read(root_dir, u"\\loader\\loader.conf", 0, 0, &content, &content_size);
         if (err == EFI_SUCCESS) {

--- a/src/boot/boot.c
+++ b/src/boot/boot.c
@@ -19,6 +19,7 @@
 #include "measure.h"
 #include "memory-util-fundamental.h"
 #include "part-discovery.h"
+#include "palette.h"
 #include "pe.h"
 #include "proto/block-io.h"
 #include "proto/disk-io.h"
@@ -108,6 +109,9 @@ static const char *reboot_on_error_table[_REBOOT_ON_ERROR_MAX] = {
 
 DEFINE_PRIVATE_STRING_TABLE_LOOKUP_TO_STRING(reboot_on_error, RebootOnError);
 
+#define CONFIG_PALETTE(config, type) EFI_PALETTE((config)->efi_palettes, type)
+#define CONFIG_COLOR(config, type, color) EFI_PALETTE_COLOR((config)->efi_palettes, type, color)
+
 typedef struct BootEntry {
         char16_t *id;         /* The unique identifier for this entry (typically the filename of the file defining the entry, possibly suffixed with a profile id) */
         char16_t *id_without_profile; /* same, but without any profile id suffixed */
@@ -170,6 +174,7 @@ typedef struct {
         bool sysfail_occurred;
         int64_t console_mode;
         int64_t console_mode_efivar;
+        EfiPalettes efi_palettes;
 } Config;
 
 /* These values have been chosen so that the transitions the user sees could employ unsigned over-/underflow
@@ -309,7 +314,7 @@ static void print_status(Config *config, char16_t *loaded_image_path) {
 
         assert(config);
 
-        clear_screen(COLOR_NORMAL);
+        clear_screen(CONFIG_COLOR(config, NORMAL, TEXT));
         console_query_mode(&x_max, &y_max);
         query_screen_resolution(&screen_width, &screen_height);
 
@@ -391,6 +396,21 @@ static void print_status(Config *config, char16_t *loaded_image_path) {
                 printf("        console-mode (EFI var): %" PRIi64 "\n", config->console_mode_efivar);
 
         printf("                     log-level: %s\n", log_level_to_string(log_get_max_level()));
+
+        for (size_t i = 0; i < _EFI_PALETTE_TYPE_MAX; i++) {
+                const char *name = efi_color_to_string(i);
+                for (size_t j = strlen8(name); j < 18; j++)
+                        printf(" ");
+                printf("efi-palette-%s: ", name);
+                for (size_t j = 0; j < _EFI_PALETTE_COLORS_MAX; j++) {
+                        if (j > 0)
+                                printf(", ");
+                        size_t color = config->efi_palettes[i][j];
+                        printf("%s, %s", efi_palette_type_to_string(EFI_TEXT_ATTR_FG(color)),
+                               efi_color_to_string(EFI_TEXT_ATTR_BG(color)));
+                }
+                printf("\n");
+        }
 
         if (!ps_continue())
                 return;
@@ -531,7 +551,7 @@ static bool menu_run(
         err = console_set_mode(config->console_mode_efivar != CONSOLE_MODE_KEEP ?
                                config->console_mode_efivar : config->console_mode);
         if (err != EFI_SUCCESS) {
-                clear_screen(COLOR_NORMAL);
+                clear_screen(CONFIG_COLOR(config, NORMAL, TEXT));
                 log_error_status(err, "Error switching console mode: %m");
         }
 
@@ -617,7 +637,7 @@ static bool menu_run(
                 }
 
                 if (clear) {
-                        clear_screen(COLOR_NORMAL);
+                        clear_screen(CONFIG_COLOR(config, NORMAL, TEXT));
                         clear = false;
                         refresh = true;
                 }
@@ -625,27 +645,27 @@ static bool menu_run(
                 if (refresh) {
                         for (size_t i = idx_first; i <= idx_last && i < config->n_entries; i++) {
                                 print_at(x_start, y_start + i - idx_first,
-                                         i == idx_highlight ? COLOR_HIGHLIGHT : COLOR_ENTRY,
+                                         i == idx_highlight ? CONFIG_COLOR(config, ENTRY, CURSOR) : CONFIG_COLOR(config, ENTRY, TEXT),
                                          lines[i]);
                                 if (i == config->idx_default_efivar)
                                         print_at(x_start,
                                                  y_start + i - idx_first,
-                                                 i == idx_highlight ? COLOR_HIGHLIGHT : COLOR_ENTRY,
+                                                 i == idx_highlight ? CONFIG_COLOR(config, ENTRY, CURSOR) : CONFIG_COLOR(config, ENTRY, TEXT),
                                                  unicode_supported() ? u" ►" : u"=>");
                         }
                         refresh = false;
                 } else if (highlight) {
-                        print_at(x_start, y_start + idx_highlight_prev - idx_first, COLOR_ENTRY, lines[idx_highlight_prev]);
-                        print_at(x_start, y_start + idx_highlight - idx_first, COLOR_HIGHLIGHT, lines[idx_highlight]);
+                        print_at(x_start, y_start + idx_highlight_prev - idx_first, CONFIG_COLOR(config, ENTRY, TEXT), lines[idx_highlight_prev]);
+                        print_at(x_start, y_start + idx_highlight - idx_first, CONFIG_COLOR(config, ENTRY, CURSOR), lines[idx_highlight]);
                         if (idx_highlight_prev == config->idx_default_efivar)
                                 print_at(x_start,
                                          y_start + idx_highlight_prev - idx_first,
-                                         COLOR_ENTRY,
+                                         CONFIG_COLOR(config, ENTRY, TEXT),
                                          unicode_supported() ? u" ►" : u"=>");
                         if (idx_highlight == config->idx_default_efivar)
                                 print_at(x_start,
                                          y_start + idx_highlight - idx_first,
-                                         COLOR_HIGHLIGHT,
+                                         CONFIG_COLOR(config, ENTRY, CURSOR),
                                          unicode_supported() ? u" ►" : u"=>");
                         highlight = false;
                 }
@@ -663,16 +683,16 @@ static bool menu_run(
                         size_t len = strnlen16(status, x_max - 1);
                         size_t x = (x_max - len) / 2;
                         status[len] = '\0';
-                        print_at(0, y_status, COLOR_NORMAL, clearline + x_max - x);
+                        print_at(0, y_status, CONFIG_COLOR(config, NORMAL, TEXT), clearline + x_max - x);
                         ST->ConOut->OutputString(ST->ConOut, status);
                         ST->ConOut->OutputString(ST->ConOut, clearline + 1 + x + len);
 
                         len = MIN(MAX(len, line_width) + 2 * entry_padding, x_max);
                         x = (x_max - len) / 2;
-                        print_at(x, y_status - 1, COLOR_NORMAL, separator + x_max - len);
+                        print_at(x, y_status - 1, CONFIG_COLOR(config, NORMAL, TEXT), separator + x_max - len);
                 } else {
-                        print_at(0, y_status - 1, COLOR_NORMAL, clearline);
-                        print_at(0, y_status, COLOR_NORMAL, clearline + 1); /* See comment above. */
+                        print_at(0, y_status - 1, CONFIG_COLOR(config, NORMAL, TEXT), clearline);
+                        print_at(0, y_status, CONFIG_COLOR(config, NORMAL, TEXT), clearline + 1); /* See comment above. */
                 }
 
                 /* Beep several times so that the selected entry can be distinguished. */
@@ -856,10 +876,10 @@ static bool menu_run(
                          * causing a scroll to happen that screws with our beautiful boot loader output.
                          * Since we cannot paint the last character of the edit line, we simply start
                          * at x-offset 1 for symmetry. */
-                        print_at(1, y_status, COLOR_EDIT, clearline + 2);
-                        if (line_edit(&config->entries[idx_highlight]->options, x_max - 2, y_status))
+                        print_at(1, y_status, CONFIG_COLOR(config, EDIT, TEXT), clearline + 2);
+                        if (line_edit(&config->entries[idx_highlight]->options, x_max - 2, y_status, CONFIG_PALETTE(config, EDIT)))
                                 action = ACTION_RUN;
-                        print_at(1, y_status, COLOR_NORMAL, clearline + 2);
+                        print_at(1, y_status, CONFIG_COLOR(config, NORMAL, TEXT), clearline + 2);
 
                         /* The options string was now edited, hence we have to pass it to the invoked
                          * binary. */
@@ -1019,7 +1039,7 @@ static bool menu_run(
         }
 
         *chosen_entry = config->entries[idx_highlight];
-        clear_screen(COLOR_NORMAL);
+        clear_screen(CONFIG_COLOR(config, NORMAL, TEXT));
         return action == ACTION_RUN;
 }
 
@@ -1099,6 +1119,38 @@ static void config_timeout_load_from_smbios(Config *config) {
                 return;
         }
         config->timeout_sec = config->timeout_sec_smbios;
+}
+
+static void config_palette_from_string(EfiPaletteType palette_type, char *value, EfiPalette dest) {
+        const char *fg_string, *bg_string;
+        EfiPaletteColors i;
+        size_t pos = 0;
+
+        assert(palette_type >= 0 && palette_type < _EFI_PALETTE_TYPE_MAX);
+        assert(value);
+        assert(dest);
+
+        for (i = 0; i < _EFI_PALETTE_COLORS_MAX; i++) {
+                fg_string = parse_array(value, ",", &pos);
+                bg_string = parse_array(value, ",", &pos);
+                if (bg_string == NULL) {
+                        if (fg_string != NULL)
+                                log_warning("Error parsing 'efi-palette-%s' config option, ignoring entry %zu: %s",
+                                          efi_palette_type_to_string(palette_type), (size_t) 2*i+1, bg_string);
+                        return;
+                }
+                if (*fg_string == '\0' && *bg_string == '\0') {
+                        /* skip empty values, instead of printing a warning */
+                        continue;
+                }
+                dest[i] = parse_palette_color(fg_string, bg_string);
+                if (dest[i] < 0)
+                        log_warning("Error parsing 'efi-palette-%s' config option, ignoring entries %zu..%zu: %s, %s",
+                                  efi_palette_type_to_string(palette_type), (size_t) 2*i+1, (size_t) 2*i+2, fg_string, bg_string);
+        }
+        if (value[pos] != '\0')
+                log_warning("Error parsing 'efi-palette-%s' config option, ignoring entries %zu..: %s",
+                          efi_palette_type_to_string(palette_type), (size_t) 2*i, &value[pos]);
 }
 
 static void config_defaults_load_from_file(Config *config, char *content) {
@@ -1228,6 +1280,19 @@ static void config_defaults_load_from_file(Config *config, char *content) {
                 } else if (streq8(key, "log-level")) {
                         if (log_set_max_level_from_string(value) < 0)
                                 log_warning("Error parsing 'log-level' config option, ignoring: %s", value);
+                } else {
+                        EfiPaletteType palette_type;
+                        EfiPalette palette;
+                        const char *palete_string;
+                        palete_string = startswith8(key, "efi-palette-");
+                        if (!palete_string)
+                                continue;
+                        palette_type = efi_palette_type_from_string(palete_string);
+                        if (palette_type < 0)
+                                continue;
+                        empty_palette(palette);
+                        config_palette_from_string(palette_type, value, palette);
+                        set_palette(palette_type, config->efi_palettes[palette_type], palette);
                 }
 }
 
@@ -1601,6 +1666,8 @@ static void config_load_defaults(Config *config, EFI_FILE *root_dir) {
                 .timeout_sec_efivar = TIMEOUT_UNSET,
                 .timeout_sec_smbios = TIMEOUT_UNSET,
         };
+
+        init_palettes(config->efi_palettes);
 
         err = file_read(root_dir, u"\\loader\\loader.conf", 0, 0, &content, &content_size);
         if (err == EFI_SUCCESS) {

--- a/src/boot/boot.c
+++ b/src/boot/boot.c
@@ -20,6 +20,7 @@
 #include "measure-smbios.h"
 #include "memory-util.h"
 #include "part-discovery.h"
+#include "palette.h"
 #include "pe.h"
 #include "proto/block-io.h"
 #include "proto/disk-io.h"
@@ -109,6 +110,9 @@ static const char *reboot_on_error_table[_REBOOT_ON_ERROR_MAX] = {
 
 DEFINE_PRIVATE_STRING_TABLE_LOOKUP_TO_STRING(reboot_on_error, RebootOnError);
 
+#define CONFIG_PALETTE(config, type) EFI_PALETTE((config)->efi_palettes, type)
+#define CONFIG_COLOR(config, type, color) EFI_PALETTE_COLOR((config)->efi_palettes, type, color)
+
 typedef struct BootEntry {
         char16_t *id;         /* The unique identifier for this entry (typically the filename of the file defining the entry, possibly suffixed with a profile id) */
         char16_t *id_without_profile; /* same, but without any profile id suffixed */
@@ -171,6 +175,7 @@ typedef struct {
         bool sysfail_occurred;
         int64_t console_mode;
         int64_t console_mode_efivar;
+        EfiPalettes efi_palettes;
 } Config;
 
 /* These values have been chosen so that the transitions the user sees could employ unsigned over-/underflow
@@ -310,7 +315,7 @@ static void print_status(Config *config, char16_t *loaded_image_path) {
 
         assert(config);
 
-        clear_screen(COLOR_NORMAL);
+        clear_screen(CONFIG_COLOR(config, NORMAL, TEXT));
         console_query_mode(&x_max, &y_max);
         query_screen_resolution(&screen_width, &screen_height);
 
@@ -392,6 +397,21 @@ static void print_status(Config *config, char16_t *loaded_image_path) {
                 printf("        console-mode (EFI var): %" PRIi64 "\n", config->console_mode_efivar);
 
         printf("                     log-level: %s\n", log_level_to_string(log_get_max_level()));
+
+        for (size_t i = 0; i < _EFI_PALETTE_TYPE_MAX; i++) {
+                const char *name = efi_color_to_string(i);
+                for (size_t j = strlen8(name); j < 18; j++)
+                        printf(" ");
+                printf("efi-palette-%s: ", name);
+                for (size_t j = 0; j < _EFI_PALETTE_COLORS_MAX; j++) {
+                        if (j > 0)
+                                printf(", ");
+                        size_t color = config->efi_palettes[i][j];
+                        printf("%s, %s", efi_palette_type_to_string(EFI_TEXT_ATTR_FG(color)),
+                               efi_color_to_string(EFI_TEXT_ATTR_BG(color)));
+                }
+                printf("\n");
+        }
 
         if (!ps_continue())
                 return;
@@ -532,7 +552,7 @@ static bool menu_run(
         err = console_set_mode(config->console_mode_efivar != CONSOLE_MODE_KEEP ?
                                config->console_mode_efivar : config->console_mode);
         if (err != EFI_SUCCESS) {
-                clear_screen(COLOR_NORMAL);
+                clear_screen(CONFIG_COLOR(config, NORMAL, TEXT));
                 log_error_status(err, "Error switching console mode: %m");
         }
 
@@ -618,7 +638,7 @@ static bool menu_run(
                 }
 
                 if (clear) {
-                        clear_screen(COLOR_NORMAL);
+                        clear_screen(CONFIG_COLOR(config, NORMAL, TEXT));
                         clear = false;
                         refresh = true;
                 }
@@ -626,27 +646,27 @@ static bool menu_run(
                 if (refresh) {
                         for (size_t i = idx_first; i <= idx_last && i < config->n_entries; i++) {
                                 print_at(x_start, y_start + i - idx_first,
-                                         i == idx_highlight ? COLOR_HIGHLIGHT : COLOR_ENTRY,
+                                         i == idx_highlight ? CONFIG_COLOR(config, ENTRY, CURSOR) : CONFIG_COLOR(config, ENTRY, TEXT),
                                          lines[i]);
                                 if (i == config->idx_default_efivar)
                                         print_at(x_start,
                                                  y_start + i - idx_first,
-                                                 i == idx_highlight ? COLOR_HIGHLIGHT : COLOR_ENTRY,
+                                                 i == idx_highlight ? CONFIG_COLOR(config, ENTRY, CURSOR) : CONFIG_COLOR(config, ENTRY, TEXT),
                                                  unicode_supported() ? u" ►" : u"=>");
                         }
                         refresh = false;
                 } else if (highlight) {
-                        print_at(x_start, y_start + idx_highlight_prev - idx_first, COLOR_ENTRY, lines[idx_highlight_prev]);
-                        print_at(x_start, y_start + idx_highlight - idx_first, COLOR_HIGHLIGHT, lines[idx_highlight]);
+                        print_at(x_start, y_start + idx_highlight_prev - idx_first, CONFIG_COLOR(config, ENTRY, TEXT), lines[idx_highlight_prev]);
+                        print_at(x_start, y_start + idx_highlight - idx_first, CONFIG_COLOR(config, ENTRY, CURSOR), lines[idx_highlight]);
                         if (idx_highlight_prev == config->idx_default_efivar)
                                 print_at(x_start,
                                          y_start + idx_highlight_prev - idx_first,
-                                         COLOR_ENTRY,
+                                         CONFIG_COLOR(config, ENTRY, TEXT),
                                          unicode_supported() ? u" ►" : u"=>");
                         if (idx_highlight == config->idx_default_efivar)
                                 print_at(x_start,
                                          y_start + idx_highlight - idx_first,
-                                         COLOR_HIGHLIGHT,
+                                         CONFIG_COLOR(config, ENTRY, CURSOR),
                                          unicode_supported() ? u" ►" : u"=>");
                         highlight = false;
                 }
@@ -664,16 +684,16 @@ static bool menu_run(
                         size_t len = strnlen16(status, x_max - 1);
                         size_t x = (x_max - len) / 2;
                         status[len] = '\0';
-                        print_at(0, y_status, COLOR_NORMAL, clearline + x_max - x);
+                        print_at(0, y_status, CONFIG_COLOR(config, NORMAL, TEXT), clearline + x_max - x);
                         ST->ConOut->OutputString(ST->ConOut, status);
                         ST->ConOut->OutputString(ST->ConOut, clearline + 1 + x + len);
 
                         len = MIN(MAX(len, line_width) + 2 * entry_padding, x_max);
                         x = (x_max - len) / 2;
-                        print_at(x, y_status - 1, COLOR_NORMAL, separator + x_max - len);
+                        print_at(x, y_status - 1, CONFIG_COLOR(config, NORMAL, TEXT), separator + x_max - len);
                 } else {
-                        print_at(0, y_status - 1, COLOR_NORMAL, clearline);
-                        print_at(0, y_status, COLOR_NORMAL, clearline + 1); /* See comment above. */
+                        print_at(0, y_status - 1, CONFIG_COLOR(config, NORMAL, TEXT), clearline);
+                        print_at(0, y_status, CONFIG_COLOR(config, NORMAL, TEXT), clearline + 1); /* See comment above. */
                 }
 
                 /* Beep several times so that the selected entry can be distinguished. */
@@ -857,10 +877,10 @@ static bool menu_run(
                          * causing a scroll to happen that screws with our beautiful boot loader output.
                          * Since we cannot paint the last character of the edit line, we simply start
                          * at x-offset 1 for symmetry. */
-                        print_at(1, y_status, COLOR_EDIT, clearline + 2);
-                        if (line_edit(&config->entries[idx_highlight]->options, x_max - 2, y_status))
+                        print_at(1, y_status, CONFIG_COLOR(config, EDIT, TEXT), clearline + 2);
+                        if (line_edit(&config->entries[idx_highlight]->options, x_max - 2, y_status, CONFIG_PALETTE(config, EDIT)))
                                 action = ACTION_RUN;
-                        print_at(1, y_status, COLOR_NORMAL, clearline + 2);
+                        print_at(1, y_status, CONFIG_COLOR(config, NORMAL, TEXT), clearline + 2);
 
                         /* The options string was now edited, hence we have to pass it to the invoked
                          * binary. */
@@ -1020,7 +1040,7 @@ static bool menu_run(
         }
 
         *chosen_entry = config->entries[idx_highlight];
-        clear_screen(COLOR_NORMAL);
+        clear_screen(CONFIG_COLOR(config, NORMAL, TEXT));
         return action == ACTION_RUN;
 }
 
@@ -1100,6 +1120,38 @@ static void config_timeout_load_from_smbios(Config *config) {
                 return;
         }
         config->timeout_sec = config->timeout_sec_smbios;
+}
+
+static void config_palette_from_string(EfiPaletteType palette_type, char *value, EfiPalette dest) {
+        const char *fg_string, *bg_string;
+        EfiPaletteColors i;
+        size_t pos = 0;
+
+        assert(palette_type >= 0 && palette_type < _EFI_PALETTE_TYPE_MAX);
+        assert(value);
+        assert(dest);
+
+        for (i = 0; i < _EFI_PALETTE_COLORS_MAX; i++) {
+                fg_string = parse_array(value, ",", &pos);
+                bg_string = parse_array(value, ",", &pos);
+                if (bg_string == NULL) {
+                        if (fg_string != NULL)
+                                log_warning("Error parsing 'efi-palette-%s' config option, ignoring entry %zu: %s",
+                                          efi_palette_type_to_string(palette_type), (size_t) 2*i+1, bg_string);
+                        return;
+                }
+                if (*fg_string == '\0' && *bg_string == '\0') {
+                        /* skip empty values, instead of printing a warning */
+                        continue;
+                }
+                dest[i] = parse_palette_color(fg_string, bg_string);
+                if (dest[i] < 0)
+                        log_warning("Error parsing 'efi-palette-%s' config option, ignoring entries %zu..%zu: %s, %s",
+                                  efi_palette_type_to_string(palette_type), (size_t) 2*i+1, (size_t) 2*i+2, fg_string, bg_string);
+        }
+        if (value[pos] != '\0')
+                log_warning("Error parsing 'efi-palette-%s' config option, ignoring entries %zu..: %s",
+                          efi_palette_type_to_string(palette_type), (size_t) 2*i, &value[pos]);
 }
 
 static void config_defaults_load_from_file(Config *config, char *content) {
@@ -1229,6 +1281,19 @@ static void config_defaults_load_from_file(Config *config, char *content) {
                 } else if (streq8(key, "log-level")) {
                         if (log_set_max_level_from_string(value) < 0)
                                 log_warning("Error parsing 'log-level' config option, ignoring: %s", value);
+                } else {
+                        EfiPaletteType palette_type;
+                        EfiPalette palette;
+                        const char *palete_string;
+                        palete_string = startswith8(key, "efi-palette-");
+                        if (!palete_string)
+                                continue;
+                        palette_type = efi_palette_type_from_string(palete_string);
+                        if (palette_type < 0)
+                                continue;
+                        empty_palette(palette);
+                        config_palette_from_string(palette_type, value, palette);
+                        set_palette(palette_type, config->efi_palettes[palette_type], palette);
                 }
 }
 
@@ -1613,6 +1678,8 @@ static void config_load_defaults(Config *config, EFI_FILE *root_dir) {
                 .timeout_sec_efivar = TIMEOUT_UNSET,
                 .timeout_sec_smbios = TIMEOUT_UNSET,
         };
+
+        init_palettes(config->efi_palettes);
 
         err = file_read(root_dir, u"\\loader\\loader.conf", 0, 0, &content, &content_size);
         if (err == EFI_SUCCESS) {

--- a/src/boot/efi-string.c
+++ b/src/boot/efi-string.c
@@ -471,9 +471,6 @@ char* line_get_key_value(char *s, const char *sep, size_t *pos, char **ret_key, 
                 if (linelen == 0)
                         continue;
 
-                /* terminate line */
-                line[linelen] = '\0';
-
                 /* remove leading whitespace */
                 while (linelen > 0 && strchr8(" \t", *line)) {
                         line++;
@@ -485,6 +482,7 @@ char* line_get_key_value(char *s, const char *sep, size_t *pos, char **ret_key, 
                         linelen--;
                 line[linelen] = '\0';
 
+                /* terminate line */
                 if (*line == '#')
                         continue;
 
@@ -509,6 +507,46 @@ char* line_get_key_value(char *s, const char *sep, size_t *pos, char **ret_key, 
                 *ret_value = value;
                 return line;
         }
+}
+
+/* This function parses an array separated by any character in sep.
+ * The values of the array are trimmed of whitespaces.
+ * A trailling separator will be ignored. */
+char* parse_array(char *s, const char *sep, size_t *pos) {
+        char *entry;
+        size_t entrylen;
+
+        assert(s);
+        assert(sep);
+        assert(pos);
+
+        entry = s + *pos;
+
+        if (*entry == '\0')
+                return NULL;
+
+        entrylen = 0;
+        while (entry[entrylen] && !strchr8(sep, entry[entrylen]))
+                entrylen++;
+
+        /* move pos to next array element */
+        *pos += entrylen;
+        if (s[*pos])
+                (*pos)++;
+
+        /* remove leading whitespace */
+        while (entrylen > 0 && strchr8(" \t", *entry)) {
+                entry++;
+                entrylen--;
+        }
+
+        /* remove trailing whitespace */
+        while (entrylen > 0 && strchr8(" \t", entry[entrylen - 1]))
+                entrylen--;
+
+        entry[entrylen] = '\0';
+
+        return entry;
 }
 
 char16_t *hexdump(const void *data, size_t size) {

--- a/src/boot/efi-string.c
+++ b/src/boot/efi-string.c
@@ -471,9 +471,6 @@ char* line_get_key_value(char *s, const char *sep, size_t *pos, char **ret_key, 
                 if (linelen == 0)
                         continue;
 
-                /* terminate line */
-                line[linelen] = '\0';
-
                 /* remove leading whitespace */
                 while (linelen > 0 && strchr8(" \t", *line)) {
                         line++;
@@ -483,6 +480,8 @@ char* line_get_key_value(char *s, const char *sep, size_t *pos, char **ret_key, 
                 /* remove trailing whitespace */
                 while (linelen > 0 && strchr8(" \t", line[linelen - 1]))
                         linelen--;
+
+                /* terminate line */
                 line[linelen] = '\0';
 
                 if (*line == '#')
@@ -508,6 +507,52 @@ char* line_get_key_value(char *s, const char *sep, size_t *pos, char **ret_key, 
                 *ret_key = line;
                 *ret_value = value;
                 return line;
+        }
+}
+
+/* This function parses an array separated by any character in sep.
+ * The values of the array are trimmed of whitespaces.
+ * A trailling separator will be ignored. */
+char* parse_array(char *s, const char *sep, size_t *pos) {
+        char *entry;
+        size_t entrylen;
+
+        assert(s);
+        assert(sep);
+        assert(pos);
+
+        for (;;) {
+                entry = s + *pos;
+
+                if (*entry == '\0')
+                        return NULL;
+
+                entrylen = 0;
+                while (entry[entrylen] && !strchr8(sep, entry[entrylen]))
+                        entrylen++;
+
+                /* move pos to next array element */
+                *pos += entrylen;
+                if (s[*pos])
+                        (*pos)++;
+
+                /* remove leading whitespace */
+                while (entrylen > 0 && strchr8(" \t", *entry)) {
+                        entry++;
+                        entrylen--;
+                }
+
+                /* remove trailing whitespace */
+                while (entrylen > 0 && strchr8(" \t", entry[entrylen - 1]))
+                        entrylen--;
+
+                /* ignore empty value if the separator is a whitespace character */
+                if (entrylen == 0 && strchr8(" \t", *entry))
+                        continue;
+
+                entry[entrylen] = '\0';
+
+                return entry;
         }
 }
 

--- a/src/boot/efi-string.h
+++ b/src/boot/efi-string.h
@@ -119,6 +119,8 @@ bool parse_boolean(const char *v, bool *ret);
 
 char* line_get_key_value(char *s, const char *sep, size_t *pos, char **ret_key, char **ret_value);
 
+char* parse_array(char *s, const char *sep, size_t *pos);
+
 char16_t *hexdump(const void *data, size_t size);
 
 #ifdef __clang__

--- a/src/boot/fuzz-efi-array.c
+++ b/src/boot/fuzz-efi-array.c
@@ -1,0 +1,27 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include "alloc-util.h"
+#include "efi-string.h"
+#include "fuzz.h"
+
+#define SEP_LEN 4
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+        if (outside_size_range(size, SEP_LEN + 1, 64 * 1024))
+                return 0;
+        if (data[SEP_LEN] != '\0')
+                return 0;
+
+        fuzz_setup_logging();
+
+        _cleanup_free_ char *p = memdup_suffix0(data + SEP_LEN + 1, size - SEP_LEN - 1);
+        assert_se(p);
+
+        size_t pos = 0;
+        char *entry;
+        while ((entry = parse_array(p, (const char *) data, &pos)) != NULL) {
+                assert_se(entry);
+        }
+
+        return 0;
+}

--- a/src/boot/line-edit.c
+++ b/src/boot/line-edit.c
@@ -25,9 +25,11 @@ static void cursor_right(size_t *cursor, size_t *first, size_t x_max, size_t len
                 (*first)++;
 }
 
-bool line_edit(char16_t **line_in, size_t x_max, size_t y_pos) {
+bool line_edit(char16_t **line_in, size_t x_max, size_t y_pos, const EfiPalette *palette) {
         _cleanup_free_ char16_t *line = NULL, *print = NULL;
         size_t size, len, first = 0, cursor = 0, clear = 0;
+        size_t color_text = *palette[EFI_PALETTE_COLORS_TEXT];
+        size_t colors[] = { color_text, *palette[EFI_PALETTE_COLORS_CURSOR] };
 
         /* Edit the line and return true if it should be executed, false if not. */
 
@@ -42,7 +44,8 @@ bool line_edit(char16_t **line_in, size_t x_max, size_t y_pos) {
         for (;;) {
                 EFI_STATUS err;
                 uint64_t key;
-                size_t j, cursor_color = EFI_TEXT_ATTR_SWAP(COLOR_EDIT);
+                size_t j;
+                size_t cursor_color = 1;
 
                 j = MIN(len - first, x_max);
                 memcpy(print, line + first, j * sizeof(char16_t));
@@ -53,20 +56,20 @@ bool line_edit(char16_t **line_in, size_t x_max, size_t y_pos) {
                 print[j] = '\0';
 
                 /* See comment at edit_line() call site for why we start at 1. */
-                print_at(1, y_pos, COLOR_EDIT, print);
+                print_at(1, y_pos, color_text, print);
 
                 if (!print[cursor])
                         print[cursor] = ' ';
                 print[cursor+1] = '\0';
                 do {
-                        print_at(cursor + 1, y_pos, cursor_color, print + cursor);
-                        cursor_color = EFI_TEXT_ATTR_SWAP(cursor_color);
+                        print_at(cursor + 1, y_pos, colors[cursor_color], print + cursor);
+                        cursor_color ^= 1;
 
                         err = console_key_read(&key, 750 * 1000);
                         if (!IN_SET(err, EFI_SUCCESS, EFI_TIMEOUT, EFI_NOT_READY))
                                 return false;
 
-                        print_at(cursor + 1, y_pos, COLOR_EDIT, print + cursor);
+                        print_at(cursor + 1, y_pos, color_text, print + cursor);
                 } while (err != EFI_SUCCESS);
 
                 switch (key) {

--- a/src/boot/line-edit.c
+++ b/src/boot/line-edit.c
@@ -25,9 +25,12 @@ static void cursor_right(size_t *cursor, size_t *first, size_t x_max, size_t len
                 (*first)++;
 }
 
-bool line_edit(char16_t **line_in, size_t x_max, size_t y_pos) {
+bool line_edit(char16_t **line_in, size_t x_max, size_t y_pos, const EfiPalette palette) {
         _cleanup_free_ char16_t *line = NULL, *print = NULL;
         size_t size, len, first = 0, cursor = 0, clear = 0;
+        size_t color_text = palette[EFI_PALETTE_COLORS_TEXT];
+        size_t color_cursor = palette[EFI_PALETTE_COLORS_CURSOR];
+        size_t colors[] = { color_text, color_cursor };
 
         /* Edit the line and return true if it should be executed, false if not. */
 
@@ -42,7 +45,7 @@ bool line_edit(char16_t **line_in, size_t x_max, size_t y_pos) {
         for (;;) {
                 EFI_STATUS err;
                 uint64_t key;
-                size_t j, cursor_color = EFI_TEXT_ATTR_SWAP(COLOR_EDIT);
+                size_t j, cursor_color = 1;
 
                 j = MIN(len - first, x_max);
                 memcpy(print, line + first, j * sizeof(char16_t));
@@ -53,20 +56,20 @@ bool line_edit(char16_t **line_in, size_t x_max, size_t y_pos) {
                 print[j] = '\0';
 
                 /* See comment at edit_line() call site for why we start at 1. */
-                print_at(1, y_pos, COLOR_EDIT, print);
+                print_at(1, y_pos, color_text, print);
 
                 if (!print[cursor])
                         print[cursor] = ' ';
                 print[cursor+1] = '\0';
                 do {
-                        print_at(cursor + 1, y_pos, cursor_color, print + cursor);
-                        cursor_color = EFI_TEXT_ATTR_SWAP(cursor_color);
+                        print_at(cursor + 1, y_pos, colors[cursor_color], print + cursor);
+                        cursor_color ^= 1;
 
                         err = console_key_read(&key, 750 * 1000);
                         if (!IN_SET(err, EFI_SUCCESS, EFI_TIMEOUT, EFI_NOT_READY))
                                 return false;
 
-                        print_at(cursor + 1, y_pos, COLOR_EDIT, print + cursor);
+                        print_at(cursor + 1, y_pos, color_text, print + cursor);
                 } while (err != EFI_SUCCESS);
 
                 switch (key) {

--- a/src/boot/line-edit.h
+++ b/src/boot/line-edit.h
@@ -2,5 +2,6 @@
 #pragma once
 
 #include "efi.h"
+#include "palette.h"
 
-bool line_edit(char16_t **line_in, size_t x_max, size_t y_pos);
+bool line_edit(char16_t **line_in, size_t x_max, size_t y_pos, const EfiPalette *palette);

--- a/src/boot/line-edit.h
+++ b/src/boot/line-edit.h
@@ -2,5 +2,6 @@
 #pragma once
 
 #include "efi.h"
+#include "palette.h"
 
-bool line_edit(char16_t **line_in, size_t x_max, size_t y_pos);
+bool line_edit(char16_t **line_in, size_t x_max, size_t y_pos, const EfiPalette palette);

--- a/src/boot/meson.build
+++ b/src/boot/meson.build
@@ -321,6 +321,7 @@ libefi_sources = files(
         'graphics.c',
         'initrd.c',
         'measure.c',
+        'palette.c',
         'part-discovery.c',
         'pe.c',
         'random-seed.c',

--- a/src/boot/meson.build
+++ b/src/boot/meson.build
@@ -9,7 +9,14 @@ libefitest = static_library(
                 'bcd.c',
                 'chid.c',
                 'efi-string.c',
+                'palette.c',
         ),
+        c_args : [
+                '-DCOLOR_NORMAL=EFI_TEXT_ATTR(EFI_LIGHTGRAY, EFI_BLACK)',
+                '-DCOLOR_ENTRY=EFI_TEXT_ATTR(EFI_LIGHTGRAY, EFI_BLACK)',
+                '-DCOLOR_HIGHLIGHT=EFI_TEXT_ATTR(EFI_BLACK, EFI_LIGHTGRAY)',
+                '-DCOLOR_EDIT=EFI_TEXT_ATTR(EFI_BLACK, EFI_LIGHTGRAY)',
+        ],
         build_by_default : false,
         include_directories : [
                 basic_includes,
@@ -59,8 +66,19 @@ executables += [
                             test_hwids_section_c,
                 'conditions' : ['ENABLE_BOOTLOADER', 'ENABLE_UKIFY'],
         },
+        efi_test_template + {
+                'sources' : files('test-palette.c'),
+                'conditions' : ['ENABLE_BOOTLOADER'],
+                'include_directories' : includes + [
+                        # needed for efi.h
+                        include_directories('.'),
+                ],
+        },
         efi_fuzz_template + {
                 'sources' : files('fuzz-bcd.c'),
+        },
+        efi_fuzz_template + {
+                'sources' : files('fuzz-efi-array.c'),
         },
         efi_fuzz_template + {
                 'sources' : files('fuzz-efi-string.c'),
@@ -323,6 +341,7 @@ libefi_sources = files(
         'hii.c',
         'initrd.c',
         'measure.c',
+        'palette.c',
         'part-discovery.c',
         'pe.c',
         'random-seed.c',

--- a/src/boot/meson.build
+++ b/src/boot/meson.build
@@ -9,7 +9,14 @@ libefitest = static_library(
                 'bcd.c',
                 'chid.c',
                 'efi-string.c',
+                'palette.c',
         ),
+        c_args : [
+                '-DCOLOR_NORMAL=EFI_TEXT_ATTR(EFI_LIGHTGRAY, EFI_BLACK)',
+                '-DCOLOR_ENTRY=EFI_TEXT_ATTR(EFI_LIGHTGRAY, EFI_BLACK)',
+                '-DCOLOR_HIGHLIGHT=EFI_TEXT_ATTR(EFI_BLACK, EFI_LIGHTGRAY)',
+                '-DCOLOR_EDIT=EFI_TEXT_ATTR(EFI_BLACK, EFI_LIGHTGRAY)',
+        ],
         build_by_default : false,
         include_directories : [
                 include_directories('.'),
@@ -59,8 +66,19 @@ executables += [
                             test_hwids_section_c,
                 'conditions' : ['ENABLE_BOOTLOADER', 'ENABLE_UKIFY'],
         },
+        efi_test_template + {
+                'sources' : files('test-palette.c'),
+                'conditions' : ['ENABLE_BOOTLOADER'],
+                'include_directories' : includes + [
+                        # needed for efi.h
+                        include_directories('.'),
+                ],
+        },
         efi_fuzz_template + {
                 'sources' : files('fuzz-bcd.c'),
+        },
+        efi_fuzz_template + {
+                'sources' : files('fuzz-efi-array.c'),
         },
         efi_fuzz_template + {
                 'sources' : files('fuzz-efi-string.c'),
@@ -327,6 +345,7 @@ libefi_sources = files(
         'initrd.c',
         'measure.c',
         'measure-smbios.c',
+        'palette.c',
         'part-discovery.c',
         'pe.c',
         'random-seed.c',

--- a/src/boot/palette.c
+++ b/src/boot/palette.c
@@ -1,0 +1,91 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include "efi.h"
+#include "palette.h"
+#include "proto/simple-text-io.h"
+#include "string-table-fundamental.h"
+#include "efi-log.h"
+#include "efi-string-table.h"
+
+static const char *efi_color_table[_EFI_COLOR_MAX] = {
+        [EFI_BLACK]        = "black",
+        [EFI_BLUE]         = "blue",
+        [EFI_GREEN]        = "green",
+        [EFI_CYAN]         = "cyan",
+        [EFI_RED]          = "red",
+        [EFI_MAGENTA]      = "magenta",
+        [EFI_BROWN]        = "brown",
+        [EFI_LIGHTGRAY]    = "lightgray",
+        [EFI_DARKGRAY]     = "darkgray",
+        [EFI_LIGHTBLUE]    = "lightblue",
+        [EFI_LIGHTGREEN]   = "lightgreen",
+        [EFI_LIGHTCYAN]    = "lightcyan",
+        [EFI_LIGHTRED]     = "lightred",
+        [EFI_LIGHTMAGENTA] = "lightmagenta",
+        [EFI_YELLOW]       = "yellow",
+        [EFI_WHITE]        = "white",
+};
+
+DEFINE_STRING_TABLE_LOOKUP(efi_color, EfiColor);
+
+static const char *efi_palette_type_table[_EFI_PALETTE_TYPE_MAX] = {
+        [EFI_PALETTE_NORMAL]        = "normal",
+        [EFI_PALETTE_ENTRY]         = "entry",
+        [EFI_PALETTE_EDIT]          = "edit",
+};
+
+DEFINE_STRING_TABLE_LOOKUP(efi_palette_type, EfiPaletteType);
+
+static const EfiPalettes efi_palettes_default = {
+        [EFI_PALETTE_NORMAL]        = {
+                [EFI_PALETTE_COLORS_TEXT] = COLOR_NORMAL,
+                [EFI_PALETTE_COLORS_CURSOR] = EFI_TEXT_ATTR_SWAP(COLOR_NORMAL),
+        },
+        [EFI_PALETTE_ENTRY]         = {
+                [EFI_PALETTE_COLORS_TEXT] = COLOR_ENTRY,
+                [EFI_PALETTE_COLORS_CURSOR] = COLOR_HIGHLIGHT,
+        },
+        [EFI_PALETTE_EDIT]          = {
+                [EFI_PALETTE_COLORS_TEXT] = COLOR_EDIT,
+                [EFI_PALETTE_COLORS_CURSOR] = EFI_TEXT_ATTR_SWAP(COLOR_EDIT),
+        },
+};
+
+void init_palettes(EfiPalettes *palettes) {
+        memcpy(palettes, &efi_palettes_default, sizeof (EfiPalettes));
+}
+
+void parse_palette(EfiPaletteType type, char *value, EfiPalette *ret_palette) {
+        size_t pos = 0;
+
+        assert(type >= 0 && type < _EFI_PALETTE_TYPE_MAX);
+        assert(value);
+        assert(ret_palette);
+        assert(EFI_PALETTE_COLORS_CURSOR > EFI_PALETTE_COLORS_TEXT);
+
+        for (EfiPaletteColors i = 0; i < _EFI_PALETTE_COLORS_MAX; i++) {
+                const char *fg_string = parse_array(value, ",", &pos);
+                const char *bg_string = parse_array(value, ",", &pos);
+                EfiColor fg_color = efi_color_from_string(fg_string);
+                EfiColor bg_color = efi_color_from_string(bg_string);
+
+                if (fg_string != NULL && (fg_color < -1 || bg_string == NULL))
+                        /* parsing error if the foreground color is an invalid color or if the background color was not set */
+                        log_warning("Error parsing 'efi-palette-%s' config option, ignoring index %zu: %s",
+                                efi_palette_type_to_string(type), (size_t)(i * 2 + 1), fg_string);
+                else if (bg_string != NULL && (bg_color < -1 || bg_color & EFI_BRIGHT))
+                        /* parsing error if the background color is an invalid color or a bright color */
+                        log_warning("Error parsing 'efi-palette-%s' config option, ignoring index %zu: %s",
+                                efi_palette_type_to_string(type), (size_t)(i * 2 + 1), bg_string);
+                else if (fg_string != NULL && bg_string != NULL) {
+                        /* set parsed value if both colors are set and valid */
+                        *ret_palette[i] = EFI_TEXT_ATTR(fg_color, bg_color);
+                        continue;
+                }
+                /* set default value if both colors are not set or if a parsing error occured */
+                if (i == EFI_PALETTE_COLORS_CURSOR)
+                        *ret_palette[EFI_PALETTE_COLORS_CURSOR] = EFI_TEXT_ATTR_SWAP(*ret_palette[EFI_PALETTE_COLORS_TEXT]);
+                else
+                        *ret_palette[i] = efi_palettes_default[type][i];
+        }
+}

--- a/src/boot/palette.c
+++ b/src/boot/palette.c
@@ -1,0 +1,98 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include "efi.h"
+#include "palette.h"
+#include "proto/simple-text-io.h"
+#include "efi-string-table.h"
+
+static const char *efi_color_table[_EFI_COLOR_MAX] = {
+        [EFI_BLACK]        = "black",
+        [EFI_BLUE]         = "blue",
+        [EFI_GREEN]        = "green",
+        [EFI_CYAN]         = "cyan",
+        [EFI_RED]          = "red",
+        [EFI_MAGENTA]      = "magenta",
+        [EFI_BROWN]        = "brown",
+        [EFI_LIGHTGRAY]    = "lightgray",
+        [EFI_DARKGRAY]     = "darkgray",
+        [EFI_LIGHTBLUE]    = "lightblue",
+        [EFI_LIGHTGREEN]   = "lightgreen",
+        [EFI_LIGHTCYAN]    = "lightcyan",
+        [EFI_LIGHTRED]     = "lightred",
+        [EFI_LIGHTMAGENTA] = "lightmagenta",
+        [EFI_YELLOW]       = "yellow",
+        [EFI_WHITE]        = "white",
+};
+
+DEFINE_STRING_TABLE_LOOKUP(efi_color, EfiColor);
+
+static const char *efi_palette_type_table[_EFI_PALETTE_TYPE_MAX] = {
+        [EFI_PALETTE_NORMAL]        = "normal",
+        [EFI_PALETTE_ENTRY]         = "entry",
+        [EFI_PALETTE_EDIT]          = "edit",
+};
+
+DEFINE_STRING_TABLE_LOOKUP(efi_palette_type, EfiPaletteType);
+
+static const EfiPalettes efi_palettes_default = {
+        [EFI_PALETTE_NORMAL]        = {
+                [EFI_PALETTE_COLORS_TEXT] = COLOR_NORMAL,
+                [EFI_PALETTE_COLORS_CURSOR] = EFI_TEXT_ATTR_SWAP(COLOR_NORMAL),
+        },
+        [EFI_PALETTE_ENTRY]         = {
+                [EFI_PALETTE_COLORS_TEXT] = COLOR_ENTRY,
+                [EFI_PALETTE_COLORS_CURSOR] = COLOR_HIGHLIGHT,
+        },
+        [EFI_PALETTE_EDIT]          = {
+                [EFI_PALETTE_COLORS_TEXT] = COLOR_EDIT,
+                [EFI_PALETTE_COLORS_CURSOR] = EFI_TEXT_ATTR_SWAP(COLOR_EDIT),
+        },
+};
+
+void init_palettes(EfiPalettes palettes) {
+        memcpy(palettes, efi_palettes_default, sizeof (EfiPalettes));
+}
+
+void empty_palette(EfiPalette palette) {
+        for (EfiPaletteColors i = 0; i < _EFI_PALETTE_COLORS_MAX; i++)
+                palette[i] = _EFI_COLOR_INVALID;
+}
+
+EfiColor parse_palette_color(const char *fg_string, const char *bg_string) {
+        EfiColor fg_color, bg_color;
+
+        assert(fg_string);
+        assert(bg_string);
+
+        fg_color = efi_color_from_string(fg_string);
+        bg_color = efi_color_from_string(bg_string);
+
+        if (fg_color < 0 || bg_color < 0 || bg_color & EFI_BRIGHT)
+                return _EFI_COLOR_INVALID;
+
+        return EFI_TEXT_ATTR(fg_color, bg_color);
+}
+
+static EfiColor get_palette_color_default(EfiPaletteType palette_type, EfiPaletteColors palette_colors, const EfiPalette src) {
+        assert(palette_type >= 0 && palette_type < _EFI_PALETTE_TYPE_MAX);
+        assert(palette_colors >= 0 && palette_colors < _EFI_PALETTE_COLORS_MAX);
+        assert(src);
+
+        if (palette_colors == EFI_PALETTE_COLORS_CURSOR && src != NULL && src[EFI_PALETTE_COLORS_TEXT] >= 0)
+                return EFI_TEXT_ATTR_SWAP(src[EFI_PALETTE_COLORS_TEXT]);
+
+        return efi_palettes_default[palette_type][palette_colors];
+}
+
+void set_palette(EfiPaletteType palette_type, EfiPalette dest, const EfiPalette src) {
+        assert(palette_type >= 0 && palette_type < _EFI_PALETTE_TYPE_MAX);
+        assert(dest);
+        assert(src);
+
+        for (EfiPaletteColors i = 0; i < _EFI_PALETTE_COLORS_MAX; i++) {
+                if (src[i] < 0)
+                        dest[i] = get_palette_color_default(palette_type, i, src);
+                else
+                        dest[i] = src[i];
+        }
+}

--- a/src/boot/palette.h
+++ b/src/boot/palette.h
@@ -1,0 +1,33 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#pragma once
+
+#include "proto/simple-text-io.h"
+#include "string-table-fundamental.h"
+
+DECLARE_STRING_TABLE_LOOKUP(efi_color, EfiColor);
+
+typedef enum {
+        EFI_PALETTE_COLORS_TEXT,
+        EFI_PALETTE_COLORS_CURSOR,
+        _EFI_PALETTE_COLORS_MAX,
+} EfiPaletteColors;
+
+typedef size_t EfiPalette[_EFI_PALETTE_COLORS_MAX];
+
+typedef enum {
+        EFI_PALETTE_NORMAL,
+        /* boot loader palette for entries and selected entries */
+        EFI_PALETTE_ENTRY,
+        /* boot loader color for option line edit and cursor */
+        EFI_PALETTE_EDIT,
+        _EFI_PALETTE_TYPE_MAX,
+        _EFI_PALETTE_TYPE_INVALID = -EINVAL,
+} EfiPaletteType;
+
+DECLARE_STRING_TABLE_LOOKUP(efi_palette_type, EfiPaletteType);
+
+typedef EfiPalette EfiPalettes[_EFI_PALETTE_TYPE_MAX];
+
+void init_palettes(EfiPalettes *palettes);
+
+void parse_palette(EfiPaletteType type, char *value, EfiPalette *ret_palette);

--- a/src/boot/palette.h
+++ b/src/boot/palette.h
@@ -1,0 +1,40 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#pragma once
+
+#include "proto/simple-text-io.h"
+#include "string-table-fundamental.h"
+
+#define EFI_PALETTE(palettes, type) ((palettes)[(EFI_PALETTE_##type)])
+#define EFI_PALETTE_COLOR(palettes, type, color) (EFI_PALETTE(palettes, type)[(EFI_PALETTE_COLORS_##color)])
+
+DECLARE_STRING_TABLE_LOOKUP(efi_color, EfiColor);
+
+typedef enum {
+        EFI_PALETTE_COLORS_TEXT,
+        EFI_PALETTE_COLORS_CURSOR,
+        _EFI_PALETTE_COLORS_MAX,
+} EfiPaletteColors;
+
+typedef EfiColor EfiPalette[_EFI_PALETTE_COLORS_MAX];
+
+typedef enum {
+        EFI_PALETTE_NORMAL,
+        /* boot loader palette for entries and selected entries */
+        EFI_PALETTE_ENTRY,
+        /* boot loader color for option line edit and cursor */
+        EFI_PALETTE_EDIT,
+        _EFI_PALETTE_TYPE_MAX,
+        _EFI_PALETTE_TYPE_INVALID = -EINVAL,
+} EfiPaletteType;
+
+DECLARE_STRING_TABLE_LOOKUP(efi_palette_type, EfiPaletteType);
+
+typedef EfiPalette EfiPalettes[_EFI_PALETTE_TYPE_MAX];
+
+void init_palettes(EfiPalettes palettes);
+
+void empty_palette(EfiPalette palette);
+
+EfiColor parse_palette_color(const char *fg_string, const char *bg_string);
+
+void set_palette(EfiPaletteType palette_type, EfiPalette dest, const EfiPalette src);

--- a/src/boot/palette.h
+++ b/src/boot/palette.h
@@ -1,0 +1,41 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#pragma once
+
+#include "efi.h"
+#include "proto/simple-text-io.h"
+#include "string-table.h"
+
+#define EFI_PALETTE(palettes, type) ((palettes)[(EFI_PALETTE_##type)])
+#define EFI_PALETTE_COLOR(palettes, type, color) (EFI_PALETTE(palettes, type)[(EFI_PALETTE_COLORS_##color)])
+
+DECLARE_STRING_TABLE_LOOKUP(efi_color, EfiColor);
+
+typedef enum {
+        EFI_PALETTE_COLORS_TEXT,
+        EFI_PALETTE_COLORS_CURSOR,
+        _EFI_PALETTE_COLORS_MAX,
+} EfiPaletteColors;
+
+typedef EfiColor EfiPalette[_EFI_PALETTE_COLORS_MAX];
+
+typedef enum {
+        EFI_PALETTE_NORMAL,
+        /* boot loader palette for entries and selected entries */
+        EFI_PALETTE_ENTRY,
+        /* boot loader color for option line edit and cursor */
+        EFI_PALETTE_EDIT,
+        _EFI_PALETTE_TYPE_MAX,
+        _EFI_PALETTE_TYPE_INVALID = -EINVAL,
+} EfiPaletteType;
+
+DECLARE_STRING_TABLE_LOOKUP(efi_palette_type, EfiPaletteType);
+
+typedef EfiPalette EfiPalettes[_EFI_PALETTE_TYPE_MAX];
+
+void init_palettes(EfiPalettes palettes);
+
+void empty_palette(EfiPalette palette);
+
+EfiColor parse_palette_color(const char *fg_string, const char *bg_string);
+
+void set_palette(EfiPaletteType palette_type, EfiPalette dest, const EfiPalette src);

--- a/src/boot/proto/simple-text-io.h
+++ b/src/boot/proto/simple-text-io.h
@@ -1,6 +1,8 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 #pragma once
 
+#include <errno.h>
+
 #include "efi.h"
 
 #define EFI_SIMPLE_TEXT_INPUT_PROTOCOL_GUID \
@@ -28,7 +30,8 @@
 #define EFI_NUM_LOCK_ACTIVE    0x02U
 #define EFI_CAPS_LOCK_ACTIVE   0x04U
 
-enum {
+typedef enum {
+        /* foreground and background colors: */
         EFI_BLACK        = 0x00,
         EFI_BLUE         = 0x01,
         EFI_GREEN        = 0x02,
@@ -37,6 +40,7 @@ enum {
         EFI_MAGENTA      = EFI_BLUE | EFI_RED,
         EFI_BROWN        = EFI_GREEN | EFI_RED,
         EFI_LIGHTGRAY    = EFI_BLUE | EFI_GREEN | EFI_RED,
+        /* foreground colors: */
         EFI_BRIGHT       = 0x08,
         EFI_DARKGRAY     = EFI_BLACK | EFI_BRIGHT,
         EFI_LIGHTBLUE    = EFI_BLUE | EFI_BRIGHT,
@@ -46,10 +50,15 @@ enum {
         EFI_LIGHTMAGENTA = EFI_MAGENTA | EFI_BRIGHT,
         EFI_YELLOW       = EFI_BROWN | EFI_BRIGHT,
         EFI_WHITE        = EFI_BLUE | EFI_GREEN | EFI_RED | EFI_BRIGHT,
-};
+        _EFI_COLOR_MAX,
+        _EFI_COLOR_INVALID = -EINVAL,
+} EfiColor;
 
-#define EFI_TEXT_ATTR(fg, bg) ((fg) | ((bg) << 4))
-#define EFI_TEXT_ATTR_SWAP(c) EFI_TEXT_ATTR(((c) & 0xF0U) >> 4, (c) & 0xFU)
+/* Note that the background colors are only from black to lightgray. */
+#define EFI_TEXT_ATTR(fg, bg) (((fg) & 0xFU) | (((bg) & 0x7U) << 4))
+#define EFI_TEXT_ATTR_FG(c) ((c) & 0xFU)
+#define EFI_TEXT_ATTR_BG(c) (((c) >> 4) & 0x7U)
+#define EFI_TEXT_ATTR_SWAP(c) EFI_TEXT_ATTR(EFI_TEXT_ATTR_BG(c), EFI_TEXT_ATTR_FG(c))
 
 enum {
         SCAN_NULL            = 0x000,

--- a/src/boot/test-efi-string.c
+++ b/src/boot/test-efi-string.c
@@ -638,6 +638,78 @@ TEST(line_get_key_value) {
         }
 }
 
+TEST(parse_array) {
+        char s1[] = "a,b, c ,\td,e\t,f";
+        char s2[] = " 1,2,3,";
+        char s3[] = "x,y,z  ,  ";
+        char s4[] = ",";
+        char s5[] = "_,,__,,___,";
+        char s6[] = " this \t also\t\t\tworks with\t\twhitespaces";
+        char s7[] = "X \t Y   Z\t \t ";
+        size_t pos = 0;
+
+        ASSERT_NULL(parse_array((char[]){ "" }, ",", &pos));
+        ASSERT_NULL(parse_array((char[]){ "\t" }, " \t", &pos));
+        ASSERT_NULL(parse_array((char[]){ " \t \t" }, " \t", &pos));
+
+        pos = 0;
+        ASSERT_TRUE(streq8(parse_array(s1, ",", &pos), "a"));
+        ASSERT_TRUE(streq8(parse_array(s1, ",", &pos), "b"));
+        ASSERT_TRUE(streq8(parse_array(s1, ",", &pos), "c"));
+        ASSERT_TRUE(streq8(parse_array(s1, ",", &pos), "d"));
+        ASSERT_TRUE(streq8(parse_array(s1, ",", &pos), "e"));
+        ASSERT_TRUE(streq8(parse_array(s1, ",", &pos), "f"));
+        ASSERT_NULL(parse_array(s1, ",", &pos));
+
+        pos = 0;
+        ASSERT_TRUE(streq8(parse_array(s2, ",", &pos), "1"));
+        ASSERT_TRUE(streq8(parse_array(s2, ",", &pos), "2"));
+        ASSERT_TRUE(streq8(parse_array(s2, ",", &pos), "3"));
+        ASSERT_NULL(parse_array(s2, ",", &pos));
+
+        pos = 0;
+        ASSERT_TRUE(streq8(parse_array(s3, ",", &pos), "x"));
+        ASSERT_TRUE(streq8(parse_array(s3, ",", &pos), "y"));
+        ASSERT_TRUE(streq8(parse_array(s3, ",", &pos), "z"));
+        ASSERT_NULL(parse_array(s3, ",", &pos));
+
+        /* empty values are allowed when the separator is not whitespace */
+        pos = 0;
+        ASSERT_TRUE(streq8(parse_array(s4, ",", &pos), ""));
+        ASSERT_NULL(parse_array(s4, ",", &pos));
+
+        /* empty values are allowed when the separator is not whitespace */
+        pos = 0;
+        ASSERT_TRUE(streq8(parse_array(s5, ",", &pos), "_"));
+        ASSERT_TRUE(streq8(parse_array(s5, ",", &pos), ""));
+        ASSERT_TRUE(streq8(parse_array(s5, ",", &pos), "__"));
+        ASSERT_TRUE(streq8(parse_array(s5, ",", &pos), ""));
+        ASSERT_TRUE(streq8(parse_array(s5, ",", &pos), "___"));
+        ASSERT_NULL(parse_array(s5, ",", &pos));
+        /* it is possible to keep using the function */
+        ASSERT_NULL(parse_array(s5, ",", &pos));
+        ASSERT_NULL(parse_array(s5, ",", &pos));
+
+        /* empty values are not allowed when the separator is whitespace */
+        pos = 0;
+        ASSERT_TRUE(streq8(parse_array(s6, " \t", &pos), "this"));
+        ASSERT_TRUE(streq8(parse_array(s6, " \t", &pos), "also"));
+        ASSERT_TRUE(streq8(parse_array(s6, " \t", &pos), "works"));
+        ASSERT_TRUE(streq8(parse_array(s6, " \t", &pos), "with"));
+        ASSERT_TRUE(streq8(parse_array(s6, " \t", &pos), "whitespaces"));
+        ASSERT_NULL(parse_array(s6, " \t", &pos));
+
+        /* empty values are not allowed when the separator is whitespace */
+        pos = 0;
+        ASSERT_TRUE(streq8(parse_array(s7, " \t", &pos), "X"));
+        ASSERT_TRUE(streq8(parse_array(s7, " \t", &pos), "Y"));
+        ASSERT_TRUE(streq8(parse_array(s7, " \t", &pos), "Z"));
+        ASSERT_NULL(parse_array(s7, " \t", &pos));
+        /* it is possible to keep using the function */
+        ASSERT_NULL(parse_array(s7, " \t", &pos));
+        ASSERT_NULL(parse_array(s7, " \t", &pos));
+}
+
 TEST(hexdump) {
         char16_t *hex;
 

--- a/src/boot/test-efi-string.c
+++ b/src/boot/test-efi-string.c
@@ -644,6 +644,78 @@ TEST(line_get_key_value) {
         }
 }
 
+TEST(parse_array) {
+        char s1[] = "a,b, c ,\td,e\t,f";
+        char s2[] = " 1,2,3,";
+        char s3[] = "x,y,z  ,  ";
+        char s4[] = ",";
+        char s5[] = "_,,__,,___,";
+        char s6[] = " this \t also\t\t\tworks with\t\twhitespaces";
+        char s7[] = "X \t Y   Z\t \t ";
+        size_t pos = 0;
+
+        ASSERT_NULL(parse_array((char[]){ "" }, ",", &pos));
+        ASSERT_NULL(parse_array((char[]){ "\t" }, " \t", &pos));
+        ASSERT_NULL(parse_array((char[]){ " \t \t" }, " \t", &pos));
+
+        pos = 0;
+        ASSERT_TRUE(streq8(parse_array(s1, ",", &pos), "a"));
+        ASSERT_TRUE(streq8(parse_array(s1, ",", &pos), "b"));
+        ASSERT_TRUE(streq8(parse_array(s1, ",", &pos), "c"));
+        ASSERT_TRUE(streq8(parse_array(s1, ",", &pos), "d"));
+        ASSERT_TRUE(streq8(parse_array(s1, ",", &pos), "e"));
+        ASSERT_TRUE(streq8(parse_array(s1, ",", &pos), "f"));
+        ASSERT_NULL(parse_array(s1, ",", &pos));
+
+        pos = 0;
+        ASSERT_TRUE(streq8(parse_array(s2, ",", &pos), "1"));
+        ASSERT_TRUE(streq8(parse_array(s2, ",", &pos), "2"));
+        ASSERT_TRUE(streq8(parse_array(s2, ",", &pos), "3"));
+        ASSERT_NULL(parse_array(s2, ",", &pos));
+
+        pos = 0;
+        ASSERT_TRUE(streq8(parse_array(s3, ",", &pos), "x"));
+        ASSERT_TRUE(streq8(parse_array(s3, ",", &pos), "y"));
+        ASSERT_TRUE(streq8(parse_array(s3, ",", &pos), "z"));
+        ASSERT_NULL(parse_array(s3, ",", &pos));
+
+        /* empty values are allowed when the separator is not whitespace */
+        pos = 0;
+        ASSERT_TRUE(streq8(parse_array(s4, ",", &pos), ""));
+        ASSERT_NULL(parse_array(s4, ",", &pos));
+
+        /* empty values are allowed when the separator is not whitespace */
+        pos = 0;
+        ASSERT_TRUE(streq8(parse_array(s5, ",", &pos), "_"));
+        ASSERT_TRUE(streq8(parse_array(s5, ",", &pos), ""));
+        ASSERT_TRUE(streq8(parse_array(s5, ",", &pos), "__"));
+        ASSERT_TRUE(streq8(parse_array(s5, ",", &pos), ""));
+        ASSERT_TRUE(streq8(parse_array(s5, ",", &pos), "___"));
+        ASSERT_NULL(parse_array(s5, ",", &pos));
+        /* it is possible to keep using the function */
+        ASSERT_NULL(parse_array(s5, ",", &pos));
+        ASSERT_NULL(parse_array(s5, ",", &pos));
+
+        /* empty values are not allowed when the separator is whitespace */
+        pos = 0;
+        ASSERT_TRUE(streq8(parse_array(s6, " \t", &pos), "this"));
+        ASSERT_TRUE(streq8(parse_array(s6, " \t", &pos), "also"));
+        ASSERT_TRUE(streq8(parse_array(s6, " \t", &pos), "works"));
+        ASSERT_TRUE(streq8(parse_array(s6, " \t", &pos), "with"));
+        ASSERT_TRUE(streq8(parse_array(s6, " \t", &pos), "whitespaces"));
+        ASSERT_NULL(parse_array(s6, " \t", &pos));
+
+        /* empty values are not allowed when the separator is whitespace */
+        pos = 0;
+        ASSERT_TRUE(streq8(parse_array(s7, " \t", &pos), "X"));
+        ASSERT_TRUE(streq8(parse_array(s7, " \t", &pos), "Y"));
+        ASSERT_TRUE(streq8(parse_array(s7, " \t", &pos), "Z"));
+        ASSERT_NULL(parse_array(s7, " \t", &pos));
+        /* it is possible to keep using the function */
+        ASSERT_NULL(parse_array(s7, " \t", &pos));
+        ASSERT_NULL(parse_array(s7, " \t", &pos));
+}
+
 TEST(hexdump) {
         char16_t *hex;
 

--- a/src/boot/test-palette.c
+++ b/src/boot/test-palette.c
@@ -1,0 +1,100 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include "palette.h"
+#include "tests.h"
+
+#define ASSERT_COLOR_EQ(expr1, expr2) ASSERT_EQ((EfiColor)(expr1), (EfiColor)(expr2))
+
+TEST(init_palettes) {
+        EfiPalettes palettes;
+
+        init_palettes(palettes);
+
+        ASSERT_COLOR_EQ(EFI_PALETTE_COLOR(palettes, NORMAL, TEXT), EFI_TEXT_ATTR(EFI_LIGHTGRAY, EFI_BLACK));
+        ASSERT_COLOR_EQ(EFI_PALETTE_COLOR(palettes, NORMAL, CURSOR), EFI_TEXT_ATTR(EFI_BLACK, EFI_LIGHTGRAY));
+        ASSERT_COLOR_EQ(EFI_PALETTE_COLOR(palettes, ENTRY, TEXT), EFI_TEXT_ATTR(EFI_LIGHTGRAY, EFI_BLACK));
+        ASSERT_COLOR_EQ(EFI_PALETTE_COLOR(palettes, ENTRY, CURSOR), EFI_TEXT_ATTR(EFI_BLACK, EFI_LIGHTGRAY));
+        ASSERT_COLOR_EQ(EFI_PALETTE_COLOR(palettes, EDIT, TEXT), EFI_TEXT_ATTR(EFI_BLACK, EFI_LIGHTGRAY));
+        ASSERT_COLOR_EQ(EFI_PALETTE_COLOR(palettes, EDIT, CURSOR), EFI_TEXT_ATTR(EFI_LIGHTGRAY, EFI_BLACK));
+}
+
+TEST(empty_palette) {
+        EfiPalette palette;
+
+        empty_palette(palette);
+        ASSERT_COLOR_EQ(palette[EFI_PALETTE_COLORS_TEXT], _EFI_COLOR_INVALID);
+        ASSERT_COLOR_EQ(palette[EFI_PALETTE_COLORS_CURSOR], _EFI_COLOR_INVALID);
+}
+
+TEST(parse_palette_color) {
+        ASSERT_COLOR_EQ(parse_palette_color("white", "black"), EFI_TEXT_ATTR(EFI_WHITE, EFI_BLACK));
+        ASSERT_COLOR_EQ(parse_palette_color("yellow", "blue"), EFI_TEXT_ATTR(EFI_YELLOW, EFI_BLUE));
+        ASSERT_COLOR_EQ(parse_palette_color("lightmagenta", "green"), EFI_TEXT_ATTR(EFI_LIGHTMAGENTA, EFI_GREEN));
+        ASSERT_COLOR_EQ(parse_palette_color("lightred", "cyan"), EFI_TEXT_ATTR(EFI_LIGHTRED, EFI_CYAN));
+        ASSERT_COLOR_EQ(parse_palette_color("lightcyan", "red"), EFI_TEXT_ATTR(EFI_LIGHTCYAN, EFI_RED));
+        ASSERT_COLOR_EQ(parse_palette_color("lightgreen", "magenta"), EFI_TEXT_ATTR(EFI_LIGHTGREEN, EFI_MAGENTA));
+        ASSERT_COLOR_EQ(parse_palette_color("lightblue", "brown"), EFI_TEXT_ATTR(EFI_LIGHTBLUE, EFI_BROWN));
+        ASSERT_COLOR_EQ(parse_palette_color("darkgray", "lightgray"), EFI_TEXT_ATTR(EFI_DARKGRAY, EFI_LIGHTGRAY));
+        /* case-sensitive */
+        ASSERT_COLOR_EQ(parse_palette_color("YELLOW", "BLUE"), _EFI_COLOR_INVALID);
+        /* invalid foreground color */
+        ASSERT_COLOR_EQ(parse_palette_color("_yellow", "blue"), _EFI_COLOR_INVALID);
+        /* invalid background color */
+        ASSERT_COLOR_EQ(parse_palette_color("yellow", "_blue"), _EFI_COLOR_INVALID);
+        /* invalid background color (light colors are not allowed) */
+        ASSERT_COLOR_EQ(parse_palette_color("blue", "lightred"), _EFI_COLOR_INVALID);
+        ASSERT_COLOR_EQ(parse_palette_color("blue", "darkgray"), _EFI_COLOR_INVALID);
+        /* empty values */
+        ASSERT_COLOR_EQ(parse_palette_color("", ""), _EFI_COLOR_INVALID);
+        ASSERT_COLOR_EQ(parse_palette_color("", "blue"), _EFI_COLOR_INVALID);
+        ASSERT_COLOR_EQ(parse_palette_color("yellow", ""), _EFI_COLOR_INVALID);
+}
+
+TEST(set_palette) {
+        EfiPalette dest, src;
+
+        /* setting both colors, sets both colors */
+        empty_palette(dest);
+        empty_palette(src);
+        src[EFI_PALETTE_COLORS_TEXT] = EFI_TEXT_ATTR(EFI_YELLOW, EFI_BLUE);
+        src[EFI_PALETTE_COLORS_CURSOR] = EFI_TEXT_ATTR(EFI_WHITE, EFI_GREEN);
+        set_palette(EFI_PALETTE_EDIT, dest, src);
+        ASSERT_COLOR_EQ(dest[EFI_PALETTE_COLORS_TEXT], EFI_TEXT_ATTR(EFI_YELLOW, EFI_BLUE));
+        ASSERT_COLOR_EQ(dest[EFI_PALETTE_COLORS_CURSOR], EFI_TEXT_ATTR(EFI_WHITE, EFI_GREEN));
+
+        /* cursor colors will be set to swapped text colors */
+        empty_palette(dest);
+        empty_palette(src);
+        src[EFI_PALETTE_COLORS_TEXT] = EFI_TEXT_ATTR(EFI_YELLOW, EFI_BLUE);
+        set_palette(EFI_PALETTE_EDIT, dest, src);
+        ASSERT_COLOR_EQ(dest[EFI_PALETTE_COLORS_TEXT], EFI_TEXT_ATTR(EFI_YELLOW, EFI_BLUE));
+        /* note that the yellow becomes brown here, since yellow is not a valid background color */
+        ASSERT_COLOR_EQ(dest[EFI_PALETTE_COLORS_CURSOR], EFI_TEXT_ATTR(EFI_BLUE, EFI_BROWN));
+
+        /* text colors will be set to deault colors */
+        empty_palette(dest);
+        empty_palette(src);
+        src[EFI_PALETTE_COLORS_CURSOR] = EFI_TEXT_ATTR(EFI_WHITE, EFI_GREEN);
+        set_palette(EFI_PALETTE_EDIT, dest, src);
+        ASSERT_COLOR_EQ(dest[EFI_PALETTE_COLORS_TEXT], EFI_TEXT_ATTR(EFI_BLACK, EFI_LIGHTGRAY));
+        ASSERT_COLOR_EQ(dest[EFI_PALETTE_COLORS_CURSOR], EFI_TEXT_ATTR(EFI_WHITE, EFI_GREEN));
+
+        /* setting invalid colors, sets default colors */
+        empty_palette(dest);
+        empty_palette(src);
+        set_palette(EFI_PALETTE_NORMAL, dest, src);
+        ASSERT_COLOR_EQ(dest[EFI_PALETTE_COLORS_TEXT], EFI_TEXT_ATTR(EFI_LIGHTGRAY, EFI_BLACK));
+        ASSERT_COLOR_EQ(dest[EFI_PALETTE_COLORS_CURSOR], EFI_TEXT_ATTR(EFI_BLACK, EFI_LIGHTGRAY));
+        empty_palette(dest);
+        empty_palette(src);
+        set_palette(EFI_PALETTE_ENTRY, dest, src);
+        ASSERT_COLOR_EQ(dest[EFI_PALETTE_COLORS_TEXT], EFI_TEXT_ATTR(EFI_LIGHTGRAY, EFI_BLACK));
+        ASSERT_COLOR_EQ(dest[EFI_PALETTE_COLORS_CURSOR], EFI_TEXT_ATTR(EFI_BLACK, EFI_LIGHTGRAY));
+        empty_palette(dest);
+        empty_palette(src);
+        set_palette(EFI_PALETTE_EDIT, dest, src);
+        ASSERT_COLOR_EQ(dest[EFI_PALETTE_COLORS_TEXT], EFI_TEXT_ATTR(EFI_BLACK, EFI_LIGHTGRAY));
+        ASSERT_COLOR_EQ(dest[EFI_PALETTE_COLORS_CURSOR], EFI_TEXT_ATTR(EFI_LIGHTGRAY, EFI_BLACK));
+}
+
+DEFINE_TEST_MAIN(LOG_INFO);

--- a/src/shared/bootspec.c
+++ b/src/shared/bootspec.c
@@ -524,7 +524,8 @@ int boot_loader_read_conf(BootConfig *config, FILE *file, const char *path) {
                 else if (STR_IN_SET(field, "timeout", "editor", "auto-entries", "auto-firmware",
                                     "auto-poweroff", "auto-reboot", "beep", "reboot-for-bitlocker",
                                     "reboot-on-error", "secure-boot-enroll", "secure-boot-enroll-action",
-                                    "secure-boot-enroll-timeout-sec", "console-mode", "log-level"))
+                                    "secure-boot-enroll-timeout-sec", "console-mode", "log-level",
+                                    "efi-palette-normal", "efi-palette-entry", "efi-palette-edit"))
                         r = 0; /* we don't parse these in userspace, but they are OK */
                 else {
                         log_syntax(NULL, LOG_WARNING, path, line, 0, "Unknown line '%s', ignoring.", field);

--- a/src/shared/bootspec.c
+++ b/src/shared/bootspec.c
@@ -626,7 +626,8 @@ int boot_loader_read_conf(BootConfig *config, FILE *file, const char *path) {
                 else if (STR_IN_SET(field, "timeout", "editor", "auto-entries", "auto-firmware",
                                     "auto-poweroff", "auto-reboot", "beep", "reboot-for-bitlocker",
                                     "reboot-on-error", "secure-boot-enroll", "secure-boot-enroll-action",
-                                    "secure-boot-enroll-timeout-sec", "console-mode", "log-level"))
+                                    "secure-boot-enroll-timeout-sec", "console-mode", "log-level",
+                                    "efi-palette-normal", "efi-palette-entry", "efi-palette-edit"))
                         r = 0; /* we don't parse these in userspace, but they are OK */
                 else {
                         log_syntax(NULL, LOG_WARNING, path, line, 0, "Unknown line '%s', ignoring.", field);

--- a/src/shared/bootspec.c
+++ b/src/shared/bootspec.c
@@ -628,7 +628,8 @@ int boot_loader_read_conf(BootConfig *config, FILE *file, const char *path) {
                 else if (STR_IN_SET(field, "timeout", "editor", "auto-entries", "auto-firmware",
                                     "auto-poweroff", "auto-reboot", "beep", "reboot-for-bitlocker",
                                     "reboot-on-error", "secure-boot-enroll", "secure-boot-enroll-action",
-                                    "secure-boot-enroll-timeout-sec", "console-mode", "log-level"))
+                                    "secure-boot-enroll-timeout-sec", "console-mode", "log-level",
+                                    "efi-palette-normal", "efi-palette-entry", "efi-palette-edit"))
                         r = 0; /* we don't parse these in userspace, but they are OK */
                 else {
                         log_syntax(NULL, LOG_WARNING, path, line, 0, "Unknown line '%s', ignoring.", field);


### PR DESCRIPTION
### Motivation

This PR has been created for the following use-cases:

- An easier way for users to change the colors of the bootloader without having to recompile systemd. See #30059 for an abandoned attempt at this.
- Being able to change the colors can help for accessibility reasons. Some people (including myself sometimes) see white text on black background blurry (sometimes referred to as ghosting). This can be a result of astigmatism, dry or damaged eyes.

### Implementation Details and Documentation

To allow users to change colors for the bootloader without needing to recompile systemd,
the following config options are added:

- efi-palette-normal: colors for the normal text
- efi-palette-entry: colors for the boot entries and highligted boot entries
- efi-palette-edit: colors for the editor and the cursor of the editor

Each configuration consists of an array of 4 colors separated by comma (`,`) for
the following purpose:

- foreground color
- background color
- foreground color of the highlight/cursor
- background color of the highlight/cursor

A trailling comma is allowed.
Note that efi-palette-normal accepts 4 colors,
but the highlight/cursor color is unused (for now).
If only the foreground color and background color is set,
the highlight/cursor color will be set to the same colors,
but foreground and background are swapped.

Allowed colors for all entries:

- black
- blue
- green
- cyan
- red
- magenta
- brown
- lightgray

Allowed colors for foreground colors (odd 1-indexed array entries):

- darkgray
- lightblue
- lightgreen
- lightcyan
- lightred
- lightmagenta
- yellow
- white

### Examples

This sets the colors of the boot entries to have a lightgreen text on a brown background
and the highlighted/selected entry is using yellow text on a magenta background.
efi-palette-entry lightgreen,brown,yellow,magenta
This sets the colors of the editor to have a lightred text on a black background
and the cursor is using black text on a red background.
efi-palette-edit lightred,black
This is because swapping lightred and black causes the background color to not be bright,
since bright background colors are not allowed for EFI colors.
Note that commas (,) are used and not whitespace, because this allows users to use
a bash command like the following:
echo "efi-palette-entry $a,$b,$c,$d" >> /boot/loader/loader.conf
If the environment variables a and b are unset, then the highlight/cursor colors are still applied.

### Tests

I added unit tests to some of the functions I wrote.
I also added a fuzzing test for the array parsing, however I did not manage to run any fuzzing tests on Cachy OS.
I ran the unit tests on Cachy OS.
I manually tested the bootloader on a X870E AORUS ELITE WIFI7 motherboard using NixOS:
```nix
{
  boot.loader = {
    systemd-boot = {
      enable = true;
      extraInstallCommands = let
        entries = {
          efi-palette-normal="lightred,lightgray";
          efi-palette-entry="lightgreen,brown,yellow,magenta";
          efi-palette-edit="lightmagenta,blue,lightgray,green";
        };
      in
        lib.concatMapAttrsStringSep "\n" (name: value: ''
        echo ${lib.escapeShellArg name} ${lib.escapeShellArg value} >> ${lib.escapeShellArg config.boot.loader.efi.efiSysMountPoint}/loader/loader.conf
        '') entries;
    };
    efi = {
      canTouchEfiVariables = true;
      efiSysMountPoint = "/boot";
    };
  };
}
```

### Further Thoughts

I noticed that the cursor is blinking when editing a line and I was wondering if disabling a blinking cursor could be nice as well. Sometimes a blinking cursor is uncomfortable to me.