### PR TITLE
dlopen: take log_level argument and log in fallback stubs

### DIFF
--- a/src/analyze/analyze-security.c
+++ b/src/analyze/analyze-security.c
@@ -605,7 +605,7 @@ static int assess_system_call_filter(
         uint64_t b;
         int r;
 
-        r = dlopen_libseccomp();
+        r = dlopen_libseccomp(LOG_DEBUG);
         if (r < 0) {
                 *ret_badness = UINT64_MAX;
                 *ret_description = NULL;
@@ -2578,7 +2578,7 @@ static int get_security_info(Unit *u, ExecContext *c, CGroupContext *g, Security
                 info->_umask = c->umask;
 
 #if HAVE_SECCOMP
-                if (dlopen_libseccomp() >= 0) {
+                if (dlopen_libseccomp(LOG_DEBUG) >= 0) {
                         SET_FOREACH(key, c->syscall_archs) {
                                 const char *name;
 

--- a/src/basic/compress.c
+++ b/src/basic/compress.c
@@ -284,7 +284,7 @@ Compression compression_detect_from_magic(const uint8_t data[static COMPRESSION_
         return _COMPRESSION_INVALID;
 }
 
-int dlopen_xz(void) {
+int dlopen_xz(int log_level) {
 #if HAVE_XZ
         SD_ELF_NOTE_DLOPEN(
                         "lzma",
@@ -294,7 +294,7 @@ int dlopen_xz(void) {
 
         return dlopen_many_sym_or_warn(
                         &lzma_dl,
-                        "liblzma.so.5", LOG_DEBUG,
+                        "liblzma.so.5", log_level,
                         DLSYM_ARG(lzma_code),
                         DLSYM_ARG(lzma_easy_encoder),
                         DLSYM_ARG(lzma_end),
@@ -302,11 +302,12 @@ int dlopen_xz(void) {
                         DLSYM_ARG(lzma_lzma_preset),
                         DLSYM_ARG(lzma_stream_decoder));
 #else
-        return -EOPNOTSUPP;
+        return log_full_errno(log_level, SYNTHETIC_ERRNO(EOPNOTSUPP),
+                              "lzma support is not compiled in.");
 #endif
 }
 
-int dlopen_lz4(void) {
+int dlopen_lz4(int log_level) {
 #if HAVE_LZ4
         SD_ELF_NOTE_DLOPEN(
                         "lz4",
@@ -316,7 +317,7 @@ int dlopen_lz4(void) {
 
         return dlopen_many_sym_or_warn(
                         &lz4_dl,
-                        "liblz4.so.1", LOG_DEBUG,
+                        "liblz4.so.1", log_level,
                         DLSYM_ARG(LZ4F_compressBegin),
                         DLSYM_ARG(LZ4F_compressBound),
                         DLSYM_ARG(LZ4F_compressEnd),
@@ -333,11 +334,12 @@ int dlopen_lz4(void) {
                         DLSYM_ARG(LZ4_decompress_safe_partial),
                         DLSYM_ARG(LZ4_versionNumber));
 #else
-        return -EOPNOTSUPP;
+        return log_full_errno(log_level, SYNTHETIC_ERRNO(EOPNOTSUPP),
+                              "lz4 support is not compiled in.");
 #endif
 }
 
-int dlopen_zstd(void) {
+int dlopen_zstd(int log_level) {
 #if HAVE_ZSTD
         SD_ELF_NOTE_DLOPEN(
                         "zstd",
@@ -347,7 +349,7 @@ int dlopen_zstd(void) {
 
         return dlopen_many_sym_or_warn(
                         &zstd_dl,
-                        "libzstd.so.1", LOG_DEBUG,
+                        "libzstd.so.1", log_level,
                         DLSYM_ARG(ZSTD_getErrorCode),
                         DLSYM_ARG(ZSTD_compress),
                         DLSYM_ARG(ZSTD_getFrameContentSize),
@@ -365,11 +367,12 @@ int dlopen_zstd(void) {
                         DLSYM_ARG(ZSTD_createDCtx),
                         DLSYM_ARG(ZSTD_createCCtx));
 #else
-        return -EOPNOTSUPP;
+        return log_full_errno(log_level, SYNTHETIC_ERRNO(EOPNOTSUPP),
+                              "zstd support is not compiled in.");
 #endif
 }
 
-int dlopen_zlib(void) {
+int dlopen_zlib(int log_level) {
 #if HAVE_ZLIB
         SD_ELF_NOTE_DLOPEN(
                         "zlib",
@@ -379,7 +382,7 @@ int dlopen_zlib(void) {
 
         return dlopen_many_sym_or_warn(
                         &zlib_dl,
-                        "libz.so.1", LOG_DEBUG,
+                        "libz.so.1", log_level,
                         DLSYM_ARG(deflateInit2_),
                         DLSYM_ARG(deflate),
                         DLSYM_ARG(deflateEnd),
@@ -387,11 +390,12 @@ int dlopen_zlib(void) {
                         DLSYM_ARG(inflate),
                         DLSYM_ARG(inflateEnd));
 #else
-        return -EOPNOTSUPP;
+        return log_full_errno(log_level, SYNTHETIC_ERRNO(EOPNOTSUPP),
+                              "zlib support is not compiled in.");
 #endif
 }
 
-int dlopen_bzip2(void) {
+int dlopen_bzip2(int log_level) {
 #if HAVE_BZIP2
         SD_ELF_NOTE_DLOPEN(
                         "bzip2",
@@ -401,7 +405,7 @@ int dlopen_bzip2(void) {
 
         return dlopen_many_sym_or_warn(
                         &bzip2_dl,
-                        "libbz2.so.1", LOG_DEBUG,
+                        "libbz2.so.1", log_level,
                         DLSYM_ARG(BZ2_bzCompressInit),
                         DLSYM_ARG(BZ2_bzCompress),
                         DLSYM_ARG(BZ2_bzCompressEnd),
@@ -409,7 +413,8 @@ int dlopen_bzip2(void) {
                         DLSYM_ARG(BZ2_bzDecompress),
                         DLSYM_ARG(BZ2_bzDecompressEnd));
 #else
-        return -EOPNOTSUPP;
+        return log_full_errno(log_level, SYNTHETIC_ERRNO(EOPNOTSUPP),
+                              "bzip2 support is not compiled in.");
 #endif
 }
 
@@ -440,7 +445,7 @@ static int compress_blob_xz(
         size_t out_pos = 0;
         int r;
 
-        r = dlopen_xz();
+        r = dlopen_xz(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -485,7 +490,7 @@ static int compress_blob_lz4(
 #if HAVE_LZ4
         int r;
 
-        r = dlopen_lz4();
+        r = dlopen_lz4(LOG_DEBUG);
         if (r < 0)
                 return r;
         /* Returns < 0 if we couldn't compress the data or the
@@ -533,7 +538,7 @@ static int compress_blob_zstd(
         size_t k;
         int r;
 
-        r = dlopen_zstd();
+        r = dlopen_zstd(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -560,7 +565,7 @@ static int compress_blob_gzip(const void *src, uint64_t src_size,
 #if HAVE_ZLIB
         int r;
 
-        r = dlopen_zlib();
+        r = dlopen_zlib(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -609,7 +614,7 @@ static int compress_blob_bzip2(
 #if HAVE_BZIP2
         int r;
 
-        r = dlopen_bzip2();
+        r = dlopen_bzip2(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -677,7 +682,7 @@ static int decompress_blob_xz(
 #if HAVE_XZ
         int r;
 
-        r = dlopen_xz();
+        r = dlopen_xz(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -744,7 +749,7 @@ static int decompress_blob_lz4(
         char* out;
         int r, size; /* LZ4 uses int for size */
 
-        r = dlopen_lz4();
+        r = dlopen_lz4(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -790,7 +795,7 @@ static int decompress_blob_zstd(
         uint64_t size;
         int r;
 
-        r = dlopen_zstd();
+        r = dlopen_zstd(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -847,7 +852,7 @@ static int decompress_blob_gzip(
 #if HAVE_ZLIB
         int r;
 
-        r = dlopen_zlib();
+        r = dlopen_zlib(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -914,7 +919,7 @@ static int decompress_blob_bzip2(
 #if HAVE_BZIP2
         int r;
 
-        r = dlopen_bzip2();
+        r = dlopen_bzip2(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -1010,7 +1015,7 @@ int decompress_zlib_raw(
 #if HAVE_ZLIB
         int r;
 
-        r = dlopen_zlib();
+        r = dlopen_zlib(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -1061,7 +1066,7 @@ static int decompress_startswith_xz(
 #if HAVE_XZ
         int r;
 
-        r = dlopen_xz();
+        r = dlopen_xz(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -1128,7 +1133,7 @@ static int decompress_startswith_lz4(
         size_t allocated;
         int r;
 
-        r = dlopen_lz4();
+        r = dlopen_lz4(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -1200,7 +1205,7 @@ static int decompress_startswith_zstd(
 #if HAVE_ZSTD
         int r;
 
-        r = dlopen_zstd();
+        r = dlopen_zstd(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -1257,7 +1262,7 @@ static int decompress_startswith_gzip(
 #if HAVE_ZLIB
         int r;
 
-        r = dlopen_zlib();
+        r = dlopen_zlib(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -1324,7 +1329,7 @@ static int decompress_startswith_bzip2(
 #if HAVE_BZIP2
         int r;
 
-        r = dlopen_bzip2();
+        r = dlopen_bzip2(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -1561,7 +1566,7 @@ static int decompressor_new(Decompressor **ret, Compression type) {
 
 #if HAVE_XZ
         case COMPRESSION_XZ:
-                r = dlopen_xz();
+                r = dlopen_xz(LOG_DEBUG);
                 if (r < 0)
                         return r;
 
@@ -1572,7 +1577,7 @@ static int decompressor_new(Decompressor **ret, Compression type) {
 
 #if HAVE_LZ4
         case COMPRESSION_LZ4: {
-                r = dlopen_lz4();
+                r = dlopen_lz4(LOG_DEBUG);
                 if (r < 0)
                         return r;
 
@@ -1586,7 +1591,7 @@ static int decompressor_new(Decompressor **ret, Compression type) {
 
 #if HAVE_ZSTD
         case COMPRESSION_ZSTD:
-                r = dlopen_zstd();
+                r = dlopen_zstd(LOG_DEBUG);
                 if (r < 0)
                         return r;
 
@@ -1598,7 +1603,7 @@ static int decompressor_new(Decompressor **ret, Compression type) {
 
 #if HAVE_ZLIB
         case COMPRESSION_GZIP:
-                r = dlopen_zlib();
+                r = dlopen_zlib(LOG_DEBUG);
                 if (r < 0)
                         return r;
 
@@ -1610,7 +1615,7 @@ static int decompressor_new(Decompressor **ret, Compression type) {
 
 #if HAVE_BZIP2
         case COMPRESSION_BZIP2:
-                r = dlopen_bzip2();
+                r = dlopen_bzip2(LOG_DEBUG);
                 if (r < 0)
                         return r;
 
@@ -1791,7 +1796,7 @@ int decompressor_detect(Decompressor **ret, const void *data, size_t size) {
 
 #if HAVE_XZ
         case COMPRESSION_XZ: {
-                r = dlopen_xz();
+                r = dlopen_xz(LOG_DEBUG);
                 if (r < 0)
                         return r;
 
@@ -1805,7 +1810,7 @@ int decompressor_detect(Decompressor **ret, const void *data, size_t size) {
 
 #if HAVE_LZ4
         case COMPRESSION_LZ4: {
-                r = dlopen_lz4();
+                r = dlopen_lz4(LOG_DEBUG);
                 if (r < 0)
                         return r;
 
@@ -1819,7 +1824,7 @@ int decompressor_detect(Decompressor **ret, const void *data, size_t size) {
 
 #if HAVE_ZSTD
         case COMPRESSION_ZSTD: {
-                r = dlopen_zstd();
+                r = dlopen_zstd(LOG_DEBUG);
                 if (r < 0)
                         return r;
 
@@ -1833,7 +1838,7 @@ int decompressor_detect(Decompressor **ret, const void *data, size_t size) {
 
 #if HAVE_ZLIB
         case COMPRESSION_GZIP: {
-                r = dlopen_zlib();
+                r = dlopen_zlib(LOG_DEBUG);
                 if (r < 0)
                         return r;
 
@@ -1847,7 +1852,7 @@ int decompressor_detect(Decompressor **ret, const void *data, size_t size) {
 
 #if HAVE_BZIP2
         case COMPRESSION_BZIP2: {
-                r = dlopen_bzip2();
+                r = dlopen_bzip2(LOG_DEBUG);
                 if (r < 0)
                         return r;
 
@@ -2092,7 +2097,7 @@ int compressor_new(Compressor **ret, Compression type) {
 
 #if HAVE_XZ
         case COMPRESSION_XZ: {
-                r = dlopen_xz();
+                r = dlopen_xz(LOG_DEBUG);
                 if (r < 0)
                         return r;
 
@@ -2107,7 +2112,7 @@ int compressor_new(Compressor **ret, Compression type) {
 
 #if HAVE_LZ4
         case COMPRESSION_LZ4: {
-                r = dlopen_lz4();
+                r = dlopen_lz4(LOG_DEBUG);
                 if (r < 0)
                         return r;
 
@@ -2133,7 +2138,7 @@ int compressor_new(Compressor **ret, Compression type) {
 
 #if HAVE_ZSTD
         case COMPRESSION_ZSTD:
-                r = dlopen_zstd();
+                r = dlopen_zstd(LOG_DEBUG);
                 if (r < 0)
                         return r;
 
@@ -2156,7 +2161,7 @@ int compressor_new(Compressor **ret, Compression type) {
 
 #if HAVE_ZLIB
         case COMPRESSION_GZIP:
-                r = dlopen_zlib();
+                r = dlopen_zlib(LOG_DEBUG);
                 if (r < 0)
                         return r;
 
@@ -2176,7 +2181,7 @@ int compressor_new(Compressor **ret, Compression type) {
 
 #if HAVE_BZIP2
         case COMPRESSION_BZIP2:
-                r = dlopen_bzip2();
+                r = dlopen_bzip2(LOG_DEBUG);
                 if (r < 0)
                         return r;
 

--- a/src/basic/compress.h
+++ b/src/basic/compress.h
@@ -80,11 +80,11 @@ int compress_stream(Compression type, int fdf, int fdt, uint64_t max_bytes, uint
 int decompress_stream(Compression type, int fdf, int fdt, uint64_t max_bytes);
 int decompress_stream_by_filename(const char *filename, int fdf, int fdt, uint64_t max_bytes);
 
-int dlopen_xz(void);
-int dlopen_lz4(void);
-int dlopen_zstd(void);
-int dlopen_zlib(void);
-int dlopen_bzip2(void);
+int dlopen_xz(int log_level);
+int dlopen_lz4(int log_level);
+int dlopen_zstd(int log_level);
+int dlopen_zlib(int log_level);
+int dlopen_bzip2(int log_level);
 
 static inline const char* default_compression_extension(void) {
         return compression_extension_to_string(DEFAULT_COMPRESSION) ?: "";

--- a/src/basic/dlfcn-util.c
+++ b/src/basic/dlfcn-util.c
@@ -47,7 +47,7 @@ int dlsym_many_or_warn_sentinel(void *dl, int log_level, ...) {
         return r;
 }
 
-int dlopen_verbose(void **dlp, const char *filename) {
+int dlopen_verbose(void **dlp, const char *filename, int log_level) {
         int r;
 
         assert(dlp);
@@ -58,10 +58,9 @@ int dlopen_verbose(void **dlp, const char *filename) {
         _cleanup_(dlclosep) void *dl = NULL;
         const char *dle = NULL;
         r = dlopen_safe(filename, &dl, &dle);
-        if (r < 0) {
-                log_debug_errno(r, "Shared library '%s' is not available: %s", filename, dle ?: STRERROR(r));
-                return -EOPNOTSUPP; /* Turn into recognizable error */
-        }
+        if (r < 0)
+                return log_full_errno(log_level, SYNTHETIC_ERRNO(EOPNOTSUPP),
+                                      "Shared library '%s' is not available: %s", filename, dle ?: STRERROR(r));
 
         log_debug("Loaded shared library '%s' via dlopen().", filename);
         *dlp = TAKE_PTR(dl);
@@ -77,7 +76,7 @@ int dlopen_many_sym_or_warn_sentinel(void **dlp, const char *filename, int log_l
                 return 0; /* Already loaded */
 
         _cleanup_(dlclosep) void *dl = NULL;
-        r = dlopen_verbose(&dl, filename);
+        r = dlopen_verbose(&dl, filename, log_level);
         if (r < 0)
                 return r;
 

--- a/src/basic/dlfcn-util.h
+++ b/src/basic/dlfcn-util.h
@@ -11,7 +11,7 @@ static inline void dlclosep(void **dlp) {
         safe_dlclose(*dlp);
 }
 
-int dlopen_verbose(void **dlp, const char *filename);
+int dlopen_verbose(void **dlp, const char *filename, int log_level);
 int dlsym_many_or_warn_sentinel(void *dl, int log_level, ...) _sentinel_;
 int dlopen_many_sym_or_warn_sentinel(void **dlp, const char *filename, int log_level, ...) _sentinel_;
 

--- a/src/basic/gcrypt-util.c
+++ b/src/basic/gcrypt-util.c
@@ -5,6 +5,7 @@
 #include "sd-dlopen.h"
 
 #include "gcrypt-util.h"
+#include "log.h"                /* IWYU pragma: keep */
 
 #if HAVE_GCRYPT
 
@@ -44,7 +45,7 @@ DLSYM_PROTOTYPE(gcry_randomize) = NULL;
 DLSYM_PROTOTYPE(gcry_strerror) = NULL;
 #endif
 
-int dlopen_gcrypt(void) {
+int dlopen_gcrypt(int log_level) {
 #if HAVE_GCRYPT
         SD_ELF_NOTE_DLOPEN(
                         "gcrypt",
@@ -54,7 +55,7 @@ int dlopen_gcrypt(void) {
 
         return dlopen_many_sym_or_warn(
                         &gcrypt_dl,
-                        "libgcrypt.so.20", LOG_DEBUG,
+                        "libgcrypt.so.20", log_level,
                         DLSYM_ARG(gcry_control),
                         DLSYM_ARG(gcry_check_version),
                         DLSYM_ARG(gcry_md_close),
@@ -88,7 +89,8 @@ int dlopen_gcrypt(void) {
                         DLSYM_ARG(gcry_randomize),
                         DLSYM_ARG(gcry_strerror));
 #else
-        return -EOPNOTSUPP;
+        return log_full_errno(log_level, SYNTHETIC_ERRNO(EOPNOTSUPP),
+                              "gcrypt support is not compiled in.");
 #endif
 }
 
@@ -96,7 +98,7 @@ int initialize_libgcrypt(bool secmem) {
 #if HAVE_GCRYPT
         int r;
 
-        r = dlopen_gcrypt();
+        r = dlopen_gcrypt(LOG_DEBUG);
         if (r < 0)
                 return r;
 

--- a/src/basic/gcrypt-util.h
+++ b/src/basic/gcrypt-util.h
@@ -4,7 +4,7 @@
 
 #include "basic-forward.h"
 
-int dlopen_gcrypt(void);
+int dlopen_gcrypt(int log_level);
 
 int initialize_libgcrypt(bool secmem);
 

--- a/src/core/bpf-bind-iface.c
+++ b/src/core/bpf-bind-iface.c
@@ -31,7 +31,7 @@ int bpf_bind_network_interface_supported(void) {
         if (supported >= 0)
                 return supported;
 
-        if (dlopen_bpf_full(LOG_WARNING) < 0)
+        if (dlopen_bpf(LOG_WARNING) < 0)
                 return (supported = false);
 
         obj = bind_iface_bpf__open();

--- a/src/core/bpf-restrict-fs.c
+++ b/src/core/bpf-restrict-fs.c
@@ -91,7 +91,7 @@ bool bpf_restrict_fs_supported(bool initialize) {
         if (!initialize)
                 return false;
 
-        if (dlopen_bpf_full(LOG_WARNING) < 0)
+        if (dlopen_bpf(LOG_WARNING) < 0)
                 return (supported = false);
 
         r = lsm_supported("bpf");

--- a/src/core/bpf-restrict-ifaces.c
+++ b/src/core/bpf-restrict-ifaces.c
@@ -86,7 +86,7 @@ int bpf_restrict_ifaces_supported(void) {
         if (supported >= 0)
                 return supported;
 
-        if (dlopen_bpf_full(LOG_WARNING) < 0)
+        if (dlopen_bpf(LOG_WARNING) < 0)
                 return (supported = false);
 
         r = prepare_restrict_ifaces_bpf(NULL, true, NULL, &obj);

--- a/src/core/bpf-socket-bind.c
+++ b/src/core/bpf-socket-bind.c
@@ -125,7 +125,7 @@ int bpf_socket_bind_supported(void) {
         _cleanup_(socket_bind_bpf_freep) struct socket_bind_bpf *obj = NULL;
         int r;
 
-        if (dlopen_bpf_full(LOG_WARNING) < 0)
+        if (dlopen_bpf(LOG_WARNING) < 0)
                 return false;
 
         r = prepare_socket_bind_bpf(/* unit= */ NULL, /* allow_rules= */ NULL, /* deny_rules= */ NULL, &obj);

--- a/src/core/exec-invoke.c
+++ b/src/core/exec-invoke.c
@@ -1359,9 +1359,9 @@ static int setup_pam(
          * parent process will exec() the actual daemon. We do things this way to ensure that the main PID of
          * the daemon is the one we initially fork()ed. */
 
-        r = dlopen_libpam();
+        r = dlopen_libpam(LOG_ERR);
         if (r < 0)
-                return log_error_errno(r, "PAM support not available: %m");
+                return r;
 
         r = barrier_create(&barrier);
         if (r < 0)
@@ -1625,7 +1625,7 @@ static bool seccomp_allows_drop_privileges(const ExecContext *c) {
         assert(c);
 
         /* No libseccomp, all is fine */
-        if (dlopen_libseccomp() < 0)
+        if (dlopen_libseccomp(LOG_DEBUG) < 0)
                 return true;
 
         /* No syscall filter, we are allowed to drop privileges */
@@ -1927,7 +1927,7 @@ static int apply_restrict_filesystems(const ExecContext *c, const ExecParameters
         }
 
         /* We are in a new binary, so dl-open again */
-        r = dlopen_bpf();
+        r = dlopen_bpf(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -6026,10 +6026,10 @@ int exec_invoke(
         }
 
         /* Load a bunch of libraries we'll possibly need later, before we turn off dlopen() */
-        (void) dlopen_bpf();
-        (void) dlopen_cryptsetup();
-        (void) dlopen_libmount();
-        (void) dlopen_libseccomp();
+        (void) dlopen_bpf(LOG_DEBUG);
+        (void) dlopen_cryptsetup(LOG_DEBUG);
+        (void) dlopen_libmount(LOG_DEBUG);
+        (void) dlopen_libseccomp(LOG_DEBUG);
 
         /* Let's now disable further dlopen()ing of libraries, since we are about to do namespace
          * shenanigans, and do not want to mix resources from host and namespace */

--- a/src/core/execute.c
+++ b/src/core/execute.c
@@ -1491,7 +1491,7 @@ void exec_context_dump(const ExecContext *c, FILE* f, const char *prefix) {
                         fputc('~', f);
 
 #if HAVE_SECCOMP
-                if (dlopen_libseccomp() >= 0) {
+                if (dlopen_libseccomp(LOG_DEBUG) >= 0) {
                         void *id, *val;
                         bool first = true;
                         HASHMAP_FOREACH_KEY(val, id, c->syscall_filter) {
@@ -1910,7 +1910,7 @@ char** exec_context_get_syscall_filter(const ExecContext *c) {
         assert(c);
 
 #if HAVE_SECCOMP
-        if (dlopen_libseccomp() < 0)
+        if (dlopen_libseccomp(LOG_DEBUG) < 0)
                 return strv_new(NULL);
 
         void *id, *val;
@@ -1979,7 +1979,7 @@ char** exec_context_get_syscall_log(const ExecContext *c) {
         assert(c);
 
 #if HAVE_SECCOMP
-        if (dlopen_libseccomp() < 0)
+        if (dlopen_libseccomp(LOG_DEBUG) < 0)
                 return strv_new(NULL);
 
         void *id, *val;

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -3378,7 +3378,7 @@ int main(int argc, char *argv[]) {
         }
 
         /* Building without libmount is allowed, but if it is compiled in, then we must be able to load it */
-        r = dlopen_libmount();
+        r = dlopen_libmount(LOG_DEBUG);
         if (r < 0 && !ERRNO_IS_NEG_NOT_SUPPORTED(r)) {
                 error_message = "Failed to load libmount.so";
                 goto finish;

--- a/src/core/mount.c
+++ b/src/core/mount.c
@@ -2408,7 +2408,7 @@ static int mount_test_startable(Unit *u) {
 }
 
 static bool mount_supported(void) {
-        return dlopen_libmount() >= 0;
+        return dlopen_libmount(LOG_DEBUG) >= 0;
 }
 
 static int mount_subsystem_ratelimited(Manager *m) {

--- a/src/core/namespace.c
+++ b/src/core/namespace.c
@@ -3984,7 +3984,7 @@ int refresh_extensions_in_namespace(
         if (r > 0)
                 return log_debug_errno(SYNTHETIC_ERRNO(EINVAL), "Target namespace is not separate, cannot reload extensions");
 
-        (void) dlopen_cryptsetup();
+        (void) dlopen_cryptsetup(LOG_DEBUG);
 
         extension_dir = path_join(p->private_namespace_dir, "unit-extensions");
         if (!extension_dir)

--- a/src/core/selinux-setup.c
+++ b/src/core/selinux-setup.c
@@ -17,11 +17,9 @@ int mac_selinux_setup(bool *loaded_policy) {
 
         assert(loaded_policy);
 
-        r = dlopen_libselinux();
-        if (r < 0) {
-                log_debug_errno(r, "No SELinux library available, skipping setup.");
+        r = dlopen_libselinux(LOG_DEBUG);
+        if (r < 0)
                 return 0;
-        }
 
         mac_selinux_disable_logging();
 

--- a/src/creds/creds.c
+++ b/src/creds/creds.c
@@ -188,7 +188,7 @@ static int is_tmpfs_with_noswap(dev_t devno) {
         _cleanup_(mnt_free_tablep) struct libmnt_table *table = NULL;
         int r;
 
-        r = dlopen_libmount();
+        r = dlopen_libmount(LOG_DEBUG);
         if (r < 0)
                 return r;
 

--- a/src/dissect/dissect.c
+++ b/src/dissect/dissect.c
@@ -494,9 +494,9 @@ static int parse_argv(int argc, char *argv[]) {
                         break;
 
                 OPTION_LONG("make-archive", NULL, "Convert the DDI to an archive file"):
-                        r = dlopen_libarchive();
+                        r = dlopen_libarchive(LOG_ERR);
                         if (r < 0)
-                                return log_error_errno(r, "Archive support not available (compiled without libarchive, or libarchive not installed?).");
+                                return r;
 
                         arg_action = ACTION_MAKE_ARCHIVE;
                         break;

--- a/src/growfs/growfs.c
+++ b/src/growfs/growfs.c
@@ -32,9 +32,9 @@ static int resize_crypt_luks_device(dev_t devno, const char *fstype, dev_t main_
         uint64_t size;
         int r;
 
-        r = dlopen_cryptsetup();
+        r = dlopen_cryptsetup(LOG_ERR);
         if (r < 0)
-                return log_error_errno(r, "Cannot resize LUKS device: %m");
+                return r;
 
         main_devfd = r = device_open_from_devnum(S_IFBLK, main_devno, O_RDONLY|O_CLOEXEC, &main_devpath);
         if (r < 0)

--- a/src/home/homework-luks.c
+++ b/src/home/homework-luks.c
@@ -146,7 +146,7 @@ static int probe_file_system_by_fd(
         assert(ret_fstype);
         assert(ret_uuid);
 
-        r = dlopen_libblkid();
+        r = dlopen_libblkid(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -529,7 +529,7 @@ static int acquire_open_luks_device(
         assert(setup);
         assert(!setup->crypt_device);
 
-        r = dlopen_cryptsetup();
+        r = dlopen_cryptsetup(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -684,7 +684,7 @@ static int luks_validate(
         assert(ret_size);
         assert(sector_size > 0);
 
-        r = dlopen_libblkid();
+        r = dlopen_libblkid(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -1289,7 +1289,7 @@ int home_setup_luks(
         assert(setup);
         assert(user_record_storage(h) == USER_LUKS);
 
-        r = dlopen_cryptsetup();
+        r = dlopen_cryptsetup(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -1590,7 +1590,7 @@ int home_activate_luks(
         assert(setup);
         assert(ret_home);
 
-        r = dlopen_cryptsetup();
+        r = dlopen_cryptsetup(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -2207,11 +2207,11 @@ int home_create_luks(
         assert(setup->image_fd < 0);
         assert(ret_home);
 
-        r = dlopen_fdisk();
+        r = dlopen_fdisk(LOG_DEBUG);
         if (r < 0)
                 return r;
 
-        r = dlopen_cryptsetup();
+        r = dlopen_cryptsetup(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -3246,11 +3246,11 @@ int home_resize_luks(
         assert(user_record_storage(h) == USER_LUKS);
         assert(setup);
 
-        r = dlopen_fdisk();
+        r = dlopen_fdisk(LOG_DEBUG);
         if (r < 0)
                 return r;
 
-        r = dlopen_cryptsetup();
+        r = dlopen_cryptsetup(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -3708,7 +3708,7 @@ int home_passwd_luks(
         assert(user_record_storage(h) == USER_LUKS);
         assert(setup);
 
-        r = dlopen_cryptsetup();
+        r = dlopen_cryptsetup(LOG_DEBUG);
         if (r < 0)
                 return r;
 

--- a/src/home/homework.c
+++ b/src/home/homework.c
@@ -1331,7 +1331,7 @@ static int determine_default_storage(UserStorage *ret) {
                         if (r < 0)
                                 log_warning_errno(r, "Failed to determine if %s is encrypted, ignoring: %m", get_home_root());
 
-                        r = dlopen_cryptsetup();
+                        r = dlopen_cryptsetup(LOG_DEBUG);
                         if (r < 0)
                                 log_info("Not using '%s' storage, since libcryptsetup could not be loaded.", user_storage_to_string(USER_LUKS));
                         else {

--- a/src/home/pam_systemd_home.c
+++ b/src/home/pam_systemd_home.c
@@ -789,7 +789,7 @@ _public_ PAM_EXTERN int pam_sm_authenticate(
         bool debug = false;
         int r;
 
-        r = dlopen_libpam();
+        r = dlopen_libpam(LOG_DEBUG);
         if (r < 0)
                 return PAM_SERVICE_ERR;
 
@@ -854,7 +854,7 @@ _public_ PAM_EXTERN int pam_sm_open_session(
         bool debug = false;
         int r;
 
-        r = dlopen_libpam();
+        r = dlopen_libpam(LOG_DEBUG);
         if (r < 0)
                 return PAM_SERVICE_ERR;
 
@@ -972,7 +972,7 @@ _public_ PAM_EXTERN int pam_sm_acct_mgmt(
         usec_t t;
         int r;
 
-        r = dlopen_libpam();
+        r = dlopen_libpam(LOG_DEBUG);
         if (r < 0)
                 return PAM_SERVICE_ERR;
 
@@ -1091,7 +1091,7 @@ _public_ PAM_EXTERN int pam_sm_chauthtok(
         bool debug = false;
         int r;
 
-        r = dlopen_libpam();
+        r = dlopen_libpam(LOG_DEBUG);
         if (r < 0)
                 return PAM_SERVICE_ERR;
 

--- a/src/imds/imdsd.c
+++ b/src/imds/imdsd.c
@@ -3070,7 +3070,7 @@ static int run(int argc, char* argv[]) {
         if (r <= 0)
                 return r;
 
-        r = dlopen_curl();
+        r = dlopen_curl(LOG_DEBUG);
         if (r < 0)
                 return r;
 

--- a/src/import/import-common.c
+++ b/src/import/import-common.c
@@ -32,7 +32,7 @@ int import_fork_tar_x(int tree_fd, int userns_fd, PidRef *ret_pid) {
         assert(tree_fd >= 0);
         assert(ret_pid);
 
-        r = dlopen_libarchive();
+        r = dlopen_libarchive(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -99,7 +99,7 @@ int import_fork_tar_c(int tree_fd, int userns_fd, PidRef *ret_pid) {
         assert(tree_fd >= 0);
         assert(ret_pid);
 
-        r = dlopen_libarchive();
+        r = dlopen_libarchive(LOG_DEBUG);
         if (r < 0)
                 return r;
 

--- a/src/import/test-tar.c
+++ b/src/import/test-tar.c
@@ -26,7 +26,7 @@ static int run(int argc, char **argv) {
         else
                 return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "Unknown operation '%s'.", argv[1]);
 
-        r = dlopen_libarchive();
+        r = dlopen_libarchive(LOG_DEBUG);
         if (r < 0)
                 return r;
 

--- a/src/journal-remote/journal-upload.c
+++ b/src/journal-remote/journal-upload.c
@@ -924,7 +924,7 @@ static int run(int argc, char **argv) {
         if (r <= 0)
                 return r;
 
-        r = dlopen_curl();
+        r = dlopen_curl(LOG_DEBUG);
         if (r < 0)
                 return r;
 

--- a/src/libsystemd/sd-device/test-sd-device.c
+++ b/src/libsystemd/sd-device/test-sd-device.c
@@ -898,7 +898,7 @@ static int intro(void) {
         if (path_is_mount_point("/sys") <= 0)
                 return log_tests_skipped("/sys/ is not mounted");
 
-        r = dlopen_libmount();
+        r = dlopen_libmount(LOG_DEBUG);
         if (r < 0)
                 return log_tests_skipped("libmount not available.");
 

--- a/src/locale/xkbcommon-util.c
+++ b/src/locale/xkbcommon-util.c
@@ -16,14 +16,14 @@ DLSYM_PROTOTYPE(xkb_context_set_log_fn) = NULL;
 DLSYM_PROTOTYPE(xkb_keymap_new_from_names) = NULL;
 DLSYM_PROTOTYPE(xkb_keymap_unref) = NULL;
 
-static int dlopen_xkbcommon(void) {
+static int dlopen_xkbcommon(int log_level) {
         SD_ELF_NOTE_DLOPEN(
                         "xkbcommon",
                         "Support for keyboard locale descriptions",
                         SD_ELF_NOTE_DLOPEN_PRIORITY_SUGGESTED, "libxkbcommon.so.0");
 
         return dlopen_many_sym_or_warn(
-                        &xkbcommon_dl, "libxkbcommon.so.0", LOG_DEBUG,
+                        &xkbcommon_dl, "libxkbcommon.so.0", log_level,
                         DLSYM_ARG(xkb_context_new),
                         DLSYM_ARG(xkb_context_unref),
                         DLSYM_ARG(xkb_context_set_log_fn),
@@ -57,7 +57,7 @@ int verify_xkb_rmlvo(const char *model, const char *layout, const char *variant,
 
         /* Compile keymap from RMLVO information to check out its validity */
 
-        r = dlopen_xkbcommon();
+        r = dlopen_xkbcommon(LOG_DEBUG);
         if (r < 0)
                 return r;
 

--- a/src/login/pam_systemd.c
+++ b/src/login/pam_systemd.c
@@ -1750,7 +1750,7 @@ _public_ PAM_EXTERN int pam_sm_open_session(
 
         assert(pamh);
 
-        r = dlopen_libpam();
+        r = dlopen_libpam(LOG_DEBUG);
         if (r < 0)
                 return PAM_SERVICE_ERR;
 

--- a/src/login/pam_systemd_loadkey.c
+++ b/src/login/pam_systemd_loadkey.c
@@ -19,7 +19,7 @@ _public_ PAM_EXTERN int pam_sm_authenticate(
 
         assert(pamh);
 
-        r = dlopen_libpam();
+        r = dlopen_libpam(LOG_DEBUG);
         if (r < 0)
                 return PAM_SERVICE_ERR;
 

--- a/src/network/networkd-sysctl.c
+++ b/src/network/networkd-sysctl.c
@@ -108,7 +108,7 @@ int manager_install_sysctl_monitor(Manager *manager) {
 
         assert(manager);
 
-        r = dlopen_bpf();
+        r = dlopen_bpf(LOG_DEBUG);
         if (ERRNO_IS_NEG_NOT_SUPPORTED(r))
                 return log_debug_errno(r, "sysctl monitor disabled, as BPF support is not available.");
         if (r < 0)

--- a/src/nspawn/nspawn-oci.c
+++ b/src/nspawn/nspawn-oci.c
@@ -1826,7 +1826,7 @@ static int oci_seccomp(const char *name, sd_json_variant *v, sd_json_dispatch_fl
         if (r < 0)
                 return json_log(def, flags, r, "Unknown default action: %s", sd_json_variant_string(def));
 
-        r = dlopen_libseccomp();
+        r = dlopen_libseccomp(LOG_DEBUG);
         if (r < 0)
                 return json_log(def, flags, r, "No support for libseccomp: %m");
 

--- a/src/nspawn/nspawn.c
+++ b/src/nspawn/nspawn.c
@@ -5961,9 +5961,9 @@ static int run(int argc, char *argv[]) {
         if (arg_cleanup)
                 return do_cleanup();
 
-        (void) dlopen_libmount();
-        (void) dlopen_libseccomp();
-        (void) dlopen_libselinux();
+        (void) dlopen_libmount(LOG_DEBUG);
+        (void) dlopen_libseccomp(LOG_DEBUG);
+        (void) dlopen_libselinux(LOG_DEBUG);
 
         r = cg_has_legacy();
         if (r < 0)

--- a/src/nsresourced/userns-restrict.c
+++ b/src/nsresourced/userns-restrict.c
@@ -68,7 +68,7 @@ int userns_restrict_install(
         if (r == 0)
                 return log_error_errno(SYNTHETIC_ERRNO(EOPNOTSUPP), "bpf-lsm not supported, can't lock down user namespace.");
 
-        r = dlopen_bpf();
+        r = dlopen_bpf(LOG_DEBUG);
         if (r < 0)
                 return r;
 

--- a/src/portable/portable.c
+++ b/src/portable/portable.c
@@ -610,8 +610,8 @@ static int portable_extract_by_path(
                  * there, and extract the metadata we need. The metadata is sent from the child back to us. */
 
                 /* Load some libraries before we fork workers off that want to use them */
-                (void) dlopen_cryptsetup();
-                (void) dlopen_libmount();
+                (void) dlopen_cryptsetup(LOG_DEBUG);
+                (void) dlopen_libmount(LOG_DEBUG);
 
                 r = mkdtemp_malloc("/tmp/inspect-XXXXXX", &tmpdir);
                 if (r < 0)

--- a/src/repart/repart.c
+++ b/src/repart/repart.c
@@ -3022,7 +3022,7 @@ static int partition_read_definition(
                                   "Cannot format %s filesystem without source files, refusing.", p->format);
 
         if (p->verity != VERITY_OFF || p->encrypt != ENCRYPT_OFF) {
-                r = dlopen_cryptsetup();
+                r = dlopen_cryptsetup(LOG_DEBUG);
                 if (r < 0)
                         return log_syntax(NULL, LOG_ERR, path, 1, r,
                                           "libcryptsetup not found, Verity=/Encrypt= are not supported: %m");
@@ -4614,9 +4614,9 @@ static int context_wipe_range(Context *context, uint64_t offset, uint64_t size) 
         assert(offset != UINT64_MAX);
         assert(size != UINT64_MAX);
 
-        r = dlopen_libblkid();
+        r = dlopen_libblkid(LOG_ERR);
         if (r < 0)
-                return log_error_errno(r, "Failed to load libblkid: %m");
+                return r;
 
         probe = sym_blkid_new_probe();
         if (!probe)
@@ -5200,9 +5200,9 @@ static int partition_encrypt(Context *context, Partition *p, PartitionTarget *ta
         assert(p);
         assert(p->encrypt != ENCRYPT_OFF);
 
-        r = dlopen_cryptsetup();
+        r = dlopen_cryptsetup(LOG_ERR);
         if (r < 0)
-                return log_error_errno(r, "libcryptsetup not found, cannot encrypt: %m");
+                return r;
 
         log_info("Encrypting future partition %" PRIu64 "...", p->partno);
 
@@ -5733,9 +5733,9 @@ static int partition_format_verity_hash(
 
         (void) partition_hint(p, node, &hint);
 
-        r = dlopen_cryptsetup();
+        r = dlopen_cryptsetup(LOG_ERR);
         if (r < 0)
-                return log_error_errno(r, "libcryptsetup not found, cannot setup verity: %m");
+                return r;
 
         if (!node) {
                 r = partition_target_prepare(context, p, p->new_size, /* need_path= */ true, &t);
@@ -6918,7 +6918,7 @@ static int partition_populate_filesystem(Context *context, Partition *p, const c
          * appear in the host namespace. Hence we fork a child that has its own file system namespace and
          * detached mount propagation. */
 
-        (void) dlopen_libmount();
+        (void) dlopen_libmount(LOG_DEBUG);
 
         r = pidref_safe_fork(
                         "(sd-copy)",
@@ -8358,9 +8358,9 @@ static int resolve_copy_blocks_auto_candidate(
                 return log_error_errno(r, "Failed to open block device " DEVNUM_FORMAT_STR ": %m",
                                        DEVNUM_FORMAT_VAL(whole_devno));
 
-        r = dlopen_libblkid();
+        r = dlopen_libblkid(LOG_ERR);
         if (r < 0)
-                return log_error_errno(r, "Failed to find libblkid: %m");
+                return r;
 
         b = sym_blkid_new_probe();
         if (!b)
@@ -11218,7 +11218,7 @@ static int run(int argc, char *argv[]) {
         if (r <= 0)
                 return r;
 
-        r = dlopen_fdisk();
+        r = dlopen_fdisk(LOG_DEBUG);
         if (r < 0)
                 return r;
 

--- a/src/report/report-upload.c
+++ b/src/report/report-upload.c
@@ -85,7 +85,7 @@ int upload_collected(Context *context) {
         _cleanup_free_ char *json = NULL;
         int r;
 
-        r = dlopen_curl();
+        r = dlopen_curl(LOG_DEBUG);
         if (r < 0)
                 return r;
 

--- a/src/resolve/resolved-util.c
+++ b/src/resolve/resolved-util.c
@@ -36,7 +36,7 @@ int resolve_system_hostname(char **full_hostname, char **first_label) {
 #if HAVE_LIBIDN2
         _cleanup_free_ char *utf8 = NULL;
 
-        if (dlopen_idn() >= 0) {
+        if (dlopen_idn(LOG_DEBUG) >= 0) {
                 r = sym_idn2_to_unicode_8z8z(label, &utf8, 0);
                 if (r != IDN2_OK)
                         return log_debug_errno(SYNTHETIC_ERRNO(EUCLEAN),

--- a/src/shared/acl-util.c
+++ b/src/shared/acl-util.c
@@ -10,6 +10,7 @@
 #include "errno-util.h"
 #include "extract-word.h"
 #include "fd-util.h"
+#include "log.h"                /* IWYU pragma: keep */
 #include "set.h"
 #include "string-util.h"
 #include "strv.h"
@@ -44,8 +45,10 @@ DLSYM_PROTOTYPE(acl_set_permset);
 DLSYM_PROTOTYPE(acl_set_qualifier);
 DLSYM_PROTOTYPE(acl_set_tag_type);
 DLSYM_PROTOTYPE(acl_to_any_text);
+#endif
 
-int dlopen_libacl(void) {
+int dlopen_libacl(int log_level) {
+#if HAVE_ACL
         SD_ELF_NOTE_DLOPEN(
                         "acl",
                         "Support for file Access Control Lists (ACLs)",
@@ -55,7 +58,7 @@ int dlopen_libacl(void) {
         return dlopen_many_sym_or_warn(
                         &libacl_dl,
                         "libacl.so.1",
-                        LOG_DEBUG,
+                        log_level,
                         DLSYM_ARG(acl_add_perm),
                         DLSYM_ARG(acl_calc_mask),
                         DLSYM_ARG(acl_copy_entry),
@@ -82,8 +85,13 @@ int dlopen_libacl(void) {
                         DLSYM_ARG(acl_set_qualifier),
                         DLSYM_ARG(acl_set_tag_type),
                         DLSYM_ARG(acl_to_any_text));
+#else
+        return log_full_errno(log_level, SYNTHETIC_ERRNO(EOPNOTSUPP),
+                              "libacl support is not compiled in.");
+#endif
 }
 
+#if HAVE_ACL
 int devnode_acl(int fd, const Set *uids) {
         _cleanup_set_free_ Set *found = NULL;
         bool changed = false;
@@ -91,7 +99,7 @@ int devnode_acl(int fd, const Set *uids) {
 
         assert(fd >= 0);
 
-        r = dlopen_libacl();
+        r = dlopen_libacl(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -336,7 +344,7 @@ int acl_search_groups(const char *path, char ***ret_groups) {
 
         assert(path);
 
-        r = dlopen_libacl();
+        r = dlopen_libacl(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -413,7 +421,7 @@ int parse_acl(
         if (!split)
                 return -ENOMEM;
 
-        r = dlopen_libacl();
+        r = dlopen_libacl(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -591,7 +599,7 @@ int acls_for_file(const char *path, acl_type_t type, acl_t acl, acl_t *ret) {
 
         assert(path);
 
-        r = dlopen_libacl();
+        r = dlopen_libacl(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -650,7 +658,7 @@ int fd_add_uid_acl_permission(
         assert(fd >= 0);
         assert(uid_is_valid(uid));
 
-        r = dlopen_libacl();
+        r = dlopen_libacl(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -716,7 +724,7 @@ int fd_acl_make_read_only(int fd) {
         /* Safely drops all W bits from all relevant ACL entries of the file, without changing entries which
          * are masked by the ACL mask */
 
-        r = dlopen_libacl();
+        r = dlopen_libacl(LOG_DEBUG);
         if (r < 0)
                 goto maybe_fallback;
 
@@ -804,7 +812,7 @@ int fd_acl_make_writable(int fd) {
         /* Safely adds the writable bit to the owner's ACL entry of this inode. (And only the owner's! – This
          * not the obvious inverse of fd_acl_make_read_only() hence!) */
 
-        r = dlopen_libacl();
+        r = dlopen_libacl(LOG_DEBUG);
         if (r < 0)
                 goto maybe_fallback;
 

--- a/src/shared/acl-util.h
+++ b/src/shared/acl-util.h
@@ -36,8 +36,6 @@ extern DLSYM_PROTOTYPE(acl_set_qualifier);
 extern DLSYM_PROTOTYPE(acl_set_tag_type);
 extern DLSYM_PROTOTYPE(acl_to_any_text);
 
-int dlopen_libacl(void);
-
 int devnode_acl(int fd, const Set *uids);
 
 int calc_acl_mask_if_needed(acl_t *acl_p);
@@ -85,10 +83,6 @@ typedef unsigned acl_type_t;
 #define ACL_TYPE_ACCESS         (0x8000)
 #define ACL_TYPE_DEFAULT        (0x4000)
 
-static inline int dlopen_libacl(void) {
-        return -EOPNOTSUPP;
-}
-
 static inline int devnode_acl(int fd, const Set *uids) {
         return -EOPNOTSUPP;
 }
@@ -97,6 +91,8 @@ static inline int fd_add_uid_acl_permission(int fd, uid_t uid, unsigned mask) {
         return -EOPNOTSUPP;
 }
 #endif
+
+int dlopen_libacl(int log_level);
 
 int fd_acl_make_read_only(int fd);
 int fd_acl_make_writable(int fd);

--- a/src/shared/apparmor-util.c
+++ b/src/shared/apparmor-util.c
@@ -1,13 +1,16 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
+#include "apparmor-util.h"
+#include "log.h"
+
+#if HAVE_APPARMOR
+
 #include <syslog.h>
 
 #include "sd-dlopen.h"
 
 #include "alloc-util.h"
-#include "apparmor-util.h"
 #include "fileio.h"
-#include "log.h"
 #include "parse-util.h"
 
 static void *libapparmor_dl = NULL;
@@ -20,27 +23,6 @@ DLSYM_PROTOTYPE(aa_policy_cache_dir_path_preview) = NULL;
 DLSYM_PROTOTYPE(aa_policy_cache_new) = NULL;
 DLSYM_PROTOTYPE(aa_policy_cache_replace_all) = NULL;
 DLSYM_PROTOTYPE(aa_policy_cache_unref) = NULL;
-
-int dlopen_libapparmor(void) {
-        SD_ELF_NOTE_DLOPEN(
-                        "apparmor",
-                        "Support for AppArmor policies",
-                        SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED,
-                        "libapparmor.so.1");
-
-        return dlopen_many_sym_or_warn(
-                        &libapparmor_dl,
-                        "libapparmor.so.1",
-                        LOG_DEBUG,
-                        DLSYM_ARG(aa_change_onexec),
-                        DLSYM_ARG(aa_change_profile),
-                        DLSYM_ARG(aa_features_new_from_kernel),
-                        DLSYM_ARG(aa_features_unref),
-                        DLSYM_ARG(aa_policy_cache_dir_path_preview),
-                        DLSYM_ARG(aa_policy_cache_new),
-                        DLSYM_ARG(aa_policy_cache_replace_all),
-                        DLSYM_ARG(aa_policy_cache_unref));
-}
 
 bool mac_apparmor_use(void) {
         static int cached_use = -1;
@@ -63,8 +45,36 @@ bool mac_apparmor_use(void) {
         if (r <= 0)
                 return (cached_use = false);
 
-        if (dlopen_libapparmor() < 0)
+        if (dlopen_libapparmor(LOG_DEBUG) < 0)
                 return (cached_use = false);
 
         return (cached_use = true);
+}
+
+#endif
+
+int dlopen_libapparmor(int log_level) {
+#if HAVE_APPARMOR
+        SD_ELF_NOTE_DLOPEN(
+                        "apparmor",
+                        "Support for AppArmor policies",
+                        SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED,
+                        "libapparmor.so.1");
+
+        return dlopen_many_sym_or_warn(
+                        &libapparmor_dl,
+                        "libapparmor.so.1",
+                        log_level,
+                        DLSYM_ARG(aa_change_onexec),
+                        DLSYM_ARG(aa_change_profile),
+                        DLSYM_ARG(aa_features_new_from_kernel),
+                        DLSYM_ARG(aa_features_unref),
+                        DLSYM_ARG(aa_policy_cache_dir_path_preview),
+                        DLSYM_ARG(aa_policy_cache_new),
+                        DLSYM_ARG(aa_policy_cache_replace_all),
+                        DLSYM_ARG(aa_policy_cache_unref));
+#else
+        return log_full_errno(log_level, SYNTHETIC_ERRNO(EOPNOTSUPP),
+                              "libapparmor support is not compiled in.");
+#endif
 }

--- a/src/shared/apparmor-util.h
+++ b/src/shared/apparmor-util.h
@@ -19,14 +19,11 @@ extern DLSYM_PROTOTYPE(aa_policy_cache_unref);
 
 DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_RENAME(aa_features*, sym_aa_features_unref, aa_features_unrefp, NULL);
 DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_RENAME(aa_policy_cache*, sym_aa_policy_cache_unref, aa_policy_cache_unrefp, NULL);
-
-int dlopen_libapparmor(void);
 bool mac_apparmor_use(void);
 #else
-static inline int dlopen_libapparmor(void) {
-        return -EOPNOTSUPP;
-}
 static inline bool mac_apparmor_use(void) {
         return false;
 }
 #endif
+
+int dlopen_libapparmor(int log_level);

--- a/src/shared/blkid-util.c
+++ b/src/shared/blkid-util.c
@@ -1,11 +1,10 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
-#include <sys/syslog.h>
-
 #include "sd-dlopen.h"
 #include "sd-id128.h"
 
 #include "blkid-util.h"
+#include "log.h"                /* IWYU pragma: keep */
 #include "parse-util.h"
 #include "string-util.h"
 
@@ -48,55 +47,6 @@ DLSYM_PROTOTYPE(blkid_probe_set_partitions_flags) = NULL;
 DLSYM_PROTOTYPE(blkid_probe_set_sectorsize) = NULL;
 DLSYM_PROTOTYPE(blkid_probe_set_superblocks_flags) = NULL;
 DLSYM_PROTOTYPE(blkid_safe_string) = NULL;
-
-int dlopen_libblkid(void) {
-        SD_ELF_NOTE_DLOPEN(
-                        "blkid",
-                        "Support for block device identification",
-                        SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED,
-                        "libblkid.so.1");
-
-        return dlopen_many_sym_or_warn(
-                        &libblkid_dl,
-                        "libblkid.so.1",
-                        LOG_DEBUG,
-                        DLSYM_ARG(blkid_do_fullprobe),
-                        DLSYM_ARG(blkid_do_probe),
-                        DLSYM_ARG(blkid_do_safeprobe),
-                        DLSYM_ARG(blkid_do_wipe),
-                        DLSYM_ARG(blkid_encode_string),
-                        DLSYM_ARG(blkid_free_probe),
-                        DLSYM_ARG(blkid_new_probe),
-                        DLSYM_ARG(blkid_new_probe_from_filename),
-                        DLSYM_ARG(blkid_partition_get_flags),
-                        DLSYM_ARG(blkid_partition_get_name),
-                        DLSYM_ARG(blkid_partition_get_partno),
-                        DLSYM_ARG(blkid_partition_get_size),
-                        DLSYM_ARG(blkid_partition_get_start),
-                        DLSYM_ARG(blkid_partition_get_type),
-                        DLSYM_ARG(blkid_partition_get_type_string),
-                        DLSYM_ARG(blkid_partition_get_uuid),
-                        DLSYM_ARG(blkid_partlist_devno_to_partition),
-                        DLSYM_ARG(blkid_partlist_get_partition),
-                        DLSYM_ARG(blkid_partlist_numof_partitions),
-                        DLSYM_ARG(blkid_probe_enable_partitions),
-                        DLSYM_ARG(blkid_probe_enable_superblocks),
-                        DLSYM_ARG(blkid_probe_filter_superblocks_type),
-                        DLSYM_ARG(blkid_probe_filter_superblocks_usage),
-                        DLSYM_ARG(blkid_probe_get_fd),
-                        DLSYM_ARG(blkid_probe_get_partitions),
-                        DLSYM_ARG(blkid_probe_get_size),
-                        DLSYM_ARG(blkid_probe_get_value),
-                        DLSYM_ARG(blkid_probe_is_wholedisk),
-                        DLSYM_ARG(blkid_probe_lookup_value),
-                        DLSYM_ARG(blkid_probe_numof_values),
-                        DLSYM_ARG(blkid_probe_set_device),
-                        DLSYM_ARG(blkid_probe_set_hint),
-                        DLSYM_ARG(blkid_probe_set_partitions_flags),
-                        DLSYM_ARG(blkid_probe_set_sectorsize),
-                        DLSYM_ARG(blkid_probe_set_superblocks_flags),
-                        DLSYM_ARG(blkid_safe_string));
-}
 
 int blkid_partition_get_uuid_id128(blkid_partition p, sd_id128_t *ret) {
         const char *s;
@@ -146,3 +96,57 @@ int blkid_probe_lookup_value_u64(blkid_probe b, const char *field, uint64_t *ret
         return safe_atou64(u, ret);
 }
 #endif
+
+int dlopen_libblkid(int log_level) {
+#if HAVE_BLKID
+        SD_ELF_NOTE_DLOPEN(
+                        "blkid",
+                        "Support for block device identification",
+                        SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED,
+                        "libblkid.so.1");
+
+        return dlopen_many_sym_or_warn(
+                        &libblkid_dl,
+                        "libblkid.so.1",
+                        log_level,
+                        DLSYM_ARG(blkid_do_fullprobe),
+                        DLSYM_ARG(blkid_do_probe),
+                        DLSYM_ARG(blkid_do_safeprobe),
+                        DLSYM_ARG(blkid_do_wipe),
+                        DLSYM_ARG(blkid_encode_string),
+                        DLSYM_ARG(blkid_free_probe),
+                        DLSYM_ARG(blkid_new_probe),
+                        DLSYM_ARG(blkid_new_probe_from_filename),
+                        DLSYM_ARG(blkid_partition_get_flags),
+                        DLSYM_ARG(blkid_partition_get_name),
+                        DLSYM_ARG(blkid_partition_get_partno),
+                        DLSYM_ARG(blkid_partition_get_size),
+                        DLSYM_ARG(blkid_partition_get_start),
+                        DLSYM_ARG(blkid_partition_get_type),
+                        DLSYM_ARG(blkid_partition_get_type_string),
+                        DLSYM_ARG(blkid_partition_get_uuid),
+                        DLSYM_ARG(blkid_partlist_devno_to_partition),
+                        DLSYM_ARG(blkid_partlist_get_partition),
+                        DLSYM_ARG(blkid_partlist_numof_partitions),
+                        DLSYM_ARG(blkid_probe_enable_partitions),
+                        DLSYM_ARG(blkid_probe_enable_superblocks),
+                        DLSYM_ARG(blkid_probe_filter_superblocks_type),
+                        DLSYM_ARG(blkid_probe_filter_superblocks_usage),
+                        DLSYM_ARG(blkid_probe_get_fd),
+                        DLSYM_ARG(blkid_probe_get_partitions),
+                        DLSYM_ARG(blkid_probe_get_size),
+                        DLSYM_ARG(blkid_probe_get_value),
+                        DLSYM_ARG(blkid_probe_is_wholedisk),
+                        DLSYM_ARG(blkid_probe_lookup_value),
+                        DLSYM_ARG(blkid_probe_numof_values),
+                        DLSYM_ARG(blkid_probe_set_device),
+                        DLSYM_ARG(blkid_probe_set_hint),
+                        DLSYM_ARG(blkid_probe_set_partitions_flags),
+                        DLSYM_ARG(blkid_probe_set_sectorsize),
+                        DLSYM_ARG(blkid_probe_set_superblocks_flags),
+                        DLSYM_ARG(blkid_safe_string));
+#else
+        return log_full_errno(log_level, SYNTHETIC_ERRNO(EOPNOTSUPP),
+                              "libblkid support is not compiled in.");
+#endif
+}

--- a/src/shared/blkid-util.h
+++ b/src/shared/blkid-util.h
@@ -46,8 +46,6 @@ extern DLSYM_PROTOTYPE(blkid_probe_set_sectorsize);
 extern DLSYM_PROTOTYPE(blkid_probe_set_superblocks_flags);
 extern DLSYM_PROTOTYPE(blkid_safe_string);
 
-int dlopen_libblkid(void);
-
 DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_RENAME(blkid_probe, sym_blkid_free_probe, blkid_free_probep, NULL);
 
 int blkid_partition_get_uuid_id128(blkid_partition p, sd_id128_t *ret);
@@ -65,8 +63,6 @@ enum {
 
 int blkid_probe_lookup_value_id128(blkid_probe b, const char *field, sd_id128_t *ret);
 int blkid_probe_lookup_value_u64(blkid_probe b, const char *field, uint64_t *ret);
-#else
-static inline int dlopen_libblkid(void) {
-        return -EOPNOTSUPP;
-}
 #endif
+
+int dlopen_libblkid(int log_level);

--- a/src/shared/bpf-dlopen.c
+++ b/src/shared/bpf-dlopen.c
@@ -76,7 +76,7 @@ static int bpf_print_func(enum libbpf_print_level level, const char *fmt, va_lis
         return log_internalv(LOG_DEBUG, errno, NULL, 0, NULL, fmt, ap);
 }
 
-int dlopen_bpf_full(int log_level) {
+int dlopen_bpf(int log_level) {
         static int cached = 0;
         int r;
 
@@ -210,7 +210,7 @@ int bpf_get_error_translated(const void *ptr) {
 
 #else
 
-int dlopen_bpf_full(int log_level) {
+int dlopen_bpf(int log_level) {
         return log_once_errno(log_level, SYNTHETIC_ERRNO(EOPNOTSUPP),
                               "libbpf support is not compiled in, cgroup BPF features disabled.");
 }

--- a/src/shared/bpf-dlopen.h
+++ b/src/shared/bpf-dlopen.h
@@ -51,7 +51,4 @@ int bpf_get_error_translated(const void *ptr);
 
 #endif
 
-int dlopen_bpf_full(int log_level);
-static inline int dlopen_bpf(void) {
-        return dlopen_bpf_full(LOG_DEBUG);
-}
+int dlopen_bpf(int log_level);

--- a/src/shared/bpf-link.c
+++ b/src/shared/bpf-link.c
@@ -9,7 +9,7 @@ bool bpf_can_link_program(struct bpf_program *prog) {
 
         assert(prog);
 
-        if (dlopen_bpf() < 0)
+        if (dlopen_bpf(LOG_DEBUG) < 0)
                 return false;
 
         /* Pass invalid cgroup fd intentionally. */

--- a/src/shared/cryptsetup-util.c
+++ b/src/shared/cryptsetup-util.c
@@ -98,7 +98,7 @@ void cryptsetup_enable_logging(struct crypt_device *cd) {
          * endless loop, but isn't because we break it via the check for 'cryptsetup_dl' early in
          * dlopen_cryptsetup(). */
 
-        if (dlopen_cryptsetup() < 0)
+        if (dlopen_cryptsetup(LOG_DEBUG) < 0)
                 return; /* If this fails, let's gracefully ignore the issue, this is just debug logging after
                          * all, and if this failed we already generated a debug log message that should help
                          * to track things down. */
@@ -124,7 +124,7 @@ int cryptsetup_set_minimal_pbkdf(struct crypt_device *cd) {
 
         /* Sets a minimal PKBDF in case we already have a high entropy key. */
 
-        r = dlopen_cryptsetup();
+        r = dlopen_cryptsetup(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -155,7 +155,7 @@ int cryptsetup_get_token_as_json(
          * -EMEDIUMTYPE → "verify_type" specified and doesn't match token's type
          */
 
-        r = dlopen_cryptsetup();
+        r = dlopen_cryptsetup(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -188,7 +188,7 @@ int cryptsetup_add_token_json(struct crypt_device *cd, sd_json_variant *v) {
         _cleanup_free_ char *text = NULL;
         int r;
 
-        r = dlopen_cryptsetup();
+        r = dlopen_cryptsetup(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -268,7 +268,7 @@ int cryptsetup_get_volume_key_id(
 }
 #endif
 
-int dlopen_cryptsetup(void) {
+int dlopen_cryptsetup(int log_level) {
 #if HAVE_LIBCRYPTSETUP
         int r;
 
@@ -284,7 +284,7 @@ int dlopen_cryptsetup(void) {
                         "libcryptsetup.so.12");
 
         r = dlopen_many_sym_or_warn(
-                        &cryptsetup_dl, "libcryptsetup.so.12", LOG_DEBUG,
+                        &cryptsetup_dl, "libcryptsetup.so.12", log_level,
                         DLSYM_ARG(crypt_activate_by_passphrase),
                         DLSYM_ARG(crypt_activate_by_signed_key),
                         DLSYM_ARG(crypt_activate_by_volume_key),
@@ -355,7 +355,8 @@ int dlopen_cryptsetup(void) {
 
         return 1;
 #else
-        return log_debug_errno(SYNTHETIC_ERRNO(EOPNOTSUPP), "cryptsetup support is not compiled in.");
+        return log_full_errno(log_level, SYNTHETIC_ERRNO(EOPNOTSUPP),
+                              "libcryptsetup support is not compiled in.");
 #endif
 }
 

--- a/src/shared/cryptsetup-util.h
+++ b/src/shared/cryptsetup-util.h
@@ -73,7 +73,7 @@ int cryptsetup_get_volume_key_id(struct crypt_device *cd, const char *volume_nam
                                  size_t volume_key_size,  char **ret);
 #endif
 
-int dlopen_cryptsetup(void);
+int dlopen_cryptsetup(int log_level);
 
 int cryptsetup_get_keyslot_from_token(sd_json_variant *v);
 

--- a/src/shared/curl-util.c
+++ b/src/shared/curl-util.c
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
 #include "curl-util.h"
+#include "log.h"
 
 #if HAVE_LIBCURL
 
@@ -11,7 +12,6 @@
 #include "dlfcn-util.h"
 #include "fd-util.h"
 #include "hashmap.h"
-#include "log.h"
 #include "string-util.h"
 #include "strv.h"
 #include "time-util.h"
@@ -39,39 +39,6 @@ DLSYM_PROTOTYPE(curl_multi_setopt) = NULL;
 DLSYM_PROTOTYPE(curl_multi_socket_action) = NULL;
 DLSYM_PROTOTYPE(curl_slist_append) = NULL;
 DLSYM_PROTOTYPE(curl_slist_free_all) = NULL;
-
-int dlopen_curl(void) {
-        SD_ELF_NOTE_DLOPEN(
-                        "curl",
-                        "Support for downloading and uploading files over HTTP",
-                        SD_ELF_NOTE_DLOPEN_PRIORITY_SUGGESTED,
-                        "libcurl.so.4");
-
-        return dlopen_many_sym_or_warn(
-                        &curl_dl,
-                        "libcurl.so.4",
-                        LOG_DEBUG,
-                        DLSYM_ARG(curl_easy_cleanup),
-                        DLSYM_ARG(curl_easy_getinfo),
-                        DLSYM_ARG(curl_easy_init),
-                        DLSYM_ARG(curl_easy_perform),
-                        DLSYM_ARG(curl_easy_setopt),
-                        DLSYM_ARG(curl_easy_strerror),
-#if LIBCURL_VERSION_NUM >= 0x075300
-                        DLSYM_ARG(curl_easy_header),
-#endif
-                        DLSYM_ARG(curl_getdate),
-                        DLSYM_ARG(curl_multi_add_handle),
-                        DLSYM_ARG(curl_multi_assign),
-                        DLSYM_ARG(curl_multi_cleanup),
-                        DLSYM_ARG(curl_multi_info_read),
-                        DLSYM_ARG(curl_multi_init),
-                        DLSYM_ARG(curl_multi_remove_handle),
-                        DLSYM_ARG(curl_multi_setopt),
-                        DLSYM_ARG(curl_multi_socket_action),
-                        DLSYM_ARG(curl_slist_append),
-                        DLSYM_ARG(curl_slist_free_all));
-}
 
 static void curl_glue_check_finished(CurlGlue *g) {
         int r;
@@ -271,7 +238,7 @@ int curl_glue_new(CurlGlue **glue, sd_event *event) {
 
         assert(glue);
 
-        r = dlopen_curl();
+        r = dlopen_curl(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -327,7 +294,7 @@ int curl_glue_make(CURL **ret, const char *url, void *userdata) {
         assert(ret);
         assert(url);
 
-        r = dlopen_curl();
+        r = dlopen_curl(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -496,3 +463,41 @@ int curl_append_to_header(struct curl_slist **list, char **headers) {
 }
 
 #endif
+
+int dlopen_curl(int log_level) {
+#if HAVE_LIBCURL
+        SD_ELF_NOTE_DLOPEN(
+                        "curl",
+                        "Support for downloading and uploading files over HTTP",
+                        SD_ELF_NOTE_DLOPEN_PRIORITY_SUGGESTED,
+                        "libcurl.so.4");
+
+        return dlopen_many_sym_or_warn(
+                        &curl_dl,
+                        "libcurl.so.4",
+                        log_level,
+                        DLSYM_ARG(curl_easy_cleanup),
+                        DLSYM_ARG(curl_easy_getinfo),
+                        DLSYM_ARG(curl_easy_init),
+                        DLSYM_ARG(curl_easy_perform),
+                        DLSYM_ARG(curl_easy_setopt),
+                        DLSYM_ARG(curl_easy_strerror),
+#if LIBCURL_VERSION_NUM >= 0x075300
+                        DLSYM_ARG(curl_easy_header),
+#endif
+                        DLSYM_ARG(curl_getdate),
+                        DLSYM_ARG(curl_multi_add_handle),
+                        DLSYM_ARG(curl_multi_assign),
+                        DLSYM_ARG(curl_multi_cleanup),
+                        DLSYM_ARG(curl_multi_info_read),
+                        DLSYM_ARG(curl_multi_init),
+                        DLSYM_ARG(curl_multi_remove_handle),
+                        DLSYM_ARG(curl_multi_setopt),
+                        DLSYM_ARG(curl_multi_socket_action),
+                        DLSYM_ARG(curl_slist_append),
+                        DLSYM_ARG(curl_slist_free_all));
+#else
+        return log_full_errno(log_level, SYNTHETIC_ERRNO(EOPNOTSUPP),
+                              "libcurl support is not compiled in.");
+#endif
+}

--- a/src/shared/curl-util.h
+++ b/src/shared/curl-util.h
@@ -29,8 +29,6 @@ extern DLSYM_PROTOTYPE(curl_multi_socket_action);
 extern DLSYM_PROTOTYPE(curl_slist_append);
 extern DLSYM_PROTOTYPE(curl_slist_free_all);
 
-int dlopen_curl(void);
-
 #define easy_setopt(curl, log_level, opt, value) ({                         \
         CURLcode code = sym_curl_easy_setopt(ASSERT_PTR(curl), opt, value); \
         if (code)                                                           \
@@ -71,10 +69,6 @@ DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_RENAME(CURL*, sym_curl_easy_cleanup, curl_easy_
 DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_RENAME(CURLM*, sym_curl_multi_cleanup, curl_multi_cleanupp, NULL);
 DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_RENAME(struct curl_slist*, sym_curl_slist_free_all, curl_slist_free_allp, NULL);
 
-#else
-
-static inline int dlopen_curl(void) {
-        return -EOPNOTSUPP;
-}
-
 #endif
+
+int dlopen_curl(int log_level);

--- a/src/shared/dissect-image.c
+++ b/src/shared/dissect-image.c
@@ -239,7 +239,7 @@ int probe_filesystem_full(
         assert(fd >= 0 || path);
         assert(ret_fstype);
 
-        r = dlopen_libblkid();
+        r = dlopen_libblkid(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -1076,7 +1076,7 @@ static int dissect_image(
                 }
         }
 
-        r = dlopen_libblkid();
+        r = dlopen_libblkid(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -2945,7 +2945,7 @@ static int decrypt_partition(
         if (!FLAGS_SET(policy_flags, PARTITION_POLICY_ENCRYPTED))
                 return log_debug_errno(SYNTHETIC_ERRNO(ERFKILL), "Attempted to unlock partition via LUKS, but it's prohibited.");
 
-        r = dlopen_cryptsetup();
+        r = dlopen_cryptsetup(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -3313,7 +3313,7 @@ static int verity_partition(
                 return 0;
         }
 
-        r = dlopen_cryptsetup();
+        r = dlopen_cryptsetup(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -4176,7 +4176,7 @@ int dissected_image_acquire_metadata(
 
         assert(m);
 
-        r = dlopen_libmount();
+        r = dlopen_libmount(LOG_DEBUG);
         if (r < 0)
                 return r;
 

--- a/src/shared/dns-domain.c
+++ b/src/shared/dns-domain.c
@@ -1267,7 +1267,7 @@ int dns_name_apply_idna(const char *name, char **ret) {
 #if HAVE_LIBIDN2
         int r;
 
-        r = dlopen_idn();
+        r = dlopen_idn(LOG_DEBUG);
         if (r == -EOPNOTSUPP) {
                 *ret = NULL;
                 return 0;

--- a/src/shared/elf-util.c
+++ b/src/shared/elf-util.c
@@ -91,7 +91,7 @@ static DLSYM_PROTOTYPE(gelf_getnote) = NULL;
 
 #endif
 
-int dlopen_dw(void) {
+int dlopen_dw(int log_level) {
 #if HAVE_ELFUTILS
         int r;
 
@@ -102,7 +102,7 @@ int dlopen_dw(void) {
                         "libdw.so.1");
 
         r = dlopen_many_sym_or_warn(
-                        &dw_dl, "libdw.so.1", LOG_DEBUG,
+                        &dw_dl, "libdw.so.1", log_level,
                         DLSYM_ARG(dwarf_getscopes),
                         DLSYM_ARG(dwarf_getscopes_die),
                         DLSYM_ARG(dwarf_tag),
@@ -141,11 +141,12 @@ int dlopen_dw(void) {
 
         return 1;
 #else
-        return -EOPNOTSUPP;
+        return log_full_errno(log_level, SYNTHETIC_ERRNO(EOPNOTSUPP),
+                              "libdw support is not compiled in.");
 #endif
 }
 
-int dlopen_elf(void) {
+int dlopen_elf(int log_level) {
 #if HAVE_ELFUTILS
         int r;
 
@@ -156,7 +157,7 @@ int dlopen_elf(void) {
                         "libelf.so.1");
 
         r = dlopen_many_sym_or_warn(
-                        &elf_dl, "libelf.so.1", LOG_DEBUG,
+                        &elf_dl, "libelf.so.1", log_level,
                         DLSYM_ARG(elf_begin),
                         DLSYM_ARG(elf_end),
                         DLSYM_ARG(elf_getphdrnum),
@@ -173,7 +174,8 @@ int dlopen_elf(void) {
 
         return 1;
 #else
-        return -EOPNOTSUPP;
+        return log_full_errno(log_level, SYNTHETIC_ERRNO(EOPNOTSUPP),
+                              "libelf support is not compiled in.");
 #endif
 }
 
@@ -824,11 +826,11 @@ int parse_elf_object(
 
         assert(fd >= 0);
 
-        r = dlopen_dw();
+        r = dlopen_dw(LOG_DEBUG);
         if (r < 0)
                 return r;
 
-        r = dlopen_elf();
+        r = dlopen_elf(LOG_DEBUG);
         if (r < 0)
                 return r;
 

--- a/src/shared/elf-util.h
+++ b/src/shared/elf-util.h
@@ -3,8 +3,8 @@
 
 #include "shared-forward.h"
 
-int dlopen_dw(void);
-int dlopen_elf(void);
+int dlopen_dw(int log_level);
+int dlopen_elf(int log_level);
 
 /* Parse an ELF object in a forked process, so that errors while iterating over
  * untrusted and potentially malicious data do not propagate to the main caller's process.

--- a/src/shared/fdisk-util.c
+++ b/src/shared/fdisk-util.c
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
 #include "fdisk-util.h"
+#include "log.h"
 
 #if HAVE_LIBFDISK
 
@@ -12,7 +13,6 @@
 #include "dlfcn-util.h"
 #include "extract-word.h"
 #include "fd-util.h"
-#include "log.h"
 #include "parse-util.h"
 #include "string-util.h"
 
@@ -78,8 +78,10 @@ DLSYM_PROTOTYPE(fdisk_unref_partition) = NULL;
 DLSYM_PROTOTYPE(fdisk_unref_parttype) = NULL;
 DLSYM_PROTOTYPE(fdisk_unref_table) = NULL;
 DLSYM_PROTOTYPE(fdisk_write_disklabel) = NULL;
+#endif
 
-int dlopen_fdisk(void) {
+int dlopen_fdisk(int log_level) {
+#if HAVE_LIBFDISK
         SD_ELF_NOTE_DLOPEN(
                         "fdisk",
                         "Support for reading and writing partition tables",
@@ -89,7 +91,7 @@ int dlopen_fdisk(void) {
         return dlopen_many_sym_or_warn(
                         &fdisk_dl,
                         "libfdisk.so.1",
-                        LOG_DEBUG,
+                        log_level,
                         DLSYM_ARG(fdisk_add_partition),
                         DLSYM_ARG(fdisk_apply_table),
                         DLSYM_ARG(fdisk_ask_get_type),
@@ -150,8 +152,13 @@ int dlopen_fdisk(void) {
                         DLSYM_ARG(fdisk_unref_parttype),
                         DLSYM_ARG(fdisk_unref_table),
                         DLSYM_ARG(fdisk_write_disklabel));
+#else
+        return log_full_errno(log_level, SYNTHETIC_ERRNO(EOPNOTSUPP),
+                              "libfdisk support is not compiled in.");
+#endif
 }
 
+#if HAVE_LIBFDISK
 int fdisk_new_context_at(
                 int dir_fd,
                 const char *path,

--- a/src/shared/fdisk-util.h
+++ b/src/shared/fdisk-util.h
@@ -70,8 +70,6 @@ extern DLSYM_PROTOTYPE(fdisk_unref_parttype);
 extern DLSYM_PROTOTYPE(fdisk_unref_table);
 extern DLSYM_PROTOTYPE(fdisk_write_disklabel);
 
-int dlopen_fdisk(void);
-
 DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_RENAME(struct fdisk_context*, sym_fdisk_unref_context, fdisk_unref_contextp, NULL);
 DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_RENAME(struct fdisk_partition*, sym_fdisk_unref_partition, fdisk_unref_partitionp, NULL);
 DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_RENAME(struct fdisk_parttype*, sym_fdisk_unref_parttype, fdisk_unref_parttypep, NULL);
@@ -85,10 +83,6 @@ int fdisk_partition_get_type_as_id128(struct fdisk_partition *p, sd_id128_t *ret
 int fdisk_partition_get_attrs_as_uint64(struct fdisk_partition *pa, uint64_t *ret);
 int fdisk_partition_set_attrs_as_uint64(struct fdisk_partition *pa, uint64_t flags);
 
-#else
-
-static inline int dlopen_fdisk(void) {
-        return -EOPNOTSUPP;
-}
-
 #endif
+
+int dlopen_fdisk(int log_level);

--- a/src/shared/find-esp.c
+++ b/src/shared/find-esp.c
@@ -75,9 +75,9 @@ static int verify_esp_blkid(
         const char *v;
         int r;
 
-        r = dlopen_libblkid();
+        r = dlopen_libblkid(LOG_DEBUG);
         if (r < 0)
-                return log_debug_errno(r, "No libblkid support: %m");
+                return r;
 
         r = devname_from_devnum(S_IFBLK, devid, &node);
         if (r < 0)
@@ -572,9 +572,9 @@ static int verify_xbootldr_blkid(
         const char *type, *v;
         int r;
 
-        r = dlopen_libblkid();
+        r = dlopen_libblkid(LOG_DEBUG);
         if (r < 0)
-                return log_debug_errno(r, "No libblkid support: %m");
+                return r;
 
         r = devname_from_devnum(S_IFBLK, devid, &node);
         if (r < 0)

--- a/src/shared/idn-util.c
+++ b/src/shared/idn-util.c
@@ -1,9 +1,11 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
-#include "sd-dlopen.h"
-
 #include "idn-util.h"
 #include "log.h"                /* IWYU pragma: keep */
+
+#if HAVE_LIBIDN2
+
+#include "sd-dlopen.h"
 
 static void* idn_dl = NULL;
 
@@ -11,7 +13,10 @@ DLSYM_PROTOTYPE(idn2_lookup_u8) = NULL;
 const char *(*sym_idn2_strerror)(int rc) _const_ = NULL;
 DLSYM_PROTOTYPE(idn2_to_unicode_8z8z) = NULL;
 
-int dlopen_idn(void) {
+#endif
+
+int dlopen_idn(int log_level) {
+#if HAVE_LIBIDN2
         SD_ELF_NOTE_DLOPEN(
                         "idn",
                         "Support for internationalized domain names",
@@ -19,8 +24,12 @@ int dlopen_idn(void) {
                         "libidn2.so.0");
 
         return dlopen_many_sym_or_warn(
-                        &idn_dl, "libidn2.so.0", LOG_DEBUG,
+                        &idn_dl, "libidn2.so.0", log_level,
                         DLSYM_ARG(idn2_lookup_u8),
                         DLSYM_ARG(idn2_strerror),
                         DLSYM_ARG(idn2_to_unicode_8z8z));
+#else
+        return log_full_errno(log_level, SYNTHETIC_ERRNO(EOPNOTSUPP),
+                              "libidn2 support is not compiled in.");
+#endif
 }

--- a/src/shared/idn-util.h
+++ b/src/shared/idn-util.h
@@ -11,10 +11,6 @@
 extern DLSYM_PROTOTYPE(idn2_lookup_u8);
 extern const char *(*sym_idn2_strerror)(int rc) _const_;
 extern DLSYM_PROTOTYPE(idn2_to_unicode_8z8z);
-
-int dlopen_idn(void);
-#else
-static inline int dlopen_idn(void) {
-        return -EOPNOTSUPP;
-}
 #endif
+
+int dlopen_idn(int log_level);

--- a/src/shared/libarchive-util.c
+++ b/src/shared/libarchive-util.c
@@ -5,6 +5,7 @@
 #include "sd-dlopen.h"
 
 #include "libarchive-util.h"
+#include "log.h"                        /* IWYU pragma: keep */
 #include "user-util.h"                  /* IWYU pragma: keep */
 
 #if HAVE_LIBARCHIVE
@@ -79,8 +80,10 @@ DLSYM_PROTOTYPE(archive_write_open_FILE) = NULL;
 DLSYM_PROTOTYPE(archive_write_open_fd) = NULL;
 DLSYM_PROTOTYPE(archive_write_set_format_filter_by_ext) = NULL;
 DLSYM_PROTOTYPE(archive_write_set_format_pax) = NULL;
+#endif
 
-int dlopen_libarchive(void) {
+int dlopen_libarchive(int log_level) {
+#if HAVE_LIBARCHIVE
         SD_ELF_NOTE_DLOPEN(
                         "archive",
                         "Support for decompressing archive files",
@@ -90,7 +93,7 @@ int dlopen_libarchive(void) {
         return dlopen_many_sym_or_warn(
                         &libarchive_dl,
                         "libarchive.so.13",
-                        LOG_DEBUG,
+                        log_level,
                         DLSYM_ARG(archive_entry_acl_add_entry),
                         DLSYM_ARG(archive_entry_acl_next),
                         DLSYM_ARG(archive_entry_acl_reset),
@@ -152,8 +155,13 @@ int dlopen_libarchive(void) {
                         DLSYM_ARG(archive_write_open_fd),
                         DLSYM_ARG(archive_write_set_format_filter_by_ext),
                         DLSYM_ARG(archive_write_set_format_pax));
+#else
+        return log_full_errno(log_level, SYNTHETIC_ERRNO(EOPNOTSUPP),
+                              "libarchive support is not compiled in.");
+#endif
 }
 
+#if HAVE_LIBARCHIVE
 /* libarchive uses its own file type macros. They happen to be defined the same way as the Linux ones, and
  * we'd like to rely on it. Let's verify this first though. */
 assert_cc(S_IFDIR == AE_IFDIR);

--- a/src/shared/libarchive-util.h
+++ b/src/shared/libarchive-util.h
@@ -79,16 +79,13 @@ extern DLSYM_PROTOTYPE(archive_write_open_fd);
 extern DLSYM_PROTOTYPE(archive_write_set_format_filter_by_ext);
 extern DLSYM_PROTOTYPE(archive_write_set_format_pax);
 
-int dlopen_libarchive(void);
-
 DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_RENAME(struct archive_entry*, sym_archive_entry_free, archive_entry_freep, NULL);
 DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_RENAME(struct archive*, sym_archive_write_free, archive_write_freep, NULL);
 DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_RENAME(struct archive*, sym_archive_read_free, archive_read_freep, NULL);
 
 #else
 
-static inline int dlopen_libarchive(void) {
-        return -EOPNOTSUPP;
-}
 
 #endif
+
+int dlopen_libarchive(int log_level);

--- a/src/shared/libaudit-util.c
+++ b/src/shared/libaudit-util.c
@@ -23,7 +23,7 @@ DLSYM_PROTOTYPE(audit_log_user_comm_message) = NULL;
 static DLSYM_PROTOTYPE(audit_open) = NULL;
 #endif
 
-int dlopen_libaudit(void) {
+int dlopen_libaudit(int log_level) {
 #if HAVE_AUDIT
         SD_ELF_NOTE_DLOPEN(
                         "audit",
@@ -34,14 +34,15 @@ int dlopen_libaudit(void) {
         return dlopen_many_sym_or_warn(
                         &libaudit_dl,
                         "libaudit.so.1",
-                        LOG_DEBUG,
+                        log_level,
                         DLSYM_ARG(audit_close),
                         DLSYM_ARG(audit_log_acct_message),
                         DLSYM_ARG(audit_log_user_avc_message),
                         DLSYM_ARG(audit_log_user_comm_message),
                         DLSYM_ARG(audit_open));
 #else
-        return -EOPNOTSUPP;
+        return log_full_errno(log_level, SYNTHETIC_ERRNO(EOPNOTSUPP),
+                              "libaudit support is not compiled in.");
 #endif
 }
 
@@ -93,7 +94,7 @@ bool use_audit(void) {
         if (cached_use >= 0)
                 return cached_use;
 
-        if (dlopen_libaudit() < 0)
+        if (dlopen_libaudit(LOG_DEBUG) < 0)
                 return (cached_use = false);
 
         _cleanup_close_ int fd = socket(AF_NETLINK, SOCK_RAW|SOCK_CLOEXEC|SOCK_NONBLOCK, NETLINK_AUDIT);
@@ -141,7 +142,7 @@ int open_audit_fd_or_warn(void) {
 #if HAVE_AUDIT
         int r;
 
-        r = dlopen_libaudit();
+        r = dlopen_libaudit(LOG_DEBUG);
         if (r < 0)
                 return r;
 

--- a/src/shared/libaudit-util.h
+++ b/src/shared/libaudit-util.h
@@ -3,7 +3,7 @@
 
 #include "shared-forward.h"
 
-int dlopen_libaudit(void);
+int dlopen_libaudit(int log_level);
 
 #if HAVE_AUDIT
 #  include <libaudit.h>         /* IWYU pragma: export */

--- a/src/shared/libcrypt-util.c
+++ b/src/shared/libcrypt-util.c
@@ -21,58 +21,6 @@ static DLSYM_PROTOTYPE(crypt_gensalt_ra) = NULL;
 static DLSYM_PROTOTYPE(crypt_preferred_method) = NULL;
 static DLSYM_PROTOTYPE(crypt_ra) = NULL;
 
-int dlopen_libcrypt(void) {
-#ifdef __GLIBC__
-        static int cached = 0;
-        int r;
-
-        if (libcrypt_dl)
-                return 0; /* Already loaded */
-
-        if (cached < 0)
-                return cached; /* Already tried, and failed. */
-
-        /* Several distributions like Debian/Ubuntu and OpenSUSE provide libxcrypt as libcrypt.so.1
-         * (libcrypt.so.1.1 on some architectures), while others like Fedora/CentOS and Arch provide it as
-         * libcrypt.so.2. */
-        SD_ELF_NOTE_DLOPEN(
-                        "crypt",
-                        "Support for hashing passwords",
-                        SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED,
-                        "libcrypt.so.2", "libcrypt.so.1", "libcrypt.so.1.1");
-
-        _cleanup_(dlclosep) void *dl = NULL;
-        const char *dle = NULL;
-        FOREACH_STRING(soname, "libcrypt.so.2", "libcrypt.so.1", "libcrypt.so.1.1") {
-                r = dlopen_safe(soname, &dl, &dle);
-                if (r >= 0) {
-                        log_debug("Loaded '%s' via dlopen().", soname);
-                        break;
-                }
-        }
-        if (r < 0) {
-                log_debug_errno(r, "Failed to load libcrypt: %s", dle ?: STRERROR(r));
-                return (cached = -EOPNOTSUPP); /* turn into recognizable error */
-        }
-
-        r = dlsym_many_or_warn(
-                        dl, LOG_DEBUG,
-                        DLSYM_ARG(crypt_gensalt_ra),
-                        DLSYM_ARG(crypt_preferred_method),
-                        DLSYM_ARG(crypt_ra));
-        if (r < 0)
-                return (cached = r);
-
-        libcrypt_dl = TAKE_PTR(dl);
-#else
-        libcrypt_dl = NULL;
-        sym_crypt_gensalt_ra = missing_crypt_gensalt_ra;
-        sym_crypt_preferred_method = missing_crypt_preferred_method;
-        sym_crypt_ra = missing_crypt_ra;
-#endif
-        return 0;
-}
-
 int make_salt(char **ret) {
         const char *e;
         char *salt;
@@ -80,7 +28,7 @@ int make_salt(char **ret) {
 
         assert(ret);
 
-        r = dlopen_libcrypt();
+        r = dlopen_libcrypt(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -127,7 +75,7 @@ int test_password_one(const char *hashed_password, const char *password) {
         assert(hashed_password);
         assert(password);
 
-        r = dlopen_libcrypt();
+        r = dlopen_libcrypt(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -174,4 +122,61 @@ bool looks_like_hashed_password(const char *s) {
         s += strspn(s, "!"); /* Skip (possibly duplicated) locking prefix */
 
         return !STR_IN_SET(s, "x", "*");
+}
+
+int dlopen_libcrypt(int log_level) {
+#if HAVE_LIBCRYPT
+#ifdef __GLIBC__
+        static int cached = 0;
+        int r;
+
+        if (libcrypt_dl)
+                return 0; /* Already loaded */
+
+        if (cached < 0)
+                return cached; /* Already tried, and failed. */
+
+        /* Several distributions like Debian/Ubuntu and OpenSUSE provide libxcrypt as libcrypt.so.1
+         * (libcrypt.so.1.1 on some architectures), while others like Fedora/CentOS and Arch provide it as
+         * libcrypt.so.2. */
+        SD_ELF_NOTE_DLOPEN(
+                        "crypt",
+                        "Support for hashing passwords",
+                        SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED,
+                        "libcrypt.so.2", "libcrypt.so.1", "libcrypt.so.1.1");
+
+        _cleanup_(dlclosep) void *dl = NULL;
+        const char *dle = NULL;
+        FOREACH_STRING(soname, "libcrypt.so.2", "libcrypt.so.1", "libcrypt.so.1.1") {
+                r = dlopen_safe(soname, &dl, &dle);
+                if (r >= 0) {
+                        log_debug("Loaded '%s' via dlopen().", soname);
+                        break;
+                }
+        }
+        if (r < 0) {
+                log_full_errno(log_level, r, "Failed to load libcrypt: %s", dle ?: STRERROR(r));
+                return (cached = -EOPNOTSUPP); /* turn into recognizable error */
+        }
+
+        r = dlsym_many_or_warn(
+                        dl, log_level,
+                        DLSYM_ARG(crypt_gensalt_ra),
+                        DLSYM_ARG(crypt_preferred_method),
+                        DLSYM_ARG(crypt_ra));
+        if (r < 0)
+                return (cached = r);
+
+        libcrypt_dl = TAKE_PTR(dl);
+#else
+        libcrypt_dl = NULL;
+        sym_crypt_gensalt_ra = missing_crypt_gensalt_ra;
+        sym_crypt_preferred_method = missing_crypt_preferred_method;
+        sym_crypt_ra = missing_crypt_ra;
+#endif
+        return 0;
+#else
+        return log_full_errno(log_level, SYNTHETIC_ERRNO(EOPNOTSUPP),
+                              "libcrypt support is not compiled in.");
+#endif
 }

--- a/src/shared/libcrypt-util.h
+++ b/src/shared/libcrypt-util.h
@@ -4,7 +4,6 @@
 #include "shared-forward.h"
 
 #if HAVE_LIBCRYPT
-int dlopen_libcrypt(void);
 int make_salt(char **ret);
 int hash_password(const char *password, char **ret);
 int test_password_one(const char *hashed_password, const char *password);
@@ -12,12 +11,11 @@ int test_password_many(char **hashed_password, const char *password);
 
 #else
 
-static inline int dlopen_libcrypt(void) {
-        return -EOPNOTSUPP;
-}
 static inline int hash_password(const char *password, char **ret) {
         return -EOPNOTSUPP;
 }
 #endif
+
+int dlopen_libcrypt(int log_level);
 
 bool looks_like_hashed_password(const char *s);

--- a/src/shared/libfido2-util.c
+++ b/src/shared/libfido2-util.c
@@ -80,7 +80,7 @@ static void fido_log_propagate_handler(const char *s) {
 
 #endif
 
-int dlopen_libfido2(void) {
+int dlopen_libfido2(int log_level) {
 #if HAVE_LIBFIDO2
         int r;
 
@@ -91,7 +91,7 @@ int dlopen_libfido2(void) {
                         "libfido2.so.1");
 
         r = dlopen_many_sym_or_warn(
-                        &libfido2_dl, "libfido2.so.1", LOG_DEBUG,
+                        &libfido2_dl, "libfido2.so.1", log_level,
                         DLSYM_ARG(fido_assert_allow_cred),
                         DLSYM_ARG(fido_assert_free),
                         DLSYM_ARG(fido_assert_hmac_secret_len),
@@ -148,7 +148,8 @@ int dlopen_libfido2(void) {
 
         return 0;
 #else
-        return -EOPNOTSUPP;
+        return log_full_errno(log_level, SYNTHETIC_ERRNO(EOPNOTSUPP),
+                              "libfido2 support is not compiled in.");
 #endif
 }
 
@@ -658,9 +659,9 @@ int fido2_use_hmac_hash(
         fido_dev_info_t *di = NULL;
         int r;
 
-        r = dlopen_libfido2();
+        r = dlopen_libfido2(LOG_ERR);
         if (r < 0)
-                return log_error_errno(r, "FIDO2 support is not installed.");
+                return r;
 
         if (device) {
                 r = fido2_is_cred_in_specific_token(device, rp_id, cid, cid_size, required);
@@ -784,9 +785,9 @@ int fido2_generate_hmac_hash(
         assert((lock_with & ~(FIDO2ENROLL_PIN|FIDO2ENROLL_UP|FIDO2ENROLL_UV)) == 0);
         assert(iovec_is_set(salt));
 
-        r = dlopen_libfido2();
+        r = dlopen_libfido2(LOG_ERR);
         if (r < 0)
-                return log_error_errno(r, "FIDO2 token support is not installed.");
+                return r;
 
         d = sym_fido_dev_new();
         if (!d)
@@ -1188,9 +1189,9 @@ int fido2_list_devices(void) {
         fido_dev_info_t *di = NULL;
         int r;
 
-        r = dlopen_libfido2();
+        r = dlopen_libfido2(LOG_ERR);
         if (r < 0)
-                return log_error_errno(r, "FIDO2 token support is not installed.");
+                return r;
 
         di = sym_fido_dev_info_new(allocated);
         if (!di)
@@ -1282,9 +1283,9 @@ int fido2_find_device_auto(char **ret) {
         const char *path;
         int r;
 
-        r = dlopen_libfido2();
+        r = dlopen_libfido2(LOG_ERR);
         if (r < 0)
-                return log_error_errno(r, "FIDO2 token support is not installed.");
+                return r;
 
         di = sym_fido_dev_info_new(di_size);
         if (!di)
@@ -1359,9 +1360,9 @@ int fido2_have_device(const char *device) {
 
         /* Return == 0 if not devices are found, > 0 if at least one is found */
 
-        r = dlopen_libfido2();
+        r = dlopen_libfido2(LOG_ERR);
         if (r < 0)
-                return log_error_errno(r, "FIDO2 support is not installed.");
+                return r;
 
         if (device) {
                 if (access(device, F_OK) < 0) {

--- a/src/shared/libfido2-util.h
+++ b/src/shared/libfido2-util.h
@@ -16,7 +16,7 @@ typedef enum Fido2EnrollFlags {
         _FIDO2ENROLL_TYPE_INVALID = -EINVAL,
 } Fido2EnrollFlags;
 
-int dlopen_libfido2(void);
+int dlopen_libfido2(int log_level);
 
 #if HAVE_LIBFIDO2
 #include <fido.h>

--- a/src/shared/libmount-util.c
+++ b/src/shared/libmount-util.c
@@ -1,12 +1,15 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
+#include "libmount-util.h"
+#include "log.h"
+
+#if HAVE_LIBMOUNT
+
 #include <stdio.h>
 
 #include "sd-dlopen.h"
 
 #include "fstab-util.h"
-#include "libmount-util.h"
-#include "log.h"
 
 static void *libmount_dl = NULL;
 
@@ -42,50 +45,6 @@ DLSYM_PROTOTYPE(mnt_table_parse_stream) = NULL;
 DLSYM_PROTOTYPE(mnt_table_parse_swaps) = NULL;
 DLSYM_PROTOTYPE(mnt_unref_monitor) = NULL;
 
-int dlopen_libmount(void) {
-        SD_ELF_NOTE_DLOPEN(
-                        "mount",
-                        "Support for mount enumeration",
-                        SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED,
-                        "libmount.so.1");
-
-        return dlopen_many_sym_or_warn(
-                        &libmount_dl,
-                        "libmount.so.1",
-                        LOG_DEBUG,
-                        DLSYM_ARG(mnt_free_iter),
-                        DLSYM_ARG(mnt_free_table),
-                        DLSYM_ARG(mnt_fs_get_fs_options),
-                        DLSYM_ARG(mnt_fs_get_fstype),
-                        DLSYM_ARG(mnt_fs_get_id),
-                        DLSYM_ARG(mnt_fs_get_option),
-                        DLSYM_ARG(mnt_fs_get_options),
-                        DLSYM_ARG(mnt_fs_get_passno),
-                        DLSYM_ARG(mnt_fs_get_propagation),
-                        DLSYM_ARG(mnt_fs_get_source),
-                        DLSYM_ARG(mnt_fs_get_target),
-                        DLSYM_ARG(mnt_fs_get_vfs_options),
-                        DLSYM_ARG(mnt_get_builtin_optmap),
-                        DLSYM_ARG(mnt_init_debug),
-                        DLSYM_ARG(mnt_monitor_enable_kernel),
-                        DLSYM_ARG(mnt_monitor_enable_userspace),
-                        DLSYM_ARG(mnt_monitor_get_fd),
-                        DLSYM_ARG(mnt_monitor_next_change),
-                        DLSYM_ARG(mnt_new_iter),
-                        DLSYM_ARG(mnt_new_monitor),
-                        DLSYM_ARG(mnt_new_table),
-                        DLSYM_ARG(mnt_optstr_get_flags),
-                        DLSYM_ARG(mnt_table_find_devno),
-                        DLSYM_ARG(mnt_table_find_target),
-                        DLSYM_ARG(mnt_table_next_child_fs),
-                        DLSYM_ARG(mnt_table_next_fs),
-                        DLSYM_ARG(mnt_table_parse_file),
-                        DLSYM_ARG(mnt_table_parse_mtab),
-                        DLSYM_ARG(mnt_table_parse_stream),
-                        DLSYM_ARG(mnt_table_parse_swaps),
-                        DLSYM_ARG(mnt_unref_monitor));
-}
-
 int libmount_parse_full(
                 const char *path,
                 FILE *source,
@@ -103,7 +62,7 @@ int libmount_parse_full(
         assert(ret_table);
         assert(ret_iter);
 
-        r = dlopen_libmount();
+        r = dlopen_libmount(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -155,4 +114,55 @@ int libmount_is_leaf(
                 return r;
 
         return r == 1;
+}
+
+#endif
+
+int dlopen_libmount(int log_level) {
+#if HAVE_LIBMOUNT
+        SD_ELF_NOTE_DLOPEN(
+                        "mount",
+                        "Support for mount enumeration",
+                        SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED,
+                        "libmount.so.1");
+
+        return dlopen_many_sym_or_warn(
+                        &libmount_dl,
+                        "libmount.so.1",
+                        log_level,
+                        DLSYM_ARG(mnt_free_iter),
+                        DLSYM_ARG(mnt_free_table),
+                        DLSYM_ARG(mnt_fs_get_fs_options),
+                        DLSYM_ARG(mnt_fs_get_fstype),
+                        DLSYM_ARG(mnt_fs_get_id),
+                        DLSYM_ARG(mnt_fs_get_option),
+                        DLSYM_ARG(mnt_fs_get_options),
+                        DLSYM_ARG(mnt_fs_get_passno),
+                        DLSYM_ARG(mnt_fs_get_propagation),
+                        DLSYM_ARG(mnt_fs_get_source),
+                        DLSYM_ARG(mnt_fs_get_target),
+                        DLSYM_ARG(mnt_fs_get_vfs_options),
+                        DLSYM_ARG(mnt_get_builtin_optmap),
+                        DLSYM_ARG(mnt_init_debug),
+                        DLSYM_ARG(mnt_monitor_enable_kernel),
+                        DLSYM_ARG(mnt_monitor_enable_userspace),
+                        DLSYM_ARG(mnt_monitor_get_fd),
+                        DLSYM_ARG(mnt_monitor_next_change),
+                        DLSYM_ARG(mnt_new_iter),
+                        DLSYM_ARG(mnt_new_monitor),
+                        DLSYM_ARG(mnt_new_table),
+                        DLSYM_ARG(mnt_optstr_get_flags),
+                        DLSYM_ARG(mnt_table_find_devno),
+                        DLSYM_ARG(mnt_table_find_target),
+                        DLSYM_ARG(mnt_table_next_child_fs),
+                        DLSYM_ARG(mnt_table_next_fs),
+                        DLSYM_ARG(mnt_table_parse_file),
+                        DLSYM_ARG(mnt_table_parse_mtab),
+                        DLSYM_ARG(mnt_table_parse_stream),
+                        DLSYM_ARG(mnt_table_parse_swaps),
+                        DLSYM_ARG(mnt_unref_monitor));
+#else
+        return log_full_errno(log_level, SYNTHETIC_ERRNO(EOPNOTSUPP),
+                              "libmount support is not compiled in.");
+#endif
 }

--- a/src/shared/libmount-util.h
+++ b/src/shared/libmount-util.h
@@ -42,8 +42,6 @@ extern DLSYM_PROTOTYPE(mnt_table_parse_stream);
 extern DLSYM_PROTOTYPE(mnt_table_parse_swaps);
 extern DLSYM_PROTOTYPE(mnt_unref_monitor);
 
-int dlopen_libmount(void);
-
 DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_RENAME(struct libmnt_table*, sym_mnt_free_table, mnt_free_tablep, NULL);
 DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_RENAME(struct libmnt_iter*, sym_mnt_free_iter, mnt_free_iterp, NULL);
 
@@ -79,9 +77,6 @@ int libmount_is_leaf(
 
 struct libmnt_monitor;
 
-static inline int dlopen_libmount(void) {
-        return -EOPNOTSUPP;
-}
 
 static inline void* sym_mnt_unref_monitor(struct libmnt_monitor *p) {
         assert(p == NULL);
@@ -89,3 +84,5 @@ static inline void* sym_mnt_unref_monitor(struct libmnt_monitor *p) {
 }
 
 #endif
+
+int dlopen_libmount(int log_level);

--- a/src/shared/meson.build
+++ b/src/shared/meson.build
@@ -3,6 +3,7 @@
 shared_sources = files(
         'acl-util.c',
         'acpi-fpdt.c',
+        'apparmor-util.c',
         'ask-password-agent.c',
         'ask-password-api.c',
         'async.c',
@@ -95,6 +96,7 @@ shared_sources = files(
         'hostname-setup.c',
         'hwdb-util.c',
         'id128-print.c',
+        'idn-util.c',
         'ima-util.c',
         'image-policy.c',
         'import-util.c',
@@ -117,6 +119,7 @@ shared_sources = files(
         'libaudit-util.c',
         'libcrypt-util.c',
         'libfido2-util.c',
+        'libmount-util.c',
         'local-addresses.c',
         'locale-setup.c',
         'log-assert-critical.c',
@@ -151,6 +154,7 @@ shared_sources = files(
         'osc-context.c',
         'output-mode.c',
         'pager.c',
+        'pam-util.c',
         'parse-argument.c',
         'parse-helpers.c',
         'password-quality-util-passwdqc.c',
@@ -282,22 +286,6 @@ endif
 
 if conf.get('HAVE_LIBBPF') == 1
         shared_sources += files('bpf-link.c')
-endif
-
-if conf.get('HAVE_PAM') == 1
-        shared_sources += files('pam-util.c')
-endif
-
-if conf.get('HAVE_LIBMOUNT') == 1
-        shared_sources += files('libmount-util.c')
-endif
-
-if conf.get('HAVE_LIBIDN2') == 1
-        shared_sources += files('idn-util.c')
-endif
-
-if conf.get('HAVE_APPARMOR') == 1
-        shared_sources += files('apparmor-util.c')
 endif
 
 generate_ip_protocol_list = files('generate-ip-protocol-list.sh')

--- a/src/shared/module-util.c
+++ b/src/shared/module-util.c
@@ -27,32 +27,6 @@ DLSYM_PROTOTYPE(kmod_set_log_fn) = NULL;
 DLSYM_PROTOTYPE(kmod_unref) = NULL;
 DLSYM_PROTOTYPE(kmod_validate_resources) = NULL;
 
-int dlopen_libkmod(void) {
-        SD_ELF_NOTE_DLOPEN(
-                        "kmod",
-                        "Support for loading kernel modules",
-                        SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED,
-                        "libkmod.so.2");
-
-        return dlopen_many_sym_or_warn(
-                        &libkmod_dl,
-                        "libkmod.so.2",
-                        LOG_DEBUG,
-                        DLSYM_ARG(kmod_list_next),
-                        DLSYM_ARG(kmod_load_resources),
-                        DLSYM_ARG(kmod_module_get_initstate),
-                        DLSYM_ARG(kmod_module_get_module),
-                        DLSYM_ARG(kmod_module_get_name),
-                        DLSYM_ARG(kmod_module_new_from_lookup),
-                        DLSYM_ARG(kmod_module_probe_insert_module),
-                        DLSYM_ARG(kmod_module_unref),
-                        DLSYM_ARG(kmod_module_unref_list),
-                        DLSYM_ARG(kmod_new),
-                        DLSYM_ARG(kmod_set_log_fn),
-                        DLSYM_ARG(kmod_unref),
-                        DLSYM_ARG(kmod_validate_resources));
-}
-
 static int parse_proc_cmdline_item(const char *key, const char *value, void *data) {
         char ***denylist = ASSERT_PTR(data);
         int r;
@@ -180,7 +154,7 @@ int module_setup_context(struct kmod_ctx **ret) {
 
         assert(ret);
 
-        r = dlopen_libkmod();
+        r = dlopen_libkmod(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -196,3 +170,34 @@ int module_setup_context(struct kmod_ctx **ret) {
 }
 
 #endif
+
+int dlopen_libkmod(int log_level) {
+#if HAVE_KMOD
+        SD_ELF_NOTE_DLOPEN(
+                        "kmod",
+                        "Support for loading kernel modules",
+                        SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED,
+                        "libkmod.so.2");
+
+        return dlopen_many_sym_or_warn(
+                        &libkmod_dl,
+                        "libkmod.so.2",
+                        log_level,
+                        DLSYM_ARG(kmod_list_next),
+                        DLSYM_ARG(kmod_load_resources),
+                        DLSYM_ARG(kmod_module_get_initstate),
+                        DLSYM_ARG(kmod_module_get_module),
+                        DLSYM_ARG(kmod_module_get_name),
+                        DLSYM_ARG(kmod_module_new_from_lookup),
+                        DLSYM_ARG(kmod_module_probe_insert_module),
+                        DLSYM_ARG(kmod_module_unref),
+                        DLSYM_ARG(kmod_module_unref_list),
+                        DLSYM_ARG(kmod_new),
+                        DLSYM_ARG(kmod_set_log_fn),
+                        DLSYM_ARG(kmod_unref),
+                        DLSYM_ARG(kmod_validate_resources));
+#else
+        return log_full_errno(log_level, SYNTHETIC_ERRNO(EOPNOTSUPP),
+                              "libkmod support is not compiled in.");
+#endif
+}

--- a/src/shared/module-util.h
+++ b/src/shared/module-util.h
@@ -23,8 +23,6 @@ extern DLSYM_PROTOTYPE(kmod_set_log_fn);
 extern DLSYM_PROTOTYPE(kmod_unref);
 extern DLSYM_PROTOTYPE(kmod_validate_resources);
 
-int dlopen_libkmod(void);
-
 DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_RENAME(struct kmod_ctx*, sym_kmod_unref, kmod_unrefp, NULL);
 DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_RENAME(struct kmod_module*, sym_kmod_module_unref, kmod_module_unrefp, NULL);
 DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_RENAME(struct kmod_list*, sym_kmod_module_unref_list, kmod_module_unref_listp, NULL);
@@ -41,9 +39,6 @@ int module_setup_context(struct kmod_ctx **ret);
 
 struct kmod_ctx;
 
-static inline int dlopen_libkmod(void) {
-        return -EOPNOTSUPP;
-}
 
 static inline int module_setup_context(struct kmod_ctx **ret) {
         return -EOPNOTSUPP;
@@ -54,3 +49,5 @@ static inline int module_load_and_warn(struct kmod_ctx *ctx, const char *module,
 }
 
 #endif
+
+int dlopen_libkmod(int log_level);

--- a/src/shared/mount-util.c
+++ b/src/shared/mount-util.c
@@ -451,7 +451,7 @@ int bind_remount_one_with_mountinfo(
 
         rewind(proc_self_mountinfo);
 
-        r = dlopen_libmount();
+        r = dlopen_libmount(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -900,7 +900,7 @@ int mount_option_mangle(
          * The validity of options stored in '*ret_remaining_options' is not checked.
          * If 'options' is NULL, this just copies 'mount_flags' to *ret_mount_flags. */
 
-        r = dlopen_libmount();
+        r = dlopen_libmount(LOG_DEBUG);
         if (r < 0)
                 return r;
 

--- a/src/shared/pam-util.c
+++ b/src/shared/pam-util.c
@@ -1,5 +1,10 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
+#include "log.h"
+#include "pam-util.h"
+
+#if HAVE_PAM
+
 #include <security/pam_ext.h>
 #include <syslog.h>
 
@@ -11,8 +16,6 @@
 #include "errno-util.h"
 #include "fd-util.h"
 #include "format-util.h"
-#include "log.h"
-#include "pam-util.h"
 #include "process-util.h"
 #include "stdio-util.h"
 #include "string-util.h"
@@ -34,34 +37,6 @@ DLSYM_PROTOTYPE(pam_start) = NULL;
 DLSYM_PROTOTYPE(pam_strerror) = NULL;
 DLSYM_PROTOTYPE(pam_syslog) = NULL;
 DLSYM_PROTOTYPE(pam_vsyslog) = NULL;
-
-int dlopen_libpam(void) {
-        SD_ELF_NOTE_DLOPEN(
-                        "pam",
-                        "Support for LinuxPAM",
-                        SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED,
-                        "libpam.so.0");
-
-        return dlopen_many_sym_or_warn(
-                        &libpam_dl,
-                        "libpam.so.0",
-                        LOG_DEBUG,
-                        DLSYM_ARG(pam_acct_mgmt),
-                        DLSYM_ARG(pam_close_session),
-                        DLSYM_ARG(pam_end),
-                        DLSYM_ARG(pam_get_data),
-                        DLSYM_ARG(pam_get_item),
-                        DLSYM_ARG(pam_getenvlist),
-                        DLSYM_ARG(pam_open_session),
-                        DLSYM_ARG(pam_putenv),
-                        DLSYM_ARG(pam_set_data),
-                        DLSYM_ARG(pam_set_item),
-                        DLSYM_ARG(pam_setcred),
-                        DLSYM_ARG(pam_start),
-                        DLSYM_ARG(pam_strerror),
-                        DLSYM_ARG(pam_syslog),
-                        DLSYM_ARG(pam_vsyslog));
-}
 
 void pam_log_setup(void) {
         /* Make sure we don't leak the syslog fd we open by opening/closing the fd each time. */
@@ -384,4 +359,39 @@ int pam_prompt_graceful(pam_handle_t *pamh, int style, char **ret_response, cons
                 *ret_response = TAKE_PTR(rr);
 
         return PAM_SUCCESS;
+}
+
+#endif
+
+int dlopen_libpam(int log_level) {
+#if HAVE_PAM
+        SD_ELF_NOTE_DLOPEN(
+                        "pam",
+                        "Support for LinuxPAM",
+                        SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED,
+                        "libpam.so.0");
+
+        return dlopen_many_sym_or_warn(
+                        &libpam_dl,
+                        "libpam.so.0",
+                        log_level,
+                        DLSYM_ARG(pam_acct_mgmt),
+                        DLSYM_ARG(pam_close_session),
+                        DLSYM_ARG(pam_end),
+                        DLSYM_ARG(pam_get_data),
+                        DLSYM_ARG(pam_get_item),
+                        DLSYM_ARG(pam_getenvlist),
+                        DLSYM_ARG(pam_open_session),
+                        DLSYM_ARG(pam_putenv),
+                        DLSYM_ARG(pam_set_data),
+                        DLSYM_ARG(pam_set_item),
+                        DLSYM_ARG(pam_setcred),
+                        DLSYM_ARG(pam_start),
+                        DLSYM_ARG(pam_strerror),
+                        DLSYM_ARG(pam_syslog),
+                        DLSYM_ARG(pam_vsyslog));
+#else
+        return log_full_errno(log_level, SYNTHETIC_ERRNO(EOPNOTSUPP),
+                              "libpam support is not compiled in.");
+#endif
 }

--- a/src/shared/pam-util.h
+++ b/src/shared/pam-util.h
@@ -27,8 +27,6 @@ extern DLSYM_PROTOTYPE(pam_strerror);
 extern DLSYM_PROTOTYPE(pam_syslog);
 extern DLSYM_PROTOTYPE(pam_vsyslog);
 
-int dlopen_libpam(void);
-
 void pam_log_setup(void);
 
 int errno_to_pam_error(int error) _const_;
@@ -92,10 +90,6 @@ int pam_get_data_many_internal(pam_handle_t *pamh, ...) _sentinel_;
 
 int pam_prompt_graceful(pam_handle_t *pamh, int style, char **ret_response, const char *fmt, ...) _printf_(4,5);
 
-#else
-
-static inline int dlopen_libpam(void) {
-        return -EOPNOTSUPP;
-}
-
 #endif
+
+int dlopen_libpam(int log_level);

--- a/src/shared/password-quality-util-passwdqc.c
+++ b/src/shared/password-quality-util-passwdqc.c
@@ -2,6 +2,9 @@
 
 #include "password-quality-util-passwdqc.h"
 
+#include "errno-util.h"          /* IWYU pragma: keep */
+#include "log.h"                 /* IWYU pragma: keep */
+
 #if HAVE_PASSWDQC
 
 #include <passwdqc.h>
@@ -10,8 +13,6 @@
 
 #include "alloc-util.h"
 #include "dlfcn-util.h"
-#include "errno-util.h"
-#include "log.h"
 #include "memory-util.h"
 #include "strv.h"
 
@@ -34,7 +35,7 @@ static int pwqc_allocate_context(passwdqc_params_t **ret) {
 
         assert(ret);
 
-        r = dlopen_passwdqc();
+        r = dlopen_passwdqc(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -137,7 +138,7 @@ int check_password_quality(
 
 #endif
 
-int dlopen_passwdqc(void) {
+int dlopen_passwdqc(int log_level) {
 #if HAVE_PASSWDQC
         SD_ELF_NOTE_DLOPEN(
                         "passwdqc",
@@ -146,7 +147,7 @@ int dlopen_passwdqc(void) {
                         "libpasswdqc.so.1");
 
         return dlopen_many_sym_or_warn(
-                        &passwdqc_dl, "libpasswdqc.so.1", LOG_DEBUG,
+                        &passwdqc_dl, "libpasswdqc.so.1", log_level,
                         DLSYM_ARG(passwdqc_params_reset),
                         DLSYM_ARG(passwdqc_params_load),
                         DLSYM_ARG(passwdqc_params_parse),
@@ -154,6 +155,7 @@ int dlopen_passwdqc(void) {
                         DLSYM_ARG(passwdqc_check),
                         DLSYM_ARG(passwdqc_random));
 #else
-        return -EOPNOTSUPP;
+        return log_full_errno(log_level, SYNTHETIC_ERRNO(EOPNOTSUPP),
+                              "libpasswdqc support is not compiled in.");
 #endif
 }

--- a/src/shared/password-quality-util-passwdqc.h
+++ b/src/shared/password-quality-util-passwdqc.h
@@ -8,4 +8,4 @@ int suggest_passwords(void);
 int check_password_quality(const char *password, const char *old, const char *username, char **ret_error);
 #endif
 
-int dlopen_passwdqc(void);
+int dlopen_passwdqc(int log_level);

--- a/src/shared/password-quality-util-pwquality.c
+++ b/src/shared/password-quality-util-pwquality.c
@@ -2,6 +2,9 @@
 
 #include "password-quality-util-pwquality.h"
 
+#include "errno-util.h"
+#include "log.h"
+
 #if HAVE_PWQUALITY
 
 #include <pwquality.h>
@@ -12,8 +15,6 @@
 
 #include "alloc-util.h"
 #include "dlfcn-util.h"
-#include "errno-util.h"
-#include "log.h"
 #include "password-quality-util.h"
 #include "string-util.h"
 #include "strv.h"
@@ -72,7 +73,7 @@ static int pwq_allocate_context(pwquality_settings_t **ret) {
 
         assert(ret);
 
-        r = dlopen_pwquality();
+        r = dlopen_pwquality(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -153,7 +154,7 @@ int check_password_quality(const char *password, const char *old, const char *us
 
 #endif
 
-int dlopen_pwquality(void) {
+int dlopen_pwquality(int log_level) {
 #if HAVE_PWQUALITY
         SD_ELF_NOTE_DLOPEN(
                         "pwquality",
@@ -162,7 +163,7 @@ int dlopen_pwquality(void) {
                         "libpwquality.so.1");
 
         return dlopen_many_sym_or_warn(
-                        &pwquality_dl, "libpwquality.so.1", LOG_DEBUG,
+                        &pwquality_dl, "libpwquality.so.1", log_level,
                         DLSYM_ARG(pwquality_check),
                         DLSYM_ARG(pwquality_default_settings),
                         DLSYM_ARG(pwquality_free_settings),
@@ -172,6 +173,7 @@ int dlopen_pwquality(void) {
                         DLSYM_ARG(pwquality_set_int_value),
                         DLSYM_ARG(pwquality_strerror));
 #else
-        return -EOPNOTSUPP;
+        return log_full_errno(log_level, SYNTHETIC_ERRNO(EOPNOTSUPP),
+                              "libpwquality support is not compiled in.");
 #endif
 }

--- a/src/shared/password-quality-util-pwquality.h
+++ b/src/shared/password-quality-util-pwquality.h
@@ -8,4 +8,4 @@ int suggest_passwords(void);
 int check_password_quality(const char *password, const char *old, const char *username, char **ret_error);
 #endif
 
-int dlopen_pwquality(void);
+int dlopen_pwquality(int log_level);

--- a/src/shared/pcre2-util.c
+++ b/src/shared/pcre2-util.c
@@ -28,7 +28,7 @@ DEFINE_HASH_OPS_WITH_KEY_DESTRUCTOR(
 const struct hash_ops pcre2_code_hash_ops_free = {};
 #endif
 
-int dlopen_pcre2(void) {
+int dlopen_pcre2(int log_level) {
 #if HAVE_PCRE2
         SD_ELF_NOTE_DLOPEN(
                         "pcre2",
@@ -45,7 +45,7 @@ int dlopen_pcre2(void) {
          * manually anymore. C is weird. 🤯 */
 
         return dlopen_many_sym_or_warn(
-                        &pcre2_dl, "libpcre2-8.so.0", LOG_ERR,
+                        &pcre2_dl, "libpcre2-8.so.0", log_level,
                         DLSYM_ARG(pcre2_match_data_create),
                         DLSYM_ARG(pcre2_match_data_free),
                         DLSYM_ARG(pcre2_code_free),
@@ -54,7 +54,8 @@ int dlopen_pcre2(void) {
                         DLSYM_ARG(pcre2_match),
                         DLSYM_ARG(pcre2_get_ovector_pointer));
 #else
-        return log_error_errno(SYNTHETIC_ERRNO(EOPNOTSUPP), "PCRE2 support is not compiled in.");
+        return log_full_errno(log_level, SYNTHETIC_ERRNO(EOPNOTSUPP),
+                              "PCRE2 support is not compiled in.");
 #endif
 }
 
@@ -67,7 +68,7 @@ int pattern_compile_and_log(const char *pattern, PatternCompileCase case_, pcre2
 
         assert(pattern);
 
-        r = dlopen_pcre2();
+        r = dlopen_pcre2(LOG_ERR);
         if (r < 0)
                 return r;
 

--- a/src/shared/pcre2-util.h
+++ b/src/shared/pcre2-util.h
@@ -44,4 +44,4 @@ typedef enum PatternCompileCase {
 int pattern_compile_and_log(const char *pattern, PatternCompileCase case_, pcre2_code **ret);
 int pattern_matches_and_log(pcre2_code *compiled_pattern, const char *message, size_t size, size_t *ret_ovec);
 
-int dlopen_pcre2(void);
+int dlopen_pcre2(int log_level);

--- a/src/shared/pcrextend-util.c
+++ b/src/shared/pcrextend-util.c
@@ -37,7 +37,7 @@ static int device_get_file_system_word(
         assert(ret);
 
 #if HAVE_BLKID
-        r = dlopen_libblkid();
+        r = dlopen_libblkid(LOG_DEBUG);
         if (r < 0)
                 return r;
 

--- a/src/shared/pkcs11-util.c
+++ b/src/shared/pkcs11-util.c
@@ -65,7 +65,7 @@ int uri_from_string(const char *p, P11KitUri **ret) {
         assert(p);
         assert(ret);
 
-        r = dlopen_p11kit();
+        r = dlopen_p11kit(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -85,7 +85,7 @@ P11KitUri *uri_from_module_info(const CK_INFO *info) {
 
         assert(info);
 
-        if (dlopen_p11kit() < 0)
+        if (dlopen_p11kit(LOG_DEBUG) < 0)
                 return NULL;
 
         uri = sym_p11_kit_uri_new();
@@ -101,7 +101,7 @@ P11KitUri *uri_from_slot_info(const CK_SLOT_INFO *slot_info) {
 
         assert(slot_info);
 
-        if (dlopen_p11kit() < 0)
+        if (dlopen_p11kit(LOG_DEBUG) < 0)
                 return NULL;
 
         uri = sym_p11_kit_uri_new();
@@ -117,7 +117,7 @@ P11KitUri *uri_from_token_info(const CK_TOKEN_INFO *token_info) {
 
         assert(token_info);
 
-        if (dlopen_p11kit() < 0)
+        if (dlopen_p11kit(LOG_DEBUG) < 0)
                 return NULL;
 
         uri = sym_p11_kit_uri_new();
@@ -221,7 +221,7 @@ int pkcs11_token_login_by_pin(
         assert(m);
         assert(token_info);
 
-        r = dlopen_p11kit();
+        r = dlopen_p11kit(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -283,7 +283,7 @@ int pkcs11_token_login(
         assert(m);
         assert(token_info);
 
-        r = dlopen_p11kit();
+        r = dlopen_p11kit(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -675,7 +675,7 @@ int pkcs11_token_read_x509_certificate(
 
         assert(ret_cert);
 
-        r = dlopen_p11kit();
+        r = dlopen_p11kit(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -1248,7 +1248,7 @@ int pkcs11_token_acquire_rng(
 
         assert(m);
 
-        r = dlopen_p11kit();
+        r = dlopen_p11kit(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -1334,7 +1334,7 @@ static int slot_process(
 
         assert(m);
 
-        r = dlopen_p11kit();
+        r = dlopen_p11kit(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -1417,7 +1417,7 @@ static int module_process(
 
         assert(m);
 
-        r = dlopen_p11kit();
+        r = dlopen_p11kit(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -1481,7 +1481,7 @@ int pkcs11_find_token(
         _cleanup_(p11_kit_uri_freep) P11KitUri *search_uri = NULL;
         int r;
 
-        r = dlopen_p11kit();
+        r = dlopen_p11kit(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -1740,7 +1740,7 @@ static int list_callback(
         assert(slot_info);
         assert(token_info);
 
-        r = dlopen_p11kit();
+        r = dlopen_p11kit(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -1784,7 +1784,7 @@ static int list_callback(
 }
 #endif
 
-int dlopen_p11kit(void) {
+int dlopen_p11kit(int log_level) {
 #if HAVE_P11KIT
         SD_ELF_NOTE_DLOPEN(
                         "p11-kit",
@@ -1794,7 +1794,7 @@ int dlopen_p11kit(void) {
 
         return dlopen_many_sym_or_warn(
                         &p11kit_dl,
-                        "libp11-kit.so.0", LOG_DEBUG,
+                        "libp11-kit.so.0", log_level,
                         DLSYM_ARG(p11_kit_module_get_name),
                         DLSYM_ARG(p11_kit_modules_finalize_and_release),
                         DLSYM_ARG(p11_kit_modules_load_and_initialize),
@@ -1812,7 +1812,8 @@ int dlopen_p11kit(void) {
                         DLSYM_ARG(p11_kit_uri_new),
                         DLSYM_ARG(p11_kit_uri_parse));
 #else
-        return log_error_errno(SYNTHETIC_ERRNO(EOPNOTSUPP), "p11kit support is not compiled in.");
+        return log_full_errno(log_level, SYNTHETIC_ERRNO(EOPNOTSUPP),
+                              "libp11-kit support is not compiled in.");
 #endif
 }
 
@@ -1858,7 +1859,7 @@ static int auto_callback(
         assert(slot_info);
         assert(token_info);
 
-        r = dlopen_p11kit();
+        r = dlopen_p11kit(LOG_DEBUG);
         if (r < 0)
                 return r;
 

--- a/src/shared/pkcs11-util.h
+++ b/src/shared/pkcs11-util.h
@@ -106,7 +106,7 @@ int pkcs11_crypt_device_callback(
 
 #endif
 
-int dlopen_p11kit(void);
+int dlopen_p11kit(int log_level);
 
 typedef struct {
         const char *friendly_name;

--- a/src/shared/qrcode-util.c
+++ b/src/shared/qrcode-util.c
@@ -28,7 +28,7 @@ static DLSYM_PROTOTYPE(QRcode_encodeString) = NULL;
 static DLSYM_PROTOTYPE(QRcode_free) = NULL;
 #endif
 
-int dlopen_qrencode(void) {
+int dlopen_qrencode(int log_level) {
 #if HAVE_QRENCODE
         int r;
 
@@ -40,7 +40,7 @@ int dlopen_qrencode(void) {
 
         FOREACH_STRING(s, "libqrencode.so.4", "libqrencode.so.3") {
                 r = dlopen_many_sym_or_warn(
-                        &qrcode_dl, s, LOG_DEBUG,
+                        &qrcode_dl, s, log_level,
                         DLSYM_ARG(QRcode_encodeString),
                         DLSYM_ARG(QRcode_free));
                 if (r >= 0)
@@ -49,7 +49,8 @@ int dlopen_qrencode(void) {
 
         return r;
 #else
-        return -EOPNOTSUPP;
+        return log_full_errno(log_level, SYNTHETIC_ERRNO(EOPNOTSUPP),
+                              "libqrencode support is not compiled in.");
 #endif
 }
 
@@ -210,7 +211,7 @@ int print_qrcode_full(
         if (check_tty && !colors_enabled())
                 return log_debug_errno(SYNTHETIC_ERRNO(EOPNOTSUPP), "Colors are disabled, cannot print qrcode");
 
-        r = dlopen_qrencode();
+        r = dlopen_qrencode(LOG_DEBUG);
         if (r < 0)
                 return r;
 

--- a/src/shared/qrcode-util.h
+++ b/src/shared/qrcode-util.h
@@ -13,7 +13,7 @@ int print_qrcode_full(
                 unsigned tty_height,
                 bool check_tty);
 
-int dlopen_qrencode(void);
+int dlopen_qrencode(int log_level);
 
 static inline int print_qrcode(FILE *out, const char *header, const char *string) {
         return print_qrcode_full(out, header, string, UINT_MAX, UINT_MAX, UINT_MAX, UINT_MAX, true);

--- a/src/shared/reread-partition-table.c
+++ b/src/shared/reread-partition-table.c
@@ -287,7 +287,7 @@ static int reread_partition_table_full(sd_device *dev, int fd, RereadPartitionTa
         }
 
 #if HAVE_BLKID
-        r = dlopen_libblkid();
+        r = dlopen_libblkid(LOG_DEBUG);
         if (ERRNO_IS_NEG_NOT_SUPPORTED(r)) {
                 log_device_debug(dev, "We don't have libblkid, falling back to BLKRRPART on '%s'.", p);
                 return fallback_ioctl(dev, fd, flags);

--- a/src/shared/seccomp-util.c
+++ b/src/shared/seccomp-util.c
@@ -50,32 +50,6 @@ DLSYM_PROTOTYPE(seccomp_rule_add_exact) = NULL;
 DLSYM_PROTOTYPE(seccomp_syscall_resolve_name) = NULL;
 DLSYM_PROTOTYPE(seccomp_syscall_resolve_num_arch) = NULL;
 
-int dlopen_libseccomp(void) {
-        SD_ELF_NOTE_DLOPEN(
-                        "seccomp",
-                        "Support for Seccomp Sandboxes",
-                        SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED,
-                        "libseccomp.so.2");
-
-        return dlopen_many_sym_or_warn(
-                        &libseccomp_dl,
-                        "libseccomp.so.2",
-                        LOG_DEBUG,
-                        DLSYM_ARG(seccomp_api_get),
-                        DLSYM_ARG(seccomp_arch_add),
-                        DLSYM_ARG(seccomp_arch_exist),
-                        DLSYM_ARG(seccomp_arch_native),
-                        DLSYM_ARG(seccomp_arch_remove),
-                        DLSYM_ARG(seccomp_attr_set),
-                        DLSYM_ARG(seccomp_init),
-                        DLSYM_ARG(seccomp_load),
-                        DLSYM_ARG(seccomp_release),
-                        DLSYM_ARG(seccomp_rule_add_array),
-                        DLSYM_ARG(seccomp_rule_add_exact),
-                        DLSYM_ARG(seccomp_syscall_resolve_name),
-                        DLSYM_ARG(seccomp_syscall_resolve_num_arch));
-}
-
 /* This array will be modified at runtime as seccomp_restrict_archs is called. */
 uint32_t seccomp_local_archs[] = {
 
@@ -283,7 +257,7 @@ int seccomp_init_for_arch(scmp_filter_ctx *ret, uint32_t arch, uint32_t default_
         /* Much like seccomp_init(), but initializes the filter for one specific architecture only, without affecting
          * any others. Also, turns off the NNP fiddling. */
 
-        r = dlopen_libseccomp();
+        r = dlopen_libseccomp(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -343,7 +317,7 @@ bool is_seccomp_available(void) {
         static int cached_enabled = -1;
 
         if (cached_enabled < 0) {
-                if (dlopen_libseccomp() < 0)
+                if (dlopen_libseccomp(LOG_DEBUG) < 0)
                         return (cached_enabled = false);
 
                 int b = secure_getenv_bool("SYSTEMD_SECCOMP");
@@ -1093,7 +1067,7 @@ int seccomp_add_syscall_filter_item(
         } else {
                 int id, r;
 
-                r = dlopen_libseccomp();
+                r = dlopen_libseccomp(LOG_DEBUG);
                 if (r < 0)
                         return r;
 
@@ -1173,7 +1147,7 @@ int seccomp_load_syscall_filter_set(uint32_t default_action, const SyscallFilter
         /* The one-stop solution: allocate a seccomp object, add the specified filter to it, and apply it. Once for
          * each local arch. */
 
-        r = dlopen_libseccomp();
+        r = dlopen_libseccomp(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -1239,7 +1213,7 @@ int seccomp_load_syscall_filter_set_raw(uint32_t default_action, Hashmap* filter
         if (hashmap_isempty(filter) && default_action == SCMP_ACT_ALLOW)
                 return 0;
 
-        r = dlopen_libseccomp();
+        r = dlopen_libseccomp(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -1362,7 +1336,7 @@ int seccomp_parse_syscall_filter(
         } else {
                 int id;
 
-                r = dlopen_libseccomp();
+                r = dlopen_libseccomp(LOG_DEBUG);
                 if (r < 0) {
                         if (!FLAGS_SET(flags, SECCOMP_PARSE_PERMISSIVE))
                                 return r;
@@ -1420,7 +1394,7 @@ int seccomp_restrict_namespaces(unsigned long retain) {
         if (FLAGS_SET(retain, NAMESPACE_FLAGS_ALL))
                 return 0;
 
-        r = dlopen_libseccomp();
+        r = dlopen_libseccomp(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -1548,7 +1522,7 @@ int seccomp_protect_sysctl(void) {
         uint32_t arch;
         int r;
 
-        r = dlopen_libseccomp();
+        r = dlopen_libseccomp(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -1600,7 +1574,7 @@ int seccomp_protect_syslog(void) {
         uint32_t arch;
         int r;
 
-        r = dlopen_libseccomp();
+        r = dlopen_libseccomp(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -1637,7 +1611,7 @@ int seccomp_restrict_address_families(Set *address_families, bool allow_list) {
         uint32_t arch;
         int r;
 
-        r = dlopen_libseccomp();
+        r = dlopen_libseccomp(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -1823,7 +1797,7 @@ int seccomp_restrict_realtime_full(int error_code) {
 
         assert(error_code > 0);
 
-        r = dlopen_libseccomp();
+        r = dlopen_libseccomp(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -1928,7 +1902,7 @@ int seccomp_memory_deny_write_execute(void) {
         unsigned loaded = 0;
         int r;
 
-        r = dlopen_libseccomp();
+        r = dlopen_libseccomp(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -2048,7 +2022,7 @@ int seccomp_restrict_archs(Set *archs) {
         int r;
         bool blocked_new = false;
 
-        r = dlopen_libseccomp();
+        r = dlopen_libseccomp(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -2141,7 +2115,7 @@ int seccomp_filter_set_add_by_name(Hashmap *filter, bool add, const char *name) 
         assert(filter);
         assert(name);
 
-        r = dlopen_libseccomp();
+        r = dlopen_libseccomp(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -2190,7 +2164,7 @@ int seccomp_lock_personality(unsigned long personality) {
         if (personality >= PERSONALITY_INVALID)
                 return -EINVAL;
 
-        r = dlopen_libseccomp();
+        r = dlopen_libseccomp(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -2228,7 +2202,7 @@ int seccomp_protect_hostname(void) {
         uint32_t arch;
         int r;
 
-        r = dlopen_libseccomp();
+        r = dlopen_libseccomp(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -2444,7 +2418,7 @@ int seccomp_restrict_suid_sgid(void) {
         uint32_t arch;
         int r, k;
 
-        r = dlopen_libseccomp();
+        r = dlopen_libseccomp(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -2571,7 +2545,7 @@ int seccomp_suppress_sync(void) {
          *
          * Additionally, O_SYNC/O_DSYNC are masked. */
 
-        r = dlopen_libseccomp();
+        r = dlopen_libseccomp(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -2627,6 +2601,37 @@ int seccomp_suppress_sync(void) {
 }
 
 #endif
+
+int dlopen_libseccomp(int log_level) {
+#if HAVE_SECCOMP
+        SD_ELF_NOTE_DLOPEN(
+                        "seccomp",
+                        "Support for Seccomp Sandboxes",
+                        SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED,
+                        "libseccomp.so.2");
+
+        return dlopen_many_sym_or_warn(
+                        &libseccomp_dl,
+                        "libseccomp.so.2",
+                        log_level,
+                        DLSYM_ARG(seccomp_api_get),
+                        DLSYM_ARG(seccomp_arch_add),
+                        DLSYM_ARG(seccomp_arch_exist),
+                        DLSYM_ARG(seccomp_arch_native),
+                        DLSYM_ARG(seccomp_arch_remove),
+                        DLSYM_ARG(seccomp_attr_set),
+                        DLSYM_ARG(seccomp_init),
+                        DLSYM_ARG(seccomp_load),
+                        DLSYM_ARG(seccomp_release),
+                        DLSYM_ARG(seccomp_rule_add_array),
+                        DLSYM_ARG(seccomp_rule_add_exact),
+                        DLSYM_ARG(seccomp_syscall_resolve_name),
+                        DLSYM_ARG(seccomp_syscall_resolve_num_arch));
+#else
+        return log_full_errno(log_level, SYNTHETIC_ERRNO(EOPNOTSUPP),
+                              "libseccomp support is not compiled in.");
+#endif
+}
 
 bool seccomp_errno_or_action_is_valid(int n) {
         return n == SECCOMP_ERROR_NUMBER_KILL || errno_is_valid(n);

--- a/src/shared/seccomp-util.h
+++ b/src/shared/seccomp-util.h
@@ -23,8 +23,6 @@ extern DLSYM_PROTOTYPE(seccomp_rule_add_exact);
 extern DLSYM_PROTOTYPE(seccomp_syscall_resolve_name);
 extern DLSYM_PROTOTYPE(seccomp_syscall_resolve_num_arch);
 
-int dlopen_libseccomp(void);
-
 DECLARE_STRING_TABLE_LOOKUP_TO_STRING(seccomp_arch, uint32_t);
 int seccomp_arch_from_string(const char *n, uint32_t *ret);
 
@@ -163,11 +161,10 @@ static inline bool is_seccomp_available(void) {
         return false;
 }
 
-static inline int dlopen_libseccomp(void) {
-        return -EOPNOTSUPP;
-}
 
 #endif
+
+int dlopen_libseccomp(int log_level);
 
 /* This is a special value to be used where syscall filters otherwise expect errno numbers, will be
    replaced with real seccomp action. */

--- a/src/shared/selinux-util.c
+++ b/src/shared/selinux-util.c
@@ -5,6 +5,8 @@
 #include <sys/stat.h>
 #include <syslog.h>
 
+#include "log.h"
+
 #if HAVE_SELINUX
 #include <malloc.h>
 #include <string.h>
@@ -20,7 +22,6 @@
 #include "alloc-util.h"
 #include "fd-util.h"
 #include "label.h"
-#include "log.h"
 #include "path-util.h"
 #include "string-util.h"
 #include "time-util.h"
@@ -90,8 +91,10 @@ DLSYM_PROTOTYPE(setfilecon_raw) = NULL;
 DLSYM_PROTOTYPE(setfscreatecon_raw) = NULL;
 DLSYM_PROTOTYPE(setsockcreatecon_raw) = NULL;
 DLSYM_PROTOTYPE(string_to_security_class) = NULL;
+#endif
 
-int dlopen_libselinux(void) {
+int dlopen_libselinux(int log_level) {
+#if HAVE_SELINUX
         SD_ELF_NOTE_DLOPEN(
                         "selinux",
                         "Support for SELinux",
@@ -101,7 +104,7 @@ int dlopen_libselinux(void) {
         return dlopen_many_sym_or_warn(
                         &libselinux_dl,
                         "libselinux.so.1",
-                        LOG_DEBUG,
+                        log_level,
                         DLSYM_ARG(avc_open),
                         DLSYM_ARG(context_free),
                         DLSYM_ARG(context_new),
@@ -136,13 +139,16 @@ int dlopen_libselinux(void) {
                         DLSYM_ARG(setfscreatecon_raw),
                         DLSYM_ARG(setsockcreatecon_raw),
                         DLSYM_ARG(string_to_security_class));
-}
+#else
+        return log_full_errno(log_level, SYNTHETIC_ERRNO(EOPNOTSUPP),
+                              "libselinux support is not compiled in.");
 #endif
+}
 
 bool mac_selinux_use(void) {
 #if HAVE_SELINUX
         if (_unlikely_(cached_use < 0)) {
-                if (dlopen_libselinux() < 0)
+                if (dlopen_libselinux(LOG_DEBUG) < 0)
                         return (cached_use = false);
 
                 cached_use = sym_is_selinux_enabled() > 0;
@@ -162,7 +168,7 @@ bool mac_selinux_enforcing(void) {
         /* If the SELinux status page has been successfully opened, retrieve the enforcing
          * status over it to avoid system calls in security_getenforce(). */
 
-        if (dlopen_libselinux() < 0)
+        if (dlopen_libselinux(LOG_DEBUG) < 0)
                 return false;
 
         if (have_status_page)
@@ -188,7 +194,7 @@ static int open_label_db(void) {
         struct mallinfo2 before_mallinfo = {};
         int r;
 
-        r = dlopen_libselinux();
+        r = dlopen_libselinux(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -302,7 +308,7 @@ void mac_selinux_maybe_reload(void) {
         if (!initialized)
                 return;
 
-        if (dlopen_libselinux() < 0)
+        if (dlopen_libselinux(LOG_DEBUG) < 0)
                 return;
 
         /* Do not use selinux_status_updated(3), cause since libselinux 3.2 selinux_check_access(3),
@@ -352,7 +358,7 @@ static int selinux_log_glue(int type, const char *fmt, ...) {
 void mac_selinux_disable_logging(void) {
 #if HAVE_SELINUX
         /* Turn off all of SELinux' own logging, we want to do that ourselves */
-        if (dlopen_libselinux() < 0)
+        if (dlopen_libselinux(LOG_DEBUG) < 0)
                 return;
 
         sym_selinux_set_callback(SELINUX_CB_LOG, (const union selinux_callback) { .func_log = selinux_log_glue });

--- a/src/shared/selinux-util.h
+++ b/src/shared/selinux-util.h
@@ -13,8 +13,6 @@
 
 #include "dlfcn-util.h"
 
-int dlopen_libselinux(void);
-
 extern DLSYM_PROTOTYPE(avc_open);
 extern DLSYM_PROTOTYPE(context_free);
 extern DLSYM_PROTOTYPE(context_new);
@@ -54,14 +52,13 @@ DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_RENAME(char*, sym_freecon, freeconp, NULL);
 
 #else
 
-static inline int dlopen_libselinux(void) {
-        return -EOPNOTSUPP;
-}
 
 static inline void freeconp(char **p) {
         assert(*p == NULL);
 }
 #endif
+
+int dlopen_libselinux(int log_level);
 
 #define _cleanup_freecon_ _cleanup_(freeconp)
 

--- a/src/shared/shift-uid.c
+++ b/src/shared/shift-uid.c
@@ -165,7 +165,7 @@ static int patch_acls(int fd, const char *name, const struct stat *st, uid_t shi
         if (!inode_type_can_acl(st->st_mode))
                 return 0;
 
-        r = dlopen_libacl();
+        r = dlopen_libacl(LOG_DEBUG);
         if (ERRNO_IS_NEG_NOT_SUPPORTED(r))
                 return 0;
         if (r < 0)

--- a/src/shared/tar-util.c
+++ b/src/shared/tar-util.c
@@ -511,11 +511,9 @@ static int archive_entry_read_acl(
         assert(c > 0);
 
 #if HAVE_ACL
-        r = dlopen_libacl();
-        if (r < 0) {
-                log_debug_errno(r, "Not restoring ACL data on inode as libacl is not available: %m");
+        r = dlopen_libacl(LOG_DEBUG);
+        if (r < 0)
                 return 0;
-        }
 
         _cleanup_(acl_freep) acl_t a = NULL;
         a = sym_acl_init(c);
@@ -1480,10 +1478,8 @@ static int archive_item(
 #if HAVE_ACL
         if (inode_type_can_acl(sx->stx_mode)) {
 
-                r = dlopen_libacl();
-                if (r < 0)
-                        log_debug_errno(r, "No trying to read ACL off inode, as libacl support is not available: %m");
-                else {
+                r = dlopen_libacl(LOG_DEBUG);
+                if (r >= 0) {
                         r = sym_acl_extended_file(FORMAT_PROC_FD_PATH(inode_fd));
                         if (r < 0 && !ERRNO_IS_NOT_SUPPORTED(errno))
                                 return log_error_errno(errno, "Failed check if '%s' has ACLs: %m", path);

--- a/src/shared/tpm2-util.c
+++ b/src/shared/tpm2-util.c
@@ -128,7 +128,7 @@ static DLSYM_PROTOTYPE(Tss2_MU_UINT32_Marshal) = NULL;
 
 static DLSYM_PROTOTYPE(Tss2_RC_Decode) = NULL;
 
-static int dlopen_tpm2_esys(void) {
+static int dlopen_tpm2_esys(int log_level) {
         int r;
 
         SD_ELF_NOTE_DLOPEN(
@@ -138,7 +138,7 @@ static int dlopen_tpm2_esys(void) {
                         "libtss2-esys.so.0");
 
         r = dlopen_many_sym_or_warn(
-                        &libtss2_esys_dl, "libtss2-esys.so.0", LOG_DEBUG,
+                        &libtss2_esys_dl, "libtss2-esys.so.0", log_level,
                         DLSYM_ARG(Esys_Create),
                         DLSYM_ARG(Esys_CreateLoaded),
                         DLSYM_ARG(Esys_CreatePrimary),
@@ -194,7 +194,7 @@ static int dlopen_tpm2_esys(void) {
         return 0;
 }
 
-static int dlopen_tpm2_rc(void) {
+static int dlopen_tpm2_rc(int log_level) {
         SD_ELF_NOTE_DLOPEN(
                         "tpm",
                         "Support for TPM",
@@ -202,11 +202,11 @@ static int dlopen_tpm2_rc(void) {
                         "libtss2-rc.so.0");
 
         return dlopen_many_sym_or_warn(
-                        &libtss2_rc_dl, "libtss2-rc.so.0", LOG_DEBUG,
+                        &libtss2_rc_dl, "libtss2-rc.so.0", log_level,
                         DLSYM_ARG(Tss2_RC_Decode));
 }
 
-static int dlopen_tpm2_mu(void) {
+static int dlopen_tpm2_mu(int log_level) {
         SD_ELF_NOTE_DLOPEN(
                         "tpm",
                         "Support for TPM",
@@ -214,7 +214,7 @@ static int dlopen_tpm2_mu(void) {
                         "libtss2-mu.so.0");
 
         return dlopen_many_sym_or_warn(
-                        &libtss2_mu_dl, "libtss2-mu.so.0", LOG_DEBUG,
+                        &libtss2_mu_dl, "libtss2-mu.so.0", log_level,
                         DLSYM_ARG(Tss2_MU_TPM2_CC_Marshal),
                         DLSYM_ARG(Tss2_MU_TPM2_HANDLE_Marshal),
                         DLSYM_ARG(Tss2_MU_TPM2B_DIGEST_Marshal),
@@ -236,7 +236,7 @@ static int dlopen_tpm2_mu(void) {
                         DLSYM_ARG(Tss2_MU_UINT32_Marshal));
 }
 
-static int dlopen_tpm2_tcti_device(void) {
+static int dlopen_tpm2_tcti_device(int log_level) {
         /* The "device" TCTI is the most relevant one, let's also load it explicitly on dlopen_tpm2(), even
          * if we don't resolve any symbols here. */
 
@@ -248,34 +248,36 @@ static int dlopen_tpm2_tcti_device(void) {
 
         return dlopen_verbose(
                         &libtss2_tcti_device_dl,
-                        "libtss2-tcti-device.so.0");
+                        "libtss2-tcti-device.so.0",
+                        log_level);
 }
 
 #endif
 
-int dlopen_tpm2(void) {
+int dlopen_tpm2(int log_level) {
 #if HAVE_TPM2
         int r;
 
-        r = dlopen_tpm2_esys();
+        r = dlopen_tpm2_esys(log_level);
         if (r < 0)
                 return r;
 
-        r = dlopen_tpm2_rc();
+        r = dlopen_tpm2_rc(log_level);
         if (r < 0)
                 return r;
 
-        r = dlopen_tpm2_mu();
+        r = dlopen_tpm2_mu(log_level);
         if (r < 0)
                 return r;
 
-        r = dlopen_tpm2_tcti_device();
+        r = dlopen_tpm2_tcti_device(log_level);
         if (r < 0)
                 return r;
 
         return 0;
 #else
-        return -EOPNOTSUPP;
+        return log_full_errno(log_level, SYNTHETIC_ERRNO(EOPNOTSUPP),
+                              "TPM2 support is not compiled in.");
 #endif
 }
 
@@ -874,9 +876,9 @@ int tpm2_context_new(const char *device, Tpm2Context **ret_context) {
                 .n_ref = 1,
         };
 
-        r = dlopen_tpm2();
+        r = dlopen_tpm2(LOG_DEBUG);
         if (r < 0)
-                return log_debug_errno(r, "TPM2 support not installed: %m");
+                return r;
 
         if (!device) {
                 device = secure_getenv("SYSTEMD_TPM2_DEVICE");
@@ -3524,9 +3526,9 @@ int tpm2_calculate_pubkey_name(const TPMT_PUBLIC *public, TPM2B_NAME *ret_name) 
         assert(public);
         assert(ret_name);
 
-        r = dlopen_tpm2();
+        r = dlopen_tpm2(LOG_DEBUG);
         if (r < 0)
-                return log_debug_errno(r, "TPM2 support not installed: %m");
+                return r;
 
         if (public->nameAlg != TPM2_ALG_SHA256)
                 return log_debug_errno(SYNTHETIC_ERRNO(EOPNOTSUPP),
@@ -3608,9 +3610,9 @@ int tpm2_calculate_nv_index_name(const TPMS_NV_PUBLIC *nvpublic, TPM2B_NAME *ret
         assert(nvpublic);
         assert(ret_name);
 
-        r = dlopen_tpm2();
+        r = dlopen_tpm2(LOG_DEBUG);
         if (r < 0)
-                return log_debug_errno(r, "TPM2 support not installed: %m");
+                return r;
 
         if (nvpublic->nameAlg != TPM2_ALG_SHA256)
                 return log_debug_errno(SYNTHETIC_ERRNO(EOPNOTSUPP),
@@ -3664,9 +3666,9 @@ int tpm2_calculate_policy_auth_value(TPM2B_DIGEST *digest) {
         assert(digest);
         assert(digest->size == SHA256_DIGEST_SIZE);
 
-        r = dlopen_tpm2();
+        r = dlopen_tpm2(LOG_DEBUG);
         if (r < 0)
-                return log_debug_errno(r, "TPM2 support not installed: %m");
+                return r;
 
         uint8_t buf[sizeof(command)];
         size_t offset = 0;
@@ -3725,9 +3727,9 @@ int tpm2_calculate_policy_signed(TPM2B_DIGEST *digest, const TPM2B_NAME *name) {
         assert(digest->size == SHA256_DIGEST_SIZE);
         assert(name);
 
-        r = dlopen_tpm2();
+        r = dlopen_tpm2(LOG_DEBUG);
         if (r < 0)
-                return log_debug_errno(r, "TPM2 support not installed: %m");
+                return r;
 
         uint8_t buf[sizeof(command)];
         size_t offset = 0;
@@ -3870,9 +3872,9 @@ int tpm2_calculate_policy_authorize_nv(
         assert(digest);
         assert(digest->size == SHA256_DIGEST_SIZE);
 
-        r = dlopen_tpm2();
+        r = dlopen_tpm2(LOG_DEBUG);
         if (r < 0)
-                return log_debug_errno(r, "TPM2 support not installed: %m");
+                return r;
 
         uint8_t buf[sizeof(command)];
         size_t offset = 0;
@@ -4005,9 +4007,9 @@ int tpm2_calculate_policy_or(const TPM2B_DIGEST *branches, size_t n_branches, TP
         if (n_branches > 8)
                 return -E2BIG;
 
-        r = dlopen_tpm2();
+        r = dlopen_tpm2(LOG_ERR);
         if (r < 0)
-                return log_error_errno(r, "TPM2 support not installed: %m");
+                return r;
 
         uint8_t buf[sizeof(command)];
         size_t offset = 0;
@@ -4060,9 +4062,9 @@ int tpm2_calculate_policy_pcr(
         assert(digest);
         assert(digest->size == SHA256_DIGEST_SIZE);
 
-        r = dlopen_tpm2();
+        r = dlopen_tpm2(LOG_DEBUG);
         if (r < 0)
-                return log_debug_errno(r, "TPM2 support not installed: %m");
+                return r;
 
         TPML_PCR_SELECTION pcr_selection;
         _cleanup_free_ TPM2B_DIGEST *values = NULL;
@@ -4152,9 +4154,9 @@ int tpm2_calculate_policy_authorize(
         assert(digest);
         assert(digest->size == SHA256_DIGEST_SIZE);
 
-        r = dlopen_tpm2();
+        r = dlopen_tpm2(LOG_DEBUG);
         if (r < 0)
-                return log_debug_errno(r, "TPM2 support not installed: %m");
+                return r;
 
         uint8_t buf[sizeof(command)];
         size_t offset = 0;
@@ -6528,9 +6530,9 @@ int tpm2_list_devices(bool legend, bool quiet) {
         _cleanup_closedir_ DIR *d = NULL;
         int r;
 
-        r = dlopen_tpm2();
+        r = dlopen_tpm2(LOG_ERR);
         if (r < 0)
-                return log_error_errno(r, "TPM2 support is not installed.");
+                return r;
 
         t = table_new("path", "device", "driver");
         if (!t)
@@ -6600,9 +6602,9 @@ int tpm2_find_device_auto(char **ret) {
         _cleanup_closedir_ DIR *d = NULL;
         int r;
 
-        r = dlopen_tpm2();
+        r = dlopen_tpm2(LOG_DEBUG);
         if (r < 0)
-                return log_debug_errno(r, "TPM2 support is not installed.");
+                return r;
 
         d = opendir("/sys/class/tpmrm");
         if (!d) {
@@ -8482,9 +8484,9 @@ int tpm2_load_public_key_file(const char *path, TPM2B_PUBLIC *ret) {
         assert(path);
         assert(ret);
 
-        r = dlopen_tpm2();
+        r = dlopen_tpm2(LOG_DEBUG);
         if (r < 0)
-                return log_debug_errno(r, "TPM2 support not installed: %m");
+                return r;
 
         r = read_full_file(path, &device_key_buffer, &device_key_buffer_size);
         if (r < 0)
@@ -9145,15 +9147,15 @@ Tpm2Support tpm2_support_full(Tpm2Support mask) {
         support |= TPM2_SUPPORT_SYSTEM;
 
         if ((mask & (TPM2_SUPPORT_LIBRARIES|TPM2_SUPPORT_LIBTSS2_ALL)) != 0) {
-                r = dlopen_tpm2_esys();
+                r = dlopen_tpm2_esys(LOG_DEBUG);
                 if (r >= 0)
                         support |= TPM2_SUPPORT_LIBTSS2_ESYS;
 
-                r = dlopen_tpm2_rc();
+                r = dlopen_tpm2_rc(LOG_DEBUG);
                 if (r >= 0)
                         support |= TPM2_SUPPORT_LIBTSS2_RC;
 
-                r = dlopen_tpm2_mu();
+                r = dlopen_tpm2_mu(LOG_DEBUG);
                 if (r >= 0)
                         support |= TPM2_SUPPORT_LIBTSS2_MU;
 

--- a/src/shared/tpm2-util.h
+++ b/src/shared/tpm2-util.h
@@ -39,7 +39,7 @@ static inline bool TPM2_PCR_MASK_VALID(uint32_t pcr_mask) {
 
 #define TPM2_N_HASH_ALGORITHMS 4U
 
-int dlopen_tpm2(void);
+int dlopen_tpm2(int log_level);
 
 #if HAVE_TPM2
 

--- a/src/shutdown/detach-swap.c
+++ b/src/shutdown/detach-swap.c
@@ -36,9 +36,9 @@ int swap_list_get(const char *swaps, SwapDevice **head) {
 
         assert(head);
 
-        r = dlopen_libmount();
+        r = dlopen_libmount(LOG_ERR);
         if (r < 0)
-                return log_error_errno(r, "Cannot enumerate swap partitions, no libmount support.");
+                return r;
 
         t = sym_mnt_new_table();
         i = sym_mnt_new_iter(MNT_ITER_FORWARD);

--- a/src/sysext/sysext.c
+++ b/src/sysext/sysext.c
@@ -565,7 +565,7 @@ static int unmerge(
         bool need_to_reload;
         int r;
 
-        (void) dlopen_libmount();
+        (void) dlopen_libmount(LOG_DEBUG);
 
         r = need_reload(image_class, hierarchies, no_reload);
         if (r < 0)
@@ -2373,9 +2373,9 @@ static int merge(ImageClass image_class,
 
         int r;
 
-        (void) dlopen_cryptsetup();
-        (void) dlopen_libblkid();
-        (void) dlopen_libmount();
+        (void) dlopen_cryptsetup(LOG_DEBUG);
+        (void) dlopen_libblkid(LOG_DEBUG);
+        (void) dlopen_libmount(LOG_DEBUG);
 
         _cleanup_(pidref_done) PidRef pidref = PIDREF_NULL;
         r = pidref_safe_fork("(sd-merge)", FORK_DEATHSIG_SIGTERM|FORK_LOG|FORK_NEW_MOUNTNS, &pidref);

--- a/src/sysupdate/sysupdate-partition.c
+++ b/src/sysupdate/sysupdate-partition.c
@@ -161,7 +161,7 @@ int find_suitable_partition(
         POINTER_MAY_BE_NULL(partition_type);
         assert(ret);
 
-        r = dlopen_fdisk();
+        r = dlopen_fdisk(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -230,7 +230,7 @@ int patch_partition(
         if (change == 0) /* Nothing to do */
                 return 0;
 
-        r = dlopen_fdisk();
+        r = dlopen_fdisk(LOG_DEBUG);
         if (r < 0)
                 return r;
 

--- a/src/sysupdate/sysupdate-resource.c
+++ b/src/sysupdate/sysupdate-resource.c
@@ -229,7 +229,7 @@ static int resource_load_from_blockdev(Resource *rr) {
 
         assert(rr);
 
-        r = dlopen_fdisk();
+        r = dlopen_fdisk(LOG_DEBUG);
         if (r < 0)
                 return r;
 

--- a/src/test/test-dlopen-so.c
+++ b/src/test/test-dlopen-so.c
@@ -29,12 +29,12 @@
 #include "tests.h"
 #include "tpm2-util.h"
 
-#define ASSERT_DLOPEN(func, cond)                               \
-        do {                                                    \
-                if (cond)                                       \
-                        ASSERT_OK(func());                      \
-                else                                            \
-                        ASSERT_ERROR(func(), EOPNOTSUPP);       \
+#define ASSERT_DLOPEN(func, cond)                                       \
+        do {                                                            \
+                if (cond)                                               \
+                        ASSERT_OK(func(LOG_DEBUG));                     \
+                else                                                    \
+                        ASSERT_ERROR(func(LOG_DEBUG), EOPNOTSUPP);      \
         } while (false)
 
 static int run(int argc, char **argv) {

--- a/src/test/test-execute.c
+++ b/src/test/test-execute.c
@@ -1633,7 +1633,7 @@ static int intro(void) {
         if (path_is_read_only_fs("/sys") > 0)
                 return log_tests_skipped("/sys is mounted read-only");
 
-        r = dlopen_libmount();
+        r = dlopen_libmount(LOG_DEBUG);
         if (r < 0)
                 return log_tests_skipped("libmount not available.");
 

--- a/src/test/test-kexec.c
+++ b/src/test/test-kexec.c
@@ -104,7 +104,7 @@ TEST(gzip_round_trip) {
                 gz_path[] = "/tmp/test-kexec-gz.XXXXXX";
         int r;
 
-        r = dlopen_zlib();
+        r = dlopen_zlib(LOG_DEBUG);
         if (r < 0) {
                 log_tests_skipped("zlib not available");
                 return;
@@ -144,7 +144,7 @@ TEST(zboot_synthetic) {
                 zboot_path[] = "/tmp/test-kexec-zboot.XXXXXX";
         int r;
 
-        r = dlopen_zlib();
+        r = dlopen_zlib(LOG_DEBUG);
         if (r < 0) {
                 log_tests_skipped("zlib not available");
                 return;

--- a/src/test/test-load-fragment.c
+++ b/src/test/test-load-fragment.c
@@ -972,7 +972,7 @@ TEST(config_parse_log_filter_patterns) {
                 TEST_PATTERN("~foobar", 0, 1),
         };
 
-        if (ERRNO_IS_NOT_SUPPORTED(dlopen_pcre2()))
+        if (ERRNO_IS_NOT_SUPPORTED(dlopen_pcre2(LOG_DEBUG)))
                 return (void) log_tests_skipped("PCRE2 support is not available");
 
         FOREACH_ELEMENT(test, regex_tests) {

--- a/src/test/test-namespace.c
+++ b/src/test/test-namespace.c
@@ -213,7 +213,7 @@ TEST(protect_kernel_logs) {
                 return;
         }
 
-        r = dlopen_libmount();
+        r = dlopen_libmount(LOG_DEBUG);
         if (ERRNO_IS_NEG_NOT_SUPPORTED(r)) {
                 (void) log_tests_skipped("libmount support not compiled in");
                 return;

--- a/src/test/test-netlink-manual.c
+++ b/src/test/test-netlink-manual.c
@@ -15,9 +15,9 @@ static int load_module(const char *mod_name) {
         struct kmod_list *l;
         int r;
 
-        r = dlopen_libkmod();
+        r = dlopen_libkmod(LOG_ERR);
         if (r < 0)
-                return log_error_errno(r, "Failed to load libkmod: %m");
+                return r;
 
         ctx = sym_kmod_new(NULL, NULL);
         if (!ctx)

--- a/src/tmpfiles/tmpfiles.c
+++ b/src/tmpfiles/tmpfiles.c
@@ -1247,7 +1247,7 @@ static int parse_acl_cond_exec(
         assert(cond_exec);
         assert(ret);
 
-        r = dlopen_libacl();
+        r = dlopen_libacl(LOG_DEBUG);
         if (r < 0)
                 return r;
 
@@ -1366,7 +1366,7 @@ static int path_set_acl(
 
         assert(c);
 
-        r = dlopen_libacl();
+        r = dlopen_libacl(LOG_DEBUG);
         if (r < 0)
                 return r;
 

--- a/src/udev/test-udev-rule-runner.c
+++ b/src/udev/test-udev-rule-runner.c
@@ -103,7 +103,7 @@ static int run(int argc, char *argv[]) {
 
         /* Let's make sure the test runs with selinux assumed disabled. */
 #if HAVE_SELINUX
-        if (dlopen_libselinux() >= 0)
+        if (dlopen_libselinux(LOG_DEBUG) >= 0)
                 sym_fini_selinuxmnt();
 #endif
         mac_selinux_retest();

--- a/src/udev/udev-builtin-blkid.c
+++ b/src/udev/udev-builtin-blkid.c
@@ -513,7 +513,7 @@ static int builtin_blkid(UdevEvent *event, int argc, char *argv[]) {
                 {}
         };
 
-        r = dlopen_libblkid();
+        r = dlopen_libblkid(LOG_DEBUG);
         if (r < 0)
                 return log_device_debug_errno(dev, r, "blkid not available: %m");
 

--- a/src/udev/udevd.c
+++ b/src/udev/udevd.c
@@ -58,11 +58,11 @@ int run_udevd(int argc, char *argv[]) {
                 return log_error_errno(r, "Failed to create /run/udev: %m");
 
         /* Load some shared libraries before we fork any workers */
-        (void) dlopen_libacl();
-        (void) dlopen_libblkid();
-        (void) dlopen_libkmod();
-        (void) dlopen_libmount();
-        (void) dlopen_tpm2();
+        (void) dlopen_libacl(LOG_DEBUG);
+        (void) dlopen_libblkid(LOG_DEBUG);
+        (void) dlopen_libkmod(LOG_DEBUG);
+        (void) dlopen_libmount(LOG_DEBUG);
+        (void) dlopen_tpm2(LOG_DEBUG);
 
         if (arg_daemonize) {
                 pid_t pid;

--- a/src/validatefs/validatefs.c
+++ b/src/validatefs/validatefs.c
@@ -291,9 +291,9 @@ static int validate_gpt_metadata_one(sd_device *d, const char *path, const Valid
         assert(d);
         assert(f);
 
-        r = dlopen_libblkid();
+        r = dlopen_libblkid(LOG_ERR);
         if (r < 0)
-                return log_error_errno(r, "Cannot validate GPT constraints, refusing.");
+                return r;
 
         _cleanup_close_ int block_fd = sd_device_open(d, O_RDONLY|O_CLOEXEC|O_NONBLOCK);
         if (block_fd < 0)


### PR DESCRIPTION
Every dlopen_xxx() helper now takes an int log_level argument. It is passed through to dlopen_many_sym_or_warn() (which in turn propagates it to dlopen_verbose() for the library-not-installed case), and is used by the fallback stub when support for the library is not compiled in to emit a "<lib> support is not compiled in." message at the caller's level. Callers pass LOG_DEBUG when gracefully degrading, or a higher level when the failure should surface, and no longer need to log redundantly at the call site.

As part of this, dlopen_bpf_full() (which already took a log_level) is merged into dlopen_bpf() rather than keeping both.

The static inline fallbacks used to live in the headers, which required pulling log.h in from every header that declared a dlopen_xxx(). Move them into the .c files instead: the declaration is always outside the #if HAVE_XXX block, the impl sits outside the outer #if HAVE_XXX wrap with its own internal #if HAVE_XXX/#else/#endif, and apparmor-util.c, idn-util.c, libmount-util.c and pam-util.c are now always compiled so they can host their stubs.