### PR TITLE
man/fstab-generator: fix option list and make formatting consistent

### DIFF
--- a/man/systemd-fstab-generator.xml
+++ b/man/systemd-fstab-generator.xml
@@ -214,12 +214,12 @@
         <term><varname>systemd.volatile=</varname></term>
 
         <listitem><para>Controls whether the system shall boot up in volatile mode. Takes a boolean argument or the
-        special value <option>state</option>.</para>
+        special values <literal>state</literal> and <literal>overlay</literal>.</para>
 
-        <para>If false (the default), this generator makes no changes to the mount tree and the system is booted up in
-        normal mode.</para>
+        <para>If <literal>no</literal> (the default), this generator makes no changes to the mount tree and the system
+        is booted up in normal mode.</para>
 
-        <para>If true the generator ensures
+        <para>If <literal>yes</literal> the generator ensures
         <citerefentry><refentrytitle>systemd-volatile-root.service</refentrytitle><manvolnum>8</manvolnum></citerefentry>
         is run in the initrd. This service changes the mount table before transitioning to the host system,
         so that a volatile memory file system (<literal>tmpfs</literal>) is used as root directory, with only
@@ -228,7 +228,7 @@
         and lost at shutdown, as <filename>/etc/</filename> and <filename>/var/</filename> will be served
         from the (initially unpopulated) volatile memory file system.</para>
 
-        <para>If set to <option>state</option> the generator will leave the root directory mount point unaltered,
+        <para>If set to <literal>state</literal> the generator will leave the root directory mount point unaltered,
         however will mount a <literal>tmpfs</literal> file system to <filename>/var/</filename>. In this mode the normal
         system configuration (i.e. the contents of <literal>/etc/</literal>) is in effect (and may be modified during
         system runtime), however the system state (i.e. the contents of <literal>/var/</literal>) is reset at boot and


### PR DESCRIPTION
Add `"overlay"`, which is already mentioned further down below, to the list of possible options.

Consistently use `<literal>` for possible values of `systemd.volatile=`, rather than `<param>` or no special formatting.

Use yes/no rather than true/false as boolean since that is what's used everywhere else and I'm already touching the lines anyway.