### PR TITLE
string-util: make make_cstring() take void* rather than char*

### DIFF
--- a/src/basic/string-util.c
+++ b/src/basic/string-util.c
@@ -1292,7 +1292,7 @@ char* string_replace_char(char *str, char old_char, char new_char) {
         return str;
 }
 
-int make_cstring(const char *s, size_t n, MakeCStringMode mode, char **ret) {
+int make_cstring(const void *s, size_t n, MakeCStringMode mode, char **ret) {
         char *b;
 
         assert(s || n == 0);
@@ -1311,11 +1311,11 @@ int make_cstring(const char *s, size_t n, MakeCStringMode mode, char **ret) {
 
                 b = new0(char, 1);
         } else {
-                const char *nul;
+                const uint8_t *nul;
 
                 nul = memchr(s, 0, n);
                 if (nul) {
-                        if (nul < s + n - 1 || /* embedded NUL? */
+                        if (nul < (const uint8_t*) s + n - 1 || /* embedded NUL? */
                             mode == MAKE_CSTRING_REFUSE_TRAILING_NUL)
                                 return -EINVAL;
 

--- a/src/basic/string-util.h
+++ b/src/basic/string-util.h
@@ -271,7 +271,7 @@ typedef enum MakeCStringMode {
         _MAKE_CSTRING_MODE_INVALID = -1,
 } MakeCStringMode;
 
-int make_cstring(const char *s, size_t n, MakeCStringMode mode, char **ret);
+int make_cstring(const void *s, size_t n, MakeCStringMode mode, char **ret);
 
 size_t strspn_from_end(const char *str, const char *accept) _pure_;
 

--- a/src/libsystemd-network/dhcp6-option.c
+++ b/src/libsystemd-network/dhcp6-option.c
@@ -548,7 +548,7 @@ int dhcp6_option_parse_string(const uint8_t *data, size_t data_len, char **ret) 
                 return 0;
         }
 
-        r = make_cstring((const char *) data, data_len, MAKE_CSTRING_REFUSE_TRAILING_NUL, &string);
+        r = make_cstring(data, data_len, MAKE_CSTRING_REFUSE_TRAILING_NUL, &string);
         if (r < 0)
                 return r;
 

--- a/src/libsystemd-network/sd-dns-resolver.c
+++ b/src/libsystemd-network/sd-dns-resolver.c
@@ -252,8 +252,8 @@ int dnr_parse_svc_params(const uint8_t *option, size_t len, sd_dns_resolver *res
                         return -EBADMSG;
 
                 case DNS_SVC_PARAM_KEY_DOHPATH:
-                        r = make_cstring((const char*) &option[offset], plen,
-                                        MAKE_CSTRING_REFUSE_TRAILING_NUL, &dohpath);
+                        r = make_cstring(&option[offset], plen,
+                                         MAKE_CSTRING_REFUSE_TRAILING_NUL, &dohpath);
                         if (ERRNO_IS_NEG_RESOURCE(r))
                                 return r;
                         if (r < 0)

--- a/src/shared/dns-packet.c
+++ b/src/shared/dns-packet.c
@@ -2861,7 +2861,7 @@ int dns_packet_ede_rcode(DnsPacket *p, int *ret_ede_rcode, char **ret_ede_msg) {
                                 return log_debug_errno(SYNTHETIC_ERRNO(EBADMSG),
                                                        "EDNS0 truncated EDE info code.");
 
-                        r = make_cstring((char *) d + 6, length - 2U, MAKE_CSTRING_ALLOW_TRAILING_NUL, &msg);
+                        r = make_cstring(d + 6, length - 2U, MAKE_CSTRING_ALLOW_TRAILING_NUL, &msg);
                         if (r < 0)
                                 return log_debug_errno(r, "Invalid EDE text in opt.");
 


### PR DESCRIPTION
It is typically used for making C string embedded in a binary data. Hence, the input pointer may not be char*.