### PR TITLE
sysupdate: Emit READY=1 status when installing

### DIFF
--- a/src/sysupdate/sysupdate.c
+++ b/src/sysupdate/sysupdate.c
@@ -1202,7 +1202,9 @@ static int context_install(
         }
 
         (void) sd_notifyf(/* unset_environment=*/ false,
-                          "STATUS=Installing '%s'.", us->version);
+                          "READY=1\n"
+                          "X_SYSUPDATE_VERSION=%s\n"
+                          "STATUS=Installing '%s'.", us->version, us->version);
 
         for (size_t i = 0; i < c->n_transfers; i++) {
                 Instance *inst = us->instances[i];

--- a/test/units/TEST-72-SYSUPDATE.sh
+++ b/test/units/TEST-72-SYSUPDATE.sh
@@ -373,7 +373,9 @@ EOF
     if $have_updatectl; then
         systemctl start systemd-sysupdated
         "$SYSUPDATE" --verify=no check-new
-        updatectl update
+        updatectl update |& tee "$WORKDIR"/updatectl-update-6
+        grep "Done" "$WORKDIR"/updatectl-update-6
+        (! grep "Already up-to-date" "$WORKDIR"/updatectl-update-6)
     else
         # If no updatectl, gracefully fall back to systemd-sysupdate
         update_now "$update_type"


### PR DESCRIPTION
`READY=1` is already correctly emitted when acquiring an update, but was forgotten to be emitted when subsequently installing that update.

That meant that the state tracking code in `sysupdated` and hence `updatectl` could not properly report the progress of the install operation, and hence printed “Already up-to-date” after a successful update installation, rather than “Done”.

Add a test to catch this in future.

Signed-off-by: Philip Withnall <pwithnall@gnome.org>

Fixes: https://github.com/systemd/systemd/issues/41502