### PR TITLE
cryptsetup: load libcryptsetup via dlopen in setup binaries

### DIFF
--- a/src/cryptenroll/cryptenroll-fido2.c
+++ b/src/cryptenroll/cryptenroll-fido2.c
@@ -54,7 +54,7 @@ int load_volume_key_fido2(
         if (passphrase_size < 0)
                 return log_oom();
 
-        r = crypt_volume_key_get(
+        r = sym_crypt_volume_key_get(
                         cd,
                         CRYPT_ANY_SLOT,
                         ret_vk,
@@ -95,9 +95,9 @@ int enroll_fido2(
         assert_se(iovec_is_set(volume_key));
         assert_se(device);
 
-        assert_se(node = crypt_get_device_name(cd));
+        assert_se(node = sym_crypt_get_device_name(cd));
 
-        un = strempty(crypt_get_uuid(cd));
+        un = strempty(sym_crypt_get_uuid(cd));
 
         if (salt_file)
                 r = fido2_read_salt_file(
@@ -140,7 +140,7 @@ int enroll_fido2(
         if (r < 0)
                 return log_error_errno(r, "Failed to set minimal PBKDF: %m");
 
-        keyslot = crypt_keyslot_add_by_volume_key(
+        keyslot = sym_crypt_keyslot_add_by_volume_key(
                         cd,
                         CRYPT_ANY_SLOT,
                         volume_key->iov_base,

--- a/src/cryptenroll/cryptenroll-list.c
+++ b/src/cryptenroll/cryptenroll-list.c
@@ -26,11 +26,11 @@ int list_enrolled(struct crypt_device *cd) {
         assert(cd);
 
         /* First step, find out all currently used slots */
-        assert_se((slot_max = crypt_keyslot_max(CRYPT_LUKS2)) > 0);
+        assert_se((slot_max = sym_crypt_keyslot_max(CRYPT_LUKS2)) > 0);
         for (int slot = 0; slot < slot_max; slot++) {
                 crypt_keyslot_info status;
 
-                status = crypt_keyslot_status(cd, slot);
+                status = sym_crypt_keyslot_status(cd, slot);
                 if (!IN_SET(status, CRYPT_SLOT_ACTIVE, CRYPT_SLOT_ACTIVE_LAST))
                         continue;
 

--- a/src/cryptenroll/cryptenroll-password.c
+++ b/src/cryptenroll/cryptenroll-password.c
@@ -31,7 +31,7 @@ int load_volume_key_password(
         if (r < 0)
                 return log_error_errno(r, "Failed to acquire password from environment: %m");
         if (r > 0) {
-                r = crypt_volume_key_get(
+                r = sym_crypt_volume_key_get(
                                 cd,
                                 CRYPT_ANY_SLOT,
                                 ret_vk,
@@ -81,7 +81,7 @@ int load_volume_key_password(
 
                         r = -EPERM;
                         STRV_FOREACH(p, passwords) {
-                                r = crypt_volume_key_get(
+                                r = sym_crypt_volume_key_get(
                                                 cd,
                                                 CRYPT_ANY_SLOT,
                                                 ret_vk,
@@ -114,7 +114,7 @@ int enroll_password(
         assert(cd);
         assert(iovec_is_set(volume_key));
 
-        assert_se(node = crypt_get_device_name(cd));
+        assert_se(node = sym_crypt_get_device_name(cd));
 
         r = getenv_steal_erase("NEWPASSWORD", &new_password);
         if (r < 0)
@@ -123,7 +123,7 @@ int enroll_password(
                 _cleanup_free_ char *disk_path = NULL, *id = NULL;
                 unsigned i = 5;
 
-                assert_se(node = crypt_get_device_name(cd));
+                assert_se(node = sym_crypt_get_device_name(cd));
 
                 (void) suggest_passwords();
 
@@ -196,7 +196,7 @@ int enroll_password(
         else if (r == 0)
                 log_warning("Specified password does not pass quality checks (%s), proceeding anyway.", error);
 
-        keyslot = crypt_keyslot_add_by_volume_key(
+        keyslot = sym_crypt_keyslot_add_by_volume_key(
                         cd,
                         CRYPT_ANY_SLOT,
                         volume_key->iov_base,

--- a/src/cryptenroll/cryptenroll-pkcs11.c
+++ b/src/cryptenroll/cryptenroll-pkcs11.c
@@ -53,7 +53,7 @@ int enroll_pkcs11(struct crypt_device *cd, const struct iovec *volume_key,const 
         assert_se(iovec_is_set(volume_key));
         assert_se(uri);
 
-        assert_se(node = crypt_get_device_name(cd));
+        assert_se(node = sym_crypt_get_device_name(cd));
 
         r = pkcs11_acquire_public_key(
                         uri,
@@ -80,7 +80,7 @@ int enroll_pkcs11(struct crypt_device *cd, const struct iovec *volume_key,const 
         if (r < 0)
                 return log_error_errno(r, "Failed to set minimal PBKDF: %m");
 
-        int keyslot = crypt_keyslot_add_by_volume_key(
+        int keyslot = sym_crypt_keyslot_add_by_volume_key(
                         cd,
                         CRYPT_ANY_SLOT,
                         volume_key->iov_base,

--- a/src/cryptenroll/cryptenroll-recovery.c
+++ b/src/cryptenroll/cryptenroll-recovery.c
@@ -24,7 +24,7 @@ int enroll_recovery(
         assert_se(cd);
         assert_se(iovec_is_set(volume_key));
 
-        assert_se(node = crypt_get_device_name(cd));
+        assert_se(node = sym_crypt_get_device_name(cd));
 
         r = make_recovery_key(&password);
         if (r < 0)
@@ -34,7 +34,7 @@ int enroll_recovery(
         if (r < 0)
                 return log_error_errno(r, "Failed to set minimal PBKDF: %m");
 
-        keyslot = crypt_keyslot_add_by_volume_key(
+        keyslot = sym_crypt_keyslot_add_by_volume_key(
                         cd,
                         CRYPT_ANY_SLOT,
                         volume_key->iov_base,
@@ -93,7 +93,7 @@ int enroll_recovery(
         return keyslot;
 
 rollback:
-        q = crypt_keyslot_destroy(cd, keyslot);
+        q = sym_crypt_keyslot_destroy(cd, keyslot);
         if (q < 0)
                 log_debug_errno(q, "Unable to remove key slot we just added again, can't rollback, sorry: %m");
 

--- a/src/cryptenroll/cryptenroll-tpm2.c
+++ b/src/cryptenroll/cryptenroll-tpm2.c
@@ -272,7 +272,7 @@ int load_volume_key_tpm2(
         if (passphrase_size < 0)
                 return log_oom();
 
-        r = crypt_volume_key_get(
+        r = sym_crypt_volume_key_get(
                         cd,
                         CRYPT_ANY_SLOT,
                         ret_vk,
@@ -329,7 +329,7 @@ int enroll_tpm2(struct crypt_device *cd,
         assert(TPM2_PCR_MASK_VALID(pubkey_pcr_mask));
         assert(ret_slot_to_wipe);
 
-        assert_se(node = crypt_get_device_name(cd));
+        assert_se(node = sym_crypt_get_device_name(cd));
 
         if (use_pin) {
                 r = get_pin(&pin_str, &flags);
@@ -579,7 +579,7 @@ int enroll_tpm2(struct crypt_device *cd,
         if (r < 0)
                 return log_error_errno(r, "Failed to set minimal PBKDF: %m");
 
-        keyslot = crypt_keyslot_add_by_volume_key(
+        keyslot = sym_crypt_keyslot_add_by_volume_key(
                         cd,
                         CRYPT_ANY_SLOT,
                         volume_key->iov_base,

--- a/src/cryptenroll/cryptenroll.c
+++ b/src/cryptenroll/cryptenroll.c
@@ -649,7 +649,7 @@ static int check_for_homed(struct crypt_device *cd) {
         /* Politely refuse operating on homed volumes. The enrolled tokens for the user record and the LUKS2
          * volume should not get out of sync. */
 
-        for (int token = 0; token < crypt_token_max(CRYPT_LUKS2); token++) {
+        for (int token = 0; token < sym_crypt_token_max(CRYPT_LUKS2); token++) {
                 r = cryptsetup_get_token_as_json(cd, token, "systemd-homed", NULL);
                 if (IN_SET(r, -ENOENT, -EINVAL, -EMEDIUMTYPE))
                         continue;
@@ -688,7 +688,7 @@ static int load_volume_key_keyfile(
         if (r < 0)
                 return log_error_errno(r, "Reading keyfile %s failed: %m", arg_unlock_keyfile);
 
-        r = crypt_volume_key_get(
+        r = sym_crypt_volume_key_get(
                         cd,
                         CRYPT_ANY_SLOT,
                         ret_vk,
@@ -710,13 +710,13 @@ static int prepare_luks(
 
         assert(ret_cd);
 
-        r = crypt_init(&cd, arg_node);
+        r = sym_crypt_init(&cd, arg_node);
         if (r < 0)
                 return log_error_errno(r, "Failed to allocate libcryptsetup context: %m");
 
         cryptsetup_enable_logging(cd);
 
-        r = crypt_load(cd, CRYPT_LUKS2, NULL);
+        r = sym_crypt_load(cd, CRYPT_LUKS2, NULL);
         if (r < 0)
                 return log_error_errno(r, "Failed to load LUKS2 superblock of %s: %m", arg_node);
 
@@ -729,7 +729,7 @@ static int prepare_luks(
                 return 0;
         }
 
-        r = crypt_get_volume_key_size(cd);
+        r = sym_crypt_get_volume_key_size(cd);
         if (r <= 0)
                 return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "Failed to determine LUKS volume key size");
 
@@ -783,10 +783,12 @@ static int run(int argc, char *argv[]) {
         if (r <= 0)
                 return r;
 
+        r = dlopen_cryptsetup(LOG_ERR);
+        if (r < 0)
+                return r;
+
         /* A delicious drop of snake oil */
         (void) safe_mlockall(MCL_CURRENT|MCL_FUTURE|MCL_ONFAULT);
-
-        cryptsetup_enable_logging(NULL);
 
         if (arg_enroll_type < 0)
                 r = prepare_luks(&cd, /* ret_volume_key= */ NULL); /* No need to unlock device if we don't need the volume key because we don't need to enroll anything */

--- a/src/cryptenroll/cryptenroll.c
+++ b/src/cryptenroll/cryptenroll.c
@@ -649,7 +649,7 @@ static int check_for_homed(struct crypt_device *cd) {
         /* Politely refuse operating on homed volumes. The enrolled tokens for the user record and the LUKS2
          * volume should not get out of sync. */
 
-        for (int token = 0; token < crypt_token_max(CRYPT_LUKS2); token++) {
+        for (int token = 0; token < sym_crypt_token_max(CRYPT_LUKS2); token++) {
                 r = cryptsetup_get_token_as_json(cd, token, "systemd-homed", NULL);
                 if (IN_SET(r, -ENOENT, -EINVAL, -EMEDIUMTYPE))
                         continue;
@@ -688,7 +688,7 @@ static int load_volume_key_keyfile(
         if (r < 0)
                 return log_error_errno(r, "Reading keyfile %s failed: %m", arg_unlock_keyfile);
 
-        r = crypt_volume_key_get(
+        r = sym_crypt_volume_key_get(
                         cd,
                         CRYPT_ANY_SLOT,
                         ret_vk,
@@ -710,13 +710,13 @@ static int prepare_luks(
 
         assert(ret_cd);
 
-        r = crypt_init(&cd, arg_node);
+        r = sym_crypt_init(&cd, arg_node);
         if (r < 0)
                 return log_error_errno(r, "Failed to allocate libcryptsetup context: %m");
 
         cryptsetup_enable_logging(cd);
 
-        r = crypt_load(cd, CRYPT_LUKS2, NULL);
+        r = sym_crypt_load(cd, CRYPT_LUKS2, NULL);
         if (r < 0)
                 return log_error_errno(r, "Failed to load LUKS2 superblock of %s: %m", arg_node);
 
@@ -729,7 +729,7 @@ static int prepare_luks(
                 return 0;
         }
 
-        r = crypt_get_volume_key_size(cd);
+        r = sym_crypt_get_volume_key_size(cd);
         if (r <= 0)
                 return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "Failed to determine LUKS volume key size");
 
@@ -781,6 +781,10 @@ static int run(int argc, char *argv[]) {
 
         r = parse_argv(argc, argv);
         if (r <= 0)
+                return r;
+
+        r = dlopen_cryptsetup();
+        if (r < 0)
                 return r;
 
         /* A delicious drop of snake oil */

--- a/src/cryptenroll/meson.build
+++ b/src/cryptenroll/meson.build
@@ -21,7 +21,7 @@ executables += [
                 'public' : true,
                 'sources' : systemd_cryptenroll_sources,
                 'dependencies' : [
-                        libcryptsetup,
+                        libcryptsetup_cflags,
                         libdl,
                         libfido2_cflags,
                         libopenssl,

--- a/src/cryptsetup/cryptsetup.c
+++ b/src/cryptsetup/cryptsetup.c
@@ -823,19 +823,19 @@ static PassphraseType check_registered_passwords(struct crypt_device *cd) {
 
         assert(cd);
 
-        if (!streq_ptr(crypt_get_type(cd), CRYPT_LUKS2)) {
-                log_debug("%s: not a LUKS2 device, only passphrases are supported", crypt_get_device_name(cd));
+        if (!streq_ptr(sym_crypt_get_type(cd), CRYPT_LUKS2)) {
+                log_debug("%s: not a LUKS2 device, only passphrases are supported", sym_crypt_get_device_name(cd));
                 return PASSPHRASE_REGULAR;
         }
 
         /* Search all used slots */
-        assert_se((slot_max = crypt_keyslot_max(CRYPT_LUKS2)) > 0);
+        assert_se((slot_max = sym_crypt_keyslot_max(CRYPT_LUKS2)) > 0);
         slots = new(bool, slot_max);
         if (!slots)
                 return log_oom();
 
         for (int slot = 0; slot < slot_max; slot++)
-                slots[slot] = IN_SET(crypt_keyslot_status(cd, slot), CRYPT_SLOT_ACTIVE, CRYPT_SLOT_ACTIVE_LAST);
+                slots[slot] = IN_SET(sym_crypt_keyslot_status(cd, slot), CRYPT_SLOT_ACTIVE, CRYPT_SLOT_ACTIVE_LAST);
 
         /* Iterate all LUKS2 tokens and keep track of all their slots */
         for (int token = 0; token < sym_crypt_token_max(CRYPT_LUKS2); token++) {
@@ -1132,7 +1132,7 @@ static int measure_keyslot(
                 return log_oom();
 
         _cleanup_free_ char *s = NULL;
-        s = strjoin("cryptsetup-keyslot:", escaped, ":", strempty(crypt_get_uuid(cd)), ":", strempty(mechanism), ":", strempty(k));
+        s = strjoin("cryptsetup-keyslot:", escaped, ":", strempty(sym_crypt_get_uuid(cd)), ":", strempty(mechanism), ":", strempty(k));
         if (!s)
                 return log_oom();
 
@@ -1207,7 +1207,7 @@ static int measured_crypt_activate_by_volume_key(
                                                 key_id, arg_fixate_volume_key);
         }
 
-        r = crypt_activate_by_volume_key(cd, name, volume_key, volume_key_size, flags);
+        r = sym_crypt_activate_by_volume_key(cd, name, volume_key, volume_key_size, flags);
         if (r == -EEXIST) /* volume is already active */
                 return log_external_activation(r, name);
         if (r < 0)
@@ -1250,7 +1250,7 @@ static int measured_crypt_activate_by_passphrase(
         if (arg_tpm2_measure_pcr == UINT_MAX && !arg_fixate_volume_key)
                 goto shortcut;
 
-        r = crypt_get_volume_key_size(cd);
+        r = sym_crypt_get_volume_key_size(cd);
         if (r < 0)
                 return r;
         if (r == 0) {
@@ -1262,14 +1262,14 @@ static int measured_crypt_activate_by_passphrase(
         if (!vk)
                 return -ENOMEM;
 
-        keyslot = crypt_volume_key_get(cd, keyslot, vk, &vks, passphrase, passphrase_size);
+        keyslot = sym_crypt_volume_key_get(cd, keyslot, vk, &vks, passphrase, passphrase_size);
         if (keyslot < 0)
                 return keyslot;
 
         return measured_crypt_activate_by_volume_key(cd, name, mechanism, keyslot, vk, vks, flags);
 
 shortcut:
-        keyslot = crypt_activate_by_passphrase(cd, name, keyslot, passphrase, passphrase_size, flags);
+        keyslot = sym_crypt_activate_by_passphrase(cd, name, keyslot, passphrase, passphrase_size, flags);
         if (keyslot == -EEXIST) /* volume is already active */
                 return log_external_activation(keyslot, name);
         if (keyslot < 0)
@@ -1320,7 +1320,7 @@ static int attach_tcrypt(
         if (key_data) {
                 params.passphrase = key_data->iov_base;
                 params.passphrase_size = key_data->iov_len;
-                r = crypt_load(cd, CRYPT_TCRYPT, &params);
+                r = sym_crypt_load(cd, CRYPT_TCRYPT, &params);
         } else if (key_file) {
                 r = read_one_line_file(key_file, &passphrase);
                 if (r < 0) {
@@ -1329,13 +1329,13 @@ static int attach_tcrypt(
                 }
                 params.passphrase = passphrase;
                 params.passphrase_size = strlen(passphrase);
-                r = crypt_load(cd, CRYPT_TCRYPT, &params);
+                r = sym_crypt_load(cd, CRYPT_TCRYPT, &params);
         } else {
                 r = -EINVAL;
                 STRV_FOREACH(p, passwords){
                         params.passphrase = *p;
                         params.passphrase_size = strlen(*p);
-                        r = crypt_load(cd, CRYPT_TCRYPT, &params);
+                        r = sym_crypt_load(cd, CRYPT_TCRYPT, &params);
                         if (r >= 0)
                                 break;
                 }
@@ -1353,7 +1353,7 @@ static int attach_tcrypt(
                         return r;
                 }
 
-                return log_error_errno(r, "Failed to load tcrypt superblock on device %s: %m", crypt_get_device_name(cd));
+                return log_error_errno(r, "Failed to load tcrypt superblock on device %s: %m", sym_crypt_get_device_name(cd));
         }
 
         r = measured_crypt_activate_by_volume_key(
@@ -1365,7 +1365,7 @@ static int attach_tcrypt(
                         /* volume_key_size= */ 0,
                         flags);
         if (r < 0)
-                return log_error_errno(r, "Failed to activate tcrypt device %s: %m", crypt_get_device_name(cd));
+                return log_error_errno(r, "Failed to activate tcrypt device %s: %m", sym_crypt_get_device_name(cd));
 
         return 0;
 }
@@ -1509,7 +1509,7 @@ static bool use_token_plugins(void) {
         if (r == 0)
                 return false;
 
-        return crypt_token_external_path();
+        return sym_crypt_token_external_path();
 #else
         return false;
 #endif
@@ -1554,7 +1554,7 @@ static int crypt_activate_by_token_pin_ask_password(
         _cleanup_strv_free_erase_ char **pins = NULL;
         int r;
 
-        r = crypt_activate_by_token_pin(cd, name, type, CRYPT_ANY_TOKEN, /* pin= */ NULL, /* pin_size= */ 0, userdata, activation_flags);
+        r = sym_crypt_activate_by_token_pin(cd, name, type, CRYPT_ANY_TOKEN, /* pin= */ NULL, /* pin_size= */ 0, userdata, activation_flags);
         if (r > 0) /* returns unlocked keyslot id on success */
                 return 0;
         if (r == -EEXIST) /* volume is already active */
@@ -1567,7 +1567,7 @@ static int crypt_activate_by_token_pin_ask_password(
                 return r;
 
         STRV_FOREACH(p, pins) {
-                r = crypt_activate_by_token_pin(cd, name, type, CRYPT_ANY_TOKEN, *p, strlen(*p), userdata, activation_flags);
+                r = sym_crypt_activate_by_token_pin(cd, name, type, CRYPT_ANY_TOKEN, *p, strlen(*p), userdata, activation_flags);
                 if (r > 0) /* returns unlocked keyslot id on success */
                         return 0;
                 if (r == -EEXIST) /* volume is already active */
@@ -1597,7 +1597,7 @@ static int crypt_activate_by_token_pin_ask_password(
                         return r;
 
                 STRV_FOREACH(p, pins) {
-                        r = crypt_activate_by_token_pin(cd, name, type, CRYPT_ANY_TOKEN, *p, strlen(*p), userdata, activation_flags);
+                        r = sym_crypt_activate_by_token_pin(cd, name, type, CRYPT_ANY_TOKEN, *p, strlen(*p), userdata, activation_flags);
                         if (r > 0) /* returns unlocked keyslot id on success */
                                 return 0;
                         if (r == -EEXIST) /* volume is already active */
@@ -1658,7 +1658,7 @@ static int attach_luks_or_plain_or_bitlk_by_fido2(
                 return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
                                         "FIDO2 mode with manual parameters selected, but no keyfile specified, refusing.");
 
-        friendly = friendly_disk_name(crypt_get_device_name(cd), name);
+        friendly = friendly_disk_name(sym_crypt_get_device_name(cd), name);
         if (!friendly)
                 return log_oom();
 
@@ -1776,7 +1776,7 @@ static int attach_luks2_by_pkcs11_via_plugin(
 #if HAVE_LIBCRYPTSETUP_PLUGINS
         int r;
 
-        if (!streq_ptr(crypt_get_type(cd), CRYPT_LUKS2))
+        if (!streq_ptr(sym_crypt_get_type(cd), CRYPT_LUKS2))
                 return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "Automatic PKCS#11 metadata requires LUKS2 device.");
 
         systemd_pkcs11_plugin_params params = {
@@ -1786,7 +1786,7 @@ static int attach_luks2_by_pkcs11_via_plugin(
                 .askpw_flags = arg_ask_password_flags,
         };
 
-        r = crypt_activate_by_token_pin(cd, name, "systemd-pkcs11", CRYPT_ANY_TOKEN, NULL, 0, &params, flags);
+        r = sym_crypt_activate_by_token_pin(cd, name, "systemd-pkcs11", CRYPT_ANY_TOKEN, NULL, 0, &params, flags);
         if (r > 0) /* returns unlocked keyslot id on success */
                 r = 0;
         if (r == -EEXIST) /* volume is already active */
@@ -1842,7 +1842,7 @@ static int attach_luks_or_plain_or_bitlk_by_pkcs11(
                         return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "PKCS#11 mode selected but no key file specified, refusing.");
         }
 
-        friendly = friendly_disk_name(crypt_get_device_name(cd), name);
+        friendly = friendly_disk_name(sym_crypt_get_device_name(cd), name);
         if (!friendly)
                 return log_oom();
 
@@ -2036,7 +2036,7 @@ static int attach_luks_or_plain_or_bitlk_by_tpm2(
         assert(name);
         assert(arg_tpm2_device || arg_tpm2_device_auto);
 
-        friendly = friendly_disk_name(crypt_get_device_name(cd), name);
+        friendly = friendly_disk_name(sym_crypt_get_device_name(cd), name);
         if (!friendly)
                 return log_oom();
 
@@ -2382,7 +2382,7 @@ static int attach_luks_or_plain_or_bitlk(
         assert(cd);
         assert(name);
 
-        if ((!arg_type && !crypt_get_type(cd)) || streq_ptr(arg_type, CRYPT_PLAIN)) {
+        if ((!arg_type && !sym_crypt_get_type(cd)) || streq_ptr(arg_type, CRYPT_PLAIN)) {
                 struct crypt_params_plain params = {
                         .offset = arg_offset,
                         .skip = arg_skip,
@@ -2421,7 +2421,7 @@ static int attach_luks_or_plain_or_bitlk(
 
                 /* In contrast to what the name crypt_format() might suggest this doesn't actually format
                  * anything, it just configures encryption parameters when used for plain mode. */
-                r = crypt_format(cd, CRYPT_PLAIN, cipher, cipher_mode, NULL, NULL, arg_keyfile_size, &params);
+                r = sym_crypt_format(cd, CRYPT_PLAIN, cipher, cipher_mode, NULL, NULL, arg_keyfile_size, &params);
                 if (r < 0)
                         return log_error_errno(r, "Loading of cryptographic parameters failed: %m");
 
@@ -2430,10 +2430,10 @@ static int attach_luks_or_plain_or_bitlk(
         }
 
         log_info("Set cipher %s, mode %s, key size %i bits for device %s.",
-                 crypt_get_cipher(cd),
-                 crypt_get_cipher_mode(cd),
-                 crypt_get_volume_key_size(cd)*8,
-                 crypt_get_device_name(cd));
+                 sym_crypt_get_cipher(cd),
+                 sym_crypt_get_cipher_mode(cd),
+                 sym_crypt_get_volume_key_size(cd)*8,
+                 sym_crypt_get_device_name(cd));
 
         if (token_type == TOKEN_TPM2)
                 return attach_luks_or_plain_or_bitlk_by_tpm2(cd, name, key_file, key_data, until, flags, pass_volume_key);
@@ -2643,19 +2643,19 @@ static int verb_attach(int argc, char *argv[], uintptr_t _data, void *userdata) 
         if (arg_header) {
                 if (streq_ptr(arg_type, CRYPT_TCRYPT)){
                         log_debug("tcrypt header: %s", arg_header);
-                        r = crypt_init_data_device(&cd, arg_header, source);
+                        r = sym_crypt_init_data_device(&cd, arg_header, source);
                 } else {
                         log_debug("LUKS header: %s", arg_header);
-                        r = crypt_init(&cd, arg_header);
+                        r = sym_crypt_init(&cd, arg_header);
                 }
         } else
-                r = crypt_init(&cd, source);
+                r = sym_crypt_init(&cd, source);
         if (r < 0)
                 return log_error_errno(r, "crypt_init() failed: %m");
 
         cryptsetup_enable_logging(cd);
 
-        status = crypt_status(cd, volume);
+        status = sym_crypt_status(cd, volume);
         if (IN_SET(status, CRYPT_ACTIVE, CRYPT_BUSY)) {
                 log_info("Volume %s already active.", volume);
                 return 0;
@@ -2680,21 +2680,21 @@ static int verb_attach(int argc, char *argv[], uintptr_t _data, void *userdata) 
         }
 
         if (!arg_type || STR_IN_SET(arg_type, ANY_LUKS, CRYPT_LUKS1, CRYPT_LUKS2)) {
-                r = crypt_load(cd, !arg_type || streq(arg_type, ANY_LUKS) ? CRYPT_LUKS : arg_type, NULL);
+                r = sym_crypt_load(cd, !arg_type || streq(arg_type, ANY_LUKS) ? CRYPT_LUKS : arg_type, NULL);
                 if (r < 0)
-                        return log_error_errno(r, "Failed to load LUKS superblock on device %s: %m", crypt_get_device_name(cd));
+                        return log_error_errno(r, "Failed to load LUKS superblock on device %s: %m", sym_crypt_get_device_name(cd));
 
 /* since cryptsetup 2.7.0 (Jan 2024) */
 #if HAVE_CRYPT_SET_KEYRING_TO_LINK
                 if (arg_link_key_description) {
-                        r = crypt_set_keyring_to_link(cd, arg_link_key_description, NULL, arg_link_key_type, arg_link_keyring);
+                        r = sym_crypt_set_keyring_to_link(cd, arg_link_key_description, NULL, arg_link_key_type, arg_link_keyring);
                         if (r < 0)
                                 log_warning_errno(r, "Failed to set keyring or key description to link volume key in, ignoring: %m");
                 }
 #endif
 
                 if (arg_header) {
-                        r = crypt_set_data_device(cd, source);
+                        r = sym_crypt_set_data_device(cd, source);
                         if (r < 0)
                                 return log_error_errno(r, "Failed to set LUKS data device %s: %m", source);
                 }
@@ -2716,14 +2716,14 @@ static int verb_attach(int argc, char *argv[], uintptr_t _data, void *userdata) 
                                 return 0;
                         }
 
-                        log_debug_errno(r, "Token activation unsuccessful for device %s: %m", crypt_get_device_name(cd));
+                        log_debug_errno(r, "Token activation unsuccessful for device %s: %m", sym_crypt_get_device_name(cd));
                 }
         }
 
         if (streq_ptr(arg_type, CRYPT_BITLK)) {
-                r = crypt_load(cd, CRYPT_BITLK, NULL);
+                r = sym_crypt_load(cd, CRYPT_BITLK, NULL);
                 if (r < 0)
-                        return log_error_errno(r, "Failed to load Bitlocker superblock on device %s: %m", crypt_get_device_name(cd));
+                        return log_error_errno(r, "Failed to load Bitlocker superblock on device %s: %m", sym_crypt_get_device_name(cd));
         }
 
         bool use_cached_passphrase = true, try_discover_key = !key_file;
@@ -2850,7 +2850,7 @@ static int verb_detach(int argc, char *argv[], uintptr_t _data, void *userdata) 
         if (!filename_is_valid(volume))
                 return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "Volume name '%s' is not valid.", volume);
 
-        r = crypt_init_by_name(&cd, volume);
+        r = sym_crypt_init_by_name(&cd, volume);
         if (r == -ENODEV) {
                 log_info("Volume %s already inactive.", volume);
                 return 0;
@@ -2860,7 +2860,7 @@ static int verb_detach(int argc, char *argv[], uintptr_t _data, void *userdata) 
 
         cryptsetup_enable_logging(cd);
 
-        r = crypt_deactivate(cd, volume);
+        r = sym_crypt_deactivate(cd, volume);
         if (r < 0)
                 return log_error_errno(r, "Failed to deactivate '%s': %m", volume);
 
@@ -2879,7 +2879,9 @@ static int run(int argc, char *argv[]) {
         if (r <= 0)
                 return r;
 
-        cryptsetup_enable_logging(NULL);
+        r = dlopen_cryptsetup(LOG_ERR);
+        if (r < 0)
+                return r;
 
         return dispatch_verb_with_args(args, NULL);
 }

--- a/src/cryptsetup/cryptsetup.c
+++ b/src/cryptsetup/cryptsetup.c
@@ -823,19 +823,19 @@ static PassphraseType check_registered_passwords(struct crypt_device *cd) {
 
         assert(cd);
 
-        if (!streq_ptr(crypt_get_type(cd), CRYPT_LUKS2)) {
-                log_debug("%s: not a LUKS2 device, only passphrases are supported", crypt_get_device_name(cd));
+        if (!streq_ptr(sym_crypt_get_type(cd), CRYPT_LUKS2)) {
+                log_debug("%s: not a LUKS2 device, only passphrases are supported", sym_crypt_get_device_name(cd));
                 return PASSPHRASE_REGULAR;
         }
 
         /* Search all used slots */
-        assert_se((slot_max = crypt_keyslot_max(CRYPT_LUKS2)) > 0);
+        assert_se((slot_max = sym_crypt_keyslot_max(CRYPT_LUKS2)) > 0);
         slots = new(bool, slot_max);
         if (!slots)
                 return log_oom();
 
         for (int slot = 0; slot < slot_max; slot++)
-                slots[slot] = IN_SET(crypt_keyslot_status(cd, slot), CRYPT_SLOT_ACTIVE, CRYPT_SLOT_ACTIVE_LAST);
+                slots[slot] = IN_SET(sym_crypt_keyslot_status(cd, slot), CRYPT_SLOT_ACTIVE, CRYPT_SLOT_ACTIVE_LAST);
 
         /* Iterate all LUKS2 tokens and keep track of all their slots */
         for (int token = 0; token < sym_crypt_token_max(CRYPT_LUKS2); token++) {
@@ -1132,7 +1132,7 @@ static int measure_keyslot(
                 return log_oom();
 
         _cleanup_free_ char *s = NULL;
-        s = strjoin("cryptsetup-keyslot:", escaped, ":", strempty(crypt_get_uuid(cd)), ":", strempty(mechanism), ":", strempty(k));
+        s = strjoin("cryptsetup-keyslot:", escaped, ":", strempty(sym_crypt_get_uuid(cd)), ":", strempty(mechanism), ":", strempty(k));
         if (!s)
                 return log_oom();
 
@@ -1207,7 +1207,7 @@ static int measured_crypt_activate_by_volume_key(
                                                 key_id, arg_fixate_volume_key);
         }
 
-        r = crypt_activate_by_volume_key(cd, name, volume_key, volume_key_size, flags);
+        r = sym_crypt_activate_by_volume_key(cd, name, volume_key, volume_key_size, flags);
         if (r == -EEXIST) /* volume is already active */
                 return log_external_activation(r, name);
         if (r < 0)
@@ -1250,7 +1250,7 @@ static int measured_crypt_activate_by_passphrase(
         if (arg_tpm2_measure_pcr == UINT_MAX && !arg_fixate_volume_key)
                 goto shortcut;
 
-        r = crypt_get_volume_key_size(cd);
+        r = sym_crypt_get_volume_key_size(cd);
         if (r < 0)
                 return r;
         if (r == 0) {
@@ -1262,14 +1262,14 @@ static int measured_crypt_activate_by_passphrase(
         if (!vk)
                 return -ENOMEM;
 
-        keyslot = crypt_volume_key_get(cd, keyslot, vk, &vks, passphrase, passphrase_size);
+        keyslot = sym_crypt_volume_key_get(cd, keyslot, vk, &vks, passphrase, passphrase_size);
         if (keyslot < 0)
                 return keyslot;
 
         return measured_crypt_activate_by_volume_key(cd, name, mechanism, keyslot, vk, vks, flags);
 
 shortcut:
-        keyslot = crypt_activate_by_passphrase(cd, name, keyslot, passphrase, passphrase_size, flags);
+        keyslot = sym_crypt_activate_by_passphrase(cd, name, keyslot, passphrase, passphrase_size, flags);
         if (keyslot == -EEXIST) /* volume is already active */
                 return log_external_activation(keyslot, name);
         if (keyslot < 0)
@@ -1320,7 +1320,7 @@ static int attach_tcrypt(
         if (key_data) {
                 params.passphrase = key_data->iov_base;
                 params.passphrase_size = key_data->iov_len;
-                r = crypt_load(cd, CRYPT_TCRYPT, &params);
+                r = sym_crypt_load(cd, CRYPT_TCRYPT, &params);
         } else if (key_file) {
                 r = read_one_line_file(key_file, &passphrase);
                 if (r < 0) {
@@ -1329,13 +1329,13 @@ static int attach_tcrypt(
                 }
                 params.passphrase = passphrase;
                 params.passphrase_size = strlen(passphrase);
-                r = crypt_load(cd, CRYPT_TCRYPT, &params);
+                r = sym_crypt_load(cd, CRYPT_TCRYPT, &params);
         } else {
                 r = -EINVAL;
                 STRV_FOREACH(p, passwords){
                         params.passphrase = *p;
                         params.passphrase_size = strlen(*p);
-                        r = crypt_load(cd, CRYPT_TCRYPT, &params);
+                        r = sym_crypt_load(cd, CRYPT_TCRYPT, &params);
                         if (r >= 0)
                                 break;
                 }
@@ -1353,7 +1353,7 @@ static int attach_tcrypt(
                         return r;
                 }
 
-                return log_error_errno(r, "Failed to load tcrypt superblock on device %s: %m", crypt_get_device_name(cd));
+                return log_error_errno(r, "Failed to load tcrypt superblock on device %s: %m", sym_crypt_get_device_name(cd));
         }
 
         r = measured_crypt_activate_by_volume_key(
@@ -1365,7 +1365,7 @@ static int attach_tcrypt(
                         /* volume_key_size= */ 0,
                         flags);
         if (r < 0)
-                return log_error_errno(r, "Failed to activate tcrypt device %s: %m", crypt_get_device_name(cd));
+                return log_error_errno(r, "Failed to activate tcrypt device %s: %m", sym_crypt_get_device_name(cd));
 
         return 0;
 }
@@ -1509,7 +1509,7 @@ static bool use_token_plugins(void) {
         if (r == 0)
                 return false;
 
-        return crypt_token_external_path();
+        return sym_crypt_token_external_path();
 #else
         return false;
 #endif
@@ -1554,7 +1554,7 @@ static int crypt_activate_by_token_pin_ask_password(
         _cleanup_strv_free_erase_ char **pins = NULL;
         int r;
 
-        r = crypt_activate_by_token_pin(cd, name, type, CRYPT_ANY_TOKEN, /* pin= */ NULL, /* pin_size= */ 0, userdata, activation_flags);
+        r = sym_crypt_activate_by_token_pin(cd, name, type, CRYPT_ANY_TOKEN, /* pin= */ NULL, /* pin_size= */ 0, userdata, activation_flags);
         if (r > 0) /* returns unlocked keyslot id on success */
                 return 0;
         if (r == -EEXIST) /* volume is already active */
@@ -1567,7 +1567,7 @@ static int crypt_activate_by_token_pin_ask_password(
                 return r;
 
         STRV_FOREACH(p, pins) {
-                r = crypt_activate_by_token_pin(cd, name, type, CRYPT_ANY_TOKEN, *p, strlen(*p), userdata, activation_flags);
+                r = sym_crypt_activate_by_token_pin(cd, name, type, CRYPT_ANY_TOKEN, *p, strlen(*p), userdata, activation_flags);
                 if (r > 0) /* returns unlocked keyslot id on success */
                         return 0;
                 if (r == -EEXIST) /* volume is already active */
@@ -1597,7 +1597,7 @@ static int crypt_activate_by_token_pin_ask_password(
                         return r;
 
                 STRV_FOREACH(p, pins) {
-                        r = crypt_activate_by_token_pin(cd, name, type, CRYPT_ANY_TOKEN, *p, strlen(*p), userdata, activation_flags);
+                        r = sym_crypt_activate_by_token_pin(cd, name, type, CRYPT_ANY_TOKEN, *p, strlen(*p), userdata, activation_flags);
                         if (r > 0) /* returns unlocked keyslot id on success */
                                 return 0;
                         if (r == -EEXIST) /* volume is already active */
@@ -1658,7 +1658,7 @@ static int attach_luks_or_plain_or_bitlk_by_fido2(
                 return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
                                         "FIDO2 mode with manual parameters selected, but no keyfile specified, refusing.");
 
-        friendly = friendly_disk_name(crypt_get_device_name(cd), name);
+        friendly = friendly_disk_name(sym_crypt_get_device_name(cd), name);
         if (!friendly)
                 return log_oom();
 
@@ -1776,7 +1776,7 @@ static int attach_luks2_by_pkcs11_via_plugin(
 #if HAVE_LIBCRYPTSETUP_PLUGINS
         int r;
 
-        if (!streq_ptr(crypt_get_type(cd), CRYPT_LUKS2))
+        if (!streq_ptr(sym_crypt_get_type(cd), CRYPT_LUKS2))
                 return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "Automatic PKCS#11 metadata requires LUKS2 device.");
 
         systemd_pkcs11_plugin_params params = {
@@ -1786,7 +1786,7 @@ static int attach_luks2_by_pkcs11_via_plugin(
                 .askpw_flags = arg_ask_password_flags,
         };
 
-        r = crypt_activate_by_token_pin(cd, name, "systemd-pkcs11", CRYPT_ANY_TOKEN, NULL, 0, &params, flags);
+        r = sym_crypt_activate_by_token_pin(cd, name, "systemd-pkcs11", CRYPT_ANY_TOKEN, NULL, 0, &params, flags);
         if (r > 0) /* returns unlocked keyslot id on success */
                 r = 0;
         if (r == -EEXIST) /* volume is already active */
@@ -1842,7 +1842,7 @@ static int attach_luks_or_plain_or_bitlk_by_pkcs11(
                         return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "PKCS#11 mode selected but no key file specified, refusing.");
         }
 
-        friendly = friendly_disk_name(crypt_get_device_name(cd), name);
+        friendly = friendly_disk_name(sym_crypt_get_device_name(cd), name);
         if (!friendly)
                 return log_oom();
 
@@ -2036,7 +2036,7 @@ static int attach_luks_or_plain_or_bitlk_by_tpm2(
         assert(name);
         assert(arg_tpm2_device || arg_tpm2_device_auto);
 
-        friendly = friendly_disk_name(crypt_get_device_name(cd), name);
+        friendly = friendly_disk_name(sym_crypt_get_device_name(cd), name);
         if (!friendly)
                 return log_oom();
 
@@ -2382,7 +2382,7 @@ static int attach_luks_or_plain_or_bitlk(
         assert(cd);
         assert(name);
 
-        if ((!arg_type && !crypt_get_type(cd)) || streq_ptr(arg_type, CRYPT_PLAIN)) {
+        if ((!arg_type && !sym_crypt_get_type(cd)) || streq_ptr(arg_type, CRYPT_PLAIN)) {
                 struct crypt_params_plain params = {
                         .offset = arg_offset,
                         .skip = arg_skip,
@@ -2421,7 +2421,7 @@ static int attach_luks_or_plain_or_bitlk(
 
                 /* In contrast to what the name crypt_format() might suggest this doesn't actually format
                  * anything, it just configures encryption parameters when used for plain mode. */
-                r = crypt_format(cd, CRYPT_PLAIN, cipher, cipher_mode, NULL, NULL, arg_keyfile_size, &params);
+                r = sym_crypt_format(cd, CRYPT_PLAIN, cipher, cipher_mode, NULL, NULL, arg_keyfile_size, &params);
                 if (r < 0)
                         return log_error_errno(r, "Loading of cryptographic parameters failed: %m");
 
@@ -2430,10 +2430,10 @@ static int attach_luks_or_plain_or_bitlk(
         }
 
         log_info("Set cipher %s, mode %s, key size %i bits for device %s.",
-                 crypt_get_cipher(cd),
-                 crypt_get_cipher_mode(cd),
-                 crypt_get_volume_key_size(cd)*8,
-                 crypt_get_device_name(cd));
+                 sym_crypt_get_cipher(cd),
+                 sym_crypt_get_cipher_mode(cd),
+                 sym_crypt_get_volume_key_size(cd)*8,
+                 sym_crypt_get_device_name(cd));
 
         if (token_type == TOKEN_TPM2)
                 return attach_luks_or_plain_or_bitlk_by_tpm2(cd, name, key_file, key_data, until, flags, pass_volume_key);
@@ -2643,19 +2643,19 @@ static int verb_attach(int argc, char *argv[], uintptr_t _data, void *userdata) 
         if (arg_header) {
                 if (streq_ptr(arg_type, CRYPT_TCRYPT)){
                         log_debug("tcrypt header: %s", arg_header);
-                        r = crypt_init_data_device(&cd, arg_header, source);
+                        r = sym_crypt_init_data_device(&cd, arg_header, source);
                 } else {
                         log_debug("LUKS header: %s", arg_header);
-                        r = crypt_init(&cd, arg_header);
+                        r = sym_crypt_init(&cd, arg_header);
                 }
         } else
-                r = crypt_init(&cd, source);
+                r = sym_crypt_init(&cd, source);
         if (r < 0)
                 return log_error_errno(r, "crypt_init() failed: %m");
 
         cryptsetup_enable_logging(cd);
 
-        status = crypt_status(cd, volume);
+        status = sym_crypt_status(cd, volume);
         if (IN_SET(status, CRYPT_ACTIVE, CRYPT_BUSY)) {
                 log_info("Volume %s already active.", volume);
                 return 0;
@@ -2680,21 +2680,21 @@ static int verb_attach(int argc, char *argv[], uintptr_t _data, void *userdata) 
         }
 
         if (!arg_type || STR_IN_SET(arg_type, ANY_LUKS, CRYPT_LUKS1, CRYPT_LUKS2)) {
-                r = crypt_load(cd, !arg_type || streq(arg_type, ANY_LUKS) ? CRYPT_LUKS : arg_type, NULL);
+                r = sym_crypt_load(cd, !arg_type || streq(arg_type, ANY_LUKS) ? CRYPT_LUKS : arg_type, NULL);
                 if (r < 0)
-                        return log_error_errno(r, "Failed to load LUKS superblock on device %s: %m", crypt_get_device_name(cd));
+                        return log_error_errno(r, "Failed to load LUKS superblock on device %s: %m", sym_crypt_get_device_name(cd));
 
 /* since cryptsetup 2.7.0 (Jan 2024) */
 #if HAVE_CRYPT_SET_KEYRING_TO_LINK
                 if (arg_link_key_description) {
-                        r = crypt_set_keyring_to_link(cd, arg_link_key_description, NULL, arg_link_key_type, arg_link_keyring);
+                        r = sym_crypt_set_keyring_to_link(cd, arg_link_key_description, NULL, arg_link_key_type, arg_link_keyring);
                         if (r < 0)
                                 log_warning_errno(r, "Failed to set keyring or key description to link volume key in, ignoring: %m");
                 }
 #endif
 
                 if (arg_header) {
-                        r = crypt_set_data_device(cd, source);
+                        r = sym_crypt_set_data_device(cd, source);
                         if (r < 0)
                                 return log_error_errno(r, "Failed to set LUKS data device %s: %m", source);
                 }
@@ -2716,14 +2716,14 @@ static int verb_attach(int argc, char *argv[], uintptr_t _data, void *userdata) 
                                 return 0;
                         }
 
-                        log_debug_errno(r, "Token activation unsuccessful for device %s: %m", crypt_get_device_name(cd));
+                        log_debug_errno(r, "Token activation unsuccessful for device %s: %m", sym_crypt_get_device_name(cd));
                 }
         }
 
         if (streq_ptr(arg_type, CRYPT_BITLK)) {
-                r = crypt_load(cd, CRYPT_BITLK, NULL);
+                r = sym_crypt_load(cd, CRYPT_BITLK, NULL);
                 if (r < 0)
-                        return log_error_errno(r, "Failed to load Bitlocker superblock on device %s: %m", crypt_get_device_name(cd));
+                        return log_error_errno(r, "Failed to load Bitlocker superblock on device %s: %m", sym_crypt_get_device_name(cd));
         }
 
         bool use_cached_passphrase = true, try_discover_key = !key_file;
@@ -2850,7 +2850,7 @@ static int verb_detach(int argc, char *argv[], uintptr_t _data, void *userdata) 
         if (!filename_is_valid(volume))
                 return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "Volume name '%s' is not valid.", volume);
 
-        r = crypt_init_by_name(&cd, volume);
+        r = sym_crypt_init_by_name(&cd, volume);
         if (r == -ENODEV) {
                 log_info("Volume %s already inactive.", volume);
                 return 0;
@@ -2860,7 +2860,7 @@ static int verb_detach(int argc, char *argv[], uintptr_t _data, void *userdata) 
 
         cryptsetup_enable_logging(cd);
 
-        r = crypt_deactivate(cd, volume);
+        r = sym_crypt_deactivate(cd, volume);
         if (r < 0)
                 return log_error_errno(r, "Failed to deactivate '%s': %m", volume);
 
@@ -2877,6 +2877,10 @@ static int run(int argc, char *argv[]) {
         char **args = NULL;
         r = parse_argv(argc, argv, &args);
         if (r <= 0)
+                return r;
+
+        r = dlopen_cryptsetup();
+        if (r < 0)
                 return r;
 
         cryptsetup_enable_logging(NULL);

--- a/src/cryptsetup/meson.build
+++ b/src/cryptsetup/meson.build
@@ -18,7 +18,7 @@ executables += [
                 'public' : true,
                 'sources' : systemd_cryptsetup_sources,
                 'dependencies' : [
-                        libcryptsetup,
+                        libcryptsetup_cflags,
                         libfido2_cflags,
                         libmount_cflags,
                         libopenssl,

--- a/src/growfs/growfs.c
+++ b/src/growfs/growfs.c
@@ -27,7 +27,7 @@ static bool arg_dry_run = false;
 #if HAVE_LIBCRYPTSETUP
 static int resize_crypt_luks_device(dev_t devno, const char *fstype, dev_t main_devno) {
         _cleanup_free_ char *devpath = NULL, *main_devpath = NULL;
-        _cleanup_(sym_crypt_freep) struct crypt_device *cd = NULL;
+        _cleanup_(crypt_freep) struct crypt_device *cd = NULL;
         _cleanup_close_ int main_devfd = -EBADF;
         uint64_t size;
         int r;

--- a/src/growfs/growfs.c
+++ b/src/growfs/growfs.c
@@ -28,7 +28,7 @@ static bool arg_dry_run = false;
 #if HAVE_LIBCRYPTSETUP
 static int resize_crypt_luks_device(dev_t devno, const char *fstype, dev_t main_devno) {
         _cleanup_free_ char *devpath = NULL, *main_devpath = NULL;
-        _cleanup_(sym_crypt_freep) struct crypt_device *cd = NULL;
+        _cleanup_(crypt_freep) struct crypt_device *cd = NULL;
         _cleanup_close_ int main_devfd = -EBADF;
         uint64_t size;
         int r;

--- a/src/home/homework-luks.c
+++ b/src/home/homework-luks.c
@@ -411,7 +411,7 @@ static int luks_setup(
                 key_serial_t *ret_key_serial) {
 
         _cleanup_(keyring_unlinkp) key_serial_t key_serial = -1;
-        _cleanup_(sym_crypt_freep) struct crypt_device *cd = NULL;
+        _cleanup_(crypt_freep) struct crypt_device *cd = NULL;
         _cleanup_(erase_and_freep) void *vk = NULL;
         sd_id128_t p;
         size_t vks;
@@ -522,7 +522,7 @@ static int acquire_open_luks_device(
                 HomeSetup *setup,
                 bool graceful) {
 
-        _cleanup_(sym_crypt_freep) struct crypt_device *cd = NULL;
+        _cleanup_(crypt_freep) struct crypt_device *cd = NULL;
         int r;
 
         assert(h);
@@ -1781,7 +1781,7 @@ static int luks_format(
                 struct crypt_device **ret) {
 
         _cleanup_(user_record_unrefp) UserRecord *reduced = NULL;
-        _cleanup_(sym_crypt_freep) struct crypt_device *cd = NULL;
+        _cleanup_(crypt_freep) struct crypt_device *cd = NULL;
         _cleanup_(erase_and_freep) void *volume_key = NULL;
         struct crypt_pbkdf_type good_pbkdf, minimal_pbkdf;
         _cleanup_free_ char *text = NULL;

--- a/src/integritysetup/integritysetup.c
+++ b/src/integritysetup/integritysetup.c
@@ -126,19 +126,19 @@ static int verb_attach(int argc, char *argv[], uintptr_t _data, void *userdata) 
                         return r;
         }
 
-        r = crypt_init(&cd, device);
+        r = sym_crypt_init(&cd, device);
         if (r < 0)
                 return log_error_errno(r, "Failed to open integrity device %s: %m", device);
 
         cryptsetup_enable_logging(cd);
 
-        status = crypt_status(cd, volume);
+        status = sym_crypt_status(cd, volume);
         if (IN_SET(status, CRYPT_ACTIVE, CRYPT_BUSY)) {
                 log_info("Volume %s already active.", volume);
                 return 0;
         }
 
-        r = crypt_load(cd,
+        r = sym_crypt_load(cd,
                        CRYPT_INTEGRITY,
                        &(struct crypt_params_integrity) {
                                .journal_watermark = arg_percent,
@@ -149,12 +149,12 @@ static int verb_attach(int argc, char *argv[], uintptr_t _data, void *userdata) 
                 return log_error_errno(r, "Failed to load integrity superblock: %m");
 
         if (!isempty(arg_existing_data_device)) {
-                r = crypt_set_data_device(cd, arg_existing_data_device);
+                r = sym_crypt_set_data_device(cd, arg_existing_data_device);
                 if (r < 0)
                         return log_error_errno(r, "Failed to add separate data device: %m");
         }
 
-        r = crypt_activate_by_volume_key(cd, volume, key_buf, key_buf_size, arg_activate_flags);
+        r = sym_crypt_activate_by_volume_key(cd, volume, key_buf, key_buf_size, arg_activate_flags);
         if (r < 0)
                 return log_error_errno(r, "Failed to set up integrity device: %m");
 
@@ -172,7 +172,7 @@ static int verb_detach(int argc, char *argv[], uintptr_t _data, void *userdata) 
         if (!filename_is_valid(volume))
                 return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "Volume name '%s' is not valid.", volume);
 
-        r = crypt_init_by_name(&cd, volume);
+        r = sym_crypt_init_by_name(&cd, volume);
         if (r == -ENODEV) {
                 log_info("Volume %s already inactive.", volume);
                 return 0;
@@ -182,7 +182,7 @@ static int verb_detach(int argc, char *argv[], uintptr_t _data, void *userdata) 
 
         cryptsetup_enable_logging(cd);
 
-        r = crypt_deactivate(cd, volume);
+        r = sym_crypt_deactivate(cd, volume);
         if (r < 0)
                 return log_error_errno(r, "Failed to deactivate: %m");
 
@@ -190,12 +190,16 @@ static int verb_detach(int argc, char *argv[], uintptr_t _data, void *userdata) 
 }
 
 static int run(int argc, char *argv[]) {
+        int r;
+
         if (argv_looks_like_help(argc, argv))
                 return help();
 
         log_setup();
 
-        cryptsetup_enable_logging(NULL);
+        r = dlopen_cryptsetup(LOG_ERR);
+        if (r < 0)
+                return r;
 
         umask(0022);
 

--- a/src/integritysetup/integritysetup.c
+++ b/src/integritysetup/integritysetup.c
@@ -126,19 +126,19 @@ static int verb_attach(int argc, char *argv[], uintptr_t _data, void *userdata) 
                         return r;
         }
 
-        r = crypt_init(&cd, device);
+        r = sym_crypt_init(&cd, device);
         if (r < 0)
                 return log_error_errno(r, "Failed to open integrity device %s: %m", device);
 
         cryptsetup_enable_logging(cd);
 
-        status = crypt_status(cd, volume);
+        status = sym_crypt_status(cd, volume);
         if (IN_SET(status, CRYPT_ACTIVE, CRYPT_BUSY)) {
                 log_info("Volume %s already active.", volume);
                 return 0;
         }
 
-        r = crypt_load(cd,
+        r = sym_crypt_load(cd,
                        CRYPT_INTEGRITY,
                        &(struct crypt_params_integrity) {
                                .journal_watermark = arg_percent,
@@ -149,12 +149,12 @@ static int verb_attach(int argc, char *argv[], uintptr_t _data, void *userdata) 
                 return log_error_errno(r, "Failed to load integrity superblock: %m");
 
         if (!isempty(arg_existing_data_device)) {
-                r = crypt_set_data_device(cd, arg_existing_data_device);
+                r = sym_crypt_set_data_device(cd, arg_existing_data_device);
                 if (r < 0)
                         return log_error_errno(r, "Failed to add separate data device: %m");
         }
 
-        r = crypt_activate_by_volume_key(cd, volume, key_buf, key_buf_size, arg_activate_flags);
+        r = sym_crypt_activate_by_volume_key(cd, volume, key_buf, key_buf_size, arg_activate_flags);
         if (r < 0)
                 return log_error_errno(r, "Failed to set up integrity device: %m");
 
@@ -172,7 +172,7 @@ static int verb_detach(int argc, char *argv[], uintptr_t _data, void *userdata) 
         if (!filename_is_valid(volume))
                 return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "Volume name '%s' is not valid.", volume);
 
-        r = crypt_init_by_name(&cd, volume);
+        r = sym_crypt_init_by_name(&cd, volume);
         if (r == -ENODEV) {
                 log_info("Volume %s already inactive.", volume);
                 return 0;
@@ -182,7 +182,7 @@ static int verb_detach(int argc, char *argv[], uintptr_t _data, void *userdata) 
 
         cryptsetup_enable_logging(cd);
 
-        r = crypt_deactivate(cd, volume);
+        r = sym_crypt_deactivate(cd, volume);
         if (r < 0)
                 return log_error_errno(r, "Failed to deactivate: %m");
 
@@ -190,10 +190,16 @@ static int verb_detach(int argc, char *argv[], uintptr_t _data, void *userdata) 
 }
 
 static int run(int argc, char *argv[]) {
+        int r;
+
         if (argv_looks_like_help(argc, argv))
                 return help();
 
         log_setup();
+
+        r = dlopen_cryptsetup();
+        if (r < 0)
+                return r;
 
         cryptsetup_enable_logging(NULL);
 

--- a/src/integritysetup/meson.build
+++ b/src/integritysetup/meson.build
@@ -9,7 +9,7 @@ executables += [
                 'name' : 'systemd-integritysetup',
                 'sources' : files('integritysetup.c'),
                 'extract' : files('integrity-util.c'),
-                'dependencies' : libcryptsetup,
+                'dependencies' : libcryptsetup_cflags,
         },
         generator_template + {
                 'name' : 'systemd-integritysetup-generator',

--- a/src/repart/repart.c
+++ b/src/repart/repart.c
@@ -5253,7 +5253,7 @@ static int partition_encrypt(Context *context, Partition *p, PartitionTarget *ta
                         return log_oom();
         }
 
-        _cleanup_(sym_crypt_freep) struct crypt_device *cd = NULL;
+        _cleanup_(crypt_freep) struct crypt_device *cd = NULL;
         r = sym_crypt_init(&cd, offline ? hp : node);
         if (r < 0)
                 return log_error_errno(r, "Failed to allocate libcryptsetup context for %s: %m", hp);
@@ -5709,7 +5709,7 @@ static int partition_format_verity_hash(
 #if HAVE_LIBCRYPTSETUP
         Partition *dp;
         _cleanup_(partition_target_freep) PartitionTarget *t = NULL;
-        _cleanup_(sym_crypt_freep) struct crypt_device *cd = NULL;
+        _cleanup_(crypt_freep) struct crypt_device *cd = NULL;
         _cleanup_free_ char *hint = NULL;
         int r;
 

--- a/src/shared/cryptsetup-util.c
+++ b/src/shared/cryptsetup-util.c
@@ -21,7 +21,9 @@ static void *cryptsetup_dl = NULL;
 
 DLSYM_PROTOTYPE(crypt_activate_by_passphrase) = NULL;
 DLSYM_PROTOTYPE(crypt_activate_by_signed_key) = NULL;
+DLSYM_PROTOTYPE(crypt_activate_by_token_pin) = NULL;
 DLSYM_PROTOTYPE(crypt_activate_by_volume_key) = NULL;
+DLSYM_PROTOTYPE(crypt_deactivate) = NULL;
 DLSYM_PROTOTYPE(crypt_deactivate_by_name) = NULL;
 DLSYM_PROTOTYPE(crypt_format) = NULL;
 DLSYM_PROTOTYPE(crypt_free) = NULL;
@@ -37,9 +39,11 @@ DLSYM_PROTOTYPE(crypt_get_volume_key_size) = NULL;
 DLSYM_PROTOTYPE(crypt_header_restore) = NULL;
 DLSYM_PROTOTYPE(crypt_init) = NULL;
 DLSYM_PROTOTYPE(crypt_init_by_name) = NULL;
+DLSYM_PROTOTYPE(crypt_init_data_device) = NULL;
 DLSYM_PROTOTYPE(crypt_keyslot_add_by_volume_key) = NULL;
 DLSYM_PROTOTYPE(crypt_keyslot_destroy) = NULL;
 DLSYM_PROTOTYPE(crypt_keyslot_max) = NULL;
+DLSYM_PROTOTYPE(crypt_keyslot_status) = NULL;
 DLSYM_PROTOTYPE(crypt_load) = NULL;
 DLSYM_PROTOTYPE(crypt_metadata_locking) = NULL;
 DLSYM_PROTOTYPE(crypt_persistent_flags_get) = NULL;
@@ -51,10 +55,15 @@ DLSYM_PROTOTYPE(crypt_resume_by_volume_key) = NULL;
 DLSYM_PROTOTYPE(crypt_set_data_device) = NULL;
 DLSYM_PROTOTYPE(crypt_set_data_offset) = NULL;
 DLSYM_PROTOTYPE(crypt_set_debug_level) = NULL;
+#if HAVE_CRYPT_SET_KEYRING_TO_LINK
+DLSYM_PROTOTYPE(crypt_set_keyring_to_link) = NULL;
+#endif
 DLSYM_PROTOTYPE(crypt_set_log_callback) = NULL;
 DLSYM_PROTOTYPE(crypt_set_metadata_size) = NULL;
 DLSYM_PROTOTYPE(crypt_set_pbkdf_type) = NULL;
+DLSYM_PROTOTYPE(crypt_status) = NULL;
 DLSYM_PROTOTYPE(crypt_suspend) = NULL;
+DLSYM_PROTOTYPE(crypt_token_external_path) = NULL;
 DLSYM_PROTOTYPE(crypt_token_json_get) = NULL;
 DLSYM_PROTOTYPE(crypt_token_json_set) = NULL;
 DLSYM_PROTOTYPE(crypt_token_max) = NULL;
@@ -287,7 +296,9 @@ int dlopen_cryptsetup(void) {
                         &cryptsetup_dl, "libcryptsetup.so.12", LOG_DEBUG,
                         DLSYM_ARG(crypt_activate_by_passphrase),
                         DLSYM_ARG(crypt_activate_by_signed_key),
+                        DLSYM_ARG(crypt_activate_by_token_pin),
                         DLSYM_ARG(crypt_activate_by_volume_key),
+                        DLSYM_ARG(crypt_deactivate),
                         DLSYM_ARG(crypt_deactivate_by_name),
                         DLSYM_ARG(crypt_format),
                         DLSYM_ARG(crypt_free),
@@ -303,9 +314,11 @@ int dlopen_cryptsetup(void) {
                         DLSYM_ARG(crypt_header_restore),
                         DLSYM_ARG(crypt_init),
                         DLSYM_ARG(crypt_init_by_name),
+                        DLSYM_ARG(crypt_init_data_device),
                         DLSYM_ARG(crypt_keyslot_add_by_volume_key),
                         DLSYM_ARG(crypt_keyslot_destroy),
                         DLSYM_ARG(crypt_keyslot_max),
+                        DLSYM_ARG(crypt_keyslot_status),
                         DLSYM_ARG(crypt_load),
                         DLSYM_ARG(crypt_metadata_locking),
                         DLSYM_ARG(crypt_persistent_flags_get),
@@ -317,10 +330,15 @@ int dlopen_cryptsetup(void) {
                         DLSYM_ARG(crypt_set_data_device),
                         DLSYM_ARG(crypt_set_data_offset),
                         DLSYM_ARG(crypt_set_debug_level),
+#if HAVE_CRYPT_SET_KEYRING_TO_LINK
+                        DLSYM_ARG(crypt_set_keyring_to_link),
+#endif
                         DLSYM_ARG(crypt_set_log_callback),
                         DLSYM_ARG(crypt_set_metadata_size),
                         DLSYM_ARG(crypt_set_pbkdf_type),
+                        DLSYM_ARG(crypt_status),
                         DLSYM_ARG(crypt_suspend),
+                        DLSYM_ARG(crypt_token_external_path),
                         DLSYM_ARG(crypt_token_json_get),
                         DLSYM_ARG(crypt_token_json_set),
                         DLSYM_ARG(crypt_token_max),

--- a/src/shared/cryptsetup-util.c
+++ b/src/shared/cryptsetup-util.c
@@ -21,7 +21,9 @@ static void *cryptsetup_dl = NULL;
 
 DLSYM_PROTOTYPE(crypt_activate_by_passphrase) = NULL;
 DLSYM_PROTOTYPE(crypt_activate_by_signed_key) = NULL;
+DLSYM_PROTOTYPE(crypt_activate_by_token_pin) = NULL;
 DLSYM_PROTOTYPE(crypt_activate_by_volume_key) = NULL;
+DLSYM_PROTOTYPE(crypt_deactivate) = NULL;
 DLSYM_PROTOTYPE(crypt_deactivate_by_name) = NULL;
 DLSYM_PROTOTYPE(crypt_format) = NULL;
 DLSYM_PROTOTYPE(crypt_free) = NULL;
@@ -37,9 +39,11 @@ DLSYM_PROTOTYPE(crypt_get_volume_key_size) = NULL;
 DLSYM_PROTOTYPE(crypt_header_restore) = NULL;
 DLSYM_PROTOTYPE(crypt_init) = NULL;
 DLSYM_PROTOTYPE(crypt_init_by_name) = NULL;
+DLSYM_PROTOTYPE(crypt_init_data_device) = NULL;
 DLSYM_PROTOTYPE(crypt_keyslot_add_by_volume_key) = NULL;
 DLSYM_PROTOTYPE(crypt_keyslot_destroy) = NULL;
 DLSYM_PROTOTYPE(crypt_keyslot_max) = NULL;
+DLSYM_PROTOTYPE(crypt_keyslot_status) = NULL;
 DLSYM_PROTOTYPE(crypt_load) = NULL;
 DLSYM_PROTOTYPE(crypt_metadata_locking) = NULL;
 DLSYM_PROTOTYPE(crypt_persistent_flags_get) = NULL;
@@ -51,10 +55,15 @@ DLSYM_PROTOTYPE(crypt_resume_by_volume_key) = NULL;
 DLSYM_PROTOTYPE(crypt_set_data_device) = NULL;
 DLSYM_PROTOTYPE(crypt_set_data_offset) = NULL;
 DLSYM_PROTOTYPE(crypt_set_debug_level) = NULL;
+#if HAVE_CRYPT_SET_KEYRING_TO_LINK
+DLSYM_PROTOTYPE(crypt_set_keyring_to_link) = NULL;
+#endif
 DLSYM_PROTOTYPE(crypt_set_log_callback) = NULL;
 DLSYM_PROTOTYPE(crypt_set_metadata_size) = NULL;
 DLSYM_PROTOTYPE(crypt_set_pbkdf_type) = NULL;
+DLSYM_PROTOTYPE(crypt_status) = NULL;
 DLSYM_PROTOTYPE(crypt_suspend) = NULL;
+DLSYM_PROTOTYPE(crypt_token_external_path) = NULL;
 DLSYM_PROTOTYPE(crypt_token_json_get) = NULL;
 DLSYM_PROTOTYPE(crypt_token_json_set) = NULL;
 DLSYM_PROTOTYPE(crypt_token_max) = NULL;
@@ -287,7 +296,9 @@ int dlopen_cryptsetup(int log_level) {
                         &cryptsetup_dl, "libcryptsetup.so.12", log_level,
                         DLSYM_ARG(crypt_activate_by_passphrase),
                         DLSYM_ARG(crypt_activate_by_signed_key),
+                        DLSYM_ARG(crypt_activate_by_token_pin),
                         DLSYM_ARG(crypt_activate_by_volume_key),
+                        DLSYM_ARG(crypt_deactivate),
                         DLSYM_ARG(crypt_deactivate_by_name),
                         DLSYM_ARG(crypt_format),
                         DLSYM_ARG(crypt_free),
@@ -303,9 +314,11 @@ int dlopen_cryptsetup(int log_level) {
                         DLSYM_ARG(crypt_header_restore),
                         DLSYM_ARG(crypt_init),
                         DLSYM_ARG(crypt_init_by_name),
+                        DLSYM_ARG(crypt_init_data_device),
                         DLSYM_ARG(crypt_keyslot_add_by_volume_key),
                         DLSYM_ARG(crypt_keyslot_destroy),
                         DLSYM_ARG(crypt_keyslot_max),
+                        DLSYM_ARG(crypt_keyslot_status),
                         DLSYM_ARG(crypt_load),
                         DLSYM_ARG(crypt_metadata_locking),
                         DLSYM_ARG(crypt_persistent_flags_get),
@@ -317,10 +330,15 @@ int dlopen_cryptsetup(int log_level) {
                         DLSYM_ARG(crypt_set_data_device),
                         DLSYM_ARG(crypt_set_data_offset),
                         DLSYM_ARG(crypt_set_debug_level),
+#if HAVE_CRYPT_SET_KEYRING_TO_LINK
+                        DLSYM_ARG(crypt_set_keyring_to_link),
+#endif
                         DLSYM_ARG(crypt_set_log_callback),
                         DLSYM_ARG(crypt_set_metadata_size),
                         DLSYM_ARG(crypt_set_pbkdf_type),
+                        DLSYM_ARG(crypt_status),
                         DLSYM_ARG(crypt_suspend),
+                        DLSYM_ARG(crypt_token_external_path),
                         DLSYM_ARG(crypt_token_json_get),
                         DLSYM_ARG(crypt_token_json_set),
                         DLSYM_ARG(crypt_token_max),

--- a/src/shared/cryptsetup-util.h
+++ b/src/shared/cryptsetup-util.h
@@ -9,7 +9,9 @@
 
 extern DLSYM_PROTOTYPE(crypt_activate_by_passphrase);
 extern DLSYM_PROTOTYPE(crypt_activate_by_signed_key);
+extern DLSYM_PROTOTYPE(crypt_activate_by_token_pin);
 extern DLSYM_PROTOTYPE(crypt_activate_by_volume_key);
+extern DLSYM_PROTOTYPE(crypt_deactivate);
 extern DLSYM_PROTOTYPE(crypt_deactivate_by_name);
 extern DLSYM_PROTOTYPE(crypt_format);
 extern DLSYM_PROTOTYPE(crypt_free);
@@ -25,9 +27,11 @@ extern DLSYM_PROTOTYPE(crypt_get_volume_key_size);
 extern DLSYM_PROTOTYPE(crypt_header_restore);
 extern DLSYM_PROTOTYPE(crypt_init);
 extern DLSYM_PROTOTYPE(crypt_init_by_name);
+extern DLSYM_PROTOTYPE(crypt_init_data_device);
 extern DLSYM_PROTOTYPE(crypt_keyslot_add_by_volume_key);
 extern DLSYM_PROTOTYPE(crypt_keyslot_destroy);
 extern DLSYM_PROTOTYPE(crypt_keyslot_max);
+extern DLSYM_PROTOTYPE(crypt_keyslot_status);
 extern DLSYM_PROTOTYPE(crypt_load);
 extern DLSYM_PROTOTYPE(crypt_metadata_locking);
 extern DLSYM_PROTOTYPE(crypt_persistent_flags_get);
@@ -39,10 +43,15 @@ extern DLSYM_PROTOTYPE(crypt_resume_by_volume_key);
 extern DLSYM_PROTOTYPE(crypt_set_data_device);
 extern DLSYM_PROTOTYPE(crypt_set_data_offset);
 extern DLSYM_PROTOTYPE(crypt_set_debug_level);
+#if HAVE_CRYPT_SET_KEYRING_TO_LINK
+extern DLSYM_PROTOTYPE(crypt_set_keyring_to_link);
+#endif
 extern DLSYM_PROTOTYPE(crypt_set_log_callback);
 extern DLSYM_PROTOTYPE(crypt_set_metadata_size);
 extern DLSYM_PROTOTYPE(crypt_set_pbkdf_type);
+extern DLSYM_PROTOTYPE(crypt_status);
 extern DLSYM_PROTOTYPE(crypt_suspend);
+extern DLSYM_PROTOTYPE(crypt_token_external_path);
 extern DLSYM_PROTOTYPE(crypt_token_json_get);
 extern DLSYM_PROTOTYPE(crypt_token_json_set);
 extern DLSYM_PROTOTYPE(crypt_token_max);
@@ -55,10 +64,9 @@ extern DLSYM_PROTOTYPE(crypt_volume_key_keyring);
 extern DLSYM_PROTOTYPE(crypt_wipe);
 extern DLSYM_PROTOTYPE(crypt_get_integrity_info);
 
-DEFINE_TRIVIAL_CLEANUP_FUNC_FULL(struct crypt_device *, crypt_free, NULL);
-DEFINE_TRIVIAL_CLEANUP_FUNC_FULL(struct crypt_device *, sym_crypt_free, NULL);
-
-/* Be careful, this works with dlopen_cryptsetup(), that is, it calls sym_crypt_free() instead of crypt_free(). */
+/* Be careful, these work with dlopen_cryptsetup(), that is, they call sym_crypt_free() instead of
+ * crypt_free() and hence depend on dlopen_cryptsetup() having been called. */
+DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_RENAME(struct crypt_device *, sym_crypt_free, crypt_freep, NULL);
 #define crypt_free_and_replace(a, b)                    \
         free_and_replace_full(a, b, sym_crypt_free)
 

--- a/src/shared/dissect-image.c
+++ b/src/shared/dissect-image.c
@@ -2925,7 +2925,7 @@ static int decrypt_partition(
                 DecryptedImage *d) {
 
         _cleanup_free_ char *node = NULL, *name = NULL;
-        _cleanup_(sym_crypt_freep) struct crypt_device *cd = NULL;
+        _cleanup_(crypt_freep) struct crypt_device *cd = NULL;
         _cleanup_close_ int fd = -EBADF;
         int r;
 
@@ -2995,7 +2995,7 @@ static int verity_can_reuse(
                 struct crypt_device **ret_cd) {
 
         /* If the same volume was already open, check that the root hashes match, and reuse it if they do */
-        _cleanup_(sym_crypt_freep) struct crypt_device *cd = NULL;
+        _cleanup_(crypt_freep) struct crypt_device *cd = NULL;
         struct crypt_params_verity crypt_params = {};
         int r;
 
@@ -3283,7 +3283,7 @@ static int verity_partition(
                 PartitionPolicyFlags policy_flags,
                 DecryptedImage *d) {
 
-        _cleanup_(sym_crypt_freep) struct crypt_device *cd = NULL;
+        _cleanup_(crypt_freep) struct crypt_device *cd = NULL;
         _cleanup_free_ char *node = NULL, *name = NULL;
         _cleanup_close_ int mount_node_fd = -EBADF;
         int r;
@@ -3353,7 +3353,7 @@ static int verity_partition(
          * retry a few times before giving up. */
         for (unsigned i = 0; i < N_DEVICE_NODE_LIST_ATTEMPTS; i++) {
                 _cleanup_(dm_deferred_remove_cleanp) char *restore_deferred_remove = NULL;
-                _cleanup_(sym_crypt_freep) struct crypt_device *existing_cd = NULL;
+                _cleanup_(crypt_freep) struct crypt_device *existing_cd = NULL;
                 _cleanup_close_ int fd = -EBADF;
 
                 /* First, check if the device already exists. */

--- a/src/veritysetup/meson.build
+++ b/src/veritysetup/meson.build
@@ -8,7 +8,7 @@ executables += [
         libexec_template + {
                 'name' : 'systemd-veritysetup',
                 'sources' : files('veritysetup.c'),
-                'dependencies' : libcryptsetup,
+                'dependencies' : libcryptsetup_cflags,
         },
         generator_template + {
                 'name' : 'systemd-veritysetup-generator',

--- a/src/veritysetup/veritysetup.c
+++ b/src/veritysetup/veritysetup.c
@@ -376,13 +376,13 @@ static int verb_attach(int argc, char *argv[], uintptr_t _data, void *userdata) 
                         return log_error_errno(r, "Failed to decode root hash signature data from udev data device: %m");
         }
 
-        r = crypt_init(&cd, verity_device);
+        r = sym_crypt_init(&cd, verity_device);
         if (r < 0)
                 return log_error_errno(r, "Failed to open verity device %s: %m", verity_device);
 
         cryptsetup_enable_logging(cd);
 
-        status = crypt_status(cd, volume);
+        status = sym_crypt_status(cd, volume);
         if (IN_SET(status, CRYPT_ACTIVE, CRYPT_BUSY)) {
                 log_info("Volume %s already active.", volume);
                 return 0;
@@ -396,7 +396,7 @@ static int verb_attach(int argc, char *argv[], uintptr_t _data, void *userdata) 
                         .fec_roots = arg_fec_roots,
                 };
 
-                r = crypt_load(cd, CRYPT_VERITY, &p);
+                r = sym_crypt_load(cd, CRYPT_VERITY, &p);
                 if (r < 0)
                         return log_error_errno(r, "Failed to load verity superblock: %m");
         } else {
@@ -416,28 +416,28 @@ static int verb_attach(int argc, char *argv[], uintptr_t _data, void *userdata) 
                         .flags = CRYPT_VERITY_NO_HEADER,
                 };
 
-                r = crypt_format(cd, CRYPT_VERITY, NULL, NULL, arg_uuid, NULL, 0, &p);
+                r = sym_crypt_format(cd, CRYPT_VERITY, NULL, NULL, arg_uuid, NULL, 0, &p);
                 if (r < 0)
                         return log_error_errno(r, "Failed to format verity superblock: %m");
         }
 
-        r = crypt_set_data_device(cd, data_device);
+        r = sym_crypt_set_data_device(cd, data_device);
         if (r < 0)
                 return log_error_errno(r, "Failed to configure data device: %m");
 
         if (arg_root_hash_signature_size > 0) {
-                r = crypt_activate_by_signed_key(cd, volume, rh, rh_size, arg_root_hash_signature, arg_root_hash_signature_size, arg_activate_flags);
+                r = sym_crypt_activate_by_signed_key(cd, volume, rh, rh_size, arg_root_hash_signature, arg_root_hash_signature_size, arg_activate_flags);
                 if (r < 0) {
                         log_info_errno(r, "Unable to activate verity device '%s' with root hash signature (%m), retrying without.", volume);
 
-                        r = crypt_activate_by_volume_key(cd, volume, rh, rh_size, arg_activate_flags);
+                        r = sym_crypt_activate_by_volume_key(cd, volume, rh, rh_size, arg_activate_flags);
                         if (r < 0)
                                 return log_error_errno(r, "Failed to activate verity device '%s' both with and without root hash signature: %m", volume);
 
                         log_info("Activation of verity device '%s' succeeded without root hash signature.", volume);
                 }
         } else
-                r = crypt_activate_by_volume_key(cd, volume, rh, rh_size, arg_activate_flags);
+                r = sym_crypt_activate_by_volume_key(cd, volume, rh, rh_size, arg_activate_flags);
         if (r < 0)
                 return log_error_errno(r, "Failed to set up verity device '%s': %m", volume);
 
@@ -460,7 +460,7 @@ static int verb_detach(int argc, char *argv[], uintptr_t _data, void *userdata) 
         if (!filename_is_valid(volume))
                 return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "Volume name '%s' is not valid.", volume);
 
-        r = crypt_init_by_name(&cd, volume);
+        r = sym_crypt_init_by_name(&cd, volume);
         if (r == -ENODEV) {
                 log_info("Volume %s 'already' inactive.", volume);
                 return 0;
@@ -470,7 +470,7 @@ static int verb_detach(int argc, char *argv[], uintptr_t _data, void *userdata) 
 
         cryptsetup_enable_logging(cd);
 
-        r = crypt_deactivate(cd, volume);
+        r = sym_crypt_deactivate(cd, volume);
         if (r < 0)
                 return log_error_errno(r, "Failed to deactivate volume '%s': %m", volume);
 
@@ -478,12 +478,16 @@ static int verb_detach(int argc, char *argv[], uintptr_t _data, void *userdata) 
 }
 
 static int run(int argc, char *argv[]) {
+        int r;
+
         if (argv_looks_like_help(argc, argv))
                 return help();
 
         log_setup();
 
-        cryptsetup_enable_logging(NULL);
+        r = dlopen_cryptsetup(LOG_ERR);
+        if (r < 0)
+                return r;
 
         umask(0022);
 

--- a/src/veritysetup/veritysetup.c
+++ b/src/veritysetup/veritysetup.c
@@ -379,13 +379,13 @@ static int verb_attach(int argc, char *argv[], uintptr_t _data, void *userdata) 
                         return log_error_errno(r, "Failed to decode root hash signature data from udev data device: %m");
         }
 
-        r = crypt_init(&cd, verity_device);
+        r = sym_crypt_init(&cd, verity_device);
         if (r < 0)
                 return log_error_errno(r, "Failed to open verity device %s: %m", verity_device);
 
         cryptsetup_enable_logging(cd);
 
-        status = crypt_status(cd, volume);
+        status = sym_crypt_status(cd, volume);
         if (IN_SET(status, CRYPT_ACTIVE, CRYPT_BUSY)) {
                 log_info("Volume %s already active.", volume);
                 return 0;
@@ -399,7 +399,7 @@ static int verb_attach(int argc, char *argv[], uintptr_t _data, void *userdata) 
                         .fec_roots = arg_fec_roots,
                 };
 
-                r = crypt_load(cd, CRYPT_VERITY, &p);
+                r = sym_crypt_load(cd, CRYPT_VERITY, &p);
                 if (r < 0)
                         return log_error_errno(r, "Failed to load verity superblock: %m");
         } else {
@@ -419,28 +419,28 @@ static int verb_attach(int argc, char *argv[], uintptr_t _data, void *userdata) 
                         .flags = CRYPT_VERITY_NO_HEADER,
                 };
 
-                r = crypt_format(cd, CRYPT_VERITY, NULL, NULL, arg_uuid, NULL, 0, &p);
+                r = sym_crypt_format(cd, CRYPT_VERITY, NULL, NULL, arg_uuid, NULL, 0, &p);
                 if (r < 0)
                         return log_error_errno(r, "Failed to format verity superblock: %m");
         }
 
-        r = crypt_set_data_device(cd, data_device);
+        r = sym_crypt_set_data_device(cd, data_device);
         if (r < 0)
                 return log_error_errno(r, "Failed to configure data device: %m");
 
         if (arg_root_hash_signature_size > 0) {
-                r = crypt_activate_by_signed_key(cd, volume, rh, rh_size, arg_root_hash_signature, arg_root_hash_signature_size, arg_activate_flags);
+                r = sym_crypt_activate_by_signed_key(cd, volume, rh, rh_size, arg_root_hash_signature, arg_root_hash_signature_size, arg_activate_flags);
                 if (r < 0) {
                         log_info_errno(r, "Unable to activate verity device '%s' with root hash signature (%m), retrying without.", volume);
 
-                        r = crypt_activate_by_volume_key(cd, volume, rh, rh_size, arg_activate_flags);
+                        r = sym_crypt_activate_by_volume_key(cd, volume, rh, rh_size, arg_activate_flags);
                         if (r < 0)
                                 return log_error_errno(r, "Failed to activate verity device '%s' both with and without root hash signature: %m", volume);
 
                         log_info("Activation of verity device '%s' succeeded without root hash signature.", volume);
                 }
         } else
-                r = crypt_activate_by_volume_key(cd, volume, rh, rh_size, arg_activate_flags);
+                r = sym_crypt_activate_by_volume_key(cd, volume, rh, rh_size, arg_activate_flags);
         if (r < 0)
                 return log_error_errno(r, "Failed to set up verity device '%s': %m", volume);
 
@@ -463,7 +463,7 @@ static int verb_detach(int argc, char *argv[], uintptr_t _data, void *userdata) 
         if (!filename_is_valid(volume))
                 return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "Volume name '%s' is not valid.", volume);
 
-        r = crypt_init_by_name(&cd, volume);
+        r = sym_crypt_init_by_name(&cd, volume);
         if (r == -ENODEV) {
                 log_info("Volume %s 'already' inactive.", volume);
                 return 0;
@@ -473,7 +473,7 @@ static int verb_detach(int argc, char *argv[], uintptr_t _data, void *userdata) 
 
         cryptsetup_enable_logging(cd);
 
-        r = crypt_deactivate(cd, volume);
+        r = sym_crypt_deactivate(cd, volume);
         if (r < 0)
                 return log_error_errno(r, "Failed to deactivate volume '%s': %m", volume);
 
@@ -481,10 +481,16 @@ static int verb_detach(int argc, char *argv[], uintptr_t _data, void *userdata) 
 }
 
 static int run(int argc, char *argv[]) {
+        int r;
+
         if (argv_looks_like_help(argc, argv))
                 return help();
 
         log_setup();
+
+        r = dlopen_cryptsetup();
+        if (r < 0)
+                return r;
 
         cryptsetup_enable_logging(NULL);
 


### PR DESCRIPTION
Convert systemd-cryptsetup, systemd-cryptenroll, systemd-veritysetup and systemd-integritysetup to go through the existing dlopen wrapper for libcryptsetup instead of linking the library directly. Each binary calls dlopen_cryptsetup() at the start of its run() and uses the sym_* variants for every libcryptsetup entry point.

Extend cryptsetup-util.{h,c} to cover the libcryptsetup symbols that these binaries use and that the wrapper was missing: crypt_activate_by_token_pin, crypt_deactivate, crypt_init_data_device, crypt_keyslot_status, crypt_set_keyring_to_link (conditional on HAVE_CRYPT_SET_KEYRING_TO_LINK), crypt_status and
crypt_token_external_path.

With no direct callers of crypt_free() left, drop the non-sym crypt_freep cleanup variant and rename sym_crypt_freep back to crypt_freep via DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_RENAME, matching the naming convention used by other dlopen wrappers (acl_freep, xkb_context_unrefp, ...). Update the remaining users in src/shared, src/repart, src/home and src/growfs to the new name.

The four affected meson targets switch from libcryptsetup to libcryptsetup_cflags so they no longer record a DT_NEEDED entry for libcryptsetup.so.12.