### PR TITLE
cleanup: VLAN Id -> VLAN ID

### DIFF
--- a/src/network/networkctl-status-link.c
+++ b/src/network/networkctl-status-link.c
@@ -577,7 +577,7 @@ static int link_status_one(
 
         } else if (streq_ptr(info->netdev_kind, "vlan") && info->vlan_id > 0) {
                 r = table_add_many(table,
-                                   TABLE_FIELD, "VLan Id",
+                                   TABLE_FIELD, "VLAN ID",
                                    TABLE_UINT16, info->vlan_id);
                 if (r < 0)
                         return table_log_add_error(r);

--- a/src/network/networkd-bridge-fdb.c
+++ b/src/network/networkd-bridge-fdb.c
@@ -139,7 +139,7 @@ static int bridge_fdb_configure_message(const BridgeFDB *fdb, Link *link, sd_net
         if (r < 0)
                 return r;
 
-        /* VLAN Id is optional. We'll add VLAN Id only if it's specified. */
+        /* VLAN ID is optional. We'll add VLAN ID only if it's specified. */
         if (fdb->vlan_id > 0) {
                 r = sd_netlink_message_append_u16(req, NDA_VLAN, fdb->vlan_id);
                 if (r < 0)

--- a/src/shared/vlan-util.h
+++ b/src/shared/vlan-util.h
@@ -7,7 +7,7 @@
 #define VLANID_MAX 4094
 #define VLANID_INVALID UINT16_MAX
 
-/* Note that we permit VLAN Id 0 here, as that is apparently OK by the Linux kernel */
+/* Note that we permit VLAN ID 0 here, as that is apparently OK by the Linux kernel */
 static inline bool vlanid_is_valid(uint16_t id) {
         return id <= VLANID_MAX;
 }


### PR DESCRIPTION
"VLAN ID" is used throughout the documentation and codebase, but appears (when present) in `networkctl status` tables as `VLan Id`.

(In `.network` and `.netdev` files it is referenced as `VLANId=`; not touched)