### PR TITLE
vmspawn: catch unsupported growing of qcow2 images

### DIFF
--- a/src/vmspawn/vmspawn.c
+++ b/src/vmspawn/vmspawn.c
@@ -4001,6 +4001,10 @@ static int verify_arguments(void) {
                         log_warning("--grow-image has no effect with --image-disk-type=scsi-cd (CD-ROMs are read-only).");
         }
 
+        if (arg_grow_image && arg_image_format == IMAGE_FORMAT_QCOW2)
+                return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
+                                       "--grow-image is not supported for qcow2 images, use 'qemu-img resize FILE SIZE'.");
+
         return 0;
 }
 


### PR DESCRIPTION
For qcow2 images it's not enough to grow the file. Since we probably don't want to shell out to qemu-img either let's just error out to make the user aware that growing needs to be done manually.