### PR TITLE
meson: bump minimum curl version to 7.85.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1294,7 +1294,7 @@ foreach ident : [
 endforeach
 
 libcurl = dependency('libcurl',
-                     version : '>= 7.32.0',
+                     version : '>= 7.85.0',
                      required : get_option('libcurl'))
 conf.set10('HAVE_LIBCURL', libcurl.found())
 conf.set10('CURL_NO_OLDIES', conf.get('BUILD_MODE_DEVELOPER') == 1)

--- a/src/import/curl-util.c
+++ b/src/import/curl-util.c
@@ -287,11 +287,7 @@ int curl_glue_make(CURL **ret, const char *url, void *userdata) {
         if (curl_easy_setopt(c, CURLOPT_LOW_SPEED_LIMIT, 30L) != CURLE_OK)
                 return -EIO;
 
-#if LIBCURL_VERSION_NUM >= 0x075500 /* libcurl 7.85.0 */
         if (curl_easy_setopt(c, CURLOPT_PROTOCOLS_STR, "HTTP,HTTPS,FILE") != CURLE_OK)
-#else
-        if (curl_easy_setopt(c, CURLOPT_PROTOCOLS, CURLPROTO_HTTP|CURLPROTO_HTTPS|CURLPROTO_FILE) != CURLE_OK)
-#endif
                 return -EIO;
 
         *ret = TAKE_PTR(c);

--- a/src/journal-remote/journal-upload.c
+++ b/src/journal-remote/journal-upload.c
@@ -518,7 +518,6 @@ static void destroy_uploader(Uploader *u) {
         sd_event_unref(u->event);
 }
 
-#if LIBCURL_VERSION_NUM >= 0x075300
 static int update_content_encoding_header(Uploader *u, const CompressionConfig *cc) {
         bool update_header = false;
 
@@ -577,10 +576,8 @@ static int update_content_encoding_header(Uploader *u, const CompressionConfig *
                 log_debug("Disabled compression algorithm.");
         return 0;
 }
-#endif
 
 static int parse_accept_encoding_header(Uploader *u) {
-#if LIBCURL_VERSION_NUM >= 0x075300
         int r;
 
         assert(u);
@@ -626,9 +623,6 @@ not_found:
                 return update_content_encoding_header(u, ordered_hashmap_first(arg_compression));
 
         return update_content_encoding_header(u, NULL);
-#else
-        return 0;
-#endif
 }
 
 static int perform_upload(Uploader *u) {


### PR DESCRIPTION
This resolves the HTTP redirect hardening issues (#41587) comprehensively on the curl side of things, which I'd argue is generally better than trying to make this better.

curl 7.85 is from 2022, i.e. 4y old.

According to https://repology.org/project/curl/versions this means that we now require the following minimal version of major distros (unless people backport curl, which would probably wise for security reasons):

* CentOS Stream 10
* Debian 12
* Fedora 38
* Ubuntu 24.4