### PR TITLE
sd-device: Allow colon in udev properties names

### DIFF
--- a/src/libsystemd/sd-device/sd-device.c
+++ b/src/libsystemd/sd-device/sd-device.c
@@ -87,7 +87,7 @@ static bool property_is_valid(const char *key, const char *value) {
          * property contains spurious characters, then the parser may be confused. Let's refuse spurious
          * properties, even if it is internal, which will not be saved to database file, for consistency. */
 
-        if (isempty(key) || !in_charset(key, ALPHANUMERICAL "_."))
+        if (isempty(key) || !in_charset(key, ALPHANUMERICAL "_.:"))
                 return false;
 
         /* an empty value means unset the property, hence that's fine. */

--- a/src/libsystemd/sd-device/test-sd-device.c
+++ b/src/libsystemd/sd-device/test-sd-device.c
@@ -878,6 +878,11 @@ TEST(device_add_property) {
         ASSERT_OK(sd_device_get_property_value(dev, ".hoge", &val));
         ASSERT_STREQ(val, "baz");
 
+        /* check property with colon */
+        ASSERT_OK(device_add_property(dev, "hoge:hoge", "baz"));
+        ASSERT_OK(sd_device_get_property_value(dev, "hoge:hoge", &val));
+        ASSERT_STREQ(val, "baz");
+
         /* refuse invalid property names */
         ASSERT_ERROR(device_add_property(dev, "hoge-hoge", "aaa"), EINVAL);
         ASSERT_ERROR(device_add_property(dev, "hoge=hoge", "aaa"), EINVAL);


### PR DESCRIPTION
This adds colon (:) to list of allowed characters in udev properties. This list was introduced  in a62cd5a153 and it breaks UDisks feature for setting default mount options via udev rules which uses colon in some properties, see
https://storaged.org/udisks/docs/mount_options.html

cc @tbzatek 