### PR TITLE
vmspawn: native QMP over varlink upgrade for io.systemd.QemuMachineInstance.AcquireQMP

### DIFF
--- a/src/shared/qmp-client.c
+++ b/src/shared/qmp-client.c
@@ -294,10 +294,17 @@ static bool qmp_client_handle_disconnect(QmpClient *c) {
         if (c->defer_event_source)
                 (void) sd_event_source_set_enabled(c->defer_event_source, SD_EVENT_OFF);
 
-        qmp_client_fail_pending(c, -ECONNRESET);
-        qmp_client_emit_synthetic_shutdown(c);
+        /* Fire the disconnect callback BEFORE failing pending commands: consumers may need
+         * to tear down per-command state (for example, proxies tracking outstanding
+         * commands via weak back-pointers into their slot userdata) before the slot
+         * callbacks fire with -ECONNRESET. Firing in the reverse order would have the
+         * slot callbacks run on consumer state that hasn't been prepared for a teardown
+         * yet. */
         if (c->disconnect_callback)
                 c->disconnect_callback(c, c->disconnect_userdata);
+
+        qmp_client_fail_pending(c, -ECONNRESET);
+        qmp_client_emit_synthetic_shutdown(c);
 
         return true;
 }

--- a/src/shared/qmp-client.c
+++ b/src/shared/qmp-client.c
@@ -114,7 +114,7 @@ static void qmp_client_dispatch_event(QmpClient *c, sd_json_variant *v) {
         if (r < 0)
                 return;
 
-        r = c->event_callback(c, p.event, p.data, c->event_userdata);
+        r = c->event_callback(c, p.event, p.data, v, c->event_userdata);
         if (r < 0)
                 json_stream_log_errno(&c->stream, r, "Event callback returned error, ignoring: %m");
 }
@@ -277,7 +277,7 @@ static void qmp_client_emit_synthetic_shutdown(QmpClient *c) {
                 return;
         }
 
-        r = c->event_callback(c, "SHUTDOWN", data, c->event_userdata);
+        r = c->event_callback(c, "SHUTDOWN", data, /* raw= */ NULL, c->event_userdata);
         if (r < 0)
                 json_stream_log_errno(&c->stream, r, "Event callback returned error, ignoring: %m");
 }

--- a/src/shared/qmp-client.c
+++ b/src/shared/qmp-client.c
@@ -56,6 +56,7 @@ struct QmpClient {
 
         QmpClientState state;
         sd_json_variant *current;  /* most recently parsed message, pending dispatch */
+        sd_json_variant *greeting; /* cached greeting variant, for replay via get_greeting() */
 };
 
 static void qmp_slot_hash_func(const QmpSlot *p, struct siphash *state) {
@@ -342,6 +343,10 @@ static int qmp_client_dispatch_handshake(QmpClient *c) {
                         return json_stream_log_errno(&c->stream, SYNTHETIC_ERRNO(EPROTO),
                                                      "Expected QMP greeting, got something else");
 
+                /* Stash a ref for later replay to consumers that wrap additional
+                 * clients over this connection. */
+                c->greeting = sd_json_variant_ref(v);
+
                 c->state = QMP_CLIENT_HANDSHAKE_GREETING_RECEIVED;
 
                 /* Fall through to immediately send capabilities */
@@ -563,6 +568,7 @@ static void qmp_client_clear(QmpClient *c) {
         qmp_client_handle_disconnect(c);
         qmp_client_detach_event(c);
         qmp_client_clear_current(c);
+        c->greeting = sd_json_variant_unref(c->greeting);
         json_stream_done(&c->stream);
         c->slots = set_free(c->slots);
 }
@@ -809,6 +815,11 @@ sd_event* qmp_client_get_event(QmpClient *c) {
 unsigned qmp_client_next_fdset_id(QmpClient *c) {
         assert(c);
         return c->next_fdset_id++;
+}
+
+sd_json_variant* qmp_client_get_greeting(QmpClient *c) {
+        assert(c);
+        return c->greeting;
 }
 
 bool qmp_schema_has_member(sd_json_variant *schema, const char *member_name) {

--- a/src/shared/qmp-client.c
+++ b/src/shared/qmp-client.c
@@ -730,30 +730,30 @@ static int qmp_client_stage_fds(QmpClient *c, QmpClientArgs *args) {
         return 0;
 }
 
-int qmp_client_invoke(
+uint64_t qmp_client_reserve_id(QmpClient *c) {
+        assert(c);
+        return c->next_id++;
+}
+
+int qmp_client_invoke_raw(
                 QmpClient *c,
-                const char *command,
+                sd_json_variant *cmd,
+                uint64_t id,
                 QmpClientArgs *args,
                 qmp_command_callback_t callback,
                 void *userdata) {
 
-        _cleanup_(sd_json_variant_unrefp) sd_json_variant *cmd = NULL;
         _cleanup_free_ QmpSlot *pending = NULL;
         /* Closes any fds in args not yet handed to the stream on every early-return path;
          * TAKE_PTR()'d on the success path below once stage_fds has consumed them. */
         _cleanup_(qmp_client_args_close_fdsp) QmpClientArgs *fds_owner = args;
-        uint64_t id;
         int r;
 
         assert(c);
-        assert(command);
+        assert(cmd);
         assert(callback);
 
         r = qmp_client_ensure_running(c);
-        if (r < 0)
-                return r;
-
-        r = qmp_client_build_command(c, command, args ? args->arguments : NULL, &cmd, &id);
         if (r < 0)
                 return r;
 
@@ -793,6 +793,39 @@ int qmp_client_invoke(
         TAKE_PTR(pending);
         TAKE_PTR(fds_owner);
         return 0;
+}
+
+int qmp_client_invoke(
+                QmpClient *c,
+                const char *command,
+                QmpClientArgs *args,
+                qmp_command_callback_t callback,
+                void *userdata) {
+
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *cmd = NULL;
+        /* Close any fds in args on every early-return path below (ensure_running,
+         * build_command); on the success path TAKE_PTR hands ownership to
+         * qmp_client_invoke_raw's own cleanup hook. */
+        _cleanup_(qmp_client_args_close_fdsp) QmpClientArgs *fds_owner = args;
+        uint64_t id;
+        int r;
+
+        assert(c);
+        assert(command);
+        assert(callback);
+
+        /* Drain the handshake first so build_command's next_id sits after the ids the
+         * handshake itself consumed for qmp_capabilities. */
+        r = qmp_client_ensure_running(c);
+        if (r < 0)
+                return r;
+
+        r = qmp_client_build_command(c, command, args ? args->arguments : NULL, &cmd, &id);
+        if (r < 0)
+                return r;
+
+        TAKE_PTR(fds_owner);
+        return qmp_client_invoke_raw(c, cmd, id, args, callback, userdata);
 }
 
 void qmp_client_bind_event(QmpClient *c, qmp_event_callback_t callback, void *userdata) {

--- a/src/shared/qmp-client.c
+++ b/src/shared/qmp-client.c
@@ -488,6 +488,11 @@ bool qmp_client_is_disconnected(QmpClient *c) {
         return c->state == QMP_CLIENT_DISCONNECTED;
 }
 
+bool qmp_client_is_running(QmpClient *c) {
+        assert(c);
+        return c->state == QMP_CLIENT_RUNNING;
+}
+
 /* Map our state to the transport phase used for POLLIN / salvage / timeout decisions. */
 static JsonStreamPhase qmp_client_phase(void *userdata) {
         QmpClient *c = ASSERT_PTR(userdata);

--- a/src/shared/qmp-client.h
+++ b/src/shared/qmp-client.h
@@ -54,6 +54,9 @@ bool qmp_client_is_idle(QmpClient *c);
 /* True iff the connection is dead. Stable terminal state — once set, it stays set. */
 bool qmp_client_is_disconnected(QmpClient *c);
 
+/* True iff the handshake has completed and the client is ready to forward commands. */
+bool qmp_client_is_running(QmpClient *c);
+
 /* Async send. Returns 0 on send (callback will fire later), negative errno on failure. */
 int qmp_client_invoke(
                 QmpClient *client,

--- a/src/shared/qmp-client.h
+++ b/src/shared/qmp-client.h
@@ -72,6 +72,12 @@ QmpClient* qmp_client_unref(QmpClient *p);
 
 DEFINE_TRIVIAL_CLEANUP_FUNC(QmpClient *, qmp_client_unref);
 
+/* Borrowed pointer to the QMP greeting variant received from QEMU during handshake, or
+ * NULL if not yet received. Consumers that need to replay the greeting (e.g. when
+ * wrapping additional clients over the same underlying connection) can use this to
+ * reproduce exactly what QEMU sent without synthesising one. */
+sd_json_variant* qmp_client_get_greeting(QmpClient *client);
+
 /* Returns true iff any object entry in schema (result of query-qmp-schema) has a member with this
  * name. QEMU's introspection replaces type names with opaque numeric ids, so lookup-by-type-name is
  * impossible — but member names are real. Use only when the member name is unique in the schema. */

--- a/src/shared/qmp-client.h
+++ b/src/shared/qmp-client.h
@@ -3,10 +3,16 @@
 
 #include "shared-forward.h"
 
+/* `raw` is the full event variant including the "timestamp" field (and anything QEMU may
+ * attach in future), or NULL for internally-synthesised events such as the SHUTDOWN that
+ * fires when the QMP transport dies. Consumers that want to forward the original wire
+ * message verbatim (e.g. proxies) can enqueue `raw` directly instead of reconstructing it
+ * from `event` + `data`. */
 typedef int (*qmp_event_callback_t)(
                 QmpClient *client,
                 const char *event,
                 sd_json_variant *data,
+                sd_json_variant *raw,
                 void *userdata);
 
 typedef void (*qmp_disconnect_callback_t)(

--- a/src/shared/qmp-client.h
+++ b/src/shared/qmp-client.h
@@ -65,6 +65,22 @@ int qmp_client_invoke(
                 qmp_command_callback_t callback,
                 void *userdata);
 
+/* Allocate and reserve an internal id for a command that the caller will build themselves.
+ * Used by consumers that need to construct the full command variant outside the client and
+ * have the response correlate back through qmp_client_invoke_raw(). */
+uint64_t qmp_client_reserve_id(QmpClient *client);
+
+/* Async send of a pre-built command. The cmd variant must already contain "execute" (or
+ * "exec-oob") and "id": <id> fields — the id is the value previously obtained from
+ * qmp_client_reserve_id(). Same return contract as qmp_client_invoke(). */
+int qmp_client_invoke_raw(
+                QmpClient *client,
+                sd_json_variant *cmd,
+                uint64_t id,
+                QmpClientArgs *args,
+                qmp_command_callback_t callback,
+                void *userdata);
+
 void qmp_client_bind_event(QmpClient *c, qmp_event_callback_t callback, void *userdata);
 void qmp_client_bind_disconnect(QmpClient *c, qmp_disconnect_callback_t callback, void *userdata);
 int qmp_client_set_description(QmpClient *c, const char *description);

--- a/src/shared/varlink-io.systemd.QemuMachineInstance.c
+++ b/src/shared/varlink-io.systemd.QemuMachineInstance.c
@@ -6,12 +6,8 @@ static SD_VARLINK_DEFINE_METHOD_FULL(
                 AcquireQMP,
                 SD_VARLINK_REQUIRES_UPGRADE);
 
-static SD_VARLINK_DEFINE_ERROR(AlreadyAcquired);
-
 SD_VARLINK_DEFINE_INTERFACE(
                 io_systemd_QemuMachineInstance,
                 "io.systemd.QemuMachineInstance",
                 SD_VARLINK_SYMBOL_COMMENT("Acquire a direct QMP connection to the QEMU instance via protocol upgrade"),
-                &vl_method_AcquireQMP,
-                SD_VARLINK_SYMBOL_COMMENT("A QMP connection has already been acquired by another client"),
-                &vl_error_AlreadyAcquired);
+                &vl_method_AcquireQMP);

--- a/src/test/test-qmp-client.c
+++ b/src/test/test-qmp-client.c
@@ -141,6 +141,7 @@ static int test_event_callback(
                 QmpClient *client,
                 const char *event,
                 sd_json_variant *data,
+                sd_json_variant *raw,
                 void *userdata) {
 
         bool *event_received = ASSERT_PTR(userdata);

--- a/src/vmspawn/meson.build
+++ b/src/vmspawn/meson.build
@@ -8,6 +8,7 @@ vmspawn_sources = files(
         'vmspawn.c',
         'vmspawn-qemu-config.c',
         'vmspawn-qmp.c',
+        'vmspawn-qmp-proxy.c',
         'vmspawn-varlink.c',
         'vmspawn-settings.c',
         'vmspawn-scope.c',

--- a/src/vmspawn/vmspawn-qmp-proxy.c
+++ b/src/vmspawn/vmspawn-qmp-proxy.c
@@ -1,0 +1,594 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include "sd-event.h"
+#include "sd-json.h"
+#include "sd-varlink.h"
+
+#include "alloc-util.h"
+#include "errno-util.h"
+#include "fd-util.h"
+#include "json-stream.h"
+#include "json-util.h"
+#include "list.h"
+#include "log.h"
+#include "qmp-client.h"
+#include "string-util.h"
+#include "vmspawn-qmp.h"
+#include "vmspawn-qmp-proxy.h"
+
+/* Cap on concurrent AcquireQMP upgrades. Each acquirer owns a 16 MiB output buffer
+ * in the worst case (see json_stream buffer_max). Sixteen is plenty for anything
+ * real; guards against a rogue or buggy client exhausting memory. */
+#define VMSPAWN_QMP_PROXY_MAX 16U
+
+/* Message that QEMU sends when a non-qmp_capabilities command is attempted during
+ * capability negotiation. We reproduce it byte-for-byte so QMP clients that match on
+ * the description (there shouldn't be any, but belt+braces) keep working. */
+#define QMP_CAP_NEGOTIATION_DESC                                               \
+        "Expecting capabilities negotiation with 'qmp_capabilities'"
+
+/* Forward-declare the typedef before the struct body so the self-referential
+ * LIST_FIELDS(ProxyCmdCtx, ...) inside the struct resolves against the typedef
+ * instead of collapsing into an implicit-int declaration. */
+typedef struct ProxyCmdCtx ProxyCmdCtx;
+
+/* Per-outstanding-command bookkeeping. Created when the proxy forwards an acquirer's
+ * command to the shared QmpClient; freed when the matching response arrives (or when
+ * the acquirer dies first, in which case `aq` is NULLed and the slot callback frees
+ * this). */
+struct ProxyCmdCtx {
+        AcquiredQmp *aq;            /* weak; set to NULL on aq teardown */
+        sd_json_variant *caller_id; /* owned; NULL iff had_caller_id == false */
+        bool had_caller_id;         /* distinguishes "absent" from "null" */
+        LIST_FIELDS(ProxyCmdCtx, pending);
+};
+
+struct AcquiredQmp {
+        VmspawnQmpBridge *bridge;            /* weak; for bridge->acquired list removal */
+        JsonStream stream;                   /* delimiter "\r\n" for native QMP */
+        sd_event_source *defer_event_source; /* armed after any step that made progress */
+        bool caps_negotiated;                /* acquirer has sent qmp_capabilities */
+        LIST_HEAD(ProxyCmdCtx, pending);     /* ProxyCmdCtx entries still in flight */
+        LIST_FIELDS(AcquiredQmp, acquired);
+};
+
+static ProxyCmdCtx* proxy_cmd_ctx_free(ProxyCmdCtx *ctx) {
+        if (!ctx)
+                return NULL;
+
+        /* If we're being freed while still linked, someone forgot to LIST_REMOVE us;
+         * assert instead of silently leaking list state. */
+        assert(ctx->aq == NULL);
+
+        sd_json_variant_unref(ctx->caller_id);
+        return mfree(ctx);
+}
+
+DEFINE_TRIVIAL_CLEANUP_FUNC(ProxyCmdCtx*, proxy_cmd_ctx_free);
+
+static AcquiredQmp* acquired_qmp_free(AcquiredQmp *aq) {
+        ProxyCmdCtx *ctx;
+
+        if (!aq)
+                return NULL;
+
+        /* Orphan every still-outstanding command so the QmpClient's slot callback
+         * (which may fire later, up to and including the -ECONNRESET sweep) drops the
+         * response instead of trying to write into our freed stream. */
+        while ((ctx = aq->pending)) {
+                LIST_REMOVE(pending, aq->pending, ctx);
+                ctx->aq = NULL;
+        }
+
+        if (aq->bridge) {
+                LIST_REMOVE(acquired, aq->bridge->acquired, aq);
+                assert(aq->bridge->n_acquired > 0);
+                aq->bridge->n_acquired--;
+        }
+
+        aq->defer_event_source = sd_event_source_disable_unref(aq->defer_event_source);
+        json_stream_done(&aq->stream);
+        return mfree(aq);
+}
+
+DEFINE_TRIVIAL_CLEANUP_FUNC(AcquiredQmp*, acquired_qmp_free);
+
+static JsonStreamPhase on_acquired_phase(void *userdata) {
+        AcquiredQmp *aq = ASSERT_PTR(userdata);
+
+        /* Any queued output waiting to be written? */
+        if (aq->stream.output_buffer_size > aq->stream.output_buffer_index ||
+            aq->stream.output_queue)
+                return JSON_STREAM_PHASE_PENDING_OUTPUT;
+
+        /* Otherwise we're waiting for the next acquirer-side command (or EOF). */
+        return JSON_STREAM_PHASE_READING;
+}
+
+/* Rebuild the acquirer's command object with a fresh id, copying every other key
+ * verbatim. QMP's id field may be any JSON value on the wire; since the QmpClient
+ * uses uint64_t ids internally we force the rewritten object to carry an unsigned
+ * integer. */
+static int rewrite_command_with_internal_id(
+                sd_json_variant *src,
+                uint64_t new_id,
+                sd_json_variant **ret) {
+
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *out = NULL;
+        const char *k;
+        sd_json_variant *w;
+        int r;
+
+        assert(src);
+        assert(ret);
+
+        JSON_VARIANT_OBJECT_FOREACH(k, w, src) {
+                if (streq(k, "id"))
+                        continue;
+
+                r = sd_json_variant_set_fieldb(
+                                &out, k,
+                                SD_JSON_BUILD_VARIANT(w));
+                if (r < 0)
+                        return r;
+        }
+
+        r = sd_json_variant_set_fieldb(
+                        &out, "id",
+                        SD_JSON_BUILD_UNSIGNED(new_id));
+        if (r < 0)
+                return r;
+
+        *ret = TAKE_PTR(out);
+        return 0;
+}
+
+static int on_proxy_reply(
+                QmpClient *client,
+                sd_json_variant *result,
+                const char *error_desc,
+                int error,
+                void *userdata) {
+
+        _cleanup_(proxy_cmd_ctx_freep) ProxyCmdCtx *ctx = ASSERT_PTR(userdata);
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *response = NULL;
+        AcquiredQmp *aq = ctx->aq;
+        int r;
+
+        assert(client);
+
+        /* Acquirer already gone — drop. Unlinking from aq->pending happens in
+         * acquired_qmp_free(); we just need to free ourselves. */
+        if (!aq)
+                return 0;
+
+        LIST_REMOVE(pending, aq->pending, ctx);
+        ctx->aq = NULL;
+
+        /* Caller didn't want to be told — honour that. (Matches native QMP: a
+         * command without an id gets no response.) */
+        if (!ctx->had_caller_id)
+                return 0;
+
+        if (error == 0) {
+                /* Success: {"return": <result or {}>, "id": <caller id>} */
+                r = sd_json_buildo(
+                                &response,
+                                SD_JSON_BUILD_PAIR_CONDITION(!!result, "return", SD_JSON_BUILD_VARIANT(result)),
+                                SD_JSON_BUILD_PAIR_CONDITION(!result, "return", SD_JSON_BUILD_EMPTY_OBJECT),
+                                SD_JSON_BUILD_PAIR_VARIANT("id", ctx->caller_id));
+                if (r < 0)
+                        return log_warning_errno(r, "Failed to build QMP proxy success response, dropping: %m");
+        } else {
+                /* Error. QEMU's error class is always "GenericError" in practice (see
+                 * qmp-error-desc-guarantees.md in the project notes); the existing
+                 * qmp_command_callback_t contract drops the original class and keeps
+                 * only the desc. Reconstruct with GenericError — QMP spec forbids
+                 * clients from parsing class values anyway. Transport errors
+                 * (ERRNO_IS_DISCONNECT(error)) are short-lived: the bridge is about
+                 * to be torn down and the acquirer sees EOF from the drain path, so
+                 * emitting a synthetic error here is courtesy, not contract. */
+                const char *desc = error_desc ?: "unspecified error";
+                r = sd_json_buildo(
+                                &response,
+                                SD_JSON_BUILD_PAIR(
+                                        "error",
+                                        SD_JSON_BUILD_OBJECT(
+                                                SD_JSON_BUILD_PAIR_STRING("class", "GenericError"),
+                                                SD_JSON_BUILD_PAIR_STRING("desc", desc))),
+                                SD_JSON_BUILD_PAIR_VARIANT("id", ctx->caller_id));
+                if (r < 0)
+                        return log_warning_errno(r, "Failed to build QMP proxy error response, dropping: %m");
+        }
+
+        r = json_stream_enqueue(&aq->stream, response);
+        if (r < 0)
+                log_warning_errno(r, "Failed to enqueue QMP proxy response to acquirer, dropping: %m");
+
+        return 0;
+}
+
+static int acquired_qmp_enqueue_error(
+                AcquiredQmp *aq,
+                const char *error_class,
+                const char *desc,
+                sd_json_variant *caller_id,
+                bool had_caller_id) {
+
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *response = NULL;
+        int r;
+
+        assert(aq);
+        assert(error_class);
+        assert(desc);
+
+        r = sd_json_buildo(
+                        &response,
+                        SD_JSON_BUILD_PAIR(
+                                "error",
+                                SD_JSON_BUILD_OBJECT(
+                                        SD_JSON_BUILD_PAIR_STRING("class", error_class),
+                                        SD_JSON_BUILD_PAIR_STRING("desc", desc))),
+                        SD_JSON_BUILD_PAIR_CONDITION(had_caller_id, "id", SD_JSON_BUILD_VARIANT(caller_id)));
+        if (r < 0)
+                return r;
+
+        return json_stream_enqueue(&aq->stream, response);
+}
+
+static int acquired_qmp_enqueue_empty_return(
+                AcquiredQmp *aq,
+                sd_json_variant *caller_id,
+                bool had_caller_id) {
+
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *response = NULL;
+        int r;
+
+        assert(aq);
+
+        r = sd_json_buildo(
+                        &response,
+                        SD_JSON_BUILD_PAIR("return", SD_JSON_BUILD_EMPTY_OBJECT),
+                        SD_JSON_BUILD_PAIR_CONDITION(had_caller_id, "id", SD_JSON_BUILD_VARIANT(caller_id)));
+        if (r < 0)
+                return r;
+
+        return json_stream_enqueue(&aq->stream, response);
+}
+
+/* Parse one QMP command from the acquirer and dispatch it.
+ *
+ * Returns 0 on success (including the cases where we replied with an error). Returns
+ * a negative errno only if the acquirer should be torn down (e.g. -ENOBUFS from a
+ * flooded output buffer, or malformed JSON). */
+static int acquired_qmp_parse_one(AcquiredQmp *aq, sd_json_variant *cmd) {
+        int r;
+
+        assert(aq);
+        assert(cmd);
+
+        /* Distinguish "id absent" from "id present but JSON null". Both are legal QMP;
+         * the former means the caller doesn't want a response, the latter carries null
+         * back as the correlation value. */
+        sd_json_variant *id_variant = sd_json_variant_by_key(cmd, "id");
+        bool had_caller_id = id_variant != NULL;
+        /* Take an independent ref so the rewritten command we build below can unref
+         * the original without affecting ctx->caller_id's lifetime. */
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *caller_id =
+                sd_json_variant_ref(id_variant);
+
+        /* Cap-negotiation gate, mirroring QEMU monitor/qmp.c semantics exactly:
+         *
+         *   a) execute=="qmp_capabilities" (with or without arguments): short-circuit
+         *      locally with an empty return and flip into full command mode. QEMU's
+         *      own monitor is already past negotiation (vmspawn did that at startup),
+         *      so forwarding would hit CommandNotFound in full mode.
+         *
+         *   b) execute=="<other>" or exec-oob=="<any>" while still in negotiation
+         *      mode: respond with CommandNotFound and the specific desc that QEMU
+         *      substitutes in monitor_qmp_dispatcher_co when a caps-mode monitor
+         *      rejects a non-qmp_capabilities command.
+         *
+         *   c) Anything else (no command key, non-string command, unexpected keys,
+         *      clashing execute+exec-oob) is a shape error. QEMU emits a very
+         *      specific GenericError desc for each of those cases; rather than
+         *      reimplement its shape validator, we forward the message unchanged and
+         *      let QEMU produce the exact error — its monitor state doesn't matter
+         *      for shape validation, so the wire response is identical to what a
+         *      fresh QMP session would produce.
+         *
+         *   d) Post-caps: forward everything (apart from qmp_capabilities, case a).
+         */
+        sd_json_variant *execute = sd_json_variant_by_key(cmd, "execute");
+        sd_json_variant *exec_oob = sd_json_variant_by_key(cmd, "exec-oob");
+        bool execute_is_string = execute && sd_json_variant_is_string(execute);
+
+        if (execute_is_string &&
+            streq(sd_json_variant_string(execute), "qmp_capabilities")) {
+                aq->caps_negotiated = true;
+                return acquired_qmp_enqueue_empty_return(aq, caller_id, had_caller_id);
+        }
+
+        if (!aq->caps_negotiated &&
+            (execute_is_string ||
+             (exec_oob && sd_json_variant_is_string(exec_oob))))
+                return acquired_qmp_enqueue_error(
+                                aq, "CommandNotFound", QMP_CAP_NEGOTIATION_DESC,
+                                caller_id, had_caller_id);
+
+        /* Remap id, forward to the shared QmpClient. */
+        uint64_t internal_id = qmp_client_reserve_id(aq->bridge->qmp);
+
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *rewritten = NULL;
+        r = rewrite_command_with_internal_id(cmd, internal_id, &rewritten);
+        if (r < 0)
+                return acquired_qmp_enqueue_error(
+                                aq, "GenericError",
+                                "Failed to rewrite QMP command for forwarding",
+                                caller_id, had_caller_id);
+
+        _cleanup_(proxy_cmd_ctx_freep) ProxyCmdCtx *ctx = new(ProxyCmdCtx, 1);
+        if (!ctx)
+                return -ENOMEM;
+
+        *ctx = (ProxyCmdCtx) {
+                .aq = aq,
+                .caller_id = TAKE_PTR(caller_id),
+                .had_caller_id = had_caller_id,
+        };
+
+        LIST_PREPEND(pending, aq->pending, ctx);
+
+        r = qmp_client_invoke_raw(
+                        aq->bridge->qmp, rewritten, internal_id,
+                        /* args= */ NULL, on_proxy_reply, ctx);
+        if (r < 0) {
+                LIST_REMOVE(pending, aq->pending, ctx);
+                ctx->aq = NULL; /* satisfy the proxy_cmd_ctx_free() assert */
+
+                if (r == -ENOTCONN)
+                        /* Shared QmpClient just died. Acquirer will see EOF shortly
+                         * via the bridge's disconnect drain; report a best-effort
+                         * error and keep going. */
+                        return acquired_qmp_enqueue_error(
+                                        aq, "GenericError",
+                                        "QMP backend is no longer connected",
+                                        ctx->caller_id, ctx->had_caller_id);
+
+                return r;
+        }
+
+        /* On successful forward ctx is owned by the QmpClient slot (via its userdata)
+         * and will be freed when on_proxy_reply fires. */
+        TAKE_PTR(ctx);
+        return 0;
+}
+
+/* One step per call: write → parse-and-dispatch → read → disconnect-test. Matches
+ * qmp_client_process()'s shape and return contract:
+ *   > 0 — made progress, caller should re-enable the defer source so we fire again
+ *   = 0 — idle, wait for the next I/O event
+ *   < 0 — fatal, acquirer torn down
+ *
+ * Any failure path falls through the cleanup attribute and frees aq; successful
+ * paths TAKE_PTR. The defer_event_source is armed/disarmed based on the progress
+ * indicator, mirroring how qmp-client and sd-varlink keep draining work that is
+ * buffered internally (where level-triggered I/O won't re-fire on its own). */
+static int acquired_qmp_process(AcquiredQmp *aq_in) {
+        _cleanup_(acquired_qmp_freep) AcquiredQmp *aq = ASSERT_PTR(aq_in);
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *msg = NULL;
+        int r;
+
+        /* 1. Write — drain output buffer */
+        r = json_stream_write(&aq->stream);
+        if (r < 0) {
+                log_debug_errno(r, "QMP acquirer write failed, disconnecting: %m");
+                return r;
+        }
+        if (r > 0)
+                goto finish;
+
+        /* 2. Parse + dispatch — handle one complete inbound message if buffered */
+        r = json_stream_parse(&aq->stream, &msg);
+        if (r < 0) {
+                log_debug_errno(r, "QMP acquirer sent malformed JSON, disconnecting: %m");
+                return r;
+        }
+        if (r > 0) {
+                r = acquired_qmp_parse_one(aq, msg);
+                if (r < 0) {
+                        log_debug_errno(r, "QMP acquirer dispatch failed, disconnecting: %m");
+                        return r;
+                }
+                r = 1; /* parse + dispatch counts as progress */
+                goto finish;
+        }
+
+        /* 3. Read — fill input buffer from fd */
+        r = json_stream_read(&aq->stream);
+        if (r < 0) {
+                log_debug_errno(r, "QMP acquirer read failed, disconnecting: %m");
+                return r;
+        }
+        if (r > 0)
+                goto finish;
+
+        /* 4. Test disconnect */
+        if (json_stream_should_disconnect(&aq->stream)) {
+                log_debug("QMP acquirer disconnected (peer closed)");
+                return -ECONNRESET;
+        }
+
+finish:
+        /* Arm the defer source if progress was made so the next event loop iteration
+         * calls us again to drain whatever follows. Disable it otherwise to avoid
+         * busy-looping when we're idle. */
+        if (aq->defer_event_source) {
+                int q = sd_event_source_set_enabled(aq->defer_event_source,
+                                                   r > 0 ? SD_EVENT_ON : SD_EVENT_OFF);
+                if (q < 0) {
+                        log_debug_errno(q, "Failed to toggle QMP acquirer defer source: %m");
+                        return q;
+                }
+        }
+
+        TAKE_PTR(aq);
+        return r;
+}
+
+static int on_acquired_dispatch(void *userdata) {
+        return acquired_qmp_process(userdata);
+}
+
+static int on_acquired_defer(sd_event_source *source, void *userdata) {
+        assert(source);
+        (void) acquired_qmp_process(userdata);
+        return 1;
+}
+
+void vmspawn_qmp_proxy_broadcast_event(
+                VmspawnQmpBridge *bridge,
+                sd_json_variant *raw,
+                const char *event,
+                sd_json_variant *data) {
+
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *synth = NULL;
+        int r;
+
+        assert(bridge);
+        assert(event);
+
+        if (!bridge->acquired)
+                return;
+
+        if (!raw) {
+                /* Synthetic event — reconstruct a minimal object. Acquirers tolerate
+                 * the missing timestamp (the QMP spec makes it optional). */
+                r = sd_json_buildo(
+                                &synth,
+                                SD_JSON_BUILD_PAIR_STRING("event", event),
+                                SD_JSON_BUILD_PAIR_CONDITION(!!data, "data", SD_JSON_BUILD_VARIANT(data)));
+                if (r < 0) {
+                        log_debug_errno(r, "Failed to build synthetic QMP event for proxy, dropping: %m");
+                        return;
+                }
+        }
+
+        LIST_FOREACH(acquired, aq, bridge->acquired) {
+                /* Mirror QEMU's monitor: events are suppressed until the acquirer has
+                 * completed its own qmp_capabilities negotiation. */
+                if (!aq->caps_negotiated)
+                        continue;
+
+                r = json_stream_enqueue(&aq->stream, raw ?: synth);
+                if (r < 0)
+                        log_debug_errno(r, "Failed to enqueue event for QMP acquirer, dropping: %m");
+        }
+}
+
+void vmspawn_qmp_proxy_drain(VmspawnQmpBridge *bridge) {
+        AcquiredQmp *aq;
+
+        if (!bridge)
+                return;
+
+        while ((aq = bridge->acquired))
+                acquired_qmp_free(aq);
+}
+
+int vmspawn_qmp_proxy_acquire(VmspawnQmpBridge *bridge, sd_varlink *link) {
+        _cleanup_close_ int input_fd = -EBADF, output_fd = -EBADF;
+        _cleanup_(acquired_qmp_freep) AcquiredQmp *aq = NULL;
+        sd_json_variant *greeting;
+        sd_event *event;
+        int r;
+
+        assert(bridge);
+        assert(link);
+
+        /* Refuse unless the shared QmpClient is in the RUNNING state: only then is the
+         * QEMU monitor in full command mode and the cached greeting available. Checking
+         * for "not running" (rather than just "disconnected") also defends against the
+         * theoretical case of AcquireQMP arriving during the bridge handshake — the
+         * varlink server isn't supposed to be up that early, but we don't rely on it. */
+        if (!qmp_client_is_running(bridge->qmp))
+                return sd_varlink_error(link, "io.systemd.MachineInstance.NotConnected", NULL);
+
+        greeting = qmp_client_get_greeting(bridge->qmp);
+        assert(greeting); /* RUNNING implies INITIAL was dispatched, which stashed it */
+
+        if (bridge->n_acquired >= VMSPAWN_QMP_PROXY_MAX)
+                return sd_varlink_error(link, "io.systemd.MachineInstance.NotSupported", NULL);
+
+        event = qmp_client_get_event(bridge->qmp);
+        if (!event)
+                return sd_varlink_error_errno(link, ENOTCONN);
+
+        /* Consume the upgrade. From here on `link` is closed by sd-varlink; we must
+         * not touch it again even on error paths — hence the separate error returns
+         * above. */
+        r = sd_varlink_reply_and_upgrade(link, /* parameters= */ NULL, &input_fd, &output_fd);
+        if (r < 0)
+                return log_warning_errno(r, "Failed to upgrade AcquireQMP varlink connection: %m");
+
+        aq = new(AcquiredQmp, 1);
+        if (!aq)
+                return -ENOMEM;
+
+        *aq = (AcquiredQmp) {
+                .bridge = bridge,
+        };
+
+        const JsonStreamParams params = {
+                .delimiter = "\r\n",
+                .phase     = on_acquired_phase,
+                .dispatch  = on_acquired_dispatch,
+                .userdata  = aq,
+        };
+
+        r = json_stream_init(&aq->stream, &params);
+        if (r < 0)
+                return log_warning_errno(r, "Failed to init JsonStream for QMP acquirer: %m");
+
+        /* json_stream_connect_fd_pair adopts the fds into the stream: even on partial
+         * failure (e.g. fstat inside attach_fds) the stream's input_fd/output_fd are
+         * already assigned, so subsequent json_stream_done closes them. Take the fds
+         * out of the local cleanup scope up front to prevent a double-close. */
+        r = json_stream_connect_fd_pair(&aq->stream, TAKE_FD(input_fd), TAKE_FD(output_fd));
+        if (r < 0)
+                return log_warning_errno(r, "Failed to attach upgraded fds to JsonStream: %m");
+
+        (void) json_stream_set_description(&aq->stream, "qmp-acquirer");
+
+        r = json_stream_attach_event(&aq->stream, event, SD_EVENT_PRIORITY_NORMAL);
+        if (r < 0)
+                return log_warning_errno(r, "Failed to attach QMP acquirer to event loop: %m");
+
+        /* Defer source re-fires the dispatch loop whenever the previous step made
+         * progress but there's no new I/O event to trigger the stream's io callback.
+         * Mirrors qmp_client_attach_event's pattern. */
+        r = sd_event_add_defer(event, &aq->defer_event_source, on_acquired_defer, aq);
+        if (r < 0)
+                return log_warning_errno(r, "Failed to add QMP acquirer defer source: %m");
+
+        r = sd_event_source_set_priority(aq->defer_event_source, SD_EVENT_PRIORITY_NORMAL);
+        if (r < 0)
+                return log_warning_errno(r, "Failed to set QMP acquirer defer priority: %m");
+
+        r = sd_event_source_set_enabled(aq->defer_event_source, SD_EVENT_OFF);
+        if (r < 0)
+                return log_warning_errno(r, "Failed to disable QMP acquirer defer source: %m");
+
+        (void) sd_event_source_set_description(aq->defer_event_source, "qmp-acquirer-defer");
+
+        /* Replay QEMU's real greeting so the acquirer can parse it like a native
+         * QMP connection. */
+        r = json_stream_enqueue(&aq->stream, greeting);
+        if (r < 0)
+                return log_warning_errno(r, "Failed to enqueue QMP greeting to acquirer: %m");
+
+        LIST_PREPEND(acquired, bridge->acquired, aq);
+        bridge->n_acquired++;
+        TAKE_PTR(aq);
+        return 0;
+}

--- a/src/vmspawn/vmspawn-qmp-proxy.h
+++ b/src/vmspawn/vmspawn-qmp-proxy.h
@@ -1,0 +1,42 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#pragma once
+
+#include "shared-forward.h"
+#include "vmspawn-qmp.h"
+
+/* AcquireQMP proxy: terminates each upgraded varlink connection and multiplexes it
+ * onto the bridge's shared QmpClient.
+ *
+ * Multiple acquirers may be active concurrently, alongside vmspawn's own internal QMP
+ * traffic. QMP uses the "id" field for request/response correlation; different
+ * acquirers will reuse the same id values and may collide with vmspawn's internal
+ * counter. The proxy solves this by rewriting ids on outbound commands (fresh id
+ * reserved from the shared QmpClient) and reversing the remap on matching responses
+ * so each acquirer sees its own id namespace.
+ *
+ * Events are fanned out to every acquirer that has completed its own
+ * qmp_capabilities negotiation — mirroring QEMU's native behaviour of suppressing
+ * events during cap-negotiation mode. */
+
+/* Handle the varlink-side AcquireQMP method. The handler has already verified that the
+ * caller requested the upgrade; this function performs the actual
+ * sd_varlink_reply_and_upgrade, adopts the returned fd pair, replays QEMU's greeting,
+ * and wires the new AcquiredQmp into the bridge. Returns 0 on success, in which case
+ * the caller must not touch `link` further (it's been closed by the upgrade). */
+int vmspawn_qmp_proxy_acquire(VmspawnQmpBridge *bridge, sd_varlink *link);
+
+/* Forward a QEMU event to every acquirer that has completed cap-negotiation. `raw` is
+ * the full event variant (preferred; includes the timestamp) or NULL for synthetic
+ * events (e.g. the SHUTDOWN emitted when the QMP transport dies), in which case the
+ * broadcaster reconstructs a minimal `{"event":...,"data":...}` variant from `event`
+ * and `data`. */
+void vmspawn_qmp_proxy_broadcast_event(
+                VmspawnQmpBridge *bridge,
+                sd_json_variant *raw,
+                const char *event,
+                sd_json_variant *data);
+
+/* Tear down every acquirer attached to the bridge. Invoked from the QMP disconnect
+ * callback (so pending slot callbacks see a NULL weak back-pointer) and from the
+ * varlink context free path. */
+void vmspawn_qmp_proxy_drain(VmspawnQmpBridge *bridge);

--- a/src/vmspawn/vmspawn-qmp.c
+++ b/src/vmspawn/vmspawn-qmp.c
@@ -19,6 +19,7 @@
 #include "string-util.h"
 #include "strv.h"
 #include "vmspawn-qmp.h"
+#include "vmspawn-qmp-proxy.h"
 
 DEFINE_PRIVATE_HASH_OPS_FULL(
                 pending_job_hash_ops,
@@ -811,6 +812,10 @@ PendingJob* pending_job_free(PendingJob *j) {
 VmspawnQmpBridge* vmspawn_qmp_bridge_free(VmspawnQmpBridge *b) {
         if (!b)
                 return NULL;
+
+        /* Drain any AcquireQMP acquirers before releasing the QmpClient: their
+         * JsonStreams share the same sd_event and back-point into this bridge. */
+        vmspawn_qmp_proxy_drain(b);
 
         hashmap_free(b->pending_jobs);
 

--- a/src/vmspawn/vmspawn-qmp.h
+++ b/src/vmspawn/vmspawn-qmp.h
@@ -3,7 +3,13 @@
 
 #include <net/ethernet.h>
 
+#include "list.h"
 #include "shared-forward.h"
+
+/* Opaque, defined in vmspawn-qmp-proxy.c. Tracked here so the bridge's drain/free path
+ * can reach every outstanding AcquireQMP upgrade without pulling the proxy header into
+ * unrelated translation units. */
+typedef struct AcquiredQmp AcquiredQmp;
 
 /* Pending job continuation — called when a QMP background job reaches "concluded" state.
  * Used by blockdev-create to chain remaining drive setup after the job completes. */
@@ -28,6 +34,8 @@ typedef struct VmspawnQmpBridge {
         QmpClient *qmp;
         Hashmap *pending_jobs;  /* job_id (string, owned) -> PendingJob* */
         VmspawnQmpFeatureFlags features;
+        LIST_HEAD(AcquiredQmp, acquired);  /* Upgraded AcquireQMP channels, multiplexed over qmp */
+        size_t n_acquired;                 /* Length of the acquired list, for the cap check */
 } VmspawnQmpBridge;
 
 VmspawnQmpBridge* vmspawn_qmp_bridge_free(VmspawnQmpBridge *b);

--- a/src/vmspawn/vmspawn-varlink.c
+++ b/src/vmspawn/vmspawn-varlink.c
@@ -262,6 +262,7 @@ static int on_qmp_event(
                 QmpClient *client,
                 const char *event,
                 sd_json_variant *data,
+                sd_json_variant *raw,
                 void *userdata) {
 
         VmspawnVarlinkContext *ctx = ASSERT_PTR(userdata);

--- a/src/vmspawn/vmspawn-varlink.c
+++ b/src/vmspawn/vmspawn-varlink.c
@@ -341,9 +341,14 @@ int vmspawn_varlink_setup(
         if (!ctx)
                 return log_oom();
 
-        /* Create varlink server for VM control */
+        /* Create varlink server for VM control.
+         *
+         * SD_VARLINK_SERVER_UPGRADABLE is required for the io.systemd.QemuMachineInstance
+         * interface: its AcquireQMP method is declared SD_VARLINK_REQUIRES_UPGRADE, and
+         * without the flag the varlink transport may over-read past the upgrade message
+         * delimiter and lose the first bytes the acquirer writes on the raw channel. */
         r = varlink_server_new(&ctx->varlink_server,
-                               SD_VARLINK_SERVER_INHERIT_USERDATA,
+                               SD_VARLINK_SERVER_INHERIT_USERDATA|SD_VARLINK_SERVER_UPGRADABLE,
                                ctx);
         if (r < 0)
                 return log_error_errno(r, "Failed to create varlink server: %m");

--- a/src/vmspawn/vmspawn-varlink.c
+++ b/src/vmspawn/vmspawn-varlink.c
@@ -12,6 +12,7 @@
 #include "varlink-io.systemd.QemuMachineInstance.h"
 #include "varlink-io.systemd.VirtualMachineInstance.h"
 #include "varlink-util.h"
+#include "vmspawn-qmp-proxy.h"
 #include "vmspawn-varlink.h"
 
 DEFINE_PRIVATE_HASH_OPS_FULL(
@@ -175,7 +176,15 @@ static int vl_method_subscribe_events(sd_varlink *link, sd_json_variant *paramet
 }
 
 static int vl_method_acquire_qmp(sd_varlink *link, sd_json_variant *parameters, sd_varlink_method_flags_t flags, void *userdata) {
-        return sd_varlink_error_errno(link, -EOPNOTSUPP);
+        VmspawnVarlinkContext *ctx = ASSERT_PTR(userdata);
+
+        /* SD_VARLINK_REQUIRES_UPGRADE in the IDL causes the dispatcher to reject calls
+         * without the upgrade flag before we're reached, so this assert-style check is
+         * defensive only. */
+        if (!FLAGS_SET(flags, SD_VARLINK_METHOD_UPGRADE))
+                return sd_varlink_error(link, SD_VARLINK_ERROR_EXPECTED_UPGRADE, NULL);
+
+        return vmspawn_qmp_proxy_acquire(ctx->bridge, link);
 }
 
 static void vl_disconnect(sd_varlink_server *server, sd_varlink *link, void *userdata) {
@@ -274,6 +283,12 @@ static int on_qmp_event(
         assert(client);
         assert(event);
 
+        /* Fan out to any AcquireQMP acquirers speaking native QMP. They want the raw event
+         * (including timestamp), so hand them the original variant when we have it; for
+         * synthesised events (QEMU disconnect -> SHUTDOWN) we pass NULL and the broadcaster
+         * rebuilds a minimal event object. */
+        vmspawn_qmp_proxy_broadcast_event(ctx->bridge, raw, event, data);
+
         /* Dispatch job status changes to pending continuations (e.g. blockdev-create) */
         if (streq(event, "JOB_STATUS_CHANGE"))
                 return dispatch_pending_job(ctx->bridge, data);
@@ -315,6 +330,11 @@ static void on_qmp_disconnect(QmpClient *client, void *userdata) {
         assert(client);
 
         log_debug("Backend connection lost");
+
+        /* Drain AcquireQMP acquirers first so their ProxyCmdCtx back-pointers are NULLed
+         * before qmp_client_fail_pending() runs the per-slot callbacks with -ECONNRESET;
+         * the callbacks then see aq == NULL and free themselves harmlessly. */
+        vmspawn_qmp_proxy_drain(ctx->bridge);
 
         /* Propagate connection loss by closing all subscriber connections */
         drain_event_subscribers(&ctx->subscribed);

--- a/test/units/TEST-87-AUX-UTILS-VM.vmspawn-acquire-qmp.sh
+++ b/test/units/TEST-87-AUX-UTILS-VM.vmspawn-acquire-qmp.sh
@@ -1,0 +1,394 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# Exercise io.systemd.QemuMachineInstance.AcquireQMP — the protocol upgrade that
+# hands a varlink caller a native QMP stream multiplexed over vmspawn's shared
+# QmpClient.
+set -eux
+set -o pipefail
+
+# shellcheck source=test/units/util.sh
+. "$(dirname "$0")"/util.sh
+
+if [[ -v ASAN_OPTIONS ]]; then
+    echo "vmspawn launches QEMU which doesn't work under ASan, skipping"
+    exit 0
+fi
+
+if ! command -v systemd-vmspawn >/dev/null 2>&1; then
+    echo "systemd-vmspawn not found, skipping"
+    exit 0
+fi
+
+if ! find_qemu_binary; then
+    echo "QEMU not found, skipping"
+    exit 0
+fi
+
+if ! command -v virtiofsd >/dev/null 2>&1 &&
+   ! test -x /usr/libexec/virtiofsd &&
+   ! test -x /usr/lib/virtiofsd; then
+    echo "virtiofsd not found, skipping"
+    exit 0
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "python3 not found, skipping"
+    exit 0
+fi
+
+KERNEL=""
+for k in /usr/lib/modules/"$(uname -r)"/vmlinuz /boot/vmlinuz-"$(uname -r)" /boot/vmlinuz; do
+    if [[ -f "$k" ]]; then
+        KERNEL="$k"
+        break
+    fi
+done
+if [[ -z "$KERNEL" ]]; then
+    echo "No kernel found for direct VM boot, skipping"
+    exit 0
+fi
+echo "Using kernel: $KERNEL"
+
+MACHINE="test-vmspawn-acquire-qmp-$$"
+WORKDIR="$(mktemp -d)"
+
+at_exit() {
+    set +e
+    if machinectl status "$MACHINE" &>/dev/null; then
+        machinectl terminate "$MACHINE" 2>/dev/null
+        timeout 10 bash -c "while machinectl status '$MACHINE' &>/dev/null; do sleep .5; done" 2>/dev/null
+    fi
+    [[ -n "${VMSPAWN_PID:-}" ]] && kill "$VMSPAWN_PID" 2>/dev/null && wait "$VMSPAWN_PID" 2>/dev/null
+    rm -rf "$WORKDIR"
+}
+trap at_exit EXIT
+
+mkdir -p "$WORKDIR/root/sbin"
+cat >"$WORKDIR/root/sbin/init" <<'EOF'
+#!/bin/sh
+exec sleep infinity
+EOF
+chmod +x "$WORKDIR/root/sbin/init"
+
+wait_for_machine() {
+    local machine="$1" pid="$2" log="$3"
+    timeout 30 bash -c "
+        while ! machinectl list --no-legend 2>/dev/null | grep >/dev/null '$machine'; do
+            if ! kill -0 $pid 2>/dev/null; then
+                if grep >/dev/null 'virtiofs.*QMP\|vhost-user-fs-pci' '$log'; then
+                    echo 'vhost-user-fs not supported (nested VM?), skipping'
+                    exit 77
+                fi
+                echo 'vmspawn exited before registering'
+                cat '$log'
+                exit 1
+            fi
+            sleep .5
+        done
+    " || {
+        local rc=$?
+        if [[ $rc -eq 77 ]]; then exit 0; fi
+        exit "$rc"
+    }
+}
+
+systemd-vmspawn \
+    --machine="$MACHINE" \
+    --ram=256M \
+    --directory="$WORKDIR/root" \
+    --linux="$KERNEL" \
+    --tpm=no \
+    --console=headless \
+    &>"$WORKDIR/vmspawn.log" &
+VMSPAWN_PID=$!
+
+wait_for_machine "$MACHINE" "$VMSPAWN_PID" "$WORKDIR/vmspawn.log"
+echo "Machine '$MACHINE' registered with machined"
+
+VARLINK_ADDR=$(varlinkctl call /run/systemd/machine/io.systemd.Machine \
+    io.systemd.Machine.List "{\"name\":\"$MACHINE\"}" | jq -r '.controlAddress')
+assert_neq "$VARLINK_ADDR" "null"
+
+# Python QMP-upgrade client. Takes the varlink socket path as argv[1], the
+# scenario name as argv[2], and any scenario-specific args after. Prints "ok"
+# on success and exits 0; otherwise prints a diagnostic and exits non-zero.
+cat >"$WORKDIR/acquire-qmp.py" <<'PY'
+#!/usr/bin/env python3
+"""AcquireQMP upgrade client used by TEST-87-AUX-UTILS-VM.vmspawn-acquire-qmp.sh."""
+
+import json
+import os
+import socket
+import sys
+import time
+
+
+def connect_and_upgrade(addr):
+    """Open the varlink socket, issue AcquireQMP with upgrade:true, verify the
+    reply, and return the connected socket already in raw-QMP mode."""
+    s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    s.connect(addr)
+    req = {
+        "method": "io.systemd.QemuMachineInstance.AcquireQMP",
+        "upgrade": True,
+    }
+    s.sendall(json.dumps(req).encode() + b"\x00")
+    # Read the varlink reply (single JSON object terminated by NUL).
+    buf = b""
+    while b"\x00" not in buf:
+        chunk = s.recv(4096)
+        if not chunk:
+            raise RuntimeError("socket closed before varlink reply arrived")
+        buf += chunk
+    reply_raw, _, rest = buf.partition(b"\x00")
+    reply = json.loads(reply_raw)
+    if "error" in reply:
+        raise RuntimeError(f"AcquireQMP returned error: {reply}")
+    return s, rest
+
+
+def read_qmp_line(s, buffered, timeout=10.0):
+    """Read one CRLF-terminated JSON message from the raw QMP stream. `buffered`
+    is any bytes pre-read from the last recv. Returns (json_obj, leftover)."""
+    deadline = time.monotonic() + timeout
+    while b"\r\n" not in buffered:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise TimeoutError(f"no CRLF in: {buffered!r}")
+        s.settimeout(remaining)
+        chunk = s.recv(4096)
+        if not chunk:
+            raise EOFError("QMP stream closed")
+        buffered += chunk
+    line, _, rest = buffered.partition(b"\r\n")
+    return json.loads(line), rest
+
+
+def expect_greeting(s, buffered):
+    obj, buffered = read_qmp_line(s, buffered)
+    if "QMP" not in obj:
+        raise RuntimeError(f"expected greeting, got {obj}")
+    return buffered
+
+
+def negotiate(s, buffered, caller_id=42):
+    """Send qmp_capabilities, verify the short-circuit reply carries caller_id
+    back. Returns buffered bytes following the reply."""
+    s.sendall(
+        json.dumps({"execute": "qmp_capabilities", "id": caller_id}).encode() + b"\r\n"
+    )
+    reply, buffered = read_qmp_line(s, buffered)
+    if reply != {"return": {}, "id": caller_id}:
+        raise RuntimeError(f"bad qmp_capabilities reply: {reply}")
+    return buffered
+
+
+def scenario_single(addr):
+    s, buffered = connect_and_upgrade(addr)
+    buffered = expect_greeting(s, buffered)
+    buffered = negotiate(s, buffered, caller_id=42)
+
+    # Use a non-integer id on purpose — QMP allows any JSON value there and we
+    # must preserve the exact variant round-trip.
+    s.sendall(json.dumps({"execute": "query-status", "id": "abc"}).encode() + b"\r\n")
+    reply, buffered = read_qmp_line(s, buffered)
+    assert reply.get("id") == "abc", f"id mismatch: {reply}"
+    assert reply["return"]["running"] is True, f"unexpected return: {reply}"
+    print("ok")
+
+
+def scenario_collision(addr):
+    """Two acquirers both send id=1; each must get id=1 back in its own reply."""
+    a, ba = connect_and_upgrade(addr)
+    b, bb = connect_and_upgrade(addr)
+    ba = expect_greeting(a, ba)
+    bb = expect_greeting(b, bb)
+    ba = negotiate(a, ba, caller_id=99)
+    bb = negotiate(b, bb, caller_id=99)
+
+    for sk, name in ((a, "A"), (b, "B")):
+        sk.sendall(json.dumps({"execute": "query-status", "id": 1}).encode() + b"\r\n")
+
+    rep_a, ba = read_qmp_line(a, ba)
+    rep_b, bb = read_qmp_line(b, bb)
+    assert rep_a.get("id") == 1, f"A id mismatch: {rep_a}"
+    assert rep_b.get("id") == 1, f"B id mismatch: {rep_b}"
+    assert rep_a["return"]["running"] is True
+    assert rep_b["return"]["running"] is True
+    print("ok")
+
+
+def scenario_pre_cap_rejected(addr):
+    """Mirrors QEMU's monitor/qmp.c semantics: a well-formed execute=<cmd> or
+    exec-oob=<cmd> sent before qmp_capabilities completes gets CommandNotFound
+    back with the QEMU-standard desc 'Expecting capabilities negotiation with
+    qmp_capabilities'."""
+    s, buffered = connect_and_upgrade(addr)
+    buffered = expect_greeting(s, buffered)
+    # Skip qmp_capabilities, send a regular command.
+    s.sendall(json.dumps({"execute": "query-status", "id": 7}).encode() + b"\r\n")
+    reply, buffered = read_qmp_line(s, buffered)
+    err = reply.get("error") or {}
+    assert err.get("class") == "CommandNotFound", f"bad reject: {reply}"
+    assert "qmp_capabilities" in err.get("desc", ""), f"bad desc: {reply}"
+    assert reply.get("id") == 7, f"id not preserved: {reply}"
+    print("ok")
+
+
+def scenario_missing_id(addr):
+    s, buffered = connect_and_upgrade(addr)
+    buffered = expect_greeting(s, buffered)
+    buffered = negotiate(s, buffered, caller_id=11)
+
+    # No id field — response must be dropped.
+    s.sendall(json.dumps({"execute": "query-status"}).encode() + b"\r\n")
+    # Follow-up with an id so we can bound the wait.
+    s.sendall(json.dumps({"execute": "query-status", "id": 22}).encode() + b"\r\n")
+    reply, buffered = read_qmp_line(s, buffered)
+    assert reply.get("id") == 22, f"got unexpected reply {reply}; the id-less one may have leaked"
+    print("ok")
+
+
+def scenario_event(addr):
+    """After negotiation, expect QMP events to flow through the proxy. The
+    shell script triggers a STOP by calling MachineInstance.Pause separately.
+    This scenario just waits for a STOP event on the raw stream."""
+    s, buffered = connect_and_upgrade(addr)
+    buffered = expect_greeting(s, buffered)
+    buffered = negotiate(s, buffered, caller_id=1)
+
+    # Tell the shell script that we are ready to receive events. The 'ready'
+    # sentinel line is written to stdout and the shell waits for it before
+    # triggering the pause.
+    print("ready", flush=True)
+
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        obj, buffered = read_qmp_line(s, buffered, timeout=deadline - time.monotonic())
+        if obj.get("event") == "STOP":
+            print("ok")
+            return
+    raise TimeoutError("STOP event not seen")
+
+
+def scenario_pre_handshake_drop(addr):
+    """Mirrors QEMU's monitor behaviour: events are not delivered to an acquirer that
+    hasn't yet sent qmp_capabilities."""
+    s, buffered = connect_and_upgrade(addr)
+    buffered = expect_greeting(s, buffered)
+
+    # Signal readiness; shell triggers a STOP now.
+    print("ready", flush=True)
+
+    # Read for ~2 seconds. A pre-handshake acquirer must NOT see STOP.
+    s.settimeout(2)
+    try:
+        chunk = s.recv(4096)
+        if chunk:
+            more_bytes = buffered + chunk
+            while b"\r\n" in more_bytes:
+                line, _, more_bytes = more_bytes.partition(b"\r\n")
+                obj = json.loads(line)
+                if obj.get("event"):
+                    raise RuntimeError(f"unexpected event pre-negotiation: {obj}")
+    except (TimeoutError, socket.timeout):
+        pass  # expected: nothing arrives pre-negotiation
+
+    print("ok")
+
+
+def scenario_eof(addr):
+    s, buffered = connect_and_upgrade(addr)
+    buffered = expect_greeting(s, buffered)
+    buffered = negotiate(s, buffered, caller_id=1)
+
+    print("ready", flush=True)
+
+    # Read until EOF (signalled by empty recv after QEMU dies).
+    deadline = time.monotonic() + 15
+    s.settimeout(deadline - time.monotonic())
+    try:
+        while time.monotonic() < deadline:
+            chunk = s.recv(4096)
+            if not chunk:
+                print("ok")
+                return
+            buffered += chunk
+    except (TimeoutError, socket.timeout):
+        pass
+    raise TimeoutError("EOF not observed after QEMU terminate")
+
+
+SCENARIOS = {
+    "single": scenario_single,
+    "collision": scenario_collision,
+    "pre_cap_rejected": scenario_pre_cap_rejected,
+    "missing_id": scenario_missing_id,
+    "event": scenario_event,
+    "pre_handshake_drop": scenario_pre_handshake_drop,
+    "eof": scenario_eof,
+}
+
+
+if __name__ == "__main__":
+    addr = sys.argv[1]
+    name = sys.argv[2]
+    SCENARIOS[name](addr)
+PY
+chmod +x "$WORKDIR/acquire-qmp.py"
+
+run_scenario() {
+    local name="$1"
+    local out
+    out=$(python3 "$WORKDIR/acquire-qmp.py" "$VARLINK_ADDR" "$name")
+    assert_in "ok" "$out"
+    echo "AcquireQMP scenario '$name' passed"
+}
+
+# --- Scenario 1: single acquirer round-trips greeting + caps + query-status ---
+run_scenario single
+
+# --- Scenario 2: two acquirers with colliding ids ---
+run_scenario collision
+
+# --- Scenario 3: pre-cap command gets CommandNotFound with the QEMU-standard desc ---
+run_scenario pre_cap_rejected
+
+# --- Scenario 4: commands without an id are forwarded but the response is dropped ---
+run_scenario missing_id
+
+# --- Scenario 5: events flow after cap negotiation ---
+# The python helper prints 'ready' once it's ready to receive events; we wait for
+# that marker, trigger a pause, then wait for the helper to exit.
+( python3 "$WORKDIR/acquire-qmp.py" "$VARLINK_ADDR" event >"$WORKDIR/event.out" 2>"$WORKDIR/event.err" ) &
+EVENT_PID=$!
+timeout 5 bash -c "until grep >/dev/null '^ready' '$WORKDIR/event.out'; do sleep 0.1; done"
+varlinkctl call "$VARLINK_ADDR" io.systemd.MachineInstance.Pause '{}'
+wait "$EVENT_PID"
+grep >/dev/null '^ok' "$WORKDIR/event.out"
+varlinkctl call "$VARLINK_ADDR" io.systemd.MachineInstance.Resume '{}'
+echo "AcquireQMP scenario 'event' passed"
+
+# --- Scenario 6: pre-handshake acquirer does NOT see events ---
+( python3 "$WORKDIR/acquire-qmp.py" "$VARLINK_ADDR" pre_handshake_drop >"$WORKDIR/drop.out" 2>"$WORKDIR/drop.err" ) &
+DROP_PID=$!
+timeout 5 bash -c "until grep >/dev/null '^ready' '$WORKDIR/drop.out'; do sleep 0.1; done"
+varlinkctl call "$VARLINK_ADDR" io.systemd.MachineInstance.Pause '{}'
+wait "$DROP_PID"
+grep >/dev/null '^ok' "$WORKDIR/drop.out"
+varlinkctl call "$VARLINK_ADDR" io.systemd.MachineInstance.Resume '{}'
+echo "AcquireQMP scenario 'pre_handshake_drop' passed"
+
+# --- Scenario 7: acquirer sees EOF when QEMU terminates ---
+( python3 "$WORKDIR/acquire-qmp.py" "$VARLINK_ADDR" eof >"$WORKDIR/eof.out" 2>"$WORKDIR/eof.err" ) &
+EOF_PID=$!
+timeout 5 bash -c "until grep >/dev/null '^ready' '$WORKDIR/eof.out'; do sleep 0.1; done"
+machinectl terminate "$MACHINE"
+wait "$EOF_PID"
+grep >/dev/null '^ok' "$WORKDIR/eof.out"
+echo "AcquireQMP scenario 'eof' passed"
+
+# VMSPAWN_PID exited when machinectl terminate ran; prevent at_exit from waiting on it.
+VMSPAWN_PID=""
+
+echo "All AcquireQMP upgrade tests passed"


### PR DESCRIPTION
systemd-vmspawn launches QEMU and exposes per-VM varlink control at
`<runtime_dir>/control`, announced to machined as `controlAddress`. The
`io.systemd.QemuMachineInstance` IDL already declares `AcquireQMP` with
`SD_VARLINK_REQUIRES_UPGRADE`, but the handler has been stubbed to
`-EOPNOTSUPP` since the original QMP-varlink bridge work. The intent was
always that a caller would vlink-upgrade into a native QMP stream and
speak QEMU's protocol directly — for debuggers, test harnesses, anything
that wants a command or introspection vmspawn doesn't expose through its
own generic interface.

Two upstream pieces now make this feasible:

- PR #41474 merged the varlink-side upgrade machinery
  (`sd_varlink_reply_and_upgrade`, `sd_varlink_call_and_upgrade`,
  `SD_VARLINK_SERVER_UPGRADABLE`, `varlinkctl serve/--upgrade`).
- PR #41449 landed the QMP-varlink bridge (`QmpClient` +
  `VmspawnQmpBridge`) this series extends.

QEMU exposes one QMP socket per monitor and does not support monitor
hotplug today. vmspawn already owns that socket for its own internal
use (handshake, feature probing, device setup, runtime event
subscribers). Three concrete constraints:

1. Handing the raw fd to a single acquirer would let vmspawn lose its
   control channel.
2. Sharing the raw fd directly would let multiple acquirers collide on
   QMP's `id` field (each picks their own; QEMU can't know whose reply
   belongs to whom).
3. An acquirer's `qmp_capabilities` handshake targets a monitor that is
   already past its own negotiation — forwarded commands would hit
   `CommandNotFound` in full-command mode.

QEMU is expected to grow monitor hotplug eventually — at the time of
writing, upstream discussion puts a first implementation at least four
months out, and realistically several years before it reaches the
baseline set of distros vmspawn needs to support. For that window the
application-level proxy in this series is the only way to let multiple
tools speak raw QMP to the same VM. Once kernel^W QEMU monitor hotplug
is broadly available we can consider retiring the proxy in favour of
simply allocating a fresh monitor per acquirer; the varlink interface
(`AcquireQMP` with `SD_VARLINK_REQUIRES_UPGRADE`) would stay stable
across that swap.

Add an application-level QMP proxy (`AcquiredQmp`) that terminates each
upgraded varlink connection with its own `JsonStream` and demuxes onto
the shared `QmpClient`, rewriting the `id` field on each command and
reversing the remap on responses so every acquirer sees its own id
namespace. QMP wire semantics visible to the acquirer match QEMU's
native monitor byte-for-byte where practical:

- **Greeting** — QEMU's real greeting is cached by the bridge during its
  own handshake and replayed per-acquirer, preserving the exact version
  and capabilities QEMU announced.
- **Capability negotiation** — `execute == "qmp_capabilities"` is
  short-circuited locally with an empty return (forwarding would fail
  because QEMU's monitor is already past negotiation). Non-caps commands
  pre-negotiation get `CommandNotFound` with QEMU's exact desc
  `"Expecting capabilities negotiation with 'qmp_capabilities'"`
  (mirrors `monitor/qmp.c:181-191`). Malformed shapes pre-caps are
  forwarded so QEMU emits the shape-specific `GenericError` — matches
  what a fresh QMP session would see.
- **Events** — fanned out to every acquirer that has completed
  negotiation. Pre-negotiation acquirers get nothing, mirroring QEMU's
  `monitor_qapi_event_emit` check. The full raw event variant (with
  timestamp) is forwarded where available; synthetic events (e.g. the
  SHUTDOWN emitted when the QMP transport dies) are re-built from
  name + data.
- **Missing `id`** — forwarded to QEMU but no response routed back (QMP
  spec semantics for commands without a correlation token). Absent-vs-null
  is preserved so clients that carry `"id": null` still see `null` back.
- **Teardown** — `ProxyCmdCtx` carries a weak `AcquiredQmp*` back-pointer;
  on acquirer disconnect the aq walks its pending list and NULLs each
  pointer, so late-arriving QmpClient slot callbacks drop silently
  instead of writing into a freed stream. Combined with commit 4's
  ordering flip, QEMU death leaves no UAF window.
- **Concurrency cap** — `VMSPAWN_QMP_PROXY_MAX = 16` bounds per-acquirer
  16 MiB buffers; further upgrades get `NotSupported`.

Signed-off-by: Christian Brauner (Amutable) <brauner@kernel.org>