### PR TITLE
sysupdated: don't crash when an mstack machine image is found

### DIFF
--- a/src/sysupdate/sysupdated.c
+++ b/src/sysupdate/sysupdated.c
@@ -1882,6 +1882,9 @@ static int manager_enumerate_image_class(Manager *m, TargetClass class) {
                 if (image_is_host(image))
                         continue; /* We already enroll the host ourselves */
 
+                if (image->type == IMAGE_MSTACK)
+                        continue; /* systemd-sysupdate doesn't support mstack images yet */
+
                 r = target_new(m, class, image->name, image->path, &t);
                 if (r < 0)
                         return r;


### PR DESCRIPTION
As soon as machinectl list-images has an mstack entry updatectl fails because systemd-sysupdated crashes with an assertion failing because the mstack case was not handled.
For now mstack is not supported as image for sysupdate to operate on and we can skip it.

Fixes https://github.com/systemd/systemd/issues/41649