### PR TITLE
nspawn,shared/nsresource: fix copy-paste errno logging args

### DIFF
--- a/src/nspawn/nspawn.c
+++ b/src/nspawn/nspawn.c
@@ -5364,7 +5364,7 @@ static int run_container(
                         assert(child_netns_fd < 0);
                         child_netns_fd = receive_one_fd(fd_inner_socket_pair[0], 0);
                         if (child_netns_fd < 0)
-                                return log_error_errno(r, "Failed to receive child network namespace: %m");
+                                return log_error_errno(child_netns_fd, "Failed to receive child network namespace: %m");
                 }
 
                 r = move_network_interfaces(child_netns_fd, arg_network_interfaces);

--- a/src/shared/nsresource.c
+++ b/src/shared/nsresource.c
@@ -270,7 +270,7 @@ int nsresource_add_cgroup(sd_varlink *vl, int userns_fd, int cgroup_fd) {
 
         cgroup_fd_idx = sd_varlink_push_dup_fd(vl, cgroup_fd);
         if (cgroup_fd_idx < 0)
-                return log_debug_errno(userns_fd_idx, "Failed to push cgroup fd into varlink connection: %m");
+                return log_debug_errno(cgroup_fd_idx, "Failed to push cgroup fd into varlink connection: %m");
 
         sd_json_variant *reply = NULL;
         r = sd_varlink_callbo(


### PR DESCRIPTION
Refs #41709. Two static-analysis-flagged copy-paste bugs where `log_(error|debug)_errno()` logged the wrong errno source.

## 1. `src/nspawn/nspawn.c` — `run_container()`

```c
child_netns_fd = receive_one_fd(fd_inner_socket_pair[0], 0);
if (child_netns_fd < 0)
-        return log_error_errno(r, "Failed to receive child network namespace: %m");
+        return log_error_errno(child_netns_fd, "Failed to receive child network namespace: %m");
```

The earlier `r` in the function is from a preceding operation; the actual errno we want to propagate is the negative value returned in `child_netns_fd`. The sibling `mntns_fd = receive_one_fd(...)` call a few lines up already uses the returned fd variable directly in its error path, which is the pattern this change aligns with.

## 2. `src/shared/nsresource.c` — `nsresource_add_cgroup()`

```c
cgroup_fd_idx = sd_varlink_push_dup_fd(vl, cgroup_fd);
if (cgroup_fd_idx < 0)
-        return log_debug_errno(userns_fd_idx, "Failed to push cgroup fd into varlink connection: %m");
+        return log_debug_errno(cgroup_fd_idx, "Failed to push cgroup fd into varlink connection: %m");
```

`userns_fd_idx` at this point is the **successful** push's positive index from the previous statement; it's not the errno we just got back from pushing `cgroup_fd`. Log the index from the failing call. The preceding `userns_fd` block uses the matching `userns_fd_idx` variable, so this change makes the two sibling error paths symmetric.

## Testing

Pure source-order / argument-name change, no behavioural change on the success path. On the failure paths the emitted log message now carries the real errno from the failing call instead of a stale value, which is exactly what the adjacent correct sites already do.

I did not run the full systemd test suite locally — if a maintainer wants a meson build confirmation I can follow up; the functional change is confined to what is already a failure-only branch.