### PR TITLE
boot: never auto-boot a menu entry with the non-default profile

### DIFF
--- a/src/boot/boot.c
+++ b/src/boot/boot.c
@@ -1918,11 +1918,15 @@ static void config_select_default_entry(Config *config) {
         }
 
         /* select the first suitable entry */
-        for (i = 0; i < config->n_entries; i++)
+        for (i = 0; i < config->n_entries; i++) {
+                if (config->entries[i]->profile > 0)
+                        continue; /* For now, never select any non-default profile */
+
                 if (LOADER_TYPE_MAY_AUTO_SELECT(config->entries[i]->type)) {
                         config->idx_default = i;
                         return;
                 }
+        }
 
         /* If no configured entry to select from was found, enable the menu. */
         config->idx_default = 0;


### PR DESCRIPTION
When figuring out which menu entry to pick by default, let's not consider any with a profile number > 0. This reflects that fact that additional profiles are generally used for
debug/recovery/factory-reset/storage target mode boots, and those should never be auto-selected. Hence do a simple check: if profile != 0, simply do not consider the entry as a default.

We might eventually want to beef this up, and add a property one can set in the profile metadata that controls this behaviour, but for now let's just do a this simple fix.