### PR TITLE
dissect-image: fix path building for non-raw images

### DIFF
--- a/src/shared/dissect-image.c
+++ b/src/shared/dissect-image.c
@@ -3728,7 +3728,7 @@ static char *build_auxiliary_path(const char *image, const char *suffix) {
 
         e = endswith(image, ".raw");
         if (!e)
-                return strjoin(e, suffix);
+                return strjoin(image, suffix);
 
         n = new(char, e - image + strlen(suffix) + 1);
         if (!n)

--- a/src/udev/scsi_id/scsi_id.c
+++ b/src/udev/scsi_id/scsi_id.c
@@ -15,6 +15,7 @@
 #include "extract-word.h"
 #include "fd-util.h"
 #include "fileio.h"
+#include "parse-util.h"
 #include "scsi_id.h"
 #include "string-util.h"
 #include "strv.h"
@@ -234,7 +235,7 @@ static void help(void) {
 
 static int set_options(int argc, char **argv,
                        char *maj_min_dev) {
-        int option;
+        int option, r;
 
         /*
          * optind is a global extern used by getopt. Since we can call
@@ -279,7 +280,11 @@ static int set_options(int argc, char **argv,
                         break;
 
                 case 's':
-                        sg_version = atoi(optarg);
+                        r = safe_atoi(optarg, &sg_version);
+                        if (r < 0)
+                                return log_error_errno(r,
+                                                       "Invalid SG version '%s'",
+                                                       optarg);
                         if (sg_version < 3 || sg_version > 4)
                                 return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
                                                        "Unknown SG version '%s'",

--- a/src/udev/udev-builtin-usb_id.c
+++ b/src/udev/udev-builtin-usb_id.c
@@ -22,6 +22,9 @@
 static void set_usb_iftype(char *to, int if_class_num, size_t len) {
         const char *type = "generic";
 
+        assert(to);
+        assert(len > 0);
+
         switch (if_class_num) {
         case 1:
                 type = "audio";
@@ -71,6 +74,8 @@ static int set_usb_mass_storage_ifsubtype(char *to, const char *from, size_t len
         int type_num = 0;
         const char *type = "generic";
 
+        assert(to);
+
         if (safe_atoi(from, &type_num) >= 0)
                 switch (type_num) {
                 case 1: /* RBC devices */
@@ -97,6 +102,8 @@ static int set_usb_mass_storage_ifsubtype(char *to, const char *from, size_t len
 static void set_scsi_type(char *to, const char *from, size_t len) {
         unsigned type_num;
         const char *type = "generic";
+
+        assert(to);
 
         if (safe_atou(from, &type_num) >= 0)
                 switch (type_num) {
@@ -142,6 +149,10 @@ static int dev_if_packed_info(sd_device *dev, char *ifs_str, size_t len) {
                 uint8_t bInterfaceProtocol;
                 uint8_t iInterface;
         } _packed_;
+
+        assert(dev);
+        assert(ifs_str);
+        assert(len >= 2);
 
         r = sd_device_get_syspath(dev, &syspath);
         if (r < 0)


### PR DESCRIPTION
If the passed in image path didn't end with .raw, we'd return an empty
string + suffix instead of the intended image + suffix path.

---

Also, fix two more nits that came up repeatedly in my searches.