### PR TITLE
oomd: reject unknown ManagedOOM properties

### DIFF
--- a/src/oom/oomd-manager.c
+++ b/src/oom/oomd-manager.c
@@ -24,6 +24,7 @@
 #include "percent-util.h"
 #include "set.h"
 #include "string-util.h"
+#include "strv.h"
 #include "time-util.h"
 #include "varlink-io.systemd.oom.h"
 #include "varlink-io.systemd.service.h"
@@ -83,6 +84,11 @@ static int process_managed_oom_message(Manager *m, uid_t uid, sd_json_variant *p
                         return r;
                 if (r < 0)
                         continue;
+
+                if (!STR_IN_SET(message.property, "ManagedOOMSwap", "ManagedOOMMemoryPressure")) {
+                        log_debug("Ignoring ManagedOOM cgroup message with invalid property: %s", message.property);
+                        continue;
+                }
 
                 if (uid != 0) {
                         uid_t cg_uid;


### PR DESCRIPTION
ReportManagedOOMCGroups accepts the ManagedOOM unit property name as a plain string. 
systemd-oomd used to route every value except ManagedOOMSwap to the memory-pressure monitor, so malformed clients could turn arbitrary property names into real memory-pressure monitoring requests.

Validate the property before selecting the monitor hashmap and skip malformed items, matching the existing lenient handling for other bad cgroup entries.

Co-developed-by: OpenAI Codex (GPT-5) <noreply@openai.com>