### PR TITLE
Add systemd-tmpfiles config type 'E' for inclusive cleanup of glob-specified files and directories

### DIFF
--- a/man/systemd-tmpfiles.xml
+++ b/man/systemd-tmpfiles.xml
@@ -159,7 +159,7 @@
         <varname>f</varname>, <varname>F</varname>, <varname>d</varname>, <varname>D</varname>,
         <varname>v</varname>, <varname>q</varname>, <varname>Q</varname>, <varname>p</varname>,
         <varname>L</varname>, <varname>c</varname>, <varname>b</varname>, <varname>C</varname>,
-        <varname>w</varname>, <varname>e</varname>. If this switch is used at least one
+        <varname>w</varname>, <varname>e</varname>, <varname>E</varname>. If this switch is used at least one
         <filename>tmpfiles.d/</filename> file (or <filename>-</filename> for standard input) must be
         specified on the command line or the invocation will be refused, for safety reasons (as otherwise
         much of the installed system files might be removed).</para>

--- a/man/tmpfiles.d.xml
+++ b/man/tmpfiles.d.xml
@@ -229,12 +229,13 @@ L     /tmp/foobar -    -    -     -   /dev/null</programlisting>
 
         <varlistentry>
           <term><varname>E</varname></term>
-          <listitem>
-            <para>Same as <varname>e</varname> except allows globs to clean up files and directories, not just
-            the contents of directories. Symlinks are not followed.</para>
+          <listitem><para>Similar to <varname>e</varname> but with changes in the cleanup behaviour. In
+          addition to cleaning the contents of directories matched by the glob, the matched files and directories
+          themselves are also subject to age-based cleanup. For all other behaviour, such as behaviour related to
+          <option>--remove</option>, mountpoints, sticky bits, and so on, <varname>E</varname> is identical to
+          <varname>e</varname>.</para>
 
-            <xi:include href="version-info.xml" xpointer="v261" xmlns:xi="http://www.w3.org/2001/XInclude"/>
-          </listitem>
+          <xi:include href="version-info.xml" xpointer="v261"/></listitem>
         </varlistentry>
 
         <varlistentry>

--- a/man/tmpfiles.d.xml
+++ b/man/tmpfiles.d.xml
@@ -49,6 +49,7 @@ w+    /file/to/append-to                       -    -    -     -           conte
 d     /directory/to/create-and-clean-up        mode user group cleanup-age -
 D     /directory/to/create-and-remove          mode user group cleanup-age -
 e     /directory/to/clean-up                   mode user group cleanup-age -
+E     /path-or-glob/to/clean-up                mode user group cleanup-age -
 v     /subvolume-or-directory/to/create        mode user group cleanup-age -
 q     /subvolume-or-directory/to/create        mode user group cleanup-age -
 Q     /subvolume-or-directory/to/create        mode user group cleanup-age -
@@ -224,6 +225,17 @@ L     /tmp/foobar -    -    -     -   /dev/null</programlisting>
           be useful when combined with <varname>!</varname>, see the examples.</para>
 
           <xi:include href="version-info.xml" xpointer="v230"/></listitem>
+        </varlistentry>
+
+        <varlistentry>
+          <term><varname>E</varname></term>
+          <listitem><para>Similar to <varname>e</varname> but with changes in the cleanup behavior. In
+          addition to cleaning the contents of directories matched by the glob, the matched files and directories
+          themselves are also subject to age-based cleanup. For all other behavior, such as behavior related to
+          <option>--remove</option>, mountpoints, sticky bits, and so on, <varname>E</varname> is identical to
+          <varname>e</varname>.</para>
+
+          <xi:include href="version-info.xml" xpointer="v262"/></listitem>
         </varlistentry>
 
         <varlistentry>
@@ -673,7 +685,7 @@ w- /proc/sys/vm/swappiness - - - - 10</programlisting></para>
 
       <para>The age field only applies to lines starting with
       <varname>d</varname>, <varname>D</varname>, <varname>e</varname>,
-      <varname>v</varname>, <varname>q</varname>,
+      <varname>E</varname>, <varname>v</varname>, <varname>q</varname>,
       <varname>Q</varname>, <varname>C</varname>, <varname>x</varname>
       and <varname>X</varname>. If omitted or set to
       <literal>-</literal>, no automatic clean-up is done.</para>

--- a/man/tmpfiles.d.xml
+++ b/man/tmpfiles.d.xml
@@ -229,9 +229,9 @@ L     /tmp/foobar -    -    -     -   /dev/null</programlisting>
 
         <varlistentry>
           <term><varname>E</varname></term>
-          <listitem><para>Similar to <varname>e</varname> but with changes in the cleanup behaviour. In
+          <listitem><para>Similar to <varname>e</varname> but with changes in the cleanup behavior. In
           addition to cleaning the contents of directories matched by the glob, the matched files and directories
-          themselves are also subject to age-based cleanup. For all other behaviour, such as behaviour related to
+          themselves are also subject to age-based cleanup. For all other behavior, such as behavior related to
           <option>--remove</option>, mountpoints, sticky bits, and so on, <varname>E</varname> is identical to
           <varname>e</varname>.</para>
 

--- a/man/tmpfiles.d.xml
+++ b/man/tmpfiles.d.xml
@@ -49,6 +49,7 @@ w+    /file/to/append-to                       -    -    -     -           conte
 d     /directory/to/create-and-clean-up        mode user group cleanup-age -
 D     /directory/to/create-and-remove          mode user group cleanup-age -
 e     /directory/to/clean-up                   mode user group cleanup-age -
+E     /path-or-glob/to/clean-up                mode user group cleanup-age -
 v     /subvolume-or-directory/to/create        mode user group cleanup-age -
 q     /subvolume-or-directory/to/create        mode user group cleanup-age -
 Q     /subvolume-or-directory/to/create        mode user group cleanup-age -
@@ -224,6 +225,16 @@ L     /tmp/foobar -    -    -     -   /dev/null</programlisting>
           be useful when combined with <varname>!</varname>, see the examples.</para>
 
           <xi:include href="version-info.xml" xpointer="v230"/></listitem>
+        </varlistentry>
+
+        <varlistentry>
+          <term><varname>E</varname></term>
+          <listitem>
+            <para>Same as <varname>e</varname> except allows globs to clean up files and directories, not just
+            the contents of directories. Symlinks are not followed.</para>
+
+            <xi:include href="version-info.xml" xpointer="v261" xmlns:xi="http://www.w3.org/2001/XInclude"/>
+          </listitem>
         </varlistentry>
 
         <varlistentry>
@@ -673,7 +684,7 @@ w- /proc/sys/vm/swappiness - - - - 10</programlisting></para>
 
       <para>The age field only applies to lines starting with
       <varname>d</varname>, <varname>D</varname>, <varname>e</varname>,
-      <varname>v</varname>, <varname>q</varname>,
+      <varname>E</varname>, <varname>v</varname>, <varname>q</varname>,
       <varname>Q</varname>, <varname>C</varname>, <varname>x</varname>
       and <varname>X</varname>. If omitted or set to
       <literal>-</literal>, no automatic clean-up is done.</para>

--- a/src/tmpfiles/tmpfiles.c
+++ b/src/tmpfiles/tmpfiles.c
@@ -449,13 +449,17 @@ static bool supports_ignore_if_target_missing(ItemType t) {
         return t == CREATE_SYMLINK;
 }
 
-static struct Item* find_glob(OrderedHashmap *h, const char *match) {
+/* Search for 'match' in all config items besides 'except' (which may be NULL if there is no exception) */
+static struct Item* find_glob(OrderedHashmap *h, const char *match, Item *except) {
         ItemArray *j;
 
         ORDERED_HASHMAP_FOREACH(j, h)
-                FOREACH_ARRAY(item, j->items, j->n_items)
+                FOREACH_ARRAY(item, j->items, j->n_items) {
+                        if (except && item == except)
+                                continue;
                         if (fnmatch(item->path, match, FNM_PATHNAME|FNM_PERIOD) == 0)
                                 return item;
+                }
         return NULL;
 }
 
@@ -738,7 +742,7 @@ static bool item_cleanup(
                 return false;
         }
 
-        if (find_glob(c->globs, pathname)) {
+        if (find_glob(c->globs, pathname, i)) {
                 log_debug("Ignoring \"%s\": a separate glob exists.", pathname);
                 return false;
         }
@@ -3237,11 +3241,21 @@ static int clean_including_item(
         struct statx sx;
         bool mountpoint;
         int r;
-
-        parent_path = path_join(instance, "..");
-        if (!parent_path) {
-                return log_oom();
+        /* Check whether item is a directory or file and determine parent path accordingly */
+        struct stat st;
+        if (stat(instance, &st) < 0)
+                return log_error_errno(errno, "Failed to stat(%s) for %s: %m", instance, i->path);
+        if (S_ISDIR(st.st_mode)) {
+                parent_path = path_join(instance, "..");
+                if (!parent_path) {
+                        return log_oom();
+                }
+        } else {
+                r = path_extract_directory(instance, &parent_path);
+                if (r < 0)
+                        return log_error_errno(r, "Unable to determine parent directory of '%s' for %s: %m", instance, i->path);
         }
+
         r = opendir_and_stat(parent_path, &d, &sx, &mountpoint);
         if (r <= 0)
                 return r;

--- a/src/tmpfiles/tmpfiles.c
+++ b/src/tmpfiles/tmpfiles.c
@@ -3235,17 +3235,41 @@ static int clean_including_item(
 
         usec_t cutoff = n - i->age;
 
-        /* Find parent path so we can get stats on the directory that holds instance file|dir */
         _cleanup_free_ char *parent_path = NULL;
         _cleanup_closedir_ DIR *d = NULL;
         struct statx sx;
         bool mountpoint;
         int r;
-        /* Check whether item is a directory or file and determine parent path accordingly */
+        _cleanup_close_ int fd = -EBADF;
+
+        /* Find parent path so we can get stats on the directory that holds instance file|dir */
+        fd = path_open_safe(instance); /* provides file opened with O_PATH which is needed for statx */
+        if (fd == -ENOENT)
+                return 0; /* ignore files that have disappeared since being sent to us */
+        if (fd < 0)
+                return fd;
+        /* Check whether item is a directory or file and determine parent path accordingly.
+         * We must determine the parent directory to open globbed filenames at that directory. */
+        r = xstatx_full(fd,
+                        /* path= */ NULL,
+                        /* statx_flags= */ AT_EMPTY_PATH|AT_NO_AUTOMOUNT,
+                        /* xstatx_flags= */ 0,
+                        /* mandatory_mask= */ STATX_TYPE,
+                        /* optional_mask= */ 0,
+                        /* mandatory_attributes= */ 0,
+                        &sx);
+        if (r == -ENOENT)
+                return false;
+        if (r < 0)
+                /* FUSE, NFS mounts, SELinux might return EACCES */
+                return log_full_errno(r == -EACCES ? LOG_DEBUG : LOG_ERR, r, "statx(%s) for %s failed: %m", instance, i->path);
+
         struct stat st;
         if (stat(instance, &st) < 0)
                 return log_error_errno(errno, "Failed to stat(%s) for %s: %m", instance, i->path);
         if (S_ISDIR(st.st_mode)) {
+                /* Append /.. to get the actual parent of the dir, not a (possible) symlink's parent,
+                 * so that item_cleanup() (below) can restore dir timestamps to the correct parent */
                 parent_path = path_join(instance, "..");
                 if (!parent_path) {
                         return log_oom();

--- a/src/tmpfiles/tmpfiles.c
+++ b/src/tmpfiles/tmpfiles.c
@@ -100,6 +100,7 @@ typedef enum ItemType {
         /* These ones take globs */
         WRITE_FILE                     = 'w',
         EMPTY_DIRECTORY                = 'e',
+        CLEAN_INCLUSIVE                = 'E',
         SET_XATTR                      = 't',
         RECURSIVE_SET_XATTR            = 'T',
         SET_ACL                        = 'a',
@@ -397,13 +398,15 @@ static bool needs_purge(ItemType t) {
                       CREATE_BLOCK_DEVICE,
                       COPY_FILES,
                       WRITE_FILE,
-                      EMPTY_DIRECTORY);
+                      EMPTY_DIRECTORY,
+                      CLEAN_INCLUSIVE);
 }
 
 static bool needs_glob(ItemType t) {
         return IN_SET(t,
                       WRITE_FILE,
                       EMPTY_DIRECTORY,
+                      CLEAN_INCLUSIVE,
                       SET_XATTR,
                       RECURSIVE_SET_XATTR,
                       SET_ACL,
@@ -435,6 +438,7 @@ static bool takes_ownership(ItemType t) {
                       COPY_FILES,
                       WRITE_FILE,
                       EMPTY_DIRECTORY,
+                      CLEAN_INCLUSIVE,
                       IGNORE_PATH,
                       IGNORE_DIRECTORY_PATH,
                       REMOVE_PATH,
@@ -660,6 +664,7 @@ static bool needs_cleanup(
         return true;
 }
 
+/* Declare prototype so that item_cleanup() can recurse into it */
 static int dir_cleanup(
                 Context *c,
                 Item *i,
@@ -668,8 +673,212 @@ static int dir_cleanup(
                 nsec_t self_atime_nsec,
                 nsec_t self_mtime_nsec,
                 nsec_t cutoff_nsec,
-                dev_t rootdev_major,
-                dev_t rootdev_minor,
+                bool mountpoint,
+                int maxdepth,
+                bool keep_this_level,
+                AgeBy age_by_file,
+                AgeBy age_by_dir);
+
+static bool item_cleanup(
+                Context *c,
+                Item *i,
+                const char *pathname, /* joined path (path/name) of directory|file to be cleaned up */
+                const char *name, /* basename of directory|file to be cleaned up */
+                DIR *d, /* directory that contains name -- used for unlinkat(d) */
+                nsec_t cutoff_nsec,
+                bool mountpoint, /* whether d is a mountpoint */
+                int maxdepth, /* max directory recursion depth */
+                bool keep_this_level,
+                AgeBy age_by_file, /* age criteria ([a|m|c|b]_time) to examine against file age */
+                AgeBy age_by_dir) { /* same age criteria for directory */
+        /* Clean up a file or directory, recursively, according to the cutoff_nsec age constraint.
+                Errors are ignored, consistent with historical behaviour for tmpfiles cleanup.
+                Return true if a file is deleted.
+        */
+        int r = 0;
+
+        assert(c);
+        assert(i);
+
+        nsec_t atime_nsec, mtime_nsec, ctime_nsec, btime_nsec;
+
+        if (dot_or_dot_dot(name))
+                return false;
+
+        struct statx sx;
+        r = xstatx_full(dirfd(d), name,
+                        AT_SYMLINK_NOFOLLOW|AT_NO_AUTOMOUNT,
+                        /* xstatx_flags= */ 0,
+                        STATX_TYPE|STATX_MODE|STATX_UID,
+                        STATX_ATIME|STATX_MTIME|STATX_CTIME|STATX_BTIME,
+                        STATX_ATTR_MOUNT_ROOT,
+                        &sx);
+        if (r == -ENOENT)
+                return false;
+        if (r < 0) {
+                /* FUSE, NFS mounts, SELinux might return EACCES */
+                log_full_errno(r == -EACCES ? LOG_DEBUG : LOG_ERR, r,
+                               "statx(%s) failed: %m", pathname);
+                return false;
+        }
+
+        if (FLAGS_SET(sx.stx_attributes, STATX_ATTR_MOUNT_ROOT)) {
+                log_debug("Ignoring \"%s\": different mount points.", pathname);
+                return false;
+        }
+
+        atime_nsec = FLAGS_SET(sx.stx_mask, STATX_ATIME) ? statx_timestamp_load_nsec(&sx.stx_atime) : 0;
+        mtime_nsec = FLAGS_SET(sx.stx_mask, STATX_MTIME) ? statx_timestamp_load_nsec(&sx.stx_mtime) : 0;
+        ctime_nsec = FLAGS_SET(sx.stx_mask, STATX_CTIME) ? statx_timestamp_load_nsec(&sx.stx_ctime) : 0;
+        btime_nsec = FLAGS_SET(sx.stx_mask, STATX_BTIME) ? statx_timestamp_load_nsec(&sx.stx_btime) : 0;
+
+        /* Is there an item configured for this path? */
+        if (ordered_hashmap_get(c->items, pathname)) {
+                log_debug("Ignoring \"%s\": a separate entry exists.", pathname);
+                return false;
+        }
+
+        if (find_glob(c->globs, pathname)) {
+                log_debug("Ignoring \"%s\": a separate glob exists.", pathname);
+                return false;
+        }
+
+        if (S_ISDIR(sx.stx_mode)) {
+                _cleanup_closedir_ DIR *sub_dir = NULL;
+
+                if (mountpoint &&
+                    streq(name, "lost+found") &&
+                    sx.stx_uid == 0) {
+                        log_debug("Ignoring directory \"%s\".", pathname);
+                        return false;
+                }
+
+                if (maxdepth <= 0)
+                        log_warning("Reached max depth on \"%s\".", pathname);
+                else {
+                        int q;
+
+                        sub_dir = xopendirat_nomod(dirfd(d), name);
+                        if (!sub_dir) {
+                                if (errno != ENOENT)
+                                        r = log_warning_errno(errno, "Opening directory \"%s\" failed, ignoring: %m", pathname);
+
+                                return false;
+                        }
+
+                        if (!arg_dry_run &&
+                            flock(dirfd(sub_dir), LOCK_EX|LOCK_NB) < 0) {
+                                log_debug_errno(errno, "Couldn't acquire shared BSD lock on directory \"%s\", skipping: %m", pathname);
+                                return false;
+                        }
+
+                        q = dir_cleanup(c, i,
+                                        pathname, sub_dir,
+                                        atime_nsec, mtime_nsec, cutoff_nsec,
+                                        false, maxdepth-1, false,
+                                        age_by_file, age_by_dir);
+                        if (q < 0)
+                                r = q;
+                }
+
+                /* Note: if you are wondering why we don't support the sticky bit for excluding
+                 * directories from cleaning like we do it for other file system objects: well, the
+                 * sticky bit already has a meaning for directories, so we don't want to overload
+                 * that. */
+
+                if (keep_this_level) {
+                        log_debug("Keeping directory \"%s\".", pathname);
+                        return false;
+                }
+
+                /*
+                 * Check the file timestamps of an entry against the
+                 * given cutoff time; delete if it is older.
+                 */
+                if (!needs_cleanup(atime_nsec, btime_nsec, ctime_nsec, mtime_nsec,
+                                   cutoff_nsec, pathname, age_by_dir, true))
+                        return false;
+
+                log_action("Would remove", "Removing", "%s directory \"%s\"", pathname);
+                if (!arg_dry_run &&
+                    unlinkat(dirfd(d), name, AT_REMOVEDIR) < 0 &&
+                    !IN_SET(errno, ENOENT, ENOTEMPTY))
+                        r = log_warning_errno(errno, "Failed to remove directory \"%s\", ignoring: %m", pathname);
+
+        } else {
+                _cleanup_close_ int fd = -EBADF; /* This file descriptor is defined here so that the
+                                                  * lock that is taken below is only dropped _after_
+                                                  * the unlink operation has finished. */
+
+                /* Skip files for which the sticky bit is set. These are semantics we define, and are
+                 * unknown elsewhere. See XDG_RUNTIME_DIR specification for details. */
+                if (sx.stx_mode & S_ISVTX) {
+                        log_debug("Skipping \"%s\": sticky bit set.", pathname);
+                        return false;
+                }
+
+                if (mountpoint &&
+                    S_ISREG(sx.stx_mode) &&
+                    sx.stx_uid == 0 &&
+                    STR_IN_SET(name,
+                               ".journal",
+                               "aquota.user",
+                               "aquota.group")) {
+                        log_debug("Skipping \"%s\".", pathname);
+                        return false;
+                }
+
+                /* Ignore sockets that are listed in /proc/net/unix */
+                if (S_ISSOCK(sx.stx_mode) && unix_socket_alive(c, pathname)) {
+                        log_debug("Skipping \"%s\": live socket.", pathname);
+                        return false;
+                }
+
+                /* Ignore device nodes */
+                if (S_ISCHR(sx.stx_mode) || S_ISBLK(sx.stx_mode)) {
+                        log_debug("Skipping \"%s\": a device.", pathname);
+                        return false;
+                }
+
+                /* Keep files on this level if this was requested */
+                if (keep_this_level) {
+                        log_debug("Keeping \"%s\".", pathname);
+                        return false;
+                }
+
+                if (!needs_cleanup(atime_nsec, btime_nsec, ctime_nsec, mtime_nsec,
+                                   cutoff_nsec, pathname, age_by_file, false))
+                        return false;
+
+                if (!arg_dry_run) {
+                        fd = xopenat(dirfd(d), name, O_RDONLY|O_CLOEXEC|O_NOFOLLOW|O_NOATIME|O_NONBLOCK|O_NOCTTY);
+                        if (fd < 0 && !IN_SET(fd, -ENOENT, -ELOOP))
+                                log_warning_errno(fd, "Opening file \"%s\" failed, proceeding without lock: %m", pathname);
+                        if (fd >= 0 && flock(fd, LOCK_EX|LOCK_NB) < 0 && errno == EAGAIN) {
+                                log_debug_errno(errno, "Couldn't acquire shared BSD lock on file \"%s\", skipping: %m", pathname);
+                                return false;
+                        }
+                }
+
+                log_action("Would remove", "Removing", "%s \"%s\"", pathname);
+                if (!arg_dry_run &&
+                    unlinkat(dirfd(d), name, 0) < 0 &&
+                    errno != ENOENT)
+                        r = log_warning_errno(errno, "Failed to remove \"%s\", ignoring: %m", pathname);
+
+                return true; /* flag that a file was deleted */
+        }
+        return false;
+}
+
+static int dir_cleanup(
+                Context *c,
+                Item *i,
+                const char *p,
+                DIR *d, /* directory to traverse for files to be cleaned up */
+                nsec_t self_atime_nsec,
+                nsec_t self_mtime_nsec,
+                nsec_t cutoff_nsec,
                 bool mountpoint,
                 int maxdepth,
                 bool keep_this_level,
@@ -685,184 +894,18 @@ static int dir_cleanup(
 
         FOREACH_DIRENT_ALL(de, d, break) {
                 _cleanup_free_ char *sub_path = NULL;
-                nsec_t atime_nsec, mtime_nsec, ctime_nsec, btime_nsec;
-
-                if (dot_or_dot_dot(de->d_name))
-                        continue;
-
-                struct statx sx;
-                r = xstatx_full(dirfd(d), de->d_name,
-                                AT_SYMLINK_NOFOLLOW|AT_NO_AUTOMOUNT,
-                                /* xstatx_flags= */ 0,
-                                STATX_TYPE|STATX_MODE|STATX_UID,
-                                STATX_ATIME|STATX_MTIME|STATX_CTIME|STATX_BTIME,
-                                STATX_ATTR_MOUNT_ROOT,
-                                &sx);
-                if (r == -ENOENT)
-                        continue;
-                if (r < 0) {
-                        /* FUSE, NFS mounts, SELinux might return EACCES */
-                        log_full_errno(r == -EACCES ? LOG_DEBUG : LOG_ERR, r,
-                                       "statx(%s/%s) failed: %m", p, de->d_name);
-                        continue;
-                }
-
-                if (FLAGS_SET(sx.stx_attributes, STATX_ATTR_MOUNT_ROOT)) {
-                        log_debug("Ignoring \"%s/%s\": different mount points.", p, de->d_name);
-                        continue;
-                }
-
-                atime_nsec = FLAGS_SET(sx.stx_mask, STATX_ATIME) ? statx_timestamp_load_nsec(&sx.stx_atime) : NSEC_INFINITY;
-                mtime_nsec = FLAGS_SET(sx.stx_mask, STATX_MTIME) ? statx_timestamp_load_nsec(&sx.stx_mtime) : NSEC_INFINITY;
-                ctime_nsec = FLAGS_SET(sx.stx_mask, STATX_CTIME) ? statx_timestamp_load_nsec(&sx.stx_ctime) : NSEC_INFINITY;
-                btime_nsec = FLAGS_SET(sx.stx_mask, STATX_BTIME) ? statx_timestamp_load_nsec(&sx.stx_btime) : NSEC_INFINITY;
-
                 sub_path = path_join(p, de->d_name);
                 if (!sub_path) {
                         r = log_oom();
-                        goto finish;
+                        break;
                 }
 
-                /* Is there an item configured for this path? */
-                if (ordered_hashmap_get(c->items, sub_path)) {
-                        log_debug("Ignoring \"%s\": a separate entry exists.", sub_path);
-                        continue;
-                }
-
-                if (find_glob(c->globs, sub_path)) {
-                        log_debug("Ignoring \"%s\": a separate glob exists.", sub_path);
-                        continue;
-                }
-
-                if (S_ISDIR(sx.stx_mode)) {
-                        _cleanup_closedir_ DIR *sub_dir = NULL;
-
-                        if (mountpoint &&
-                            streq(de->d_name, "lost+found") &&
-                            sx.stx_uid == 0) {
-                                log_debug("Ignoring directory \"%s\".", sub_path);
-                                continue;
-                        }
-
-                        if (maxdepth <= 0)
-                                log_warning("Reached max depth on \"%s\".", sub_path);
-                        else {
-                                int q;
-
-                                sub_dir = xopendirat_nomod(dirfd(d), de->d_name);
-                                if (!sub_dir) {
-                                        if (errno != ENOENT)
-                                                r = log_warning_errno(errno, "Opening directory \"%s\" failed, ignoring: %m", sub_path);
-
-                                        continue;
-                                }
-
-                                if (!arg_dry_run &&
-                                    flock(dirfd(sub_dir), LOCK_EX|LOCK_NB) < 0) {
-                                        log_debug_errno(errno, "Couldn't acquire shared BSD lock on directory \"%s\", skipping: %m", sub_path);
-                                        continue;
-                                }
-
-                                q = dir_cleanup(c, i,
-                                                sub_path, sub_dir,
-                                                atime_nsec, mtime_nsec, cutoff_nsec,
-                                                rootdev_major, rootdev_minor,
-                                                false, maxdepth-1, false,
-                                                age_by_file, age_by_dir);
-                                if (q < 0)
-                                        r = q;
-                        }
-
-                        /* Note: if you are wondering why we don't support the sticky bit for excluding
-                         * directories from cleaning like we do it for other file system objects: well, the
-                         * sticky bit already has a meaning for directories, so we don't want to overload
-                         * that. */
-
-                        if (keep_this_level) {
-                                log_debug("Keeping directory \"%s\".", sub_path);
-                                continue;
-                        }
-
-                        /*
-                         * Check the file timestamps of an entry against the
-                         * given cutoff time; delete if it is older.
-                         */
-                        if (!needs_cleanup(atime_nsec, btime_nsec, ctime_nsec, mtime_nsec,
-                                           cutoff_nsec, sub_path, age_by_dir, true))
-                                continue;
-
-                        log_action("Would remove", "Removing", "%s directory \"%s\"", sub_path);
-                        if (!arg_dry_run &&
-                            unlinkat(dirfd(d), de->d_name, AT_REMOVEDIR) < 0 &&
-                            !IN_SET(errno, ENOENT, ENOTEMPTY))
-                                r = log_warning_errno(errno, "Failed to remove directory \"%s\", ignoring: %m", sub_path);
-
-                } else {
-                        _cleanup_close_ int fd = -EBADF; /* This file descriptor is defined here so that the
-                                                          * lock that is taken below is only dropped _after_
-                                                          * the unlink operation has finished. */
-
-                        /* Skip files for which the sticky bit is set. These are semantics we define, and are
-                         * unknown elsewhere. See XDG_RUNTIME_DIR specification for details. */
-                        if (sx.stx_mode & S_ISVTX) {
-                                log_debug("Skipping \"%s\": sticky bit set.", sub_path);
-                                continue;
-                        }
-
-                        if (mountpoint &&
-                            S_ISREG(sx.stx_mode) &&
-                            sx.stx_uid == 0 &&
-                            STR_IN_SET(de->d_name,
-                                       ".journal",
-                                       "aquota.user",
-                                       "aquota.group")) {
-                                log_debug("Skipping \"%s\".", sub_path);
-                                continue;
-                        }
-
-                        /* Ignore sockets that are listed in /proc/net/unix */
-                        if (S_ISSOCK(sx.stx_mode) && unix_socket_alive(c, sub_path)) {
-                                log_debug("Skipping \"%s\": live socket.", sub_path);
-                                continue;
-                        }
-
-                        /* Ignore device nodes */
-                        if (S_ISCHR(sx.stx_mode) || S_ISBLK(sx.stx_mode)) {
-                                log_debug("Skipping \"%s\": a device.", sub_path);
-                                continue;
-                        }
-
-                        /* Keep files on this level if this was requested */
-                        if (keep_this_level) {
-                                log_debug("Keeping \"%s\".", sub_path);
-                                continue;
-                        }
-
-                        if (!needs_cleanup(atime_nsec, btime_nsec, ctime_nsec, mtime_nsec,
-                                           cutoff_nsec, sub_path, age_by_file, false))
-                                continue;
-
-                        if (!arg_dry_run) {
-                                fd = xopenat(dirfd(d), de->d_name, O_RDONLY|O_CLOEXEC|O_NOFOLLOW|O_NOATIME|O_NONBLOCK|O_NOCTTY);
-                                if (fd < 0 && !IN_SET(fd, -ENOENT, -ELOOP))
-                                        log_warning_errno(fd, "Opening file \"%s\" failed, proceeding without lock: %m", sub_path);
-                                if (fd >= 0 && flock(fd, LOCK_EX|LOCK_NB) < 0 && errno == EAGAIN) {
-                                        log_debug_errno(errno, "Couldn't acquire shared BSD lock on file \"%s\", skipping: %m", sub_path);
-                                        continue;
-                                }
-                        }
-
-                        log_action("Would remove", "Removing", "%s \"%s\"", sub_path);
-                        if (!arg_dry_run &&
-                            unlinkat(dirfd(d), de->d_name, 0) < 0 &&
-                            errno != ENOENT)
-                                r = log_warning_errno(errno, "Failed to remove \"%s\", ignoring: %m", sub_path);
-
-                        deleted = true;
-                }
+                deleted |= item_cleanup(c, i,
+                                sub_path, de->d_name, d,
+                                cutoff_nsec,
+                                mountpoint, maxdepth, keep_this_level,
+                                age_by_file, age_by_dir);
         }
-
-finish:
         if (deleted && (self_atime_nsec < NSEC_INFINITY || self_mtime_nsec < NSEC_INFINITY)) {
                 struct timespec ts[2];
 
@@ -2150,13 +2193,13 @@ static int empty_directory(
 
         assert(c);
         assert(i);
-        assert(i->type == EMPTY_DIRECTORY);
+        assert(i->type == EMPTY_DIRECTORY || i->type == CLEAN_INCLUSIVE);
 
         r = chase(path, arg_root, CHASE_SAFE|CHASE_WARN, NULL, &fd);
         if (r == -ENOLINK) /* Unsafe symlink: already covered by CHASE_WARN */
                 return r;
         if (r == -ENOENT) {
-                /* Option "e" operates only on existing objects. Do not print errors about non-existent files
+                /* Option "e" and "E" operate only on existing objects. Do not print errors about non-existent files
                  * or directories */
                 log_debug_errno(r, "Skipping missing directory: %s", path);
                 return 0;
@@ -2872,6 +2915,7 @@ static int create_item(Context *c, Item *i) {
                 break;
 
         case EMPTY_DIRECTORY:
+        case CLEAN_INCLUSIVE:
                 r = glob_item(c, i, empty_directory);
                 if (r < 0)
                         return r;
@@ -3000,7 +3044,6 @@ static int remove_recursive(
                         /* self_atime_nsec= */ NSEC_INFINITY,
                         /* self_mtime_nsec= */ NSEC_INFINITY,
                         /* cutoff_nsec= */ NSEC_INFINITY,
-                        sx.stx_dev_major, sx.stx_dev_minor,
                         mountpoint,
                         MAX_DEPTH,
                         /* keep_this_level= */ false,
@@ -3110,6 +3153,7 @@ static char *age_by_to_string(AgeBy ab, bool is_dir) {
         return ret;
 }
 
+/* Cleanup contents of directory */
 static int clean_item_instance(
                 Context *c,
                 Item *i,
@@ -3162,7 +3206,67 @@ static int clean_item_instance(
                            atime_nsec,
                            mtime_nsec,
                            cutoff * NSEC_PER_USEC,
-                           sx.stx_dev_major, sx.stx_dev_minor,
+                           mountpoint,
+                           MAX_DEPTH, i->keep_first_level,
+                           i->age_by_file, i->age_by_dir);
+}
+
+/* Cleanup file or directory, including the actual file and directory, not just its contents  */
+static int clean_including_item(
+                Context *c,
+                Item *i,
+                const char* instance,
+                CreationMode creation) {
+
+        assert(i);
+
+        /* If age not specified in .conf file, do nothing */
+        if (!i->age_set)
+                return 0;
+
+        usec_t n = now(CLOCK_REALTIME);
+        /* If file age is in the future, do nothing */
+        if (n < i->age)
+                return 0;
+
+        usec_t cutoff = n - i->age;
+
+        /* Find parent path so we can get stats on the directory that holds instance file|dir */
+        _cleanup_free_ char *parent_path = NULL;
+        _cleanup_closedir_ DIR *d = NULL;
+        struct statx sx;
+        bool mountpoint;
+        int r;
+
+        parent_path = path_join(instance, "..");
+        if (!parent_path) {
+                return log_oom();
+        }
+        r = opendir_and_stat(parent_path, &d, &sx, &mountpoint);
+        if (r <= 0)
+                return r;
+
+        if (DEBUG_LOGGING) {
+                _cleanup_free_ char *ab_f = NULL, *ab_d = NULL;
+
+                ab_f = age_by_to_string(i->age_by_file, false);
+                if (!ab_f)
+                        return log_oom();
+
+                ab_d = age_by_to_string(i->age_by_dir, true);
+                if (!ab_d)
+                        return log_oom();
+
+                log_debug("Cleanup threshold for %s \"%s\" is %s; age-by: %s%s",
+                          mountpoint ? "mount point" : "directory",
+                          instance,
+                          FORMAT_TIMESTAMP_STYLE(cutoff, TIMESTAMP_US),
+                          ab_f, ab_d);
+        }
+
+        const char *name = last_path_component(instance);
+        return item_cleanup(c, i, instance, name, d,
+                           cutoff * NSEC_PER_USEC,
                            mountpoint,
                            MAX_DEPTH, i->keep_first_level,
                            i->age_by_file, i->age_by_dir);
@@ -3189,6 +3293,9 @@ static int clean_item(Context *c, Item *i) {
         case IGNORE_PATH:
         case IGNORE_DIRECTORY_PATH:
                 return glob_item(c, i, clean_item_instance);
+
+        case CLEAN_INCLUSIVE:
+                return glob_item(c, i, clean_including_item);
 
         default:
                 return 0;
@@ -3717,6 +3824,7 @@ static int parse_line(
         case CREATE_SUBVOLUME_INHERIT_QUOTA:
         case CREATE_SUBVOLUME_NEW_QUOTA:
         case EMPTY_DIRECTORY:
+        case CLEAN_INCLUSIVE:
         case TRUNCATE_DIRECTORY:
         case CREATE_FIFO:
         case IGNORE_PATH:

--- a/src/tmpfiles/tmpfiles.c
+++ b/src/tmpfiles/tmpfiles.c
@@ -101,6 +101,7 @@ typedef enum ItemType {
         /* These ones take globs */
         WRITE_FILE                     = 'w',
         EMPTY_DIRECTORY                = 'e',
+        CLEAN_INCLUSIVE                = 'E',
         SET_XATTR                      = 't',
         RECURSIVE_SET_XATTR            = 'T',
         SET_ACL                        = 'a',
@@ -415,13 +416,15 @@ static bool needs_purge(ItemType t) {
                       CREATE_BLOCK_DEVICE,
                       COPY_FILES,
                       WRITE_FILE,
-                      EMPTY_DIRECTORY);
+                      EMPTY_DIRECTORY,
+                      CLEAN_INCLUSIVE);
 }
 
 static bool needs_glob(ItemType t) {
         return IN_SET(t,
                       WRITE_FILE,
                       EMPTY_DIRECTORY,
+                      CLEAN_INCLUSIVE,
                       SET_XATTR,
                       RECURSIVE_SET_XATTR,
                       SET_ACL,
@@ -455,6 +458,7 @@ static bool takes_ownership(ItemType t) {
                       COPY_FILES,
                       WRITE_FILE,
                       EMPTY_DIRECTORY,
+                      CLEAN_INCLUSIVE,
                       IGNORE_PATH,
                       IGNORE_DIRECTORY_PATH,
                       REMOVE_PATH,
@@ -465,13 +469,17 @@ static bool supports_ignore_if_target_missing(ItemType t) {
         return t == CREATE_SYMLINK;
 }
 
-static struct Item* find_glob(OrderedHashmap *h, const char *match) {
+/* Search for 'match' in all config items besides 'except' (which may be NULL if there is no exception) */
+static struct Item* find_glob(OrderedHashmap *h, const char *match, const Item *except) {
         ItemArray *j;
 
         ORDERED_HASHMAP_FOREACH(j, h)
-                FOREACH_ARRAY(item, j->items, j->n_items)
+                FOREACH_ARRAY(item, j->items, j->n_items) {
+                        if (except && item == except)
+                                continue;
                         if (fnmatch(item->path, match, FNM_PATHNAME|FNM_PERIOD) == 0)
                                 return item;
+                }
         return NULL;
 }
 
@@ -680,6 +688,7 @@ static bool needs_cleanup(
         return true;
 }
 
+/* Declare prototype so that item_cleanup() can call dir_cleanup() (mutual recursion) */
 static int dir_cleanup(
                 Context *c,
                 Item *i,
@@ -688,8 +697,209 @@ static int dir_cleanup(
                 nsec_t self_atime_nsec,
                 nsec_t self_mtime_nsec,
                 nsec_t cutoff_nsec,
-                dev_t rootdev_major,
-                dev_t rootdev_minor,
+                bool mountpoint,
+                int maxdepth,
+                bool keep_this_level,
+                AgeBy age_by_file,
+                AgeBy age_by_dir);
+
+static bool item_cleanup(
+                Context *c,
+                Item *i,
+                const char *pathname, /* joined path (path/name) of directory|file to be cleaned up */
+                const char *name, /* basename of directory|file to be cleaned up */
+                int dir_fd, /* dirfd of directory that contains name -- used for unlinkat(dirfd) */
+                nsec_t cutoff_nsec,
+                bool mountpoint, /* whether the parent directory (dir_fd) is a mountpoint */
+                int maxdepth, /* max directory recursion depth */
+                bool keep_this_level,
+                AgeBy age_by_file, /* age criteria ([a|m|c|b]_time) to examine against file age */
+                AgeBy age_by_dir) { /* same age criteria for directory */
+        /* Clean up a file or directory, recursively, according to the cutoff_nsec age constraint.
+         * Errors are ignored, consistent with historical behaviour for tmpfiles cleanup.
+         * Return true if a file or directory is deleted.
+        */
+        int r = 0;
+
+        assert(c);
+        assert(i);
+
+        nsec_t atime_nsec, mtime_nsec, ctime_nsec, btime_nsec;
+
+        if (dot_or_dot_dot(name))
+                return false;
+
+        struct statx sx;
+        r = xstatx_full(dir_fd, name,
+                        AT_SYMLINK_NOFOLLOW|AT_NO_AUTOMOUNT,
+                        /* xstatx_flags= */ 0,
+                        STATX_TYPE|STATX_MODE|STATX_UID,
+                        STATX_ATIME|STATX_MTIME|STATX_CTIME|STATX_BTIME,
+                        STATX_ATTR_MOUNT_ROOT,
+                        &sx);
+        if (r == -ENOENT)
+                return false;
+        if (r < 0) {
+                /* FUSE, NFS mounts, SELinux might return EACCES */
+                log_full_errno(r == -EACCES ? LOG_DEBUG : LOG_ERR, r,
+                               "statx(%s) failed: %m", pathname);
+                return false;
+        }
+
+        if (FLAGS_SET(sx.stx_attributes, STATX_ATTR_MOUNT_ROOT)) {
+                log_debug("Ignoring \"%s\": different mount points.", pathname);
+                return false;
+        }
+
+        atime_nsec = FLAGS_SET(sx.stx_mask, STATX_ATIME) ? statx_timestamp_load_nsec(&sx.stx_atime) : NSEC_INFINITY;
+        mtime_nsec = FLAGS_SET(sx.stx_mask, STATX_MTIME) ? statx_timestamp_load_nsec(&sx.stx_mtime) : NSEC_INFINITY;
+        ctime_nsec = FLAGS_SET(sx.stx_mask, STATX_CTIME) ? statx_timestamp_load_nsec(&sx.stx_ctime) : NSEC_INFINITY;
+        btime_nsec = FLAGS_SET(sx.stx_mask, STATX_BTIME) ? statx_timestamp_load_nsec(&sx.stx_btime) : NSEC_INFINITY;
+
+        /* Is there an item configured for this path? */
+        if (ordered_hashmap_get(c->items, pathname)) {
+                log_debug("Ignoring \"%s\": a separate entry exists.", pathname);
+                return false;
+        }
+
+        if (find_glob(c->globs, pathname, i)) {
+                log_debug("Ignoring \"%s\": a separate glob exists.", pathname);
+                return false;
+        }
+
+        if (S_ISDIR(sx.stx_mode)) {
+                _cleanup_closedir_ DIR *sub_dir = NULL;
+
+                if (mountpoint &&
+                    streq(name, "lost+found") &&
+                    sx.stx_uid == 0) {
+                        log_debug("Ignoring directory \"%s\".", pathname);
+                        return false;
+                }
+
+                if (maxdepth <= 0)
+                        log_warning("Reached max depth on \"%s\".", pathname);
+                else {
+                        sub_dir = xopendirat_nomod(dir_fd, name);
+                        if (!sub_dir) {
+                                if (errno != ENOENT)
+                                        log_warning_errno(errno, "Opening directory \"%s\" failed, ignoring: %m", pathname);
+                                return false;
+                        }
+
+                        if (!arg_dry_run &&
+                            flock(dirfd(sub_dir), LOCK_EX|LOCK_NB) < 0) {
+                                log_debug_errno(errno, "Couldn't acquire shared BSD lock on directory \"%s\", skipping: %m", pathname);
+                                return false;
+                        }
+
+                        dir_cleanup(c, i,
+                                        pathname, sub_dir,
+                                        atime_nsec, mtime_nsec, cutoff_nsec,
+                                        false, maxdepth-1, false,
+                                        age_by_file, age_by_dir);
+                }
+
+                /* Note: if you are wondering why we don't support the sticky bit for excluding
+                 * directories from cleaning like we do it for other file system objects: well, the
+                 * sticky bit already has a meaning for directories, so we don't want to overload
+                 * that. */
+
+                if (keep_this_level) {
+                        log_debug("Keeping directory \"%s\".", pathname);
+                        return false;
+                }
+
+                /*
+                 * Check the file timestamps of an entry against the
+                 * given cutoff time; delete if it is older.
+                 */
+                if (!needs_cleanup(atime_nsec, btime_nsec, ctime_nsec, mtime_nsec,
+                                   cutoff_nsec, pathname, age_by_dir, true))
+                        return false;
+
+                log_action("Would remove", "Removing", "%s directory \"%s\"", pathname);
+                if (!arg_dry_run &&
+                    (r=unlinkat(dir_fd, name, AT_REMOVEDIR)) < 0 &&
+                    !IN_SET(errno, ENOENT, ENOTEMPTY))
+                        log_warning_errno(errno, "Failed to remove directory \"%s\", ignoring: %m", pathname);
+                if (r >= 0)
+                        return true; /* flag that a directory entry was deleted */
+
+        } else {
+                _cleanup_close_ int fd = -EBADF; /* This file descriptor is defined here so that the
+                                                  * lock that is taken below is only dropped _after_
+                                                  * the unlink operation has finished. */
+
+                /* Skip files for which the sticky bit is set. These are semantics we define, and are
+                 * unknown elsewhere. See XDG_RUNTIME_DIR specification for details. */
+                if (sx.stx_mode & S_ISVTX) {
+                        log_debug("Skipping \"%s\": sticky bit set.", pathname);
+                        return false;
+                }
+
+                if (mountpoint &&
+                    S_ISREG(sx.stx_mode) &&
+                    sx.stx_uid == 0 &&
+                    STR_IN_SET(name,
+                               ".journal",
+                               "aquota.user",
+                               "aquota.group")) {
+                        log_debug("Skipping \"%s\".", pathname);
+                        return false;
+                }
+
+                /* Ignore sockets that are listed in /proc/net/unix */
+                if (S_ISSOCK(sx.stx_mode) && unix_socket_alive(c, pathname)) {
+                        log_debug("Skipping \"%s\": live socket.", pathname);
+                        return false;
+                }
+
+                /* Ignore device nodes */
+                if (S_ISCHR(sx.stx_mode) || S_ISBLK(sx.stx_mode)) {
+                        log_debug("Skipping \"%s\": a device.", pathname);
+                        return false;
+                }
+
+                /* Keep files on this level if this was requested */
+                if (keep_this_level) {
+                        log_debug("Keeping \"%s\".", pathname);
+                        return false;
+                }
+
+                if (!needs_cleanup(atime_nsec, btime_nsec, ctime_nsec, mtime_nsec,
+                                   cutoff_nsec, pathname, age_by_file, false))
+                        return false;
+
+                if (!arg_dry_run) {
+                        fd = xopenat(dir_fd, name, O_RDONLY|O_CLOEXEC|O_NOFOLLOW|O_NOATIME|O_NONBLOCK|O_NOCTTY);
+                        if (fd < 0 && !IN_SET(fd, -ENOENT, -ELOOP))
+                                log_warning_errno(fd, "Opening file \"%s\" failed, proceeding without lock: %m", pathname);
+                        if (fd >= 0 && flock(fd, LOCK_EX|LOCK_NB) < 0 && errno == EAGAIN) {
+                                log_debug_errno(errno, "Couldn't acquire shared BSD lock on file \"%s\", skipping: %m", pathname);
+                                return false;
+                        }
+                }
+
+                log_action("Would remove", "Removing", "%s \"%s\"", pathname);
+                if (!arg_dry_run &&
+                    (r=unlinkat(dir_fd, name, 0)) < 0 &&
+                    errno != ENOENT)
+                        log_warning_errno(errno, "Failed to remove \"%s\", ignoring: %m", pathname);
+                if (r >= 0)
+                        return true; /* flag that a file was deleted */
+        }
+        return false;
+}
+
+static int dir_cleanup(
+                Context *c,
+                Item *i,
+                const char *p,
+                DIR *d, /* directory to traverse for files to be cleaned up */
+                nsec_t self_atime_nsec,
+                nsec_t self_mtime_nsec,
+                nsec_t cutoff_nsec,
                 bool mountpoint,
                 int maxdepth,
                 bool keep_this_level,
@@ -705,184 +915,18 @@ static int dir_cleanup(
 
         FOREACH_DIRENT_ALL(de, d, break) {
                 _cleanup_free_ char *sub_path = NULL;
-                nsec_t atime_nsec, mtime_nsec, ctime_nsec, btime_nsec;
-
-                if (dot_or_dot_dot(de->d_name))
-                        continue;
-
-                struct statx sx;
-                r = xstatx_full(dirfd(d), de->d_name,
-                                AT_SYMLINK_NOFOLLOW|AT_NO_AUTOMOUNT,
-                                /* xstatx_flags= */ 0,
-                                STATX_TYPE|STATX_MODE|STATX_UID,
-                                STATX_ATIME|STATX_MTIME|STATX_CTIME|STATX_BTIME,
-                                STATX_ATTR_MOUNT_ROOT,
-                                &sx);
-                if (r == -ENOENT)
-                        continue;
-                if (r < 0) {
-                        /* FUSE, NFS mounts, SELinux might return EACCES */
-                        log_full_errno(r == -EACCES ? LOG_DEBUG : LOG_ERR, r,
-                                       "statx(%s/%s) failed: %m", p, de->d_name);
-                        continue;
-                }
-
-                if (FLAGS_SET(sx.stx_attributes, STATX_ATTR_MOUNT_ROOT)) {
-                        log_debug("Ignoring \"%s/%s\": different mount points.", p, de->d_name);
-                        continue;
-                }
-
-                atime_nsec = FLAGS_SET(sx.stx_mask, STATX_ATIME) ? statx_timestamp_load_nsec(&sx.stx_atime) : NSEC_INFINITY;
-                mtime_nsec = FLAGS_SET(sx.stx_mask, STATX_MTIME) ? statx_timestamp_load_nsec(&sx.stx_mtime) : NSEC_INFINITY;
-                ctime_nsec = FLAGS_SET(sx.stx_mask, STATX_CTIME) ? statx_timestamp_load_nsec(&sx.stx_ctime) : NSEC_INFINITY;
-                btime_nsec = FLAGS_SET(sx.stx_mask, STATX_BTIME) ? statx_timestamp_load_nsec(&sx.stx_btime) : NSEC_INFINITY;
-
                 sub_path = path_join(p, de->d_name);
                 if (!sub_path) {
                         r = log_oom();
-                        goto finish;
+                        break;
                 }
 
-                /* Is there an item configured for this path? */
-                if (ordered_hashmap_get(c->items, sub_path)) {
-                        log_debug("Ignoring \"%s\": a separate entry exists.", sub_path);
-                        continue;
-                }
-
-                if (find_glob(c->globs, sub_path)) {
-                        log_debug("Ignoring \"%s\": a separate glob exists.", sub_path);
-                        continue;
-                }
-
-                if (S_ISDIR(sx.stx_mode)) {
-                        _cleanup_closedir_ DIR *sub_dir = NULL;
-
-                        if (mountpoint &&
-                            streq(de->d_name, "lost+found") &&
-                            sx.stx_uid == 0) {
-                                log_debug("Ignoring directory \"%s\".", sub_path);
-                                continue;
-                        }
-
-                        if (maxdepth <= 0)
-                                log_warning("Reached max depth on \"%s\".", sub_path);
-                        else {
-                                int q;
-
-                                sub_dir = xopendirat_nomod(dirfd(d), de->d_name);
-                                if (!sub_dir) {
-                                        if (errno != ENOENT)
-                                                r = log_warning_errno(errno, "Opening directory \"%s\" failed, ignoring: %m", sub_path);
-
-                                        continue;
-                                }
-
-                                if (!arg_dry_run &&
-                                    flock(dirfd(sub_dir), LOCK_EX|LOCK_NB) < 0) {
-                                        log_debug_errno(errno, "Couldn't acquire shared BSD lock on directory \"%s\", skipping: %m", sub_path);
-                                        continue;
-                                }
-
-                                q = dir_cleanup(c, i,
-                                                sub_path, sub_dir,
-                                                atime_nsec, mtime_nsec, cutoff_nsec,
-                                                rootdev_major, rootdev_minor,
-                                                false, maxdepth-1, false,
-                                                age_by_file, age_by_dir);
-                                if (q < 0)
-                                        r = q;
-                        }
-
-                        /* Note: if you are wondering why we don't support the sticky bit for excluding
-                         * directories from cleaning like we do it for other file system objects: well, the
-                         * sticky bit already has a meaning for directories, so we don't want to overload
-                         * that. */
-
-                        if (keep_this_level) {
-                                log_debug("Keeping directory \"%s\".", sub_path);
-                                continue;
-                        }
-
-                        /*
-                         * Check the file timestamps of an entry against the
-                         * given cutoff time; delete if it is older.
-                         */
-                        if (!needs_cleanup(atime_nsec, btime_nsec, ctime_nsec, mtime_nsec,
-                                           cutoff_nsec, sub_path, age_by_dir, true))
-                                continue;
-
-                        log_action("Would remove", "Removing", "%s directory \"%s\"", sub_path);
-                        if (!arg_dry_run &&
-                            unlinkat(dirfd(d), de->d_name, AT_REMOVEDIR) < 0 &&
-                            !IN_SET(errno, ENOENT, ENOTEMPTY))
-                                r = log_warning_errno(errno, "Failed to remove directory \"%s\", ignoring: %m", sub_path);
-
-                } else {
-                        _cleanup_close_ int fd = -EBADF; /* This file descriptor is defined here so that the
-                                                          * lock that is taken below is only dropped _after_
-                                                          * the unlink operation has finished. */
-
-                        /* Skip files for which the sticky bit is set. These are semantics we define, and are
-                         * unknown elsewhere. See XDG_RUNTIME_DIR specification for details. */
-                        if (sx.stx_mode & S_ISVTX) {
-                                log_debug("Skipping \"%s\": sticky bit set.", sub_path);
-                                continue;
-                        }
-
-                        if (mountpoint &&
-                            S_ISREG(sx.stx_mode) &&
-                            sx.stx_uid == 0 &&
-                            STR_IN_SET(de->d_name,
-                                       ".journal",
-                                       "aquota.user",
-                                       "aquota.group")) {
-                                log_debug("Skipping \"%s\".", sub_path);
-                                continue;
-                        }
-
-                        /* Ignore sockets that are listed in /proc/net/unix */
-                        if (S_ISSOCK(sx.stx_mode) && unix_socket_alive(c, sub_path)) {
-                                log_debug("Skipping \"%s\": live socket.", sub_path);
-                                continue;
-                        }
-
-                        /* Ignore device nodes */
-                        if (S_ISCHR(sx.stx_mode) || S_ISBLK(sx.stx_mode)) {
-                                log_debug("Skipping \"%s\": a device.", sub_path);
-                                continue;
-                        }
-
-                        /* Keep files on this level if this was requested */
-                        if (keep_this_level) {
-                                log_debug("Keeping \"%s\".", sub_path);
-                                continue;
-                        }
-
-                        if (!needs_cleanup(atime_nsec, btime_nsec, ctime_nsec, mtime_nsec,
-                                           cutoff_nsec, sub_path, age_by_file, false))
-                                continue;
-
-                        if (!arg_dry_run) {
-                                fd = xopenat(dirfd(d), de->d_name, O_RDONLY|O_CLOEXEC|O_NOFOLLOW|O_NOATIME|O_NONBLOCK|O_NOCTTY);
-                                if (fd < 0 && !IN_SET(fd, -ENOENT, -ELOOP))
-                                        log_warning_errno(fd, "Opening file \"%s\" failed, proceeding without lock: %m", sub_path);
-                                if (fd >= 0 && flock(fd, LOCK_EX|LOCK_NB) < 0 && errno == EAGAIN) {
-                                        log_debug_errno(errno, "Couldn't acquire shared BSD lock on file \"%s\", skipping: %m", sub_path);
-                                        continue;
-                                }
-                        }
-
-                        log_action("Would remove", "Removing", "%s \"%s\"", sub_path);
-                        if (!arg_dry_run &&
-                            unlinkat(dirfd(d), de->d_name, 0) < 0 &&
-                            errno != ENOENT)
-                                r = log_warning_errno(errno, "Failed to remove \"%s\", ignoring: %m", sub_path);
-
-                        deleted = true;
-                }
+                deleted |= item_cleanup(c, i,
+                                sub_path, de->d_name, dirfd(d),
+                                cutoff_nsec,
+                                mountpoint, maxdepth, keep_this_level,
+                                age_by_file, age_by_dir);
         }
-
-finish:
         if (deleted && (self_atime_nsec < NSEC_INFINITY || self_mtime_nsec < NSEC_INFINITY)) {
                 struct timespec ts[2];
 
@@ -2435,13 +2479,13 @@ static int empty_directory(
 
         assert(c);
         assert(i);
-        assert(i->type == EMPTY_DIRECTORY);
+        assert(i->type == EMPTY_DIRECTORY || i->type == CLEAN_INCLUSIVE);
 
         r = chase(path, arg_root, CHASE_SAFE|CHASE_WARN, NULL, &fd);
         if (r == -ENOLINK) /* Unsafe symlink: already covered by CHASE_WARN */
                 return r;
         if (r == -ENOENT) {
-                /* Option "e" operates only on existing objects. Do not print errors about non-existent files
+                /* Option "e" and "E" operate only on existing objects. Do not print errors about non-existent files
                  * or directories */
                 log_debug_errno(r, "Skipping missing directory: %s", path);
                 return 0;
@@ -3157,6 +3201,7 @@ static int create_item(Context *c, Item *i) {
                 break;
 
         case EMPTY_DIRECTORY:
+        case CLEAN_INCLUSIVE:
                 r = glob_item(c, i, empty_directory);
                 if (r < 0)
                         return r;
@@ -3297,7 +3342,6 @@ static int remove_recursive(
                         /* self_atime_nsec= */ NSEC_INFINITY,
                         /* self_mtime_nsec= */ NSEC_INFINITY,
                         /* cutoff_nsec= */ NSEC_INFINITY,
-                        sx.stx_dev_major, sx.stx_dev_minor,
                         mountpoint,
                         MAX_DEPTH,
                         /* keep_this_level= */ false,
@@ -3407,6 +3451,7 @@ static char *age_by_to_string(AgeBy ab, bool is_dir) {
         return ret;
 }
 
+/* Cleanup contents of directory */
 static int clean_item_instance(
                 Context *c,
                 Item *i,
@@ -3459,10 +3504,82 @@ static int clean_item_instance(
                            atime_nsec,
                            mtime_nsec,
                            cutoff * NSEC_PER_USEC,
-                           sx.stx_dev_major, sx.stx_dev_minor,
                            mountpoint,
                            MAX_DEPTH, i->keep_first_level,
                            i->age_by_file, i->age_by_dir);
+}
+
+/* Cleanup file or directory, including the actual file and directory, not just its contents  */
+static int clean_including_item(
+                Context *c,
+                Item *i,
+                const char *instance,
+                CreationMode creation) {
+
+        assert(i);
+
+        /* If age not specified in .conf file, do nothing */
+        if (!i->age_set)
+                return 0;
+
+        usec_t n = now(CLOCK_REALTIME);
+        /* If file age is in the future, do nothing */
+        if (n < i->age)
+                return 0;
+
+        usec_t cutoff = n - i->age;
+
+        _cleanup_close_ int dir_fd = -EBADF;
+        struct statx sx;
+        bool mountpoint;
+        int r;
+
+        /* Find parent path so we can get stats on the directory that holds instance (file or dir) */
+        ChaseFlags chase_flags = CHASE_SAFE | CHASE_NOFOLLOW | (i->allow_failure ? 0 : CHASE_WARN);
+        dir_fd = chase_and_open_parent_at(AT_FDCWD, instance, chase_flags, NULL);
+        if (dir_fd < 0)
+                return log_full_errno(i->allow_failure ? LOG_INFO : LOG_ERR,
+                                      dir_fd,
+                                      "Failed to open path '%s'%s: %m",
+                                      instance,
+                                      i->allow_failure ? ", ignoring" : "");
+        r = xstatx_full(dir_fd,
+                        /* path= */ NULL,
+                        /* statx_flags= */ AT_EMPTY_PATH|AT_NO_AUTOMOUNT,
+                        /* xstatx_flags= */ 0,
+                        /* mandatory_mask= */ 0,
+                        /* optional_mask= */ 0,
+                        /* mandatory_attributes= */ STATX_ATTR_MOUNT_ROOT,
+                        &sx);
+        if (r < 0)
+                return log_error_errno(r, "statx on parent of '%s' failed: %m", instance);
+
+        mountpoint = FLAGS_SET(sx.stx_attributes, STATX_ATTR_MOUNT_ROOT);
+        if (DEBUG_LOGGING) {
+                _cleanup_free_ char *ab_f = NULL, *ab_d = NULL;
+
+                ab_f = age_by_to_string(i->age_by_file, false);
+                if (!ab_f)
+                        return log_oom();
+
+                ab_d = age_by_to_string(i->age_by_dir, true);
+                if (!ab_d)
+                        return log_oom();
+
+                log_debug("Cleanup threshold for %s \"%s\" is %s; age-by: %s%s",
+                          mountpoint ? "mount point" : "directory",
+                          instance,
+                          FORMAT_TIMESTAMP_STYLE(cutoff, TIMESTAMP_US),
+                          ab_f, ab_d);
+        }
+
+        const char *name = last_path_component(instance);
+        item_cleanup(c, i, instance, name, dir_fd,
+                           cutoff * NSEC_PER_USEC,
+                           mountpoint,
+                           MAX_DEPTH, i->keep_first_level,
+                           i->age_by_file, i->age_by_dir);
+        return 0;
 }
 
 static int clean_item(Context *c, Item *i) {
@@ -3486,6 +3603,9 @@ static int clean_item(Context *c, Item *i) {
         case IGNORE_PATH:
         case IGNORE_DIRECTORY_PATH:
                 return glob_item(c, i, clean_item_instance);
+
+        case CLEAN_INCLUSIVE:
+                return glob_item(c, i, clean_including_item);
 
         default:
                 return 0;
@@ -4014,6 +4134,7 @@ static int parse_line(
         case CREATE_SUBVOLUME_INHERIT_QUOTA:
         case CREATE_SUBVOLUME_NEW_QUOTA:
         case EMPTY_DIRECTORY:
+        case CLEAN_INCLUSIVE:
         case TRUNCATE_DIRECTORY:
         case CREATE_FIFO:
         case IGNORE_PATH:

--- a/src/tmpfiles/tmpfiles.c
+++ b/src/tmpfiles/tmpfiles.c
@@ -820,7 +820,7 @@ static bool item_cleanup(
 
                 log_action("Would remove", "Removing", "%s directory \"%s\"", pathname);
                 if (!arg_dry_run &&
-                    (r=unlinkat(dir_fd, name, AT_REMOVEDIR)) < 0 &&
+                    (r = unlinkat(dir_fd, name, AT_REMOVEDIR)) < 0 &&
                     !IN_SET(errno, ENOENT, ENOTEMPTY))
                         log_warning_errno(errno, "Failed to remove directory \"%s\", ignoring: %m", pathname);
                 if (r >= 0)
@@ -883,7 +883,7 @@ static bool item_cleanup(
 
                 log_action("Would remove", "Removing", "%s \"%s\"", pathname);
                 if (!arg_dry_run &&
-                    (r=unlinkat(dir_fd, name, 0)) < 0 &&
+                    (r = unlinkat(dir_fd, name, 0)) < 0 &&
                     errno != ENOENT)
                         log_warning_errno(errno, "Failed to remove \"%s\", ignoring: %m", pathname);
                 if (r >= 0)

--- a/src/tmpfiles/tmpfiles.c
+++ b/src/tmpfiles/tmpfiles.c
@@ -3535,14 +3535,10 @@ static int clean_including_item(
         int r;
 
         /* Find parent path so we can get stats on the directory that holds instance (file or dir) */
-        ChaseFlags chase_flags = CHASE_SAFE | CHASE_NOFOLLOW | (i->allow_failure ? 0 : CHASE_WARN);
-        dir_fd = chase_and_open_parent_at(AT_FDCWD, instance, chase_flags, NULL);
+        dir_fd = path_open_parent_safe(instance, i->allow_failure);
         if (dir_fd < 0)
-                return log_full_errno(i->allow_failure ? LOG_INFO : LOG_ERR,
-                                      dir_fd,
-                                      "Failed to open path '%s'%s: %m",
-                                      instance,
-                                      i->allow_failure ? ", ignoring" : "");
+                return dir_fd;
+
         r = xstatx_full(dir_fd,
                         /* path= */ NULL,
                         /* statx_flags= */ AT_EMPTY_PATH|AT_NO_AUTOMOUNT,

--- a/src/tmpfiles/tmpfiles.c
+++ b/src/tmpfiles/tmpfiles.c
@@ -102,6 +102,7 @@ typedef enum ItemType {
         /* These ones take globs */
         WRITE_FILE                     = 'w',
         EMPTY_DIRECTORY                = 'e',
+        CLEAN_INCLUSIVE                = 'E',
         SET_XATTR                      = 't',
         RECURSIVE_SET_XATTR            = 'T',
         SET_ACL                        = 'a',
@@ -410,13 +411,15 @@ static bool needs_purge(ItemType t) {
                       CREATE_BLOCK_DEVICE,
                       COPY_FILES,
                       WRITE_FILE,
-                      EMPTY_DIRECTORY);
+                      EMPTY_DIRECTORY,
+                      CLEAN_INCLUSIVE);
 }
 
 static bool needs_glob(ItemType t) {
         return IN_SET(t,
                       WRITE_FILE,
                       EMPTY_DIRECTORY,
+                      CLEAN_INCLUSIVE,
                       SET_XATTR,
                       RECURSIVE_SET_XATTR,
                       SET_ACL,
@@ -450,6 +453,7 @@ static bool takes_ownership(ItemType t) {
                       COPY_FILES,
                       WRITE_FILE,
                       EMPTY_DIRECTORY,
+                      CLEAN_INCLUSIVE,
                       IGNORE_PATH,
                       IGNORE_DIRECTORY_PATH,
                       REMOVE_PATH,
@@ -460,13 +464,17 @@ static bool supports_ignore_if_target_missing(ItemType t) {
         return t == CREATE_SYMLINK;
 }
 
-static struct Item* find_glob(OrderedHashmap *h, const char *match) {
+/* Search for 'match' in all config items besides 'except' (which may be NULL if there is no exception) */
+static struct Item* find_glob(OrderedHashmap *h, const char *match, const Item *except) {
         ItemArray *j;
 
         ORDERED_HASHMAP_FOREACH(j, h)
-                FOREACH_ARRAY(item, j->items, j->n_items)
+                FOREACH_ARRAY(item, j->items, j->n_items) {
+                        if (except && item == except)
+                                continue;
                         if (fnmatch(item->path, match, FNM_PATHNAME|FNM_PERIOD) == 0)
                                 return item;
+                }
         return NULL;
 }
 
@@ -675,6 +683,7 @@ static bool needs_cleanup(
         return true;
 }
 
+/* Declare prototype so that item_cleanup() can call dir_cleanup() (mutual recursion) */
 static int dir_cleanup(
                 Context *c,
                 Item *i,
@@ -683,15 +692,252 @@ static int dir_cleanup(
                 nsec_t self_atime_nsec,
                 nsec_t self_mtime_nsec,
                 nsec_t cutoff_nsec,
-                dev_t rootdev_major,
-                dev_t rootdev_minor,
+                bool mountpoint,
+                int maxdepth,
+                bool keep_this_level,
+                AgeBy age_by_file,
+                AgeBy age_by_dir);
+
+static int item_cleanup(
+                Context *c,
+                Item *i,
+                const char *pathname, /* joined path (path/name) of directory|file to be cleaned up */
+                const char *name, /* basename of directory|file to be cleaned up */
+                int dir_fd, /* dirfd of directory that contains name -- used for unlinkat(dirfd) */
+                nsec_t cutoff_nsec,
+                bool mountpoint, /* whether the parent directory (dir_fd) is a mountpoint */
+                int maxdepth, /* max directory recursion depth */
+                bool keep_this_level,
+                AgeBy age_by_file, /* age criteria ([a|m|c|b]_time) to examine against file age */
+                AgeBy age_by_dir) { /* same age criteria for directory */
+        /* Clean up a file or directory, recursively, according to the cutoff_nsec age constraint.
+         * Errors are ignored (except out-of-memory), consistent with historical behaviour for tmpfiles cleanup.
+         * On success, return 1 if an item was deleted from the supplied directory; otherwise 0.
+         * On error, return <0.
+         */
+        int r = 0;
+
+        assert(c);
+        assert(i);
+
+        nsec_t atime_nsec, mtime_nsec, ctime_nsec, btime_nsec;
+
+        if (dot_or_dot_dot(name))
+                return 0;
+
+        struct statx sx;
+        r = xstatx_full(dir_fd, name,
+                        AT_SYMLINK_NOFOLLOW|AT_NO_AUTOMOUNT,
+                        /* xstatx_flags= */ 0,
+                        STATX_TYPE|STATX_MODE|STATX_UID,
+                        STATX_ATIME|STATX_MTIME|STATX_CTIME|STATX_BTIME,
+                        STATX_ATTR_MOUNT_ROOT,
+                        &sx);
+        if (r == -ENOENT)
+                return 0;
+        if (r < 0) {
+                /* FUSE, NFS mounts, SELinux might return EACCES */
+                log_full_errno(r == -EACCES ? LOG_DEBUG : LOG_ERR, r,
+                               "statx(%s) failed: %m", pathname);
+                return 0;
+        }
+
+        if (FLAGS_SET(sx.stx_attributes, STATX_ATTR_MOUNT_ROOT)) {
+                log_debug("Ignoring \"%s\": different mount points.", pathname);
+                return 0;
+        }
+
+        atime_nsec = FLAGS_SET(sx.stx_mask, STATX_ATIME) ? statx_timestamp_load_nsec(&sx.stx_atime) : NSEC_INFINITY;
+        mtime_nsec = FLAGS_SET(sx.stx_mask, STATX_MTIME) ? statx_timestamp_load_nsec(&sx.stx_mtime) : NSEC_INFINITY;
+        ctime_nsec = FLAGS_SET(sx.stx_mask, STATX_CTIME) ? statx_timestamp_load_nsec(&sx.stx_ctime) : NSEC_INFINITY;
+        btime_nsec = FLAGS_SET(sx.stx_mask, STATX_BTIME) ? statx_timestamp_load_nsec(&sx.stx_btime) : NSEC_INFINITY;
+
+        /* Is there an item configured for this path? */
+        if (ordered_hashmap_get(c->items, pathname)) {
+                log_debug("Ignoring \"%s\": a separate entry exists.", pathname);
+                return 0;
+        }
+
+        if (find_glob(c->globs, pathname, i)) {
+                log_debug("Ignoring \"%s\": a separate glob exists.", pathname);
+                return 0;
+        }
+
+        if (S_ISDIR(sx.stx_mode)) {
+                _cleanup_closedir_ DIR *sub_dir = NULL;
+
+                if (mountpoint &&
+                    streq(name, "lost+found") &&
+                    sx.stx_uid == 0) {
+                        log_debug("Ignoring directory \"%s\".", pathname);
+                        return 0;
+                }
+
+                if (maxdepth <= 0)
+                        log_warning("Reached max depth on \"%s\".", pathname);
+                else {
+                        sub_dir = xopendirat_nomod(dir_fd, name);
+                        if (!sub_dir) {
+                                if (errno != ENOENT)
+                                        log_warning_errno(errno, "Opening directory \"%s\" failed, ignoring: %m", pathname);
+                                return 0;
+                        }
+
+                        if (!arg_dry_run &&
+                            flock(dirfd(sub_dir), LOCK_EX|LOCK_NB) < 0) {
+                                log_debug_errno(errno, "Couldn't acquire lock on directory \"%s\", skipping: %m", pathname);
+                                return 0;
+                        }
+
+                        r = dir_cleanup(c, i,
+                                        pathname, sub_dir,
+                                        atime_nsec, mtime_nsec, cutoff_nsec,
+                                        false, maxdepth-1, false,
+                                        age_by_file, age_by_dir);
+                        /* the only error dir_cleanup returns is out-of-memory */
+                        if (r < 0)
+                                return r;
+                }
+
+                /* Note: if you are wondering why we don't support the sticky bit for excluding
+                 * directories from cleaning like we do it for other file system objects: well, the
+                 * sticky bit already has a meaning for directories, so we don't want to overload
+                 * that. */
+
+                if (keep_this_level) {
+                        log_debug("Keeping directory \"%s\".", pathname);
+                        return 0;
+                }
+
+                /*
+                 * Check the file timestamps of an entry against the
+                 * given cutoff time; delete if it is older.
+                 */
+                if (!needs_cleanup(atime_nsec, btime_nsec, ctime_nsec, mtime_nsec,
+                                   cutoff_nsec, pathname, age_by_dir, true))
+                        return 0;
+
+                log_action("Would remove", "Removing", "%s directory \"%s\"", pathname);
+                if (!arg_dry_run) {
+                        r = unlinkat(dir_fd, name, AT_REMOVEDIR);
+                        if (r < 0) {
+                                if (errno == ENOTEMPTY)
+                                        return 0;
+                                if (errno != ENOENT)
+                                        log_warning_errno(errno, "Failed to remove directory \"%s\", ignoring: %m", pathname);
+                        }
+                }
+        } else {
+                _cleanup_close_ int fd = -EBADF; /* This file descriptor is defined here so that the
+                                                  * lock that is taken below is only dropped _after_
+                                                  * the unlink operation has finished. */
+
+                /* Skip files for which the sticky bit is set. These are semantics we define, and are
+                 * unknown elsewhere. See XDG_RUNTIME_DIR specification for details. */
+                if (sx.stx_mode & S_ISVTX) {
+                        log_debug("Skipping \"%s\": sticky bit set.", pathname);
+                        return 0;
+                }
+
+                if (mountpoint &&
+                    S_ISREG(sx.stx_mode) &&
+                    sx.stx_uid == 0 &&
+                    STR_IN_SET(name,
+                               ".journal",
+                               "aquota.user",
+                               "aquota.group")) {
+                        log_debug("Skipping \"%s\".", pathname);
+                        return 0;
+                }
+
+                /* Ignore sockets that are listed in /proc/net/unix */
+                if (S_ISSOCK(sx.stx_mode) && unix_socket_alive(c, pathname)) {
+                        log_debug("Skipping \"%s\": live socket.", pathname);
+                        return 0;
+                }
+
+                /* Ignore device nodes */
+                if (S_ISCHR(sx.stx_mode) || S_ISBLK(sx.stx_mode)) {
+                        log_debug("Skipping \"%s\": a device.", pathname);
+                        return 0;
+                }
+
+                /* Keep files on this level if this was requested */
+                if (keep_this_level) {
+                        log_debug("Keeping \"%s\".", pathname);
+                        return 0;
+                }
+
+                if (!needs_cleanup(atime_nsec, btime_nsec, ctime_nsec, mtime_nsec,
+                                   cutoff_nsec, pathname, age_by_file, false))
+                        return 0;
+
+                if (!arg_dry_run) {
+                        fd = xopenat(dir_fd, name, O_RDONLY|O_CLOEXEC|O_NOFOLLOW|O_NOATIME|O_NONBLOCK|O_NOCTTY);
+                        if (fd < 0 && !IN_SET(fd, -ENOENT, -ELOOP))
+                                log_warning_errno(fd, "Opening file \"%s\" failed, proceeding without lock: %m", pathname);
+                        if (fd >= 0 && flock(fd, LOCK_EX|LOCK_NB) < 0 && errno == EAGAIN) {
+                                log_debug_errno(errno, "Couldn't acquire lock on file \"%s\", skipping: %m", pathname);
+                                return 0;
+                        }
+                }
+
+                log_action("Would remove", "Removing", "%s \"%s\"", pathname);
+                if (!arg_dry_run) {
+                        r = unlinkat(dir_fd, name, 0);
+                        if (r < 0 && errno != ENOENT)
+                                log_warning_errno(errno, "Failed to remove \"%s\", ignoring: %m", pathname);
+                }
+        }
+        /* flag that a file or directory was deleted, so timestamps on the parent should be restored */
+        return 1;
+}
+
+static void restore_timestamps(int dir_fd, const char *p, nsec_t atime_nsec, nsec_t mtime_nsec) {
+        /* Restore timestamps on directory specified by dir_fd with path p.
+         * If either timestamp is NSEC_INFINITY, it will be ignored rather than restored.
+         */
+        if (atime_nsec == NSEC_INFINITY && mtime_nsec == NSEC_INFINITY)
+                return;
+
+        log_action("Would restore", "Restoring",
+                   "%s access and modification time on \"%s\": %s, %s",
+                   p,
+                   atime_nsec != NSEC_INFINITY
+                        ? FORMAT_TIMESTAMP_STYLE(atime_nsec / NSEC_PER_USEC, TIMESTAMP_US)
+                        : "(omitted)",
+                   mtime_nsec != NSEC_INFINITY
+                        ? FORMAT_TIMESTAMP_STYLE(mtime_nsec / NSEC_PER_USEC, TIMESTAMP_US)
+                        : "(omitted)");
+
+        struct timespec ts[2];
+        ts[0] = atime_nsec != NSEC_INFINITY
+                ? *TIMESPEC_STORE_NSEC(atime_nsec)
+                : TIMESPEC_OMIT;
+        ts[1] = mtime_nsec != NSEC_INFINITY
+                ? *TIMESPEC_STORE_NSEC(mtime_nsec)
+                : TIMESPEC_OMIT;
+
+        /* Restore original directory timestamps */
+        if (!arg_dry_run && utimensat(dir_fd, "", ts, AT_EMPTY_PATH) < 0)
+                log_warning_errno(errno, "Failed to revert timestamps of '%s', ignoring: %m", p);
+}
+
+static int dir_cleanup(
+                Context *c,
+                Item *i,
+                const char *p,
+                DIR *d, /* directory to traverse for files to be cleaned up */
+                nsec_t self_atime_nsec,
+                nsec_t self_mtime_nsec,
+                nsec_t cutoff_nsec,
                 bool mountpoint,
                 int maxdepth,
                 bool keep_this_level,
                 AgeBy age_by_file,
                 AgeBy age_by_dir) {
 
-        bool deleted = false;
+        bool any_deleted = false;
         int r = 0;
 
         assert(c);
@@ -700,214 +946,23 @@ static int dir_cleanup(
 
         FOREACH_DIRENT_ALL(de, d, break) {
                 _cleanup_free_ char *sub_path = NULL;
-                nsec_t atime_nsec, mtime_nsec, ctime_nsec, btime_nsec;
-
-                if (dot_or_dot_dot(de->d_name))
-                        continue;
-
-                struct statx sx;
-                r = xstatx_full(dirfd(d), de->d_name,
-                                AT_SYMLINK_NOFOLLOW|AT_NO_AUTOMOUNT,
-                                /* xstatx_flags= */ 0,
-                                STATX_TYPE|STATX_MODE|STATX_UID,
-                                STATX_ATIME|STATX_MTIME|STATX_CTIME|STATX_BTIME,
-                                STATX_ATTR_MOUNT_ROOT,
-                                &sx);
-                if (r == -ENOENT)
-                        continue;
-                if (r < 0) {
-                        /* FUSE, NFS mounts, SELinux might return EACCES */
-                        log_full_errno(r == -EACCES ? LOG_DEBUG : LOG_ERR, r,
-                                       "statx(%s/%s) failed: %m", p, de->d_name);
-                        continue;
-                }
-
-                if (FLAGS_SET(sx.stx_attributes, STATX_ATTR_MOUNT_ROOT)) {
-                        log_debug("Ignoring \"%s/%s\": different mount points.", p, de->d_name);
-                        continue;
-                }
-
-                atime_nsec = FLAGS_SET(sx.stx_mask, STATX_ATIME) ? statx_timestamp_load_nsec(&sx.stx_atime) : NSEC_INFINITY;
-                mtime_nsec = FLAGS_SET(sx.stx_mask, STATX_MTIME) ? statx_timestamp_load_nsec(&sx.stx_mtime) : NSEC_INFINITY;
-                ctime_nsec = FLAGS_SET(sx.stx_mask, STATX_CTIME) ? statx_timestamp_load_nsec(&sx.stx_ctime) : NSEC_INFINITY;
-                btime_nsec = FLAGS_SET(sx.stx_mask, STATX_BTIME) ? statx_timestamp_load_nsec(&sx.stx_btime) : NSEC_INFINITY;
-
                 sub_path = path_join(p, de->d_name);
                 if (!sub_path) {
                         r = log_oom();
-                        goto finish;
+                        break;
                 }
 
-                /* Is there an item configured for this path? */
-                if (ordered_hashmap_get(c->items, sub_path)) {
-                        log_debug("Ignoring \"%s\": a separate entry exists.", sub_path);
-                        continue;
-                }
-
-                if (find_glob(c->globs, sub_path)) {
-                        log_debug("Ignoring \"%s\": a separate glob exists.", sub_path);
-                        continue;
-                }
-
-                if (S_ISDIR(sx.stx_mode)) {
-                        _cleanup_closedir_ DIR *sub_dir = NULL;
-
-                        if (mountpoint &&
-                            streq(de->d_name, "lost+found") &&
-                            sx.stx_uid == 0) {
-                                log_debug("Ignoring directory \"%s\".", sub_path);
-                                continue;
-                        }
-
-                        if (maxdepth <= 0)
-                                log_warning("Reached max depth on \"%s\".", sub_path);
-                        else {
-                                int q;
-
-                                sub_dir = xopendirat_nomod(dirfd(d), de->d_name);
-                                if (!sub_dir) {
-                                        if (errno != ENOENT)
-                                                r = log_warning_errno(errno, "Opening directory \"%s\" failed, ignoring: %m", sub_path);
-
-                                        continue;
-                                }
-
-                                if (!arg_dry_run &&
-                                    flock(dirfd(sub_dir), LOCK_EX|LOCK_NB) < 0) {
-                                        log_debug_errno(errno, "Couldn't acquire shared BSD lock on directory \"%s\", skipping: %m", sub_path);
-                                        continue;
-                                }
-
-                                q = dir_cleanup(c, i,
-                                                sub_path, sub_dir,
-                                                atime_nsec, mtime_nsec, cutoff_nsec,
-                                                rootdev_major, rootdev_minor,
-                                                false, maxdepth-1, false,
-                                                age_by_file, age_by_dir);
-                                if (q < 0)
-                                        r = q;
-                        }
-
-                        /* Note: if you are wondering why we don't support the sticky bit for excluding
-                         * directories from cleaning like we do it for other file system objects: well, the
-                         * sticky bit already has a meaning for directories, so we don't want to overload
-                         * that. */
-
-                        if (keep_this_level) {
-                                log_debug("Keeping directory \"%s\".", sub_path);
-                                continue;
-                        }
-
-                        /*
-                         * Check the file timestamps of an entry against the
-                         * given cutoff time; delete if it is older.
-                         */
-                        if (!needs_cleanup(atime_nsec, btime_nsec, ctime_nsec, mtime_nsec,
-                                           cutoff_nsec, sub_path, age_by_dir, true))
-                                continue;
-
-                        log_action("Would remove", "Removing", "%s directory \"%s\"", sub_path);
-                        if (!arg_dry_run &&
-                            unlinkat(dirfd(d), de->d_name, AT_REMOVEDIR) < 0) {
-                                if (errno == ENOTEMPTY)
-                                        continue;
-                                if (errno != ENOENT)
-                                        r = log_warning_errno(errno, "Failed to remove directory \"%s\", ignoring: %m", sub_path);
-                        }
-
-                        deleted = true;
-
-                } else {
-                        _cleanup_close_ int fd = -EBADF; /* This file descriptor is defined here so that the
-                                                          * lock that is taken below is only dropped _after_
-                                                          * the unlink operation has finished. */
-
-                        /* Skip files for which the sticky bit is set. These are semantics we define, and are
-                         * unknown elsewhere. See XDG_RUNTIME_DIR specification for details. */
-                        if (sx.stx_mode & S_ISVTX) {
-                                log_debug("Skipping \"%s\": sticky bit set.", sub_path);
-                                continue;
-                        }
-
-                        if (mountpoint &&
-                            S_ISREG(sx.stx_mode) &&
-                            sx.stx_uid == 0 &&
-                            STR_IN_SET(de->d_name,
-                                       ".journal",
-                                       "aquota.user",
-                                       "aquota.group")) {
-                                log_debug("Skipping \"%s\".", sub_path);
-                                continue;
-                        }
-
-                        /* Ignore sockets that are listed in /proc/net/unix */
-                        if (S_ISSOCK(sx.stx_mode) && unix_socket_alive(c, sub_path)) {
-                                log_debug("Skipping \"%s\": live socket.", sub_path);
-                                continue;
-                        }
-
-                        /* Ignore device nodes */
-                        if (S_ISCHR(sx.stx_mode) || S_ISBLK(sx.stx_mode)) {
-                                log_debug("Skipping \"%s\": a device.", sub_path);
-                                continue;
-                        }
-
-                        /* Keep files on this level if this was requested */
-                        if (keep_this_level) {
-                                log_debug("Keeping \"%s\".", sub_path);
-                                continue;
-                        }
-
-                        if (!needs_cleanup(atime_nsec, btime_nsec, ctime_nsec, mtime_nsec,
-                                           cutoff_nsec, sub_path, age_by_file, false))
-                                continue;
-
-                        if (!arg_dry_run) {
-                                fd = xopenat(dirfd(d), de->d_name, O_RDONLY|O_CLOEXEC|O_NOFOLLOW|O_NOATIME|O_NONBLOCK|O_NOCTTY);
-                                if (fd < 0 && !IN_SET(fd, -ENOENT, -ELOOP))
-                                        log_warning_errno(fd, "Opening file \"%s\" failed, proceeding without lock: %m", sub_path);
-                                if (fd >= 0 && flock(fd, LOCK_EX|LOCK_NB) < 0 && errno == EAGAIN) {
-                                        log_debug_errno(errno, "Couldn't acquire shared BSD lock on file \"%s\", skipping: %m", sub_path);
-                                        continue;
-                                }
-                        }
-
-                        log_action("Would remove", "Removing", "%s \"%s\"", sub_path);
-                        if (!arg_dry_run &&
-                            unlinkat(dirfd(d), de->d_name, 0) < 0 &&
-                            errno != ENOENT)
-                                r = log_warning_errno(errno, "Failed to remove \"%s\", ignoring: %m", sub_path);
-
-                        deleted = true;
-                }
+                r = item_cleanup(c, i,
+                                sub_path, de->d_name, dirfd(d),
+                                cutoff_nsec,
+                                mountpoint, maxdepth, keep_this_level,
+                                age_by_file, age_by_dir);
+                if (r < 0)
+                        break;
+                any_deleted = any_deleted || r;
         }
-
-finish:
-        if (deleted && (self_atime_nsec < NSEC_INFINITY || self_mtime_nsec < NSEC_INFINITY)) {
-                struct timespec ts[2];
-
-                log_action("Would restore", "Restoring",
-                           "%s access and modification time on \"%s\": %s, %s",
-                           p,
-                           self_atime_nsec != NSEC_INFINITY
-                                ? FORMAT_TIMESTAMP_STYLE(self_atime_nsec / NSEC_PER_USEC, TIMESTAMP_US)
-                                : "(omitted)",
-                           self_mtime_nsec != NSEC_INFINITY
-                                ? FORMAT_TIMESTAMP_STYLE(self_mtime_nsec / NSEC_PER_USEC, TIMESTAMP_US)
-                                : "(omitted)");
-
-                ts[0] = self_atime_nsec != NSEC_INFINITY
-                        ? *TIMESPEC_STORE_NSEC(self_atime_nsec)
-                        : TIMESPEC_OMIT;
-                ts[1] = self_mtime_nsec != NSEC_INFINITY
-                        ? *TIMESPEC_STORE_NSEC(self_mtime_nsec)
-                        : TIMESPEC_OMIT;
-
-                /* Restore original directory timestamps */
-                if (!arg_dry_run &&
-                    futimens(dirfd(d), ts) < 0)
-                        log_warning_errno(errno, "Failed to revert timestamps of '%s', ignoring: %m", p);
-        }
+        if (any_deleted)
+                restore_timestamps(dirfd(d), p, self_atime_nsec, self_mtime_nsec);
 
         return r;
 }
@@ -1065,10 +1120,13 @@ shortcut:
         return label_fix_full(fd, /* inode_path= */ NULL, /* label_path= */ path, 0);
 }
 
-static int path_open_parent_safe(const char *path, bool allow_failure) {
-        _cleanup_free_ char *dn = NULL;
+static int path_open_parent_safe_full(const char *path, bool allow_failure, char **ret_dirname) {
+        /* Open parent and return its file descriptor.
+         * If ret_dirname is not NULL, also allocate and return the parent path in ret_dirname, which the caller must free
+         */
         int r, fd;
 
+        _cleanup_free_ char *dirname = NULL;
         if (!path_is_normalized(path))
                 return log_full_errno(allow_failure ? LOG_INFO : LOG_ERR,
                                       SYNTHETIC_ERRNO(EINVAL),
@@ -1076,7 +1134,7 @@ static int path_open_parent_safe(const char *path, bool allow_failure) {
                                       path,
                                       allow_failure ? ", ignoring" : "");
 
-        r = path_extract_directory(path, &dn);
+        r = path_extract_directory(path, &dirname);
         if (r < 0)
                 return log_full_errno(allow_failure ? LOG_INFO : LOG_ERR,
                                       r,
@@ -1084,17 +1142,24 @@ static int path_open_parent_safe(const char *path, bool allow_failure) {
                                       path,
                                       allow_failure ? ", ignoring" : "");
 
-        r = chase(dn, arg_root, allow_failure ? CHASE_SAFE : CHASE_SAFE|CHASE_WARN, NULL, &fd);
+        r = chase(dirname, arg_root, allow_failure ? CHASE_SAFE : CHASE_SAFE|CHASE_WARN, NULL, &fd);
         if (r == -ENOLINK) /* Unsafe symlink: already covered by CHASE_WARN */
                 return r;
         if (r < 0)
                 return log_full_errno(allow_failure ? LOG_INFO : LOG_ERR,
                                       r,
                                       "Failed to open path '%s'%s: %m",
-                                      dn,
+                                      dirname,
                                       allow_failure ? ", ignoring" : "");
 
+        if (ret_dirname)
+                *ret_dirname = TAKE_PTR(dirname);
+
         return fd;
+}
+
+static int path_open_parent_safe(const char *path, bool allow_failure) {
+        return path_open_parent_safe_full(path, allow_failure, /* ret_dirname= */ NULL);
 }
 
 static int path_open_safe(const char *path) {
@@ -2442,13 +2507,13 @@ static int empty_directory(
 
         assert(c);
         assert(i);
-        assert(i->type == EMPTY_DIRECTORY);
+        assert(i->type == EMPTY_DIRECTORY || i->type == CLEAN_INCLUSIVE);
 
         r = chase(path, arg_root, CHASE_SAFE|CHASE_WARN, NULL, &fd);
         if (r == -ENOLINK) /* Unsafe symlink: already covered by CHASE_WARN */
                 return r;
         if (r == -ENOENT) {
-                /* Option "e" operates only on existing objects. Do not print errors about non-existent files
+                /* Option "e" and "E" operate only on existing objects. Do not print errors about non-existent files
                  * or directories */
                 log_debug_errno(r, "Skipping missing directory: %s", path);
                 return 0;
@@ -3177,6 +3242,7 @@ static int create_item(Context *c, Item *i) {
                 break;
 
         case EMPTY_DIRECTORY:
+        case CLEAN_INCLUSIVE:
                 r = glob_item(c, i, empty_directory);
                 if (r < 0)
                         return r;
@@ -3317,7 +3383,6 @@ static int remove_recursive(
                         /* self_atime_nsec= */ NSEC_INFINITY,
                         /* self_mtime_nsec= */ NSEC_INFINITY,
                         /* cutoff_nsec= */ NSEC_INFINITY,
-                        sx.stx_dev_major, sx.stx_dev_minor,
                         mountpoint,
                         MAX_DEPTH,
                         /* keep_this_level= */ false,
@@ -3427,6 +3492,7 @@ static char *age_by_to_string(AgeBy ab, bool is_dir) {
         return ret;
 }
 
+/* Cleanup contents of directory */
 static int clean_item_instance(
                 Context *c,
                 Item *i,
@@ -3443,7 +3509,6 @@ static int clean_item_instance(
                 return 0;
 
         usec_t cutoff = n - i->age;
-        nsec_t atime_nsec, mtime_nsec;
 
         _cleanup_closedir_ DIR *d = NULL;
         struct statx sx;
@@ -3454,8 +3519,8 @@ static int clean_item_instance(
         if (r <= 0)
                 return r;
 
-        atime_nsec = FLAGS_SET(sx.stx_mask, STATX_ATIME) ? statx_timestamp_load_nsec(&sx.stx_atime) : NSEC_INFINITY;
-        mtime_nsec = FLAGS_SET(sx.stx_mask, STATX_MTIME) ? statx_timestamp_load_nsec(&sx.stx_mtime) : NSEC_INFINITY;
+        nsec_t atime_nsec = FLAGS_SET(sx.stx_mask, STATX_ATIME) ? statx_timestamp_load_nsec(&sx.stx_atime) : NSEC_INFINITY;
+        nsec_t mtime_nsec = FLAGS_SET(sx.stx_mask, STATX_MTIME) ? statx_timestamp_load_nsec(&sx.stx_mtime) : NSEC_INFINITY;
 
         if (DEBUG_LOGGING) {
                 _cleanup_free_ char *ab_f = NULL, *ab_d = NULL;
@@ -3479,10 +3544,84 @@ static int clean_item_instance(
                            atime_nsec,
                            mtime_nsec,
                            cutoff * NSEC_PER_USEC,
-                           sx.stx_dev_major, sx.stx_dev_minor,
                            mountpoint,
                            MAX_DEPTH, i->keep_first_level,
                            i->age_by_file, i->age_by_dir);
+}
+
+/* Cleanup file or directory, including the actual file and directory, not just its contents  */
+static int clean_item_inclusive(
+                Context *c,
+                Item *i,
+                const char *instance,
+                CreationMode creation) {
+
+        assert(i);
+
+        /* If age not specified in .conf file, do nothing */
+        if (!i->age_set)
+                return 0;
+
+        usec_t n = now(CLOCK_REALTIME);
+        /* If file age is in the future, do nothing */
+        if (n < i->age)
+                return 0;
+
+        usec_t cutoff = n - i->age;
+
+        _cleanup_close_ int dir_fd = -EBADF;
+        struct statx sx;
+        bool mountpoint;
+        int r;
+
+        /* Find parent path so we can get stats on the directory that holds instance (file or dir) */
+        _cleanup_free_ char *parent_name = NULL;
+        dir_fd = path_open_parent_safe_full(instance, i->allow_failure, &parent_name);
+        if (dir_fd < 0)
+                return dir_fd;
+
+        r = xstatx_full(dir_fd,
+                        /* path= */ NULL,
+                        /* statx_flags= */ AT_EMPTY_PATH|AT_NO_AUTOMOUNT,
+                        /* xstatx_flags= */ 0,
+                        /* mandatory_mask= */ 0,
+                        /* optional_mask= */ STATX_ATIME|STATX_MTIME,
+                        /* mandatory_attributes= */ STATX_ATTR_MOUNT_ROOT,
+                        &sx);
+        if (r < 0)
+                return log_error_errno(r, "statx on parent of '%s' failed: %m", instance);
+        mountpoint = FLAGS_SET(sx.stx_attributes, STATX_ATTR_MOUNT_ROOT);
+
+        nsec_t atime_nsec = FLAGS_SET(sx.stx_mask, STATX_ATIME) ? statx_timestamp_load_nsec(&sx.stx_atime) : NSEC_INFINITY;
+        nsec_t mtime_nsec = FLAGS_SET(sx.stx_mask, STATX_MTIME) ? statx_timestamp_load_nsec(&sx.stx_mtime) : NSEC_INFINITY;
+
+        if (DEBUG_LOGGING) {
+                _cleanup_free_ char *ab_f = NULL, *ab_d = NULL;
+
+                ab_f = age_by_to_string(i->age_by_file, false);
+                if (!ab_f)
+                        return log_oom();
+
+                ab_d = age_by_to_string(i->age_by_dir, true);
+                if (!ab_d)
+                        return log_oom();
+
+                log_debug("Cleanup threshold for %s \"%s\" is %s; age-by: %s%s",
+                          mountpoint ? "mount point" : "directory",
+                          instance,
+                          FORMAT_TIMESTAMP_STYLE(cutoff, TIMESTAMP_US),
+                          ab_f, ab_d);
+        }
+
+        const char *name = last_path_component(instance);
+        r = item_cleanup(c, i, instance, name, dir_fd,
+                                    cutoff * NSEC_PER_USEC,
+                                    mountpoint,
+                                    MAX_DEPTH, i->keep_first_level,
+                                    i->age_by_file, i->age_by_dir);
+        if (r > 0)
+                restore_timestamps(dir_fd, parent_name, atime_nsec, mtime_nsec);
+        return r;
 }
 
 static int clean_item(Context *c, Item *i) {
@@ -3505,6 +3644,9 @@ static int clean_item(Context *c, Item *i) {
         case IGNORE_PATH:
         case IGNORE_DIRECTORY_PATH:
                 return glob_item(c, i, clean_item_instance);
+
+        case CLEAN_INCLUSIVE:
+                return glob_item(c, i, clean_item_inclusive);
 
         default:
                 return 0;
@@ -4034,6 +4176,7 @@ static int parse_line(
         case CREATE_SUBVOLUME_INHERIT_QUOTA:
         case CREATE_SUBVOLUME_NEW_QUOTA:
         case EMPTY_DIRECTORY:
+        case CLEAN_INCLUSIVE:
         case TRUNCATE_DIRECTORY:
         case CREATE_FIFO:
         case IGNORE_PATH:


### PR DESCRIPTION
## History

This PR is sponsored by the University of Antwerp to make systemd-tmpfiles perform the requirements of their system cleanup without the extra cleanup scripts they currently use. Others have previously requested this feature in #27395 and have been told to [submit a patch](https://github.com/systemd/systemd/issues/27395#issuecomment-1576454700). This PR achieves that requirement.

## Feature

The new type 'E' is similar to type `e` (recursive cleanup) but with changes to the cleanup behavior as follows. Whereas type 'e' only deletes children of the directories specified by the glob (not the files and directories themselves) the new type `E` enhancement also cleans up the globbed files and directories themselves (cf. `man tmpfiles.d` for type specifications). In all other respects, `E` operates the same as `e`.

All of the age-based cleanup mechanisms of type `e` cleanup are also implemented for type `E` cleanup. Specifically:
* As with type `e`, if the age field starts with a tilde character `~`, clean-up is only applied to files and directories one level inside the directory specified, but not the files and directories immediately inside it. (This makes `E` with `~` act very similar to `e` without `~`, so it probably not very useful.)
* Directories containing removed items have their timestamps restored after the items are removed.
* Files or directories addressed by other config line-items are ignored (not cleaned up) since they are addressed by other lines.
* As with type `e` cleanup several files/directories are ignored:
  * Root mountpoints are ignored;
  * `.` and `..` are ignored;
  * Directories called `lost+found` are ignored;
  * Files with the sticky bit are ignored;
  * Files that are mountpoints named `.journal`, `aquota.user`, or `aquota.group` are ignored;
  * Sockets listed in `/proc/net/unix` are ignored;
  * Device nodes are ignored;
  * No cleanup is performed if `--dry-run` is specified.

## Bugfixes

1. Fix a bug in `dir_cleanup` where parent directory dates were not restored when a directory entry was deleted; only when a file was deleted.

2. A misfeature in `dir_cleanup` has also been fixed. Previously, systemd-tmpfiles would ignore all errors when trying to clean up a file (debug logging only). However, if and only if an error (such as file no longer found) happened to occur on the very final cleaned entry in any subdirectory of the recursive tree, then the error would propagate up to the caller and cause systemd-tmpfiles to exit with error, rather than continuing on to subsequent line items of the configuration file. This change factors `item_cleanup` code out of `dir_cleanup`, and in the processes fixes this anomaly so that errors (other than out-of-memory errors which now abort) also are ignored for all directory entries, now including the final item. This affects both cleanup and removal, since the `dir_cleanup` function is called by both.

3. Two error message "Couldn't acquire shared BSD lock on [file/directory] nnn" were corrected to "Couldn't acquire lock on [file/directory] nnn" because it was actually trying to access an exclusive lock, not a shared lock.

## Getting Started

To clone and build this PR, run the bash script [rebuild-systemd-tmpfiles.sh](https://github.com/user-attachments/files/27037205/rebuild-systemd-tmpfiles.sh) in a directory where you want to clone systemd. (If you intend to develop, change it to clone your fork instead). This script will:
* shallow-clone systemd
* `apt install meson ninja` (required to build)
* setup meson
* then build executable `build/systemd/tmpfiles`

You can re-run that script to rebuild if you change the source.

In order to test it, create `wtest.conf` containing the following lines in that same systemd clone directory:
```
#Type   Path                            Mode    User    Group   Age     Argument
E       /tmp/tmpfile-test/*             -       -       -       0s      -
```

Then run bash script [wtest.sh](https://github.com/user-attachments/files/26821006/wtest.sh) from that same directory.
