### PR TITLE
bootctl: add --print-efi-architecture switch

### DIFF
--- a/man/bootctl.xml
+++ b/man/bootctl.xml
@@ -407,6 +407,15 @@
       </varlistentry>
 
       <varlistentry>
+        <term><option>--print-efi-architecture</option></term>
+
+        <listitem><para>Print the EFI architecture string of the local firmware. This is useful to
+        generically format filenames such as <filename>boot<replaceable>x64</replaceable>.efi</filename> that
+        include the local firmware architecture in the name.</para>
+        <xi:include href="version-info.xml" xpointer="v261"/></listitem>
+      </varlistentry>
+
+      <varlistentry>
         <term><option>--variables=yes|no|auto</option></term>
         <listitem><para>Controls whether to touch the firmware's boot loader list stored in EFI variables,
         and other EFI variables. If not specified or set to <option>auto</option>, EFI variables will not

--- a/shell-completion/bash/bootctl
+++ b/shell-completion/bash/bootctl
@@ -35,6 +35,7 @@ _bootctl() {
         [STANDALONE]='-h --help --version
                       -p --print-esp-path -x --print-boot-path --print-loader-path
                       --print-stub-path -R --print-root-device -RR
+                      --print-efi-architecture
                       --no-pager --graceful -q --quiet --all-architectures
                       --dry-run'
         [ARG]='--esp-path --boot-path --root --image --image-policy --install-source

--- a/shell-completion/zsh/_bootctl
+++ b/shell-completion/zsh/_bootctl
@@ -74,6 +74,7 @@ _arguments \
     '--boot-path=[Path to the $BOOT partition]:path:_directories' \
     '(-p --print-esp-path)'{-p,--print-esp-path}'[Print path to the EFI system partition]' \
     '(-x --print-boot-path)'{-x,--print-boot-path}'[Print path to the $BOOT partition]' \
+    '--print-efi-architecture[Print the EFI architecture identifier]' \
     '--make-machine-id-directory=[Control creation and deletion of the top-level machine ID directory.]:options:(yes no auto)' \
     '--no-pager[Do not pipe output into a pager]' \
     '--graceful[Do not fail when locating ESP or writing fails]' \

--- a/src/bootctl/bootctl.c
+++ b/src/bootctl/bootctl.c
@@ -15,6 +15,7 @@
 #include "bootctl-status.h"
 #include "bootctl-uki.h"
 #include "bootctl-unlink.h"
+#include "bootctl-util.h"
 #include "build.h"
 #include "devnum-util.h"
 #include "dissect-image.h"
@@ -52,6 +53,7 @@ bool arg_print_esp_path = false;
 bool arg_print_dollar_boot_path = false;
 bool arg_print_loader_path = false;
 bool arg_print_stub_path = false;
+bool arg_print_efi_architecture = false;
 unsigned arg_print_root_device = 0;
 int arg_touch_variables = -1;
 bool arg_install_random_seed = true;
@@ -450,6 +452,10 @@ static int parse_argv(int argc, char *argv[], char ***ret_args) {
                         arg_print_root_device++;
                         break;
 
+                OPTION_LONG("print-efi-architecture", NULL, "Print the local EFI architecture string"):
+                        arg_print_efi_architecture = true;
+                        break;
+
                 OPTION_GROUP("Options"):
                         break;
 
@@ -639,9 +645,9 @@ static int parse_argv(int argc, char *argv[], char ***ret_args) {
 
         char **args = option_parser_get_args(&state);
 
-        if (!!arg_print_esp_path + !!arg_print_dollar_boot_path + (arg_print_root_device > 0) + arg_print_loader_path + arg_print_stub_path > 1)
+        if (!!arg_print_esp_path + !!arg_print_dollar_boot_path + (arg_print_root_device > 0) + arg_print_loader_path + arg_print_stub_path + arg_print_efi_architecture > 1)
                 return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
-                                                       "--print-esp-path/-p, --print-boot-path/-x, --print-root-device=/-R, --print-loader-path, --print-stub-path cannot be combined.");
+                                                       "--print-esp-path/-p, --print-boot-path/-x, --print-root-device=/-R, --print-loader-path, --print-stub-path, --print-efi-architecture cannot be combined.");
 
         if ((arg_root || arg_image) && args[0] && !STR_IN_SET(args[0], "status", "list",
                         "install", "update", "remove", "is-installed", "random-seed", "unlink", "cleanup"))
@@ -760,6 +766,11 @@ static int run(int argc, char *argv[]) {
 
         if (arg_print_loader_path || arg_print_stub_path)
                 return print_loader_or_stub_path();
+
+        if (arg_print_efi_architecture) {
+                printf("%s\n", get_efi_arch());
+                return 0;
+        }
 
         /* Open up and mount the image */
         if (arg_image) {

--- a/src/bootctl/bootctl.h
+++ b/src/bootctl/bootctl.h
@@ -24,6 +24,7 @@ extern bool arg_print_dollar_boot_path;
 extern bool arg_print_loader_path;
 extern bool arg_print_stub_path;
 extern unsigned arg_print_root_device;
+extern bool arg_print_efi_architecture;
 extern int arg_touch_variables;
 extern bool arg_install_random_seed;
 extern PagerFlags arg_pager_flags;

--- a/test/units/TEST-87-AUX-UTILS-VM.bootctl.sh
+++ b/test/units/TEST-87-AUX-UTILS-VM.bootctl.sh
@@ -101,7 +101,14 @@ basic_tests() {
 testcase_bootctl_basic() {
     assert_in "$(bootctl --print-esp-path)" "^(/boot/|/efi)$"
     assert_in "$(bootctl --print-boot-path)" "^(/boot/|/efi)$"
+
     bootctl --print-root-device
+    bootctl --print-root-device --print-root-device
+    bootctl --print-esp-path
+    bootctl --print-boot-path
+    bootctl --print-loader-path
+    bootctl --print-stub-path
+    bootctl --print-efi-architecture
 
     basic_tests
 }


### PR DESCRIPTION
This is extremely useful for our own test cases, since acquiring the right EFI architecture string is otherwise a bit nasty.