### PR TITLE
gpt-auto-generator: do not fail on missing libcryptsetup when verity is not used

### DIFF
--- a/src/gpt-auto-generator/gpt-auto-generator.c
+++ b/src/gpt-auto-generator/gpt-auto-generator.c
@@ -295,8 +295,8 @@ static int add_veritysetup(
 
         return 0;
 #else
-        return log_error_errno(SYNTHETIC_ERRNO(EOPNOTSUPP),
-                               "Partition is Verity protected, but systemd-gpt-auto-generator was compiled without libcryptsetup support.");
+        log_warning("Compiled without libcryptsetup support, skipping verity setup for '%s'.", id);
+        return 0;
 #endif
 }
 #endif


### PR DESCRIPTION
add_veritysetup() is called unconditionally  from add_root_mount() and add_usr_mount() whenever in_initrd() is true, to generate units that only activate if verity devices appear. However, when compiled without libcryptsetup, this function returned a hard error, causing the entire generator to fail even when no verity protection is in use.

Change the #else fallback to log a warning message and return 0, matching the pattern already used by add_root_cryptsetup().

Fixes [41749](https://github.com/systemd/systemd/issues/41749)