### PR TITLE
various: fix compilation with openssl-4.0.0-beta1

### DIFF
--- a/src/sbsign/sbsign.c
+++ b/src/sbsign/sbsign.c
@@ -265,8 +265,9 @@ static int spc_indirect_data_content_new(const void *digest, size_t digestsz, ui
                 return log_error_errno(SYNTHETIC_ERRNO(EIO), "Failed to get SpcPeImageData object: %s",
                                        ERR_error_string(ERR_get_error(), NULL));
 
-        idc->data->value->value.sequence->data = TAKE_PTR(peidraw);
-        idc->data->value->value.sequence->length = peidrawsz;
+        if (!ASN1_STRING_set(idc->data->value->value.sequence, peidraw, peidrawsz))
+                return log_error_errno(SYNTHETIC_ERRNO(EIO), "Failed to set ASN1_STRING data.");
+
         idc->messageDigest->digestAlgorithm->algorithm = OBJ_nid2obj(NID_sha256);
         if (!idc->messageDigest->digestAlgorithm->algorithm)
                 return log_error_errno(SYNTHETIC_ERRNO(EIO), "Failed to get SHA256 object: %s",

--- a/src/shared/pkcs11-util.c
+++ b/src/shared/pkcs11-util.c
@@ -560,7 +560,11 @@ int pkcs11_token_read_public_key(
                         return log_debug_errno(SYNTHETIC_ERRNO(EIO), "Failed to init an EVP_PKEY_CTX for EC.");
 
                 OSSL_PARAM ec_params[8] = {
-                        OSSL_PARAM_octet_string(OSSL_PKEY_PARAM_PUB_KEY, os->data, os->length)
+                        /* We need to drop the const from the data param, because ec_params is
+                         * modified below. But we'll not modify ec_params[0]. */
+                        OSSL_PARAM_octet_string(OSSL_PKEY_PARAM_PUB_KEY,
+                                                (unsigned char *) ASN1_STRING_get0_data(os),
+                                                ASN1_STRING_length(os)),
                 };
 
                 _cleanup_free_ void *order = NULL, *p = NULL, *a = NULL, *b = NULL, *generator = NULL;
@@ -663,13 +667,10 @@ int pkcs11_token_read_x509_certificate(
                 CK_OBJECT_HANDLE object,
                 X509 **ret_cert) {
 
-        _cleanup_free_ char *t = NULL;
         CK_ATTRIBUTE attribute = {
                 .type = CKA_VALUE
         };
         CK_RV rv;
-        _cleanup_(X509_freep) X509 *x509 = NULL;
-        X509_NAME *name = NULL;
         int r;
 
         assert(ret_cert);
@@ -695,15 +696,15 @@ int pkcs11_token_read_x509_certificate(
                                        "Failed to read X.509 certificate data off token: %s", sym_p11_kit_strerror(rv));
 
         const unsigned char *p = attribute.pValue;
-        x509 = d2i_X509(NULL, &p, attribute.ulValueLen);
+        _cleanup_(X509_freep) X509 *x509 = d2i_X509(NULL, &p, attribute.ulValueLen);
         if (!x509)
                 return log_debug_errno(SYNTHETIC_ERRNO(EBADMSG), "Failed to parse X.509 certificate.");
 
-        name = X509_get_subject_name(x509);
+        const X509_NAME *name = X509_get_subject_name(x509);
         if (!name)
                 return log_debug_errno(SYNTHETIC_ERRNO(EBADMSG), "Failed to acquire X.509 subject name.");
 
-        t = X509_NAME_oneline(name, NULL, 0);
+        _cleanup_free_ char *t = X509_NAME_oneline(name, NULL, 0);
         if (!t)
                 return log_debug_errno(SYNTHETIC_ERRNO(EIO), "Failed to format X.509 subject name as string.");
 


### PR DESCRIPTION
Various types have been made opaque, so we need to use some accessor functions.