### PR TITLE
test: re-enable sync in TEST-25-IMPORT

### DIFF
--- a/test/integration-tests/TEST-25-IMPORT/meson.build
+++ b/test/integration-tests/TEST-25-IMPORT/meson.build
@@ -3,5 +3,8 @@
 integration_tests += [
         integration_test_template + {
                 'name' : fs.name(meson.current_source_dir()),
+                # Newer tar started using openat2() (without openat() fallback) which
+                # we currently filter out completely in nspawn with --suppress-sync
+                'suppress-sync' : false,
         },
 ]


### PR DESCRIPTION
Newer tar started using openat2() via open_subdir() to address CVE-2025-45582 [0]. Now, gnulib, that tar uses, provides the openat2() syscall in two ways [1]:

1) If glibc doesn't provide openat2(), it provides its own version in
   openat2.c, that tries to call openat2() syscall first, and if it
   returns ENOSYS, it emulates the function in userspace.

2) If glibc provides openat2(), it uses that directly, without providing
   any fallback on ENOSYS.

Quite recently our test suite started calling nspawn with --suppress-sync=yes. This means that we call seccomp_suppress_sync(), which eventually calls block_open_flag(), that blocks the openat2() syscall completely and refuses it with ENOSYS as this syscall can't be sensibly filtered (see the openat2()-relevant comments in block_open_flag() and seccomp_restrict_sxid()). And when glibc provides openat2(), there's no fallback, so the ENOSYS bubbles up to the user as:
```
TEST-25-IMPORT.sh[163]: + tar xzf /var/tmp/scratch.tar.gz
TEST-25-IMPORT.sh[163]: tar: ./adirectory/athirdfile: Cannot open: Function not implemented
TEST-25-IMPORT.sh[163]: tar: Exiting with failure status due to previous errors
```
Let's mitigate this by re-enabling sync for TEST-25-IMPORT, at least for now.

[0] https://cgit.git.savannah.gnu.org/cgit/tar.git/commit/?id=75b03fdff48916bd0654677ed21379bdb0db016d
[1] https://cgit.git.savannah.gnu.org/cgit/gnulib.git/commit/?id=0b97ffdf32bdab909d02449043447237273df75e