### PR TITLE
NEWS: pre-announce removal of /run/boot-loader-entries/ support in lo…

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,21 @@ systemd System and Service Manager
 
 CHANGES WITH 261 in spe:
 
+        Announcements of Future Feature Removals and Incompatible Changes:
+
+        * systemd-logind's integration with the UAPI.1 Boot Loader
+          Specification (which allows systemctl reboot --boot-loader-entry=
+          switch to work) so far has supported a special directory
+          /run/boot-loader-entries/ which allowed defining boot loader entries
+          outside of the ESP/XBOOTLDR partition for compatibility with legacy
+          systems that do not natively implement UAPI.1. However, it appears
+          that (to our knowledge) it is not actually being used by any project
+          (quite unlike UAPI.1 itself, which found adoption far beyond
+          systemd), and its implementation is incomplete. With the future 262
+          release we intend to remove support for /run/boot-loader-entries/ and
+          related interfaces, in order to simplify our codebase. Support for
+          UAPI.1 is – of course – kept in place.
+
         Feature Removals and Incompatible Changes:
 
         * systemd-nspawn's --user= option has been renamed to --uid=. The -u


### PR DESCRIPTION
…gind

logind could read UAPI.1 Boot Loader Spec entries from /run/boot-loader-entries/ in addition to ESP/XBOOTLDR. This was pretty half-assed, and to my knowledge was never actually used much.

Let's remove support for it and simplify our codebase.

Let's schedule it for removal via NEWS in a future version, to give people a chance to speak up.