### PR TITLE
parse-util: rework safe_atou64() as wrapper around safe_atou64_full()

### DIFF
--- a/src/basic/parse-util.h
+++ b/src/basic/parse-util.h
@@ -78,14 +78,13 @@ static inline int safe_atollu(const char *s, unsigned long long *ret_llu) {
         return safe_atollu_full(s, 0, ret_llu);
 }
 
-static inline int safe_atou64(const char *s, uint64_t *ret_u) {
-        assert_cc(sizeof(uint64_t) == sizeof(unsigned long long));
-        return safe_atollu(s, (unsigned long long*) ret_u);
-}
-
 static inline int safe_atou64_full(const char *s, unsigned base, uint64_t *ret_u) {
         assert_cc(sizeof(uint64_t) == sizeof(unsigned long long));
         return safe_atollu_full(s, base, (unsigned long long*) ret_u);
+}
+
+static inline int safe_atou64(const char *s, uint64_t *ret_u) {
+        return safe_atou64_full(s, 0, ret_u);
 }
 
 static inline int safe_atoi64(const char *s, int64_t *ret_i) {


### PR DESCRIPTION
Follow-up for: 023f88a6ab76b9784e9b6c6396227f1490c1a8c2

Claude complained...