### PR TITLE
mkosi: update fedora commit reference to 207e2d004468bf79a8bd78182d9b10956edf45c7

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -39,7 +39,7 @@ jobs:
   trigger: pull_request
   fmf_url: https://src.fedoraproject.org/rpms/systemd
   # This is automatically updated by tools/fetch-distro.py --update fedora
-  fmf_ref: 23a1c1fed99e152d9c498204175a7643371a822c
+  fmf_ref: 207e2d004468bf79a8bd78182d9b10956edf45c7
   targets:
   - fedora-rawhide-x86_64
   # testing-farm in the Fedora repository is explicitly configured to use testing-farm bare metal runners as

--- a/mkosi/mkosi.pkgenv/mkosi.conf.d/centos-fedora.conf
+++ b/mkosi/mkosi.pkgenv/mkosi.conf.d/centos-fedora.conf
@@ -9,5 +9,5 @@ Profiles=!hyperscale
 Environment=
         GIT_URL=https://src.fedoraproject.org/rpms/systemd.git
         GIT_BRANCH=rawhide
-        GIT_COMMIT=23a1c1fed99e152d9c498204175a7643371a822c
+        GIT_COMMIT=207e2d004468bf79a8bd78182d9b10956edf45c7
         PKG_SUBDIR=fedora


### PR DESCRIPTION
* 207e2d0044 Stop building support for openssl engines
* 36a234147f Upload sources
* 3681163f81 Version 260.1
* 8f4f0f58e3 Version 260
* e3fab23aa0 Version 260~rc4
* e4c1c2100b Version 260~rc3
* 453696813e Fix typo in unit name in %post scriptlet
* 154edb7cdb Silence false positive "HWID match failed, no DT blob" error (rhbz#2444759)
* 03b6637c35 riscv64 port has LTO disabled
* ce1dec6a40 Version 260~rc2
* 809049777c Add patch for symlink creation error
* 6ff27708f7 Enable getty@.service through presets
* ba7807fbce Drop scriptlet for upgrades from versions <253
* 455f277188 Move support for tpm2 to systemd-udev subpackage
* 0183bc784e Version 260~rc1