### PR TITLE
build: Compile fuzz-journald-util.c only if want_fuzz_tests

### DIFF
--- a/src/journal/meson.build
+++ b/src/journal/meson.build
@@ -19,10 +19,15 @@ systemd_journald_extract_sources = files(
         'journald-syslog.c',
         'journald-varlink.c',
         'journald-wall.c',
-        # Build fuzz-journald.c as part of systemd-journald so we only compile it once instead of once per
-        # fuzz test.
-        'fuzz-journald-util.c',
 )
+
+if want_fuzz_tests
+        # Build fuzz-journald-util.c as part of systemd-journald so we only
+        # compile it once instead of once per fuzz test.
+        systemd_journald_extract_sources += files(
+                'fuzz-journald-util.c',
+        )
+endif
 
 journald_gperf_c = custom_target(
         input : 'journald-gperf.gperf',


### PR DESCRIPTION
## Disclaimer
As I know meson since yesterday, so take it with a grain of salt

## Summary
fuzz-journald-util.c is compiled unconditionally even though fuzzing tests aren't enabled. Only build it if fuzzing tests are configured. This also ensure that the functions it uses from src/shared/tests.c are available.

Fixes 32bd43d768a4bdd54481c5e37ce9ea3d1009a824
Closes #39984