### PR TITLE
test: avoid using external commands in trap handlers

### DIFF
--- a/test/units/TEST-13-NSPAWN.machined.sh
+++ b/test/units/TEST-13-NSPAWN.machined.sh
@@ -44,21 +44,27 @@ set -x
 
 PID=0
 
-trap 'touch /terminate; kill 0' RTMIN+3
-trap 'touch /poweroff' RTMIN+4
-trap 'touch /reboot' INT
-trap 'touch /trap' TRAP
+# Use only builtins in trap handlers to avoid forking. External commands
+# (like touch) cause bash to enter wait_for() for the child, and a nested
+# signal arriving during that wait triggers a bash bug where
+# run_interrupt_trap() clears catch_flag while other traps are still
+# pending, creating an orphaned pending_traps[] entry that makes 'wait'
+# busy-loop indefinitely.
+trap ': >/terminate; kill 0' RTMIN+3
+trap ': >/poweroff' RTMIN+4
+trap ': >/reboot' INT
+trap ': >/trap' TRAP
 trap 'exit 0' TERM
 trap 'kill $PID' EXIT
 
 # We need to wait for the sleep process asynchronously in order to allow
 # bash to process signals
 sleep infinity &
+PID=$!
 
 # notify that the process is ready
-touch /ready
+: >/ready
 
-PID=$!
 while :; do
     wait || :
 done
@@ -332,11 +338,11 @@ trap 'kill $PID' EXIT
 # We need to wait for the sleep process asynchronously in order to allow
 # bash to process signals
 sleep infinity &
+PID=$!
 
 # notify that the process is ready
-touch /ready
+: >/ready
 
-PID=$!
 while :; do
     wait || :
 done


### PR DESCRIPTION
In #39675 the reported fail was as follows:
```
5580s [  247.559994] TEST-13-NSPAWN.sh[1858]: Exported 93%.
5580s [  247.659002] TEST-13-NSPAWN.sh[1858]: Exported 95%.
5580s [  247.785893] TEST-13-NSPAWN.sh[1858]: Operation completed successfully.
5580s [  247.923727] TEST-13-NSPAWN.sh[1858]: Exiting.
5580s [  258.300406] TEST-13-NSPAWN.sh[1074]: + machinectl import-raw /var/tmp/container-export.raw container-raw-reimport
5580s [  258.323328] TEST-13-NSPAWN.sh[1884]: The 'machinectl import-raw' command has been replaced by 'importctl -m import-raw'. Redirecting invocation.
5580s [  258.659982] TEST-13-NSPAWN.sh[1884]: Failed to transfer image: Remote peer disconnected
5580s [  258.734218] TEST-13-NSPAWN.sh[1074]: + at_exit
```
Turns out that the real reason behind this fail is that the machine was under heavy load due to a busy-loop from the stub init. The cause of this is a bug in bash, where running commands that fork (i.e. not built-ins) can cause a permanent busy-loop due to a desync in trap handling if you send the signals to the bash process _just right_:
```
[   90.855318] TEST-13-NSPAWN.sh[1074]: + machinectl poweroff long-running long-running long-running
[   90.855318] TEST-13-NSPAWN.sh[1074]: + machinectl reboot long-running long-running long-running
[   90.928980] systemd-nspawn[1679]: ++ touch /poweroff
[   90.928980] systemd-nspawn[1679]: +++ touch /reboot
[   90.928980] systemd-nspawn[1679]: + :
[   90.928980] systemd-nspawn[1679]: + :
[   90.928980] systemd-nspawn[1679]: + wait
[   90.928980] systemd-nspawn[1679]: + :
[   90.928980] systemd-nspawn[1679]: + :
[   90.928980] systemd-nspawn[1679]: + wait
[   90.928980] systemd-nspawn[1679]: + :
[   90.928980] systemd-nspawn[1679]: + :
[   90.928980] systemd-nspawn[1679]: + wait
...
```
```
$ journalctl --file TEST-13-NSPAWN-1.journal -o short-monotonic --no-hostname --grep "^\+ wait$" | wc -l
349734
```
So the stub-init was hammering the machine in a tight endless loop, which then caused systemd-importd to timeout when talking to D-Bus:
```
[  258.300096] TEST-13-NSPAWN.sh[1074]: + machinectl import-raw /var/tmp/container-export.raw container-raw-reimport ...
[  258.415319] systemd-importd[1859]: Unable to request name, failing connection: Method call timed out
[  258.483662] systemd-importd[1859]: Bus n/a: changing state RUNNING → CLOSING [  258.605442] systemd-importd[1859]: Bus n/a: changing state CLOSING → CLOSED
[  258.659958] TEST-13-NSPAWN.sh[1884]: Failed to transfer image: Remote peer disconnected
```
Given this is not our issue, let's work around it by using just built-ins from the trap handlers, which are not susceptible to this bug.

Resolves: #39675

---

A minimal reproducer for this issue is something like this:

```bash
#!/bin/bash

set -x

: "Leader: $$"

PID=0

trap 'echo RTMIN+3' RTMIN+3
trap 'echo RTMIN+4; sleep 1' RTMIN+4
trap 'echo INT' INT

sleep infinity &
PID=$!

while :; do
    wait "$PID" || :
done
```

If you run it and send it the signals in the right order, you get a busy loop:
```
$ PID=1801028; kill -RTMIN+4 $PID; sleep .1; kill -INT $PID; sleep .1; kill -RTMIN+3 $PID
$ head -n 30 log.txt 
+ : 'Leader: 1801028'
+ PID=0
+ trap 'echo RTMIN+3' RTMIN+3
+ trap 'echo RTMIN+4; sleep 1' RTMIN+4
+ trap 'echo INT' INT
+ PID=1801030
+ :
+ wait 1801030
+ sleep infinity
++ echo RTMIN+4
RTMIN+4
++ sleep 1
+++ echo INT
INT
+ :
+ :
+ wait 1801030
+ :
+ :
+ wait 1801030
+ :
+ :
+ wait 1801030
+ :
+ :
+ wait 1801030
+ :
+ :
+ wait 1801030
+ :
```

Now, if I understand this mayhem correctly, this happens if you call an external command from a trap handler and send signal1 + SIGINT + signal2, where signal1 > signal2, when bash is waiting for the external process to finish. Once the waited-for process exits, bash notices it got SIGINT in the meantime and calls `run_interrupt_trap()` which _unconditionally_ resets `catch_flag` to 0 even though we still have another signal in the queue. Once everything unwinds, bash goes back to processing `pending_traps[]` array in `run_pending_traps()` where it continues from the last position, and when the already processed signal (signal1) is > than the pending signal (signal2), it gets skipped and never processed, but still remains in the `pending_traps[]` queue. At this point, `run_pending_traps()` returns.

Now, when the `wait` builtin is called again, it calls `first_pending_trap()`, which returns the unprocessed signal2, so `wait_builtin()` returns immediately with 128+signal2. This calls `run_pending_traps()` again, but `catch_flag` is 0 (reset earlier in `run_interrupt_trap()` so it returns immediately without processing anything. So, the `wait` builtin is called again, calls `first_pending_trap()`, and the loop continues...

I'll try to report the issue to the bash issue tracker (once/if I actually understand it fully), but let's just work around it in the meantime.