### PR TITLE
meson: add link-osc-context-dropin option

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -232,7 +232,12 @@ if shellprofiledir == ''
         shellprofiledir = sysconfdir / 'profile.d'
 endif
 conf.set10('LINK_SHELL_EXTRA_DROPIN', shellprofiledir != 'no' and not shellprofiledir.startswith('/usr/'))
-conf.set10('LINK_OSC_CONTEXT_DROPIN', shellprofiledir != 'no' and not shellprofiledir.startswith('/usr/'))
+link_osc_context_dropin = get_option('link-osc-context-dropin')
+if link_osc_context_dropin == 'auto'
+        conf.set10('LINK_OSC_CONTEXT_DROPIN', shellprofiledir != 'no' and not shellprofiledir.startswith('/usr/'))
+else
+        conf.set10('LINK_OSC_CONTEXT_DROPIN', link_osc_context_dropin != 'false')
+endif
 conf.set('SHELLPROFILEDIR', shellprofiledir, description : 'shell profile directory')
 
 memory_accounting_default = get_option('memory-accounting-default')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -237,6 +237,8 @@ option('libcryptsetup-plugins-dir', type : 'string',
        description : 'directory for libcryptsetup plugins')
 option('shellprofiledir', type : 'string',
        description : 'directory for Shell profile drop-ins ["no" disables]')
+option('link-osc-context-dropin', type : 'combo', choices : ['auto', 'true', 'false'], value: 'auto',
+       description : 'control whether to install osc context shell profile dropin')
 option('docdir', type : 'string',
        description : 'documentation directory')
 option('install-sysconfdir', type : 'combo', choices : ['true', 'no-samples', 'false'], value : 'true',


### PR DESCRIPTION
There's some terminal that that does support OSC 3008 standard. In such case, having /etc/profile.d/80-systemd-osc-context.sh will give people bad experience.

Add a new option, link-osc-context-dropin, to give distributions a choice to disable installing it.