### PR TITLE
ci: Switch PR review workflow to Opus 4.7 via Mantle endpoint

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -192,6 +192,7 @@ jobs:
         env:
           CLAUDE_CODE_DISABLE_BACKGROUND_TASKS: "1"
           CLAUDE_CODE_USE_BEDROCK: "1"
+          CLAUDE_CODE_USE_MANTLE: "1"
         run: |
           mkdir -p ~/.claude
 
@@ -369,7 +370,7 @@ jobs:
           PROMPT
 
           claude \
-            --model us.anthropic.claude-opus-4-6-v1 \
+            --model anthropic.claude-opus-4-7 \
             --effort max \
             --max-turns 200 \
             --setting-sources user \


### PR DESCRIPTION
Opus 4.7 is in research preview on Bedrock and the Invoke API rejects the beta headers Claude Code sends ("invalid beta flag"). Enable the Mantle endpoint, which serves Claude via the native Anthropic API shape and accepts those headers, and switch the model ID to the Mantle form (no region prefix or version suffix).