### PR TITLE
timesync: verify the actual size of the received data

### DIFF
--- a/src/timesync/timesyncd-manager.c
+++ b/src/timesync/timesyncd-manager.c
@@ -437,7 +437,7 @@ static int manager_receive_response(sd_event_source *source, int fd, uint32_t re
         }
 
         /* Too short packet? */
-        if (iov.iov_len < sizeof(struct ntp_msg)) {
+        if ((size_t) len < sizeof(struct ntp_msg)) {
                 log_warning("Invalid response from server. Disconnecting.");
                 return manager_connect(m);
         }


### PR DESCRIPTION
iov.iov_len doesn't change after calling recvmsg() so it remains set to sizeof(ntpmsg), which makes the check for a short packet always false. Let's fix that by checking the actual size of the received data instead.