### PR TITLE
Revert "ci: Switch PR review workflow to Opus 4.7 via Mantle endpoint"

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -192,7 +192,6 @@ jobs:
         env:
           CLAUDE_CODE_DISABLE_BACKGROUND_TASKS: "1"
           CLAUDE_CODE_USE_BEDROCK: "1"
-          CLAUDE_CODE_USE_MANTLE: "1"
         run: |
           mkdir -p ~/.claude
 
@@ -370,7 +369,7 @@ jobs:
           PROMPT
 
           claude \
-            --model anthropic.claude-opus-4-7 \
+            --model us.anthropic.claude-opus-4-6-v1 \
             --effort max \
             --max-turns 200 \
             --setting-sources user \


### PR DESCRIPTION
Most PRs bot reviews are timing out since the switch, it seems it's not ready for prime time, so revert for now

Reverts systemd/systemd#41663