### PR TITLE
sysupdate: remove @h hash matching and docs for it

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -109,6 +109,11 @@ CHANGES WITH 261 in spe:
           link flags, or passed to systemd's meson build options via
           '-Dc_link_args=-Wl,--push-state,--no-as-needed,-lm,--pop-state'.
 
+        * systemd-sysupdate does not support matching update candidate files
+          with the "@h" pattern anymore. For backwards compatibility the pattern
+          is still recognized and will match on hashes of the correct length,
+          but not match the exact hash value.
+
         Changes in the system and service manager:
 
         * PID1 now supports the kernel's Live Update Orchestration (LUO) /

--- a/NEWS
+++ b/NEWS
@@ -109,6 +109,11 @@ CHANGES WITH 261 in spe:
           link flags, or passed to systemd's meson build options via
           '-Dc_link_args=-Wl,--push-state,--no-as-needed,-lm,--pop-state'.
 
+        * systemd-sysupdate does not support matching update candidate files
+          with the "@h" pattern anymore. For backwards compatibility the pattern
+          is still recognized and will match on hashes of the correct legnth,
+          but not match the exact hash value.
+
         Changes in the system and service manager:
 
         * PID1 now supports the kernel's Live Update Orchestration (LUO) /

--- a/man/sysupdate.d.xml
+++ b/man/sysupdate.d.xml
@@ -429,13 +429,6 @@
             <entry>Formatted decimal integer</entry>
             <entry>Useful when operating with kernel image files, as per <ulink url="https://systemd.io/AUTOMATIC_BOOT_ASSESSMENT">Automatic Boot Assessment</ulink></entry>
           </row>
-
-          <row>
-            <entry><literal>@h</literal></entry>
-            <entry>SHA256 hash of compressed file</entry>
-            <entry>64 hexadecimal characters</entry>
-            <entry>The SHA256 hash of the compressed file; not useful for <constant>url-file</constant> or <constant>url-tar</constant> where the SHA256 hash is already included in the manifest file anyway</entry>
-          </row>
         </tbody>
       </tgroup>
     </table>

--- a/src/sysupdate/sysupdate-pattern.c
+++ b/src/sysupdate/sysupdate-pattern.c
@@ -399,7 +399,7 @@ int pattern_match(const char *pattern, const char *s, InstanceMetadata *ret) {
                         found.growfs = r;
                         break;
 
-                case PATTERN_SHA256SUM: {
+                case PATTERN_SHA256SUM: { /* only check, nothing else (deprecated) */
                         _cleanup_free_ void *d = NULL;
                         size_t l;
 
@@ -414,8 +414,6 @@ int pattern_match(const char *pattern, const char *s, InstanceMetadata *ret) {
 
                         assert(!found.sha256sum_set);
                         assert(l == sizeof(found.sha256sum));
-                        memcpy(found.sha256sum, d, l);
-                        found.sha256sum_set = true;
                         break;
                 }
 

--- a/src/sysupdate/sysupdate-pattern.c
+++ b/src/sysupdate/sysupdate-pattern.c
@@ -399,9 +399,11 @@ int pattern_match(const char *pattern, const char *s, InstanceMetadata *ret) {
                         found.growfs = r;
                         break;
 
-                case PATTERN_SHA256SUM: {
+                case PATTERN_SHA256SUM: { /* only check, nothing else (deprecated) */
                         _cleanup_free_ void *d = NULL;
                         size_t l;
+
+                        log_once(LOG_WARNING, "@h pattern matching has been removed. It matches any hash string with the correct length now.");
 
                         if (strlen(t) != sizeof(found.sha256sum) * 2)
                                 goto nope;
@@ -414,8 +416,6 @@ int pattern_match(const char *pattern, const char *s, InstanceMetadata *ret) {
 
                         assert(!found.sha256sum_set);
                         assert(l == sizeof(found.sha256sum));
-                        memcpy(found.sha256sum, d, l);
-                        found.sha256sum_set = true;
                         break;
                 }
 

--- a/src/sysupdate/sysupdate-resource.c
+++ b/src/sysupdate/sysupdate-resource.c
@@ -567,14 +567,10 @@ static int resource_load_from_web(
                                         return r;
 
                                 assert(h.iov_len == sizeof(instance->metadata.sha256sum));
+                                assert(!instance->metadata.sha256sum_set);
 
-                                if (instance->metadata.sha256sum_set) {
-                                        if (memcmp(instance->metadata.sha256sum, h.iov_base, h.iov_len) != 0)
-                                                return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "SHA256 sum parsed from filename and manifest don't match at line %zu, refusing.", line_nr);
-                                } else {
-                                        memcpy(instance->metadata.sha256sum, h.iov_base, h.iov_len);
-                                        instance->metadata.sha256sum_set = true;
-                                }
+                                memcpy(instance->metadata.sha256sum, h.iov_base, h.iov_len);
+                                instance->metadata.sha256sum_set = true;
 
                                 /* Web resources can only be a source, not a target, so
                                  * can never be partial or pending. */

--- a/src/sysupdate/sysupdate-resource.c
+++ b/src/sysupdate/sysupdate-resource.c
@@ -579,14 +579,10 @@ static int resource_load_from_web(
                                         return r;
 
                                 assert(h.iov_len == sizeof(instance->metadata.sha256sum));
+                                assert(!instance->metadata.sha256sum_set);
 
-                                if (instance->metadata.sha256sum_set) {
-                                        if (memcmp(instance->metadata.sha256sum, h.iov_base, h.iov_len) != 0)
-                                                return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "SHA256 sum parsed from filename and manifest don't match at line %zu, refusing.", line_nr);
-                                } else {
-                                        memcpy(instance->metadata.sha256sum, h.iov_base, h.iov_len);
-                                        instance->metadata.sha256sum_set = true;
-                                }
+                                memcpy(instance->metadata.sha256sum, h.iov_base, h.iov_len);
+                                instance->metadata.sha256sum_set = true;
 
                                 /* Web resources can only be a source, not a target, so
                                  * can never be partial or pending. */

--- a/src/sysupdate/sysupdate.c
+++ b/src/sysupdate/sysupdate.c
@@ -586,7 +586,7 @@ static int context_show_version(Context *c, const char *version) {
         bool show_fs_columns = false, show_partition_columns = false,
                 have_fs_attributes = false, have_partition_attributes = false,
                 have_size = false, have_tries = false, have_no_auto = false,
-                have_read_only = false, have_growfs = false, have_sha256 = false;
+                have_read_only = false, have_growfs = false;
         _cleanup_(sd_json_variant_unrefp) sd_json_variant *json = NULL;
         _cleanup_(table_unrefp) Table *t = NULL;
         _cleanup_strv_free_ char **changelog_urls = NULL;
@@ -618,7 +618,7 @@ static int context_show_version(Context *c, const char *version) {
                        FLAGS_SET(us->flags, UPDATE_INSTALLED|UPDATE_PROTECTED) ? ansi_highlight() : "", yes_no(FLAGS_SET(us->flags, UPDATE_INSTALLED|UPDATE_PROTECTED)), ansi_normal(),
                        us->flags & UPDATE_OBSOLETE ? ansi_highlight_red() : "", yes_no(us->flags & UPDATE_OBSOLETE), ansi_normal());
 
-        t = table_new("type", "path", "ptuuid", "ptflags", "mtime", "mode", "size", "tries-done", "tries-left", "noauto", "ro", "growfs", "sha256");
+        t = table_new("type", "path", "ptuuid", "ptflags", "mtime", "mode", "size", "tries-done", "tries-left", "noauto", "ro", "growfs");
         if (!t)
                 return log_oom();
 
@@ -764,18 +764,6 @@ static int context_show_version(Context *c, const char *version) {
                 if (r < 0)
                         return table_log_add_error(r);
 
-                if (i->metadata.sha256sum_set) {
-                        _cleanup_free_ char *formatted = NULL;
-
-                        have_sha256 = true;
-
-                        formatted = hexmem(i->metadata.sha256sum, sizeof(i->metadata.sha256sum));
-                        if (!formatted)
-                                return log_oom();
-
-                        r = table_add_cell(t, NULL, TABLE_STRING, formatted);
-                } else
-                        r = table_add_cell(t, NULL, TABLE_EMPTY, NULL);
                 if (r < 0)
                         return table_log_add_error(r);
         }
@@ -800,8 +788,6 @@ static int context_show_version(Context *c, const char *version) {
                 (void) table_hide_column_from_display(t, 10);
         if (!have_growfs)
                 (void) table_hide_column_from_display(t, 11);
-        if (!have_sha256)
-                (void) table_hide_column_from_display(t, 12);
 
         if (!sd_json_format_enabled(arg_json_format_flags)) {
                 printf("%s%s%s Version: %s\n"

--- a/src/sysupdate/sysupdate.c
+++ b/src/sysupdate/sysupdate.c
@@ -10,7 +10,6 @@
 #include "dissect-image.h"
 #include "format-table.h"
 #include "glyph-util.h"
-#include "hexdecoct.h"
 #include "image-policy.h"
 #include "loop-util.h"
 #include "main-func.h"
@@ -596,7 +595,7 @@ static int context_show_version(Context *c, const char *version) {
         bool show_fs_columns = false, show_partition_columns = false,
                 have_fs_attributes = false, have_partition_attributes = false,
                 have_size = false, have_tries = false, have_no_auto = false,
-                have_read_only = false, have_growfs = false, have_sha256 = false;
+                have_read_only = false, have_growfs = false;
         _cleanup_(sd_json_variant_unrefp) sd_json_variant *json = NULL;
         _cleanup_(table_unrefp) Table *t = NULL;
         _cleanup_strv_free_ char **changelog_urls = NULL;
@@ -628,7 +627,7 @@ static int context_show_version(Context *c, const char *version) {
                        FLAGS_SET(us->flags, UPDATE_INSTALLED|UPDATE_PROTECTED) ? ansi_highlight() : "", yes_no(FLAGS_SET(us->flags, UPDATE_INSTALLED|UPDATE_PROTECTED)), ansi_normal(),
                        us->flags & UPDATE_OBSOLETE ? ansi_highlight_red() : "", yes_no(us->flags & UPDATE_OBSOLETE), ansi_normal());
 
-        t = table_new("type", "path", "ptuuid", "ptflags", "mtime", "mode", "size", "tries-done", "tries-left", "noauto", "ro", "growfs", "sha256");
+        t = table_new("type", "path", "ptuuid", "ptflags", "mtime", "mode", "size", "tries-done", "tries-left", "noauto", "ro", "growfs");
         if (!t)
                 return log_oom();
 
@@ -773,21 +772,6 @@ static int context_show_version(Context *c, const char *version) {
                         r = table_add_cell(t, NULL, TABLE_EMPTY, NULL);
                 if (r < 0)
                         return table_log_add_error(r);
-
-                if (i->metadata.sha256sum_set) {
-                        _cleanup_free_ char *formatted = NULL;
-
-                        have_sha256 = true;
-
-                        formatted = hexmem(i->metadata.sha256sum, sizeof(i->metadata.sha256sum));
-                        if (!formatted)
-                                return log_oom();
-
-                        r = table_add_cell(t, NULL, TABLE_STRING, formatted);
-                } else
-                        r = table_add_cell(t, NULL, TABLE_EMPTY, NULL);
-                if (r < 0)
-                        return table_log_add_error(r);
         }
 
         /* Hide the fs/partition columns if we don't have any data to show there */
@@ -810,8 +794,6 @@ static int context_show_version(Context *c, const char *version) {
                 (void) table_hide_column_from_display(t, 10);
         if (!have_growfs)
                 (void) table_hide_column_from_display(t, 11);
-        if (!have_sha256)
-                (void) table_hide_column_from_display(t, 12);
 
         if (!sd_json_format_enabled(arg_json_format_flags)) {
                 printf("%s%s%s Version: %s\n"


### PR DESCRIPTION
It is not useful for anything because it is only used in url-file/url-tar, but there the hashes come from the manifest already.