### PR TITLE
edit-util: do not assume the editor can handle +LINE

### DIFF
--- a/src/shared/edit-util.c
+++ b/src/shared/edit-util.c
@@ -260,13 +260,6 @@ static int run_editor_child(const EditFileContext *context) {
                 }
         }
 
-        if (context->n_files == 1 && context->files[0].line > 1) {
-                /* If editing a single file only, use the +LINE syntax to put cursor on the right line */
-                r = strv_extendf(&args, "+%u", context->files[0].line);
-                if (r < 0)
-                        return log_oom();
-        }
-
         FOREACH_ARRAY(i, context->files, context->n_files) {
                 r = strv_extend(&args, i->temp);
                 if (r < 0)


### PR DESCRIPTION
If we're checking $EDITOR and trying to use an arbitrary list of text editors we shouldn't just assume they know how to handle the +LINE notation for jumping to a line in the specified file.

Nano and Ed can handle it, but require that the line number is given before the file. Vim and Neovim can take it as any positional argument and just assume the last file specified was the intended target. Vi cannot handle a line number specifier at all.

There's nothing that states the $EDITOR has to take anything other than a list of file names. Even that isn't really written anywhere. The latest version of IEEE Std 1003.1-2024 does not indicate that the two required utilities (vi and ex) need to support this functionality.