### PR TITLE
cryptsetup/cryptenroll: Iterate over TPM tokens when they don't match

### DIFF
--- a/src/creds/creds.c
+++ b/src/creds/creds.c
@@ -1411,7 +1411,7 @@ static int vl_method_decrypt(sd_varlink *link, sd_json_variant *parameters, sd_v
                 ask_polkit = true;
         }
 
-        if (IN_SET(r, -EREMCHG, -ENOANO, -EUCLEAN, -EPERM))
+        if (ERRNO_IS_NEG_TPM2_UNSEAL_BAD_PCR(r))
                 return sd_varlink_error(link, "io.systemd.Credentials.UnexpectedPCRState", NULL);
         if (r < 0) {
                 const CredentialsVarlinkError *e = credentials_varlink_error_by_errno(r);

--- a/src/cryptenroll/cryptenroll-tpm2.c
+++ b/src/cryptenroll/cryptenroll-tpm2.c
@@ -259,7 +259,10 @@ int load_volume_key_tpm2(
                                 &decrypted_key);
                 if (IN_SET(r, -EACCES, -ENOLCK))
                         return log_notice_errno(SYNTHETIC_ERRNO(EAGAIN), "TPM2 PIN unlock failed");
-                if (r != -EPERM)
+                /* Stop unless we should keep iterating to next token because the tried one
+                 * does not match boot state. For now without -EUCLEAN because currently the
+                 * only error it reports won't be solved by moving to another token. */
+                if (!IN_SET(r, -EPERM, -ENOANO, -EREMCHG, -ENXIO, -EREMOTE))
                         break;
 
                 token++; /* try a different token next time */

--- a/src/cryptenroll/cryptenroll-tpm2.c
+++ b/src/cryptenroll/cryptenroll-tpm2.c
@@ -260,7 +260,10 @@ int load_volume_key_tpm2(
                                 &decrypted_key);
                 if (IN_SET(r, -EACCES, -ENOLCK))
                         return log_notice_errno(SYNTHETIC_ERRNO(EAGAIN), "TPM2 PIN unlock failed");
-                if (r != -EPERM)
+                /* Stop unless we should keep iterating to next token because the tried one
+                 * does not match boot state. For now without -EUCLEAN because currently the
+                 * only error it reports won't be solved by moving to another token. */
+                if (!ERRNO_IS_NEG_TPM2_TOKEN_MISMATCH(r))
                         break;
 
                 token++; /* try a different token next time */

--- a/src/cryptenroll/cryptenroll-tpm2.c
+++ b/src/cryptenroll/cryptenroll-tpm2.c
@@ -39,7 +39,7 @@ static int search_policy_hash(
                 sd_json_variant *w;
 
                 r = cryptsetup_get_token_as_json(cd, token, "systemd-tpm2", &v);
-                if (IN_SET(r, -ENOENT, -EINVAL, -EMEDIUMTYPE))
+                if (ERRNO_IS_NEG_CRYPTSETUP_TOKEN_SKIP(r))
                         continue;
                 if (r < 0)
                         return log_error_errno(r, "Failed to read JSON token data off disk: %m");

--- a/src/cryptenroll/cryptenroll.c
+++ b/src/cryptenroll/cryptenroll.c
@@ -802,7 +802,7 @@ static int check_for_homed(struct crypt_device *cd) {
 
         for (int token = 0; token < sym_crypt_token_max(CRYPT_LUKS2); token++) {
                 r = cryptsetup_get_token_as_json(cd, token, "systemd-homed", NULL);
-                if (IN_SET(r, -ENOENT, -EINVAL, -EMEDIUMTYPE))
+                if (ERRNO_IS_NEG_CRYPTSETUP_TOKEN_SKIP(r))
                         continue;
                 if (r < 0)
                         return log_error_errno(r, "Failed to read JSON token data off disk: %m");

--- a/src/cryptsetup/cryptsetup-pkcs11.c
+++ b/src/cryptsetup/cryptsetup-pkcs11.c
@@ -110,7 +110,7 @@ int find_pkcs11_auto_data(
                 int ks;
 
                 r = cryptsetup_get_token_as_json(cd, token, "systemd-pkcs11", &v);
-                if (IN_SET(r, -ENOENT, -EINVAL, -EMEDIUMTYPE))
+                if (ERRNO_IS_NEG_CRYPTSETUP_TOKEN_SKIP(r))
                         continue;
                 if (r < 0)
                         return log_error_errno(r, "Failed to read JSON token data off disk: %m");

--- a/src/cryptsetup/cryptsetup-tokens/cryptsetup-token-systemd-tpm2.c
+++ b/src/cryptsetup/cryptsetup-tokens/cryptsetup-token-systemd-tpm2.c
@@ -23,13 +23,22 @@ _public_ const char *cryptsetup_token_version(void) {
         return TOKEN_VERSION_MAJOR "." TOKEN_VERSION_MINOR " systemd-v" PROJECT_VERSION_FULL " (" GIT_VERSION ")";
 }
 
-static int log_debug_open_error(struct crypt_device *cd, int r) {
+static int log_debug_open_error(struct crypt_device *cd, int token, int r) {
         if (r == -EAGAIN)
                 return crypt_log_debug_errno(cd, r, "TPM2 device not found.");
-        if (r == -ENXIO)
-                return crypt_log_debug_errno(cd, r, "No matching TPM2 token data found.");
+        if (r == -ENXIO) {
+                /* Remap to -EPERM so libcryptsetup's CRYPT_ANY_TOKEN loop keeps iterating. */
+                (void) crypt_log_debug_errno(cd, r, "Token %d: no matching TPM2 token data found.", token);
+                return -EPERM;
+        }
+        if (IN_SET(r, -EREMCHG, -EREMOTE)) {
+                /* Remap as above. Note: For now without -EUCLEAN because currently the only error it
+                 * reports won't be solved by moving to another token. */
+                (void) crypt_log_debug_errno(cd, r, "Token %d: TPM policy does not match current system state, skipping.", token);
+                return -EPERM;
+        }
 
-        return crypt_log_debug_errno(cd, r, TOKEN_NAME " open failed: %m.");
+        return crypt_log_debug_errno(cd, r, "Token %d: open failed: %m.", token);
 }
 
 _public_ int cryptsetup_token_open_pin(
@@ -73,8 +82,11 @@ _public_ int cryptsetup_token_open_pin(
                 params = *(systemd_tpm2_plugin_params *)usrptr;
 
         r = sd_json_parse(json, SD_JSON_PARSE_MUST_BE_OBJECT, &v, /* reterr_line= */ NULL, /* reterr_column= */ NULL);
-        if (r < 0)
-                return crypt_log_debug_errno(cd, r, "Failed to parse token JSON data: %m");
+        if (r < 0) {
+                /* Remap to -EPERM so libcryptsetup keeps iterating past a broken token. */
+                (void) crypt_log_debug_errno(cd, r, "Token %d: failed to parse JSON data: %m", token);
+                return -EPERM;
+        }
 
         struct iovec *blobs = NULL, *policy_hash = NULL;
         size_t n_blobs = 0, n_policy_hash = 0;
@@ -98,10 +110,13 @@ _public_ int cryptsetup_token_open_pin(
                         &pcrlock_nv,
                         &flags);
         if (r < 0)
-                return log_debug_open_error(cd, r);
+                return log_debug_open_error(cd, token, r);
 
-        if (params.search_pcr_mask != UINT32_MAX && hash_pcr_mask != params.search_pcr_mask)
-                return crypt_log_debug_errno(cd, ENXIO, "PCR mask doesn't match expectation (%" PRIu32 " vs. %" PRIu32 ")", hash_pcr_mask, params.search_pcr_mask);
+        if (params.search_pcr_mask != UINT32_MAX && hash_pcr_mask != params.search_pcr_mask) {
+                /* Remap to -EPERM so libcryptsetup keeps iterating to the next token. */
+                crypt_log_debug(cd, "Token %d: PCR mask doesn't match expectation (%" PRIu32 " vs. %" PRIu32 ")", token, hash_pcr_mask, params.search_pcr_mask);
+                return -EPERM;
+        }
 
         r = acquire_luks2_key(
                         params.device,
@@ -123,12 +138,12 @@ _public_ int cryptsetup_token_open_pin(
                         flags,
                         &decrypted_key);
         if (r < 0)
-                return log_debug_open_error(cd, r);
+                return log_debug_open_error(cd, token, r);
 
         /* Before using this key as passphrase we base64 encode it, for compat with homed */
         base64_encoded_size = base64mem(decrypted_key.iov_base, decrypted_key.iov_len, &base64_encoded);
         if (base64_encoded_size < 0)
-                return log_debug_open_error(cd, base64_encoded_size);
+                return log_debug_open_error(cd, token, base64_encoded_size);
 
         /* free'd automatically by libcryptsetup */
         *ret_password = TAKE_PTR(base64_encoded);

--- a/src/cryptsetup/cryptsetup-tokens/cryptsetup-token-systemd-tpm2.c
+++ b/src/cryptsetup/cryptsetup-tokens/cryptsetup-token-systemd-tpm2.c
@@ -23,13 +23,22 @@ _public_ const char *cryptsetup_token_version(void) {
         return TOKEN_VERSION_MAJOR "." TOKEN_VERSION_MINOR " systemd-v" PROJECT_VERSION_FULL " (" GIT_VERSION ")";
 }
 
-static int log_debug_open_error(struct crypt_device *cd, int r) {
+static int log_debug_open_error(struct crypt_device *cd, int token, int r) {
         if (r == -EAGAIN)
                 return crypt_log_debug_errno(cd, r, "TPM2 device not found.");
-        if (r == -ENOSTR)
-                return crypt_log_debug_errno(cd, r, "No matching TPM2 token data found.");
+        if (r == -ENOSTR) {
+                /* Remap to -EPERM so libcryptsetup's CRYPT_ANY_TOKEN loop keeps iterating. */
+                (void) crypt_log_debug_errno(cd, r, "Token %d: no matching TPM2 token data found.", token);
+                return -EPERM;
+        }
+        if (IN_SET(r, -EREMCHG, -EREMOTE)) {
+                /* Remap as above. Note: For now without -EUCLEAN because currently the only error it
+                 * reports won't be solved by moving to another token. */
+                (void) crypt_log_debug_errno(cd, r, "Token %d: TPM policy does not match current system state, skipping.", token);
+                return -EPERM;
+        }
 
-        return crypt_log_debug_errno(cd, r, TOKEN_NAME " open failed: %m.");
+        return crypt_log_debug_errno(cd, r, "Token %d: open failed: %m.", token);
 }
 
 _public_ int cryptsetup_token_open_pin(
@@ -78,8 +87,11 @@ _public_ int cryptsetup_token_open_pin(
                 params = *(systemd_tpm2_plugin_params *)usrptr;
 
         r = sd_json_parse(json, SD_JSON_PARSE_MUST_BE_OBJECT, &v, /* reterr_line= */ NULL, /* reterr_column= */ NULL);
-        if (r < 0)
-                return crypt_log_debug_errno(cd, r, "Failed to parse token JSON data: %m");
+        if (r < 0) {
+                /* Remap to -EPERM so libcryptsetup keeps iterating past a broken token. */
+                (void) crypt_log_debug_errno(cd, r, "Token %d: failed to parse JSON data: %m", token);
+                return -EPERM;
+        }
 
         struct iovec *blobs = NULL, *policy_hash = NULL;
         size_t n_blobs = 0, n_policy_hash = 0;
@@ -104,10 +116,13 @@ _public_ int cryptsetup_token_open_pin(
                         &pcrlock_nv,
                         &flags);
         if (r < 0)
-                return log_debug_open_error(cd, r);
+                return log_debug_open_error(cd, token, r);
 
-        if (params.search_pcr_mask != UINT32_MAX && hash_pcr_mask != params.search_pcr_mask)
-                return crypt_log_debug_errno(cd, ENXIO, "PCR mask doesn't match expectation (%" PRIu32 " vs. %" PRIu32 ")", hash_pcr_mask, params.search_pcr_mask);
+        if (params.search_pcr_mask != UINT32_MAX && hash_pcr_mask != params.search_pcr_mask) {
+                /* Remap to -EPERM so libcryptsetup keeps iterating to the next token. */
+                crypt_log_debug(cd, "Token %d: PCR mask doesn't match expectation (%" PRIu32 " vs. %" PRIu32 ")", token, hash_pcr_mask, params.search_pcr_mask);
+                return -EPERM;
+        }
 
         r = acquire_luks2_key(
                         params.device,
@@ -130,12 +145,12 @@ _public_ int cryptsetup_token_open_pin(
                         flags,
                         &decrypted_key);
         if (r < 0)
-                return log_debug_open_error(cd, r);
+                return log_debug_open_error(cd, token, r);
 
         /* Before using this key as passphrase we base64 encode it, for compat with homed */
         base64_encoded_size = base64mem(decrypted_key.iov_base, decrypted_key.iov_len, &base64_encoded);
         if (base64_encoded_size < 0)
-                return log_debug_open_error(cd, base64_encoded_size);
+                return log_debug_open_error(cd, token, base64_encoded_size);
 
         /* free'd automatically by libcryptsetup */
         *ret_password = TAKE_PTR(base64_encoded);

--- a/src/cryptsetup/cryptsetup-tokens/cryptsetup-token-systemd-tpm2.c
+++ b/src/cryptsetup/cryptsetup-tokens/cryptsetup-token-systemd-tpm2.c
@@ -26,7 +26,7 @@ _public_ const char *cryptsetup_token_version(void) {
 static int log_debug_open_error(struct crypt_device *cd, int r) {
         if (r == -EAGAIN)
                 return crypt_log_debug_errno(cd, r, "TPM2 device not found.");
-        if (r == -ENXIO)
+        if (r == -ENOSTR)
                 return crypt_log_debug_errno(cd, r, "No matching TPM2 token data found.");
 
         return crypt_log_debug_errno(cd, r, TOKEN_NAME " open failed: %m.");

--- a/src/cryptsetup/cryptsetup-tokens/cryptsetup-token-systemd-tpm2.c
+++ b/src/cryptsetup/cryptsetup-tokens/cryptsetup-token-systemd-tpm2.c
@@ -87,6 +87,8 @@ _public_ int cryptsetup_token_open_pin(
                 params = *(systemd_tpm2_plugin_params *)usrptr;
 
         r = sd_json_parse(json, SD_JSON_PARSE_MUST_BE_OBJECT, &v, /* reterr_line= */ NULL, /* reterr_column= */ NULL);
+        if (r == -ENOMEM)
+                return r;
         if (r < 0) {
                 /* Remap to -EPERM so libcryptsetup keeps iterating past a broken token. */
                 (void) crypt_log_debug_errno(cd, r, "Token %d: failed to parse JSON data: %m", token);

--- a/src/cryptsetup/cryptsetup-tokens/cryptsetup-token-systemd-tpm2.c
+++ b/src/cryptsetup/cryptsetup-tokens/cryptsetup-token-systemd-tpm2.c
@@ -31,7 +31,7 @@ static int log_debug_open_error(struct crypt_device *cd, int token, int r) {
                 (void) crypt_log_debug_errno(cd, r, "Token %d: no matching TPM2 token data found.", token);
                 return -EPERM;
         }
-        if (IN_SET(r, -EREMCHG, -EREMOTE)) {
+        if (IN_SET(r, -EREMCHG, -EREMOTE, -EADDRNOTAVAIL)) {
                 /* Remap as above. Note: For now without -EUCLEAN because currently the only error it
                  * reports won't be solved by moving to another token. */
                 (void) crypt_log_debug_errno(cd, r, "Token %d: TPM policy does not match current system state, skipping.", token);

--- a/src/cryptsetup/cryptsetup-tokens/luks2-tpm2.c
+++ b/src/cryptsetup/cryptsetup-tokens/luks2-tpm2.c
@@ -110,7 +110,7 @@ int acquire_luks2_key(
                         srk,
                         ret_decrypted_key);
         if (r == -EREMOTE)
-                return log_error_errno(r, "TPM key integrity check failed. Key enrolled in superblock most likely does not belong to this TPM.");
+                return log_error_errno(r, "TPM key integrity check failed or NV index unusable. Key enrolled in superblock most likely does not belong to this TPM.");
         if (r == -EILSEQ)
                 return log_error_errno(SYNTHETIC_ERRNO(ENOANO), "Bad PIN."); /* cryptsetup docs say we should return ENOANO on bad PIN */
         if (r == -ENOLCK)

--- a/src/cryptsetup/cryptsetup-tokens/luks2-tpm2.c
+++ b/src/cryptsetup/cryptsetup-tokens/luks2-tpm2.c
@@ -117,6 +117,8 @@ int acquire_luks2_key(
                 return log_error_errno(r, "TPM is in dictionary attack lock-out mode.");
         if (ERRNO_IS_NEG_TPM2_UNSEAL_BAD_PCR(r))
                 return log_error_errno(r, "TPM policy does not match current system state. Either system has been tempered with or policy out-of-date: %m");
+        if (r == -ENXIO)
+                return log_error_errno(r, "No signature for current PCR policy in TPM2 signature JSON, token does not apply to current boot state: %m");
         if (r < 0)
                 return log_error_errno(r, "Failed to unseal secret using TPM2: %m");
 

--- a/src/cryptsetup/cryptsetup-tokens/luks2-tpm2.c
+++ b/src/cryptsetup/cryptsetup-tokens/luks2-tpm2.c
@@ -115,8 +115,11 @@ int acquire_luks2_key(
                 return log_error_errno(SYNTHETIC_ERRNO(ENOANO), "Bad PIN."); /* cryptsetup docs say we should return ENOANO on bad PIN */
         if (r == -ENOLCK)
                 return log_error_errno(r, "TPM is in dictionary attack lock-out mode.");
-        if (ERRNO_IS_NEG_TPM2_UNSEAL_BAD_PCR(r))
-                return log_error_errno(r, "TPM policy does not match current system state. Either system has been tempered with or policy out-of-date: %m");
+        if (ERRNO_IS_NEG_TPM2_UNSEAL_BAD_PCR(r)) {
+                log_error_errno(r, "TPM policy does not match current system state. Either system has been tempered with or policy out-of-date: %m");
+                /* Normalize to -EPERM so callers don't confuse it with -ENOANO's "needs PIN" meaning. */
+                return -EPERM;
+        }
         if (r == -ENXIO)
                 return log_error_errno(r, "No signature for current PCR policy in TPM2 signature JSON, token does not apply to current boot state: %m");
         if (r < 0)

--- a/src/cryptsetup/cryptsetup-tokens/luks2-tpm2.c
+++ b/src/cryptsetup/cryptsetup-tokens/luks2-tpm2.c
@@ -112,7 +112,7 @@ int acquire_luks2_key(
                         srk,
                         ret_decrypted_key);
         if (r == -EREMOTE)
-                return log_error_errno(r, "TPM key integrity check failed. Key enrolled in superblock most likely does not belong to this TPM.");
+                return log_error_errno(r, "TPM key integrity check failed or NV index unusable. Key enrolled in superblock most likely does not belong to this TPM.");
         if (r == -EILSEQ)
                 return log_error_errno(SYNTHETIC_ERRNO(ENOANO), "Bad PIN."); /* cryptsetup docs say we should return ENOANO on bad PIN */
         if (r == -ENOLCK)

--- a/src/cryptsetup/cryptsetup-tokens/luks2-tpm2.c
+++ b/src/cryptsetup/cryptsetup-tokens/luks2-tpm2.c
@@ -119,6 +119,8 @@ int acquire_luks2_key(
                 return log_error_errno(r, "TPM is in dictionary attack lock-out mode.");
         if (ERRNO_IS_NEG_TPM2_UNSEAL_BAD_PCR(r))
                 return log_error_errno(r, "TPM policy does not match current system state. Either system has been tempered with or policy out-of-date: %m");
+        if (r == -ENOSTR)
+                return log_error_errno(r, "No signature for current PCR policy in TPM2 signature JSON, token does not apply to current boot state: %m");
         if (r < 0)
                 return log_error_errno(r, "Failed to unseal secret using TPM2: %m");
 

--- a/src/cryptsetup/cryptsetup-tokens/luks2-tpm2.c
+++ b/src/cryptsetup/cryptsetup-tokens/luks2-tpm2.c
@@ -112,18 +112,18 @@ int acquire_luks2_key(
                         srk,
                         ret_decrypted_key);
         if (r == -EREMOTE)
-                return log_error_errno(r, "TPM key integrity check failed or NV index unusable. Key enrolled in superblock most likely does not belong to this TPM.");
+                return log_warning_errno(r, "TPM key integrity check failed or NV index unusable. Key enrolled in superblock most likely does not belong to this TPM.");
         if (r == -EILSEQ)
                 return log_error_errno(SYNTHETIC_ERRNO(ENOANO), "Bad PIN."); /* cryptsetup docs say we should return ENOANO on bad PIN */
         if (r == -ENOLCK)
                 return log_error_errno(r, "TPM is in dictionary attack lock-out mode.");
         if (ERRNO_IS_NEG_TPM2_UNSEAL_BAD_PCR(r)) {
-                log_error_errno(r, "TPM policy does not match current system state. Either system has been tempered with or policy out-of-date: %m");
+                log_warning_errno(r, "TPM policy does not match current system state. Either system has been tempered with or policy out-of-date: %m");
                 /* Normalize to -EPERM so callers don't confuse it with -ENOANO's "needs PIN" meaning. */
                 return -EPERM;
         }
         if (r == -ENOSTR)
-                return log_error_errno(r, "No signature for current PCR policy in TPM2 signature JSON, token does not apply to current boot state: %m");
+                return log_warning_errno(r, "No signature for current PCR policy in TPM2 signature JSON, token does not apply to current boot state: %m");
         if (r < 0)
                 return log_error_errno(r, "Failed to unseal secret using TPM2: %m");
 

--- a/src/cryptsetup/cryptsetup-tokens/luks2-tpm2.c
+++ b/src/cryptsetup/cryptsetup-tokens/luks2-tpm2.c
@@ -117,8 +117,11 @@ int acquire_luks2_key(
                 return log_error_errno(SYNTHETIC_ERRNO(ENOANO), "Bad PIN."); /* cryptsetup docs say we should return ENOANO on bad PIN */
         if (r == -ENOLCK)
                 return log_error_errno(r, "TPM is in dictionary attack lock-out mode.");
-        if (ERRNO_IS_NEG_TPM2_UNSEAL_BAD_PCR(r))
-                return log_error_errno(r, "TPM policy does not match current system state. Either system has been tempered with or policy out-of-date: %m");
+        if (ERRNO_IS_NEG_TPM2_UNSEAL_BAD_PCR(r)) {
+                log_error_errno(r, "TPM policy does not match current system state. Either system has been tempered with or policy out-of-date: %m");
+                /* Normalize to -EPERM so callers don't confuse it with -ENOANO's "needs PIN" meaning. */
+                return -EPERM;
+        }
         if (r == -ENOSTR)
                 return log_error_errno(r, "No signature for current PCR policy in TPM2 signature JSON, token does not apply to current boot state: %m");
         if (r < 0)

--- a/src/cryptsetup/cryptsetup-tokens/luks2-tpm2.c
+++ b/src/cryptsetup/cryptsetup-tokens/luks2-tpm2.c
@@ -112,7 +112,9 @@ int acquire_luks2_key(
                         srk,
                         ret_decrypted_key);
         if (r == -EREMOTE)
-                return log_warning_errno(r, "TPM key integrity check failed or NV index unusable. Key enrolled in superblock most likely does not belong to this TPM.");
+                return log_warning_errno(r, "TPM key integrity check failed. Key enrolled in superblock most likely does not belong to this TPM.");
+        if (r == -EADDRNOTAVAIL)
+                return log_warning_errno(r, "NV index referenced by token is missing, unwritten, or unusable, it could be for another system.");
         if (r == -EILSEQ)
                 return log_error_errno(SYNTHETIC_ERRNO(ENOANO), "Bad PIN."); /* cryptsetup docs say we should return ENOANO on bad PIN */
         if (r == -ENOLCK)

--- a/src/cryptsetup/cryptsetup.c
+++ b/src/cryptsetup/cryptsetup.c
@@ -2174,7 +2174,10 @@ static int attach_luks_or_plain_or_bitlk_by_tpm2(
                                                 &decrypted_key);
                                 if (IN_SET(r, -EACCES, -ENOLCK))
                                         return log_notice_errno(SYNTHETIC_ERRNO(EAGAIN), "TPM2 PIN unlock failed, falling back to traditional unlocking.");
-                                if (r != -EPERM)
+                                /* Stop unless we should keep iterating to next token because the tried one
+                                 * does not match boot state. For now without -EUCLEAN because currently the
+                                 * only error it reports won't be solved by moving to another token. */
+                                if (!IN_SET(r, -EPERM, -ENOANO, -EREMCHG, -ENXIO, -EREMOTE))
                                         break;
 
                                 token++; /* try a different token next time */

--- a/src/cryptsetup/cryptsetup.c
+++ b/src/cryptsetup/cryptsetup.c
@@ -2181,7 +2181,10 @@ static int attach_luks_or_plain_or_bitlk_by_tpm2(
                                                 &decrypted_key);
                                 if (IN_SET(r, -EACCES, -ENOLCK))
                                         return log_notice_errno(SYNTHETIC_ERRNO(EAGAIN), "TPM2 PIN unlock failed, falling back to traditional unlocking.");
-                                if (r != -EPERM)
+                                /* Stop unless we should keep iterating to next token because the tried one
+                                 * does not match boot state. For now without -EUCLEAN because currently the
+                                 * only error it reports won't be solved by moving to another token. */
+                                if (!ERRNO_IS_NEG_TPM2_TOKEN_MISMATCH(r))
                                         break;
 
                                 token++; /* try a different token next time */

--- a/src/shared/creds-util.c
+++ b/src/shared/creds-util.c
@@ -1393,6 +1393,8 @@ int decrypt_credential_and_warn(
                                 &tpm2_key);
                 if (r == -EREMOTE)
                         return log_error_errno(r, "TPM key integrity check failed. Key most likely does not belong to this TPM.");
+                if (r == -EADDRNOTAVAIL)
+                        return log_error_errno(r, "NV index referenced by key is missing, unwritten, or unusable, it could be for another system.");
                 if (ERRNO_IS_NEG_TPM2_UNSEAL_BAD_PCR(r))
                         return log_error_errno(r, "TPM policy does not match current system state. Either system has been tempered with or policy out-of-date: %m");
                 if (r < 0)
@@ -1837,6 +1839,7 @@ static const CredentialsVarlinkError credentials_varlink_error_table[] = {
         { "io.systemd.Credentials.KeyBelongsToOtherTPM",   EREMOTE,      "The TPM integrity check for this key failed, key probably belongs to another TPM, or was corrupted." },
         { "io.systemd.Credentials.TPMInDictionaryLockout", ENOLCK,       "The TPM is in dictionary lockout mode, cannot operate." },
         { "io.systemd.Credentials.UnexpectedPCRState" ,    EUCLEAN,      "Unexpected TPM PCR state of the system." },
+        { "io.systemd.Credentials.NVIndexUnusable",        EADDRNOTAVAIL, "The NV index referenced by the key is missing, unwritten, or unusable, it could be for another system." },
 };
 
 const CredentialsVarlinkError* credentials_varlink_error_by_id(const char *id) {

--- a/src/shared/cryptsetup-fido2.c
+++ b/src/shared/cryptsetup-fido2.c
@@ -167,7 +167,7 @@ int acquire_fido2_key_auto(
                 int ks;
 
                 r = cryptsetup_get_token_as_json(cd, token, "systemd-fido2", &v);
-                if (IN_SET(r, -ENOENT, -EINVAL, -EMEDIUMTYPE))
+                if (ERRNO_IS_NEG_CRYPTSETUP_TOKEN_SKIP(r))
                         continue;
                 if (r < 0)
                         return log_error_errno(r, "Failed to read JSON token data off disk: %m");

--- a/src/shared/cryptsetup-tpm2.c
+++ b/src/shared/cryptsetup-tpm2.c
@@ -175,6 +175,8 @@ int acquire_tpm2_key(
                         return log_error_errno(r, "TPM key integrity check failed. Key enrolled in superblock most likely does not belong to this TPM.");
                 if (ERRNO_IS_NEG_TPM2_UNSEAL_BAD_PCR(r))
                         return log_error_errno(r, "TPM policy does not match current system state. Either system has been tempered with or policy out-of-date: %m");
+                if (r == -ENXIO)
+                        return log_error_errno(r, "No signature for current PCR policy in TPM2 signature JSON, token does not apply to current boot state: %m");
                 if (r < 0)
                         return log_error_errno(r, "Failed to unseal secret using TPM2: %m");
 
@@ -227,6 +229,8 @@ int acquire_tpm2_key(
                         return log_error_errno(r, "TPM key integrity check failed. Key enrolled in superblock most likely does not belong to this TPM.");
                 if (ERRNO_IS_NEG_TPM2_UNSEAL_BAD_PCR(r))
                         return log_error_errno(r, "TPM policy does not match current system state. Either system has been tempered with or policy out-of-date: %m");
+                if (r == -ENXIO)
+                        return log_error_errno(r, "No signature for current PCR policy in TPM2 signature JSON, token does not apply to current boot state: %m");
                 if (r == -ENOLCK)
                         return log_error_errno(r, "TPM is in dictionary attack lock-out mode.");
                 if (r == -EILSEQ) {

--- a/src/shared/cryptsetup-tpm2.c
+++ b/src/shared/cryptsetup-tpm2.c
@@ -172,7 +172,7 @@ int acquire_tpm2_key(
                                 srk,
                                 ret_decrypted_key);
                 if (r == -EREMOTE)
-                        return log_error_errno(r, "TPM key integrity check failed. Key enrolled in superblock most likely does not belong to this TPM.");
+                        return log_error_errno(r, "TPM key integrity check failed or NV index unusable. Key enrolled in superblock most likely does not belong to this TPM.");
                 if (ERRNO_IS_NEG_TPM2_UNSEAL_BAD_PCR(r))
                         return log_error_errno(r, "TPM policy does not match current system state. Either system has been tempered with or policy out-of-date: %m");
                 if (r == -ENXIO)
@@ -226,7 +226,7 @@ int acquire_tpm2_key(
                                 srk,
                                 ret_decrypted_key);
                 if (r == -EREMOTE)
-                        return log_error_errno(r, "TPM key integrity check failed. Key enrolled in superblock most likely does not belong to this TPM.");
+                        return log_error_errno(r, "TPM key integrity check failed or NV index unusable. Key enrolled in superblock most likely does not belong to this TPM.");
                 if (ERRNO_IS_NEG_TPM2_UNSEAL_BAD_PCR(r))
                         return log_error_errno(r, "TPM policy does not match current system state. Either system has been tempered with or policy out-of-date: %m");
                 if (r == -ENXIO)

--- a/src/shared/cryptsetup-tpm2.c
+++ b/src/shared/cryptsetup-tpm2.c
@@ -173,8 +173,11 @@ int acquire_tpm2_key(
                                 ret_decrypted_key);
                 if (r == -EREMOTE)
                         return log_error_errno(r, "TPM key integrity check failed or NV index unusable. Key enrolled in superblock most likely does not belong to this TPM.");
-                if (ERRNO_IS_NEG_TPM2_UNSEAL_BAD_PCR(r))
-                        return log_error_errno(r, "TPM policy does not match current system state. Either system has been tempered with or policy out-of-date: %m");
+                if (ERRNO_IS_NEG_TPM2_UNSEAL_BAD_PCR(r)) {
+                        log_error_errno(r, "TPM policy does not match current system state. Either system has been tempered with or policy out-of-date: %m");
+                        /* Normalize to -EPERM so callers don't confuse it with -ENOANO's "needs PIN" meaning. */
+                        return -EPERM;
+                }
                 if (r == -ENXIO)
                         return log_error_errno(r, "No signature for current PCR policy in TPM2 signature JSON, token does not apply to current boot state: %m");
                 if (r < 0)
@@ -227,8 +230,11 @@ int acquire_tpm2_key(
                                 ret_decrypted_key);
                 if (r == -EREMOTE)
                         return log_error_errno(r, "TPM key integrity check failed or NV index unusable. Key enrolled in superblock most likely does not belong to this TPM.");
-                if (ERRNO_IS_NEG_TPM2_UNSEAL_BAD_PCR(r))
-                        return log_error_errno(r, "TPM policy does not match current system state. Either system has been tempered with or policy out-of-date: %m");
+                if (ERRNO_IS_NEG_TPM2_UNSEAL_BAD_PCR(r)) {
+                        log_error_errno(r, "TPM policy does not match current system state. Either system has been tempered with or policy out-of-date: %m");
+                        /* Normalize to -EPERM so callers don't confuse it with -ENOANO's "needs PIN" meaning. */
+                        return -EPERM;
+                }
                 if (r == -ENXIO)
                         return log_error_errno(r, "No signature for current PCR policy in TPM2 signature JSON, token does not apply to current boot state: %m");
                 if (r == -ENOLCK)

--- a/src/shared/cryptsetup-tpm2.c
+++ b/src/shared/cryptsetup-tpm2.c
@@ -175,8 +175,11 @@ int acquire_tpm2_key(
                                 ret_decrypted_key);
                 if (r == -EREMOTE)
                         return log_error_errno(r, "TPM key integrity check failed or NV index unusable. Key enrolled in superblock most likely does not belong to this TPM.");
-                if (ERRNO_IS_NEG_TPM2_UNSEAL_BAD_PCR(r))
-                        return log_error_errno(r, "TPM policy does not match current system state. Either system has been tempered with or policy out-of-date: %m");
+                if (ERRNO_IS_NEG_TPM2_UNSEAL_BAD_PCR(r)) {
+                        log_error_errno(r, "TPM policy does not match current system state. Either system has been tempered with or policy out-of-date: %m");
+                        /* Normalize to -EPERM so callers don't confuse it with -ENOANO's "needs PIN" meaning. */
+                        return -EPERM;
+                }
                 if (r == -ENOSTR)
                         return log_error_errno(r, "No signature for current PCR policy in TPM2 signature JSON, token does not apply to current boot state: %m");
                 if (r < 0)
@@ -230,8 +233,11 @@ int acquire_tpm2_key(
                                 ret_decrypted_key);
                 if (r == -EREMOTE)
                         return log_error_errno(r, "TPM key integrity check failed or NV index unusable. Key enrolled in superblock most likely does not belong to this TPM.");
-                if (ERRNO_IS_NEG_TPM2_UNSEAL_BAD_PCR(r))
-                        return log_error_errno(r, "TPM policy does not match current system state. Either system has been tempered with or policy out-of-date: %m");
+                if (ERRNO_IS_NEG_TPM2_UNSEAL_BAD_PCR(r)) {
+                        log_error_errno(r, "TPM policy does not match current system state. Either system has been tempered with or policy out-of-date: %m");
+                        /* Normalize to -EPERM so callers don't confuse it with -ENOANO's "needs PIN" meaning. */
+                        return -EPERM;
+                }
                 if (r == -ENOSTR)
                         return log_error_errno(r, "No signature for current PCR policy in TPM2 signature JSON, token does not apply to current boot state: %m");
                 if (r == -ENOLCK)

--- a/src/shared/cryptsetup-tpm2.c
+++ b/src/shared/cryptsetup-tpm2.c
@@ -174,7 +174,7 @@ int acquire_tpm2_key(
                                 srk,
                                 ret_decrypted_key);
                 if (r == -EREMOTE)
-                        return log_error_errno(r, "TPM key integrity check failed. Key enrolled in superblock most likely does not belong to this TPM.");
+                        return log_error_errno(r, "TPM key integrity check failed or NV index unusable. Key enrolled in superblock most likely does not belong to this TPM.");
                 if (ERRNO_IS_NEG_TPM2_UNSEAL_BAD_PCR(r))
                         return log_error_errno(r, "TPM policy does not match current system state. Either system has been tempered with or policy out-of-date: %m");
                 if (r == -ENOSTR)
@@ -229,7 +229,7 @@ int acquire_tpm2_key(
                                 srk,
                                 ret_decrypted_key);
                 if (r == -EREMOTE)
-                        return log_error_errno(r, "TPM key integrity check failed. Key enrolled in superblock most likely does not belong to this TPM.");
+                        return log_error_errno(r, "TPM key integrity check failed or NV index unusable. Key enrolled in superblock most likely does not belong to this TPM.");
                 if (ERRNO_IS_NEG_TPM2_UNSEAL_BAD_PCR(r))
                         return log_error_errno(r, "TPM policy does not match current system state. Either system has been tempered with or policy out-of-date: %m");
                 if (r == -ENOSTR)

--- a/src/shared/cryptsetup-tpm2.c
+++ b/src/shared/cryptsetup-tpm2.c
@@ -174,14 +174,14 @@ int acquire_tpm2_key(
                                 srk,
                                 ret_decrypted_key);
                 if (r == -EREMOTE)
-                        return log_error_errno(r, "TPM key integrity check failed or NV index unusable. Key enrolled in superblock most likely does not belong to this TPM.");
+                        return log_warning_errno(r, "TPM key integrity check failed or NV index unusable. Key enrolled in superblock most likely does not belong to this TPM.");
                 if (ERRNO_IS_NEG_TPM2_UNSEAL_BAD_PCR(r)) {
-                        log_error_errno(r, "TPM policy does not match current system state. Either system has been tempered with or policy out-of-date: %m");
+                        log_warning_errno(r, "TPM policy does not match current system state. Either system has been tempered with or policy out-of-date: %m");
                         /* Normalize to -EPERM so callers don't confuse it with -ENOANO's "needs PIN" meaning. */
                         return -EPERM;
                 }
                 if (r == -ENOSTR)
-                        return log_error_errno(r, "No signature for current PCR policy in TPM2 signature JSON, token does not apply to current boot state: %m");
+                        return log_warning_errno(r, "No signature for current PCR policy in TPM2 signature JSON, token does not apply to current boot state: %m");
                 if (r < 0)
                         return log_error_errno(r, "Failed to unseal secret using TPM2: %m");
 
@@ -232,14 +232,14 @@ int acquire_tpm2_key(
                                 srk,
                                 ret_decrypted_key);
                 if (r == -EREMOTE)
-                        return log_error_errno(r, "TPM key integrity check failed or NV index unusable. Key enrolled in superblock most likely does not belong to this TPM.");
+                        return log_warning_errno(r, "TPM key integrity check failed or NV index unusable. Key enrolled in superblock most likely does not belong to this TPM.");
                 if (ERRNO_IS_NEG_TPM2_UNSEAL_BAD_PCR(r)) {
-                        log_error_errno(r, "TPM policy does not match current system state. Either system has been tempered with or policy out-of-date: %m");
+                        log_warning_errno(r, "TPM policy does not match current system state. Either system has been tempered with or policy out-of-date: %m");
                         /* Normalize to -EPERM so callers don't confuse it with -ENOANO's "needs PIN" meaning. */
                         return -EPERM;
                 }
                 if (r == -ENOSTR)
-                        return log_error_errno(r, "No signature for current PCR policy in TPM2 signature JSON, token does not apply to current boot state: %m");
+                        return log_warning_errno(r, "No signature for current PCR policy in TPM2 signature JSON, token does not apply to current boot state: %m");
                 if (r == -ENOLCK)
                         return log_error_errno(r, "TPM is in dictionary attack lock-out mode.");
                 if (r == -EILSEQ) {

--- a/src/shared/cryptsetup-tpm2.c
+++ b/src/shared/cryptsetup-tpm2.c
@@ -313,7 +313,7 @@ int find_tpm2_auto_data(
                 CLEANUP_ARRAY(policy_hash, n_policy_hash, iovec_array_free);
 
                 r = cryptsetup_get_token_as_json(cd, token, "systemd-tpm2", &v);
-                if (IN_SET(r, -ENOENT, -EINVAL, -EMEDIUMTYPE))
+                if (ERRNO_IS_NEG_CRYPTSETUP_TOKEN_SKIP(r))
                         continue;
                 if (r < 0)
                         return log_error_errno(r, "Failed to read JSON token data off disk: %m");

--- a/src/shared/cryptsetup-tpm2.c
+++ b/src/shared/cryptsetup-tpm2.c
@@ -174,7 +174,9 @@ int acquire_tpm2_key(
                                 srk,
                                 ret_decrypted_key);
                 if (r == -EREMOTE)
-                        return log_warning_errno(r, "TPM key integrity check failed or NV index unusable. Key enrolled in superblock most likely does not belong to this TPM.");
+                        return log_warning_errno(r, "TPM key integrity check failed. Key enrolled in superblock most likely does not belong to this TPM.");
+                if (r == -EADDRNOTAVAIL)
+                        return log_warning_errno(r, "NV index referenced by token is missing, unwritten, or unusable, it could be for another system.");
                 if (ERRNO_IS_NEG_TPM2_UNSEAL_BAD_PCR(r)) {
                         log_warning_errno(r, "TPM policy does not match current system state. Either system has been tempered with or policy out-of-date: %m");
                         /* Normalize to -EPERM so callers don't confuse it with -ENOANO's "needs PIN" meaning. */
@@ -232,7 +234,9 @@ int acquire_tpm2_key(
                                 srk,
                                 ret_decrypted_key);
                 if (r == -EREMOTE)
-                        return log_warning_errno(r, "TPM key integrity check failed or NV index unusable. Key enrolled in superblock most likely does not belong to this TPM.");
+                        return log_warning_errno(r, "TPM key integrity check failed. Key enrolled in superblock most likely does not belong to this TPM.");
+                if (r == -EADDRNOTAVAIL)
+                        return log_warning_errno(r, "NV index referenced by token is missing, unwritten, or unusable, it could be for another system.");
                 if (ERRNO_IS_NEG_TPM2_UNSEAL_BAD_PCR(r)) {
                         log_warning_errno(r, "TPM policy does not match current system state. Either system has been tempered with or policy out-of-date: %m");
                         /* Normalize to -EPERM so callers don't confuse it with -ENOANO's "needs PIN" meaning. */

--- a/src/shared/cryptsetup-tpm2.c
+++ b/src/shared/cryptsetup-tpm2.c
@@ -177,6 +177,8 @@ int acquire_tpm2_key(
                         return log_error_errno(r, "TPM key integrity check failed. Key enrolled in superblock most likely does not belong to this TPM.");
                 if (ERRNO_IS_NEG_TPM2_UNSEAL_BAD_PCR(r))
                         return log_error_errno(r, "TPM policy does not match current system state. Either system has been tempered with or policy out-of-date: %m");
+                if (r == -ENOSTR)
+                        return log_error_errno(r, "No signature for current PCR policy in TPM2 signature JSON, token does not apply to current boot state: %m");
                 if (r < 0)
                         return log_error_errno(r, "Failed to unseal secret using TPM2: %m");
 
@@ -230,6 +232,8 @@ int acquire_tpm2_key(
                         return log_error_errno(r, "TPM key integrity check failed. Key enrolled in superblock most likely does not belong to this TPM.");
                 if (ERRNO_IS_NEG_TPM2_UNSEAL_BAD_PCR(r))
                         return log_error_errno(r, "TPM policy does not match current system state. Either system has been tempered with or policy out-of-date: %m");
+                if (r == -ENOSTR)
+                        return log_error_errno(r, "No signature for current PCR policy in TPM2 signature JSON, token does not apply to current boot state: %m");
                 if (r == -ENOLCK)
                         return log_error_errno(r, "TPM is in dictionary attack lock-out mode.");
                 if (r == -EILSEQ) {

--- a/src/shared/cryptsetup-util.c
+++ b/src/shared/cryptsetup-util.c
@@ -164,6 +164,7 @@ int cryptsetup_get_token_as_json(
          *      -EINVAL → token index out of range or "type" field missing
          *      -ENOENT → token doesn't exist
          * -EMEDIUMTYPE → "verify_type" specified and doesn't match token's type
+         *     -EUCLEAN → token JSON data cannot be parsed
          */
 
         r = sym_crypt_token_json_get(cd, idx, &text);
@@ -172,7 +173,7 @@ int cryptsetup_get_token_as_json(
 
         r = sd_json_parse(text, 0, &v, NULL, NULL);
         if (r < 0)
-                return r;
+                return r == -ENOMEM ? r : -EUCLEAN; /* Report unparseable token data in a single way for callers to skip */
 
         if (verify_type) {
                 sd_json_variant *w;

--- a/src/shared/cryptsetup-util.h
+++ b/src/shared/cryptsetup-util.h
@@ -91,6 +91,9 @@ void cryptsetup_enable_logging(struct crypt_device *cd);
 int cryptsetup_set_minimal_pbkdf(struct crypt_device *cd);
 
 int cryptsetup_get_token_as_json(struct crypt_device *cd, int idx, const char *verify_type, sd_json_variant **ret);
+/* Errors cryptsetup_get_token_as_json() returns for a token that is absent, of a different type, or
+ * unparseable, and callers should keep iterating other tokens. */
+#define ERRNO_IS_NEG_CRYPTSETUP_TOKEN_SKIP(r) IN_SET(r, -ENOENT, -EINVAL, -EMEDIUMTYPE, -EUCLEAN)
 int cryptsetup_add_token_json(struct crypt_device *cd, sd_json_variant *v);
 int cryptsetup_get_volume_key_prefix(struct crypt_device *cd, const char *volume_name, char **ret);
 int cryptsetup_get_volume_key_id(struct crypt_device *cd, const char *volume_name, const void *volume_key,

--- a/src/shared/tpm2-util.c
+++ b/src/shared/tpm2-util.c
@@ -2450,7 +2450,10 @@ int tpm2_load(
         if (rc == TPM2_RC_LOCKOUT)
                 return log_debug_errno(SYNTHETIC_ERRNO(ENOLCK),
                                        "TPM2 device is in dictionary attack lockout mode.");
-        if ((rc & ~(TPM2_RC_N_MASK|TPM2_RC_P)) == TPM2_RC_INTEGRITY) /* Return a recognizable error if this key does not belong to the local TPM */
+        uint32_t masked_rc = rc & ~(TPM2_RC_N_MASK|TPM2_RC_P);
+        if (masked_rc == TPM2_RC_INTEGRITY || masked_rc == TPM2_RC_SIZE)
+                /* Return a recognizable error if this key does not belong to the local TPM
+                 * (TPM2_RC_INTEGRITY if for a different parent, TPM2_RC_SIZE if different template). */
                 return log_debug_errno(SYNTHETIC_ERRNO(EREMOTE),
                                        "Key invalid or does not belong to current TPM.");
         if (rc != TSS2_RC_SUCCESS)
@@ -2670,7 +2673,10 @@ static int tpm2_import(
                         seed,
                         symmetric ?: &(TPMT_SYM_DEF_OBJECT){ .algorithm = TPM2_ALG_NULL, },
                         ret_private);
-        if ((rc & ~(TPM2_RC_N_MASK|TPM2_RC_P)) == TPM2_RC_INTEGRITY) /* Return a recognizable error if this key does not belong to the local TPM */
+        uint32_t masked_rc = rc & ~(TPM2_RC_N_MASK|TPM2_RC_P);
+        if (masked_rc == TPM2_RC_INTEGRITY || masked_rc == TPM2_RC_SIZE)
+                /* Return a recognizable error if this key does not belong to the local TPM
+                 * (TPM2_RC_INTEGRITY if for a different parent, TPM2_RC_SIZE if different template). */
                 return log_debug_errno(SYNTHETIC_ERRNO(EREMOTE),
                                        "Key invalid or does not belong to current TPM.");
         if (rc != TSS2_RC_SUCCESS)

--- a/src/shared/tpm2-util.c
+++ b/src/shared/tpm2-util.c
@@ -3937,6 +3937,10 @@ int tpm2_policy_authorize_nv(
                                                                   * just put together */
                 return log_debug_errno(SYNTHETIC_ERRNO(EREMCHG),
                                        "Submitted policy does not match policy stored in PolicyAuthorizeNV.");
+        if ((rc & ~(TPM2_RC_N_MASK|TPM2_RC_P)) == TPM2_RC_HANDLE ||
+            rc == TPM2_RC_NV_UNINITIALIZED) /* NV index is missing, unwritten, or otherwise unusable for this policy (or: wrong authHandle/policySession). */
+                return log_debug_errno(SYNTHETIC_ERRNO(EREMOTE),
+                                       "NV index referenced by token is missing, unwritten, or unusable.");
         if (rc != TSS2_RC_SUCCESS)
                 return log_debug_errno(SYNTHETIC_ERRNO(ENOTRECOVERABLE),
                                        "Failed to add AuthorizeNV policy to TPM: %s",
@@ -5775,7 +5779,7 @@ int tpm2_unseal(Tpm2Context *c,
 
         /* Returns the following errors:
          *
-         *   -EREMOTE         → blob is from a different TPM
+         *   -EREMOTE         → blob is from a different TPM, or NV index referenced by policy is unusable
          *   -ENXIO           → signature JSON has no matching entry for the current PCR policy
          *   -EDEADLK         → couldn't create primary key because authorization failure
          *   -ENOLCK          → TPM is in dictionary lockout mode

--- a/src/shared/tpm2-util.c
+++ b/src/shared/tpm2-util.c
@@ -2670,6 +2670,9 @@ static int tpm2_import(
                         seed,
                         symmetric ?: &(TPMT_SYM_DEF_OBJECT){ .algorithm = TPM2_ALG_NULL, },
                         ret_private);
+        if ((rc & ~(TPM2_RC_N_MASK|TPM2_RC_P)) == TPM2_RC_INTEGRITY) /* Return a recognizable error if this key does not belong to the local TPM */
+                return log_debug_errno(SYNTHETIC_ERRNO(EREMOTE),
+                                       "Key invalid or does not belong to current TPM.");
         if (rc != TSS2_RC_SUCCESS)
                 return log_debug_errno(SYNTHETIC_ERRNO(ENOTRECOVERABLE),
                                        "Failed to import key into TPM: %s", sym_Tss2_RC_Decode(rc));

--- a/src/shared/tpm2-util.c
+++ b/src/shared/tpm2-util.c
@@ -5773,6 +5773,7 @@ int tpm2_unseal(Tpm2Context *c,
         /* Returns the following errors:
          *
          *   -EREMOTE         → blob is from a different TPM
+         *   -ENXIO           → signature JSON has no matching entry for the current PCR policy
          *   -EDEADLK         → couldn't create primary key because authorization failure
          *   -ENOLCK          → TPM is in dictionary lockout mode
          *   -EREMCHG         → submitted policy doesn't match NV index stored policy (in case of PolicyAuthorizeNV)

--- a/src/shared/tpm2-util.c
+++ b/src/shared/tpm2-util.c
@@ -4751,6 +4751,10 @@ int tpm2_policy_authorize_nv(
                                                                   * just put together */
                 return log_debug_errno(SYNTHETIC_ERRNO(EREMCHG),
                                        "Submitted policy does not match policy stored in PolicyAuthorizeNV.");
+        if ((rc & ~(TPM2_RC_N_MASK|TPM2_RC_P)) == TPM2_RC_HANDLE ||
+            rc == TPM2_RC_NV_UNINITIALIZED) /* NV index is missing, unwritten, or otherwise unusable for this policy (or: wrong authHandle/policySession). */
+                return log_debug_errno(SYNTHETIC_ERRNO(EREMOTE),
+                                       "NV index referenced by token is missing, unwritten, or unusable.");
         if (rc != TSS2_RC_SUCCESS)
                 return log_debug_errno(SYNTHETIC_ERRNO(ENOTRECOVERABLE),
                                        "Failed to add AuthorizeNV policy to TPM: %s",
@@ -6663,7 +6667,7 @@ int tpm2_unseal(Tpm2Context *c,
 
         /* Returns the following errors:
          *
-         *   -EREMOTE         → blob is from a different TPM
+         *   -EREMOTE         → blob is from a different TPM, or NV index referenced by policy is unusable
          *   -ENOSTR          → signature JSON has no matching entry for the current PCR policy
          *   -EDEADLK         → couldn't create primary key because authorization failure
          *   -ENOLCK          → TPM is in dictionary lockout mode

--- a/src/shared/tpm2-util.c
+++ b/src/shared/tpm2-util.c
@@ -4241,7 +4241,7 @@ static int find_signature(
         /* First, find field by bank */
         b = sd_json_variant_by_key(v, k);
         if (!b)
-                return log_debug_errno(SYNTHETIC_ERRNO(ENXIO), "Signature lacks data for PCR bank '%s'.", k);
+                return log_debug_errno(SYNTHETIC_ERRNO(ENOSTR), "Signature lacks data for PCR bank '%s'.", k);
 
         if (!sd_json_variant_is_array(b))
                 return log_debug_errno(SYNTHETIC_ERRNO(EINVAL), "Bank data is not a JSON array.");
@@ -4311,7 +4311,7 @@ static int find_signature(
                 return sd_json_variant_unbase64(sigj, ret_signature, ret_signature_size);
         }
 
-        return log_debug_errno(SYNTHETIC_ERRNO(ENXIO), "Couldn't find signature for this PCR bank, PCR index and public key.");
+        return log_debug_errno(SYNTHETIC_ERRNO(ENOSTR), "Couldn't find signature for this PCR bank, PCR index and public key.");
 #else /* HAVE_OPENSSL */
         return log_debug_errno(SYNTHETIC_ERRNO(EOPNOTSUPP), "OpenSSL support is disabled.");
 #endif
@@ -6661,6 +6661,7 @@ int tpm2_unseal(Tpm2Context *c,
         /* Returns the following errors:
          *
          *   -EREMOTE         → blob is from a different TPM
+         *   -ENOSTR          → signature JSON has no matching entry for the current PCR policy
          *   -EDEADLK         → couldn't create primary key because authorization failure
          *   -ENOLCK          → TPM is in dictionary lockout mode
          *   -EREMCHG         → submitted policy doesn't match NV index stored policy (in case of PolicyAuthorizeNV)

--- a/src/shared/tpm2-util.c
+++ b/src/shared/tpm2-util.c
@@ -3454,6 +3454,9 @@ static int tpm2_import(
                         seed,
                         symmetric ?: &(TPMT_SYM_DEF_OBJECT){ .algorithm = TPM2_ALG_NULL, },
                         ret_private);
+        if ((rc & ~(TPM2_RC_N_MASK|TPM2_RC_P)) == TPM2_RC_INTEGRITY) /* Return a recognizable error if this key does not belong to the local TPM */
+                return log_debug_errno(SYNTHETIC_ERRNO(EREMOTE),
+                                       "Key invalid or does not belong to current TPM.");
         if (rc != TSS2_RC_SUCCESS)
                 return log_debug_errno(SYNTHETIC_ERRNO(ENOTRECOVERABLE),
                                        "Failed to import key into TPM: %s", sym_Tss2_RC_Decode(rc));

--- a/src/shared/tpm2-util.c
+++ b/src/shared/tpm2-util.c
@@ -4753,8 +4753,8 @@ int tpm2_policy_authorize_nv(
                                        "Submitted policy does not match policy stored in PolicyAuthorizeNV.");
         if ((rc & ~(TPM2_RC_N_MASK|TPM2_RC_P)) == TPM2_RC_HANDLE ||
             rc == TPM2_RC_NV_UNINITIALIZED) /* NV index is missing, unwritten, or otherwise unusable for this policy (or: wrong authHandle/policySession). */
-                return log_debug_errno(SYNTHETIC_ERRNO(EREMOTE),
-                                       "NV index referenced by token is missing, unwritten, or unusable.");
+                return log_debug_errno(SYNTHETIC_ERRNO(EADDRNOTAVAIL),
+                                       "NV index referenced by token is missing, unwritten, or unusable, it could be for another system.");
         if (rc != TSS2_RC_SUCCESS)
                 return log_debug_errno(SYNTHETIC_ERRNO(ENOTRECOVERABLE),
                                        "Failed to add AuthorizeNV policy to TPM: %s",
@@ -6667,7 +6667,8 @@ int tpm2_unseal(Tpm2Context *c,
 
         /* Returns the following errors:
          *
-         *   -EREMOTE         → blob is from a different TPM, or NV index referenced by policy is unusable
+         *   -EREMOTE         → blob is from a different TPM
+         *   -EADDRNOTAVAIL   → NV index referenced by policy is missing, unwritten, or unusable
          *   -ENOSTR          → signature JSON has no matching entry for the current PCR policy
          *   -EDEADLK         → couldn't create primary key because authorization failure
          *   -ENOLCK          → TPM is in dictionary lockout mode

--- a/src/shared/tpm2-util.c
+++ b/src/shared/tpm2-util.c
@@ -3234,7 +3234,7 @@ int tpm2_load(
         if (rc == TPM2_RC_LOCKOUT)
                 return log_debug_errno(SYNTHETIC_ERRNO(ENOLCK),
                                        "TPM2 device is in dictionary attack lockout mode.");
-        if ((rc & ~(TPM2_RC_N_MASK|TPM2_RC_P)) == TPM2_RC_INTEGRITY) /* Return a recognizable error if this key does not belong to the local TPM */
+        if (TPM2_RC_IS_FOREIGN_KEY(rc))
                 return log_debug_errno(SYNTHETIC_ERRNO(EREMOTE),
                                        "Key invalid or does not belong to current TPM.");
         if (rc != TSS2_RC_SUCCESS)
@@ -3454,7 +3454,7 @@ static int tpm2_import(
                         seed,
                         symmetric ?: &(TPMT_SYM_DEF_OBJECT){ .algorithm = TPM2_ALG_NULL, },
                         ret_private);
-        if ((rc & ~(TPM2_RC_N_MASK|TPM2_RC_P)) == TPM2_RC_INTEGRITY) /* Return a recognizable error if this key does not belong to the local TPM */
+        if (TPM2_RC_IS_FOREIGN_KEY(rc))
                 return log_debug_errno(SYNTHETIC_ERRNO(EREMOTE),
                                        "Key invalid or does not belong to current TPM.");
         if (rc != TSS2_RC_SUCCESS)

--- a/src/shared/tpm2-util.h
+++ b/src/shared/tpm2-util.h
@@ -54,8 +54,9 @@ int dlopen_tpm2(int log_level);
 #define ERRNO_IS_NEG_TPM2_UNSEAL_BAD_PCR(r) IN_SET(r, -EREMCHG, -ENOANO, -EUCLEAN, -EPERM)
 
 /* Errors that mean the tried TPM2 token does not match the boot state, be it due to wrong PCR state, a
- * different PCR signing key/policy, or even a different TPM. The caller should keep trying other tokens. */
-#define ERRNO_IS_NEG_TPM2_TOKEN_MISMATCH(r) IN_SET(r, -EREMCHG, -ENOANO, -EPERM, -ENOSTR, -EREMOTE)
+ * different PCR signing key/policy, a different TPM, or an unusable NV index. The caller should keep trying
+ * other tokens. */
+#define ERRNO_IS_NEG_TPM2_TOKEN_MISMATCH(r) IN_SET(r, -EREMCHG, -ENOANO, -EPERM, -ENOSTR, -EREMOTE, -EADDRNOTAVAIL)
 
 #if HAVE_TPM2
 #ifndef SYSTEMD_CFLAGS_MARKER_TPM2

--- a/src/shared/tpm2-util.h
+++ b/src/shared/tpm2-util.h
@@ -386,6 +386,10 @@ int tpm2_get_or_create_ek(Tpm2Context *c, const Tpm2Handle *session, TPM2B_PUBLI
 int tpm2_seal(Tpm2Context *c, uint32_t seal_key_handle, const TPM2B_DIGEST policy_hash[], size_t n_policy, const char *pin, struct iovec *ret_secret, struct iovec **ret_blobs, size_t *ret_n_blobs, uint16_t *ret_primary_alg, struct iovec *ret_srk);
 int tpm2_unseal(Tpm2Context *c, uint32_t hash_pcr_mask, uint16_t pcr_bank, const struct iovec *pubkey, const char *pubkey_policy_ref, uint32_t pubkey_pcr_mask, sd_json_variant *signature, const char *pin, const Tpm2PCRLockPolicy *pcrlock_policy, uint16_t primary_alg, const struct iovec blobs[], size_t n_blobs, const struct iovec known_policy_hash[], size_t n_known_policy_hash, const struct iovec *srk, struct iovec *ret_secret);
 
+/* On load/import the return codes mean the key was wrapped for a different parent (INTEGRITY) or used a
+ * different template (SIZE), so it's probably not for our TPM. */
+#define TPM2_RC_IS_FOREIGN_KEY(rc) IN_SET((rc) & ~(TPM2_RC_N_MASK|TPM2_RC_P), TPM2_RC_INTEGRITY, TPM2_RC_SIZE)
+
 #if HAVE_OPENSSL
 int tpm2_tpm2b_public_to_openssl_pkey(const TPM2B_PUBLIC *public, EVP_PKEY **ret);
 int tpm2_tpm2b_public_from_openssl_pkey(const EVP_PKEY *pkey, TPM2B_PUBLIC *ret);

--- a/src/shared/tpm2-util.h
+++ b/src/shared/tpm2-util.h
@@ -49,6 +49,14 @@ static inline bool TPM2_PCR_MASK_VALID(uint32_t pcr_mask) {
 
 int dlopen_tpm2(int log_level);
 
+/* tpm2_unseal() returns a bunch of different errors for various flavours of PCR issues, let's group them.
+ * Kept outside the HAVE_TPM2 guard as callers switch on these errnos even in builds without TPM2. */
+#define ERRNO_IS_NEG_TPM2_UNSEAL_BAD_PCR(r) IN_SET(r, -EREMCHG, -ENOANO, -EUCLEAN, -EPERM)
+
+/* Errors that mean the tried TPM2 token does not match the boot state, be it due to wrong PCR state, a
+ * different PCR signing key/policy, or even a different TPM. The caller should keep trying other tokens. */
+#define ERRNO_IS_NEG_TPM2_TOKEN_MISMATCH(r) IN_SET(r, -EREMCHG, -ENOANO, -EPERM, -ENOSTR, -EREMOTE)
+
 #if HAVE_TPM2
 #ifndef SYSTEMD_CFLAGS_MARKER_TPM2
 #  error "missing tpm2_cflags in meson dependency."
@@ -377,9 +385,6 @@ int tpm2_get_or_create_ek(Tpm2Context *c, const Tpm2Handle *session, TPM2B_PUBLI
 
 int tpm2_seal(Tpm2Context *c, uint32_t seal_key_handle, const TPM2B_DIGEST policy_hash[], size_t n_policy, const char *pin, struct iovec *ret_secret, struct iovec **ret_blobs, size_t *ret_n_blobs, uint16_t *ret_primary_alg, struct iovec *ret_srk);
 int tpm2_unseal(Tpm2Context *c, uint32_t hash_pcr_mask, uint16_t pcr_bank, const struct iovec *pubkey, const char *pubkey_policy_ref, uint32_t pubkey_pcr_mask, sd_json_variant *signature, const char *pin, const Tpm2PCRLockPolicy *pcrlock_policy, uint16_t primary_alg, const struct iovec blobs[], size_t n_blobs, const struct iovec known_policy_hash[], size_t n_known_policy_hash, const struct iovec *srk, struct iovec *ret_secret);
-
-/* tpm2_unseal() returns a bunch of different errors for various flavours of PCR issues, let's group them */
-#define ERRNO_IS_NEG_TPM2_UNSEAL_BAD_PCR(r) IN_SET(r, -EREMCHG, -ENOANO, -EUCLEAN, -EPERM)
 
 #if HAVE_OPENSSL
 int tpm2_tpm2b_public_to_openssl_pkey(const TPM2B_PUBLIC *public, EVP_PKEY **ret);

--- a/src/shared/varlink-io.systemd.Credentials.c
+++ b/src/shared/varlink-io.systemd.Credentials.c
@@ -79,6 +79,7 @@ static SD_VARLINK_DEFINE_ERROR(NullKeyNotAllowed);
 static SD_VARLINK_DEFINE_ERROR(KeyBelongsToOtherTPM);
 static SD_VARLINK_DEFINE_ERROR(TPMInDictionaryLockout);
 static SD_VARLINK_DEFINE_ERROR(UnexpectedPCRState);
+static SD_VARLINK_DEFINE_ERROR(NVIndexUnusable);
 
 SD_VARLINK_DEFINE_INTERFACE(
                 io_systemd_Credentials,
@@ -111,4 +112,6 @@ SD_VARLINK_DEFINE_INTERFACE(
                 SD_VARLINK_SYMBOL_COMMENT("The TPM is in dictionary lockout mode, cannot operate."),
                 &vl_error_TPMInDictionaryLockout,
                 SD_VARLINK_SYMBOL_COMMENT("Unexpected TPM PCR state of the system."),
-                &vl_error_UnexpectedPCRState);
+                &vl_error_UnexpectedPCRState,
+                SD_VARLINK_SYMBOL_COMMENT("The NV index referenced by the key is missing, unwritten, or unusable, it could be for another system."),
+                &vl_error_NVIndexUnusable);

--- a/test/units/TEST-70-TPM2.cryptsetup.sh
+++ b/test/units/TEST-70-TPM2.cryptsetup.sh
@@ -224,4 +224,48 @@ EOF
     rmdir /tmp/dditest
 fi
 
+# Ensure we iterate over foreign tokens, e.g., other PCR signing keys or LUKS
+# slots for other TPMs (e.g., external drives). This test makes it so that the
+# first tokens don't unseal but the last one will. This way we check that
+# iteration works.
+if openssl_supports_kdf SSKDF; then
+    # Foreign PCR-policy pubkeys (no matching signatures will be available)
+    openssl genpkey -algorithm RSA -out /tmp/unknown1.priv.pem -pkeyopt rsa_keygen_bits:2048
+    openssl rsa -in /tmp/unknown1.priv.pem -pubout -out /tmp/unknown1.pem
+    openssl genpkey -algorithm RSA -out /tmp/unknown2.priv.pem -pkeyopt rsa_keygen_bits:2048
+    openssl rsa -in /tmp/unknown2.priv.pem -pubout -out /tmp/unknown2.pem
+
+    # Foreign TPM pub key, created from random transient primary under the null hierarchy.
+    # Note: This hits TPM2_RC_SIZE not TPM2_RC_INTEGRITY but both are handled the same.
+    tpm2_createprimary -C n -c /tmp/unknown-srk.ctx
+    tpm2_readpublic -c /tmp/unknown-srk.ctx -o /tmp/unknown-srk.pub
+    tpm2_flushcontext -t
+
+    # Empty signature meaing nothing is found for the foreign PCR-policy pubkeys
+    echo '{}' > /tmp/empty-pcrsig.json
+
+    systemd-cryptenroll --wipe-slot=tpm2 "$IMAGE"
+    # Token 1: unknown pubkey, unseal fails at signature lookup (ENXIO)
+    PASSWORD=passphrase systemd-cryptenroll --tpm2-device=auto --tpm2-pcrlock= \
+        --tpm2-public-key=/tmp/unknown1.pem --tpm2-public-key-pcrs=11 "$IMAGE"
+    # Token 2: unknown pubkey and unknown SRK (EREMOTE)
+    PASSWORD=passphrase systemd-cryptenroll --tpm2-device-key=/tmp/unknown-srk.pub --tpm2-pcrlock= \
+        --tpm2-public-key=/tmp/unknown2.pem --tpm2-public-key-pcrs=11 "$IMAGE"
+    # Token 3: no pubkey, current-PCR-7 policy, unseals successfully
+    PASSWORD=passphrase systemd-cryptenroll --tpm2-device=auto --tpm2-pcrlock= --tpm2-public-key= --tpm2-pcrs=7 "$IMAGE"
+    # Note: Not covered yet is a plain PCR mismatch, the NV index missing/corrupted, and different PCR masks.
+
+    # This should iterate over the tokens reporting failures until we reach token 3.
+    # Do it for both the token module and fallback path because iteration differs there.
+    for mod in 1 0; do
+        SYSTEMD_CRYPTSETUP_USE_TOKEN_MODULE=$mod \
+            systemd-cryptsetup attach test-volume "$IMAGE" - \
+            tpm2-device=auto,tpm2-signature=/tmp/empty-pcrsig.json,headless=1
+        systemd-cryptsetup detach test-volume
+    done
+
+    rm -f /tmp/unknown1.priv.pem /tmp/unknown1.pem /tmp/unknown2.priv.pem /tmp/unknown2.pem \
+          /tmp/unknown-srk.pub /tmp/unknown-srk.ctx /tmp/empty-pcrsig.json
+fi
+
 rm -f "$IMAGE" "$PRIMARY"

--- a/test/units/TEST-70-TPM2.cryptsetup.sh
+++ b/test/units/TEST-70-TPM2.cryptsetup.sh
@@ -246,4 +246,48 @@ systemd-cryptsetup detach test-volume
 # Negative test: invalid passphrase should not work.
 (! systemd-cryptsetup attach test-volume "$IMAGE" /tmp/wrong_passphrase tpm2-device=auto,headless=1)
 
+# Ensure we iterate over foreign tokens, e.g., other PCR signing keys or LUKS
+# slots for other TPMs (e.g., external drives). This test makes it so that the
+# first tokens don't unseal but the last one will. This way we check that
+# iteration works.
+if openssl_supports_kdf SSKDF; then
+    # Foreign PCR-policy pubkeys (no matching signatures will be available)
+    openssl genpkey -algorithm RSA -out /tmp/unknown1.priv.pem -pkeyopt rsa_keygen_bits:2048
+    openssl rsa -in /tmp/unknown1.priv.pem -pubout -out /tmp/unknown1.pem
+    openssl genpkey -algorithm RSA -out /tmp/unknown2.priv.pem -pkeyopt rsa_keygen_bits:2048
+    openssl rsa -in /tmp/unknown2.priv.pem -pubout -out /tmp/unknown2.pem
+
+    # Foreign TPM pub key, created from random transient primary under the null hierarchy.
+    # Note: This hits TPM2_RC_SIZE not TPM2_RC_INTEGRITY but both are handled the same.
+    tpm2_createprimary -C n -c /tmp/unknown-srk.ctx
+    tpm2_readpublic -c /tmp/unknown-srk.ctx -o /tmp/unknown-srk.pub
+    tpm2_flushcontext -t
+
+    # Empty signature meaning nothing is found for the foreign PCR-policy pubkeys
+    echo '{}' > /tmp/empty-pcrsig.json
+
+    systemd-cryptenroll --wipe-slot=tpm2 "$IMAGE"
+    # Token 1: unknown pubkey, unseal fails at signature lookup (ENXIO)
+    PASSWORD=passphrase systemd-cryptenroll --tpm2-device=auto --tpm2-pcrlock= \
+        --tpm2-public-key=/tmp/unknown1.pem --tpm2-public-key-pcrs=11 "$IMAGE"
+    # Token 2: unknown pubkey and unknown SRK (EREMOTE)
+    PASSWORD=passphrase systemd-cryptenroll --tpm2-device-key=/tmp/unknown-srk.pub --tpm2-pcrlock= \
+        --tpm2-public-key=/tmp/unknown2.pem --tpm2-public-key-pcrs=11 "$IMAGE"
+    # Token 3: no pubkey, current-PCR-7 policy, unseals successfully
+    PASSWORD=passphrase systemd-cryptenroll --tpm2-device=auto --tpm2-pcrlock= --tpm2-public-key= --tpm2-pcrs=7 "$IMAGE"
+    # Note: Not covered yet is a plain PCR mismatch, the NV index missing/corrupted, and different PCR masks.
+
+    # This should iterate over the tokens reporting failures until we reach token 3.
+    # Do it for both the token module and fallback path because iteration differs there.
+    for mod in 1 0; do
+        SYSTEMD_CRYPTSETUP_USE_TOKEN_MODULE=$mod \
+            systemd-cryptsetup attach test-volume "$IMAGE" - \
+            tpm2-device=auto,tpm2-signature=/tmp/empty-pcrsig.json,headless=1
+        systemd-cryptsetup detach test-volume
+    done
+
+    rm -f /tmp/unknown1.priv.pem /tmp/unknown1.pem /tmp/unknown2.priv.pem /tmp/unknown2.pem \
+          /tmp/unknown-srk.pub /tmp/unknown-srk.ctx /tmp/empty-pcrsig.json
+fi
+
 rm -f "$IMAGE" "$PRIMARY" /tmp/passphrase /tmp/wrong_passphrase


### PR DESCRIPTION
- cryptsetup/cryptenroll: Iterate over TPM tokens when they don't match
    
    When we enroll two UKIs with different PCR pub keys into one LUKS slot/
    token each, we can encounter the wrong one and should not give up
    but continue iterating instead of requiring the passphrase. Similarly,
    a pcrlock token might be for another UKI and we should continue the
    search. Same for a token that is meant for another TPM (e.g., external
    storage). While this is mainly about cryptsetup's automatic unlocking
    from the initrd, it also matters for usage in the system, e.g., for
    other storage and when cryptenroll should unlock using the TPM.
    There are two code paths, one is the libcryptsetup plugin and the other
    is the fallback when that's not available.
    To let the libcryptsetup loop continue to iterate, remap the above
    error conditions to EPERM. For the fallback path check all of them (no
    remapping) and continue iteration. For better log output, include the
    token ID to be able understand which token fails.

… and more commits not pasted here.


Tests done:
- Tested enrolling different pub keys, one for each UKI, and then checking that one of the boots will start with the wrong token and then continue.
- Tested direct PCR value binding in the first slot and for the other system the pub key in the second slot and checked that the other system first encountered the direct PCR value token but then continued with the next.
- For the mask mismatch I did `SYSTEMD_LOG_LEVEL=debug systemd-cryptsetup attach test-vol /dev/vda8 - tpm2-device=auto,tpm2-pcrs=13` while having enrolled with PCR 11 and then I saw it use the other JSON token compared to not passing `,tpm2-pcrs=13`.
- For a test image with wrong PCR keys enrolled and finally the right one, both `SYSTEMD_CRYPTSETUP_USE_TOKEN_MODULE=0` and `SYSTEMD_CRYPTSETUP_USE_TOKEN_MODULE=1` for `systemd-cryptsetup attach test /dev/loop0 - tpm2-device=auto` iterated over the wrong keys and then succeeded.
- Tested skipping over a token with a broken NV index setup which works now with the added fix.¹
- Tested skipping over a token with a foreign TPM from `--tpm2-device-key=` works with the added fix.
- And only then thought about having this automated with a test case. Added one now but it's not covering all of the above.

¹ For reference, done by using pcrlock in the to-be-skipped token and then `tpm2_nvundefine 0x… -C o` to undefine and reboot, then `tpm2_nvdefine 0x… -C o -s 34` and reboot and finally `printf '\x00\x0b' > /tmp/th; head -c 32 /dev/urandom >> /tmp/th ; tpm2_nvwrite 0x… -C o -i /tmp/th` and reboot.