### PR TITLE
boot: gracefully handle LoadFile() implementations that return EFI_SU…

### DIFF
--- a/src/boot/boot.c
+++ b/src/boot/boot.c
@@ -2715,7 +2715,12 @@ static EFI_STATUS expand_path(
                 if (IN_SET(err, EFI_NOT_FOUND, EFI_INVALID_PARAMETER))
                         continue; /* Skip over LoadFile() handles that after all don't consider themselves
                                    * appropriate for this kind of path */
-                if (err != EFI_BUFFER_TOO_SMALL) {
+                if (!IN_SET(err, EFI_SUCCESS, EFI_BUFFER_TOO_SMALL)) {
+                        /* NB: firmwares are supposed to return EFI_BUFFER_TOO_SMALL whenever we pass a NULL
+                         * buffer. But for compatibility with quirky firmwares let's be lenient for the
+                         * special case of a zero sized file: the firmware might return EFI_SUCCESS here and
+                         * initialize the size to zero, as a buffer is not actually necessary for that
+                         * case. */
                         log_warning_status(err, "Failed to get file via LoadFile() protocol, ignoring: %m");
                         continue;
                 }


### PR DESCRIPTION
…CCESS with a NULL buffer

LoadFile() with a NULL buffer is supposed to return the file size without acquiring the data and return EFI_BUFFER_TOO_SMALL.

However it appears some firmware returns EFI_SUCCESS in case the file is empty, i.e. the file size returned is zero. And I guess that's even fine.

Let's handle this gracefully hence.