### PR TITLE
mountpoint-util: initialize mnt_id for name_to_handle_at(AT_HANDLE_MNT_ID_UNIQUE)

### DIFF
--- a/src/basic/mountpoint-util.c
+++ b/src/basic/mountpoint-util.c
@@ -84,7 +84,13 @@ int name_to_handle_at_loop(
                 h->handle_bytes = n;
 
                 if (ret_unique_mnt_id) {
-                        uint64_t mnt_id;
+                        /* Here, explicitly initialize mnt_id, otherwise valgrind complains:
+                         *
+                         * ==175708== Conditional jump or move depends on uninitialised value(s)
+                         * ==175708==    at 0x4BC33D1: inode_same_at (stat-util.c:610)
+                         * ==175708==    by 0x4BF1972: inode_same (stat-util.h:86)
+                         */
+                        uint64_t mnt_id = 0;
 
                         /* The kernel will still use this as uint64_t pointer */
                         r = name_to_handle_at(fd, path, h, (int *) &mnt_id, flags|AT_HANDLE_MNT_ID_UNIQUE);


### PR DESCRIPTION
Suppress the following message:
```
$ sudo valgrind --leak-check=full build/networkctl dhcp-lease wlp59s0
==175708== Memcheck, a memory error detector
==175708== Copyright (C) 2002-2024, and GNU GPL'd, by Julian Seward et al.
==175708== Using Valgrind-3.26.0 and LibVEX; rerun with -h for copyright info
==175708== Command: build/networkctl status wlp59s0
==175708==
==175708== Conditional jump or move depends on uninitialised value(s)
==175708==    at 0x4BC33D1: inode_same_at (stat-util.c:610)
==175708==    by 0x4BF1972: inode_same (stat-util.h:86)
==175708==    by 0x4BF48FE: running_in_chroot (virt.c:817)
==175708==    by 0x4B16643: running_in_chroot_or_offline (verbs.c:37)
==175708==    by 0x4B175CE: _dispatch_verb_with_args (verbs.c:136)
==175708==    by 0x4B17868: dispatch_verb (verbs.c:160)
==175708==    by 0x407CBB: networkctl_main (networkctl.c:249)
==175708==    by 0x407D06: run (networkctl.c:263)
==175708==    by 0x407D39: main (networkctl.c:266)
==175708==
```
Not sure if it is an issue in valgrind or glibc, but at least there is nothing we can do except for working around it.