### PR TITLE
 systemd-vmspawn: block device hotplug via varlink

### DIFF
--- a/man/machinectl.xml
+++ b/man/machinectl.xml
@@ -390,6 +390,62 @@
       </varlistentry>
     </variablelist></refsect2>
 
+    <refsect2><title>Virtual Machine Block Device Commands</title>
+
+    <variablelist>
+      <varlistentry>
+        <term><command>attach-disk</command> <replaceable>NAME</replaceable> <replaceable>PATH</replaceable> [<option>--disk-id=</option><replaceable>ID</replaceable>] [<option>--read-only</option>]</term>
+
+        <listitem><para>Hotplugs a block device into a running virtual machine managed by
+        <citerefentry><refentrytitle>systemd-vmspawn</refentrytitle><manvolnum>1</manvolnum></citerefentry>.
+        Takes the machine name, followed by a path to a raw or qcow2 image file or a block device
+        node. The image descriptor is passed to vmspawn over the control socket; the caller does
+        not need to place the file inside the guest's mount namespace.</para>
+
+        <para>If <option>--disk-id=</option> is given, the argument becomes the varlink-visible
+        id of the new device (matching <literal>[A-Za-z0-9_-]+</literal>, up to 28 characters);
+        otherwise the server auto-assigns an id of the form <literal>bd<replaceable>N</replaceable></literal>.
+        On success the (possibly auto-assigned) id is printed to standard output. When
+        <option>--read-only</option> is given, the device is presented to the guest as
+        read-only.</para>
+
+        <para>Only virtio-blk devices are attached from this verb. For lower-level control
+        (SCSI, NVMe, custom driver options) use the
+        <literal>io.systemd.VirtualMachineInstance.AddBlockDevice</literal> varlink method
+        directly.</para>
+
+        <xi:include href="version-info.xml" xpointer="v259"/></listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term><command>detach-disk</command> <replaceable>NAME</replaceable> <replaceable>ID</replaceable></term>
+
+        <listitem><para>Hot-removes a previously attached block device from a running
+        virtual machine. Takes the machine name and the device id (as reported by
+        <command>list-disks</command> or returned by <command>attach-disk</command>).</para>
+
+        <para>The detach is asynchronous: the guest is asked to release the device via
+        ACPI eject, and the host-side cleanup (blockdev and fdset teardown) happens once
+        the guest has acknowledged. Subscribers of
+        <literal>io.systemd.MachineInstance.SubscribeEvents</literal> observe a
+        <literal>BlockDeviceRemoved</literal> event when the teardown completes.</para>
+
+        <xi:include href="version-info.xml" xpointer="v259"/></listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term><command>list-disks</command> <replaceable>NAME</replaceable></term>
+
+        <listitem><para>Lists the block devices currently attached to a running virtual
+        machine, including both boot-time drives (from
+        <option>--image=</option>/<option>--extra-drive=</option>) and drives added at
+        runtime via <command>attach-disk</command>. For each device prints the id, image
+        format and read-only flag.</para>
+
+        <xi:include href="version-info.xml" xpointer="v259"/></listitem>
+      </varlistentry>
+    </variablelist></refsect2>
+
     <refsect2><title>Image Commands</title>
 
     <variablelist>
@@ -675,7 +731,23 @@
 
         <para>When used with <command>clone</command> a read-only container or VM image is created.</para>
 
+        <para>When used with <command>attach-disk</command>, the block device is presented to
+        the guest as read-only.</para>
+
         <xi:include href="version-info.xml" xpointer="v219"/></listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term><option>--disk-id=</option></term>
+
+        <listitem><para>Used with <command>attach-disk</command>. Sets the caller-chosen id
+        for the new block device, matching <literal>[A-Za-z0-9_-]+</literal> and up to 28
+        characters long. If omitted, the server auto-assigns an id of the form
+        <literal>bd<replaceable>N</replaceable></literal>. The id is the handle used by
+        <command>detach-disk</command> and appears in <command>list-disks</command>
+        output.</para>
+
+        <xi:include href="version-info.xml" xpointer="v259"/></listitem>
       </varlistentry>
 
       <varlistentry>

--- a/man/machinectl.xml
+++ b/man/machinectl.xml
@@ -390,6 +390,64 @@
       </varlistentry>
     </variablelist></refsect2>
 
+    <refsect2><title>Virtual Machine Block Device Commands</title>
+
+    <variablelist>
+      <varlistentry>
+        <term><command>attach-disk</command> <replaceable>NAME</replaceable> [<replaceable>FORMAT</replaceable>:][<replaceable>DISKTYPE</replaceable>:]<replaceable>PATH</replaceable> [<option>--disk-id=</option><replaceable>ID</replaceable>] [<option>--read-only</option>]</term>
+
+        <listitem><para>Add a block device to a running virtual machine managed by
+        <citerefentry><refentrytitle>systemd-vmspawn</refentrytitle><manvolnum>1</manvolnum></citerefentry>.
+        Takes the machine name, followed by a path to an image file or a block device node,
+        optionally prefixed with <replaceable>FORMAT</replaceable> (<literal>raw</literal> or
+        <literal>qcow2</literal>; default <literal>raw</literal>) and
+        <replaceable>DISKTYPE</replaceable> (<literal>virtio-blk</literal>,
+        <literal>virtio-scsi</literal>, <literal>nvme</literal>, or <literal>scsi-cd</literal>;
+        default <literal>virtio-blk</literal>). The prefixes may appear in any order and
+        mirror the <option>--extra-drive=</option> syntax of
+        <citerefentry><refentrytitle>systemd-vmspawn</refentrytitle><manvolnum>1</manvolnum></citerefentry>.
+        The image descriptor is passed to vmspawn over the control socket; the caller does
+        not need to place the file inside the guest's mount namespace.</para>
+
+        <para>If <option>--disk-id=</option> is given, the argument becomes the varlink-visible
+        id of the new device (matching <literal>[A-Za-z0-9_-]+</literal>, up to 28 characters);
+        otherwise the server auto-assigns an id of the form <literal>bd<replaceable>N</replaceable></literal>.
+        On success the (possibly auto-assigned) id is printed to standard output. When
+        <option>--read-only</option> is given, the device is presented to the guest as
+        read-only.</para>
+
+        <xi:include href="version-info.xml" xpointer="v259"/></listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term><command>detach-disk</command> <replaceable>NAME</replaceable> <replaceable>ID</replaceable></term>
+
+        <listitem><para>Remove a block device from a running virtual machine.
+        Takes the machine name and the device id (as reported by
+        <command>list-disks</command> or returned by <command>attach-disk</command>).</para>
+
+        <para>The detach is asynchronous: the guest is asked to release the device via
+        ACPI eject, and the host-side cleanup (blockdev and fdset teardown) happens once
+        the guest has acknowledged. Subscribers of
+        <literal>io.systemd.MachineInstance.SubscribeEvents</literal> observe a
+        <literal>BlockDeviceRemoved</literal> event when the teardown completes.</para>
+
+        <xi:include href="version-info.xml" xpointer="v259"/></listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term><command>list-disks</command> <replaceable>NAME</replaceable></term>
+
+        <listitem><para>Lists the block devices currently attached to a running virtual
+        machine, including both boot-time drives (from
+        <option>--image=</option>/<option>--extra-drive=</option>) and drives added at
+        runtime via <command>attach-disk</command>. For each device prints the id, image
+        format and read-only flag.</para>
+
+        <xi:include href="version-info.xml" xpointer="v259"/></listitem>
+      </varlistentry>
+    </variablelist></refsect2>
+
     <refsect2><title>Image Commands</title>
 
     <variablelist>
@@ -675,7 +733,23 @@
 
         <para>When used with <command>clone</command> a read-only container or VM image is created.</para>
 
+        <para>When used with <command>attach-disk</command>, the block device is presented to
+        the guest as read-only.</para>
+
         <xi:include href="version-info.xml" xpointer="v219"/></listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term><option>--disk-id=</option></term>
+
+        <listitem><para>Used with <command>attach-disk</command>. Sets the caller-chosen id
+        for the new block device, matching <literal>[A-Za-z0-9_-]+</literal> and up to 28
+        characters long. If omitted, the server auto-assigns an id of the form
+        <literal>bd<replaceable>N</replaceable></literal>. The id is the handle used by
+        <command>detach-disk</command> and appears in <command>list-disks</command>
+        output.</para>
+
+        <xi:include href="version-info.xml" xpointer="v259"/></listitem>
       </varlistentry>
 
       <varlistentry>

--- a/man/systemd-vmspawn.xml
+++ b/man/systemd-vmspawn.xml
@@ -563,6 +563,11 @@
           <option>--image-disk-type=</option> (which itself defaults to <literal>virtio-blk</literal>).
           Note that <literal>qcow2</literal> is only supported for regular files, not block devices.</para>
 
+          <para>Block devices may also be added to and removed from a running VM at runtime via
+          the <command>attach-disk</command>, <command>detach-disk</command> and
+          <command>list-disks</command> verbs of
+          <citerefentry><refentrytitle>machinectl</refentrytitle><manvolnum>1</manvolnum></citerefentry>.</para>
+
           <xi:include href="version-info.xml" xpointer="v256"/></listitem>
         </varlistentry>
 

--- a/mkosi/mkosi.conf.d/arch/mkosi.conf
+++ b/mkosi/mkosi.conf.d/arch/mkosi.conf
@@ -17,6 +17,7 @@ Packages=
         bind
         bpf
         btrfs-progs
+        busybox
         coreutils
         cryptsetup
         dbus-broker

--- a/mkosi/mkosi.conf.d/centos-fedora/mkosi.conf
+++ b/mkosi/mkosi.conf.d/centos-fedora/mkosi.conf
@@ -23,6 +23,7 @@ VolatilePackages=
 Packages=
         bind-utils
         bpftool
+        busybox
         coreutils
         cryptsetup
         device-mapper-event

--- a/mkosi/mkosi.conf.d/debian-ubuntu/mkosi.conf
+++ b/mkosi/mkosi.conf.d/debian-ubuntu/mkosi.conf
@@ -36,6 +36,7 @@ Packages=
         apt
         bind9-dnsutils
         bsdutils
+        busybox-static
         cryptsetup-bin
         dbus-broker
         dbus-user-session

--- a/mkosi/mkosi.conf.d/opensuse/mkosi.conf
+++ b/mkosi/mkosi.conf.d/opensuse/mkosi.conf
@@ -35,6 +35,7 @@ Packages=
         bind-utils
         bpftool
         btrfs-progs
+        busybox-static
         coreutils
         cryptsetup
         device-mapper

--- a/shell-completion/bash/machinectl
+++ b/shell-completion/bash/machinectl
@@ -32,6 +32,13 @@ __get_machines() {
         sort -u
 }
 
+__get_disks() {
+    local mode=$1 machine=$2
+    local a b
+    machinectl $mode list-disks "$machine" --no-legend --no-pager 2>/dev/null |
+        { while read -r a b; do echo " $a"; done; }
+}
+
 _machinectl() {
     local cur=${COMP_WORDS[COMP_CWORD]} prev=${COMP_WORDS[COMP_CWORD-1]} words cword
     local i verb comps mode
@@ -40,7 +47,7 @@ _machinectl() {
         [STANDALONE]='--all -a -l --full --help -h --no-ask-password --no-legend --no-pager --version --value
                       --mkdir --read-only --force -q --quiet --system --user --now -V'
         [ARG]='--host -H --kill-whom -M --machine --property -p -P --signal -s --uid -E --setenv -n --lines
-                      -o --output --verify --format --max-addresses --runner'
+                      -o --output --verify --format --max-addresses --runner --disk-id'
     )
 
     local -A VERBS=(
@@ -48,10 +55,12 @@ _machinectl() {
         [MACHINES]='status show start stop login shell enable disable poweroff reboot pause resume terminate kill
                     image-status show-image remove export-tar export-raw'
         [MACHINES_OR_FILES]='edit cat'
-        [MACHINE_ONLY]='clone rename set-limit'
+        [MACHINE_ONLY]='clone rename set-limit list-disks'
         [READONLY]='read-only'
         [FILE]='import-tar import-raw'
         [MACHINES_AND_FILES]='copy-to copy-from bind'
+        [MACHINE_AND_FILE]='attach-disk'
+        [MACHINE_AND_DISK_ID]='detach-disk'
     )
 
     _init_completion || return
@@ -184,6 +193,50 @@ _machinectl() {
         if (( COMP_CWORD == i + 1 )); then # first argument after verb
             comps=$(compgen -f -- "$cur")
             compopt -o filenames
+        else
+            comps=''
+        fi
+
+    elif __contains_word "$verb" ${VERBS[MACHINE_AND_FILE]}; then
+        local k args=0
+        for ((k=i+1; k < COMP_CWORD; k++)); do
+            if __contains_word "${COMP_WORDS[k]}" ${OPTS[ARG]}; then
+                ((k++))
+            elif [[ ${COMP_WORDS[k]} = -* ]]; then
+                continue
+            else
+                ((args++))
+            fi
+        done
+        if (( args == 0 )); then
+            comps=$( __get_machines $mode )
+        elif (( args == 1 )); then
+            comps=$(compgen -f -- "$cur")
+            compopt -o filenames
+        else
+            comps=''
+        fi
+
+    elif __contains_word "$verb" ${VERBS[MACHINE_AND_DISK_ID]}; then
+        local k args=0 machine_name=""
+        for ((k=i+1; k < COMP_CWORD; k++)); do
+            if __contains_word "${COMP_WORDS[k]}" ${OPTS[ARG]}; then
+                ((k++))
+            elif [[ ${COMP_WORDS[k]} = -* ]]; then
+                continue
+            else
+                if (( args == 0 )); then
+                    machine_name=${COMP_WORDS[k]}
+                fi
+                ((args++))
+            fi
+        done
+        if (( args == 0 )); then
+            comps=$( __get_machines $mode )
+        elif (( args == 1 )); then
+            if [[ -n "$machine_name" ]]; then
+                comps=$( __get_disks $mode "$machine_name" )
+            fi
         else
             comps=''
         fi

--- a/shell-completion/bash/machinectl
+++ b/shell-completion/bash/machinectl
@@ -32,6 +32,13 @@ __get_machines() {
         sort -u
 }
 
+__get_disks() {
+    local mode=$1 machine=$2
+    local a b
+    machinectl $mode list-disks "$machine" --no-legend --no-pager 2>/dev/null |
+        { while read -r a b; do echo " $a"; done; }
+}
+
 _machinectl() {
     local cur=${COMP_WORDS[COMP_CWORD]} prev=${COMP_WORDS[COMP_CWORD-1]} words cword
     local i verb comps mode
@@ -40,18 +47,20 @@ _machinectl() {
         [STANDALONE]='--all -a -l --full --help -h --no-ask-password --no-legend --no-pager --version --value
                       --mkdir --read-only --force -q --quiet --system --user --now -V'
         [ARG]='--host -H --kill-whom -M --machine --property -p -P --signal -s --uid -E --setenv -n --lines
-                      -o --output --verify --format --max-addresses --runner'
+                      -o --output --verify --format --max-addresses --runner --disk-id'
     )
 
     local -A VERBS=(
         [STANDALONE]='list list-images clean pull-tar pull-raw list-transfers cancel-transfer import-fs'
         [MACHINES]='status show start stop login shell enable disable poweroff reboot pause resume terminate kill
-                    image-status show-image remove export-tar export-raw'
+                    image-status show-image remove export-tar export-raw list-disks'
         [MACHINES_OR_FILES]='edit cat'
         [MACHINE_ONLY]='clone rename set-limit'
         [READONLY]='read-only'
         [FILE]='import-tar import-raw'
         [MACHINES_AND_FILES]='copy-to copy-from bind'
+        [MACHINE_AND_FILE]='attach-disk'
+        [MACHINE_AND_DISK_ID]='detach-disk'
     )
 
     _init_completion || return
@@ -184,6 +193,50 @@ _machinectl() {
         if (( COMP_CWORD == i + 1 )); then # first argument after verb
             comps=$(compgen -f -- "$cur")
             compopt -o filenames
+        else
+            comps=''
+        fi
+
+    elif __contains_word "$verb" ${VERBS[MACHINE_AND_FILE]}; then
+        local k args=0
+        for ((k=i+1; k < COMP_CWORD; k++)); do
+            if __contains_word "${COMP_WORDS[k]}" ${OPTS[ARG]}; then
+                ((k++))
+            elif [[ ${COMP_WORDS[k]} = -* ]]; then
+                continue
+            else
+                ((args++))
+            fi
+        done
+        if (( args == 0 )); then
+            comps=$( __get_machines $mode )
+        elif (( args == 1 )); then
+            comps=$(compgen -f -- "$cur")
+            compopt -o filenames
+        else
+            comps=''
+        fi
+
+    elif __contains_word "$verb" ${VERBS[MACHINE_AND_DISK_ID]}; then
+        local k args=0 machine_name=""
+        for ((k=i+1; k < COMP_CWORD; k++)); do
+            if __contains_word "${COMP_WORDS[k]}" ${OPTS[ARG]}; then
+                ((k++))
+            elif [[ ${COMP_WORDS[k]} = -* ]]; then
+                continue
+            else
+                if (( args == 0 )); then
+                    machine_name=${COMP_WORDS[k]}
+                fi
+                ((args++))
+            fi
+        done
+        if (( args == 0 )); then
+            comps=$( __get_machines $mode )
+        elif (( args == 1 )); then
+            if [[ -n "$machine_name" ]]; then
+                comps=$( __get_disks $mode "$machine_name" )
+            fi
         else
             comps=''
         fi

--- a/shell-completion/zsh/_machinectl
+++ b/shell-completion/zsh/_machinectl
@@ -23,6 +23,19 @@
         fi
     }
 
+(( $+functions[_machinectl_disks] )) ||
+    _machinectl_disks() {
+        local machine=$1 a b
+        local -a _disks
+        _disks=("${(fo)$(machinectl --no-legend --no-pager list-disks "$machine" 2>/dev/null | while read -r a b; do printf -- '%s\n' $a; done)}")
+        typeset -U _disks
+        if [[ -n "$_disks" ]]; then
+            _describe 'disks' _disks
+        else
+            _message 'no disks'
+        fi
+    }
+
 (( $+functions[_machinectl_commands] )) || _machinectl_commands()
 {
     local -a _machinectl_cmds
@@ -57,6 +70,10 @@
         "remove:Remove an image"
         "set-limits:Set image or pool size limit (disk quota)"
         "clean:Remove hidden (or all) images"
+
+        "attach-disk:Hotplug a block device into a VM"
+        "detach-disk:Hot-remove a block device from a VM"
+        "list-disks:List block devices attached to a VM"
 
         "pull-tar:Download a TAR container image"
         "pull-raw:Download a RAW container or VM image"
@@ -103,6 +120,23 @@
 
         image-status|show-image|remove)
             _machinectl_images ;;
+
+        attach-disk)
+            if (( CURRENT == 2 )); then _sd_machines
+            elif (( CURRENT == 3 )); then _files
+            else stop=1
+            fi ;;
+
+        detach-disk)
+            if (( CURRENT == 2 )); then _sd_machines
+            elif (( CURRENT == 3 )); then _machinectl_disks "$words[2]"
+            else stop=1
+            fi ;;
+
+        list-disks)
+            if (( CURRENT == 2 )); then _sd_machines
+            else stop=1
+            fi ;;
 
         edit|cat)
             if (( CURRENT == 2 )); then _machinectl_images
@@ -183,7 +217,8 @@ _arguments \
     '(-l --full)'{-l,--full}'[Do not ellipsize cgroup members.]' \
     '--kill-whom=[Whom to send signal to.]:killwhom:(leader all)' \
     '(-s --signal)'{-s+,--signal=}'[Which signal to send.]:signal:_signals' \
-    '--read-only[Create read-only bind mount.]' \
+    '--read-only[Create read-only bind mount or attach disk read-only.]' \
+    '--disk-id=[Caller-chosen id for an attached block device.]:disk id' \
     '--mkdir[Create directory before bind mounting, if missing.]' \
     '(-n --lines)'{-n+,--lines=}'[Number of journal entries to show.]:integer' \
     '(-o --output)'{-o+,--output=}'[Change journal output mode.]:output modes:_sd_outputmodes' \

--- a/shell-completion/zsh/_machinectl
+++ b/shell-completion/zsh/_machinectl
@@ -23,6 +23,19 @@
         fi
     }
 
+(( $+functions[_machinectl_disks] )) ||
+    _machinectl_disks() {
+        local machine=$1 a b
+        local -a _disks
+        _disks=("${(fo)$(machinectl --no-legend list-disks "$machine" 2>/dev/null | while read -r a b; do printf -- '%s\n' $a; done)}")
+        typeset -U _disks
+        if [[ -n "$_disks" ]]; then
+            _describe 'disks' _disks
+        else
+            _message 'no disks'
+        fi
+    }
+
 (( $+functions[_machinectl_commands] )) || _machinectl_commands()
 {
     local -a _machinectl_cmds
@@ -57,6 +70,10 @@
         "remove:Remove an image"
         "set-limits:Set image or pool size limit (disk quota)"
         "clean:Remove hidden (or all) images"
+
+        "attach-disk:Hotplug a block device into a VM"
+        "detach-disk:Hot-remove a block device from a VM"
+        "list-disks:List block devices attached to a VM"
 
         "pull-tar:Download a TAR container image"
         "pull-raw:Download a RAW container or VM image"
@@ -103,6 +120,23 @@
 
         image-status|show-image|remove)
             _machinectl_images ;;
+
+        attach-disk)
+            if (( CURRENT == 2 )); then _sd_machines
+            elif (( CURRENT == 3 )); then _files
+            else stop=1
+            fi ;;
+
+        detach-disk)
+            if (( CURRENT == 2 )); then _sd_machines
+            elif (( CURRENT == 3 )); then _machinectl_disks "$words[2]"
+            else stop=1
+            fi ;;
+
+        list-disks)
+            if (( CURRENT == 2 )); then _sd_machines
+            else stop=1
+            fi ;;
 
         edit|cat)
             if (( CURRENT == 2 )); then _machinectl_images
@@ -183,7 +217,8 @@ _arguments \
     '(-l --full)'{-l,--full}'[Do not ellipsize cgroup members.]' \
     '--kill-whom=[Whom to send signal to.]:killwhom:(leader all)' \
     '(-s --signal)'{-s+,--signal=}'[Which signal to send.]:signal:_signals' \
-    '--read-only[Create read-only bind mount.]' \
+    '--read-only[Create read-only bind mount or attach disk read-only.]' \
+    '--disk-id=[Caller-chosen id for an attached block device.]:disk id' \
     '--mkdir[Create directory before bind mounting, if missing.]' \
     '(-n --lines)'{-n+,--lines=}'[Number of journal entries to show.]:integer' \
     '(-o --output)'{-o+,--output=}'[Change journal output mode.]:output modes:_sd_outputmodes' \

--- a/src/machine/machinectl.c
+++ b/src/machine/machinectl.c
@@ -29,12 +29,14 @@
 #include "cgroup-util.h"
 #include "edit-util.h"
 #include "env-util.h"
+#include "fd-util.h"
 #include "format-ifname.h"
 #include "format-table.h"
 #include "format-util.h"
 #include "hostname-util.h"
 #include "import-util.h"
 #include "in-addr-util.h"
+#include "json-util.h"
 #include "label-util.h"
 #include "log.h"
 #include "logs-show.h"
@@ -107,6 +109,7 @@ static const char *arg_uid = NULL;
 static char **arg_setenv = NULL;
 static unsigned arg_max_addresses = 1;
 static RuntimeScope arg_runtime_scope = RUNTIME_SCOPE_SYSTEM;
+static const char *arg_disk_id = NULL;
 
 STATIC_DESTRUCTOR_REGISTER(arg_property, strv_freep);
 STATIC_DESTRUCTOR_REGISTER(arg_setenv, strv_freep);
@@ -1276,6 +1279,159 @@ static int verb_resume(int argc, char *argv[], uintptr_t _data, void *userdata) 
         return verb_vm_control(argc, argv, "io.systemd.MachineInstance.Resume");
 }
 
+static int verb_attach_disk(int argc, char *argv[], uintptr_t _data, void *userdata) {
+        _cleanup_(sd_varlink_unrefp) sd_varlink *vl = NULL;
+        _cleanup_free_ char *address = NULL;
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *reply = NULL;
+        const char *error_id = NULL;
+        int r;
+
+        r = machine_get_control_address(argv[1], &address);
+        if (r == -EOPNOTSUPP)
+                return log_error_errno(r, "Machine '%s' does not expose a varlink control socket.", argv[1]);
+        if (r < 0)
+                return r;
+
+        r = sd_varlink_connect_address(&vl, address);
+        if (r < 0)
+                return log_error_errno(r, "Failed to connect to machine control socket: %m");
+
+        r = sd_varlink_set_allow_fd_passing_output(vl, true);
+        if (r < 0)
+                return log_error_errno(r, "Failed to enable fd passing: %m");
+
+        /* QEMU's fdset match is strict on O_ACCMODE: a read-only blockdev-add
+         * refuses an O_RDWR fd, so respect arg_read_only at open time. */
+        int open_flags = (arg_read_only ? O_RDONLY : O_RDWR) | O_CLOEXEC;
+        _cleanup_close_ int image_fd = open(argv[2], open_flags);
+        if (image_fd < 0 && !arg_read_only && errno == EACCES)
+                image_fd = open(argv[2], O_RDONLY|O_CLOEXEC);
+        if (image_fd < 0)
+                return log_error_errno(errno, "Failed to open '%s': %m", argv[2]);
+
+        int fd_idx = sd_varlink_push_fd(vl, image_fd);
+        if (fd_idx < 0)
+                return log_error_errno(fd_idx, "Failed to push fd: %m");
+        TAKE_FD(image_fd);
+
+        r = sd_varlink_callbo(
+                        vl,
+                        "io.systemd.VirtualMachineInstance.AddBlockDevice",
+                        &reply,
+                        &error_id,
+                        SD_JSON_BUILD_PAIR_UNSIGNED("fileDescriptor", fd_idx),
+                        SD_JSON_BUILD_PAIR_STRING("format", "raw"),
+                        SD_JSON_BUILD_PAIR_STRING("driver", "virtio_blk"),
+                        SD_JSON_BUILD_PAIR_CONDITION(arg_read_only, "readOnly", SD_JSON_BUILD_BOOLEAN(true)),
+                        SD_JSON_BUILD_PAIR_CONDITION(!!arg_disk_id, "id", SD_JSON_BUILD_STRING(arg_disk_id)));
+        if (r < 0)
+                return log_error_errno(r, "Failed to call AddBlockDevice: %m");
+        if (error_id)
+                return log_error_errno(sd_varlink_error_to_errno(error_id, reply),
+                                       "AddBlockDevice failed: %s", error_id);
+
+        const char *id = NULL;
+        if (reply)
+                id = sd_json_variant_string(sd_json_variant_by_key(reply, "id"));
+        if (id)
+                log_info("Attached disk '%s' as '%s'", argv[2], id);
+
+        return 0;
+}
+
+static int verb_detach_disk(int argc, char *argv[], uintptr_t _data, void *userdata) {
+        _cleanup_(sd_varlink_unrefp) sd_varlink *vl = NULL;
+        _cleanup_free_ char *address = NULL;
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *reply = NULL;
+        const char *error_id = NULL;
+        int r;
+
+        r = machine_get_control_address(argv[1], &address);
+        if (r == -EOPNOTSUPP)
+                return log_error_errno(r, "Machine '%s' does not expose a varlink control socket.", argv[1]);
+        if (r < 0)
+                return r;
+
+        r = sd_varlink_connect_address(&vl, address);
+        if (r < 0)
+                return log_error_errno(r, "Failed to connect to machine control socket: %m");
+
+        r = sd_varlink_callbo(
+                        vl,
+                        "io.systemd.VirtualMachineInstance.RemoveBlockDevice",
+                        &reply,
+                        &error_id,
+                        SD_JSON_BUILD_PAIR_STRING("id", argv[2]));
+        if (r < 0)
+                return log_error_errno(r, "Failed to call RemoveBlockDevice: %m");
+        if (error_id)
+                return log_error_errno(sd_varlink_error_to_errno(error_id, reply),
+                                       "RemoveBlockDevice failed: %s", error_id);
+
+        log_info("Requested removal of block device '%s'", argv[2]);
+        return 0;
+}
+
+static int verb_list_disks(int argc, char *argv[], uintptr_t _data, void *userdata) {
+        _cleanup_(sd_varlink_unrefp) sd_varlink *vl = NULL;
+        _cleanup_free_ char *address = NULL;
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *reply = NULL;
+        const char *error_id = NULL;
+        int r;
+
+        r = machine_get_control_address(argv[1], &address);
+        if (r == -EOPNOTSUPP)
+                return log_error_errno(r, "Machine '%s' does not expose a varlink control socket.", argv[1]);
+        if (r < 0)
+                return r;
+
+        r = sd_varlink_connect_address(&vl, address);
+        if (r < 0)
+                return log_error_errno(r, "Failed to connect to machine control socket: %m");
+
+        r = sd_varlink_collectb(
+                        vl,
+                        "io.systemd.VirtualMachineInstance.ListBlockDevices",
+                        &reply,
+                        &error_id);
+        if (r < 0)
+                return log_error_errno(r, "Failed to call ListBlockDevices: %m");
+        if (error_id)
+                return log_error_errno(sd_varlink_error_to_errno(error_id, reply),
+                                       "ListBlockDevices failed: %s", error_id);
+
+        _cleanup_(table_unrefp) Table *table = table_new("id", "format", "read-only");
+        if (!table)
+                return log_oom();
+
+        size_t n = sd_json_variant_elements(reply);
+        for (size_t i = 0; i < n; i++) {
+                sd_json_variant *entry = sd_json_variant_by_index(reply, i);
+                const char *id = NULL, *format = NULL;
+                bool read_only = false;
+
+                sd_json_variant *v;
+                v = sd_json_variant_by_key(entry, "id");
+                if (v && sd_json_variant_is_string(v))
+                        id = sd_json_variant_string(v);
+                v = sd_json_variant_by_key(entry, "format");
+                if (v && sd_json_variant_is_string(v))
+                        format = sd_json_variant_string(v);
+                v = sd_json_variant_by_key(entry, "readOnly");
+                if (v)
+                        read_only = sd_json_variant_boolean(v);
+
+                r = table_add_many(table,
+                                   TABLE_STRING, strna(id),
+                                   TABLE_STRING, strna(format),
+                                   TABLE_BOOLEAN, read_only);
+                if (r < 0)
+                        return table_log_add_error(r);
+        }
+
+        return show_table(table, "block devices");
+}
+
 static const char *select_copy_method(bool copy_from, bool force) {
         if (force)
                 return copy_from ? "CopyFromMachineWithFlags" : "CopyToMachineWithFlags";
@@ -2301,6 +2457,7 @@ static int parse_argv(int argc, char *argv[]) {
                 ARG_MAX_ADDRESSES,
                 ARG_SYSTEM,
                 ARG_USER,
+                ARG_DISK_ID,
         };
 
         static const struct option options[] = {
@@ -2332,6 +2489,7 @@ static int parse_argv(int argc, char *argv[]) {
                 { "max-addresses",   required_argument, NULL, ARG_MAX_ADDRESSES   },
                 { "user",            no_argument,       NULL, ARG_USER            },
                 { "system",          no_argument,       NULL, ARG_SYSTEM          },
+                { "disk-id",         required_argument, NULL, ARG_DISK_ID         },
                 {}
         };
 
@@ -2559,6 +2717,10 @@ static int parse_argv(int argc, char *argv[]) {
                         arg_runtime_scope = RUNTIME_SCOPE_SYSTEM;
                         break;
 
+                case ARG_DISK_ID:
+                        arg_disk_id = optarg;
+                        break;
+
                 case '?':
                         return -EINVAL;
 
@@ -2603,6 +2765,9 @@ static int machinectl_main(int argc, char *argv[], sd_bus *bus) {
                 { "kill",            2,        VERB_ANY, 0,            verb_kill_machine      },
                 { "pause",           2,        VERB_ANY, 0,            verb_pause             },
                 { "resume",          2,        VERB_ANY, 0,            verb_resume            },
+                { "attach-disk",     3,        3,        0,            verb_attach_disk       },
+                { "detach-disk",     3,        3,        0,            verb_detach_disk       },
+                { "list-disks",      2,        2,        0,            verb_list_disks        },
                 { "login",           VERB_ANY, 2,        0,            verb_login_machine     },
                 { "shell",           VERB_ANY, VERB_ANY, 0,            verb_shell_machine     },
                 { "bind",            3,        4,        0,            verb_bind_mount        },

--- a/src/machine/machinectl.c
+++ b/src/machine/machinectl.c
@@ -9,6 +9,7 @@
 #include "sd-bus.h"
 #include "sd-event.h"
 #include "sd-journal.h"
+#include "sd-json.h"
 #include "sd-varlink.h"
 
 #include "alloc-util.h"
@@ -29,6 +30,7 @@
 #include "cgroup-util.h"
 #include "edit-util.h"
 #include "env-util.h"
+#include "fd-util.h"
 #include "format-ifname.h"
 #include "format-table.h"
 #include "format-util.h"
@@ -39,6 +41,7 @@
 #include "log.h"
 #include "logs-show.h"
 #include "machine-dbus.h"
+#include "machine-util.h"
 #include "main-func.h"
 #include "nulstr-util.h"
 #include "osc-context.h"
@@ -107,6 +110,7 @@ static const char *arg_uid = NULL;
 static char **arg_setenv = NULL;
 static unsigned arg_max_addresses = 1;
 static RuntimeScope arg_runtime_scope = RUNTIME_SCOPE_SYSTEM;
+static const char *arg_disk_id = NULL;
 
 STATIC_DESTRUCTOR_REGISTER(arg_property, strv_freep);
 STATIC_DESTRUCTOR_REGISTER(arg_setenv, strv_freep);
@@ -1276,6 +1280,166 @@ static int verb_resume(int argc, char *argv[], uintptr_t _data, void *userdata) 
         return verb_vm_control(argc, argv, "io.systemd.MachineInstance.Resume");
 }
 
+static int verb_attach_disk(int argc, char *argv[], uintptr_t _data, void *userdata) {
+        _cleanup_(sd_varlink_unrefp) sd_varlink *vl = NULL;
+        _cleanup_free_ char *address = NULL;
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *reply = NULL;
+        const char *error_id = NULL;
+        int r;
+
+        r = machine_get_control_address(argv[1], &address);
+        if (r == -EOPNOTSUPP)
+                return log_error_errno(r, "Machine '%s' does not expose a varlink control socket.", argv[1]);
+        if (r < 0)
+                return r;
+
+        r = sd_varlink_connect_address(&vl, address);
+        if (r < 0)
+                return log_error_errno(r, "Failed to connect to machine control socket: %m");
+
+        r = sd_varlink_set_allow_fd_passing_output(vl, true);
+        if (r < 0)
+                return log_error_errno(r, "Failed to enable fd passing: %m");
+
+        ImageFormat format = IMAGE_FORMAT_RAW;
+        DiskType disk_type = DISK_TYPE_VIRTIO_BLK;
+        _cleanup_free_ char *path = NULL;
+        r = parse_disk_spec(argv[2], &format, &disk_type, &path);
+        if (r < 0)
+                return log_error_errno(r, "Failed to parse disk spec '%s': %m", argv[2]);
+
+        const char *driver = ASSERT_PTR(disk_type_to_block_driver(disk_type));
+
+        /* QEMU's fdset match is strict on O_ACCMODE: a read-only blockdev-add
+         * refuses an O_RDWR fd, so respect arg_read_only at open time. */
+        int open_flags = (arg_read_only ? O_RDONLY : O_RDWR) | O_CLOEXEC;
+        _cleanup_close_ int image_fd = open(path, open_flags);
+        if (image_fd < 0)
+                return log_error_errno(errno, "Failed to open '%s': %m", path);
+
+        int fd_idx = sd_varlink_push_fd(vl, image_fd);
+        if (fd_idx < 0)
+                return log_error_errno(fd_idx, "Failed to push fd: %m");
+        TAKE_FD(image_fd);
+
+        r = sd_varlink_callbo(
+                        vl,
+                        "io.systemd.VirtualMachineInstance.AddBlockDevice",
+                        &reply,
+                        &error_id,
+                        SD_JSON_BUILD_PAIR_UNSIGNED("fileDescriptor", fd_idx),
+                        SD_JSON_BUILD_PAIR_STRING("format", image_format_to_string(format)),
+                        SD_JSON_BUILD_PAIR_STRING("driver", driver),
+                        SD_JSON_BUILD_PAIR_CONDITION(arg_read_only, "readOnly", SD_JSON_BUILD_BOOLEAN(true)),
+                        SD_JSON_BUILD_PAIR_CONDITION(!!arg_disk_id, "id", SD_JSON_BUILD_STRING(arg_disk_id)));
+        if (r < 0)
+                return log_error_errno(r, "Failed to call AddBlockDevice: %m");
+        if (error_id)
+                return log_error_errno(sd_varlink_error_to_errno(error_id, reply),
+                                       "AddBlockDevice failed: %s", error_id);
+
+        const char *id = NULL;
+        if (reply)
+                id = sd_json_variant_string(sd_json_variant_by_key(reply, "id"));
+        if (id)
+                log_info("Attached disk '%s' as '%s'", path, id);
+
+        return 0;
+}
+
+static int verb_detach_disk(int argc, char *argv[], uintptr_t _data, void *userdata) {
+        _cleanup_(sd_varlink_unrefp) sd_varlink *vl = NULL;
+        _cleanup_free_ char *address = NULL;
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *reply = NULL;
+        const char *error_id = NULL;
+        int r;
+
+        r = machine_get_control_address(argv[1], &address);
+        if (r == -EOPNOTSUPP)
+                return log_error_errno(r, "Machine '%s' does not expose a varlink control socket.", argv[1]);
+        if (r < 0)
+                return r;
+
+        r = sd_varlink_connect_address(&vl, address);
+        if (r < 0)
+                return log_error_errno(r, "Failed to connect to machine control socket: %m");
+
+        r = sd_varlink_callbo(
+                        vl,
+                        "io.systemd.VirtualMachineInstance.RemoveBlockDevice",
+                        &reply,
+                        &error_id,
+                        SD_JSON_BUILD_PAIR_STRING("id", argv[2]));
+        if (r < 0)
+                return log_error_errno(r, "Failed to call RemoveBlockDevice: %m");
+        if (error_id)
+                return log_error_errno(sd_varlink_error_to_errno(error_id, reply),
+                                       "RemoveBlockDevice failed: %s", error_id);
+
+        log_info("Requested removal of block device '%s'", argv[2]);
+        return 0;
+}
+
+static int verb_list_disks(int argc, char *argv[], uintptr_t _data, void *userdata) {
+        _cleanup_(sd_varlink_unrefp) sd_varlink *vl = NULL;
+        _cleanup_free_ char *address = NULL;
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *reply = NULL;
+        const char *error_id = NULL;
+        int r;
+
+        r = machine_get_control_address(argv[1], &address);
+        if (r == -EOPNOTSUPP)
+                return log_error_errno(r, "Machine '%s' does not expose a varlink control socket.", argv[1]);
+        if (r < 0)
+                return r;
+
+        r = sd_varlink_connect_address(&vl, address);
+        if (r < 0)
+                return log_error_errno(r, "Failed to connect to machine control socket: %m");
+
+        r = sd_varlink_collectb(
+                        vl,
+                        "io.systemd.VirtualMachineInstance.ListBlockDevices",
+                        &reply,
+                        &error_id);
+        if (r < 0)
+                return log_error_errno(r, "Failed to call ListBlockDevices: %m");
+        if (error_id)
+                return log_error_errno(sd_varlink_error_to_errno(error_id, reply),
+                                       "ListBlockDevices failed: %s", error_id);
+
+        _cleanup_(table_unrefp) Table *table = table_new("id", "format", "read-only");
+        if (!table)
+                return log_oom();
+
+        size_t n = sd_json_variant_elements(reply);
+        for (size_t i = 0; i < n; i++) {
+                sd_json_variant *entry = sd_json_variant_by_index(reply, i);
+                const char *id = NULL, *format = NULL;
+                bool read_only = false;
+
+                sd_json_variant *v;
+                v = sd_json_variant_by_key(entry, "id");
+                if (v && sd_json_variant_is_string(v))
+                        id = sd_json_variant_string(v);
+                v = sd_json_variant_by_key(entry, "format");
+                if (v && sd_json_variant_is_string(v))
+                        format = sd_json_variant_string(v);
+                v = sd_json_variant_by_key(entry, "readOnly");
+                if (v)
+                        read_only = sd_json_variant_boolean(v);
+
+                r = table_add_many(table,
+                                   TABLE_STRING, strna(id),
+                                   TABLE_STRING, strna(format),
+                                   TABLE_BOOLEAN, read_only);
+                if (r < 0)
+                        return table_log_add_error(r);
+        }
+
+        return show_table(table, "block devices");
+}
+
 static const char *select_copy_method(bool copy_from, bool force) {
         if (force)
                 return copy_from ? "CopyFromMachineWithFlags" : "CopyToMachineWithFlags";
@@ -2301,6 +2465,7 @@ static int parse_argv(int argc, char *argv[]) {
                 ARG_MAX_ADDRESSES,
                 ARG_SYSTEM,
                 ARG_USER,
+                ARG_DISK_ID,
         };
 
         static const struct option options[] = {
@@ -2332,6 +2497,7 @@ static int parse_argv(int argc, char *argv[]) {
                 { "max-addresses",   required_argument, NULL, ARG_MAX_ADDRESSES   },
                 { "user",            no_argument,       NULL, ARG_USER            },
                 { "system",          no_argument,       NULL, ARG_SYSTEM          },
+                { "disk-id",         required_argument, NULL, ARG_DISK_ID         },
                 {}
         };
 
@@ -2559,6 +2725,10 @@ static int parse_argv(int argc, char *argv[]) {
                         arg_runtime_scope = RUNTIME_SCOPE_SYSTEM;
                         break;
 
+                case ARG_DISK_ID:
+                        arg_disk_id = optarg;
+                        break;
+
                 case '?':
                         return -EINVAL;
 
@@ -2603,6 +2773,9 @@ static int machinectl_main(int argc, char *argv[], sd_bus *bus) {
                 { "kill",            2,        VERB_ANY, 0,            verb_kill_machine      },
                 { "pause",           2,        VERB_ANY, 0,            verb_pause             },
                 { "resume",          2,        VERB_ANY, 0,            verb_resume            },
+                { "attach-disk",     3,        3,        0,            verb_attach_disk       },
+                { "detach-disk",     3,        3,        0,            verb_detach_disk       },
+                { "list-disks",      2,        2,        0,            verb_list_disks        },
                 { "login",           VERB_ANY, 2,        0,            verb_login_machine     },
                 { "shell",           VERB_ANY, VERB_ANY, 0,            verb_shell_machine     },
                 { "bind",            3,        4,        0,            verb_bind_mount        },

--- a/src/shared/machine-util.c
+++ b/src/shared/machine-util.c
@@ -1,0 +1,108 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include "alloc-util.h"
+#include "machine-util.h"
+#include "parse-argument.h"
+#include "string-table.h"
+#include "string-util.h"
+
+static const char *const image_format_table[_IMAGE_FORMAT_MAX] = {
+        [IMAGE_FORMAT_RAW]   = "raw",
+        [IMAGE_FORMAT_QCOW2] = "qcow2",
+};
+
+DEFINE_STRING_TABLE_LOOKUP(image_format, ImageFormat);
+
+static const char *const disk_type_table[_DISK_TYPE_MAX] = {
+        [DISK_TYPE_VIRTIO_BLK]          = "virtio-blk",
+        [DISK_TYPE_VIRTIO_SCSI]         = "virtio-scsi",
+        [DISK_TYPE_NVME]                = "nvme",
+        [DISK_TYPE_VIRTIO_SCSI_CDROM]   = "scsi-cd",
+};
+
+DEFINE_STRING_TABLE_LOOKUP(disk_type, DiskType);
+
+const char* disk_type_to_block_driver(DiskType t) {
+        switch (t) {
+        case DISK_TYPE_VIRTIO_BLK:        return "virtio_blk";
+        case DISK_TYPE_VIRTIO_SCSI:       return "scsi_hd";
+        case DISK_TYPE_NVME:              return "nvme";
+        case DISK_TYPE_VIRTIO_SCSI_CDROM: return "scsi_cd";
+        default:                          return NULL;
+        }
+}
+
+DiskType disk_type_from_block_driver(const char *s) {
+        if (streq_ptr(s, "virtio_blk"))
+                return DISK_TYPE_VIRTIO_BLK;
+        if (streq_ptr(s, "scsi_hd"))
+                return DISK_TYPE_VIRTIO_SCSI;
+        if (streq_ptr(s, "nvme"))
+                return DISK_TYPE_NVME;
+        if (streq_ptr(s, "scsi_cd"))
+                return DISK_TYPE_VIRTIO_SCSI_CDROM;
+        return _DISK_TYPE_INVALID;
+}
+
+const char* disk_type_to_qemu_device_driver(DiskType t) {
+        switch (t) {
+        case DISK_TYPE_VIRTIO_BLK:        return "virtio-blk-pci";
+        case DISK_TYPE_VIRTIO_SCSI:       return "scsi-hd";
+        case DISK_TYPE_NVME:              return "nvme";
+        case DISK_TYPE_VIRTIO_SCSI_CDROM: return "scsi-cd";
+        default:                          return NULL;
+        }
+}
+
+int parse_disk_spec(
+                const char *arg,
+                ImageFormat *format,
+                DiskType *disk_type,
+                char **ret_path) {
+
+        assert(arg);
+        assert(format);
+        assert(disk_type);
+        assert(ret_path);
+
+        ImageFormat parsed_format = *format;
+        DiskType parsed_disk_type = *disk_type;
+        const char *dp = arg;
+
+        /* Format and disk-type vocabularies don't overlap, so prefixes may appear in any order. */
+        for (;;) {
+                const char *colon = strchr(dp, ':');
+                if (!colon)
+                        break;
+
+                _cleanup_free_ char *prefix = strndup(dp, colon - dp);
+                if (!prefix)
+                        return -ENOMEM;
+
+                ImageFormat f = image_format_from_string(prefix);
+                if (f >= 0) {
+                        parsed_format = f;
+                        dp = colon + 1;
+                        continue;
+                }
+
+                DiskType dt = disk_type_from_string(prefix);
+                if (dt >= 0) {
+                        parsed_disk_type = dt;
+                        dp = colon + 1;
+                        continue;
+                }
+
+                break;
+        }
+
+        _cleanup_free_ char *path = NULL;
+        int r = parse_path_argument(dp, /* suppress_root= */ false, &path);
+        if (r < 0)
+                return r;
+
+        *format = parsed_format;
+        *disk_type = parsed_disk_type;
+        *ret_path = TAKE_PTR(path);
+        return 0;
+}

--- a/src/shared/machine-util.h
+++ b/src/shared/machine-util.h
@@ -1,0 +1,39 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#pragma once
+
+#include "shared-forward.h"
+
+typedef enum ImageFormat {
+        IMAGE_FORMAT_RAW,
+        IMAGE_FORMAT_QCOW2,
+        _IMAGE_FORMAT_MAX,
+        _IMAGE_FORMAT_INVALID = -EINVAL,
+} ImageFormat;
+
+typedef enum DiskType {
+        DISK_TYPE_VIRTIO_BLK,
+        DISK_TYPE_VIRTIO_SCSI,
+        DISK_TYPE_NVME,
+        DISK_TYPE_VIRTIO_SCSI_CDROM,
+        _DISK_TYPE_MAX,
+        _DISK_TYPE_INVALID = -EINVAL,
+} DiskType;
+
+DECLARE_STRING_TABLE_LOOKUP(image_format, ImageFormat);
+DECLARE_STRING_TABLE_LOOKUP(disk_type, DiskType);
+
+/* Map DiskType to the io.systemd.VirtualMachineInstance.BlockDriver wire value. */
+const char* disk_type_to_block_driver(DiskType t);
+
+/* Reverse: parse an IDL BlockDriver wire value back to DiskType. */
+DiskType disk_type_from_block_driver(const char *s);
+
+/* Map DiskType to the QEMU device driver name (e.g. "virtio-blk-pci"). */
+const char* disk_type_to_qemu_device_driver(DiskType t);
+
+/* Parse "[FORMAT:][DISKTYPE:]PATH"; *format and *disk_type are in-out. */
+int parse_disk_spec(
+                const char *arg,
+                ImageFormat *format,
+                DiskType *disk_type,
+                char **ret_path);

--- a/src/shared/meson.build
+++ b/src/shared/meson.build
@@ -127,6 +127,7 @@ shared_sources = files(
         'machine-credential.c',
         'machine-id-setup.c',
         'machine-register.c',
+        'machine-util.c',
         'macvlan-util.c',
         'main-func.c',
         'metrics.c',

--- a/src/shared/qmp-client.c
+++ b/src/shared/qmp-client.c
@@ -56,6 +56,8 @@ struct QmpClient {
 
         QmpClientState state;
         sd_json_variant *current;  /* most recently parsed message, pending dispatch */
+
+        void *userdata;
 };
 
 static void qmp_slot_hash_func(const QmpSlot *p, struct siphash *state) {
@@ -481,6 +483,21 @@ bool qmp_client_is_idle(QmpClient *c) {
 bool qmp_client_is_disconnected(QmpClient *c) {
         assert(c);
         return c->state == QMP_CLIENT_DISCONNECTED;
+}
+
+void* qmp_client_set_userdata(QmpClient *c, void *userdata) {
+        void *old;
+
+        assert(c);
+
+        old = c->userdata;
+        c->userdata = userdata;
+        return old;
+}
+
+void* qmp_client_get_userdata(QmpClient *c) {
+        assert(c);
+        return c->userdata;
 }
 
 /* Map our state to the transport phase used for POLLIN / salvage / timeout decisions. */

--- a/src/shared/qmp-client.c
+++ b/src/shared/qmp-client.c
@@ -52,7 +52,7 @@ struct QmpClient {
         qmp_disconnect_callback_t disconnect_callback;
         void *disconnect_userdata;
 
-        unsigned next_fdset_id;   /* monotonic fdset-id allocator for add-fd */
+        uint64_t next_fdset_id;   /* monotonic fdset-id allocator for add-fd */
 
         QmpClientState state;
         sd_json_variant *current;  /* most recently parsed message, pending dispatch */
@@ -790,7 +790,7 @@ sd_event* qmp_client_get_event(QmpClient *c) {
         return json_stream_get_event(&c->stream);
 }
 
-unsigned qmp_client_next_fdset_id(QmpClient *c) {
+uint64_t qmp_client_next_fdset_id(QmpClient *c) {
         assert(c);
         return c->next_fdset_id++;
 }

--- a/src/shared/qmp-client.c
+++ b/src/shared/qmp-client.c
@@ -52,7 +52,7 @@ struct QmpClient {
         qmp_disconnect_callback_t disconnect_callback;
         void *disconnect_userdata;
 
-        unsigned next_fdset_id;   /* monotonic fdset-id allocator for add-fd */
+        uint64_t next_fdset_id;   /* monotonic fdset-id allocator for add-fd */
 
         QmpClientState state;
         sd_json_variant *current;  /* most recently parsed message, pending dispatch */
@@ -823,7 +823,7 @@ sd_event* qmp_client_get_event(QmpClient *c) {
         return json_stream_get_event(&c->stream);
 }
 
-unsigned qmp_client_next_fdset_id(QmpClient *c) {
+uint64_t qmp_client_next_fdset_id(QmpClient *c) {
         assert(c);
         return c->next_fdset_id++;
 }

--- a/src/shared/qmp-client.h
+++ b/src/shared/qmp-client.h
@@ -69,7 +69,7 @@ void qmp_client_bind_event(QmpClient *c, qmp_event_callback_t callback, void *us
 void qmp_client_bind_disconnect(QmpClient *c, qmp_disconnect_callback_t callback, void *userdata);
 int qmp_client_set_description(QmpClient *c, const char *description);
 sd_event* qmp_client_get_event(QmpClient *c);
-unsigned qmp_client_next_fdset_id(QmpClient *client);
+uint64_t qmp_client_next_fdset_id(QmpClient *client);
 
 QmpClient* qmp_client_unref(QmpClient *p);
 

--- a/src/shared/qmp-client.h
+++ b/src/shared/qmp-client.h
@@ -54,6 +54,9 @@ bool qmp_client_is_idle(QmpClient *c);
 /* True iff the connection is dead. Stable terminal state — once set, it stays set. */
 bool qmp_client_is_disconnected(QmpClient *c);
 
+void* qmp_client_set_userdata(QmpClient *c, void *userdata);
+void* qmp_client_get_userdata(QmpClient *c);
+
 /* Async send. Returns 0 on send (callback will fire later), negative errno on failure. */
 int qmp_client_invoke(
                 QmpClient *client,

--- a/src/shared/varlink-io.systemd.VirtualMachineInstance.c
+++ b/src/shared/varlink-io.systemd.VirtualMachineInstance.c
@@ -2,8 +2,69 @@
 
 #include "varlink-io.systemd.VirtualMachineInstance.h"
 
-/* VM-specific control interface. Currently empty — reserved for methods that apply to virtual
- * machines generically but not to containers (e.g. snapshot, migration, device hotplug). */
+static SD_VARLINK_DEFINE_ENUM_TYPE(
+                BlockFormat,
+                SD_VARLINK_DEFINE_ENUM_VALUE(raw),
+                SD_VARLINK_DEFINE_ENUM_VALUE(qcow2));
+
+static SD_VARLINK_DEFINE_ENUM_TYPE(
+                BlockDriver,
+                SD_VARLINK_DEFINE_ENUM_VALUE(virtio_blk),
+                SD_VARLINK_DEFINE_ENUM_VALUE(nvme),
+                SD_VARLINK_DEFINE_ENUM_VALUE(scsi_hd),
+                SD_VARLINK_DEFINE_ENUM_VALUE(scsi_cd));
+
+static SD_VARLINK_DEFINE_METHOD(
+                AddBlockDevice,
+                SD_VARLINK_FIELD_COMMENT("File descriptor index of the opened block device or image file"),
+                SD_VARLINK_DEFINE_INPUT(fileDescriptor, SD_VARLINK_INT, 0),
+                SD_VARLINK_FIELD_COMMENT("Image format"),
+                SD_VARLINK_DEFINE_INPUT_BY_TYPE(format, BlockFormat, 0),
+                SD_VARLINK_FIELD_COMMENT("Guest-visible device driver"),
+                SD_VARLINK_DEFINE_INPUT_BY_TYPE(driver, BlockDriver, 0),
+                SD_VARLINK_FIELD_COMMENT("If true, attach the device read-only"),
+                SD_VARLINK_DEFINE_INPUT(readOnly, SD_VARLINK_BOOL, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("If true, enable discard/trim"),
+                SD_VARLINK_DEFINE_INPUT(discard, SD_VARLINK_BOOL, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("Drive serial string"),
+                SD_VARLINK_DEFINE_INPUT(serial, SD_VARLINK_STRING, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("Caller-chosen device id; auto-generated if omitted"),
+                SD_VARLINK_DEFINE_INPUT(id, SD_VARLINK_STRING, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("Assigned device id"),
+                SD_VARLINK_DEFINE_OUTPUT(id, SD_VARLINK_STRING, 0));
+
+static SD_VARLINK_DEFINE_METHOD(
+                RemoveBlockDevice,
+                SD_VARLINK_FIELD_COMMENT("Id of the block device to remove"),
+                SD_VARLINK_DEFINE_INPUT(id, SD_VARLINK_STRING, 0));
+
+static SD_VARLINK_DEFINE_METHOD_FULL(
+                ListBlockDevices,
+                SD_VARLINK_SUPPORTS_MORE,
+                SD_VARLINK_FIELD_COMMENT("Device id"),
+                SD_VARLINK_DEFINE_OUTPUT(id, SD_VARLINK_STRING, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("Image format"),
+                SD_VARLINK_DEFINE_OUTPUT_BY_TYPE(format, BlockFormat, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("Whether the device is read-only"),
+                SD_VARLINK_DEFINE_OUTPUT(readOnly, SD_VARLINK_BOOL, SD_VARLINK_NULLABLE));
+
+static SD_VARLINK_DEFINE_ERROR(NoSuchBlockDevice);
+static SD_VARLINK_DEFINE_ERROR(BlockDeviceIdInUse);
+static SD_VARLINK_DEFINE_ERROR(InvalidBlockDeviceId);
+static SD_VARLINK_DEFINE_ERROR(BlockBackendBusy);
+
 SD_VARLINK_DEFINE_INTERFACE(
                 io_systemd_VirtualMachineInstance,
-                "io.systemd.VirtualMachineInstance");
+                "io.systemd.VirtualMachineInstance",
+                &vl_type_BlockFormat,
+                &vl_type_BlockDriver,
+                SD_VARLINK_SYMBOL_COMMENT("Hotplug a block device into the VM"),
+                &vl_method_AddBlockDevice,
+                SD_VARLINK_SYMBOL_COMMENT("Hot-remove a block device from the VM"),
+                &vl_method_RemoveBlockDevice,
+                SD_VARLINK_SYMBOL_COMMENT("List all registered block devices"),
+                &vl_method_ListBlockDevices,
+                &vl_error_NoSuchBlockDevice,
+                &vl_error_BlockDeviceIdInUse,
+                &vl_error_InvalidBlockDeviceId,
+                &vl_error_BlockBackendBusy);

--- a/src/vmspawn/vmspawn-qmp.c
+++ b/src/vmspawn/vmspawn-qmp.c
@@ -25,19 +25,34 @@ DEFINE_PRIVATE_HASH_OPS_FULL(
                 char, string_hash_func, string_compare_func, free,
                 PendingJob, pending_job_free);
 
-void drive_info_done(DriveInfo *info) {
-        assert(info);
-        info->serial = mfree(info->serial);
-        info->node_name = mfree(info->node_name);
-        info->pcie_port = mfree(info->pcie_port);
-        info->fd = safe_close(info->fd);
-        info->overlay_fd = safe_close(info->overlay_fd);
+DriveInfo* drive_info_new(void) {
+        DriveInfo *d = new0(DriveInfo, 1);
+        if (d) {
+                d->fd = -EBADF;
+                d->overlay_fd = -EBADF;
+        }
+        return d;
+}
+
+DriveInfo* drive_info_free(DriveInfo *d) {
+        if (!d)
+                return NULL;
+
+        free(d->path);
+        free(d->format);
+        free(d->disk_driver);
+        free(d->serial);
+        free(d->node_name);
+        free(d->pcie_port);
+        safe_close(d->fd);
+        safe_close(d->overlay_fd);
+        return mfree(d);
 }
 
 void drive_infos_done(DriveInfos *infos) {
         assert(infos);
         FOREACH_ARRAY(d, infos->drives, infos->n_drives)
-                drive_info_done(d);
+                drive_info_free(*d);
         infos->drives = mfree(infos->drives);
         infos->n_drives = 0;
         infos->scsi_pcie_port = mfree(infos->scsi_pcie_port);
@@ -748,7 +763,7 @@ static bool drives_need_scsi_controller(DriveInfos *drives) {
         assert(drives);
 
         FOREACH_ARRAY(d, drives->drives, drives->n_drives)
-                if (STR_IN_SET(d->disk_driver, "scsi-hd", "scsi-cd"))
+                if (STR_IN_SET((*d)->disk_driver, "scsi-hd", "scsi-cd"))
                         return true;
 
         return false;
@@ -792,7 +807,7 @@ int vmspawn_qmp_setup_drives(VmspawnQmpBridge *bridge, DriveInfos *drives) {
         }
 
         FOREACH_ARRAY(d, drives->drives, drives->n_drives) {
-                r = qmp_setup_drive(bridge, qmp, d);
+                r = qmp_setup_drive(bridge, qmp, *d);
                 if (r < 0)
                         return r;
         }

--- a/src/vmspawn/vmspawn-qmp.c
+++ b/src/vmspawn/vmspawn-qmp.c
@@ -6,9 +6,11 @@
 
 #include "sd-event.h"
 #include "sd-json.h"
+#include "sd-varlink.h"
 
 #include "alloc-util.h"
 #include "blockdev-util.h"
+#include "errno-util.h"
 #include "ether-addr-util.h"
 #include "fd-util.h"
 #include "hashmap.h"
@@ -19,6 +21,7 @@
 #include "string-util.h"
 #include "strv.h"
 #include "vmspawn-qmp.h"
+#include "vmspawn-util.h"
 
 DEFINE_PRIVATE_HASH_OPS_FULL(
                 pending_job_hash_ops,
@@ -28,22 +31,89 @@ DEFINE_PRIVATE_HASH_OPS_FULL(
 DriveInfo* drive_info_new(void) {
         DriveInfo *d = new0(DriveInfo, 1);
         if (d) {
+                d->n_ref = 1;
                 d->fd = -EBADF;
                 d->overlay_fd = -EBADF;
+                d->pcie_port_idx = -1;
         }
         return d;
 }
 
-DriveInfo* drive_info_free(DriveInfo *d) {
+int vmspawn_qmp_bridge_allocate_pcie_port(VmspawnQmpBridge *bridge, const char *owner_id, char **ret_name, int *ret_idx) {
+        assert(bridge);
+        assert(owner_id);
+        assert(ret_name);
+        assert(ret_idx);
+
+        for (unsigned i = 0; i < VMSPAWN_PCIE_HOTPLUG_SPARES; i++) {
+                if (bridge->hotplug_port_owner[i])
+                        continue;
+
+                _cleanup_free_ char *owner = strdup(owner_id);
+                _cleanup_free_ char *name = NULL;
+                if (!owner || asprintf(&name, "vmspawn-hotplug-pci-root-port-%u", i) < 0)
+                        return -ENOMEM;
+
+                bridge->hotplug_port_owner[i] = TAKE_PTR(owner);
+                *ret_name = TAKE_PTR(name);
+                *ret_idx = (int) i;
+                return 0;
+        }
+
+        return -EBUSY;
+}
+
+void vmspawn_qmp_bridge_release_pcie_port_by_idx(VmspawnQmpBridge *bridge, int idx) {
+        assert(bridge);
+
+        if (idx < 0)
+                return;
+
+        assert((unsigned) idx < VMSPAWN_PCIE_HOTPLUG_SPARES);
+        bridge->hotplug_port_owner[idx] = mfree(bridge->hotplug_port_owner[idx]);
+}
+
+int vmspawn_qmp_bridge_release_pcie_port_by_id(VmspawnQmpBridge *bridge, const char *owner_id) {
+        assert(bridge);
+        assert(owner_id);
+
+        for (unsigned i = 0; i < VMSPAWN_PCIE_HOTPLUG_SPARES; i++)
+                if (streq_ptr(bridge->hotplug_port_owner[i], owner_id)) {
+                        bridge->hotplug_port_owner[i] = mfree(bridge->hotplug_port_owner[i]);
+                        return 1;
+                }
+
+        return 0;
+}
+
+DriveInfo* drive_info_ref(DriveInfo *d) {
         if (!d)
                 return NULL;
+
+        assert(d->n_ref > 0);
+        d->n_ref++;
+        return d;
+}
+
+DriveInfo* drive_info_unref(DriveInfo *d) {
+        if (!d)
+                return NULL;
+
+        assert(d->n_ref > 0);
+        if (--d->n_ref > 0)
+                return NULL;
+
+        if (d->bridge)
+                vmspawn_qmp_bridge_release_pcie_port_by_idx(d->bridge, d->pcie_port_idx);
 
         free(d->path);
         free(d->format);
         free(d->disk_driver);
         free(d->serial);
-        free(d->node_name);
         free(d->pcie_port);
+        free(d->id);
+        free(d->fdset_path);
+        sd_varlink_unref(d->link);
         safe_close(d->fd);
         safe_close(d->overlay_fd);
         return mfree(d);
@@ -52,7 +122,7 @@ DriveInfo* drive_info_free(DriveInfo *d) {
 void drive_infos_done(DriveInfos *infos) {
         assert(infos);
         FOREACH_ARRAY(d, infos->drives, infos->n_drives)
-                drive_info_free(*d);
+                drive_info_unref(*d);
         infos->drives = mfree(infos->drives);
         infos->n_drives = 0;
         infos->scsi_pcie_port = mfree(infos->scsi_pcie_port);
@@ -97,9 +167,7 @@ void machine_config_done(MachineConfig *c) {
         vsock_info_done(&c->vsock);
 }
 
-/* Generic async QMP setup-completion callback. The userdata argument carries the
- * command name (as a string literal) for logging. On failure, request a clean
- * event loop exit so vmspawn shuts down instead of running a VM with missing devices. */
+/* Generic completion callback; userdata is a string literal label. Exits the event loop on boot-time failures. */
 static int on_qmp_complete(
                 QmpClient *client,
                 sd_json_variant *result,
@@ -107,29 +175,41 @@ static int on_qmp_complete(
                 int error,
                 void *userdata) {
 
-        const char *label = ASSERT_PTR(userdata);
-
         assert(client);
+
+        VmspawnQmpBridge *bridge = ASSERT_PTR(qmp_client_get_userdata(client));
+        const char *label = ASSERT_PTR(userdata);
 
         if (error < 0) {
                 log_error_errno(error, "%s failed: %s", label, strna(error_desc));
+
+                if (bridge->setup_done)
+                        return 0;
+
                 return sd_event_exit(qmp_client_get_event(client), error);
         }
 
         return 0;
 }
 
-/* Send add-fd via SCM_RIGHTS; return /dev/fdset/N. Allocations run before invoke so a late
- * OOM cannot orphan an fdset on QEMU's side; *ret_path is only written on full success. */
-static int qmp_fdset_add(QmpClient *qmp, int fd_consume, char **ret_path) {
+/* Send add-fd via SCM_RIGHTS; return /dev/fdset/N and the numeric fdset id. */
+static int qmp_fdset_add(
+                QmpClient *qmp,
+                int fd_consume,
+                qmp_command_callback_t callback,
+                void *userdata,
+                char **ret_path,
+                uint64_t *ret_fdset_id) {
+
         _cleanup_(sd_json_variant_unrefp) sd_json_variant *args = NULL;
         _cleanup_close_ int fd = fd_consume;
         _cleanup_free_ char *path = NULL;
-        unsigned id;
+        uint64_t id;
         int r;
 
         assert(qmp);
         assert(fd_consume >= 0);
+        assert(callback);
         assert(ret_path);
 
         id = qmp_client_next_fdset_id(qmp);
@@ -138,16 +218,41 @@ static int qmp_fdset_add(QmpClient *qmp, int fd_consume, char **ret_path) {
         if (r < 0)
                 return r;
 
-        if (asprintf(&path, "/dev/fdset/%u", id) < 0)
+        if (asprintf(&path, "/dev/fdset/%" PRIu64, id) < 0)
                 return -ENOMEM;
 
         r = qmp_client_invoke(qmp, "add-fd", QMP_CLIENT_ARGS_FD(args, TAKE_FD(fd)),
-                              on_qmp_complete, (void*) "add-fd");
+                              callback, userdata);
         if (r < 0)
                 return r;
 
         *ret_path = TAKE_PTR(path);
+        if (ret_fdset_id)
+                *ret_fdset_id = id;
         return 0;
+}
+
+/* Issue remove-fd for an fdset whose dup is now held by a blockdev. The fdset
+ * persists until the dup is closed (in raw_close at blockdev-del time) — see
+ * QEMU's monitor/fds.c:177-181 on the fds/dup_fds split. */
+static int qmp_fdset_remove(
+                QmpClient *qmp,
+                uint64_t fdset_id,
+                qmp_command_callback_t callback,
+                void *userdata) {
+
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *args = NULL;
+        int r;
+
+        assert(qmp);
+        assert(callback);
+
+        r = sd_json_buildo(&args, SD_JSON_BUILD_PAIR_UNSIGNED("fdset-id", fdset_id));
+        if (r < 0)
+                return r;
+
+        return qmp_client_invoke(qmp, "remove-fd", QMP_CLIENT_ARGS(args),
+                                 callback, userdata);
 }
 
 typedef struct QmpFileNodeParams {
@@ -208,16 +313,18 @@ static int qmp_build_blockdev_add_format(const QmpFormatNodeParams *p, sd_json_v
                         SD_JSON_BUILD_PAIR_CONDITION(!!p->backing, "backing", SD_JSON_BUILD_STRING(p->backing)));
 }
 
-/* Build device_add JSON arguments for a drive */
-static int qmp_build_device_add(const DriveInfo *drive, sd_json_variant **ret) {
+/* qmp_name is the fully-qualified QMP name ("bd-<id>"); used as both the
+ * qdev id and the drive-backend reference. */
+static int qmp_build_device_add(const DriveInfo *drive, const char *qmp_name, sd_json_variant **ret) {
         assert(drive);
+        assert(qmp_name);
         assert(ret);
 
         return sd_json_buildo(
                         ret,
                         SD_JSON_BUILD_PAIR_STRING("driver", drive->disk_driver),
-                        SD_JSON_BUILD_PAIR_STRING("drive", drive->node_name),
-                        SD_JSON_BUILD_PAIR_STRING("id", drive->node_name),
+                        SD_JSON_BUILD_PAIR_STRING("drive", qmp_name),
+                        SD_JSON_BUILD_PAIR_STRING("id", qmp_name),
                         SD_JSON_BUILD_PAIR_CONDITION(FLAGS_SET(drive->flags, QMP_DRIVE_BOOT), "bootindex", SD_JSON_BUILD_INTEGER(1)),
                         SD_JSON_BUILD_PAIR_CONDITION(!!drive->serial, "serial", SD_JSON_BUILD_STRING(drive->serial)),
                         SD_JSON_BUILD_PAIR_CONDITION(STR_IN_SET(drive->disk_driver, "scsi-hd", "scsi-cd"),
@@ -225,6 +332,43 @@ static int qmp_build_device_add(const DriveInfo *drive, sd_json_variant **ret) {
                         SD_JSON_BUILD_PAIR_CONDITION(
                                         !STR_IN_SET(drive->disk_driver, "scsi-hd", "scsi-cd") && !!drive->pcie_port,
                                         "bus", SD_JSON_BUILD_STRING(drive->pcie_port)));
+}
+
+/* Inline form: one blockdev-add creates format+file; one blockdev-del tears
+ * down the whole tree. Used for regular boot drives and hotplug. */
+static int qmp_build_blockdev_add_inline(
+                const char *node_name,
+                const char *format,
+                const char *filename,
+                const char *file_driver,
+                QmpDriveFlags flags,
+                VmspawnQmpFeatureFlags features,
+                sd_json_variant **ret) {
+
+        bool use_io_uring = FLAGS_SET(features, VMSPAWN_QMP_FEATURE_IO_URING);
+        bool use_discard_no_unref = FLAGS_SET(flags, QMP_DRIVE_DISCARD_NO_UNREF);
+
+        assert(node_name);
+        assert(format);
+        assert(filename);
+        assert(file_driver);
+        assert(ret);
+
+        return sd_json_buildo(
+                        ret,
+                        SD_JSON_BUILD_PAIR_STRING("node-name", node_name),
+                        SD_JSON_BUILD_PAIR_STRING("driver", format),
+                        SD_JSON_BUILD_PAIR_CONDITION(FLAGS_SET(flags, QMP_DRIVE_READ_ONLY), "read-only", SD_JSON_BUILD_BOOLEAN(true)),
+                        SD_JSON_BUILD_PAIR_CONDITION(FLAGS_SET(flags, QMP_DRIVE_DISCARD), "discard", JSON_BUILD_CONST_STRING("unmap")),
+                        SD_JSON_BUILD_PAIR_CONDITION(use_discard_no_unref, "discard-no-unref", SD_JSON_BUILD_BOOLEAN(true)),
+                        SD_JSON_BUILD_PAIR("file", SD_JSON_BUILD_OBJECT(
+                                        SD_JSON_BUILD_PAIR_STRING("driver", file_driver),
+                                        SD_JSON_BUILD_PAIR_STRING("filename", filename),
+                                        SD_JSON_BUILD_PAIR_CONDITION(FLAGS_SET(flags, QMP_DRIVE_READ_ONLY), "read-only", SD_JSON_BUILD_BOOLEAN(true)),
+                                        SD_JSON_BUILD_PAIR_CONDITION(use_io_uring, "aio", JSON_BUILD_CONST_STRING("io_uring")),
+                                        SD_JSON_BUILD_PAIR("cache", SD_JSON_BUILD_OBJECT(
+                                                        SD_JSON_BUILD_PAIR_BOOLEAN("direct", false),
+                                                        SD_JSON_BUILD_PAIR_BOOLEAN("no-flush", FLAGS_SET(flags, QMP_DRIVE_NO_FLUSH)))))));
 }
 
 /* Issue blockdev-add for a file node. */
@@ -340,17 +484,17 @@ static int on_ephemeral_create_concluded(QmpClient *qmp, void *userdata) {
                 return r;
 
         /* device_add: attach to virtual hardware. Build a temporary DriveInfo as a
-         * read-only view into the continuation context to reuse qmp_build_device_add(). */
+         * read-only view into the continuation context to reuse qmp_build_device_add().
+         * ctx->node_name is already the bd-prefixed QMP name. */
         const DriveInfo tmp = {
                 .disk_driver = ctx->disk_driver,
-                .node_name   = ctx->node_name,
                 .serial      = ctx->serial,
                 .pcie_port   = ctx->pcie_port,
                 .flags       = ctx->flags & QMP_DRIVE_BOOT,
                 .fd          = -EBADF,
                 .overlay_fd  = -EBADF,
         };
-        r = qmp_build_device_add(&tmp, &device_args);
+        r = qmp_build_device_add(&tmp, ctx->node_name, &device_args);
         if (r < 0)
                 return log_error_errno(r, "Failed to build device_add JSON for '%s': %m", ctx->node_name);
 
@@ -374,10 +518,19 @@ static int qmp_setup_ephemeral_drive(VmspawnQmpBridge *bridge, QmpClient *qmp, D
         assert(drive->fd >= 0);
         assert(drive->overlay_fd >= 0);
 
-        /* Node names: <name>-base-file, <name>-base-fmt, <name>-overlay-file, <name> */
-        _cleanup_free_ char *base_file_node = strjoin(drive->node_name, "-base-file");
-        _cleanup_free_ char *base_fmt_node = strjoin(drive->node_name, "-base-fmt");
-        _cleanup_free_ char *overlay_file_node = strjoin(drive->node_name, "-overlay-file");
+        _cleanup_free_ char *drive_id = NULL;
+        if (asprintf(&drive_id, "bd%" PRIu64, bridge->next_id++) < 0)
+                return log_oom();
+
+        /* QMP names all carry the bd- prefix so DEVICE_DELETED filtering works
+         * uniformly across ephemeral, boot-time, and hotplug drives. */
+        _cleanup_free_ char *qmp_name = strjoin(QMP_BLOCK_QDEV_PREFIX, drive_id);
+        if (!qmp_name)
+                return log_oom();
+
+        _cleanup_free_ char *base_file_node = strjoin(qmp_name, "-base-file");
+        _cleanup_free_ char *base_fmt_node = strjoin(qmp_name, "-base-fmt");
+        _cleanup_free_ char *overlay_file_node = strjoin(qmp_name, "-overlay-file");
         if (!base_file_node || !base_fmt_node || !overlay_file_node)
                 return log_oom();
 
@@ -389,12 +542,16 @@ static int qmp_setup_ephemeral_drive(VmspawnQmpBridge *bridge, QmpClient *qmp, D
 
         /* Step 1-2: Pass both fds to QEMU */
         _cleanup_free_ char *base_path = NULL;
-        r = qmp_fdset_add(qmp, TAKE_FD(drive->fd), &base_path);
+        uint64_t base_fdset_id;
+        r = qmp_fdset_add(qmp, TAKE_FD(drive->fd),
+                          on_qmp_complete, (void*) "add-fd", &base_path, &base_fdset_id);
         if (r < 0)
                 return log_error_errno(r, "Failed to send add-fd for base image '%s': %m", drive->path);
 
         _cleanup_free_ char *overlay_path = NULL;
-        r = qmp_fdset_add(qmp, TAKE_FD(drive->overlay_fd), &overlay_path);
+        uint64_t overlay_fdset_id;
+        r = qmp_fdset_add(qmp, TAKE_FD(drive->overlay_fd),
+                          on_qmp_complete, (void*) "add-fd", &overlay_path, &overlay_fdset_id);
         if (r < 0)
                 return log_error_errno(r, "Failed to send add-fd for overlay of '%s': %m", drive->path);
 
@@ -410,6 +567,12 @@ static int qmp_setup_ephemeral_drive(VmspawnQmpBridge *bridge, QmpClient *qmp, D
         r = qmp_add_file_node(qmp, &base_file_params);
         if (r < 0)
                 return log_error_errno(r, "Failed to send blockdev-add for base file '%s': %m", drive->path);
+
+        /* The base file node now holds a dup of the fd; release the monitor's
+         * original so the fdset auto-frees when raw_close runs at teardown. */
+        r = qmp_fdset_remove(qmp, base_fdset_id, on_qmp_complete, (void*) "remove-fd");
+        if (r < 0)
+                return log_error_errno(r, "Failed to send remove-fd for base image '%s': %m", drive->path);
 
         /* Step 4: Base image format node (read-only) */
         QmpFormatNodeParams base_fmt_params = {
@@ -443,6 +606,11 @@ static int qmp_setup_ephemeral_drive(VmspawnQmpBridge *bridge, QmpClient *qmp, D
         if (r < 0)
                 return log_error_errno(r, "Failed to send blockdev-add for overlay file '%s': %m", drive->path);
 
+        /* Same as for base: the overlay file node has the dup. */
+        r = qmp_fdset_remove(qmp, overlay_fdset_id, on_qmp_complete, (void*) "remove-fd");
+        if (r < 0)
+                return log_error_errno(r, "Failed to send remove-fd for overlay of '%s': %m", drive->path);
+
         /* Step 6: Fire blockdev-create to format the overlay */
         _cleanup_(sd_json_variant_unrefp) sd_json_variant *create_options = NULL;
         r = sd_json_buildo(&create_options,
@@ -454,7 +622,7 @@ static int qmp_setup_ephemeral_drive(VmspawnQmpBridge *bridge, QmpClient *qmp, D
         if (r < 0)
                 return log_error_errno(r, "Failed to build blockdev-create options: %m");
 
-        _cleanup_free_ char *job_id = strjoin("create-", drive->node_name);
+        _cleanup_free_ char *job_id = strjoin("create-", qmp_name);
         if (!job_id)
                 return log_oom();
 
@@ -476,7 +644,7 @@ static int qmp_setup_ephemeral_drive(VmspawnQmpBridge *bridge, QmpClient *qmp, D
                 ectx_flags |= QMP_DRIVE_DISCARD_NO_UNREF;
 
         *ectx = (EphemeralDriveCtx) {
-                .node_name          = strdup(drive->node_name),
+                .node_name          = strdup(qmp_name),
                 .overlay_file_node  = strdup(overlay_file_node),
                 .base_fmt_node      = strdup(base_fmt_node),
                 .disk_driver        = strdup(drive->disk_driver),
@@ -498,81 +666,346 @@ static int qmp_setup_ephemeral_drive(VmspawnQmpBridge *bridge, QmpClient *qmp, D
         TAKE_PTR(ectx);
 
         r = qmp_client_invoke(qmp, "blockdev-create", QMP_CLIENT_ARGS(cmd_args), on_qmp_complete, (void*) "blockdev-create");
-        if (r < 0)
+        if (r < 0) {
+                _cleanup_(pending_job_freep) PendingJob *dead = hashmap_remove(bridge->pending_jobs, job_id);
                 return log_error_errno(r, "Failed to send blockdev-create for '%s': %m", drive->path);
+        }
 
         log_debug("Queued ephemeral drive setup for '%s' (job %s)", drive->path, job_id);
         return 0;
 }
 
-/* Set up a regular (non-ephemeral) drive: single file node + format node + device_add. */
-static int qmp_setup_regular_drive(VmspawnQmpBridge *bridge, QmpClient *qmp, DriveInfo *drive) {
-        int r;
+static int qmp_setup_regular_drive(VmspawnQmpBridge *bridge, DriveInfo *drive) {
+        _cleanup_(drive_info_unrefp) DriveInfo *owned = drive;
 
         assert(bridge);
-        assert(qmp);
         assert(drive);
         assert(drive->fd >= 0);
+        assert(!drive->id);
 
-        /* Node names: <name>-file, <name> */
-        _cleanup_free_ char *file_node_name = strjoin(drive->node_name, "-file");
-        if (!file_node_name)
+        if (asprintf(&owned->id, "bd%" PRIu64, bridge->next_id) < 0)
                 return log_oom();
+        bridge->next_id++;
 
-        _cleanup_free_ char *fdset_path = NULL;
-        r = qmp_fdset_add(qmp, TAKE_FD(drive->fd), &fdset_path);
-        if (r < 0)
-                return log_error_errno(r, "Failed to send add-fd for '%s': %m", drive->path);
+        return vmspawn_qmp_add_block_device(bridge, TAKE_PTR(owned));
+}
 
-        QmpFileNodeParams file_params = {
-                .node_name = file_node_name,
-                .filename  = fdset_path,
-                .driver    = FLAGS_SET(drive->flags, QMP_DRIVE_BLOCK_DEVICE) ? "host_device" : "file",
-                .flags     = drive->flags & (QMP_DRIVE_READ_ONLY|QMP_DRIVE_NO_FLUSH),
-        };
-        if (FLAGS_SET(bridge->features, VMSPAWN_QMP_FEATURE_IO_URING))
-                file_params.flags |= QMP_DRIVE_IO_URING;
-        r = qmp_add_file_node(qmp, &file_params);
-        if (r < 0)
-                return log_error_errno(r, "Failed to send blockdev-add for '%s': %m", drive->path);
+static int reply_qmp_error(sd_varlink *link, const char *error_desc, int error) {
+        assert(link);
 
-        QmpFormatNodeParams fmt_params = {
-                .node_name      = drive->node_name,
-                .format         = drive->format,
-                .file_node_name = file_node_name,
-                .flags          = drive->flags & (QMP_DRIVE_READ_ONLY|QMP_DRIVE_DISCARD),
-        };
-        _cleanup_(sd_json_variant_unrefp) sd_json_variant *fmt_args = NULL;
-        r = qmp_build_blockdev_add_format(&fmt_params, &fmt_args);
-        if (r < 0)
-                return r;
+        if (ERRNO_IS_DISCONNECT(error))
+                return sd_varlink_error(link, "io.systemd.MachineInstance.NotConnected", NULL);
+        if (error_desc)
+                log_warning("QMP error: %s", error_desc);
+        return sd_varlink_error_errno(link, error < 0 ? error : -EIO);
+}
 
-        r = qmp_client_invoke(qmp, "blockdev-add", QMP_CLIENT_ARGS(fmt_args), on_qmp_complete, (void*) "blockdev-add");
-        if (r < 0)
-                return log_error_errno(r, "Failed to send blockdev-add format for '%s': %m", drive->path);
+static int reply_qmp_add_error(sd_varlink *link, const char *error_desc, int error) {
+        assert(link);
 
-        /* device_add: attach to virtual hardware */
-        _cleanup_(sd_json_variant_unrefp) sd_json_variant *device_args = NULL;
-        r = qmp_build_device_add(drive, &device_args);
-        if (r < 0)
-                return r;
+        if (error_desc && strcasestr(error_desc, "duplicate"))
+                return sd_varlink_error(link, "io.systemd.VirtualMachineInstance.BlockDeviceIdInUse", NULL);
+        return reply_qmp_error(link, error_desc, error);
+}
 
-        r = qmp_client_invoke(qmp, "device_add", QMP_CLIENT_ARGS(device_args), on_qmp_complete, (void*) "device_add");
-        if (r < 0)
-                return log_error_errno(r, "Failed to send device_add for '%s': %m", drive->path);
+/* After the pipelined remove-fd at add time, QEMU auto-frees the fdset when
+ * raw_close (during blockdev-del) releases the last dup. So teardown only
+ * needs to fire blockdev-del. */
+void vmspawn_qmp_block_device_teardown(QmpClient *client, const char *id, unsigned stages) {
+        assert(client);
+        assert(id);
 
-        log_debug("Queued drive setup for '%s'", drive->path);
+        if (!FLAGS_SET(stages, BLOCK_DEVICE_ADD_STAGE_BLOCKDEV_ADD))
+                return;
+
+        _cleanup_free_ char *qmp_name = strjoin(QMP_BLOCK_QDEV_PREFIX, id);
+        if (!qmp_name) {
+                (void) log_oom();
+                return;
+        }
+
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *args = NULL;
+        if (sd_json_buildo(&args, SD_JSON_BUILD_PAIR_STRING("node-name", qmp_name)) >= 0)
+                (void) qmp_client_invoke(client, "blockdev-del", QMP_CLIENT_ARGS(args),
+                                         on_qmp_complete, (void*) "teardown blockdev-del");
+}
+
+/* FAILED bit marks the rollback_mask after the first error fires, so cascading
+ * stage callbacks become no-ops. Hotplug replies to the link; boot-time tears
+ * down the event loop. */
+static int drive_info_add_fail(DriveInfo *d, int error, const char *error_desc) {
+        assert(d);
+
+        if (FLAGS_SET(d->rollback_mask, BLOCK_DEVICE_ADD_STAGE_FAILED))
+                return 0;
+
+        vmspawn_qmp_block_device_teardown(d->bridge->qmp, d->id, d->rollback_mask);
+        d->rollback_mask = BLOCK_DEVICE_ADD_STAGE_FAILED;
+
+        if (d->link) {
+                (void) reply_qmp_add_error(d->link, error_desc, error);
+                d->link = sd_varlink_unref(d->link);
+                return 0;
+        }
+
+        log_error_errno(error, "Block device '%s' setup failed: %s",
+                        strna(d->id), strna(error_desc));
+        return sd_event_exit(qmp_client_get_event(d->bridge->qmp), error);
+}
+
+/* Shared by the intermediate stages that don't need to record a rollback bit
+ * (add-fd, remove-fd). Just forwards errors to drive_info_add_fail so cascades
+ * from earlier stage failures get suppressed via the FAILED sentinel. */
+static int on_add_observe_stage(
+                QmpClient *client,
+                sd_json_variant *result,
+                const char *error_desc,
+                int error,
+                void *userdata) {
+
+        _cleanup_(drive_info_unrefp) DriveInfo *d = ASSERT_PTR(userdata);
+        assert(client);
+
+        if (error < 0)
+                return drive_info_add_fail(d, error, error_desc);
         return 0;
 }
 
-/* Configure a single drive via QMP. Dispatches to ephemeral or regular setup. */
-static int qmp_setup_drive(VmspawnQmpBridge *bridge, QmpClient *qmp, DriveInfo *drive) {
+static int on_add_blockdev_stage(
+                QmpClient *client,
+                sd_json_variant *result,
+                const char *error_desc,
+                int error,
+                void *userdata) {
+
+        _cleanup_(drive_info_unrefp) DriveInfo *d = ASSERT_PTR(userdata);
+        assert(client);
+
+        if (error < 0)
+                return drive_info_add_fail(d, error, error_desc);
+
+        d->rollback_mask |= BLOCK_DEVICE_ADD_STAGE_BLOCKDEV_ADD;
+
+        /* A sync error after blockdev-add was queued may have marked the chain FAILED.
+         * The blockdev node we just created is orphaned — tear it down retroactively. */
+        if (FLAGS_SET(d->rollback_mask, BLOCK_DEVICE_ADD_STAGE_FAILED))
+                vmspawn_qmp_block_device_teardown(d->bridge->qmp, d->id,
+                                                  BLOCK_DEVICE_ADD_STAGE_BLOCKDEV_ADD);
+        return 0;
+}
+
+static int on_add_device_add_complete(
+                QmpClient *client,
+                sd_json_variant *result,
+                const char *error_desc,
+                int error,
+                void *userdata) {
+
+        _cleanup_(drive_info_unrefp) DriveInfo *d = ASSERT_PTR(userdata);
+
+        assert(client);
+
+        if (error < 0)
+                return drive_info_add_fail(d, error, error_desc);
+
+        if (FLAGS_SET(d->rollback_mask, BLOCK_DEVICE_ADD_STAGE_FAILED))
+                return 0;
+
+        /* Commit: port stays reserved under owner id until DEVICE_DELETED. */
+        d->pcie_port_idx = -1;
+
+        if (d->link)
+                (void) sd_varlink_replybo(d->link, SD_JSON_BUILD_PAIR_STRING("id", d->id));
+
+        log_info("Block device '%s' attached", d->id);
+        return 0;
+}
+
+static int on_scsi_controller_complete(
+                QmpClient *client,
+                sd_json_variant *result,
+                const char *error_desc,
+                int error,
+                void *userdata) {
+
+        assert(client);
+
+        VmspawnQmpBridge *bridge = ASSERT_PTR(qmp_client_get_userdata(client));
+
+        if (error < 0) {
+                vmspawn_qmp_bridge_release_pcie_port_by_idx(bridge, bridge->scsi_controller_port_idx);
+                bridge->scsi_controller_port_idx = -1;
+                log_warning("virtio-scsi-pci controller setup failed: %s", strna(error_desc));
+                if (!bridge->setup_done)
+                        return sd_event_exit(qmp_client_get_event(client), error);
+                return 0;
+        }
+
+        bridge->scsi_controller_created = true;
+        return 0;
+}
+
+static int qmp_setup_scsi_controller(VmspawnQmpBridge *bridge, const char *pcie_port) {
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *args = NULL;
+        int r;
+
+        assert(bridge);
+
+        r = sd_json_buildo(
+                        &args,
+                        SD_JSON_BUILD_PAIR_STRING("driver", "virtio-scsi-pci"),
+                        SD_JSON_BUILD_PAIR_STRING("id", "vmspawn_scsi"),
+                        SD_JSON_BUILD_PAIR_CONDITION(!!pcie_port, "bus", SD_JSON_BUILD_STRING(pcie_port)));
+        if (r < 0)
+                return log_error_errno(r, "Failed to build SCSI controller JSON: %m");
+
+        r = qmp_client_invoke(bridge->qmp, "device_add", QMP_CLIENT_ARGS(args),
+                              on_scsi_controller_complete, NULL);
+        if (r < 0)
+                return log_error_errno(r, "Failed to send SCSI controller device_add: %m");
+
+        log_debug("Queued virtio-scsi-pci controller setup");
+        return 0;
+}
+
+int vmspawn_qmp_add_block_device(VmspawnQmpBridge *bridge, DriveInfo *drive) {
+        int r;
+
+        assert(bridge);
         assert(drive);
+        assert(drive->id);
+        assert(drive->format);
+        assert(drive->disk_driver);
+        assert(drive->fd >= 0);
 
-        if (drive->overlay_fd >= 0)
-                return qmp_setup_ephemeral_drive(bridge, qmp, drive);
+        _cleanup_(drive_info_unrefp) DriveInfo *owned = drive, *slot_ref = NULL;
+        drive->bridge = bridge;
 
-        return qmp_setup_regular_drive(bridge, qmp, drive);
+        _cleanup_free_ char *qmp_name = strjoin(QMP_BLOCK_QDEV_PREFIX, drive->id);
+        if (!qmp_name)
+                return log_oom();
+
+        /* First SCSI hotplug needs a virtio-scsi-pci controller to attach to. */
+        if (STR_IN_SET(drive->disk_driver, "scsi-hd", "scsi-cd") && !bridge->scsi_controller_created) {
+                _cleanup_free_ char *controller_port = NULL;
+                int controller_port_idx = -1;
+                if (ARCHITECTURE_NEEDS_PCIE_ROOT_PORTS) {
+                        r = vmspawn_qmp_bridge_allocate_pcie_port(bridge, "vmspawn_scsi",
+                                                                  &controller_port, &controller_port_idx);
+                        if (r == -EBUSY)
+                                return log_error_errno(r, "No PCIe hotplug ports left for SCSI controller");
+                        if (r < 0)
+                                return log_oom();
+                }
+
+                r = qmp_setup_scsi_controller(bridge, controller_port);
+                if (r < 0) {
+                        vmspawn_qmp_bridge_release_pcie_port_by_idx(bridge, controller_port_idx);
+                        return r;
+                }
+
+                bridge->scsi_controller_port_idx = controller_port_idx;
+        }
+
+        uint64_t fdset_id;
+        slot_ref = drive_info_ref(drive);
+        r = qmp_fdset_add(bridge->qmp, TAKE_FD(drive->fd),
+                          on_add_observe_stage, slot_ref, &drive->fdset_path, &fdset_id);
+        if (r < 0)
+                return r;
+        TAKE_PTR(slot_ref);
+
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *blockdev_args = NULL;
+        r = qmp_build_blockdev_add_inline(
+                        qmp_name, drive->format, drive->fdset_path,
+                        FLAGS_SET(drive->flags, QMP_DRIVE_BLOCK_DEVICE) ? "host_device" : "file",
+                        drive->flags, bridge->features, &blockdev_args);
+        if (r < 0)
+                return r;
+
+        slot_ref = drive_info_ref(drive);
+        r = qmp_client_invoke(bridge->qmp, "blockdev-add", QMP_CLIENT_ARGS(blockdev_args),
+                              on_add_blockdev_stage, slot_ref);
+        if (r < 0)
+                return r;
+        TAKE_PTR(slot_ref);
+
+        /* Release the monitor's original fd; the blockdev-add above took a dup.
+         * From this point on, blockdev-add is live in QEMU's command queue, so a sync
+         * error here must mark FAILED — the blockdev-add callback will see it and
+         * issue retroactive teardown. */
+        slot_ref = drive_info_ref(drive);
+        r = qmp_fdset_remove(bridge->qmp, fdset_id, on_add_observe_stage, slot_ref);
+        if (r < 0) {
+                drive->rollback_mask |= BLOCK_DEVICE_ADD_STAGE_FAILED;
+                return r;
+        }
+        TAKE_PTR(slot_ref);
+
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *device_args = NULL;
+        r = qmp_build_device_add(drive, qmp_name, &device_args);
+        if (r < 0) {
+                drive->rollback_mask |= BLOCK_DEVICE_ADD_STAGE_FAILED;
+                return r;
+        }
+
+        slot_ref = drive_info_ref(drive);
+        r = qmp_client_invoke(bridge->qmp, "device_add", QMP_CLIENT_ARGS(device_args),
+                              on_add_device_add_complete, slot_ref);
+        if (r < 0) {
+                drive->rollback_mask |= BLOCK_DEVICE_ADD_STAGE_FAILED;
+                return r;
+        }
+        TAKE_PTR(slot_ref);
+
+        TAKE_PTR(owned);
+        return 0;
+}
+
+static int on_remove_device_del_complete(
+                QmpClient *client,
+                sd_json_variant *result,
+                const char *error_desc,
+                int error,
+                void *userdata) {
+
+        _cleanup_(sd_varlink_unrefp) sd_varlink *link = ASSERT_PTR(userdata);
+
+        assert(client);
+
+        if (error < 0) {
+                if (error_desc && strstr(error_desc, "not found"))
+                        return sd_varlink_error(link, "io.systemd.VirtualMachineInstance.NoSuchBlockDevice", NULL);
+                return reply_qmp_error(link, error_desc, error);
+        }
+
+        return sd_varlink_reply(link, NULL);
+}
+
+int vmspawn_qmp_remove_block_device(VmspawnQmpBridge *bridge, sd_varlink *link, const char *id) {
+        int r;
+
+        assert(bridge);
+        assert(link);
+        assert(id);
+
+        _cleanup_free_ char *qmp_name = strjoin(QMP_BLOCK_QDEV_PREFIX, id);
+        if (!qmp_name)
+                return log_oom();
+
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *args = NULL;
+        r = sd_json_buildo(&args, SD_JSON_BUILD_PAIR_STRING("id", qmp_name));
+        if (r < 0)
+                return r;
+
+        sd_varlink_ref(link);
+        r = qmp_client_invoke(bridge->qmp, "device_del", QMP_CLIENT_ARGS(args),
+                              on_remove_device_del_complete, link);
+        if (r < 0) {
+                sd_varlink_unref(link);
+                return r;
+        }
+        return 0;
 }
 
 int vmspawn_qmp_setup_network(VmspawnQmpBridge *bridge, NetworkInfo *network) {
@@ -762,31 +1195,13 @@ int vmspawn_qmp_setup_vsock(VmspawnQmpBridge *bridge, VsockInfo *vsock) {
 static bool drives_need_scsi_controller(DriveInfos *drives) {
         assert(drives);
 
-        FOREACH_ARRAY(d, drives->drives, drives->n_drives)
-                if (STR_IN_SET((*d)->disk_driver, "scsi-hd", "scsi-cd"))
+        FOREACH_ARRAY(d, drives->drives, drives->n_drives) {
+                DriveInfo *drive = *d;
+                if (STR_IN_SET(drive->disk_driver, "scsi-hd", "scsi-cd"))
                         return true;
+        }
 
         return false;
-}
-
-static int qmp_setup_scsi_controller(QmpClient *qmp, const char *pcie_port) {
-        _cleanup_(sd_json_variant_unrefp) sd_json_variant *args = NULL;
-        int r;
-
-        r = sd_json_buildo(
-                        &args,
-                        SD_JSON_BUILD_PAIR_STRING("driver", "virtio-scsi-pci"),
-                        SD_JSON_BUILD_PAIR_STRING("id", "vmspawn_scsi"),
-                        SD_JSON_BUILD_PAIR_CONDITION(!!pcie_port, "bus", SD_JSON_BUILD_STRING(pcie_port)));
-        if (r < 0)
-                return log_error_errno(r, "Failed to build SCSI controller JSON: %m");
-
-        r = qmp_client_invoke(qmp, "device_add", QMP_CLIENT_ARGS(args), on_qmp_complete, (void*) "device_add");
-        if (r < 0)
-                return log_error_errno(r, "Failed to send SCSI controller device_add: %m");
-
-        log_debug("Queued virtio-scsi-pci controller setup");
-        return 0;
 }
 
 int vmspawn_qmp_setup_drives(VmspawnQmpBridge *bridge, DriveInfos *drives) {
@@ -801,13 +1216,16 @@ int vmspawn_qmp_setup_drives(VmspawnQmpBridge *bridge, DriveInfos *drives) {
          * bridge->features is passed to each file node setup call. */
 
         if (drives_need_scsi_controller(drives)) {
-                r = qmp_setup_scsi_controller(qmp, drives->scsi_pcie_port);
+                r = qmp_setup_scsi_controller(bridge, drives->scsi_pcie_port);
                 if (r < 0)
                         return r;
         }
 
         FOREACH_ARRAY(d, drives->drives, drives->n_drives) {
-                r = qmp_setup_drive(bridge, qmp, *d);
+                if ((*d)->overlay_fd >= 0)
+                        r = qmp_setup_ephemeral_drive(bridge, qmp, *d);
+                else
+                        r = qmp_setup_regular_drive(bridge, TAKE_PTR(*d));
                 if (r < 0)
                         return r;
         }
@@ -828,6 +1246,9 @@ VmspawnQmpBridge* vmspawn_qmp_bridge_free(VmspawnQmpBridge *b) {
                 return NULL;
 
         hashmap_free(b->pending_jobs);
+
+        FOREACH_ELEMENT(owner, b->hotplug_port_owner)
+                free(*owner);
 
         qmp_client_unref(b->qmp);
         return mfree(b);
@@ -996,6 +1417,8 @@ int vmspawn_qmp_init(VmspawnQmpBridge **ret, int fd, sd_event *event) {
         if (!bridge)
                 return log_oom();
 
+        bridge->scsi_controller_port_idx = -1;
+
         r = qmp_client_connect_fd(&bridge->qmp, fd);
         if (r < 0)
                 return log_error_errno(r, "Failed to create QMP client: %m");
@@ -1057,9 +1480,9 @@ static int on_cont_complete(
                 int error,
                 void *userdata) {
 
-        VmspawnQmpBridge *bridge = ASSERT_PTR(qmp_client_get_userdata(client));
-
         assert(client);
+
+        VmspawnQmpBridge *bridge = ASSERT_PTR(qmp_client_get_userdata(client));
 
         if (error < 0) {
                 log_error_errno(error, "Failed to resume QEMU execution: %s", strna(error_desc));

--- a/src/vmspawn/vmspawn-qmp.c
+++ b/src/vmspawn/vmspawn-qmp.c
@@ -1494,7 +1494,7 @@ static int on_cont_complete(
 
         assert(client);
 
-        VmspawnQmpBridge *bridge = ASSERT_PTR(qmp_client_get_userdata(client));
+        VmspawnQmpBridge *bridge = ASSERT_PTR(userdata);
 
         if (error < 0) {
                 log_error_errno(error, "Failed to resume QEMU execution: %s", strna(error_desc));
@@ -1509,5 +1509,5 @@ static int on_cont_complete(
 int vmspawn_qmp_start(VmspawnQmpBridge *bridge) {
         assert(bridge);
 
-        return qmp_client_invoke(bridge->qmp, "cont", /* args= */ NULL, on_cont_complete, /* userdata= */ NULL);
+        return qmp_client_invoke(bridge->qmp, "cont", /* args= */ NULL, on_cont_complete, bridge);
 }

--- a/src/vmspawn/vmspawn-qmp.c
+++ b/src/vmspawn/vmspawn-qmp.c
@@ -85,7 +85,7 @@ void machine_config_done(MachineConfig *c) {
 /* Generic async QMP setup-completion callback. The userdata argument carries the
  * command name (as a string literal) for logging. On failure, request a clean
  * event loop exit so vmspawn shuts down instead of running a VM with missing devices. */
-static int on_qmp_setup_complete(
+static int on_qmp_complete(
                 QmpClient *client,
                 sd_json_variant *result,
                 const char *error_desc,
@@ -127,7 +127,7 @@ static int qmp_fdset_add(QmpClient *qmp, int fd_consume, char **ret_path) {
                 return -ENOMEM;
 
         r = qmp_client_invoke(qmp, "add-fd", QMP_CLIENT_ARGS_FD(args, TAKE_FD(fd)),
-                              on_qmp_setup_complete, (void*) "add-fd");
+                              on_qmp_complete, (void*) "add-fd");
         if (r < 0)
                 return r;
 
@@ -221,7 +221,7 @@ static int qmp_add_file_node(QmpClient *qmp, const QmpFileNodeParams *p) {
         if (r < 0)
                 return r;
 
-        return qmp_client_invoke(qmp, "blockdev-add", QMP_CLIENT_ARGS(args), on_qmp_setup_complete, (void*) "blockdev-add");
+        return qmp_client_invoke(qmp, "blockdev-add", QMP_CLIENT_ARGS(args), on_qmp_complete, (void*) "blockdev-add");
 }
 
 /* Get the virtual size of an image from the fd directly. For raw images the virtual size
@@ -320,7 +320,7 @@ static int on_ephemeral_create_concluded(QmpClient *qmp, void *userdata) {
         if (r < 0)
                 return log_error_errno(r, "Failed to build overlay format JSON for '%s': %m", ctx->node_name);
 
-        r = qmp_client_invoke(qmp, "blockdev-add", QMP_CLIENT_ARGS(fmt_args), on_qmp_setup_complete, (void*) "blockdev-add");
+        r = qmp_client_invoke(qmp, "blockdev-add", QMP_CLIENT_ARGS(fmt_args), on_qmp_complete, (void*) "blockdev-add");
         if (r < 0)
                 return r;
 
@@ -339,7 +339,7 @@ static int on_ephemeral_create_concluded(QmpClient *qmp, void *userdata) {
         if (r < 0)
                 return log_error_errno(r, "Failed to build device_add JSON for '%s': %m", ctx->node_name);
 
-        r = qmp_client_invoke(qmp, "device_add", QMP_CLIENT_ARGS(device_args), on_qmp_setup_complete, (void*) "device_add");
+        r = qmp_client_invoke(qmp, "device_add", QMP_CLIENT_ARGS(device_args), on_qmp_complete, (void*) "device_add");
         if (r < 0)
                 return r;
 
@@ -408,7 +408,7 @@ static int qmp_setup_ephemeral_drive(VmspawnQmpBridge *bridge, QmpClient *qmp, D
         if (r < 0)
                 return r;
 
-        r = qmp_client_invoke(qmp, "blockdev-add", QMP_CLIENT_ARGS(base_fmt_args), on_qmp_setup_complete, (void*) "blockdev-add");
+        r = qmp_client_invoke(qmp, "blockdev-add", QMP_CLIENT_ARGS(base_fmt_args), on_qmp_complete, (void*) "blockdev-add");
         if (r < 0)
                 return log_error_errno(r, "Failed to send blockdev-add for base format '%s': %m", drive->path);
 
@@ -424,7 +424,7 @@ static int qmp_setup_ephemeral_drive(VmspawnQmpBridge *bridge, QmpClient *qmp, D
         if (r < 0)
                 return r;
 
-        r = qmp_client_invoke(qmp, "blockdev-add", QMP_CLIENT_ARGS(overlay_file_args), on_qmp_setup_complete, (void*) "blockdev-add");
+        r = qmp_client_invoke(qmp, "blockdev-add", QMP_CLIENT_ARGS(overlay_file_args), on_qmp_complete, (void*) "blockdev-add");
         if (r < 0)
                 return log_error_errno(r, "Failed to send blockdev-add for overlay file '%s': %m", drive->path);
 
@@ -482,7 +482,7 @@ static int qmp_setup_ephemeral_drive(VmspawnQmpBridge *bridge, QmpClient *qmp, D
 
         TAKE_PTR(ectx);
 
-        r = qmp_client_invoke(qmp, "blockdev-create", QMP_CLIENT_ARGS(cmd_args), on_qmp_setup_complete, (void*) "blockdev-create");
+        r = qmp_client_invoke(qmp, "blockdev-create", QMP_CLIENT_ARGS(cmd_args), on_qmp_complete, (void*) "blockdev-create");
         if (r < 0)
                 return log_error_errno(r, "Failed to send blockdev-create for '%s': %m", drive->path);
 
@@ -532,7 +532,7 @@ static int qmp_setup_regular_drive(VmspawnQmpBridge *bridge, QmpClient *qmp, Dri
         if (r < 0)
                 return r;
 
-        r = qmp_client_invoke(qmp, "blockdev-add", QMP_CLIENT_ARGS(fmt_args), on_qmp_setup_complete, (void*) "blockdev-add");
+        r = qmp_client_invoke(qmp, "blockdev-add", QMP_CLIENT_ARGS(fmt_args), on_qmp_complete, (void*) "blockdev-add");
         if (r < 0)
                 return log_error_errno(r, "Failed to send blockdev-add format for '%s': %m", drive->path);
 
@@ -542,7 +542,7 @@ static int qmp_setup_regular_drive(VmspawnQmpBridge *bridge, QmpClient *qmp, Dri
         if (r < 0)
                 return r;
 
-        r = qmp_client_invoke(qmp, "device_add", QMP_CLIENT_ARGS(device_args), on_qmp_setup_complete, (void*) "device_add");
+        r = qmp_client_invoke(qmp, "device_add", QMP_CLIENT_ARGS(device_args), on_qmp_complete, (void*) "device_add");
         if (r < 0)
                 return log_error_errno(r, "Failed to send device_add for '%s': %m", drive->path);
 
@@ -585,7 +585,7 @@ int vmspawn_qmp_setup_network(VmspawnQmpBridge *bridge, NetworkInfo *network) {
                         return log_error_errno(r, "Failed to build getfd JSON: %m");
 
                 r = qmp_client_invoke(qmp, "getfd", QMP_CLIENT_ARGS_FD(getfd_args, TAKE_FD(network->fd)),
-                                      on_qmp_setup_complete, (void*) "getfd");
+                                      on_qmp_complete, (void*) "getfd");
                 if (r < 0)
                         return log_error_errno(r, "Failed to send getfd for TAP fd: %m");
         }
@@ -606,7 +606,7 @@ int vmspawn_qmp_setup_network(VmspawnQmpBridge *bridge, NetworkInfo *network) {
         if (r < 0)
                 return log_error_errno(r, "Failed to build netdev_add JSON: %m");
 
-        r = qmp_client_invoke(qmp, "netdev_add", QMP_CLIENT_ARGS(netdev_args), on_qmp_setup_complete, (void*) "netdev_add");
+        r = qmp_client_invoke(qmp, "netdev_add", QMP_CLIENT_ARGS(netdev_args), on_qmp_complete, (void*) "netdev_add");
         if (r < 0)
                 return log_error_errno(r, "Failed to send netdev_add: %m");
 
@@ -623,7 +623,7 @@ int vmspawn_qmp_setup_network(VmspawnQmpBridge *bridge, NetworkInfo *network) {
         if (r < 0)
                 return log_error_errno(r, "Failed to build NIC device_add JSON: %m");
 
-        r = qmp_client_invoke(qmp, "device_add", QMP_CLIENT_ARGS(device_args), on_qmp_setup_complete, (void*) "device_add");
+        r = qmp_client_invoke(qmp, "device_add", QMP_CLIENT_ARGS(device_args), on_qmp_complete, (void*) "device_add");
         if (r < 0)
                 return log_error_errno(r, "Failed to send NIC device_add: %m");
 
@@ -658,7 +658,7 @@ static int vmspawn_qmp_setup_one_virtiofs(QmpClient *qmp, const VirtiofsInfo *vf
         if (r < 0)
                 return log_error_errno(r, "Failed to build chardev-add JSON for '%s': %m", vfs->id);
 
-        r = qmp_client_invoke(qmp, "chardev-add", QMP_CLIENT_ARGS(chardev_args), on_qmp_setup_complete, (void*) "chardev-add");
+        r = qmp_client_invoke(qmp, "chardev-add", QMP_CLIENT_ARGS(chardev_args), on_qmp_complete, (void*) "chardev-add");
         if (r < 0)
                 return log_error_errno(r, "Failed to send chardev-add '%s': %m", vfs->id);
 
@@ -675,7 +675,7 @@ static int vmspawn_qmp_setup_one_virtiofs(QmpClient *qmp, const VirtiofsInfo *vf
         if (r < 0)
                 return log_error_errno(r, "Failed to build virtiofs device_add JSON for '%s': %m", vfs->id);
 
-        r = qmp_client_invoke(qmp, "device_add", QMP_CLIENT_ARGS(device_args), on_qmp_setup_complete, (void*) "device_add");
+        r = qmp_client_invoke(qmp, "device_add", QMP_CLIENT_ARGS(device_args), on_qmp_complete, (void*) "device_add");
         if (r < 0)
                 return log_error_errno(r, "Failed to send virtiofs device_add '%s': %m", vfs->id);
 
@@ -720,7 +720,7 @@ int vmspawn_qmp_setup_vsock(VmspawnQmpBridge *bridge, VsockInfo *vsock) {
                 return log_error_errno(r, "Failed to build getfd JSON for VSOCK: %m");
 
         r = qmp_client_invoke(qmp, "getfd", QMP_CLIENT_ARGS_FD(getfd_args, TAKE_FD(vsock->fd)),
-                              on_qmp_setup_complete, (void*) "getfd");
+                              on_qmp_complete, (void*) "getfd");
         if (r < 0)
                 return log_error_errno(r, "Failed to send getfd for VSOCK fd: %m");
 
@@ -736,7 +736,7 @@ int vmspawn_qmp_setup_vsock(VmspawnQmpBridge *bridge, VsockInfo *vsock) {
         if (r < 0)
                 return log_error_errno(r, "Failed to build VSOCK device_add JSON: %m");
 
-        r = qmp_client_invoke(qmp, "device_add", QMP_CLIENT_ARGS(device_args), on_qmp_setup_complete, (void*) "device_add");
+        r = qmp_client_invoke(qmp, "device_add", QMP_CLIENT_ARGS(device_args), on_qmp_complete, (void*) "device_add");
         if (r < 0)
                 return log_error_errno(r, "Failed to send VSOCK device_add: %m");
 
@@ -766,7 +766,7 @@ static int qmp_setup_scsi_controller(QmpClient *qmp, const char *pcie_port) {
         if (r < 0)
                 return log_error_errno(r, "Failed to build SCSI controller JSON: %m");
 
-        r = qmp_client_invoke(qmp, "device_add", QMP_CLIENT_ARGS(args), on_qmp_setup_complete, (void*) "device_add");
+        r = qmp_client_invoke(qmp, "device_add", QMP_CLIENT_ARGS(args), on_qmp_complete, (void*) "device_add");
         if (r < 0)
                 return log_error_errno(r, "Failed to send SCSI controller device_add: %m");
 

--- a/src/vmspawn/vmspawn-qmp.c
+++ b/src/vmspawn/vmspawn-qmp.c
@@ -6,9 +6,11 @@
 
 #include "sd-event.h"
 #include "sd-json.h"
+#include "sd-varlink.h"
 
 #include "alloc-util.h"
 #include "blockdev-util.h"
+#include "errno-util.h"
 #include "ether-addr-util.h"
 #include "fd-util.h"
 #include "hashmap.h"
@@ -19,6 +21,7 @@
 #include "string-util.h"
 #include "strv.h"
 #include "vmspawn-qmp.h"
+#include "vmspawn-util.h"
 
 DEFINE_PRIVATE_HASH_OPS_FULL(
                 pending_job_hash_ops,
@@ -26,24 +29,94 @@ DEFINE_PRIVATE_HASH_OPS_FULL(
                 PendingJob, pending_job_free);
 
 DriveInfo* drive_info_new(void) {
-        DriveInfo *d = new0(DriveInfo, 1);
-        if (d) {
-                d->fd = -EBADF;
-                d->overlay_fd = -EBADF;
-        }
+        DriveInfo *d = new(DriveInfo, 1);
+        if (!d)
+                return NULL;
+
+        *d = (DriveInfo) {
+                .n_ref = 1,
+                .fd = -EBADF,
+                .overlay_fd = -EBADF,
+                .pcie_port_idx = -1,
+        };
         return d;
 }
 
-DriveInfo* drive_info_free(DriveInfo *d) {
+int vmspawn_qmp_bridge_allocate_pcie_port(VmspawnQmpBridge *bridge, const char *owner_id, char **ret_name, int *ret_idx) {
+        assert(bridge);
+        assert(owner_id);
+        assert(ret_name);
+        assert(ret_idx);
+
+        for (unsigned i = 0; i < VMSPAWN_PCIE_HOTPLUG_SPARES; i++) {
+                if (bridge->hotplug_port_owner[i])
+                        continue;
+
+                _cleanup_free_ char *owner = strdup(owner_id);
+                _cleanup_free_ char *name = NULL;
+                if (!owner || asprintf(&name, "vmspawn-hotplug-pci-root-port-%u", i) < 0)
+                        return -ENOMEM;
+
+                bridge->hotplug_port_owner[i] = TAKE_PTR(owner);
+                *ret_name = TAKE_PTR(name);
+                *ret_idx = (int) i;
+                return 0;
+        }
+
+        return -EBUSY;
+}
+
+void vmspawn_qmp_bridge_release_pcie_port_by_idx(VmspawnQmpBridge *bridge, int idx) {
+        assert(bridge);
+
+        if (idx < 0)
+                return;
+
+        assert((unsigned) idx < VMSPAWN_PCIE_HOTPLUG_SPARES);
+        bridge->hotplug_port_owner[idx] = mfree(bridge->hotplug_port_owner[idx]);
+}
+
+int vmspawn_qmp_bridge_release_pcie_port_by_id(VmspawnQmpBridge *bridge, const char *owner_id) {
+        assert(bridge);
+        assert(owner_id);
+
+        for (unsigned i = 0; i < VMSPAWN_PCIE_HOTPLUG_SPARES; i++)
+                if (streq_ptr(bridge->hotplug_port_owner[i], owner_id)) {
+                        bridge->hotplug_port_owner[i] = mfree(bridge->hotplug_port_owner[i]);
+                        return 1;
+                }
+
+        return 0;
+}
+
+DriveInfo* drive_info_ref(DriveInfo *d) {
         if (!d)
                 return NULL;
+
+        assert(d->n_ref > 0);
+        d->n_ref++;
+        return d;
+}
+
+DriveInfo* drive_info_unref(DriveInfo *d) {
+        if (!d)
+                return NULL;
+
+        assert(d->n_ref > 0);
+        if (--d->n_ref > 0)
+                return NULL;
+
+        if (d->bridge)
+                vmspawn_qmp_bridge_release_pcie_port_by_idx(d->bridge, d->pcie_port_idx);
 
         free(d->path);
         free(d->format);
         free(d->disk_driver);
         free(d->serial);
-        free(d->node_name);
         free(d->pcie_port);
+        free(d->id);
+        free(d->fdset_path);
+        sd_varlink_unref(d->link);
         safe_close(d->fd);
         safe_close(d->overlay_fd);
         return mfree(d);
@@ -52,7 +125,7 @@ DriveInfo* drive_info_free(DriveInfo *d) {
 void drive_infos_done(DriveInfos *infos) {
         assert(infos);
         FOREACH_ARRAY(d, infos->drives, infos->n_drives)
-                drive_info_free(*d);
+                drive_info_unref(*d);
         infos->drives = mfree(infos->drives);
         infos->n_drives = 0;
         infos->scsi_pcie_port = mfree(infos->scsi_pcie_port);
@@ -97,9 +170,7 @@ void machine_config_done(MachineConfig *c) {
         vsock_info_done(&c->vsock);
 }
 
-/* Generic async QMP setup-completion callback. The userdata argument carries the
- * command name (as a string literal) for logging. On failure, request a clean
- * event loop exit so vmspawn shuts down instead of running a VM with missing devices. */
+/* Generic completion callback; userdata is a string literal label. Exits the event loop on boot-time failures. */
 static int on_qmp_complete(
                 QmpClient *client,
                 sd_json_variant *result,
@@ -107,29 +178,41 @@ static int on_qmp_complete(
                 int error,
                 void *userdata) {
 
-        const char *label = ASSERT_PTR(userdata);
-
         assert(client);
+
+        VmspawnQmpBridge *bridge = ASSERT_PTR(qmp_client_get_userdata(client));
+        const char *label = ASSERT_PTR(userdata);
 
         if (error < 0) {
                 log_error_errno(error, "%s failed: %s", label, strna(error_desc));
+
+                if (bridge->setup_done)
+                        return 0;
+
                 return sd_event_exit(qmp_client_get_event(client), error);
         }
 
         return 0;
 }
 
-/* Send add-fd via SCM_RIGHTS; return /dev/fdset/N. Allocations run before invoke so a late
- * OOM cannot orphan an fdset on QEMU's side; *ret_path is only written on full success. */
-static int qmp_fdset_add(QmpClient *qmp, int fd_consume, char **ret_path) {
+/* Send add-fd via SCM_RIGHTS; return /dev/fdset/N and the numeric fdset id. */
+static int qmp_fdset_add(
+                QmpClient *qmp,
+                int fd_consume,
+                qmp_command_callback_t callback,
+                void *userdata,
+                char **ret_path,
+                uint64_t *ret_fdset_id) {
+
         _cleanup_(sd_json_variant_unrefp) sd_json_variant *args = NULL;
         _cleanup_close_ int fd = fd_consume;
         _cleanup_free_ char *path = NULL;
-        unsigned id;
+        uint64_t id;
         int r;
 
         assert(qmp);
         assert(fd_consume >= 0);
+        assert(callback);
         assert(ret_path);
 
         id = qmp_client_next_fdset_id(qmp);
@@ -138,16 +221,41 @@ static int qmp_fdset_add(QmpClient *qmp, int fd_consume, char **ret_path) {
         if (r < 0)
                 return r;
 
-        if (asprintf(&path, "/dev/fdset/%u", id) < 0)
+        if (asprintf(&path, "/dev/fdset/%" PRIu64, id) < 0)
                 return -ENOMEM;
 
         r = qmp_client_invoke(qmp, "add-fd", QMP_CLIENT_ARGS_FD(args, TAKE_FD(fd)),
-                              on_qmp_complete, (void*) "add-fd");
+                              callback, userdata);
         if (r < 0)
                 return r;
 
         *ret_path = TAKE_PTR(path);
+        if (ret_fdset_id)
+                *ret_fdset_id = id;
         return 0;
+}
+
+/* Issue remove-fd for an fdset whose dup is now held by a blockdev. The fdset
+ * persists until the dup is closed (in raw_close at blockdev-del time) — see
+ * QEMU's monitor/fds.c:177-181 on the fds/dup_fds split. */
+static int qmp_fdset_remove(
+                QmpClient *qmp,
+                uint64_t fdset_id,
+                qmp_command_callback_t callback,
+                void *userdata) {
+
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *args = NULL;
+        int r;
+
+        assert(qmp);
+        assert(callback);
+
+        r = sd_json_buildo(&args, SD_JSON_BUILD_PAIR_UNSIGNED("fdset-id", fdset_id));
+        if (r < 0)
+                return r;
+
+        return qmp_client_invoke(qmp, "remove-fd", QMP_CLIENT_ARGS(args),
+                                 callback, userdata);
 }
 
 typedef struct QmpFileNodeParams {
@@ -208,16 +316,18 @@ static int qmp_build_blockdev_add_format(const QmpFormatNodeParams *p, sd_json_v
                         SD_JSON_BUILD_PAIR_CONDITION(!!p->backing, "backing", SD_JSON_BUILD_STRING(p->backing)));
 }
 
-/* Build device_add JSON arguments for a drive */
-static int qmp_build_device_add(const DriveInfo *drive, sd_json_variant **ret) {
+/* qmp_name is the fully-qualified QMP name ("bd-<id>"); used as both the
+ * qdev id and the drive-backend reference. */
+static int qmp_build_device_add(const DriveInfo *drive, const char *qmp_name, sd_json_variant **ret) {
         assert(drive);
+        assert(qmp_name);
         assert(ret);
 
         return sd_json_buildo(
                         ret,
                         SD_JSON_BUILD_PAIR_STRING("driver", drive->disk_driver),
-                        SD_JSON_BUILD_PAIR_STRING("drive", drive->node_name),
-                        SD_JSON_BUILD_PAIR_STRING("id", drive->node_name),
+                        SD_JSON_BUILD_PAIR_STRING("drive", qmp_name),
+                        SD_JSON_BUILD_PAIR_STRING("id", qmp_name),
                         SD_JSON_BUILD_PAIR_CONDITION(FLAGS_SET(drive->flags, QMP_DRIVE_BOOT), "bootindex", SD_JSON_BUILD_INTEGER(1)),
                         SD_JSON_BUILD_PAIR_CONDITION(!!drive->serial, "serial", SD_JSON_BUILD_STRING(drive->serial)),
                         SD_JSON_BUILD_PAIR_CONDITION(STR_IN_SET(drive->disk_driver, "scsi-hd", "scsi-cd"),
@@ -225,6 +335,43 @@ static int qmp_build_device_add(const DriveInfo *drive, sd_json_variant **ret) {
                         SD_JSON_BUILD_PAIR_CONDITION(
                                         !STR_IN_SET(drive->disk_driver, "scsi-hd", "scsi-cd") && !!drive->pcie_port,
                                         "bus", SD_JSON_BUILD_STRING(drive->pcie_port)));
+}
+
+/* Inline form: one blockdev-add creates format+file; one blockdev-del tears
+ * down the whole tree. Used for regular boot drives and hotplug. */
+static int qmp_build_blockdev_add_inline(
+                const char *node_name,
+                const char *format,
+                const char *filename,
+                const char *file_driver,
+                QmpDriveFlags flags,
+                VmspawnQmpFeatureFlags features,
+                sd_json_variant **ret) {
+
+        bool use_io_uring = FLAGS_SET(features, VMSPAWN_QMP_FEATURE_IO_URING);
+        bool use_discard_no_unref = FLAGS_SET(flags, QMP_DRIVE_DISCARD_NO_UNREF);
+
+        assert(node_name);
+        assert(format);
+        assert(filename);
+        assert(file_driver);
+        assert(ret);
+
+        return sd_json_buildo(
+                        ret,
+                        SD_JSON_BUILD_PAIR_STRING("node-name", node_name),
+                        SD_JSON_BUILD_PAIR_STRING("driver", format),
+                        SD_JSON_BUILD_PAIR_CONDITION(FLAGS_SET(flags, QMP_DRIVE_READ_ONLY), "read-only", SD_JSON_BUILD_BOOLEAN(true)),
+                        SD_JSON_BUILD_PAIR_CONDITION(FLAGS_SET(flags, QMP_DRIVE_DISCARD), "discard", JSON_BUILD_CONST_STRING("unmap")),
+                        SD_JSON_BUILD_PAIR_CONDITION(use_discard_no_unref, "discard-no-unref", SD_JSON_BUILD_BOOLEAN(true)),
+                        SD_JSON_BUILD_PAIR("file", SD_JSON_BUILD_OBJECT(
+                                        SD_JSON_BUILD_PAIR_STRING("driver", file_driver),
+                                        SD_JSON_BUILD_PAIR_STRING("filename", filename),
+                                        SD_JSON_BUILD_PAIR_CONDITION(FLAGS_SET(flags, QMP_DRIVE_READ_ONLY), "read-only", SD_JSON_BUILD_BOOLEAN(true)),
+                                        SD_JSON_BUILD_PAIR_CONDITION(use_io_uring, "aio", JSON_BUILD_CONST_STRING("io_uring")),
+                                        SD_JSON_BUILD_PAIR("cache", SD_JSON_BUILD_OBJECT(
+                                                        SD_JSON_BUILD_PAIR_BOOLEAN("direct", false),
+                                                        SD_JSON_BUILD_PAIR_BOOLEAN("no-flush", FLAGS_SET(flags, QMP_DRIVE_NO_FLUSH)))))));
 }
 
 /* Issue blockdev-add for a file node. */
@@ -340,17 +487,17 @@ static int on_ephemeral_create_concluded(QmpClient *qmp, void *userdata) {
                 return r;
 
         /* device_add: attach to virtual hardware. Build a temporary DriveInfo as a
-         * read-only view into the continuation context to reuse qmp_build_device_add(). */
+         * read-only view into the continuation context to reuse qmp_build_device_add().
+         * ctx->node_name is already the bd-prefixed QMP name. */
         const DriveInfo tmp = {
                 .disk_driver = ctx->disk_driver,
-                .node_name   = ctx->node_name,
                 .serial      = ctx->serial,
                 .pcie_port   = ctx->pcie_port,
                 .flags       = ctx->flags & QMP_DRIVE_BOOT,
                 .fd          = -EBADF,
                 .overlay_fd  = -EBADF,
         };
-        r = qmp_build_device_add(&tmp, &device_args);
+        r = qmp_build_device_add(&tmp, ctx->node_name, &device_args);
         if (r < 0)
                 return log_error_errno(r, "Failed to build device_add JSON for '%s': %m", ctx->node_name);
 
@@ -374,10 +521,19 @@ static int qmp_setup_ephemeral_drive(VmspawnQmpBridge *bridge, QmpClient *qmp, D
         assert(drive->fd >= 0);
         assert(drive->overlay_fd >= 0);
 
-        /* Node names: <name>-base-file, <name>-base-fmt, <name>-overlay-file, <name> */
-        _cleanup_free_ char *base_file_node = strjoin(drive->node_name, "-base-file");
-        _cleanup_free_ char *base_fmt_node = strjoin(drive->node_name, "-base-fmt");
-        _cleanup_free_ char *overlay_file_node = strjoin(drive->node_name, "-overlay-file");
+        _cleanup_free_ char *drive_id = NULL;
+        if (asprintf(&drive_id, "bd%" PRIu64, bridge->next_id++) < 0)
+                return log_oom();
+
+        /* QMP names all carry the bd- prefix so DEVICE_DELETED filtering works
+         * uniformly across ephemeral, boot-time, and hotplug drives. */
+        _cleanup_free_ char *qmp_name = strjoin(QMP_BLOCK_QDEV_PREFIX, drive_id);
+        if (!qmp_name)
+                return log_oom();
+
+        _cleanup_free_ char *base_file_node = strjoin(qmp_name, "-base-file");
+        _cleanup_free_ char *base_fmt_node = strjoin(qmp_name, "-base-fmt");
+        _cleanup_free_ char *overlay_file_node = strjoin(qmp_name, "-overlay-file");
         if (!base_file_node || !base_fmt_node || !overlay_file_node)
                 return log_oom();
 
@@ -389,12 +545,16 @@ static int qmp_setup_ephemeral_drive(VmspawnQmpBridge *bridge, QmpClient *qmp, D
 
         /* Step 1-2: Pass both fds to QEMU */
         _cleanup_free_ char *base_path = NULL;
-        r = qmp_fdset_add(qmp, TAKE_FD(drive->fd), &base_path);
+        uint64_t base_fdset_id;
+        r = qmp_fdset_add(qmp, TAKE_FD(drive->fd),
+                          on_qmp_complete, (void*) "add-fd", &base_path, &base_fdset_id);
         if (r < 0)
                 return log_error_errno(r, "Failed to send add-fd for base image '%s': %m", drive->path);
 
         _cleanup_free_ char *overlay_path = NULL;
-        r = qmp_fdset_add(qmp, TAKE_FD(drive->overlay_fd), &overlay_path);
+        uint64_t overlay_fdset_id;
+        r = qmp_fdset_add(qmp, TAKE_FD(drive->overlay_fd),
+                          on_qmp_complete, (void*) "add-fd", &overlay_path, &overlay_fdset_id);
         if (r < 0)
                 return log_error_errno(r, "Failed to send add-fd for overlay of '%s': %m", drive->path);
 
@@ -410,6 +570,12 @@ static int qmp_setup_ephemeral_drive(VmspawnQmpBridge *bridge, QmpClient *qmp, D
         r = qmp_add_file_node(qmp, &base_file_params);
         if (r < 0)
                 return log_error_errno(r, "Failed to send blockdev-add for base file '%s': %m", drive->path);
+
+        /* The base file node now holds a dup of the fd; release the monitor's
+         * original so the fdset auto-frees when raw_close runs at teardown. */
+        r = qmp_fdset_remove(qmp, base_fdset_id, on_qmp_complete, (void*) "remove-fd");
+        if (r < 0)
+                return log_error_errno(r, "Failed to send remove-fd for base image '%s': %m", drive->path);
 
         /* Step 4: Base image format node (read-only) */
         QmpFormatNodeParams base_fmt_params = {
@@ -443,6 +609,11 @@ static int qmp_setup_ephemeral_drive(VmspawnQmpBridge *bridge, QmpClient *qmp, D
         if (r < 0)
                 return log_error_errno(r, "Failed to send blockdev-add for overlay file '%s': %m", drive->path);
 
+        /* Same as for base: the overlay file node has the dup. */
+        r = qmp_fdset_remove(qmp, overlay_fdset_id, on_qmp_complete, (void*) "remove-fd");
+        if (r < 0)
+                return log_error_errno(r, "Failed to send remove-fd for overlay of '%s': %m", drive->path);
+
         /* Step 6: Fire blockdev-create to format the overlay */
         _cleanup_(sd_json_variant_unrefp) sd_json_variant *create_options = NULL;
         r = sd_json_buildo(&create_options,
@@ -454,7 +625,7 @@ static int qmp_setup_ephemeral_drive(VmspawnQmpBridge *bridge, QmpClient *qmp, D
         if (r < 0)
                 return log_error_errno(r, "Failed to build blockdev-create options: %m");
 
-        _cleanup_free_ char *job_id = strjoin("create-", drive->node_name);
+        _cleanup_free_ char *job_id = strjoin("create-", qmp_name);
         if (!job_id)
                 return log_oom();
 
@@ -476,7 +647,7 @@ static int qmp_setup_ephemeral_drive(VmspawnQmpBridge *bridge, QmpClient *qmp, D
                 ectx_flags |= QMP_DRIVE_DISCARD_NO_UNREF;
 
         *ectx = (EphemeralDriveCtx) {
-                .node_name          = strdup(drive->node_name),
+                .node_name          = strdup(qmp_name),
                 .overlay_file_node  = strdup(overlay_file_node),
                 .base_fmt_node      = strdup(base_fmt_node),
                 .disk_driver        = strdup(drive->disk_driver),
@@ -498,81 +669,355 @@ static int qmp_setup_ephemeral_drive(VmspawnQmpBridge *bridge, QmpClient *qmp, D
         TAKE_PTR(ectx);
 
         r = qmp_client_invoke(qmp, "blockdev-create", QMP_CLIENT_ARGS(cmd_args), on_qmp_complete, (void*) "blockdev-create");
-        if (r < 0)
+        if (r < 0) {
+                _unused_ _cleanup_(pending_job_freep) PendingJob *dead = hashmap_remove(bridge->pending_jobs, job_id);
                 return log_error_errno(r, "Failed to send blockdev-create for '%s': %m", drive->path);
+        }
 
         log_debug("Queued ephemeral drive setup for '%s' (job %s)", drive->path, job_id);
         return 0;
 }
 
-/* Set up a regular (non-ephemeral) drive: single file node + format node + device_add. */
-static int qmp_setup_regular_drive(VmspawnQmpBridge *bridge, QmpClient *qmp, DriveInfo *drive) {
-        int r;
+static int qmp_setup_regular_drive(VmspawnQmpBridge *bridge, DriveInfo *drive) {
+        _cleanup_(drive_info_unrefp) DriveInfo *owned = drive;
 
         assert(bridge);
-        assert(qmp);
         assert(drive);
         assert(drive->fd >= 0);
+        assert(!drive->id);
 
-        /* Node names: <name>-file, <name> */
-        _cleanup_free_ char *file_node_name = strjoin(drive->node_name, "-file");
-        if (!file_node_name)
+        if (asprintf(&owned->id, "bd%" PRIu64, bridge->next_id) < 0)
                 return log_oom();
+        bridge->next_id++;
 
-        _cleanup_free_ char *fdset_path = NULL;
-        r = qmp_fdset_add(qmp, TAKE_FD(drive->fd), &fdset_path);
-        if (r < 0)
-                return log_error_errno(r, "Failed to send add-fd for '%s': %m", drive->path);
+        return vmspawn_qmp_add_block_device(bridge, TAKE_PTR(owned));
+}
 
-        QmpFileNodeParams file_params = {
-                .node_name = file_node_name,
-                .filename  = fdset_path,
-                .driver    = FLAGS_SET(drive->flags, QMP_DRIVE_BLOCK_DEVICE) ? "host_device" : "file",
-                .flags     = drive->flags & (QMP_DRIVE_READ_ONLY|QMP_DRIVE_NO_FLUSH),
-        };
-        if (FLAGS_SET(bridge->features, VMSPAWN_QMP_FEATURE_IO_URING))
-                file_params.flags |= QMP_DRIVE_IO_URING;
-        r = qmp_add_file_node(qmp, &file_params);
-        if (r < 0)
-                return log_error_errno(r, "Failed to send blockdev-add for '%s': %m", drive->path);
+static int reply_qmp_error(sd_varlink *link, const char *error_desc, int error) {
+        assert(link);
 
-        QmpFormatNodeParams fmt_params = {
-                .node_name      = drive->node_name,
-                .format         = drive->format,
-                .file_node_name = file_node_name,
-                .flags          = drive->flags & (QMP_DRIVE_READ_ONLY|QMP_DRIVE_DISCARD),
-        };
-        _cleanup_(sd_json_variant_unrefp) sd_json_variant *fmt_args = NULL;
-        r = qmp_build_blockdev_add_format(&fmt_params, &fmt_args);
-        if (r < 0)
-                return r;
+        if (ERRNO_IS_DISCONNECT(error))
+                return sd_varlink_error(link, "io.systemd.MachineInstance.NotConnected", NULL);
+        if (error_desc)
+                log_warning("QMP error: %s", error_desc);
+        return sd_varlink_error_errno(link, error < 0 ? error : -EIO);
+}
 
-        r = qmp_client_invoke(qmp, "blockdev-add", QMP_CLIENT_ARGS(fmt_args), on_qmp_complete, (void*) "blockdev-add");
-        if (r < 0)
-                return log_error_errno(r, "Failed to send blockdev-add format for '%s': %m", drive->path);
+static int reply_qmp_add_error(sd_varlink *link, const char *error_desc, int error) {
+        assert(link);
 
-        /* device_add: attach to virtual hardware */
-        _cleanup_(sd_json_variant_unrefp) sd_json_variant *device_args = NULL;
-        r = qmp_build_device_add(drive, &device_args);
-        if (r < 0)
-                return r;
+        /* Exact prefixes asserted verbatim in QEMU's iotests (tests/qemu-iotests/087.out);
+         * stable since QEMU 6.0 (blockdev-add) / 6.2 (device_add). */
+        if (error_desc &&
+            (startswith(error_desc, "Duplicate nodes with node-name=") ||
+             startswith(error_desc, "Duplicate device ID ")))
+                return sd_varlink_error(link, "io.systemd.VirtualMachineInstance.BlockDeviceIdInUse", NULL);
+        return reply_qmp_error(link, error_desc, error);
+}
 
-        r = qmp_client_invoke(qmp, "device_add", QMP_CLIENT_ARGS(device_args), on_qmp_complete, (void*) "device_add");
-        if (r < 0)
-                return log_error_errno(r, "Failed to send device_add for '%s': %m", drive->path);
+/* After the pipelined remove-fd at add time, QEMU auto-frees the fdset when
+ * raw_close (during blockdev-del) releases the last dup. So teardown only
+ * needs to fire blockdev-del. */
+void vmspawn_qmp_block_device_teardown(QmpClient *client, const char *id, unsigned stages) {
+        assert(client);
+        assert(id);
 
-        log_debug("Queued drive setup for '%s'", drive->path);
+        if (!FLAGS_SET(stages, BLOCK_DEVICE_ADD_STAGE_BLOCKDEV_ADD))
+                return;
+
+        _cleanup_free_ char *qmp_name = strjoin(QMP_BLOCK_QDEV_PREFIX, id);
+        if (!qmp_name) {
+                (void) log_oom();
+                return;
+        }
+
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *args = NULL;
+        if (sd_json_buildo(&args, SD_JSON_BUILD_PAIR_STRING("node-name", qmp_name)) >= 0)
+                (void) qmp_client_invoke(client, "blockdev-del", QMP_CLIENT_ARGS(args),
+                                         on_qmp_complete, (void*) "teardown blockdev-del");
+}
+
+/* FAILED bit marks the rollback_mask after the first error fires, so cascading
+ * stage callbacks become no-ops. Hotplug replies to the link; boot-time tears
+ * down the event loop. */
+static int drive_info_add_fail(DriveInfo *d, int error, const char *error_desc) {
+        assert(d);
+
+        if (FLAGS_SET(d->rollback_mask, BLOCK_DEVICE_ADD_STAGE_FAILED))
+                return 0;
+
+        vmspawn_qmp_block_device_teardown(d->bridge->qmp, d->id, d->rollback_mask);
+        d->rollback_mask = BLOCK_DEVICE_ADD_STAGE_FAILED;
+
+        if (d->link) {
+                (void) reply_qmp_add_error(d->link, error_desc, error);
+                d->link = sd_varlink_unref(d->link);
+                return 0;
+        }
+
+        log_error_errno(error, "Block device '%s' setup failed: %s",
+                        strna(d->id), strna(error_desc));
+        return sd_event_exit(qmp_client_get_event(d->bridge->qmp), error);
+}
+
+/* Shared by the intermediate stages that don't need to record a rollback bit
+ * (add-fd, remove-fd). Just forwards errors to drive_info_add_fail so cascades
+ * from earlier stage failures get suppressed via the FAILED sentinel. */
+static int on_add_observe_stage(
+                QmpClient *client,
+                sd_json_variant *result,
+                const char *error_desc,
+                int error,
+                void *userdata) {
+
+        _cleanup_(drive_info_unrefp) DriveInfo *d = ASSERT_PTR(userdata);
+        assert(client);
+
+        if (error < 0)
+                return drive_info_add_fail(d, error, error_desc);
         return 0;
 }
 
-/* Configure a single drive via QMP. Dispatches to ephemeral or regular setup. */
-static int qmp_setup_drive(VmspawnQmpBridge *bridge, QmpClient *qmp, DriveInfo *drive) {
+static int on_add_blockdev_stage(
+                QmpClient *client,
+                sd_json_variant *result,
+                const char *error_desc,
+                int error,
+                void *userdata) {
+
+        _cleanup_(drive_info_unrefp) DriveInfo *d = ASSERT_PTR(userdata);
+        assert(client);
+
+        if (error < 0)
+                return drive_info_add_fail(d, error, error_desc);
+
+        d->rollback_mask |= BLOCK_DEVICE_ADD_STAGE_BLOCKDEV_ADD;
+
+        /* A sync error after blockdev-add was queued may have marked the chain FAILED.
+         * The blockdev node we just created is orphaned — tear it down retroactively. */
+        if (FLAGS_SET(d->rollback_mask, BLOCK_DEVICE_ADD_STAGE_FAILED))
+                vmspawn_qmp_block_device_teardown(d->bridge->qmp, d->id,
+                                                  BLOCK_DEVICE_ADD_STAGE_BLOCKDEV_ADD);
+        return 0;
+}
+
+static int on_add_device_add_complete(
+                QmpClient *client,
+                sd_json_variant *result,
+                const char *error_desc,
+                int error,
+                void *userdata) {
+
+        _cleanup_(drive_info_unrefp) DriveInfo *d = ASSERT_PTR(userdata);
+
+        assert(client);
+
+        if (error < 0)
+                return drive_info_add_fail(d, error, error_desc);
+
+        if (FLAGS_SET(d->rollback_mask, BLOCK_DEVICE_ADD_STAGE_FAILED))
+                return 0;
+
+        /* Commit: port stays reserved under owner id until DEVICE_DELETED. */
+        d->pcie_port_idx = -1;
+
+        if (d->link)
+                (void) sd_varlink_replybo(d->link, SD_JSON_BUILD_PAIR_STRING("id", d->id));
+
+        log_info("Block device '%s' attached", d->id);
+        return 0;
+}
+
+static int on_scsi_controller_complete(
+                QmpClient *client,
+                sd_json_variant *result,
+                const char *error_desc,
+                int error,
+                void *userdata) {
+
+        assert(client);
+
+        VmspawnQmpBridge *bridge = ASSERT_PTR(qmp_client_get_userdata(client));
+
+        if (error < 0) {
+                vmspawn_qmp_bridge_release_pcie_port_by_idx(bridge, bridge->scsi_controller_port_idx);
+                bridge->scsi_controller_port_idx = -1;
+                bridge->scsi_controller_created = false;
+                log_warning("virtio-scsi-pci controller setup failed: %s", strna(error_desc));
+                if (!bridge->setup_done)
+                        return sd_event_exit(qmp_client_get_event(client), error);
+                return 0;
+        }
+
+        return 0;
+}
+
+static int qmp_setup_scsi_controller(VmspawnQmpBridge *bridge, const char *pcie_port) {
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *args = NULL;
+        int r;
+
+        assert(bridge);
+
+        r = sd_json_buildo(
+                        &args,
+                        SD_JSON_BUILD_PAIR_STRING("driver", "virtio-scsi-pci"),
+                        SD_JSON_BUILD_PAIR_STRING("id", "vmspawn_scsi"),
+                        SD_JSON_BUILD_PAIR_CONDITION(!!pcie_port, "bus", SD_JSON_BUILD_STRING(pcie_port)));
+        if (r < 0)
+                return log_error_errno(r, "Failed to build SCSI controller JSON: %m");
+
+        r = qmp_client_invoke(bridge->qmp, "device_add", QMP_CLIENT_ARGS(args),
+                              on_scsi_controller_complete, NULL);
+        if (r < 0)
+                return log_error_errno(r, "Failed to send SCSI controller device_add: %m");
+
+        log_debug("Queued virtio-scsi-pci controller setup");
+        return 0;
+}
+
+int vmspawn_qmp_add_block_device(VmspawnQmpBridge *bridge, DriveInfo *drive) {
+        int r;
+
+        assert(bridge);
         assert(drive);
+        assert(drive->id);
+        assert(drive->format);
+        assert(drive->disk_driver);
+        assert(drive->fd >= 0);
 
-        if (drive->overlay_fd >= 0)
-                return qmp_setup_ephemeral_drive(bridge, qmp, drive);
+        _cleanup_(drive_info_unrefp) DriveInfo *owned = drive, *slot_ref = NULL;
+        drive->bridge = bridge;
 
-        return qmp_setup_regular_drive(bridge, qmp, drive);
+        _cleanup_free_ char *qmp_name = strjoin(QMP_BLOCK_QDEV_PREFIX, drive->id);
+        if (!qmp_name)
+                return log_oom();
+
+        /* First SCSI hotplug needs a virtio-scsi-pci controller to attach to. */
+        if (STR_IN_SET(drive->disk_driver, "scsi-hd", "scsi-cd") && !bridge->scsi_controller_created) {
+                _cleanup_free_ char *controller_port = NULL;
+                int controller_port_idx = -1;
+                if (ARCHITECTURE_NEEDS_PCIE_ROOT_PORTS) {
+                        r = vmspawn_qmp_bridge_allocate_pcie_port(bridge, "vmspawn_scsi",
+                                                                  &controller_port, &controller_port_idx);
+                        if (r == -EBUSY)
+                                return log_error_errno(r, "No PCIe hotplug ports left for SCSI controller");
+                        if (r < 0)
+                                return log_oom();
+                }
+
+                r = qmp_setup_scsi_controller(bridge, controller_port);
+                if (r < 0) {
+                        vmspawn_qmp_bridge_release_pcie_port_by_idx(bridge, controller_port_idx);
+                        return r;
+                }
+
+                /* Flip the flag before returning to the event loop so a second SCSI
+                 * hotplug queued before the device_add reply doesn't re-create the
+                 * controller. Reset in the error path of on_scsi_controller_complete. */
+                bridge->scsi_controller_port_idx = controller_port_idx;
+                bridge->scsi_controller_created = true;
+        }
+
+        uint64_t fdset_id;
+        slot_ref = drive_info_ref(drive);
+        r = qmp_fdset_add(bridge->qmp, TAKE_FD(drive->fd),
+                          on_add_observe_stage, slot_ref, &drive->fdset_path, &fdset_id);
+        if (r < 0)
+                return r;
+        TAKE_PTR(slot_ref);
+
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *blockdev_args = NULL;
+        r = qmp_build_blockdev_add_inline(
+                        qmp_name, drive->format, drive->fdset_path,
+                        FLAGS_SET(drive->flags, QMP_DRIVE_BLOCK_DEVICE) ? "host_device" : "file",
+                        drive->flags, bridge->features, &blockdev_args);
+        if (r < 0)
+                return r;
+
+        slot_ref = drive_info_ref(drive);
+        r = qmp_client_invoke(bridge->qmp, "blockdev-add", QMP_CLIENT_ARGS(blockdev_args),
+                              on_add_blockdev_stage, slot_ref);
+        if (r < 0)
+                return r;
+        TAKE_PTR(slot_ref);
+
+        /* Release the monitor's original fd; the blockdev-add above took a dup.
+         * From this point on, blockdev-add is live in QEMU's command queue, so a sync
+         * error here must mark FAILED — the blockdev-add callback will see it and
+         * issue retroactive teardown. */
+        slot_ref = drive_info_ref(drive);
+        r = qmp_fdset_remove(bridge->qmp, fdset_id, on_add_observe_stage, slot_ref);
+        if (r < 0) {
+                drive->rollback_mask |= BLOCK_DEVICE_ADD_STAGE_FAILED;
+                return r;
+        }
+        TAKE_PTR(slot_ref);
+
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *device_args = NULL;
+        r = qmp_build_device_add(drive, qmp_name, &device_args);
+        if (r < 0) {
+                drive->rollback_mask |= BLOCK_DEVICE_ADD_STAGE_FAILED;
+                return r;
+        }
+
+        slot_ref = drive_info_ref(drive);
+        r = qmp_client_invoke(bridge->qmp, "device_add", QMP_CLIENT_ARGS(device_args),
+                              on_add_device_add_complete, slot_ref);
+        if (r < 0) {
+                drive->rollback_mask |= BLOCK_DEVICE_ADD_STAGE_FAILED;
+                return r;
+        }
+        TAKE_PTR(slot_ref);
+
+        TAKE_PTR(owned);
+        return 0;
+}
+
+static int on_remove_device_del_complete(
+                QmpClient *client,
+                sd_json_variant *result,
+                const char *error_desc,
+                int error,
+                void *userdata) {
+
+        _cleanup_(sd_varlink_unrefp) sd_varlink *link = ASSERT_PTR(userdata);
+
+        assert(client);
+
+        if (error < 0) {
+                /* Matches qdev-monitor.c find_device_state(): "Device '%s' not found". */
+                if (error_desc && startswith(error_desc, "Device '"))
+                        return sd_varlink_error(link, "io.systemd.VirtualMachineInstance.NoSuchBlockDevice", NULL);
+                return reply_qmp_error(link, error_desc, error);
+        }
+
+        return sd_varlink_reply(link, NULL);
+}
+
+int vmspawn_qmp_remove_block_device(VmspawnQmpBridge *bridge, sd_varlink *link, const char *id) {
+        int r;
+
+        assert(bridge);
+        assert(link);
+        assert(id);
+
+        _cleanup_free_ char *qmp_name = strjoin(QMP_BLOCK_QDEV_PREFIX, id);
+        if (!qmp_name)
+                return log_oom();
+
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *args = NULL;
+        r = sd_json_buildo(&args, SD_JSON_BUILD_PAIR_STRING("id", qmp_name));
+        if (r < 0)
+                return r;
+
+        sd_varlink_ref(link);
+        r = qmp_client_invoke(bridge->qmp, "device_del", QMP_CLIENT_ARGS(args),
+                              on_remove_device_del_complete, link);
+        if (r < 0) {
+                sd_varlink_unref(link);
+                return r;
+        }
+        return 0;
 }
 
 int vmspawn_qmp_setup_network(VmspawnQmpBridge *bridge, NetworkInfo *network) {
@@ -762,31 +1207,13 @@ int vmspawn_qmp_setup_vsock(VmspawnQmpBridge *bridge, VsockInfo *vsock) {
 static bool drives_need_scsi_controller(DriveInfos *drives) {
         assert(drives);
 
-        FOREACH_ARRAY(d, drives->drives, drives->n_drives)
-                if (STR_IN_SET((*d)->disk_driver, "scsi-hd", "scsi-cd"))
+        FOREACH_ARRAY(d, drives->drives, drives->n_drives) {
+                DriveInfo *drive = *d;
+                if (STR_IN_SET(drive->disk_driver, "scsi-hd", "scsi-cd"))
                         return true;
+        }
 
         return false;
-}
-
-static int qmp_setup_scsi_controller(QmpClient *qmp, const char *pcie_port) {
-        _cleanup_(sd_json_variant_unrefp) sd_json_variant *args = NULL;
-        int r;
-
-        r = sd_json_buildo(
-                        &args,
-                        SD_JSON_BUILD_PAIR_STRING("driver", "virtio-scsi-pci"),
-                        SD_JSON_BUILD_PAIR_STRING("id", "vmspawn_scsi"),
-                        SD_JSON_BUILD_PAIR_CONDITION(!!pcie_port, "bus", SD_JSON_BUILD_STRING(pcie_port)));
-        if (r < 0)
-                return log_error_errno(r, "Failed to build SCSI controller JSON: %m");
-
-        r = qmp_client_invoke(qmp, "device_add", QMP_CLIENT_ARGS(args), on_qmp_complete, (void*) "device_add");
-        if (r < 0)
-                return log_error_errno(r, "Failed to send SCSI controller device_add: %m");
-
-        log_debug("Queued virtio-scsi-pci controller setup");
-        return 0;
 }
 
 int vmspawn_qmp_setup_drives(VmspawnQmpBridge *bridge, DriveInfos *drives) {
@@ -801,13 +1228,16 @@ int vmspawn_qmp_setup_drives(VmspawnQmpBridge *bridge, DriveInfos *drives) {
          * bridge->features is passed to each file node setup call. */
 
         if (drives_need_scsi_controller(drives)) {
-                r = qmp_setup_scsi_controller(qmp, drives->scsi_pcie_port);
+                r = qmp_setup_scsi_controller(bridge, drives->scsi_pcie_port);
                 if (r < 0)
                         return r;
         }
 
         FOREACH_ARRAY(d, drives->drives, drives->n_drives) {
-                r = qmp_setup_drive(bridge, qmp, *d);
+                if ((*d)->overlay_fd >= 0)
+                        r = qmp_setup_ephemeral_drive(bridge, qmp, *d);
+                else
+                        r = qmp_setup_regular_drive(bridge, TAKE_PTR(*d));
                 if (r < 0)
                         return r;
         }
@@ -828,6 +1258,9 @@ VmspawnQmpBridge* vmspawn_qmp_bridge_free(VmspawnQmpBridge *b) {
                 return NULL;
 
         hashmap_free(b->pending_jobs);
+
+        FOREACH_ELEMENT(owner, b->hotplug_port_owner)
+                free(*owner);
 
         qmp_client_unref(b->qmp);
         return mfree(b);
@@ -996,6 +1429,8 @@ int vmspawn_qmp_init(VmspawnQmpBridge **ret, int fd, sd_event *event) {
         if (!bridge)
                 return log_oom();
 
+        bridge->scsi_controller_port_idx = -1;
+
         r = qmp_client_connect_fd(&bridge->qmp, fd);
         if (r < 0)
                 return log_error_errno(r, "Failed to create QMP client: %m");
@@ -1057,9 +1492,9 @@ static int on_cont_complete(
                 int error,
                 void *userdata) {
 
-        VmspawnQmpBridge *bridge = ASSERT_PTR(qmp_client_get_userdata(client));
-
         assert(client);
+
+        VmspawnQmpBridge *bridge = ASSERT_PTR(qmp_client_get_userdata(client));
 
         if (error < 0) {
                 log_error_errno(error, "Failed to resume QEMU execution: %s", strna(error_desc));

--- a/src/vmspawn/vmspawn-qmp.c
+++ b/src/vmspawn/vmspawn-qmp.c
@@ -1042,6 +1042,8 @@ static int on_cont_complete(
                 int error,
                 void *userdata) {
 
+        VmspawnQmpBridge *bridge = ASSERT_PTR(qmp_client_get_userdata(client));
+
         assert(client);
 
         if (error < 0) {
@@ -1049,6 +1051,8 @@ static int on_cont_complete(
                 return sd_event_exit(qmp_client_get_event(client), error);
         }
 
+        /* VM is running — all boot-time device setup has completed. */
+        bridge->setup_done = true;
         return 0;
 }
 

--- a/src/vmspawn/vmspawn-qmp.h
+++ b/src/vmspawn/vmspawn-qmp.h
@@ -5,6 +5,8 @@
 
 #include "shared-forward.h"
 
+#define VMSPAWN_PCIE_HOTPLUG_SPARES 10u
+
 /* Pending job continuation — called when a QMP background job reaches "concluded" state.
  * Used by blockdev-create to chain remaining drive setup after the job completes. */
 typedef int (*pending_job_callback_t)(QmpClient *qmp, void *userdata);
@@ -24,17 +26,29 @@ typedef enum VmspawnQmpFeatureFlags {
         VMSPAWN_QMP_FEATURE_DISCARD_NO_UNREF = 1u << 1,
 } VmspawnQmpFeatureFlags;
 
+/* QMP qdev-id and node-name for every block device are "bd-<varlink-id>";
+ * DEVICE_DELETED events filter on this prefix. */
+#define QMP_BLOCK_QDEV_PREFIX "bd-"
+
 typedef struct VmspawnQmpBridge {
         QmpClient *qmp;
-        Hashmap *pending_jobs;  /* job_id (string, owned) -> PendingJob* */
+        Hashmap *pending_jobs;         /* blockdev-create continuations */
+        char *hotplug_port_owner[VMSPAWN_PCIE_HOTPLUG_SPARES];  /* owner id per port; NULL = free */
+        int scsi_controller_port_idx;  /* hotplug port idx taken by virtio-scsi-pci, -1 if none */
+        uint64_t next_id;              /* monotonic counter for server-assigned bd<N> ids */
         VmspawnQmpFeatureFlags features;
         bool setup_done;
+        bool scsi_controller_created;  /* virtio-scsi-pci has been device_add'd */
 } VmspawnQmpBridge;
 
 VmspawnQmpBridge* vmspawn_qmp_bridge_free(VmspawnQmpBridge *b);
 DEFINE_TRIVIAL_CLEANUP_FUNC(VmspawnQmpBridge *, vmspawn_qmp_bridge_free);
 
 QmpClient* vmspawn_qmp_bridge_get_qmp(VmspawnQmpBridge *b);
+
+int vmspawn_qmp_bridge_allocate_pcie_port(VmspawnQmpBridge *bridge, const char *owner_id, char **ret_name, int *ret_idx);
+void vmspawn_qmp_bridge_release_pcie_port_by_idx(VmspawnQmpBridge *bridge, int idx);
+int vmspawn_qmp_bridge_release_pcie_port_by_id(VmspawnQmpBridge *bridge, const char *owner_id);
 
 /* Phase 1: Connect to VMM backend. Returns an opaque bridge ready for device setup. */
 int vmspawn_qmp_init(VmspawnQmpBridge **ret, int fd, sd_event *event);
@@ -65,24 +79,41 @@ typedef enum QmpDriveFlags {
         QMP_DRIVE_DISCARD_NO_UNREF = 1u << 6,  /* qcow2 only */
 } QmpDriveFlags;
 
-/* Drive info for QMP-based drive setup. All string fields are owned.
- * Each DriveInfo is individually heap-allocated so it can be handed off
- * to the block device registry via TAKE_PTR. */
+typedef enum BlockDeviceAddStage {
+        BLOCK_DEVICE_ADD_STAGE_BLOCKDEV_ADD = 1u << 0,
+        BLOCK_DEVICE_ADD_STAGE_FAILED       = 1u << 1,  /* first error fired; suppress cascades */
+} BlockDeviceAddStage;
+
+/* Ref-counted; each of the four add-stage QMP slots holds one ref.
+ *
+ * link == NULL → boot-time: failure calls sd_event_exit (if !setup_done).
+ * link != NULL → hotplug:    failure replies via the varlink link. */
 typedef struct DriveInfo {
+        unsigned n_ref;
+
+        /* Config */
         char *path;                /* original path (for logging; not passed to QEMU) */
         char *format;              /* "raw" or "qcow2" */
         char *disk_driver;         /* "virtio-blk-pci", "scsi-hd", "scsi-cd", "nvme" */
         char *serial;
-        char *node_name;
         char *pcie_port;           /* pcie-root-port id for device_add bus (NULL on non-PCIe) */
         int fd;                    /* pre-opened image fd (-EBADF if unused) */
         int overlay_fd;            /* pre-opened anonymous overlay fd for ephemeral (-EBADF if unused) */
         QmpDriveFlags flags;
+
+        /* Per-add-op state (populated by the add flow; zeroed at CLI-parse time) */
+        VmspawnQmpBridge *bridge;  /* weak */
+        char *id;                  /* varlink-visible id (bd<N> synthesised, or caller-supplied) */
+        char *fdset_path;          /* "/dev/fdset/N" */
+        int pcie_port_idx;         /* hotplug port idx held by this drive; -1 once committed or unused */
+        unsigned rollback_mask;    /* BlockDeviceAddStage bits of completed stages */
+        sd_varlink *link;          /* ref'd iff hotplug */
 } DriveInfo;
 
 DriveInfo* drive_info_new(void);
-DriveInfo* drive_info_free(DriveInfo *d);
-DEFINE_TRIVIAL_CLEANUP_FUNC(DriveInfo *, drive_info_free);
+DriveInfo* drive_info_ref(DriveInfo *d);
+DriveInfo* drive_info_unref(DriveInfo *d);
+DEFINE_TRIVIAL_CLEANUP_FUNC(DriveInfo *, drive_info_unref);
 
 typedef struct DriveInfos {
         DriveInfo **drives;     /* array of individually heap-allocated entries */
@@ -148,3 +179,10 @@ int vmspawn_qmp_setup_drives(VmspawnQmpBridge *bridge, DriveInfos *drives);
 int vmspawn_qmp_setup_network(VmspawnQmpBridge *bridge, NetworkInfo *network);
 int vmspawn_qmp_setup_virtiofs(VmspawnQmpBridge *bridge, const VirtiofsInfos *virtiofs);
 int vmspawn_qmp_setup_vsock(VmspawnQmpBridge *bridge, VsockInfo *vsock);
+
+int vmspawn_qmp_add_block_device(VmspawnQmpBridge *bridge, DriveInfo *drive);
+int vmspawn_qmp_remove_block_device(VmspawnQmpBridge *bridge, sd_varlink *link, const char *id);
+
+/* Tears down only the stages bit-set in `stages`, so we don't touch state we
+ * didn't create. Used for both error rollback and post-DEVICE_DELETED cleanup. */
+void vmspawn_qmp_block_device_teardown(QmpClient *client, const char *id, unsigned stages);

--- a/src/vmspawn/vmspawn-qmp.h
+++ b/src/vmspawn/vmspawn-qmp.h
@@ -28,6 +28,7 @@ typedef struct VmspawnQmpBridge {
         QmpClient *qmp;
         Hashmap *pending_jobs;  /* job_id (string, owned) -> PendingJob* */
         VmspawnQmpFeatureFlags features;
+        bool setup_done;
 } VmspawnQmpBridge;
 
 VmspawnQmpBridge* vmspawn_qmp_bridge_free(VmspawnQmpBridge *b);

--- a/src/vmspawn/vmspawn-qmp.h
+++ b/src/vmspawn/vmspawn-qmp.h
@@ -65,23 +65,27 @@ typedef enum QmpDriveFlags {
         QMP_DRIVE_DISCARD_NO_UNREF = 1u << 6,  /* qcow2 only */
 } QmpDriveFlags;
 
-/* Drive info for QMP-based drive setup */
+/* Drive info for QMP-based drive setup. All string fields are owned.
+ * Each DriveInfo is individually heap-allocated so it can be handed off
+ * to the block device registry via TAKE_PTR. */
 typedef struct DriveInfo {
-        const char *path;          /* kept for logging only — not passed to QEMU */
-        const char *format;        /* "raw" or "qcow2" */
-        const char *disk_driver;   /* "virtio-blk-pci", "scsi-hd", "scsi-cd", "nvme" */
-        char *serial;              /* owned */
-        char *node_name;           /* owned */
-        char *pcie_port;           /* owned: pcie-root-port id for device_add bus (NULL on non-PCIe) */
-        int fd;                    /* pre-opened image fd (owned, -EBADF if unused) */
-        int overlay_fd;            /* pre-opened anonymous overlay fd for ephemeral (owned, -EBADF if unused) */
+        char *path;                /* original path (for logging; not passed to QEMU) */
+        char *format;              /* "raw" or "qcow2" */
+        char *disk_driver;         /* "virtio-blk-pci", "scsi-hd", "scsi-cd", "nvme" */
+        char *serial;
+        char *node_name;
+        char *pcie_port;           /* pcie-root-port id for device_add bus (NULL on non-PCIe) */
+        int fd;                    /* pre-opened image fd (-EBADF if unused) */
+        int overlay_fd;            /* pre-opened anonymous overlay fd for ephemeral (-EBADF if unused) */
         QmpDriveFlags flags;
 } DriveInfo;
 
-void drive_info_done(DriveInfo *info);
+DriveInfo* drive_info_new(void);
+DriveInfo* drive_info_free(DriveInfo *d);
+DEFINE_TRIVIAL_CLEANUP_FUNC(DriveInfo *, drive_info_free);
 
 typedef struct DriveInfos {
-        DriveInfo *drives;
+        DriveInfo **drives;     /* array of individually heap-allocated entries */
         size_t n_drives;
         char *scsi_pcie_port;  /* owned: pcie-root-port id for SCSI controller (NULL if no SCSI or non-PCIe) */
 } DriveInfos;

--- a/src/vmspawn/vmspawn-settings.c
+++ b/src/vmspawn/vmspawn-settings.c
@@ -3,22 +3,6 @@
 #include "string-table.h"
 #include "vmspawn-settings.h"
 
-static const char *const image_format_table[_IMAGE_FORMAT_MAX] = {
-        [IMAGE_FORMAT_RAW]   = "raw",
-        [IMAGE_FORMAT_QCOW2] = "qcow2",
-};
-
-DEFINE_STRING_TABLE_LOOKUP(image_format, ImageFormat);
-
-static const char *const disk_type_table[_DISK_TYPE_MAX] = {
-        [DISK_TYPE_VIRTIO_BLK]          = "virtio-blk",
-        [DISK_TYPE_VIRTIO_SCSI]         = "virtio-scsi",
-        [DISK_TYPE_NVME]                = "nvme",
-        [DISK_TYPE_VIRTIO_SCSI_CDROM]   = "scsi-cd",
-};
-
-DEFINE_STRING_TABLE_LOOKUP(disk_type, DiskType);
-
 void extra_drive_context_done(ExtraDriveContext *ctx) {
         assert(ctx);
 

--- a/src/vmspawn/vmspawn-settings.h
+++ b/src/vmspawn/vmspawn-settings.h
@@ -1,23 +1,8 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 #pragma once
 
+#include "machine-util.h"
 #include "shared-forward.h"
-
-typedef enum ImageFormat {
-        IMAGE_FORMAT_RAW,
-        IMAGE_FORMAT_QCOW2,
-        _IMAGE_FORMAT_MAX,
-        _IMAGE_FORMAT_INVALID = -EINVAL,
-} ImageFormat;
-
-typedef enum DiskType {
-        DISK_TYPE_VIRTIO_BLK,
-        DISK_TYPE_VIRTIO_SCSI,
-        DISK_TYPE_NVME,
-        DISK_TYPE_VIRTIO_SCSI_CDROM,
-        _DISK_TYPE_MAX,
-        _DISK_TYPE_INVALID = -EINVAL,
-} DiskType;
 
 typedef struct ExtraDrive {
         char *path;
@@ -69,6 +54,4 @@ typedef enum SettingsMask {
 
 DECLARE_STRING_TABLE_LOOKUP(console_mode, ConsoleMode);
 DECLARE_STRING_TABLE_LOOKUP(console_transport, ConsoleTransport);
-DECLARE_STRING_TABLE_LOOKUP(disk_type, DiskType);
 DECLARE_STRING_TABLE_LOOKUP(firmware, Firmware);
-DECLARE_STRING_TABLE_LOOKUP(image_format, ImageFormat);

--- a/src/vmspawn/vmspawn-varlink.c
+++ b/src/vmspawn/vmspawn-varlink.c
@@ -387,6 +387,7 @@ int vmspawn_varlink_setup(
         ctx->bridge = bridge;
         qmp_client_bind_event(ctx->bridge->qmp, on_qmp_event, ctx);
         qmp_client_bind_disconnect(ctx->bridge->qmp, on_qmp_disconnect, ctx);
+        qmp_client_set_userdata(ctx->bridge->qmp, ctx->bridge);
 
         log_debug("Varlink control server listening on %s", listen_address);
 

--- a/src/vmspawn/vmspawn-varlink.c
+++ b/src/vmspawn/vmspawn-varlink.c
@@ -1,23 +1,32 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
+#include <sys/stat.h>
+
 #include "alloc-util.h"
 #include "errno-util.h"
+#include "fd-util.h"
 #include "hashmap.h"
+#include "json-util.h"
 #include "log.h"
 #include "path-util.h"
 #include "qmp-client.h"
+#include "stat-util.h"
 #include "string-util.h"
 #include "strv.h"
 #include "varlink-io.systemd.MachineInstance.h"
 #include "varlink-io.systemd.QemuMachineInstance.h"
 #include "varlink-io.systemd.VirtualMachineInstance.h"
 #include "varlink-util.h"
+#include "vmspawn-qmp.h"
+#include "vmspawn-util.h"
 #include "vmspawn-varlink.h"
 
 DEFINE_PRIVATE_HASH_OPS_FULL(
                 varlink_subscriber_hash_ops,
                 void, trivial_hash_func, trivial_compare_func, sd_varlink_close_unref,
                 char*, strv_free);
+
+static int dispatch_device_deleted(VmspawnVarlinkContext *ctx, sd_json_variant *data);
 
 struct VmspawnVarlinkContext {
         sd_varlink_server *varlink_server;
@@ -51,10 +60,10 @@ static int on_qmp_simple_complete(
 
         assert(client);
 
-        if (error == 0)
-                (void) sd_varlink_reply(link, NULL);
-        else
+        if (error < 0)
                 (void) qmp_error_to_varlink(link, error_desc, error);
+        else
+                (void) sd_varlink_reply(link, NULL);
 
         sd_varlink_unref(link);
         return 0;
@@ -118,18 +127,26 @@ static int on_qmp_describe_complete(
 
         assert(client);
 
-        if (error != 0) {
+        if (error < 0) {
                 (void) qmp_error_to_varlink(link, error_desc, error);
                 return 0;
         }
 
-        sd_json_variant *running = sd_json_variant_by_key(result, "running");
-        sd_json_variant *status = sd_json_variant_by_key(result, "status");
+        sd_json_variant *running_v = sd_json_variant_by_key(result, "running");
+        sd_json_variant *status_v = sd_json_variant_by_key(result, "status");
+
+        bool running = false;
+        if (running_v)
+                running = sd_json_variant_boolean(running_v);
+
+        const char *status = "unknown";
+        if (status_v && sd_json_variant_is_string(status_v))
+                status = sd_json_variant_string(status_v);
 
         (void) sd_varlink_replybo(
                         link,
-                        SD_JSON_BUILD_PAIR_BOOLEAN("running", running ? sd_json_variant_boolean(running) : false),
-                        SD_JSON_BUILD_PAIR_STRING("status", status && sd_json_variant_is_string(status) ? sd_json_variant_string(status) : "unknown"));
+                        SD_JSON_BUILD_PAIR_BOOLEAN("running", running),
+                        SD_JSON_BUILD_PAIR_STRING("status", status));
 
         return 0;
 }
@@ -153,6 +170,10 @@ static int vl_method_subscribe_events(sd_varlink *link, sd_json_variant *paramet
         }, &filter);
         if (r != 0)
                 return r;
+
+        /* Treat [] identically to null: deliver all events. */
+        if (strv_isempty(filter))
+                filter = strv_free(filter);
 
         sd_varlink_ref(link);
 
@@ -258,31 +279,21 @@ static int dispatch_pending_job(VmspawnQmpBridge *bridge, sd_json_variant *data)
         return 1;
 }
 
-static int on_qmp_event(
-                QmpClient *client,
-                const char *event,
-                sd_json_variant *data,
-                void *userdata) {
-
-        VmspawnVarlinkContext *ctx = ASSERT_PTR(userdata);
+static int notify_event_subscribers(VmspawnVarlinkContext *ctx, const char *event_name, sd_json_variant *data) {
         _cleanup_(sd_json_variant_unrefp) sd_json_variant *notification = NULL;
         sd_varlink *link;
         char **filter;
         int r;
 
-        assert(client);
-        assert(event);
-
-        /* Dispatch job status changes to pending continuations (e.g. blockdev-create) */
-        if (streq(event, "JOB_STATUS_CHANGE"))
-                return dispatch_pending_job(ctx->bridge, data);
+        assert(ctx);
+        assert(event_name);
 
         if (hashmap_isempty(ctx->subscribed))
                 return 0;
 
         r = sd_json_buildo(
                         &notification,
-                        SD_JSON_BUILD_PAIR_STRING("event", event),
+                        SD_JSON_BUILD_PAIR_STRING("event", event_name),
                         SD_JSON_BUILD_PAIR_CONDITION(!!data, "data", SD_JSON_BUILD_VARIANT(data)));
         if (r < 0) {
                 log_warning_errno(r, "Failed to build event notification, ignoring: %m");
@@ -290,7 +301,7 @@ static int on_qmp_event(
         }
 
         HASHMAP_FOREACH_KEY(filter, link, ctx->subscribed) {
-                if (filter && !strv_contains(filter, event))
+                if (filter && !strv_contains(filter, event_name))
                         continue;
 
                 r = sd_varlink_notify(link, notification);
@@ -299,6 +310,31 @@ static int on_qmp_event(
         }
 
         return 0;
+}
+
+static int on_qmp_event(
+                QmpClient *client,
+                const char *event,
+                sd_json_variant *data,
+                void *userdata) {
+
+        VmspawnVarlinkContext *ctx = ASSERT_PTR(userdata);
+
+        assert(client);
+        assert(event);
+
+        /* Dispatch job status changes to pending continuations (e.g. blockdev-create) */
+        if (streq(event, "JOB_STATUS_CHANGE"))
+                return dispatch_pending_job(ctx->bridge, data);
+
+        /* Only our own hotplug ids route to the block-device handler; other frontends fall through. */
+        if (streq(event, "DEVICE_DELETED") && data) {
+                const char *id = sd_json_variant_string(sd_json_variant_by_key(data, "device"));
+                if (id && startswith(id, QMP_BLOCK_QDEV_PREFIX))
+                        return dispatch_device_deleted(ctx, data);
+        }
+
+        return notify_event_subscribers(ctx, event, data);
 }
 
 /* Free all subscriber entries — varlink_subscriber_hash_ops handles
@@ -317,6 +353,269 @@ static void on_qmp_disconnect(QmpClient *client, void *userdata) {
 
         /* Propagate connection loss by closing all subscriber connections */
         drain_event_subscribers(&ctx->subscribed);
+}
+
+/* 28-char limit: QEMU's 31-byte BDS node-name limit minus the "bd-" prefix. */
+static bool block_device_id_valid(const char *id) {
+        if (isempty(id))
+                return false;
+        if (strlen(id) > 28)
+                return false;
+        for (const char *p = id; *p; p++)
+                if (!ascii_isalpha(*p) && !ascii_isdigit(*p) && *p != '_' && *p != '-')
+                        return false;
+        return true;
+}
+
+static int vl_method_add_block_device(sd_varlink *link, sd_json_variant *parameters, sd_varlink_method_flags_t flags, void *userdata) {
+        VmspawnVarlinkContext *ctx = ASSERT_PTR(userdata);
+        VmspawnQmpBridge *bridge = ASSERT_PTR(ctx->bridge);
+        struct {
+                unsigned file_descriptor;
+                const char *format;
+                const char *driver;
+                int read_only;
+                int discard;
+                const char *serial;
+                const char *id;
+        } p = {
+                .read_only = -1,
+                .discard = -1,
+        };
+        int r;
+
+        r = sd_varlink_dispatch(link, parameters, (const sd_json_dispatch_field[]) {
+                { "fileDescriptor", _SD_JSON_VARIANT_TYPE_INVALID, sd_json_dispatch_uint,     offsetof(typeof(p), file_descriptor), SD_JSON_MANDATORY },
+                { "format",         SD_JSON_VARIANT_STRING,        sd_json_dispatch_string,   offsetof(typeof(p), format),          SD_JSON_MANDATORY },
+                { "driver",         SD_JSON_VARIANT_STRING,        sd_json_dispatch_string,   offsetof(typeof(p), driver),          SD_JSON_MANDATORY },
+                { "readOnly",       SD_JSON_VARIANT_BOOLEAN,       sd_json_dispatch_tristate, offsetof(typeof(p), read_only),       0                 },
+                { "discard",        SD_JSON_VARIANT_BOOLEAN,       sd_json_dispatch_tristate, offsetof(typeof(p), discard),         0                 },
+                { "serial",         SD_JSON_VARIANT_STRING,        sd_json_dispatch_string,   offsetof(typeof(p), serial),          0                 },
+                { "id",             SD_JSON_VARIANT_STRING,        sd_json_dispatch_string,   offsetof(typeof(p), id),              0                 },
+                {},
+        }, &p);
+        if (r != 0)
+                return r;
+
+        if (!STR_IN_SET(p.format, "raw", "qcow2"))
+                return sd_varlink_error_invalid_parameter_name(link, "format");
+
+        const char *disk_driver;
+        if (streq(p.driver, "virtio_blk"))
+                disk_driver = "virtio-blk-pci";
+        else if (streq(p.driver, "nvme"))
+                disk_driver = "nvme";
+        else if (streq(p.driver, "scsi_hd"))
+                disk_driver = "scsi-hd";
+        else if (streq(p.driver, "scsi_cd"))
+                disk_driver = "scsi-cd";
+        else
+                return sd_varlink_error_invalid_parameter_name(link, "driver");
+
+        bool is_scsi = STR_IN_SET(disk_driver, "scsi-hd", "scsi-cd");
+
+        if (p.id && !block_device_id_valid(p.id))
+                return sd_varlink_error(link, "io.systemd.VirtualMachineInstance.InvalidBlockDeviceId", NULL);
+
+        _cleanup_close_ int image_fd = sd_varlink_peek_dup_fd(link, p.file_descriptor);
+        if (image_fd == -ENXIO)
+                return sd_varlink_error_invalid_parameter_name(link, "fileDescriptor");
+        if (image_fd < 0)
+                return log_debug_errno(image_fd, "Failed to peek fd %u: %m", p.file_descriptor);
+
+        struct stat st;
+        if (fstat(image_fd, &st) < 0)
+                return log_error_errno(errno, "Failed to stat image fd: %m");
+
+        r = stat_verify_regular_or_block(&st);
+        if (r < 0)
+                return sd_varlink_error_invalid_parameter_name(link, "fileDescriptor");
+
+        _cleanup_(drive_info_unrefp) DriveInfo *drive = drive_info_new();
+        if (!drive)
+                return log_oom();
+
+        drive->link = sd_varlink_ref(link);
+
+        if (p.id) {
+                drive->id = strdup(p.id);
+                if (!drive->id)
+                        return log_oom();
+        } else {
+                if (asprintf(&drive->id, "bd%" PRIu64, bridge->next_id) < 0)
+                        return log_oom();
+                bridge->next_id++;
+        }
+
+        drive->format = strdup(p.format);
+        drive->disk_driver = strdup(disk_driver);
+        if (!drive->format || !drive->disk_driver)
+                return log_oom();
+
+        /* NVMe requires a serial; default to the varlink id if caller didn't set one. */
+        const char *serial_src = p.serial;
+        if (!serial_src && streq(disk_driver, "nvme"))
+                serial_src = drive->id;
+        if (serial_src) {
+                drive->serial = strdup(serial_src);
+                if (!drive->serial)
+                        return log_oom();
+        }
+
+        /* SCSI disks attach to the virtio-scsi-pci controller's bus, not a PCIe
+         * root port. The controller itself may consume a port if we have to
+         * create it on-demand — handled inside vmspawn_qmp_add_block_device. */
+        if (ARCHITECTURE_NEEDS_PCIE_ROOT_PORTS && !is_scsi) {
+                r = vmspawn_qmp_bridge_allocate_pcie_port(bridge, drive->id,
+                                                          &drive->pcie_port, &drive->pcie_port_idx);
+                if (r == -EBUSY)
+                        return sd_varlink_error(link, "io.systemd.VirtualMachineInstance.BlockBackendBusy", NULL);
+                if (r < 0)
+                        return log_oom();
+        }
+
+        if (S_ISBLK(st.st_mode))
+                drive->flags |= QMP_DRIVE_BLOCK_DEVICE;
+        if (p.discard > 0)
+                drive->flags |= QMP_DRIVE_DISCARD;
+
+        /* QEMU's fdset match is strict on O_ACCMODE: the pushed fd's access
+         * mode has to match the blockdev's read-only flag. Derive the flag
+         * from the fd; if the caller also set readOnly=true but pushed an
+         * O_RDWR fd, that's inconsistent — reject it. */
+        int fd_flags = fcntl(image_fd, F_GETFL);
+        if (fd_flags < 0)
+                return log_error_errno(errno, "Failed to read fd flags: %m");
+        if ((fd_flags & O_ACCMODE) == O_RDONLY)
+                drive->flags |= QMP_DRIVE_READ_ONLY;
+        else if (p.read_only > 0)
+                return sd_varlink_error_invalid_parameter_name(link, "readOnly");
+
+        drive->fd = TAKE_FD(image_fd);
+
+        return vmspawn_qmp_add_block_device(bridge, TAKE_PTR(drive));
+}
+
+static int dispatch_device_deleted(VmspawnVarlinkContext *ctx, sd_json_variant *data) {
+        assert(ctx);
+        assert(data);
+
+        const char *device = ASSERT_PTR(sd_json_variant_string(sd_json_variant_by_key(data, "device")));
+        assert(startswith(device, QMP_BLOCK_QDEV_PREFIX));
+
+        const char *varlink_id = device + strlen(QMP_BLOCK_QDEV_PREFIX);
+
+        (void) vmspawn_qmp_bridge_release_pcie_port_by_id(ctx->bridge, varlink_id);
+
+        vmspawn_qmp_block_device_teardown(ctx->bridge->qmp, varlink_id,
+                                          BLOCK_DEVICE_ADD_STAGE_BLOCKDEV_ADD);
+
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *event_data = NULL;
+        (void) sd_json_buildo(&event_data, SD_JSON_BUILD_PAIR_STRING("id", varlink_id));
+        (void) notify_event_subscribers(ctx, "BlockDeviceRemoved", event_data);
+
+        log_info("Block device '%s' removed", varlink_id);
+        return 0;
+}
+
+static int vl_method_remove_block_device(sd_varlink *link, sd_json_variant *parameters, sd_varlink_method_flags_t flags, void *userdata) {
+        VmspawnVarlinkContext *ctx = ASSERT_PTR(userdata);
+        VmspawnQmpBridge *bridge = ASSERT_PTR(ctx->bridge);
+        const char *id = NULL;
+        int r;
+
+        r = sd_varlink_dispatch(link, parameters, (const sd_json_dispatch_field[]) {
+                { "id", SD_JSON_VARIANT_STRING, sd_json_dispatch_string, 0, SD_JSON_MANDATORY },
+                {},
+        }, &id);
+        if (r != 0)
+                return r;
+
+        if (!block_device_id_valid(id))
+                return sd_varlink_error(link, "io.systemd.VirtualMachineInstance.InvalidBlockDeviceId", NULL);
+
+        return vmspawn_qmp_remove_block_device(bridge, link, id);
+}
+
+/* Filter by inserted.node-name (the blockdev-add name, e.g. "bd-bd0") — the
+ * top-level "device" field is the legacy -drive name (empty for us), and
+ * "qdev" for virtio-blk-pci is the nested virtio-backend QOM path. */
+static void notify_block_device_entry(sd_varlink *link, sd_json_variant *entry) {
+        assert(link);
+        assert(entry);
+
+        sd_json_variant *inserted = sd_json_variant_by_key(entry, "inserted");
+        if (!inserted)
+                return;
+
+        const char *node_name = sd_json_variant_string(sd_json_variant_by_key(inserted, "node-name"));
+        if (!node_name || !startswith(node_name, QMP_BLOCK_QDEV_PREFIX))
+                return;
+
+        const char *varlink_id = node_name + strlen(QMP_BLOCK_QDEV_PREFIX);
+
+        const char *drv = sd_json_variant_string(sd_json_variant_by_key(inserted, "drv"));
+        const char *format;
+        if (streq_ptr(drv, "raw"))
+                format = "raw";
+        else if (streq_ptr(drv, "qcow2"))
+                format = "qcow2";
+        else
+                return;
+
+        bool ro = false;
+        sd_json_variant *ro_v = sd_json_variant_by_key(inserted, "ro");
+        if (ro_v)
+                ro = sd_json_variant_boolean(ro_v);
+
+        (void) sd_varlink_notifybo(
+                        link,
+                        SD_JSON_BUILD_PAIR_STRING("id", varlink_id),
+                        SD_JSON_BUILD_PAIR_STRING("format", format),
+                        SD_JSON_BUILD_PAIR_BOOLEAN("readOnly", ro));
+}
+
+static int on_list_block_devices_reply(
+                QmpClient *client,
+                sd_json_variant *result,
+                const char *error_desc,
+                int error,
+                void *userdata) {
+
+        _cleanup_(sd_varlink_unrefp) sd_varlink *link = ASSERT_PTR(userdata);
+
+        assert(client);
+
+        if (error < 0) {
+                if (ERRNO_IS_DISCONNECT(error))
+                        return sd_varlink_error(link, "io.systemd.MachineInstance.NotConnected", NULL);
+                if (error_desc)
+                        log_warning("query-block failed: %s", error_desc);
+                return sd_varlink_error_errno(link, error);
+        }
+
+        sd_json_variant *entry;
+        JSON_VARIANT_ARRAY_FOREACH(entry, result)
+                notify_block_device_entry(link, entry);
+
+        return sd_varlink_reply(link, NULL);
+}
+
+static int vl_method_list_block_devices(sd_varlink *link, sd_json_variant *parameters, sd_varlink_method_flags_t flags, void *userdata) {
+        VmspawnVarlinkContext *ctx = ASSERT_PTR(userdata);
+        int r;
+
+        if (!FLAGS_SET(flags, SD_VARLINK_METHOD_MORE))
+                return sd_varlink_error(link, SD_VARLINK_ERROR_EXPECTED_MORE, NULL);
+
+        sd_varlink_ref(link);
+        r = qmp_client_invoke(ctx->bridge->qmp, "query-block", QMP_CLIENT_ARGS(NULL),
+                              on_list_block_devices_reply, link);
+        if (r < 0) {
+                sd_varlink_unref(link);
+                return r;
+        }
+        return 0;
 }
 
 int vmspawn_varlink_setup(
@@ -342,7 +641,7 @@ int vmspawn_varlink_setup(
 
         /* Create varlink server for VM control */
         r = varlink_server_new(&ctx->varlink_server,
-                               SD_VARLINK_SERVER_INHERIT_USERDATA,
+                               SD_VARLINK_SERVER_INHERIT_USERDATA|SD_VARLINK_SERVER_ALLOW_FD_PASSING_INPUT,
                                ctx);
         if (r < 0)
                 return log_error_errno(r, "Failed to create varlink server: %m");
@@ -357,14 +656,17 @@ int vmspawn_varlink_setup(
 
         r = sd_varlink_server_bind_method_many(
                         ctx->varlink_server,
-                        "io.systemd.MachineInstance.Terminate",         vl_method_terminate,
-                        "io.systemd.MachineInstance.PowerOff",          vl_method_power_off,
-                        "io.systemd.MachineInstance.Pause",             vl_method_pause,
-                        "io.systemd.MachineInstance.Resume",            vl_method_resume,
-                        "io.systemd.MachineInstance.Reboot",            vl_method_reboot,
-                        "io.systemd.MachineInstance.Describe",          vl_method_describe,
-                        "io.systemd.MachineInstance.SubscribeEvents",   vl_method_subscribe_events,
-                        "io.systemd.QemuMachineInstance.AcquireQMP",    vl_method_acquire_qmp);
+                        "io.systemd.MachineInstance.Terminate",                   vl_method_terminate,
+                        "io.systemd.MachineInstance.PowerOff",                    vl_method_power_off,
+                        "io.systemd.MachineInstance.Pause",                       vl_method_pause,
+                        "io.systemd.MachineInstance.Resume",                      vl_method_resume,
+                        "io.systemd.MachineInstance.Reboot",                      vl_method_reboot,
+                        "io.systemd.MachineInstance.Describe",                    vl_method_describe,
+                        "io.systemd.MachineInstance.SubscribeEvents",             vl_method_subscribe_events,
+                        "io.systemd.VirtualMachineInstance.AddBlockDevice",       vl_method_add_block_device,
+                        "io.systemd.VirtualMachineInstance.RemoveBlockDevice",    vl_method_remove_block_device,
+                        "io.systemd.VirtualMachineInstance.ListBlockDevices",     vl_method_list_block_devices,
+                        "io.systemd.QemuMachineInstance.AcquireQMP",              vl_method_acquire_qmp);
         if (r < 0)
                 return log_error_errno(r, "Failed to bind varlink methods: %m");
 

--- a/src/vmspawn/vmspawn-varlink.c
+++ b/src/vmspawn/vmspawn-varlink.c
@@ -1,17 +1,25 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
+#include <sys/stat.h>
+
 #include "alloc-util.h"
 #include "errno-util.h"
+#include "fd-util.h"
 #include "hashmap.h"
+#include "json-util.h"
 #include "log.h"
+#include "machine-util.h"
 #include "path-util.h"
 #include "qmp-client.h"
+#include "stat-util.h"
 #include "string-util.h"
 #include "strv.h"
 #include "varlink-io.systemd.MachineInstance.h"
 #include "varlink-io.systemd.QemuMachineInstance.h"
 #include "varlink-io.systemd.VirtualMachineInstance.h"
 #include "varlink-util.h"
+#include "vmspawn-qmp.h"
+#include "vmspawn-util.h"
 #include "vmspawn-varlink.h"
 
 DEFINE_PRIVATE_HASH_OPS_FULL(
@@ -51,10 +59,10 @@ static int on_qmp_simple_complete(
 
         assert(client);
 
-        if (error == 0)
-                (void) sd_varlink_reply(link, NULL);
-        else
+        if (error < 0)
                 (void) qmp_error_to_varlink(link, error_desc, error);
+        else
+                (void) sd_varlink_reply(link, NULL);
 
         sd_varlink_unref(link);
         return 0;
@@ -118,18 +126,26 @@ static int on_qmp_describe_complete(
 
         assert(client);
 
-        if (error != 0) {
+        if (error < 0) {
                 (void) qmp_error_to_varlink(link, error_desc, error);
                 return 0;
         }
 
-        sd_json_variant *running = sd_json_variant_by_key(result, "running");
-        sd_json_variant *status = sd_json_variant_by_key(result, "status");
+        sd_json_variant *running_v = sd_json_variant_by_key(result, "running");
+        sd_json_variant *status_v = sd_json_variant_by_key(result, "status");
+
+        bool running = false;
+        if (running_v)
+                running = sd_json_variant_boolean(running_v);
+
+        const char *status = "unknown";
+        if (status_v && sd_json_variant_is_string(status_v))
+                status = sd_json_variant_string(status_v);
 
         (void) sd_varlink_replybo(
                         link,
-                        SD_JSON_BUILD_PAIR_BOOLEAN("running", running ? sd_json_variant_boolean(running) : false),
-                        SD_JSON_BUILD_PAIR_STRING("status", status && sd_json_variant_is_string(status) ? sd_json_variant_string(status) : "unknown"));
+                        SD_JSON_BUILD_PAIR_BOOLEAN("running", running),
+                        SD_JSON_BUILD_PAIR_STRING("status", status));
 
         return 0;
 }
@@ -153,6 +169,10 @@ static int vl_method_subscribe_events(sd_varlink *link, sd_json_variant *paramet
         }, &filter);
         if (r != 0)
                 return r;
+
+        /* Treat [] identically to null: deliver all events. */
+        if (strv_isempty(filter))
+                filter = strv_free(filter);
 
         sd_varlink_ref(link);
 
@@ -258,31 +278,21 @@ static int dispatch_pending_job(VmspawnQmpBridge *bridge, sd_json_variant *data)
         return 1;
 }
 
-static int on_qmp_event(
-                QmpClient *client,
-                const char *event,
-                sd_json_variant *data,
-                void *userdata) {
-
-        VmspawnVarlinkContext *ctx = ASSERT_PTR(userdata);
+static int notify_event_subscribers(VmspawnVarlinkContext *ctx, const char *event_name, sd_json_variant *data) {
         _cleanup_(sd_json_variant_unrefp) sd_json_variant *notification = NULL;
         sd_varlink *link;
         char **filter;
         int r;
 
-        assert(client);
-        assert(event);
-
-        /* Dispatch job status changes to pending continuations (e.g. blockdev-create) */
-        if (streq(event, "JOB_STATUS_CHANGE"))
-                return dispatch_pending_job(ctx->bridge, data);
+        assert(ctx);
+        assert(event_name);
 
         if (hashmap_isempty(ctx->subscribed))
                 return 0;
 
         r = sd_json_buildo(
                         &notification,
-                        SD_JSON_BUILD_PAIR_STRING("event", event),
+                        SD_JSON_BUILD_PAIR_STRING("event", event_name),
                         SD_JSON_BUILD_PAIR_CONDITION(!!data, "data", SD_JSON_BUILD_VARIANT(data)));
         if (r < 0) {
                 log_warning_errno(r, "Failed to build event notification, ignoring: %m");
@@ -290,7 +300,7 @@ static int on_qmp_event(
         }
 
         HASHMAP_FOREACH_KEY(filter, link, ctx->subscribed) {
-                if (filter && !strv_contains(filter, event))
+                if (filter && !strv_contains(filter, event_name))
                         continue;
 
                 r = sd_varlink_notify(link, notification);
@@ -299,6 +309,51 @@ static int on_qmp_event(
         }
 
         return 0;
+}
+
+static int dispatch_device_deleted(VmspawnVarlinkContext *ctx, const char *drive_id) {
+        assert(ctx);
+        assert(drive_id);
+
+        (void) vmspawn_qmp_bridge_release_pcie_port_by_id(ctx->bridge, drive_id);
+
+        vmspawn_qmp_block_device_teardown(ctx->bridge->qmp, drive_id,
+                                          BLOCK_DEVICE_ADD_STAGE_BLOCKDEV_ADD);
+
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *event_data = NULL;
+        (void) sd_json_buildo(&event_data, SD_JSON_BUILD_PAIR_STRING("id", drive_id));
+        (void) notify_event_subscribers(ctx, "BlockDeviceRemoved", event_data);
+
+        log_info("Block device '%s' removed", drive_id);
+        return 0;
+}
+
+static int on_qmp_event(
+                QmpClient *client,
+                const char *event,
+                sd_json_variant *data,
+                void *userdata) {
+
+        VmspawnVarlinkContext *ctx = ASSERT_PTR(userdata);
+
+        assert(client);
+        assert(event);
+
+        /* Dispatch job status changes to pending continuations (e.g. blockdev-create) */
+        if (streq(event, "JOB_STATUS_CHANGE"))
+                return dispatch_pending_job(ctx->bridge, data);
+
+        /* Only our own hotplug ids route to the block-device handler; other frontends fall through. */
+        if (streq(event, "DEVICE_DELETED") && data) {
+                const char *id = sd_json_variant_string(sd_json_variant_by_key(data, "device"));
+                if (id) {
+                        const char *drive_id = startswith(id, QMP_BLOCK_QDEV_PREFIX);
+                        if (drive_id)
+                                return dispatch_device_deleted(ctx, drive_id);
+                }
+        }
+
+        return notify_event_subscribers(ctx, event, data);
 }
 
 /* Free all subscriber entries — varlink_subscriber_hash_ops handles
@@ -317,6 +372,238 @@ static void on_qmp_disconnect(QmpClient *client, void *userdata) {
 
         /* Propagate connection loss by closing all subscriber connections */
         drain_event_subscribers(&ctx->subscribed);
+}
+
+/* 28-char limit: QEMU's 31-byte BDS node-name limit minus the "bd-" prefix. */
+static bool block_device_id_valid(const char *id) {
+        if (isempty(id))
+                return false;
+        if (strlen(id) > 28)
+                return false;
+        for (const char *p = id; *p; p++)
+                if (!ascii_isalpha(*p) && !ascii_isdigit(*p) && *p != '_' && *p != '-')
+                        return false;
+        return true;
+}
+
+static int vl_method_add_block_device(sd_varlink *link, sd_json_variant *parameters, sd_varlink_method_flags_t flags, void *userdata) {
+        VmspawnVarlinkContext *ctx = ASSERT_PTR(userdata);
+        VmspawnQmpBridge *bridge = ASSERT_PTR(ctx->bridge);
+        struct {
+                unsigned file_descriptor;
+                const char *format;
+                const char *driver;
+                int read_only;
+                int discard;
+                const char *serial;
+                const char *id;
+        } p = {
+                .read_only = -1,
+                .discard = -1,
+        };
+        int r;
+
+        r = sd_varlink_dispatch(link, parameters, (const sd_json_dispatch_field[]) {
+                { "fileDescriptor", _SD_JSON_VARIANT_TYPE_INVALID, sd_json_dispatch_uint,     offsetof(typeof(p), file_descriptor), SD_JSON_MANDATORY },
+                { "format",         SD_JSON_VARIANT_STRING,        sd_json_dispatch_string,   offsetof(typeof(p), format),          SD_JSON_MANDATORY },
+                { "driver",         SD_JSON_VARIANT_STRING,        sd_json_dispatch_string,   offsetof(typeof(p), driver),          SD_JSON_MANDATORY },
+                { "readOnly",       SD_JSON_VARIANT_BOOLEAN,       sd_json_dispatch_tristate, offsetof(typeof(p), read_only),       0                 },
+                { "discard",        SD_JSON_VARIANT_BOOLEAN,       sd_json_dispatch_tristate, offsetof(typeof(p), discard),         0                 },
+                { "serial",         SD_JSON_VARIANT_STRING,        sd_json_dispatch_string,   offsetof(typeof(p), serial),          0                 },
+                { "id",             SD_JSON_VARIANT_STRING,        sd_json_dispatch_string,   offsetof(typeof(p), id),              0                 },
+                {},
+        }, &p);
+        if (r != 0)
+                return r;
+
+        if (!STR_IN_SET(p.format, "raw", "qcow2"))
+                return sd_varlink_error_invalid_parameter_name(link, "format");
+
+        DiskType dt = disk_type_from_block_driver(p.driver);
+        if (dt < 0)
+                return sd_varlink_error_invalid_parameter_name(link, "driver");
+
+        const char *disk_driver = ASSERT_PTR(disk_type_to_qemu_device_driver(dt));
+        bool is_scsi = IN_SET(dt, DISK_TYPE_VIRTIO_SCSI, DISK_TYPE_VIRTIO_SCSI_CDROM);
+
+        if (p.id && !block_device_id_valid(p.id))
+                return sd_varlink_error(link, "io.systemd.VirtualMachineInstance.InvalidBlockDeviceId", NULL);
+
+        _cleanup_close_ int image_fd = sd_varlink_peek_dup_fd(link, p.file_descriptor);
+        if (image_fd == -ENXIO)
+                return sd_varlink_error_invalid_parameter_name(link, "fileDescriptor");
+        if (image_fd < 0)
+                return log_debug_errno(image_fd, "Failed to peek fd %u: %m", p.file_descriptor);
+
+        struct stat st;
+        if (fstat(image_fd, &st) < 0)
+                return log_error_errno(errno, "Failed to stat image fd: %m");
+
+        r = stat_verify_regular_or_block(&st);
+        if (r < 0)
+                return sd_varlink_error_invalid_parameter_name(link, "fileDescriptor");
+
+        _cleanup_(drive_info_unrefp) DriveInfo *drive = drive_info_new();
+        if (!drive)
+                return log_oom();
+
+        drive->link = sd_varlink_ref(link);
+
+        if (p.id) {
+                drive->id = strdup(p.id);
+                if (!drive->id)
+                        return log_oom();
+        } else {
+                if (asprintf(&drive->id, "bd%" PRIu64, bridge->next_id) < 0)
+                        return log_oom();
+                bridge->next_id++;
+        }
+
+        drive->format = strdup(p.format);
+        drive->disk_driver = strdup(disk_driver);
+        if (!drive->format || !drive->disk_driver)
+                return log_oom();
+
+        /* NVMe requires a serial; default to the varlink id if caller didn't set one. */
+        const char *serial_src = p.serial;
+        if (!serial_src && streq(disk_driver, "nvme"))
+                serial_src = drive->id;
+        if (serial_src) {
+                drive->serial = strdup(serial_src);
+                if (!drive->serial)
+                        return log_oom();
+        }
+
+        /* SCSI disks attach to the virtio-scsi-pci controller's bus, not a PCIe
+         * root port. The controller itself may consume a port if we have to
+         * create it on-demand — handled inside vmspawn_qmp_add_block_device. */
+        if (ARCHITECTURE_NEEDS_PCIE_ROOT_PORTS && !is_scsi) {
+                r = vmspawn_qmp_bridge_allocate_pcie_port(bridge, drive->id,
+                                                          &drive->pcie_port, &drive->pcie_port_idx);
+                if (r == -EBUSY)
+                        return sd_varlink_error(link, "io.systemd.VirtualMachineInstance.BlockBackendBusy", NULL);
+                if (r < 0)
+                        return log_oom();
+        }
+
+        if (S_ISBLK(st.st_mode))
+                drive->flags |= QMP_DRIVE_BLOCK_DEVICE;
+        if (p.discard > 0)
+                drive->flags |= QMP_DRIVE_DISCARD;
+
+        /* QEMU's fdset match is strict on O_ACCMODE: the pushed fd's access
+         * mode has to match the blockdev's read-only flag. Derive the flag
+         * from the fd; if the caller also set readOnly=true but pushed an
+         * O_RDWR fd, that's inconsistent — reject it. */
+        int fd_flags = fcntl(image_fd, F_GETFL);
+        if (fd_flags < 0)
+                return log_error_errno(errno, "Failed to read fd flags: %m");
+        if ((fd_flags & O_ACCMODE) == O_RDONLY)
+                drive->flags |= QMP_DRIVE_READ_ONLY;
+        else if (p.read_only > 0)
+                return sd_varlink_error_invalid_parameter_name(link, "readOnly");
+
+        drive->fd = TAKE_FD(image_fd);
+
+        return vmspawn_qmp_add_block_device(bridge, TAKE_PTR(drive));
+}
+
+static int vl_method_remove_block_device(sd_varlink *link, sd_json_variant *parameters, sd_varlink_method_flags_t flags, void *userdata) {
+        VmspawnVarlinkContext *ctx = ASSERT_PTR(userdata);
+        VmspawnQmpBridge *bridge = ASSERT_PTR(ctx->bridge);
+        const char *id = NULL;
+        int r;
+
+        r = sd_varlink_dispatch(link, parameters, (const sd_json_dispatch_field[]) {
+                { "id", SD_JSON_VARIANT_STRING, sd_json_dispatch_string, 0, SD_JSON_MANDATORY },
+                {},
+        }, &id);
+        if (r != 0)
+                return r;
+
+        if (!block_device_id_valid(id))
+                return sd_varlink_error(link, "io.systemd.VirtualMachineInstance.InvalidBlockDeviceId", NULL);
+
+        return vmspawn_qmp_remove_block_device(bridge, link, id);
+}
+
+/* Filter by inserted.node-name (the blockdev-add name, e.g. "bd-bd0") — the
+ * top-level "device" field is the legacy -drive name (empty for us), and
+ * "qdev" for virtio-blk-pci is the nested virtio-backend QOM path. */
+static void notify_block_device_entry(sd_varlink *link, sd_json_variant *entry) {
+        assert(link);
+        assert(entry);
+
+        sd_json_variant *inserted = sd_json_variant_by_key(entry, "inserted");
+        if (!inserted)
+                return;
+
+        const char *node_name = sd_json_variant_string(sd_json_variant_by_key(inserted, "node-name"));
+        if (!node_name || !startswith(node_name, QMP_BLOCK_QDEV_PREFIX))
+                return;
+
+        const char *varlink_id = node_name + strlen(QMP_BLOCK_QDEV_PREFIX);
+
+        const char *drv = sd_json_variant_string(sd_json_variant_by_key(inserted, "drv"));
+        const char *format = NULL;
+        if (streq_ptr(drv, "raw"))
+                format = "raw";
+        else if (streq_ptr(drv, "qcow2"))
+                format = "qcow2";
+
+        bool ro = false;
+        sd_json_variant *ro_v = sd_json_variant_by_key(inserted, "ro");
+        if (ro_v)
+                ro = sd_json_variant_boolean(ro_v);
+
+        (void) sd_varlink_notifybo(
+                        link,
+                        SD_JSON_BUILD_PAIR_STRING("id", varlink_id),
+                        SD_JSON_BUILD_PAIR_CONDITION(!!format, "format", SD_JSON_BUILD_STRING(format)),
+                        SD_JSON_BUILD_PAIR_BOOLEAN("readOnly", ro));
+}
+
+static int on_list_block_devices_reply(
+                QmpClient *client,
+                sd_json_variant *result,
+                const char *error_desc,
+                int error,
+                void *userdata) {
+
+        _cleanup_(sd_varlink_unrefp) sd_varlink *link = ASSERT_PTR(userdata);
+
+        assert(client);
+
+        if (error < 0) {
+                if (ERRNO_IS_DISCONNECT(error))
+                        return sd_varlink_error(link, "io.systemd.MachineInstance.NotConnected", NULL);
+                if (error_desc)
+                        log_warning("query-block failed: %s", error_desc);
+                return sd_varlink_error_errno(link, error);
+        }
+
+        sd_json_variant *entry;
+        JSON_VARIANT_ARRAY_FOREACH(entry, result)
+                notify_block_device_entry(link, entry);
+
+        return sd_varlink_reply(link, NULL);
+}
+
+static int vl_method_list_block_devices(sd_varlink *link, sd_json_variant *parameters, sd_varlink_method_flags_t flags, void *userdata) {
+        VmspawnVarlinkContext *ctx = ASSERT_PTR(userdata);
+        int r;
+
+        if (!FLAGS_SET(flags, SD_VARLINK_METHOD_MORE))
+                return sd_varlink_error(link, SD_VARLINK_ERROR_EXPECTED_MORE, NULL);
+
+        sd_varlink_ref(link);
+        r = qmp_client_invoke(ctx->bridge->qmp, "query-block", QMP_CLIENT_ARGS(NULL),
+                              on_list_block_devices_reply, link);
+        if (r < 0) {
+                sd_varlink_unref(link);
+                return r;
+        }
+        return 0;
 }
 
 int vmspawn_varlink_setup(
@@ -342,7 +629,7 @@ int vmspawn_varlink_setup(
 
         /* Create varlink server for VM control */
         r = varlink_server_new(&ctx->varlink_server,
-                               SD_VARLINK_SERVER_INHERIT_USERDATA,
+                               SD_VARLINK_SERVER_INHERIT_USERDATA|SD_VARLINK_SERVER_ALLOW_FD_PASSING_INPUT,
                                ctx);
         if (r < 0)
                 return log_error_errno(r, "Failed to create varlink server: %m");
@@ -357,14 +644,17 @@ int vmspawn_varlink_setup(
 
         r = sd_varlink_server_bind_method_many(
                         ctx->varlink_server,
-                        "io.systemd.MachineInstance.Terminate",         vl_method_terminate,
-                        "io.systemd.MachineInstance.PowerOff",          vl_method_power_off,
-                        "io.systemd.MachineInstance.Pause",             vl_method_pause,
-                        "io.systemd.MachineInstance.Resume",            vl_method_resume,
-                        "io.systemd.MachineInstance.Reboot",            vl_method_reboot,
-                        "io.systemd.MachineInstance.Describe",          vl_method_describe,
-                        "io.systemd.MachineInstance.SubscribeEvents",   vl_method_subscribe_events,
-                        "io.systemd.QemuMachineInstance.AcquireQMP",    vl_method_acquire_qmp);
+                        "io.systemd.MachineInstance.Terminate",                   vl_method_terminate,
+                        "io.systemd.MachineInstance.PowerOff",                    vl_method_power_off,
+                        "io.systemd.MachineInstance.Pause",                       vl_method_pause,
+                        "io.systemd.MachineInstance.Resume",                      vl_method_resume,
+                        "io.systemd.MachineInstance.Reboot",                      vl_method_reboot,
+                        "io.systemd.MachineInstance.Describe",                    vl_method_describe,
+                        "io.systemd.MachineInstance.SubscribeEvents",             vl_method_subscribe_events,
+                        "io.systemd.VirtualMachineInstance.AddBlockDevice",       vl_method_add_block_device,
+                        "io.systemd.VirtualMachineInstance.RemoveBlockDevice",    vl_method_remove_block_device,
+                        "io.systemd.VirtualMachineInstance.ListBlockDevices",     vl_method_list_block_devices,
+                        "io.systemd.QemuMachineInstance.AcquireQMP",              vl_method_acquire_qmp);
         if (r < 0)
                 return log_error_errno(r, "Failed to bind varlink methods: %m");
 

--- a/src/vmspawn/vmspawn.c
+++ b/src/vmspawn/vmspawn.c
@@ -2298,7 +2298,6 @@ static int qemu_config_add_qmp_monitor(FILE *config_file, int bridge_fds[2], int
 }
 
 static int resolve_disk_driver(DiskType dt, const char *filename, DriveInfo *info) {
-        const char *driver;
         size_t serial_max;
         int r;
 
@@ -2307,19 +2306,15 @@ static int resolve_disk_driver(DiskType dt, const char *filename, DriveInfo *inf
 
         switch (dt) {
         case DISK_TYPE_VIRTIO_BLK:
-                driver = "virtio-blk-pci";
                 serial_max = DISK_SERIAL_MAX_LEN_VIRTIO_BLK;
                 break;
         case DISK_TYPE_VIRTIO_SCSI:
-                driver = "scsi-hd";
                 serial_max = DISK_SERIAL_MAX_LEN_SCSI;
                 break;
         case DISK_TYPE_NVME:
-                driver = "nvme";
                 serial_max = DISK_SERIAL_MAX_LEN_NVME;
                 break;
         case DISK_TYPE_VIRTIO_SCSI_CDROM:
-                driver = "scsi-cd";
                 serial_max = DISK_SERIAL_MAX_LEN_SCSI;
                 info->flags |= QMP_DRIVE_READ_ONLY;
                 break;
@@ -2327,7 +2322,7 @@ static int resolve_disk_driver(DiskType dt, const char *filename, DriveInfo *inf
                 assert_not_reached();
         }
 
-        info->disk_driver = strdup(driver);
+        info->disk_driver = strdup(ASSERT_PTR(disk_type_to_qemu_device_driver(dt)));
         if (!info->disk_driver)
                 return log_oom();
 

--- a/src/vmspawn/vmspawn.c
+++ b/src/vmspawn/vmspawn.c
@@ -757,39 +757,9 @@ static int parse_argv(int argc, char *argv[]) {
                 OPTION_LONG("extra-drive", "[FORMAT:][DISKTYPE:]PATH", "Adds an additional disk to the VM"): {
                         ImageFormat format = IMAGE_FORMAT_RAW;
                         DiskType extra_disk_type = _DISK_TYPE_INVALID;
-                        const char *dp = arg;
-
-                        /* Parse optional colon-separated prefixes. The format and disk type
-                         * value sets don't overlap, so they can appear in any order. */
-                        for (;;) {
-                                const char *colon = strchr(dp, ':');
-                                if (!colon)
-                                        break;
-
-                                _cleanup_free_ char *prefix = strndup(dp, colon - dp);
-                                if (!prefix)
-                                        return log_oom();
-
-                                ImageFormat f = image_format_from_string(prefix);
-                                if (f >= 0) {
-                                        format = f;
-                                        dp = colon + 1;
-                                        continue;
-                                }
-
-                                DiskType dt = disk_type_from_string(prefix);
-                                if (dt >= 0) {
-                                        extra_disk_type = dt;
-                                        dp = colon + 1;
-                                        continue;
-                                }
-
-                                /* Not a recognized prefix, treat the rest as the path */
-                                break;
-                        }
-
                         _cleanup_free_ char *drive_path = NULL;
-                        r = parse_path_argument(dp, /* suppress_root= */ false, &drive_path);
+
+                        r = parse_disk_spec(arg, &format, &extra_disk_type, &drive_path);
                         if (r < 0)
                                 return r;
 

--- a/src/vmspawn/vmspawn.c
+++ b/src/vmspawn/vmspawn.c
@@ -104,8 +104,7 @@
 #define DISK_SERIAL_MAX_LEN_NVME        20
 #define DISK_SERIAL_MAX_LEN_VIRTIO_BLK  20
 
-/* Spare pcie-root-ports reserved for future runtime hotplug beyond the pre-wired devices. */
-#define VMSPAWN_PCIE_HOTPLUG_SPARES 10u
+/* VMSPAWN_PCIE_HOTPLUG_SPARES lives in vmspawn-qmp.h */
 
 /* An enum controlling how auxiliary state for the VM are maintained, i.e. the TPM state and the EFI variable
  * NVRAM. */
@@ -2382,7 +2381,7 @@ static int prepare_primary_drive(const char *runtime_dir, DriveInfos *drives) {
         if (r < 0)
                 return log_error_errno(r, "Failed to extract filename from path '%s': %m", arg_image);
 
-        _cleanup_(drive_info_freep) DriveInfo *d = drive_info_new();
+        _cleanup_(drive_info_unrefp) DriveInfo *d = drive_info_new();
         if (!d)
                 return log_oom();
 
@@ -2406,8 +2405,7 @@ static int prepare_primary_drive(const char *runtime_dir, DriveInfos *drives) {
 
         d->path = strdup(arg_image);
         d->format = strdup(image_format_to_string(arg_image_format));
-        d->node_name = strdup("vmspawn");
-        if (!d->path || !d->format || !d->node_name)
+        if (!d->path || !d->format)
                 return log_oom();
         d->fd = TAKE_FD(image_fd);
         if (S_ISBLK(st.st_mode))
@@ -2443,7 +2441,6 @@ static int prepare_extra_drives(DriveInfos *drives) {
 
         assert(drives);
 
-        size_t extra_idx = 0;
         FOREACH_ARRAY(drive, arg_extra_drives.drives, arg_extra_drives.n_drives) {
                 _cleanup_free_ char *drive_fn = NULL;
                 r = path_extract_filename(drive->path, &drive_fn);
@@ -2452,7 +2449,7 @@ static int prepare_extra_drives(DriveInfos *drives) {
 
                 DiskType dt = drive->disk_type >= 0 ? drive->disk_type : arg_image_disk_type;
 
-                _cleanup_(drive_info_freep) DriveInfo *d = drive_info_new();
+                _cleanup_(drive_info_unrefp) DriveInfo *d = drive_info_new();
                 if (!d)
                         return log_oom();
 
@@ -2484,9 +2481,6 @@ static int prepare_extra_drives(DriveInfos *drives) {
                         d->flags |= QMP_DRIVE_BLOCK_DEVICE;
                 d->flags |= QMP_DRIVE_NO_FLUSH;
 
-                if (asprintf(&d->node_name, "vmspawn_extra_%zu", extra_idx++) < 0)
-                        return log_oom();
-
                 drives->drives[drives->n_drives++] = TAKE_PTR(d);
         }
 
@@ -2511,11 +2505,12 @@ static int assign_pcie_ports(MachineConfig *c) {
         /* Drives: non-SCSI drives get individual ports, SCSI controller gets one port */
         bool need_scsi = false;
         FOREACH_ARRAY(d, drives->drives, drives->n_drives) {
-                if (STR_IN_SET((*d)->disk_driver, "scsi-hd", "scsi-cd")) {
+                DriveInfo *drive = *d;
+                if (STR_IN_SET(drive->disk_driver, "scsi-hd", "scsi-cd")) {
                         need_scsi = true;
                         continue;
                 }
-                if (asprintf(&(*d)->pcie_port, "vmspawn-pcieport-%zu", port++) < 0)
+                if (asprintf(&drive->pcie_port, "vmspawn-pcieport-%zu", port++) < 0)
                         return log_oom();
         }
         if (need_scsi)

--- a/src/vmspawn/vmspawn.c
+++ b/src/vmspawn/vmspawn.c
@@ -104,8 +104,7 @@
 #define DISK_SERIAL_MAX_LEN_NVME        20
 #define DISK_SERIAL_MAX_LEN_VIRTIO_BLK  20
 
-/* Spare pcie-root-ports reserved for future runtime hotplug beyond the pre-wired devices. */
-#define VMSPAWN_PCIE_HOTPLUG_SPARES 10u
+/* VMSPAWN_PCIE_HOTPLUG_SPARES lives in vmspawn-qmp.h */
 
 /* An enum controlling how auxiliary state for the VM are maintained, i.e. the TPM state and the EFI variable
  * NVRAM. */
@@ -2347,7 +2346,7 @@ static int prepare_primary_drive(const char *runtime_dir, DriveInfos *drives) {
         if (r < 0)
                 return log_error_errno(r, "Failed to extract filename from path '%s': %m", arg_image);
 
-        _cleanup_(drive_info_freep) DriveInfo *d = drive_info_new();
+        _cleanup_(drive_info_unrefp) DriveInfo *d = drive_info_new();
         if (!d)
                 return log_oom();
 
@@ -2371,8 +2370,7 @@ static int prepare_primary_drive(const char *runtime_dir, DriveInfos *drives) {
 
         d->path = strdup(arg_image);
         d->format = strdup(image_format_to_string(arg_image_format));
-        d->node_name = strdup("vmspawn");
-        if (!d->path || !d->format || !d->node_name)
+        if (!d->path || !d->format)
                 return log_oom();
         d->fd = TAKE_FD(image_fd);
         if (S_ISBLK(st.st_mode))
@@ -2408,7 +2406,6 @@ static int prepare_extra_drives(DriveInfos *drives) {
 
         assert(drives);
 
-        size_t extra_idx = 0;
         FOREACH_ARRAY(drive, arg_extra_drives.drives, arg_extra_drives.n_drives) {
                 _cleanup_free_ char *drive_fn = NULL;
                 r = path_extract_filename(drive->path, &drive_fn);
@@ -2417,7 +2414,7 @@ static int prepare_extra_drives(DriveInfos *drives) {
 
                 DiskType dt = drive->disk_type >= 0 ? drive->disk_type : arg_image_disk_type;
 
-                _cleanup_(drive_info_freep) DriveInfo *d = drive_info_new();
+                _cleanup_(drive_info_unrefp) DriveInfo *d = drive_info_new();
                 if (!d)
                         return log_oom();
 
@@ -2449,9 +2446,6 @@ static int prepare_extra_drives(DriveInfos *drives) {
                         d->flags |= QMP_DRIVE_BLOCK_DEVICE;
                 d->flags |= QMP_DRIVE_NO_FLUSH;
 
-                if (asprintf(&d->node_name, "vmspawn_extra_%zu", extra_idx++) < 0)
-                        return log_oom();
-
                 drives->drives[drives->n_drives++] = TAKE_PTR(d);
         }
 
@@ -2476,11 +2470,12 @@ static int assign_pcie_ports(MachineConfig *c) {
         /* Drives: non-SCSI drives get individual ports, SCSI controller gets one port */
         bool need_scsi = false;
         FOREACH_ARRAY(d, drives->drives, drives->n_drives) {
-                if (STR_IN_SET((*d)->disk_driver, "scsi-hd", "scsi-cd")) {
+                DriveInfo *drive = *d;
+                if (STR_IN_SET(drive->disk_driver, "scsi-hd", "scsi-cd")) {
                         need_scsi = true;
                         continue;
                 }
-                if (asprintf(&(*d)->pcie_port, "vmspawn-pcieport-%zu", port++) < 0)
+                if (asprintf(&drive->pcie_port, "vmspawn-pcieport-%zu", port++) < 0)
                         return log_oom();
         }
         if (need_scsi)

--- a/src/vmspawn/vmspawn.c
+++ b/src/vmspawn/vmspawn.c
@@ -2328,6 +2328,8 @@ static int qemu_config_add_qmp_monitor(FILE *config_file, int bridge_fds[2], int
 }
 
 static int resolve_disk_driver(DiskType dt, const char *filename, DriveInfo *info) {
+        const char *driver;
+        size_t serial_max;
         int r;
 
         assert(filename);
@@ -2335,33 +2337,33 @@ static int resolve_disk_driver(DiskType dt, const char *filename, DriveInfo *inf
 
         switch (dt) {
         case DISK_TYPE_VIRTIO_BLK:
-                info->disk_driver = "virtio-blk-pci";
-                r = disk_serial(filename, DISK_SERIAL_MAX_LEN_VIRTIO_BLK, &info->serial);
-                if (r < 0)
-                        return r;
+                driver = "virtio-blk-pci";
+                serial_max = DISK_SERIAL_MAX_LEN_VIRTIO_BLK;
                 break;
         case DISK_TYPE_VIRTIO_SCSI:
-                info->disk_driver = "scsi-hd";
-                r = disk_serial(filename, DISK_SERIAL_MAX_LEN_SCSI, &info->serial);
-                if (r < 0)
-                        return r;
+                driver = "scsi-hd";
+                serial_max = DISK_SERIAL_MAX_LEN_SCSI;
                 break;
         case DISK_TYPE_NVME:
-                info->disk_driver = "nvme";
-                r = disk_serial(filename, DISK_SERIAL_MAX_LEN_NVME, &info->serial);
-                if (r < 0)
-                        return r;
+                driver = "nvme";
+                serial_max = DISK_SERIAL_MAX_LEN_NVME;
                 break;
         case DISK_TYPE_VIRTIO_SCSI_CDROM:
-                info->disk_driver = "scsi-cd";
+                driver = "scsi-cd";
+                serial_max = DISK_SERIAL_MAX_LEN_SCSI;
                 info->flags |= QMP_DRIVE_READ_ONLY;
-                r = disk_serial(filename, DISK_SERIAL_MAX_LEN_SCSI, &info->serial);
-                if (r < 0)
-                        return r;
                 break;
         default:
                 assert_not_reached();
         }
+
+        info->disk_driver = strdup(driver);
+        if (!info->disk_driver)
+                return log_oom();
+
+        r = disk_serial(filename, serial_max, &info->serial);
+        if (r < 0)
+                return r;
 
         return 0;
 }
@@ -2380,8 +2382,9 @@ static int prepare_primary_drive(const char *runtime_dir, DriveInfos *drives) {
         if (r < 0)
                 return log_error_errno(r, "Failed to extract filename from path '%s': %m", arg_image);
 
-        DriveInfo *d = &drives->drives[drives->n_drives++];
-        *d = (DriveInfo) { .fd = -EBADF, .overlay_fd = -EBADF };
+        _cleanup_(drive_info_freep) DriveInfo *d = drive_info_new();
+        if (!d)
+                return log_oom();
 
         r = resolve_disk_driver(arg_image_disk_type, image_fn, d);
         if (r < 0)
@@ -2401,10 +2404,10 @@ static int prepare_primary_drive(const char *runtime_dir, DriveInfos *drives) {
         if (r < 0)
                 return log_error_errno(r, "Expected regular file or block device for image: %s", arg_image);
 
-        d->path = arg_image;
-        d->format = image_format_to_string(arg_image_format);
+        d->path = strdup(arg_image);
+        d->format = strdup(image_format_to_string(arg_image_format));
         d->node_name = strdup("vmspawn");
-        if (!d->node_name)
+        if (!d->path || !d->format || !d->node_name)
                 return log_oom();
         d->fd = TAKE_FD(image_fd);
         if (S_ISBLK(st.st_mode))
@@ -2431,6 +2434,7 @@ static int prepare_primary_drive(const char *runtime_dir, DriveInfos *drives) {
                 d->flags |= QMP_DRIVE_NO_FLUSH;
         }
 
+        drives->drives[drives->n_drives++] = TAKE_PTR(d);
         return 0;
 }
 
@@ -2448,8 +2452,9 @@ static int prepare_extra_drives(DriveInfos *drives) {
 
                 DiskType dt = drive->disk_type >= 0 ? drive->disk_type : arg_image_disk_type;
 
-                DriveInfo *d = &drives->drives[drives->n_drives++];
-                *d = (DriveInfo) { .fd = -EBADF, .overlay_fd = -EBADF };
+                _cleanup_(drive_info_freep) DriveInfo *d = drive_info_new();
+                if (!d)
+                        return log_oom();
 
                 r = resolve_disk_driver(dt, drive_fn, d);
                 if (r < 0)
@@ -2470,8 +2475,10 @@ static int prepare_extra_drives(DriveInfos *drives) {
                                                "Block device '%s' cannot be used with 'qcow2' format, only 'raw' is supported.",
                                                drive->path);
 
-                d->path = drive->path;
-                d->format = image_format_to_string(drive->format);
+                d->path = strdup(drive->path);
+                d->format = strdup(image_format_to_string(drive->format));
+                if (!d->path || !d->format)
+                        return log_oom();
                 d->fd = TAKE_FD(drive_fd);
                 if (S_ISBLK(drive_st.st_mode))
                         d->flags |= QMP_DRIVE_BLOCK_DEVICE;
@@ -2479,6 +2486,8 @@ static int prepare_extra_drives(DriveInfos *drives) {
 
                 if (asprintf(&d->node_name, "vmspawn_extra_%zu", extra_idx++) < 0)
                         return log_oom();
+
+                drives->drives[drives->n_drives++] = TAKE_PTR(d);
         }
 
         return 0;
@@ -2502,11 +2511,11 @@ static int assign_pcie_ports(MachineConfig *c) {
         /* Drives: non-SCSI drives get individual ports, SCSI controller gets one port */
         bool need_scsi = false;
         FOREACH_ARRAY(d, drives->drives, drives->n_drives) {
-                if (STR_IN_SET(d->disk_driver, "scsi-hd", "scsi-cd")) {
+                if (STR_IN_SET((*d)->disk_driver, "scsi-hd", "scsi-cd")) {
                         need_scsi = true;
                         continue;
                 }
-                if (asprintf(&d->pcie_port, "vmspawn-pcieport-%zu", port++) < 0)
+                if (asprintf(&(*d)->pcie_port, "vmspawn-pcieport-%zu", port++) < 0)
                         return log_oom();
         }
         if (need_scsi)
@@ -2538,7 +2547,7 @@ static int prepare_device_info(const char *runtime_dir, MachineConfig *c) {
 
         /* Build drive info for QMP-based setup. vmspawn opens all image files and
          * passes fds to QEMU via add-fd — QEMU never needs filesystem access. */
-        drives->drives = new0(DriveInfo, 1 + arg_extra_drives.n_drives);
+        drives->drives = new0(DriveInfo*, 1 + arg_extra_drives.n_drives);
         if (!drives->drives)
                 return log_oom();
 

--- a/test/units/TEST-87-AUX-UTILS-VM.vmspawn-disk-hotplug.sh
+++ b/test/units/TEST-87-AUX-UTILS-VM.vmspawn-disk-hotplug.sh
@@ -1,0 +1,444 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# Test machinectl attach-disk / detach-disk / list-disks for vmspawn.
+set -eux
+set -o pipefail
+
+# shellcheck source=test/units/util.sh
+. "$(dirname "$0")"/util.sh
+
+if [[ -v ASAN_OPTIONS ]]; then
+    echo "vmspawn launches QEMU which doesn't work under ASan, skipping"
+    exit 0
+fi
+
+if ! command -v systemd-vmspawn >/dev/null 2>&1; then
+    echo "systemd-vmspawn not found, skipping"
+    exit 0
+fi
+
+if ! find_qemu_binary; then
+    echo "QEMU not found, skipping"
+    exit 0
+fi
+
+KERNEL=""
+for k in /usr/lib/modules/"$(uname -r)"/vmlinuz /boot/vmlinuz-"$(uname -r)" /boot/vmlinuz; do
+    if [[ -f "$k" ]]; then
+        KERNEL="$k"
+        break
+    fi
+done
+
+if [[ -z "$KERNEL" ]]; then
+    echo "No kernel found for direct VM boot, skipping"
+    exit 0
+fi
+echo "Using kernel: $KERNEL"
+
+MACHINE="test-vmspawn-disk-$$"
+WORKDIR="$(mktemp -d)"
+
+at_exit() {
+    set +e
+    if machinectl status "$MACHINE" &>/dev/null; then
+        machinectl terminate "$MACHINE" 2>/dev/null
+        timeout 10 bash -c "while machinectl status '$MACHINE' &>/dev/null; do sleep .5; done" 2>/dev/null
+    fi
+    [[ -n "${VMSPAWN_PID:-}" ]] && kill "$VMSPAWN_PID" 2>/dev/null && wait "$VMSPAWN_PID" 2>/dev/null
+    [[ -n "${SUB_PID:-}" ]] && kill "$SUB_PID" 2>/dev/null && wait "$SUB_PID" 2>/dev/null
+    rm -rf "$WORKDIR"
+}
+trap at_exit EXIT
+
+# The guest has to actually boot Linux (ACPI hotplug detach requires the
+# guest's acpiphp driver, and on q35 the eject SCI is dropped unless OSPM
+# has finished initialising). Fedora's kernel keeps virtio_fs + fuse as
+# modules and we don't ship an initramfs, so --directory= (virtiofs) panics
+# at mount-root. Build a tiny ext4 rootfs instead — ext4 + virtio_blk are
+# built into the kernel.
+mkdir -p "$WORKDIR/root"/{sbin,proc,sys,dev,etc,bin}
+# Use a statically linked busybox as the sole guest userspace binary — no
+# libc, no dynamic linker, no distro-layout variance. The package is pulled
+# in via mkosi/mkosi.conf.d/{arch,centos-fedora,debian-ubuntu,opensuse};
+# install locations differ by distro.
+BUSYBOX=""
+for c in /sbin/busybox /usr/bin/busybox.static /usr/bin/busybox /bin/busybox; do
+    [[ -x "$c" ]] || continue
+    BUSYBOX="$c"
+    break
+done
+[[ -n "$BUSYBOX" ]] || { echo "busybox not found, skipping"; exit 0; }
+cp --reflink=auto -L "$BUSYBOX" "$WORKDIR/root/bin/busybox"
+# busybox dispatches on argv[0]; sh, sleep, echo are all applets.
+ln -s busybox "$WORKDIR/root/bin/sh"
+ln -s busybox "$WORKDIR/root/bin/sleep"
+ln -s busybox "$WORKDIR/root/bin/echo"
+# The "[init] start" marker lets the test barrier on actual guest userspace
+# rather than on machinectl registration alone. Without the barrier, the first
+# attach+detach can race ahead of guest ACPI OSPM init: QEMU queues the eject
+# SCI, but OSPM clears pending GPE status bits during boot and the unplug
+# event is silently dropped — see hw/acpi/pcihp.c acpi_pcihp_eject_request().
+cat >"$WORKDIR/root/sbin/init" <<'INITEOF'
+#!/bin/sh
+echo "[init] start"
+exec /bin/sleep infinity
+INITEOF
+chmod +x "$WORKDIR/root/sbin/init"
+
+# Pack into a GPT-ful raw image for vmspawn's --image= dissect logic.
+mkdir -p "$WORKDIR/repart.d"
+cat >"$WORKDIR/repart.d/10-root.conf" <<'EOF'
+[Partition]
+Type=root
+Format=ext4
+CopyFiles=/
+SizeMinBytes=128M
+SizeMaxBytes=128M
+EOF
+systemd-repart \
+    --definitions="$WORKDIR/repart.d" \
+    --empty=create \
+    --size=auto \
+    --root="$WORKDIR/root" \
+    "$WORKDIR/rootfs.raw" >/dev/null
+
+# Reuse wait_for_machine from the main vmspawn test
+wait_for_machine() {
+    local machine="$1" pid="$2" log="$3"
+    timeout 30 bash -c "
+        while ! machinectl list --no-legend 2>/dev/null | grep >/dev/null '$machine'; do
+            if ! kill -0 $pid 2>/dev/null; then
+                if grep >/dev/null 'virtiofs.*QMP\|vhost-user-fs-pci' '$log'; then
+                    echo 'vhost-user-fs not supported (nested VM?), skipping'
+                    exit 77
+                fi
+                echo 'vmspawn exited before registering'
+                cat '$log'
+                exit 1
+            fi
+            sleep .5
+        done
+    " || {
+        local rc=$?
+        if [[ $rc -eq 77 ]]; then exit 0; fi
+        exit "$rc"
+    }
+}
+
+# Create test disk images. bootdisk is opened by QEMU at boot (taking its
+# image lock), so it must be distinct from the disks re-attached below.
+truncate -s 64M "$WORKDIR/disk1.raw"
+truncate -s 32M "$WORKDIR/disk2.raw"
+truncate -s 16M "$WORKDIR/bootdisk.raw"
+
+# Launch vmspawn with a boot-time extra drive so Test 1 has something to see.
+# 1G of RAM because the EFI stub decompressing the kernel needs some headroom.
+# A second -serial captures the guest console so the barrier below can wait
+# for "[init] start" and the failure diagnostic can dump kernel messages.
+SYSTEMD_VMSPAWN_QEMU_EXTRA="-serial file:$WORKDIR/guest-console.log" \
+systemd-vmspawn \
+    --machine="$MACHINE" \
+    --ram=1G \
+    --image="$WORKDIR/rootfs.raw" \
+    --linux="$KERNEL" \
+    --extra-drive="$WORKDIR/bootdisk.raw" \
+    --tpm=no \
+    --console=headless \
+    console=ttyS0 \
+    selinux=0 \
+    &>"$WORKDIR/vmspawn.log" &
+VMSPAWN_PID=$!
+
+wait_for_machine "$MACHINE" "$VMSPAWN_PID" "$WORKDIR/vmspawn.log"
+echo "Machine '$MACHINE' registered"
+
+# Wait for the guest to actually reach /sbin/init. Without this, the first
+# attach+detach in Test 2 can race ahead of guest ACPI OSPM and the eject
+# SCI gets dropped (see hw/acpi/pcihp.c acpi_pcihp_eject_request). The init
+# script above emits "[init] start" as its first echo to /dev/console.
+echo "--- Waiting for guest init to reach userspace ---"
+if ! timeout 120 bash -c "
+    while ! grep >/dev/null '\[init\] start' '$WORKDIR/guest-console.log' 2>/dev/null; do
+        sleep 0.5
+    done
+"; then
+    echo "=== guest never reached /sbin/init; console log ==="
+    tail -200 "$WORKDIR/guest-console.log" 2>/dev/null || echo "(no console log)"
+    exit 1
+fi
+echo "Guest init reached userspace"
+
+# --- Test 1: Boot-time drives visible in list-disks ---
+# Machine registration races with the async blockdev-add + device_add dispatch
+# at boot, so poll for the boot-time drive to appear rather than querying once.
+echo "--- Test 1: list-disks shows boot-time drives ---"
+timeout 10 bash -c "
+    while ! machinectl list-disks '$MACHINE' --no-legend 2>/dev/null | grep >/dev/null 'bd0'; do
+        sleep 0.5
+    done
+"
+echo "Boot-time drives listed"
+
+# --- Test 2: Basic attach-disk / list-disks / detach-disk ---
+echo "--- Test 2: Basic attach/list/detach cycle ---"
+machinectl attach-disk "$MACHINE" "$WORKDIR/disk1.raw" --disk-id=scratch-01
+machinectl list-disks "$MACHINE" --no-legend | grep >/dev/null "scratch-01"
+echo "Disk attached and visible"
+
+machinectl detach-disk "$MACHINE" scratch-01
+# Wait for removal. If this hangs, guest OSPM probably wasn't up by the time
+# we fired device_del and the guest silently dropped the pending GPE — dump
+# the guest console so the regression is self-diagnosing.
+if ! timeout 10 bash -c "
+    while machinectl list-disks '$MACHINE' --no-legend 2>/dev/null | grep >/dev/null 'scratch-01'; do
+        sleep 0.5
+    done
+"; then
+    echo "=== detach timed out; guest-console.log tail ==="
+    tail -80 "$WORKDIR/guest-console.log" 2>/dev/null || echo "(no console log)"
+    exit 1
+fi
+echo "Disk detached"
+
+# --- Test 3: Attach with --read-only ---
+echo "--- Test 3: Read-only attach ---"
+machinectl attach-disk "$MACHINE" "$WORKDIR/disk1.raw" --read-only --disk-id=ro-disk
+machinectl -o json list-disks "$MACHINE" |
+    jq -e '.[] | select(.id == "ro-disk") | .read_only' >/dev/null
+machinectl detach-disk "$MACHINE" ro-disk
+timeout 10 bash -c "
+    while machinectl list-disks '$MACHINE' --no-legend 2>/dev/null | grep >/dev/null 'ro-disk'; do
+        sleep 0.5
+    done
+"
+echo "Read-only disk attached and detached"
+
+# --- Test 4: Two disks concurrently ---
+echo "--- Test 4: Concurrent attach ---"
+machinectl attach-disk "$MACHINE" "$WORKDIR/disk1.raw" --disk-id=concurrent-a
+machinectl attach-disk "$MACHINE" "$WORKDIR/disk2.raw" --disk-id=concurrent-b
+machinectl list-disks "$MACHINE" --no-legend | grep >/dev/null "concurrent-a"
+machinectl list-disks "$MACHINE" --no-legend | grep >/dev/null "concurrent-b"
+echo "Both concurrent disks visible"
+
+machinectl detach-disk "$MACHINE" concurrent-a
+machinectl detach-disk "$MACHINE" concurrent-b
+timeout 10 bash -c "
+    while machinectl list-disks '$MACHINE' --no-legend 2>/dev/null | grep >/dev/null 'concurrent-'; do
+        sleep 0.5
+    done
+"
+echo "Both concurrent disks detached"
+
+# --- Test 5: Duplicate id rejected ---
+echo "--- Test 5: Duplicate id error ---"
+machinectl attach-disk "$MACHINE" "$WORKDIR/disk1.raw" --disk-id=dup-test
+(! machinectl attach-disk "$MACHINE" "$WORKDIR/disk2.raw" --disk-id=dup-test)
+echo "Duplicate id correctly rejected"
+
+machinectl detach-disk "$MACHINE" dup-test
+timeout 10 bash -c "
+    while machinectl list-disks '$MACHINE' --no-legend 2>/dev/null | grep >/dev/null 'dup-test'; do
+        sleep 0.5
+    done
+"
+
+# --- Test 6: Detach nonexistent id rejected ---
+echo "--- Test 6: Detach nonexistent id ---"
+(! machinectl detach-disk "$MACHINE" does-not-exist-12345)
+echo "Detach nonexistent id correctly rejected"
+
+# --- Test 7: Reattach after detach ---
+echo "--- Test 7: Reattach ---"
+machinectl attach-disk "$MACHINE" "$WORKDIR/disk1.raw" --disk-id=reattach-test
+machinectl detach-disk "$MACHINE" reattach-test
+timeout 10 bash -c "
+    while machinectl list-disks '$MACHINE' --no-legend 2>/dev/null | grep >/dev/null 'reattach-test'; do
+        sleep 0.5
+    done
+"
+machinectl attach-disk "$MACHINE" "$WORKDIR/disk1.raw" --disk-id=reattach-test
+machinectl list-disks "$MACHINE" --no-legend | grep >/dev/null "reattach-test"
+echo "Reattach succeeded"
+
+machinectl detach-disk "$MACHINE" reattach-test
+timeout 10 bash -c "
+    while machinectl list-disks '$MACHINE' --no-legend 2>/dev/null | grep >/dev/null 'reattach-test'; do
+        sleep 0.5
+    done
+"
+
+# --- The remaining tests exercise the varlink IDL directly, bypassing
+#     machinectl, so they can cover driver/format combinations that
+#     machinectl doesn't expose. ---
+CTRL=$(varlinkctl call --json=short \
+        /run/systemd/machine/io.systemd.Machine \
+        io.systemd.Machine.List "{\"name\":\"$MACHINE\"}" 2>/dev/null |
+        jq -r '.controlAddress // empty' || true)
+
+if [[ -z "$CTRL" ]]; then
+    echo "Could not determine control address; skipping direct varlink tests"
+else
+    echo "Control socket: $CTRL"
+
+    # --- Test 8: Direct varlink attach/list/remove cycle ---
+    echo "--- Test 8: Direct varlink IDL ---"
+    exec 3<"$WORKDIR/disk1.raw"
+    varlinkctl --push-fd=3 call "$CTRL" \
+        io.systemd.VirtualMachineInstance.AddBlockDevice \
+        '{"fileDescriptor": 0, "format": "raw", "driver": "virtio_blk", "id": "vl-direct"}' >/dev/null
+    exec 3<&-
+
+    varlinkctl call --more "$CTRL" \
+        io.systemd.VirtualMachineInstance.ListBlockDevices '{}' |
+        grep >/dev/null '"id" *: *"vl-direct"'
+
+    varlinkctl call "$CTRL" \
+        io.systemd.VirtualMachineInstance.RemoveBlockDevice \
+        '{"id": "vl-direct"}' >/dev/null
+
+    timeout 10 bash -c "
+        while varlinkctl call --more '$CTRL' \
+                io.systemd.VirtualMachineInstance.ListBlockDevices '{}' 2>/dev/null |
+                grep >/dev/null '\"id\" *: *\"vl-direct\"'; do
+            sleep 0.5
+        done
+    "
+    echo "Direct varlink attach/list/remove passed"
+
+    # --- Test 9: NVMe driver attach ---
+    echo "--- Test 9: NVMe driver ---"
+    exec 3<"$WORKDIR/disk1.raw"
+    varlinkctl --push-fd=3 call "$CTRL" \
+        io.systemd.VirtualMachineInstance.AddBlockDevice \
+        '{"fileDescriptor": 0, "format": "raw", "driver": "nvme", "id": "nvme-test"}' >/dev/null
+    exec 3<&-
+    varlinkctl call --more "$CTRL" \
+        io.systemd.VirtualMachineInstance.ListBlockDevices '{}' |
+        grep >/dev/null '"id" *: *"nvme-test"'
+    varlinkctl call "$CTRL" \
+        io.systemd.VirtualMachineInstance.RemoveBlockDevice \
+        '{"id": "nvme-test"}' >/dev/null
+    timeout 10 bash -c "
+        while varlinkctl call --more '$CTRL' \
+                io.systemd.VirtualMachineInstance.ListBlockDevices '{}' 2>/dev/null |
+                grep >/dev/null '\"id\" *: *\"nvme-test\"'; do
+            sleep 0.5
+        done
+    "
+    echo "NVMe attach/detach passed"
+
+    # --- Test 10: SCSI driver attach (exercises on-demand controller) ---
+    echo "--- Test 10: SCSI driver ---"
+    exec 3<"$WORKDIR/disk1.raw"
+    varlinkctl --push-fd=3 call "$CTRL" \
+        io.systemd.VirtualMachineInstance.AddBlockDevice \
+        '{"fileDescriptor": 0, "format": "raw", "driver": "scsi_hd", "id": "scsi-test", "serial": "SCSI01"}' >/dev/null
+    exec 3<&-
+    varlinkctl call --more "$CTRL" \
+        io.systemd.VirtualMachineInstance.ListBlockDevices '{}' |
+        grep >/dev/null '"id" *: *"scsi-test"'
+    varlinkctl call "$CTRL" \
+        io.systemd.VirtualMachineInstance.RemoveBlockDevice \
+        '{"id": "scsi-test"}' >/dev/null
+    timeout 10 bash -c "
+        while varlinkctl call --more '$CTRL' \
+                io.systemd.VirtualMachineInstance.ListBlockDevices '{}' 2>/dev/null |
+                grep >/dev/null '\"id\" *: *\"scsi-test\"'; do
+            sleep 0.5
+        done
+    "
+    echo "SCSI attach/detach passed"
+
+    # --- Test 11: qcow2 format attach (needs qemu-img) ---
+    if command -v qemu-img >/dev/null 2>&1; then
+        echo "--- Test 11: qcow2 format ---"
+        qemu-img create -f qcow2 "$WORKDIR/test.qcow2" 32M >/dev/null
+        exec 3<"$WORKDIR/test.qcow2"
+        varlinkctl --push-fd=3 call "$CTRL" \
+            io.systemd.VirtualMachineInstance.AddBlockDevice \
+            '{"fileDescriptor": 0, "format": "qcow2", "driver": "virtio_blk", "id": "qcow2-test"}' >/dev/null
+        exec 3<&-
+        varlinkctl call --more "$CTRL" \
+            io.systemd.VirtualMachineInstance.ListBlockDevices '{}' |
+            grep >/dev/null '"id" *: *"qcow2-test"'
+        varlinkctl call --more "$CTRL" \
+            io.systemd.VirtualMachineInstance.ListBlockDevices '{}' |
+            grep >/dev/null '"format" *: *"qcow2"'
+        varlinkctl call "$CTRL" \
+            io.systemd.VirtualMachineInstance.RemoveBlockDevice \
+            '{"id": "qcow2-test"}' >/dev/null
+        timeout 10 bash -c "
+            while varlinkctl call --more '$CTRL' \
+                    io.systemd.VirtualMachineInstance.ListBlockDevices '{}' 2>/dev/null |
+                    grep >/dev/null '\"id\" *: *\"qcow2-test\"'; do
+                sleep 0.5
+            done
+        "
+        echo "qcow2 attach/detach passed"
+    else
+        echo "qemu-img not found; skipping qcow2 test"
+    fi
+
+    # --- Test 12: BlockDeviceRemoved event fires on detach ---
+    echo "--- Test 12: BlockDeviceRemoved event ---"
+    varlinkctl call --more "$CTRL" \
+        io.systemd.MachineInstance.SubscribeEvents \
+        '{"filter":["BlockDeviceRemoved"]}' >"$WORKDIR/events.log" 2>&1 &
+    SUB_PID=$!
+    # Let the subscription register (READY notifier from server).
+    timeout 10 bash -c "while ! grep >/dev/null '\"READY\"' '$WORKDIR/events.log'; do sleep 0.2; done"
+
+    exec 3<"$WORKDIR/disk1.raw"
+    varlinkctl --push-fd=3 call "$CTRL" \
+        io.systemd.VirtualMachineInstance.AddBlockDevice \
+        '{"fileDescriptor": 0, "format": "raw", "driver": "virtio_blk", "id": "event-test"}' >/dev/null
+    exec 3<&-
+    varlinkctl call "$CTRL" \
+        io.systemd.VirtualMachineInstance.RemoveBlockDevice \
+        '{"id": "event-test"}' >/dev/null
+
+    timeout 10 bash -c "
+        while ! grep >/dev/null 'BlockDeviceRemoved' '$WORKDIR/events.log' ||
+              ! grep >/dev/null 'event-test' '$WORKDIR/events.log'; do
+            sleep 0.5
+        done
+    "
+    # `wait` on a signal-terminated child returns 128+sig (143 for SIGTERM);
+    # with `set -e` that'd abort the script before Test 13 runs.
+    kill "$SUB_PID" 2>/dev/null || true
+    wait "$SUB_PID" 2>/dev/null || true
+    echo "BlockDeviceRemoved event observed"
+
+    # --- Test 13: Auto-assigned id (no id supplied) ---
+    echo "--- Test 13: Auto-assigned id ---"
+    exec 3<"$WORKDIR/disk1.raw"
+    AUTO_REPLY=$(varlinkctl --push-fd=3 call --json=short "$CTRL" \
+        io.systemd.VirtualMachineInstance.AddBlockDevice \
+        '{"fileDescriptor": 0, "format": "raw", "driver": "virtio_blk"}')
+    exec 3<&-
+    AUTO_ID=$(echo "$AUTO_REPLY" | jq -r '.id // empty')
+    [[ -n "$AUTO_ID" ]] || { echo "No auto id returned"; exit 1; }
+    [[ "$AUTO_ID" =~ ^bd[0-9]+$ ]] || { echo "Unexpected auto id: $AUTO_ID"; exit 1; }
+    echo "Auto-assigned id: $AUTO_ID"
+
+    varlinkctl call "$CTRL" \
+        io.systemd.VirtualMachineInstance.RemoveBlockDevice \
+        "{\"id\":\"$AUTO_ID\"}" >/dev/null
+    timeout 10 bash -c "
+        while varlinkctl call --more '$CTRL' \
+                io.systemd.VirtualMachineInstance.ListBlockDevices '{}' 2>/dev/null |
+                grep >/dev/null '\"id\" *: *\"$AUTO_ID\"'; do
+            sleep 0.5
+        done
+    "
+    echo "Auto-id attach/detach passed"
+fi
+
+# Clean up
+machinectl terminate "$MACHINE"
+timeout 10 bash -c "while machinectl status '$MACHINE' &>/dev/null; do sleep .5; done"
+timeout 10 bash -c "while kill -0 '$VMSPAWN_PID' 2>/dev/null; do sleep .5; done" 2>/dev/null
+
+echo "All vmspawn disk hotplug tests passed"

--- a/test/units/TEST-87-AUX-UTILS-VM.vmspawn-disk-hotplug.sh
+++ b/test/units/TEST-87-AUX-UTILS-VM.vmspawn-disk-hotplug.sh
@@ -1,0 +1,463 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# Test machinectl attach-disk / detach-disk / list-disks for vmspawn.
+set -eux
+set -o pipefail
+
+# shellcheck source=test/units/util.sh
+. "$(dirname "$0")"/util.sh
+
+if [[ -v ASAN_OPTIONS ]]; then
+    echo "vmspawn launches QEMU which doesn't work under ASan, skipping"
+    exit 0
+fi
+
+if ! command -v systemd-vmspawn >/dev/null 2>&1; then
+    echo "systemd-vmspawn not found, skipping"
+    exit 0
+fi
+
+if ! find_qemu_binary; then
+    echo "QEMU not found, skipping"
+    exit 0
+fi
+
+if ! command -v virtiofsd >/dev/null 2>&1 &&
+   ! test -x /usr/libexec/virtiofsd &&
+   ! test -x /usr/lib/virtiofsd; then
+    echo "virtiofsd not found, skipping"
+    exit 0
+fi
+
+KERNEL=""
+for k in /usr/lib/modules/"$(uname -r)"/vmlinuz /boot/vmlinuz-"$(uname -r)" /boot/vmlinuz; do
+    if [[ -f "$k" ]]; then
+        KERNEL="$k"
+        break
+    fi
+done
+
+if [[ -z "$KERNEL" ]]; then
+    echo "No kernel found for direct VM boot, skipping"
+    exit 0
+fi
+echo "Using kernel: $KERNEL"
+
+MACHINE="test-vmspawn-disk-$$"
+WORKDIR="$(mktemp -d)"
+
+at_exit() {
+    set +e
+    if machinectl status "$MACHINE" &>/dev/null; then
+        machinectl terminate "$MACHINE" 2>/dev/null
+        timeout 10 bash -c "while machinectl status '$MACHINE' &>/dev/null; do sleep .5; done" 2>/dev/null
+    fi
+    [[ -n "${VMSPAWN_PID:-}" ]] && kill "$VMSPAWN_PID" 2>/dev/null && wait "$VMSPAWN_PID" 2>/dev/null
+    rm -rf "$WORKDIR"
+}
+trap at_exit EXIT
+
+# The guest has to actually boot Linux (ACPI hotplug detach requires the
+# guest's acpiphp driver, and on q35 the eject SCI is dropped unless OSPM
+# has finished initialising). Fedora's kernel keeps virtio_fs + fuse as
+# modules and we don't ship an initramfs, so --directory= (virtiofs) panics
+# at mount-root. Build a tiny ext4 rootfs instead — ext4 + virtio_blk are
+# built into the kernel.
+mkdir -p "$WORKDIR/root"/{sbin,proc,sys,dev,etc,bin,lib64}
+# Copy /bin/sh + a few helpers plus the libraries ldd reports. Fedora's /bin
+# is typically a symlink to /usr/bin, so pull through `command -v`.
+HOSTLIB=""
+for d in /lib/x86_64-linux-gnu /usr/lib/x86_64-linux-gnu /usr/lib64 /lib64; do
+    [[ -d "$d" ]] || continue
+    HOSTLIB="$d"
+    break
+done
+mkdir -p "$WORKDIR/root$HOSTLIB"
+copy_with_libs() {
+    local bin="$1" lib dest
+    cp --reflink=auto -L "$bin" "$WORKDIR/root/bin/"
+    while read -r lib; do
+        dest=$(awk '{ for (i=1;i<=NF;i++) if ($i ~ /^\//) { print $i; exit } }' <<<"$lib")
+        [[ -n "$dest" && -f "$dest" ]] || continue
+        cp --reflink=auto -L -n "$dest" "$WORKDIR/root$HOSTLIB/" 2>/dev/null || true
+    done < <(ldd "$bin" 2>/dev/null)
+}
+for b in sh sleep; do
+    src=$(command -v "$b" 2>/dev/null) || continue
+    copy_with_libs "$src"
+done
+# ld-linux must live at /lib64 on x86_64 regardless of where the rest is.
+for ld in /lib64/ld-linux-x86-64.so.2 /lib/ld-linux-x86-64.so.2; do
+    if [[ -f "$ld" ]]; then
+        cp --reflink=auto -L "$ld" "$WORKDIR/root/lib64/"
+        break
+    fi
+done
+# ld.so.cache helps ld-linux find libraries without writing ld.so.conf.
+[[ -e /etc/ld.so.cache ]] && cp --reflink=auto -L /etc/ld.so.cache "$WORKDIR/root/etc/"
+# The "[init] start" marker lets the test barrier on actual guest userspace
+# rather than on machinectl registration alone. Without the barrier, the first
+# attach+detach can race ahead of guest ACPI OSPM init: QEMU queues the eject
+# SCI, but OSPM clears pending GPE status bits during boot and the unplug
+# event is silently dropped — see hw/acpi/pcihp.c acpi_pcihp_eject_request().
+cat >"$WORKDIR/root/sbin/init" <<'INITEOF'
+#!/bin/sh
+echo "[init] start"
+exec /bin/sleep infinity
+INITEOF
+chmod +x "$WORKDIR/root/sbin/init"
+
+# Pack into a GPT-ful raw image for vmspawn's --image= dissect logic.
+mkdir -p "$WORKDIR/repart.d"
+cat >"$WORKDIR/repart.d/10-root.conf" <<'EOF'
+[Partition]
+Type=root
+Format=ext4
+CopyFiles=/
+SizeMinBytes=128M
+SizeMaxBytes=128M
+EOF
+systemd-repart \
+    --definitions="$WORKDIR/repart.d" \
+    --empty=create \
+    --size=auto \
+    --root="$WORKDIR/root" \
+    "$WORKDIR/rootfs.raw" >/dev/null
+
+# Reuse wait_for_machine from the main vmspawn test
+wait_for_machine() {
+    local machine="$1" pid="$2" log="$3"
+    timeout 30 bash -c "
+        while ! machinectl list --no-legend 2>/dev/null | grep >/dev/null '$machine'; do
+            if ! kill -0 $pid 2>/dev/null; then
+                if grep >/dev/null 'virtiofs.*QMP\|vhost-user-fs-pci' '$log'; then
+                    echo 'vhost-user-fs not supported (nested VM?), skipping'
+                    exit 77
+                fi
+                echo 'vmspawn exited before registering'
+                cat '$log'
+                exit 1
+            fi
+            sleep .5
+        done
+    " || {
+        local rc=$?
+        if [[ $rc -eq 77 ]]; then exit 0; fi
+        exit "$rc"
+    }
+}
+
+# Create test disk images. bootdisk is opened by QEMU at boot (taking its
+# image lock), so it must be distinct from the disks re-attached below.
+truncate -s 64M "$WORKDIR/disk1.raw"
+truncate -s 32M "$WORKDIR/disk2.raw"
+truncate -s 16M "$WORKDIR/bootdisk.raw"
+
+# Launch vmspawn with a boot-time extra drive so Test 1 has something to see.
+# 1G of RAM because the EFI stub decompressing the kernel needs some headroom.
+# A second -serial captures the guest console so the barrier below can wait
+# for "[init] start" and the failure diagnostic can dump kernel messages.
+SYSTEMD_VMSPAWN_QEMU_EXTRA="-serial file:$WORKDIR/guest-console.log" \
+systemd-vmspawn \
+    --machine="$MACHINE" \
+    --ram=1G \
+    --image="$WORKDIR/rootfs.raw" \
+    --linux="$KERNEL" \
+    --extra-drive="$WORKDIR/bootdisk.raw" \
+    --tpm=no \
+    --console=headless \
+    console=ttyS0 \
+    &>"$WORKDIR/vmspawn.log" &
+VMSPAWN_PID=$!
+
+wait_for_machine "$MACHINE" "$VMSPAWN_PID" "$WORKDIR/vmspawn.log"
+echo "Machine '$MACHINE' registered"
+
+# Wait for the guest to actually reach /sbin/init. Without this, the first
+# attach+detach in Test 2 can race ahead of guest ACPI OSPM and the eject
+# SCI gets dropped (see hw/acpi/pcihp.c acpi_pcihp_eject_request). The init
+# script above emits "[init] start" as its first echo to /dev/console.
+echo "--- Waiting for guest init to reach userspace ---"
+if ! timeout 45 bash -c "
+    while ! grep >/dev/null '\[init\] start' '$WORKDIR/guest-console.log' 2>/dev/null; do
+        sleep 0.5
+    done
+"; then
+    echo "=== guest never reached /sbin/init; console log ==="
+    tail -200 "$WORKDIR/guest-console.log" 2>/dev/null || echo "(no console log)"
+    exit 1
+fi
+echo "Guest init reached userspace"
+
+# --- Test 1: Boot-time drives visible in list-disks ---
+# Machine registration races with the async blockdev-add + device_add dispatch
+# at boot, so poll for the boot-time drive to appear rather than querying once.
+echo "--- Test 1: list-disks shows boot-time drives ---"
+timeout 10 bash -c "
+    while ! machinectl list-disks '$MACHINE' --no-legend 2>/dev/null | grep >/dev/null 'bd0'; do
+        sleep 0.5
+    done
+"
+echo "Boot-time drives listed"
+
+# --- Test 2: Basic attach-disk / list-disks / detach-disk ---
+echo "--- Test 2: Basic attach/list/detach cycle ---"
+machinectl attach-disk "$MACHINE" "$WORKDIR/disk1.raw" --disk-id=scratch-01
+machinectl list-disks "$MACHINE" --no-legend | grep >/dev/null "scratch-01"
+echo "Disk attached and visible"
+
+machinectl detach-disk "$MACHINE" scratch-01
+# Wait for removal. If this hangs, guest OSPM probably wasn't up by the time
+# we fired device_del and the guest silently dropped the pending GPE — dump
+# the guest console so the regression is self-diagnosing.
+if ! timeout 10 bash -c "
+    while machinectl list-disks '$MACHINE' --no-legend 2>/dev/null | grep >/dev/null 'scratch-01'; do
+        sleep 0.5
+    done
+"; then
+    echo "=== detach timed out; guest-console.log tail ==="
+    tail -80 "$WORKDIR/guest-console.log" 2>/dev/null || echo "(no console log)"
+    exit 1
+fi
+echo "Disk detached"
+
+# --- Test 3: Attach with --read-only ---
+echo "--- Test 3: Read-only attach ---"
+machinectl attach-disk "$MACHINE" "$WORKDIR/disk1.raw" --read-only --disk-id=ro-disk
+machinectl list-disks "$MACHINE" --no-legend | grep >/dev/null "ro-disk"
+machinectl detach-disk "$MACHINE" ro-disk
+timeout 10 bash -c "
+    while machinectl list-disks '$MACHINE' --no-legend 2>/dev/null | grep >/dev/null 'ro-disk'; do
+        sleep 0.5
+    done
+"
+echo "Read-only disk attached and detached"
+
+# --- Test 4: Two disks concurrently ---
+echo "--- Test 4: Concurrent attach ---"
+machinectl attach-disk "$MACHINE" "$WORKDIR/disk1.raw" --disk-id=concurrent-a
+machinectl attach-disk "$MACHINE" "$WORKDIR/disk2.raw" --disk-id=concurrent-b
+machinectl list-disks "$MACHINE" --no-legend | grep >/dev/null "concurrent-a"
+machinectl list-disks "$MACHINE" --no-legend | grep >/dev/null "concurrent-b"
+echo "Both concurrent disks visible"
+
+machinectl detach-disk "$MACHINE" concurrent-a
+machinectl detach-disk "$MACHINE" concurrent-b
+timeout 10 bash -c "
+    while machinectl list-disks '$MACHINE' --no-legend 2>/dev/null | grep >/dev/null 'concurrent-'; do
+        sleep 0.5
+    done
+"
+echo "Both concurrent disks detached"
+
+# --- Test 5: Duplicate id rejected ---
+echo "--- Test 5: Duplicate id error ---"
+machinectl attach-disk "$MACHINE" "$WORKDIR/disk1.raw" --disk-id=dup-test
+(! machinectl attach-disk "$MACHINE" "$WORKDIR/disk2.raw" --disk-id=dup-test)
+echo "Duplicate id correctly rejected"
+
+machinectl detach-disk "$MACHINE" dup-test
+timeout 10 bash -c "
+    while machinectl list-disks '$MACHINE' --no-legend 2>/dev/null | grep >/dev/null 'dup-test'; do
+        sleep 0.5
+    done
+"
+
+# --- Test 6: Detach nonexistent id rejected ---
+echo "--- Test 6: Detach nonexistent id ---"
+(! machinectl detach-disk "$MACHINE" does-not-exist-12345)
+echo "Detach nonexistent id correctly rejected"
+
+# --- Test 7: Reattach after detach ---
+echo "--- Test 7: Reattach ---"
+machinectl attach-disk "$MACHINE" "$WORKDIR/disk1.raw" --disk-id=reattach-test
+machinectl detach-disk "$MACHINE" reattach-test
+timeout 10 bash -c "
+    while machinectl list-disks '$MACHINE' --no-legend 2>/dev/null | grep >/dev/null 'reattach-test'; do
+        sleep 0.5
+    done
+"
+machinectl attach-disk "$MACHINE" "$WORKDIR/disk1.raw" --disk-id=reattach-test
+machinectl list-disks "$MACHINE" --no-legend | grep >/dev/null "reattach-test"
+echo "Reattach succeeded"
+
+machinectl detach-disk "$MACHINE" reattach-test
+timeout 10 bash -c "
+    while machinectl list-disks '$MACHINE' --no-legend 2>/dev/null | grep >/dev/null 'reattach-test'; do
+        sleep 0.5
+    done
+"
+
+# --- The remaining tests exercise the varlink IDL directly, bypassing
+#     machinectl, so they can cover driver/format combinations that
+#     machinectl doesn't expose. ---
+CTRL=$(varlinkctl call --json=short \
+        /run/systemd/machine/io.systemd.Machine \
+        io.systemd.Machine.List "{\"name\":\"$MACHINE\"}" 2>/dev/null |
+        sed -n 's/.*"controlAddress":"\([^"]*\)".*/\1/p')
+
+if [[ -z "$CTRL" ]]; then
+    echo "Could not determine control address; skipping direct varlink tests"
+else
+    echo "Control socket: $CTRL"
+
+    # --- Test 8: Direct varlink attach/list/remove cycle ---
+    echo "--- Test 8: Direct varlink IDL ---"
+    exec 3<"$WORKDIR/disk1.raw"
+    varlinkctl --push-fd=3 call "$CTRL" \
+        io.systemd.VirtualMachineInstance.AddBlockDevice \
+        '{"fileDescriptor": 0, "format": "raw", "driver": "virtio_blk", "id": "vl-direct"}' >/dev/null
+    exec 3<&-
+
+    varlinkctl call --more "$CTRL" \
+        io.systemd.VirtualMachineInstance.ListBlockDevices '{}' |
+        grep >/dev/null '"id" *: *"vl-direct"'
+
+    varlinkctl call "$CTRL" \
+        io.systemd.VirtualMachineInstance.RemoveBlockDevice \
+        '{"id": "vl-direct"}' >/dev/null
+
+    timeout 10 bash -c "
+        while varlinkctl call --more '$CTRL' \
+                io.systemd.VirtualMachineInstance.ListBlockDevices '{}' 2>/dev/null |
+                grep >/dev/null '\"id\" *: *\"vl-direct\"'; do
+            sleep 0.5
+        done
+    "
+    echo "Direct varlink attach/list/remove passed"
+
+    # --- Test 9: NVMe driver attach ---
+    echo "--- Test 9: NVMe driver ---"
+    exec 3<"$WORKDIR/disk1.raw"
+    varlinkctl --push-fd=3 call "$CTRL" \
+        io.systemd.VirtualMachineInstance.AddBlockDevice \
+        '{"fileDescriptor": 0, "format": "raw", "driver": "nvme", "id": "nvme-test"}' >/dev/null
+    exec 3<&-
+    varlinkctl call --more "$CTRL" \
+        io.systemd.VirtualMachineInstance.ListBlockDevices '{}' |
+        grep >/dev/null '"id" *: *"nvme-test"'
+    varlinkctl call "$CTRL" \
+        io.systemd.VirtualMachineInstance.RemoveBlockDevice \
+        '{"id": "nvme-test"}' >/dev/null
+    timeout 10 bash -c "
+        while varlinkctl call --more '$CTRL' \
+                io.systemd.VirtualMachineInstance.ListBlockDevices '{}' 2>/dev/null |
+                grep >/dev/null '\"id\" *: *\"nvme-test\"'; do
+            sleep 0.5
+        done
+    "
+    echo "NVMe attach/detach passed"
+
+    # --- Test 10: SCSI driver attach (exercises on-demand controller) ---
+    echo "--- Test 10: SCSI driver ---"
+    exec 3<"$WORKDIR/disk1.raw"
+    varlinkctl --push-fd=3 call "$CTRL" \
+        io.systemd.VirtualMachineInstance.AddBlockDevice \
+        '{"fileDescriptor": 0, "format": "raw", "driver": "scsi_hd", "id": "scsi-test", "serial": "SCSI01"}' >/dev/null
+    exec 3<&-
+    varlinkctl call --more "$CTRL" \
+        io.systemd.VirtualMachineInstance.ListBlockDevices '{}' |
+        grep >/dev/null '"id" *: *"scsi-test"'
+    varlinkctl call "$CTRL" \
+        io.systemd.VirtualMachineInstance.RemoveBlockDevice \
+        '{"id": "scsi-test"}' >/dev/null
+    timeout 10 bash -c "
+        while varlinkctl call --more '$CTRL' \
+                io.systemd.VirtualMachineInstance.ListBlockDevices '{}' 2>/dev/null |
+                grep >/dev/null '\"id\" *: *\"scsi-test\"'; do
+            sleep 0.5
+        done
+    "
+    echo "SCSI attach/detach passed"
+
+    # --- Test 11: qcow2 format attach (needs qemu-img) ---
+    if command -v qemu-img >/dev/null 2>&1; then
+        echo "--- Test 11: qcow2 format ---"
+        qemu-img create -f qcow2 "$WORKDIR/test.qcow2" 32M >/dev/null
+        exec 3<"$WORKDIR/test.qcow2"
+        varlinkctl --push-fd=3 call "$CTRL" \
+            io.systemd.VirtualMachineInstance.AddBlockDevice \
+            '{"fileDescriptor": 0, "format": "qcow2", "driver": "virtio_blk", "id": "qcow2-test"}' >/dev/null
+        exec 3<&-
+        varlinkctl call --more "$CTRL" \
+            io.systemd.VirtualMachineInstance.ListBlockDevices '{}' |
+            grep >/dev/null '"id" *: *"qcow2-test"'
+        varlinkctl call --more "$CTRL" \
+            io.systemd.VirtualMachineInstance.ListBlockDevices '{}' |
+            grep >/dev/null '"format" *: *"qcow2"'
+        varlinkctl call "$CTRL" \
+            io.systemd.VirtualMachineInstance.RemoveBlockDevice \
+            '{"id": "qcow2-test"}' >/dev/null
+        timeout 10 bash -c "
+            while varlinkctl call --more '$CTRL' \
+                    io.systemd.VirtualMachineInstance.ListBlockDevices '{}' 2>/dev/null |
+                    grep >/dev/null '\"id\" *: *\"qcow2-test\"'; do
+                sleep 0.5
+            done
+        "
+        echo "qcow2 attach/detach passed"
+    else
+        echo "qemu-img not found; skipping qcow2 test"
+    fi
+
+    # --- Test 12: BlockDeviceRemoved event fires on detach ---
+    echo "--- Test 12: BlockDeviceRemoved event ---"
+    varlinkctl call --more "$CTRL" \
+        io.systemd.MachineInstance.SubscribeEvents \
+        '{"filter":["BlockDeviceRemoved"]}' >"$WORKDIR/events.log" 2>&1 &
+    SUB_PID=$!
+    # Let the subscription register (READY notifier from server).
+    timeout 10 bash -c "while ! grep >/dev/null 'READY' '$WORKDIR/events.log'; do sleep 0.2; done"
+
+    exec 3<"$WORKDIR/disk1.raw"
+    varlinkctl --push-fd=3 call "$CTRL" \
+        io.systemd.VirtualMachineInstance.AddBlockDevice \
+        '{"fileDescriptor": 0, "format": "raw", "driver": "virtio_blk", "id": "event-test"}' >/dev/null
+    exec 3<&-
+    varlinkctl call "$CTRL" \
+        io.systemd.VirtualMachineInstance.RemoveBlockDevice \
+        '{"id": "event-test"}' >/dev/null
+
+    timeout 10 bash -c "
+        while ! grep >/dev/null 'BlockDeviceRemoved' '$WORKDIR/events.log' ||
+              ! grep >/dev/null 'event-test' '$WORKDIR/events.log'; do
+            sleep 0.5
+        done
+    "
+    # `wait` on a signal-terminated child returns 128+sig (143 for SIGTERM);
+    # with `set -e` that'd abort the script before Test 13 runs.
+    kill "$SUB_PID" 2>/dev/null || true
+    wait "$SUB_PID" 2>/dev/null || true
+    echo "BlockDeviceRemoved event observed"
+
+    # --- Test 13: Auto-assigned id (no id supplied) ---
+    echo "--- Test 13: Auto-assigned id ---"
+    exec 3<"$WORKDIR/disk1.raw"
+    AUTO_REPLY=$(varlinkctl --push-fd=3 call --json=short "$CTRL" \
+        io.systemd.VirtualMachineInstance.AddBlockDevice \
+        '{"fileDescriptor": 0, "format": "raw", "driver": "virtio_blk"}')
+    exec 3<&-
+    AUTO_ID=$(echo "$AUTO_REPLY" | sed -n 's/.*"id":"\([^"]*\)".*/\1/p')
+    [[ -n "$AUTO_ID" ]] || { echo "No auto id returned"; exit 1; }
+    [[ "$AUTO_ID" =~ ^bd[0-9]+$ ]] || { echo "Unexpected auto id: $AUTO_ID"; exit 1; }
+    echo "Auto-assigned id: $AUTO_ID"
+
+    varlinkctl call "$CTRL" \
+        io.systemd.VirtualMachineInstance.RemoveBlockDevice \
+        "{\"id\":\"$AUTO_ID\"}" >/dev/null
+    timeout 10 bash -c "
+        while varlinkctl call --more '$CTRL' \
+                io.systemd.VirtualMachineInstance.ListBlockDevices '{}' 2>/dev/null |
+                grep >/dev/null '\"id\" *: *\"$AUTO_ID\"'; do
+            sleep 0.5
+        done
+    "
+    echo "Auto-id attach/detach passed"
+fi
+
+# Clean up
+machinectl terminate "$MACHINE"
+timeout 10 bash -c "while machinectl status '$MACHINE' &>/dev/null; do sleep .5; done"
+timeout 10 bash -c "while kill -0 '$VMSPAWN_PID' 2>/dev/null; do sleep .5; done" 2>/dev/null
+
+echo "All vmspawn disk hotplug tests passed"


### PR DESCRIPTION
This series adds hotplug and hot-remove of block devices to a running
`systemd-vmspawn` VM, exposed via the varlink interface that vmspawn
already publishes on `$RUNTIME_DIR/vmspawn/<machine>/varlink`.
`machinectl` gains `attach-disk`, `detach-disk`, and `list-disks`
verbs as the user-facing surface.

It builds directly on the QMP-varlink bridge landed in #41449, which
introduced `QmpClient` and a varlink server in
`src/vmspawn/vmspawn-varlink.c` but left
`io.systemd.VirtualMachineInstance` deliberately empty, reserved for
exactly this work.

## Design: cross-VMM by construction

vmspawn only launches QEMU today, but the varlink interface is
intended to outlive that. The IDL and completion model were
cross-validated against **firecracker** and **cloud-hypervisor**
before landing, to avoid baking in QEMU-only assumptions:

| Constraint        | QEMU                              | firecracker                              | cloud-hypervisor                        |
|-------------------|-----------------------------------|------------------------------------------|-----------------------------------------|
| Hot-add           | ✅ `blockdev-add`+`device_add`    | ❌ only pre-boot PUT / post-boot PATCH   | ✅ `PUT /vm.add-disk`                   |
| Hot-remove        | ✅ `device_del`+`blockdev-del`    | ❌ not supported                         | ✅ `PUT /vm.remove-device`              |
| Completion event  | `DEVICE_DELETED`                  | n/a                                      | none (guest-driven B0EJ write, silent)  |
| fd passing        | ✅ `add-fd`→fdset                  | ❌ no SCM_RIGHTS                         | ❌ handler drops fds for disks          |
| Caller-assigned id| caller-supplied                   | `[A-Za-z0-9_]+` required                 | optional, backend auto-assigns          |

Consequences baked into the v1 shape:

- **Interface is named `io.systemd.VirtualMachineInstance`, not
  `QemuMachineInstance`.** QEMU-specific knobs (`io_uring`, cache
  mode, throttle groups, BlockdevOptions overlays) would go on an
  `io.systemd.QemuMachineInstance` extension — none needed in v1.
- **Rejected a QMP-mirror two-object shape** (separate
  `blockdev-add` + `device_add` in the IDL). It fits QEMU perfectly
  and maps onto nothing else: firecracker's `Drive` and
  cloud-hypervisor's `DiskConfig` are single objects.
- **Rejected streamed-completion over varlink `more`** for Remove.
  cloud-hypervisor has no completion event at all (would force
  vmspawn to do the caller's polling), and firecracker has no
  remove. So Remove is fire-and-forget; completion flows back as a
  `BlockDeviceRemoved` event on the existing
  `io.systemd.MachineInstance.SubscribeEvents` stream (which cleanly
  wraps QEMU's `DEVICE_DELETED`).
- **fd passing is optional.** A future firecracker/CH backend just
  rejects the fd arm — the path-free hot-add surface still works
  once those backends grow hotplug support.
- **Unified id namespace.** Boot-time and hotplugged disks share
  the same id space; `RemoveBlockDevice` can detach a boot-time
  disk too.

## Interface surface

```varlink
interface io.systemd.VirtualMachineInstance

type BlockFormat (raw, qcow2)
type BlockDriver (virtio_blk, nvme, scsi_hd, scsi_cd)

method AddBlockDevice(
    fileDescriptor: int,
    format: BlockFormat,
    driver: BlockDriver,
    readOnly: ?bool,
    discard: ?bool,
    serial: ?string,
    id: ?string
) -> (id: string)

method RemoveBlockDevice(id: string) -> ()

method ListBlockDevices() -> (
    id: ?string,
    format: ?BlockFormat,
    readOnly: ?bool
)

error NoSuchBlockDevice
error BlockDeviceIdInUse
error InvalidBlockDeviceId
error BlockBackendBusy
```

Naming invariant inside QEMU:
`qdev-id = blockdev-add node-name = "bd-<id>"`. Caller-supplied ids
match `[A-Za-z0-9_-]+` capped at 28 chars (QEMU's 31-byte node-name
limit minus the `bd-` prefix); auto-assigned ids are `bd<N>` from a
monotonic counter shared with boot-time drives.

## Example usage

### AddBlockDevice

Caller opens the backing file and passes the fd via SCM_RIGHTS on
the varlink socket; vmspawn forwards it to QEMU via `add-fd` and
wires up `blockdev-add` + `device_add` in one async chain.

Request (fd index 0 passed out-of-band):
```json
{
  "method": "io.systemd.VirtualMachineInstance.AddBlockDevice",
  "parameters": {
    "fileDescriptor": 0,
    "format": "qcow2",
    "driver": "virtio_blk",
    "readOnly": false,
    "discard": true,
    "serial": "data-0001",
    "id": "data"
  }
}
```

Reply:
```json
{
  "parameters": { "id": "data" }
}
```

With no `id` supplied, vmspawn auto-assigns one:
```json
{ "parameters": { "id": "bd3" } }
```

### ListBlockDevices (streaming)

Request:
```json
{
  "method": "io.systemd.VirtualMachineInstance.ListBlockDevices",
  "parameters": {},
  "more": true
}
```

Reply stream (one JSON object per device, `continues` drops to
`false` on the last):
```json
{"parameters": {"id": "bd0",  "format": "qcow2", "readOnly": false}, "continues": true}
{"parameters": {"id": "bd1",  "format": "raw",   "readOnly": true},  "continues": true}
{"parameters": {"id": "data", "format": "qcow2", "readOnly": false}, "continues": false}
```

`bd0`/`bd1` are boot-time drives configured via `--image`/`--extra-drive`;
`data` was hotplugged. State lives entirely in QEMU — `ListBlockDevices`
is a thin translator over `query-block`, so vmspawn holds no shadow
registry.

### RemoveBlockDevice + async completion

Request:
```json
{
  "method": "io.systemd.VirtualMachineInstance.RemoveBlockDevice",
  "parameters": { "id": "data" }
}
```

Immediate reply (QEMU accepted `device_del`; guest has not yet
ACPI-ejected):
```json
{ "parameters": {} }
```

Actual completion arrives as an event on
`io.systemd.MachineInstance.SubscribeEvents` (open the stream
**before** calling `RemoveBlockDevice` if you need to observe it):
```json
{
  "parameters": {
    "event": "BlockDeviceRemoved",
    "data": { "id": "data" }
  },
  "continues": true
}
```

### Errors

```json
{"error": "io.systemd.VirtualMachineInstance.NoSuchBlockDevice",
 "parameters": {}}

{"error": "io.systemd.VirtualMachineInstance.BlockDeviceIdInUse",
 "parameters": {}}

{"error": "io.systemd.VirtualMachineInstance.InvalidBlockDeviceId",
 "parameters": {}}

{"error": "io.systemd.VirtualMachineInstance.BlockBackendBusy",
 "parameters": {}}
```

## CLI

```sh
# Attach a disk image (fd is opened by machinectl and pushed to vmspawn)
machinectl attach-disk myvm /var/lib/vms/data.qcow2 --disk-id=data

# Attach read-only
machinectl attach-disk myvm /srv/images/rescue.iso --read-only

# List what's attached (includes boot-time drives)
machinectl list-disks myvm

# Detach — completes asynchronously when the guest ACPI-ejects
machinectl detach-disk myvm data
```

`machinectl attach-disk` hardcodes `format=raw`, `driver=virtio_blk`
for the common case; lower-level control (NVMe, SCSI, qcow2) stays
available via direct varlink.