### PR TITLE
string-util: check for overflow in strrep()

### DIFF
--- a/src/basic/string-util.c
+++ b/src/basic/string-util.c
@@ -977,22 +977,27 @@ oom:
         return -ENOMEM;
 }
 
-char* strrep(const char *s, unsigned n) {
-        char *r, *p;
+char* strrep(const char *s, size_t n) {
+        char *ret, *p;
         size_t l;
 
         assert(s);
 
         l = strlen(s);
-        p = r = malloc(l * n + 1);
-        if (!r)
+        if (!MUL_ASSIGN_SAFE(&l, n))
+                return NULL;
+        if (!INC_SAFE(&l, 1))
                 return NULL;
 
-        for (unsigned i = 0; i < n; i++)
+        p = ret = malloc(l);
+        if (!ret)
+                return NULL;
+
+        for (size_t i = 0; i < n; i++)
                 p = stpcpy(p, s);
 
         *p = 0;
-        return r;
+        return ret;
 }
 
 int split_pair(const char *s, const char *sep, char **ret_first, char **ret_second) {

--- a/src/basic/string-util.h
+++ b/src/basic/string-util.h
@@ -193,7 +193,7 @@ int strextendf_with_separator(char **x, const char *separator, const char *forma
         })
 #define strprepend(x, ...) strprepend_with_separator(x, NULL, __VA_ARGS__)
 
-char* strrep(const char *s, unsigned n);
+char* strrep(const char *s, size_t n);
 
 #define strrepa(s, n)                                                   \
         ({                                                              \

--- a/src/test/test-string-util.c
+++ b/src/test/test-string-util.c
@@ -325,6 +325,8 @@ TEST(strrep) {
 
         ASSERT_STREQ(onea, "waldo");
         ASSERT_STREQ(threea, "waldowaldowaldo");
+
+        ASSERT_NULL(strrep("waldo", SIZE_MAX - 1));
 }
 
 TEST(string_has_cc) {


### PR DESCRIPTION
This simply mirrors the same overflow check we already have in strrepa(), in case someone passed us a sufficiently long string.

strrep() is currently used only in tests, so this is just hardening.