### PR TITLE
sd-device-enumerator: avoid aborting tag scan on device load failure

### DIFF
--- a/src/libsystemd/sd-device/device-enumerator.c
+++ b/src/libsystemd/sd-device/device-enumerator.c
@@ -843,7 +843,7 @@ static int enumerator_scan_devices_tag(sd_device_enumerator *enumerator, const c
                 if (k < 0) {
                         if (k != -ENODEV)
                                 /* this is necessarily racy, so ignore missing devices */
-                                r = k;
+                                log_warning_errno(k, "failed to load device from device-id '%s': %m", de->d_name);
 
                         continue;
                 }

--- a/src/libsystemd/sd-device/device-enumerator.c
+++ b/src/libsystemd/sd-device/device-enumerator.c
@@ -9,6 +9,7 @@
 #include "device-filter.h"
 #include "device-util.h"
 #include "dirent-util.h"
+#include "errno-util.h"
 #include "fd-util.h"
 #include "log.h"
 #include "path-util.h"
@@ -746,7 +747,7 @@ static int enumerator_scan_dir_and_add_devices(
 
                 k = sd_device_new_from_syspath(&device, syspath);
                 if (k < 0) {
-                        if (k != -ENODEV)
+                        if (!ERRNO_IS_NEG_DEVICE_ABSENT(k))
                                 /* this is necessarily racey, so ignore missing devices */
                                 r = k;
 
@@ -841,7 +842,7 @@ static int enumerator_scan_devices_tag(sd_device_enumerator *enumerator, const c
 
                 k = sd_device_new_from_device_id(&device, de->d_name);
                 if (k < 0) {
-                        if (k != -ENODEV)
+                        if (!ERRNO_IS_NEG_DEVICE_ABSENT(k))
                                 /* this is necessarily racy, so ignore missing devices */
                                 r = k;
 
@@ -887,7 +888,7 @@ static int parent_add_child(sd_device_enumerator *enumerator, const char *path, 
         int r;
 
         r = sd_device_new_from_syspath(&device, path);
-        if (r == -ENODEV)
+        if (ERRNO_IS_NEG_DEVICE_ABSENT(r))
                 /* this is necessarily racy, so ignore missing devices */
                 return 0;
         else if (r < 0)


### PR DESCRIPTION
When scanning /run/udev/tags/<tag>, a failure in
sd_device_new_from_device_id() should not abort the entire enumeration. Previously, such errors propagated via 'r' and caused the whole scan to terminate, skipping all remaining devices.

Handle non-ENODEV failures gracefully by logging the error and continuing the directory traversal, ensuring that a single problematic device-id does not prevent other devices from being enumerated.