### PR TITLE
nspawn: avoid passing NULL to log_syntax() 

### DIFF
--- a/src/basic/strxcpyx.c
+++ b/src/basic/strxcpyx.c
@@ -64,6 +64,8 @@ size_t strpcpyf_full(char **dest, size_t size, bool *ret_truncated, const char *
         i = vsnprintf(*dest, size, src, va);
         va_end(va);
 
+        assert(i >= 0);
+
         if (i < (int) size) {
                 *dest += i;
                 size -= i;

--- a/src/core/namespace.c
+++ b/src/core/namespace.c
@@ -3662,7 +3662,7 @@ static int unpeel_get_fd(const char *mount_path, int *ret_fd) {
                         _exit(EXIT_FAILURE);
                 }
                 if (r > 0) {
-                        log_debug_errno(r, "'%s' is still an overlay after opening mount tree: %m", mount_path);
+                        log_debug("'%s' is still an overlay after opening mount tree", mount_path);
                         _exit(EXIT_FAILURE);
                 }
 

--- a/src/import/pull-tar.c
+++ b/src/import/pull-tar.c
@@ -445,7 +445,7 @@ static void tar_pull_job_on_finished(PullJob *j) {
                 else if (j == p->settings_job)
                         log_info_errno(j->error, "Settings file could not be retrieved, proceeding without.");
                 else
-                        assert("unexpected job");
+                        assert_not_reached();
         }
 
         /* This is invoked if either the download completed successfully, or the download was skipped because

--- a/src/nspawn/nspawn-settings.c
+++ b/src/nspawn/nspawn-settings.c
@@ -720,12 +720,12 @@ int config_parse_private_users(
 
                 r = parse_uid(shift, &sh);
                 if (r < 0) {
-                        log_syntax(unit, LOG_WARNING, filename, line, r, "UID/GID shift invalid, ignoring: %s", range);
+                        log_syntax(unit, LOG_WARNING, filename, line, r, "UID/GID shift invalid, ignoring: %s", rvalue);
                         return 0;
                 }
 
                 if (!userns_shift_range_valid(sh, rn)) {
-                        log_syntax(unit, LOG_WARNING, filename, line, 0, "UID/GID shift and range combination invalid, ignoring: %s", range);
+                        log_syntax(unit, LOG_WARNING, filename, line, 0, "UID/GID shift and range combination invalid, ignoring: %s", rvalue);
                         return 0;
                 }
 


### PR DESCRIPTION
And a couple of other cosmetic tweaks.