### PR TITLE
random-util: introduce random_bytes_allocate_iovec() helper function

### DIFF
--- a/src/basic/random-util.c
+++ b/src/basic/random-util.c
@@ -96,6 +96,19 @@ void random_bytes(void *p, size_t n) {
         fallback_random_bytes(p, n);
 }
 
+int random_bytes_allocate_iovec(size_t n, struct iovec *ret) {
+        assert(ret);
+
+        void *p = malloc(MAX(n, 1U));
+        if (!p)
+                return -ENOMEM;
+
+        random_bytes(p, n);
+
+        *ret = IOVEC_MAKE(TAKE_PTR(p), n);
+        return 0;
+}
+
 int crypto_random_bytes(void *p, size_t n) {
         assert(p || n == 0);
 

--- a/src/basic/random-util.h
+++ b/src/basic/random-util.h
@@ -3,8 +3,12 @@
 
 #include "basic-forward.h"
 
-void random_bytes(void *p, size_t n) _nonnull_if_nonzero_(1, 2); /* Returns random bytes suitable for most uses, but may be insecure sometimes. */
-int crypto_random_bytes(void *p, size_t n) _nonnull_if_nonzero_(1, 2); /* Returns secure random bytes after waiting for the RNG to initialize. */
+/* Returns random bytes suitable for most uses, but may be insecure sometimes. */
+void random_bytes(void *p, size_t n) _nonnull_if_nonzero_(1, 2);
+int random_bytes_allocate_iovec(size_t n, struct iovec *ret);
+
+/* Returns secure random bytes after waiting for the RNG to initialize. */
+int crypto_random_bytes(void *p, size_t n) _nonnull_if_nonzero_(1, 2);
 int crypto_random_bytes_allocate_iovec(size_t n, struct iovec *ret);
 
 static inline uint64_t random_u64(void) {


### PR DESCRIPTION
It is similar to crypto_random_bytes_allocate_iovec(), but possibly insecure.