### PR TITLE
shared: find-esp fsroot check skip

### DIFF
--- a/src/shared/find-esp.c
+++ b/src/shared/find-esp.c
@@ -31,6 +31,7 @@ typedef enum VerifyESPFlags {
         VERIFY_ESP_UNPRIVILEGED_MODE = 1 << 1, /* Call into udev rather than blkid */
         VERIFY_ESP_SKIP_FSTYPE_CHECK = 1 << 2, /* Skip filesystem check */
         VERIFY_ESP_SKIP_DEVICE_CHECK = 1 << 3, /* Skip device node check  */
+        VERIFY_ESP_SKIP_FSROOT_CHECK = 1 << 4, /* Skip fsroot check  */
 } VerifyESPFlags;
 
 static VerifyESPFlags verify_esp_flags_init(int unprivileged_mode, const char *env_name_for_relaxing) {
@@ -48,7 +49,7 @@ static VerifyESPFlags verify_esp_flags_init(int unprivileged_mode, const char *e
         if (r < 0 && r != -ENXIO)
                 log_debug_errno(r, "Failed to parse $%s environment variable, assuming false.", env_name_for_relaxing);
         else if (r > 0)
-                flags |= VERIFY_ESP_SKIP_FSTYPE_CHECK | VERIFY_ESP_SKIP_DEVICE_CHECK;
+                flags |= VERIFY_ESP_SKIP_FSTYPE_CHECK | VERIFY_ESP_SKIP_DEVICE_CHECK | VERIFY_ESP_SKIP_FSROOT_CHECK;
 
         if (detect_container() > 0)
                 flags |= VERIFY_ESP_SKIP_DEVICE_CHECK;
@@ -356,9 +357,11 @@ static int verify_esp(
         }
 
         dev_t devid = 0;
-        r = verify_fsroot_dir(p, fd, flags, FLAGS_SET(flags, VERIFY_ESP_SKIP_DEVICE_CHECK) ? NULL : &devid);
-        if (r < 0)
-                return r;
+        if (!FLAGS_SET(flags, VERIFY_ESP_SKIP_FSROOT_CHECK)) {
+                r = verify_fsroot_dir(p, fd, flags, FLAGS_SET(flags, VERIFY_ESP_SKIP_DEVICE_CHECK) ? NULL : &devid);
+                if (r < 0)
+                        return r;
+        }
 
         /* In a container we don't have access to block devices, skip this part of the verification, we trust
          * the container manager set everything up correctly on its own. */
@@ -742,9 +745,11 @@ static int verify_xbootldr(
                                       r, "Failed to open directory \"%s\": %m", path);
 
         dev_t devid = 0;
-        r = verify_fsroot_dir(p, fd, flags, FLAGS_SET(flags, VERIFY_ESP_SKIP_DEVICE_CHECK) ? NULL : &devid);
-        if (r < 0)
-                return r;
+        if (!FLAGS_SET(flags, VERIFY_ESP_SKIP_FSROOT_CHECK)) {
+                r = verify_fsroot_dir(p, fd, flags, FLAGS_SET(flags, VERIFY_ESP_SKIP_DEVICE_CHECK) ? NULL : &devid);
+                if (r < 0)
+                        return r;
+        }
 
         if (FLAGS_SET(flags, VERIFY_ESP_SKIP_DEVICE_CHECK)) {
                 if (ret_uuid)

--- a/src/shared/find-esp.c
+++ b/src/shared/find-esp.c
@@ -32,6 +32,7 @@ typedef enum VerifyESPFlags {
         VERIFY_ESP_UNPRIVILEGED_MODE = 1 << 1, /* Call into udev rather than blkid */
         VERIFY_ESP_SKIP_FSTYPE_CHECK = 1 << 2, /* Skip filesystem check */
         VERIFY_ESP_SKIP_DEVICE_CHECK = 1 << 3, /* Skip device node check  */
+        VERIFY_ESP_SKIP_FSROOT_CHECK = 1 << 4, /* Skip fsroot check  */
 } VerifyESPFlags;
 
 static VerifyESPFlags verify_esp_flags_init(int unprivileged_mode, const char *env_name_for_relaxing) {
@@ -49,7 +50,7 @@ static VerifyESPFlags verify_esp_flags_init(int unprivileged_mode, const char *e
         if (r < 0 && r != -ENXIO)
                 log_debug_errno(r, "Failed to parse $%s environment variable, assuming false.", env_name_for_relaxing);
         else if (r > 0)
-                flags |= VERIFY_ESP_SKIP_FSTYPE_CHECK | VERIFY_ESP_SKIP_DEVICE_CHECK;
+                flags |= VERIFY_ESP_SKIP_FSTYPE_CHECK | VERIFY_ESP_SKIP_DEVICE_CHECK | VERIFY_ESP_SKIP_FSROOT_CHECK;
 
         if (detect_container() > 0)
                 flags |= VERIFY_ESP_SKIP_DEVICE_CHECK;
@@ -380,9 +381,11 @@ static int verify_esp(
                                               "File system \"%s\" is not a FAT EFI System Partition (ESP) file system.", p);
         }
 
-        r = verify_fsroot_dir(pfd, p, flags, FLAGS_SET(flags, VERIFY_ESP_SKIP_DEVICE_CHECK) ? NULL : &devid);
-        if (r < 0)
-                return r;
+        if (!FLAGS_SET(flags, VERIFY_ESP_SKIP_FSROOT_CHECK)) {
+                r = verify_fsroot_dir(pfd, p, flags, FLAGS_SET(flags, VERIFY_ESP_SKIP_DEVICE_CHECK) ? NULL : &devid);
+                if (r < 0)
+                        return r;
+        }
 
         /* In a container we don't have access to block devices, skip this part of the verification, we trust
          * the container manager set everything up correctly on its own. */
@@ -753,9 +756,11 @@ static int verify_xbootldr(
                                       (unprivileged_mode && ERRNO_IS_PRIVILEGE(r)) ? LOG_DEBUG : LOG_ERR,
                                       r, "Failed to open parent directory of \"%s\": %m", path);
 
-        r = verify_fsroot_dir(pfd, p, flags, FLAGS_SET(flags, VERIFY_ESP_SKIP_DEVICE_CHECK) ? NULL : &devid);
-        if (r < 0)
-                return r;
+        if (!FLAGS_SET(flags, VERIFY_ESP_SKIP_FSROOT_CHECK)) {
+                r = verify_fsroot_dir(pfd, p, flags, FLAGS_SET(flags, VERIFY_ESP_SKIP_DEVICE_CHECK) ? NULL : &devid);
+                if (r < 0)
+                        return r;
+        }
 
         if (FLAGS_SET(flags, VERIFY_ESP_SKIP_DEVICE_CHECK))
                 goto finish;


### PR DESCRIPTION
When running with `SYSTEMD_RELAX_ESP_CHECKS=1` the fsroot check is still being ran; preventing (for example) `bootctl` from operating a on a tree as it expects a filesystem to be mounted where it finds the ESP (or XBOOTLDR).

Expand the enum with an additional option to skip the fsroot checks and enable it by default when `SYSTEMD_RELAX_ESP_CHECKS=1`.

See these RFEs [1], [2] for rationale.

[1]: https://github.com/systemd/systemd/issues/29871
[2]: https://github.com/systemd/systemd/issues/41707

---

I might be overseeing a reason why this check is absolutely mandatory and cannot be skipped. If so let me know! I think the original intent is to loosen up the requirements when block devices can't be accessed and this PR expands on that by loosening it so far that we could operate on trees.

There's also some coupling introduced here between `VERIFY_ESP_SKIP_FSROOT_CHECK` and `VERIFY_ESP_SKIP_DEVICE_CHECK` when either one is set but not both. `devid` would stay `0` if the former is set but not the latter; so `devnum_is_zero` would fail.

Perhaps they should be both done under a single enum value, perhaps I could/should also skip the device check when `VERIFY_ESP_SKIP_FSROOT_CHECK` is set, or make this skip happen when `VERIFY_ESP_SKIP_DEVICE_CHECK` is set instead of introducing a new option.

Fixes: #29871 #41707