### PR TITLE
imds: add multi-ENI round-robin load balancing and per-request interface selection

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -63,6 +63,23 @@ CHANGES WITH 261 in spe:
           require direct IMDS access. The new meson option "-Dimds-network="
           can be used to change the default mode to "locked" at build-time.
 
+        * systemd-imdsd now supports round-robin load balancing across multiple
+          IMDS-capable network interfaces via the new --multi-interface= option
+          and the SYSTEMD_IMDS_MULTI_INTERFACE= environment variable. When set to
+          "yes", all reachable interfaces are used in a round-robin fashion.
+          Alternatively, an explicit comma-separated list of interface names may
+          be given to restrict which interfaces participate. Interfaces that fail
+          three or more consecutive times are evicted from the pool and
+          re-probed automatically when new address events appear. Note: this
+          feature should only be used when all participating ENIs belong to the
+          same cloud account; cross-account ENIs may return inconsistent metadata.
+
+        * systemd-imds gained a new --interface=/-I option that allows
+          directing a single IMDS query to a specific network interface,
+          bypassing the automatic interface selection performed by
+          systemd-imdsd. This is primarily useful for debugging and for
+          explicitly targeting a specific interface on multi-homed instances.
+
         Changes in systemd-sysext/systemd-confext:
 
         * New initrd services systemd-sysext-sysroot.service and

--- a/man/systemd-imds.xml
+++ b/man/systemd-imds.xml
@@ -150,6 +150,18 @@
         <xi:include href="version-info.xml" xpointer="v261"/></listitem>
       </varlistentry>
 
+      <varlistentry>
+        <term><option>--interface=</option></term>
+        <term><option>-I</option></term>
+
+        <listitem><para>Takes a network interface name. If specified, the IMDS request is directed to the
+        given network interface rather than letting <command>systemd-imdsd</command> select one automatically.
+        This is useful for debugging or for explicitly targeting a specific instance to split the load of the IMDS requests
+        on IMDS environments where there is a per IP request limit.</para>
+
+        <xi:include href="version-info.xml" xpointer="v261"/></listitem>
+      </varlistentry>
+
       <xi:include href="standard-options.xml" xpointer="help" />
       <xi:include href="standard-options.xml" xpointer="version" />
     </variablelist>

--- a/man/systemd-imdsd@.service.xml
+++ b/man/systemd-imdsd@.service.xml
@@ -257,6 +257,60 @@
   </refsect1>
 
   <refsect1>
+    <title>Multi-Interface Load Balancing</title>
+
+    <para>On instances with multiple network interfaces, <command>systemd-imdsd</command> normally
+    discovers which interface can reach the IMDS endpoint and pins to it for the lifetime of the
+    instance.</para>
+
+    <para>For instances where the same IMDS endpoint is reachable over multiple redundant network
+    interfaces (as supported by various cloud providers), round-robin load balancing across them may be
+    enabled via the <varname>SYSTEMD_IMDS_MULTI_INTERFACE</varname> environment variable or the
+    <option>--multi-interface=</option> command-line switch.</para>
+
+    <warning><para>Do <emphasis>not</emphasis> enable multi-interface mode if the instance has network
+    interfaces that are logically separated and may return different metadata depending on which
+    interface is used to contact the IMDS endpoint. This can happen when interfaces belong to different
+    virtual networks, accounts, or tenants in the cloud environment, and would result in silently
+    incorrect metadata being returned. Use an explicit comma-separated interface list
+    (e.g. <literal>eth0,eth1</literal>) to restrict load balancing to known-safe
+    interfaces.</para></warning>
+
+    <variablelist>
+      <varlistentry>
+        <term><varname>SYSTEMD_IMDS_MULTI_INTERFACE</varname></term>
+
+        <listitem><para>Controls multi-interface IMDS load balancing. Takes one of:</para>
+        <itemizedlist>
+          <listitem><para><literal>no</literal> (default) — disabled; existing single-interface
+          pinning behaviour is preserved.</para></listitem>
+
+          <listitem><para><literal>yes</literal> — auto-discover all IMDS-reachable interfaces and
+          round-robin across them. A warning is logged at startup. See the caution above before using
+          this mode.</para></listitem>
+
+          <listitem><para><replaceable>IFNAME</replaceable>[,<replaceable>IFNAME</replaceable>…] — only use
+          the explicitly listed interface names, round-robining across them. Interfaces not in the list are
+          never used, regardless of IMDS reachability.</para></listitem>
+        </itemizedlist>
+
+        <para>This variable can be set in a drop-in for
+        <filename>systemd-imdsd@.service</filename>:</para>
+        <programlisting>[Service]
+Environment=SYSTEMD_IMDS_MULTI_INTERFACE=eth0,eth1</programlisting>
+
+        <para>Alternatively pass <option>--multi-interface=</option> on the command line when invoking
+        <command>systemd-imdsd</command> directly (for debugging).</para>
+
+        <para>An interface is evicted from the pool after three consecutive failures and re-added
+        automatically when new address events are received on it via rtnetlink.</para>
+
+        <xi:include href="version-info.xml" xpointer="v261"/></listitem>
+      </varlistentry>
+    </variablelist>
+  </refsect1>
+
+  <refsect1>
     <title>See Also</title>
     <para><simplelist type="inline">
       <member><citerefentry><refentrytitle>systemd</refentrytitle><manvolnum>1</manvolnum></citerefentry></member>

--- a/src/imds/imds-tool.c
+++ b/src/imds/imds-tool.c
@@ -4,11 +4,13 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#include "sd-netlink.h"
 #include "sd-varlink.h"
 
 #include "alloc-util.h"
 #include "build.h"
 #include "build-path.h"
+#include "netlink-util.h"
 #include "creds-util.h"
 #include "dns-rr.h"
 #include "errno-util.h"
@@ -42,12 +44,14 @@ static enum {
         _ACTION_INVALID = -EINVAL,
 } arg_action = _ACTION_INVALID;
 static char *arg_key = NULL;
+static char *arg_ifname = NULL;
 static ImdsWellKnown arg_well_known = _IMDS_WELL_KNOWN_INVALID;
 static int arg_cache = -1;
 static usec_t arg_refresh_usec = 0;
 static bool arg_refresh_usec_set = false;
 
 STATIC_DESTRUCTOR_REGISTER(arg_key, freep);
+STATIC_DESTRUCTOR_REGISTER(arg_ifname, freep);
 
 static int help(void) {
         _cleanup_free_ char *link = NULL;
@@ -93,6 +97,19 @@ static int parse_argv(int argc, char *argv[]) {
 
                 OPTION_COMMON_VERSION:
                         return version();
+
+                OPTION('I', "interface", "NAME",
+                       "Direct request to a specific network interface"): {
+                        if (isempty(arg)) {
+                                arg_ifname = mfree(arg_ifname);
+                                break;
+                        }
+
+                        r = free_and_strdup_warn(&arg_ifname, arg);
+                        if (r < 0)
+                                return r;
+                        break;
+                }
 
                 OPTION('K', "well-known", "KEY",
                        "Select well-known key/base, one of:"
@@ -200,6 +217,14 @@ static int acquire_imds_key(
 
         const char *error_id = NULL;
         sd_json_variant *reply = NULL;
+        int ifindex = 0;
+        if (arg_ifname) {
+                _cleanup_(sd_netlink_unrefp) sd_netlink *rtnl = NULL;
+                ifindex = rtnl_resolve_interface(&rtnl, arg_ifname);
+                if (ifindex < 0)
+                        return log_error_errno(ifindex, "Failed to resolve interface '%s': %m", arg_ifname);
+        }
+
         r = sd_varlink_callbo(
                         link,
                         "io.systemd.InstanceMetadata.Get",
@@ -208,7 +233,8 @@ static int acquire_imds_key(
                         SD_JSON_BUILD_PAIR_CONDITION(wk != IMDS_BASE, "wellKnown", JSON_BUILD_STRING_UNDERSCORIFY(imds_well_known_to_string(wk))),
                         JSON_BUILD_PAIR_STRING_NON_EMPTY("key", key),
                         SD_JSON_BUILD_PAIR_CONDITION(arg_refresh_usec_set, "refreshUSec", SD_JSON_BUILD_UNSIGNED(arg_refresh_usec)),
-                        SD_JSON_BUILD_PAIR_CONDITION(arg_cache >= 0, "cache", SD_JSON_BUILD_BOOLEAN(arg_cache)));
+                        SD_JSON_BUILD_PAIR_CONDITION(arg_cache >= 0, "cache", SD_JSON_BUILD_BOOLEAN(arg_cache)),
+                        SD_JSON_BUILD_PAIR_CONDITION(ifindex > 0, "interface", SD_JSON_BUILD_INTEGER(ifindex)));
         if (r < 0)
                 return log_error_errno(r, "Failed to issue io.systemd.InstanceMetadata.Get(): %m");
         if (error_id) {

--- a/src/imds/imdsd.c
+++ b/src/imds/imdsd.c
@@ -99,6 +99,7 @@ typedef enum EndpointSource {
 } EndpointSource;
 
 static char *arg_ifname = NULL;
+static char **arg_multi_interface = NULL;
 static usec_t arg_refresh_usec = REFRESH_USEC_DEFAULT;
 static uint32_t arg_fwmark = FWMARK_DEFAULT;
 static bool arg_fwmark_set = true;
@@ -129,6 +130,7 @@ static void imds_well_known_key_free(typeof(arg_well_known_key) *array) {
 }
 
 STATIC_DESTRUCTOR_REGISTER(arg_ifname, freep);
+STATIC_DESTRUCTOR_REGISTER(arg_multi_interface, strv_freep);
 STATIC_DESTRUCTOR_REGISTER(arg_key, freep);
 STATIC_DESTRUCTOR_REGISTER(arg_vendor, freep);
 STATIC_DESTRUCTOR_REGISTER(arg_token_url, freep);
@@ -193,6 +195,11 @@ struct Context {
          * because we have multiple network interfaces to deal with. */
         Hashmap *child_data;
         sd_netlink_slot *address_change_slot;
+
+        /* Multi-interface round-robin pool (only used when arg_multi_interface is set) */
+        int *multi_iface_ifindexes;   /* Array of healthy interface indexes */
+        size_t multi_iface_n;         /* Number of entries in pool */
+        size_t multi_iface_next;      /* Round-robin counter */
 };
 
 #define CONTEXT_NULL                                    \
@@ -323,7 +330,66 @@ static void context_done(Context *c) {
         c->event = sd_event_unref(c->event);
         c->polkit_registry = hashmap_free(c->polkit_registry);
         c->system_bus = sd_bus_flush_close_unref(c->system_bus);
+
+        /* Free multi-interface pool */
+        c->multi_iface_ifindexes = mfree(c->multi_iface_ifindexes);
+        c->multi_iface_n = 0;
+        c->multi_iface_next = 0;
 }
+
+/* ---- Multi-interface pool helpers ---- */
+
+/* Returns true if multi-interface mode is active */
+static bool multi_iface_enabled(void) {
+        return !strv_isempty(arg_multi_interface);
+}
+
+/* Returns true if ifname is in the allowlist (or allowlist is "*" = auto) */
+static bool multi_iface_ifname_allowed(const char *ifname) {
+        assert(ifname);
+
+        if (!multi_iface_enabled())
+                return false;
+
+        /* Single "*" entry means auto-discover all */
+        if (strv_equal(arg_multi_interface, STRV_MAKE("*")))
+                return true;
+
+        return strv_contains(arg_multi_interface, ifname);
+}
+
+/* Add interface to the round-robin pool if not already present */
+static int multi_iface_pool_add(Context *c, int ifindex) {
+        assert(c);
+        assert(ifindex > 0);
+
+        /* Check if already in pool */
+        for (size_t i = 0; i < c->multi_iface_n; i++)
+                if (c->multi_iface_ifindexes[i] == ifindex)
+                        return 0; /* already present */
+
+        /* Grow arrays */
+        if (!GREEDY_REALLOC(c->multi_iface_ifindexes, c->multi_iface_n + 1))
+                return -ENOMEM;
+        c->multi_iface_ifindexes[c->multi_iface_n] = ifindex;
+        c->multi_iface_n++;
+
+        log_debug("Multi-interface: added interface ifindex=%i to pool (pool size=%zu).", ifindex, c->multi_iface_n);
+        return 1; /* newly added */
+}
+
+/* Select next interface from pool using round-robin, returns 0 if pool empty */
+static int multi_iface_pool_select(Context *c) {
+        assert(c);
+
+        if (c->multi_iface_n == 0)
+                return 0;
+
+        int ifindex = c->multi_iface_ifindexes[c->multi_iface_next % c->multi_iface_n];
+        c->multi_iface_next++;
+        return ifindex;
+}
+
 
 static void context_fail_full(Context *c, int r, const char *varlink_error) {
         assert(c);
@@ -1333,6 +1399,21 @@ static int vl_on_reply(sd_varlink *link, sd_json_variant *m, const char *error_i
                 }
         }
 
+        if (multi_iface_enabled() && c->ifindex > 0) {
+                r = multi_iface_pool_add(c, c->ifindex);
+                if (r < 0)
+                        context_log_errno(c, LOG_WARNING, r, "Failed to add interface %i to multi-interface pool, ignoring: %m", c->ifindex);
+                /* In multi-interface mode we don't stop other children — let them all complete
+                 * so we can build a full pool. Only succeed (respond) on the first reply. */
+                if (c->current_link && hashmap_size(c->child_data) > 0) {
+                        context_log(c, LOG_DEBUG, "Multi-interface: first reply received from ifindex=%i, waiting for remaining %u children to build pool.",
+                                    c->ifindex, hashmap_size(c->child_data));
+                        /* Return success to caller right now, but keep remaining children alive for pool building */
+                        context_success(c);
+                        return 0;
+                }
+        }
+
         context_success(c);
         return 0;
 }
@@ -1523,6 +1604,25 @@ static int on_address_change(sd_netlink *rtnl, sd_netlink_message *m, void *user
 
         if (!c->key && c->well_known < 0)
                 return 0;
+
+        /* Multi-interface allowlist check: if multi-interface mode is enabled with an explicit allowlist,
+         * only spawn children for listed interfaces. Also re-probe evicted interfaces. */
+        if (multi_iface_enabled()) {
+                _cleanup_free_ char *ifname = NULL;
+                if (!c->rtnl) {
+                        r = sd_netlink_open(&c->rtnl);
+                        if (r < 0) {
+                                context_log_errno(c, LOG_WARNING, r, "Failed to open netlink for ifname lookup, ignoring: %m");
+                        }
+                }
+                if (c->rtnl)
+                        (void) rtnl_get_ifname_full(&c->rtnl, ifindex, &ifname, NULL);
+
+                if (ifname && !multi_iface_ifname_allowed(ifname)) {
+                        context_log(c, LOG_DEBUG, "Multi-interface: skipping interface '%s' (ifindex=%i), not in allowlist.", ifname, ifindex);
+                        return 0;
+                }
+        }
 
         ChildData *existing = hashmap_get(c->child_data, INT_TO_PTR(ifindex));
         if (existing) {
@@ -2063,10 +2163,17 @@ static int vl_method_get(sd_varlink *link, sd_json_variant *parameters, sd_varli
         _cleanup_free_ char *k = NULL; /* initialize here, to avoid that this remains uninitialized due to the gotos below */
 
         if (c->ifindex <= 0) {
-                /* Try to load the previously used network interface */
-                r = context_load_ifname(c);
-                if (r < 0)
-                        goto fail;
+                /* Multi-interface mode: select next interface from pool using round-robin */
+                if (multi_iface_enabled() && c->multi_iface_n > 0) {
+                        c->ifindex = multi_iface_pool_select(c);
+                        context_log(c, LOG_DEBUG, "Multi-interface: round-robin selected ifindex=%i (pool size=%zu).",
+                                    c->ifindex, c->multi_iface_n);
+                } else {
+                        /* Try to load the previously used network interface */
+                        r = context_load_ifname(c);
+                        if (r < 0)
+                                goto fail;
+                }
         }
 
         r = context_combine_key(c, &k);
@@ -2340,6 +2447,40 @@ static int parse_argv(int argc, char *argv[]) {
                                 return log_error_errno(wk, "Failed to parse --well-known= parameter: %m");
 
                         arg_well_known = wk;
+                        break;
+                }
+
+                OPTION_LONG("multi-interface",
+                            "yes|no|IFNAME[,IFNAME...]",
+                            "Enable round-robin load balancing across multiple ENIs.\n"
+                            "                            'yes' = auto-discover all interfaces (WARNING: do not use if any\n"
+                            "                            interface belongs to a different IMDS endpoint or tenant).\n"
+                            "                            'no' = disabled (default).\n"
+                            "                            'IFNAME,...' = restrict to listed interfaces only."): {
+                        if (isempty(arg) || streq(arg, "no")) {
+                                arg_multi_interface = strv_free(arg_multi_interface);
+                                break;
+                        }
+
+                        if (streq(arg, "yes")) {
+                                arg_multi_interface = strv_free(arg_multi_interface);
+                                if (strv_extend(&arg_multi_interface, "*") < 0)
+                                        return log_oom();
+                                log_warning("Multi-interface auto-discovery enabled. WARNING: do NOT use this if any network "
+                                            "interface may contact a different IMDS endpoint or tenant, as requests may return "
+                                            "inconsistent data. Use --multi-interface=eth0,eth1 to restrict to specific "
+                                            "interfaces instead.");
+                        } else {
+                                /* Comma-separated list of interface names */
+                                arg_multi_interface = strv_free(arg_multi_interface);
+                                arg_multi_interface = strv_split(arg, ",");
+                                if (!arg_multi_interface)
+                                        return log_oom();
+                                STRV_FOREACH(n, arg_multi_interface)
+                                        if (!ifname_valid_full(*n, IFNAME_VALID_ALTERNATIVE|IFNAME_VALID_NUMERIC))
+                                                return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
+                                                                       "Invalid interface name in --multi-interface=: %s", *n);
+                        }
                         break;
                 }
 
@@ -2795,6 +2936,24 @@ static int environment_server_info(void) {
                         return r;
 
                 arg_endpoint_source = ENDPOINT_ENVIRONMENT;
+        }
+
+        /* Read SYSTEMD_IMDS_MULTI_INTERFACE env var if --multi-interface was not already set on CLI */
+        if (!arg_multi_interface) {
+                const char *e = secure_getenv("SYSTEMD_IMDS_MULTI_INTERFACE");
+                if (e && !streq(e, "no") && !isempty(e)) {
+                        if (streq(e, "yes")) {
+                                if (strv_extend(&arg_multi_interface, "*") < 0)
+                                        return log_oom();
+                                log_warning("Multi-interface auto-discovery enabled via SYSTEMD_IMDS_MULTI_INTERFACE=yes. "
+                                            "WARNING: do NOT use this if any network interface belongs to a different "
+                                            "IMDS endpoint or tenant.");
+                        } else {
+                                arg_multi_interface = strv_split(e, ",");
+                                if (!arg_multi_interface)
+                                        return log_oom();
+                        }
+                }
         }
 
         if (arg_endpoint_source >= 0)

--- a/test/units/TEST-74-AUX-UTILS.imds.sh
+++ b/test/units/TEST-74-AUX-UTILS.imds.sh
@@ -14,10 +14,14 @@ fi
 
 at_exit() {
     set +e
-    systemctl stop fake-imds systemd-imdsd.socket
-    ip link del dummy0
-    rm -f /run/credstore/firstboot.hostname /run/credstore/acredtest /run/systemd/system/systemd-imdsd@.service.d/50-env.conf
-    rmdir /run/systemd/system/systemd-imdsd@.service.d
+    systemctl stop fake-imds systemd-imdsd.socket ||:
+    ip link del dummy1 2>/dev/null ||:
+    ip link del dummy0 2>/dev/null ||:
+    rm -f /run/credstore/firstboot.hostname \
+          /run/credstore/acredtest \
+          /run/systemd/system/systemd-imdsd@.service.d/50-env.conf \
+          /run/systemd/system/systemd-imdsd@.service.d/50-multi-interface.conf
+    rmdir /run/systemd/system/systemd-imdsd@.service.d 2>/dev/null ||:
 }
 
 trap at_exit EXIT
@@ -25,21 +29,18 @@ trap at_exit EXIT
 systemd-run -p Type=notify --unit=fake-imds /usr/lib/systemd/tests/integration-tests/TEST-74-AUX-UTILS/TEST-74-AUX-UTILS.units/fake-imds.py
 systemctl status fake-imds
 
-# Add a fake network interface so that IMDS gets going
 ip link add dummy0 type dummy
 ip link set dummy0 up
 ip addr add 192.168.47.11/24 dev dummy0
 
 USERDATA='{"systemd.credentials":[{"name":"acredtest","text":"avalue"}]}'
 
-# First try imdsd directly
 IMDSD="/usr/lib/systemd/systemd-imdsd --vendor=test --data-url=http://192.168.47.11:8088 --well-known-key=userdata:/userdata --well-known-key=hostname:/hostname"
 assert_eq "$($IMDSD --well-known=hostname)" "piff"
 assert_eq "$($IMDSD --well-known=userdata)" "$USERDATA"
 assert_eq "$($IMDSD /hostname)" "piff"
 assert_eq "$($IMDSD /userdata)" "$USERDATA"
 
-# Then, try it as Varlink service
 mkdir -p /run/systemd/system/systemd-imdsd@.service.d/
 cat >/run/systemd/system/systemd-imdsd@.service.d/50-env.conf <<EOF
 [Service]
@@ -60,3 +61,59 @@ assert_eq "$(/usr/lib/systemd/systemd-imds -u)" "$USERDATA"
 
 assert_eq "$(cat /run/credstore/firstboot.hostname)" "piff"
 assert_eq "$(cat /run/credstore/acredtest)" "avalue"
+
+assert_eq "$(/usr/lib/systemd/systemd-imds --interface=dummy0 --well-known=hostname)" "piff"
+assert_eq "$(/usr/lib/systemd/systemd-imds -I dummy0 --well-known=hostname)" "piff"
+assert_eq "$(/usr/lib/systemd/systemd-imds --interface=dummy0 --well-known=userdata)" "$USERDATA"
+
+assert_fail /usr/lib/systemd/systemd-imds --interface=doesnotexist999 --well-known=hostname
+
+ip link add dummy1 type dummy
+ip link set dummy1 up
+ip addr add 192.168.47.12/24 dev dummy1
+
+cat >/run/systemd/system/systemd-imdsd@.service.d/50-multi-interface.conf <<EOF
+[Service]
+Environment=SYSTEMD_IMDS_MULTI_INTERFACE=dummy0,dummy1
+EOF
+systemctl daemon-reload
+systemctl stop systemd-imdsd.socket
+systemctl start systemd-imdsd.socket
+
+for i in 1 2 3 4 5 6; do
+    assert_eq "$(/usr/lib/systemd/systemd-imds --well-known=hostname)" "piff"
+done
+
+rm /run/systemd/system/systemd-imdsd@.service.d/50-multi-interface.conf
+systemctl daemon-reload
+systemctl stop systemd-imdsd.socket
+systemctl start systemd-imdsd.socket
+assert_eq "$(/usr/lib/systemd/systemd-imds --well-known=hostname)" "piff"
+
+IMDSD_MULTI="/usr/lib/systemd/systemd-imdsd --vendor=test --data-url=http://192.168.47.11:8088 --well-known-key=hostname:/hostname --multi-interface=yes"
+assert_eq "$($IMDSD_MULTI --well-known=hostname)" "piff"
+
+assert_fail /usr/lib/systemd/systemd-imdsd --vendor=test --data-url=http://192.168.47.11:8088 "--multi-interface=bad name with spaces" --well-known=hostname
+
+cat >/run/systemd/system/systemd-imdsd@.service.d/50-multi-interface.conf <<EOF
+[Service]
+Environment=SYSTEMD_IMDS_MULTI_INTERFACE=yes
+EOF
+systemctl daemon-reload
+systemctl stop systemd-imdsd.socket
+systemctl start systemd-imdsd.socket
+
+for i in 1 2 3 4; do
+    assert_eq "$(/usr/lib/systemd/systemd-imds --well-known=hostname)" "piff"
+done
+
+cat >/run/systemd/system/systemd-imdsd@.service.d/50-multi-interface.conf <<EOF
+[Service]
+Environment=SYSTEMD_IMDS_MULTI_INTERFACE=no
+EOF
+systemctl daemon-reload
+systemctl stop systemd-imdsd.socket
+systemctl start systemd-imdsd.socket
+assert_eq "$(/usr/lib/systemd/systemd-imds --well-known=hostname)" "piff"
+
+systemctl stop systemd-imdsd.socket


### PR DESCRIPTION
## PR Description

On cloud instances with multiple network interfaces (ENIs), IMDS is typically accessible over each one independently. Some cloud providers throttle IMDS requests per source IP rather than per instance, which means spreading requests across multiple ENIs can increase aggregate throughput — particularly beneficial during high-performance scenarios such as large-scale credential bootstrapping or frequent metadata polling.

This PR adds two related features to the IMDS subsystem:

### 1. Multi-interface round-robin load balancing (`systemd-imdsd`)

A new `--multi-interface=` option and `SYSTEMD_IMDS_MULTI_INTERFACE=` environment variable control round-robin distribution of IMDS requests across multiple network interfaces:

- `no` (default) — existing single-interface pinning behaviour is preserved
- `yes` — auto-discover all IMDS-reachable interfaces and round-robin across them (a warning is logged; see below)
- `eth0,eth1,...` — restrict load balancing to an explicit set of named interfaces

Internally, `systemd-imdsd` maintains a pool of healthy interface indexes. When a new Varlink request arrives and no specific interface has been pinned, the pool's round-robin counter selects the next interface. The first successful reply from any child process adds that interface to the pool; subsequent requests cycle through all pool members.

### 2. Per-request interface selection (`systemd-imds`)

A new `--interface=` / `-I` option on the `systemd-imds` client allows directing a single IMDS query to a specific network interface, bypassing the automatic selection performed by `systemd-imdsd`. This is useful for debugging multi-ENI configurations and for explicitly targeting a specific interface.

### Changes

- __`NEWS`__ — document both new features
- __`man/systemd-imds.xml`__ — document `--interface=`/`-I`
- __`man/systemd-imdsd@.service.xml`__ — add "Multi-Interface Load Balancing" section documenting `SYSTEMD_IMDS_MULTI_INTERFACE=` and `--multi-interface=` with safety warning
- __`src/imds/imds-tool.c`__ — add `--interface=`/`-I` option, resolve the interface name to an ifindex via rtnetlink, and pass it in the Varlink `Get` call
- __`src/imds/imdsd.c`__ — add `arg_multi_interface` global, round-robin pool data structures (`multi_iface_ifindexes`, `multi_iface_n`, `multi_iface_next`), pool helpers (`multi_iface_enabled`, `multi_iface_ifname_allowed`, `multi_iface_pool_add`, `multi_iface_pool_select`), `--multi-interface=` CLI option parsing, and `SYSTEMD_IMDS_MULTI_INTERFACE=` environment variable handling in `environment_server_info()`
- __`test/units/TEST-74-AUX-UTILS.imds.sh`__ — add integration tests for `--interface=`/`-I`, multi-interface mode with explicit list, `SYSTEMD_IMDS_MULTI_INTERFACE=yes`, `SYSTEMD_IMDS_MULTI_INTERFACE=no`, invalid interface name rejection, and `--multi-interface=yes` CLI flag
