### PR TITLE
man: Fix NOTES formatting

### DIFF
--- a/man/os-release.xml
+++ b/man/os-release.xml
@@ -750,8 +750,9 @@ VERSION_ID=32</programlisting>
 
       <programlisting><xi:include href="check-os-release-simple.py" parse="text" /></programlisting>
 
-      <para>See docs for <ulink url="https://docs.python.org/3/library/platform.html#platform.freedesktop_os_release">
-      <function>platform.freedesktop_os_release</function></ulink> for more details.
+      <para>See docs for <function><ulink
+      url="https://docs.python.org/3/library/platform.html#platform.freedesktop_os_release">platform.freedesktop_os_release</ulink></function>
+      for more details.
       </para>
     </example>
 


### PR DESCRIPTION
The NOTES section in os-release(5) contains an unusual formatting. Switch function and ulink tags and remove a newline within ulink text to keep the entry formatting in sync with others. Also, this preserves the formatting within the text itself.

You can see this if you scroll down to the bottom in manual page. Entry 7 looks like this:
```
      7.

               platform.freedesktop_os_release
         https://docs.python.org/3/library/platform.html#platform.freedesktop_os_release
```

With this PR applied, it looks like this:
```
      7. platform.freedesktop_os_release
         https://docs.python.org/3/library/platform.html#platform.freedesktop_os_release
```