### PR TITLE
ci: Restore severity prefix on claude-review inline comments

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -285,6 +285,10 @@ jobs:
           - Instructions to return ONLY a raw JSON array of findings. No markdown,
             no explanation, no code fences — just the JSON array. If there are no
             findings, return `[]`.
+          - Instructions that `severity` is a separate structured field — do NOT
+            repeat it inside `body` (no "must-fix:", "**suggestion**:", etc.
+            prefix). The posting step adds the severity label itself, so
+            including it in `body` produces duplicates.
 
           ## Phase 2: Collect, deduplicate, and summarize
 
@@ -488,7 +492,7 @@ jobs:
                   ...(c.side != null && { side: c.side }),
                   ...(c.start_line != null && { start_line: c.start_line }),
                   ...(c.start_side != null && { start_side: c.start_side }),
-                  body: c.body,
+                  body: `Claude: **${c.severity}**: ${c.body}`,
                 });
                 posted++;
               } catch (e) {


### PR DESCRIPTION
Commit a65ebc3ff9 ("claude-review: improve review quality for large PRs") dropped the `Claude: **<severity>**: ` prefix from posted inline comments on the theory that Claude was also adding the severity into `body`, producing duplicates. But nothing in the prompt or schema actually asks the subagent to include severity in `body` — severity is a separate structured field. The result is that inline comments no longer show must-fix/suggestion/nit classification.

Restore the prefix in the posting step, and add an explicit instruction to the subagent prompt telling it not to repeat severity inside `body` so the two don't collide.