### PR TITLE
localed-util: respect env var when writing vconsole.conf

### DIFF
--- a/src/locale/localed-util.c
+++ b/src/locale/localed-util.c
@@ -319,7 +319,7 @@ int vconsole_write_data(Context *c) {
                 return 0;
         }
 
-        r = write_vconsole_conf(AT_FDCWD, "/etc/vconsole.conf", l);
+        r = write_vconsole_conf(AT_FDCWD, etc_vconsole_conf(), l);
         if (r < 0)
                 return r;
 


### PR DESCRIPTION
Adjusted localed-util vconsole_write_data() to respect the vconsole.conf value determined by `etc_vconsole_conf()`, instead of writing to hard-coded `/etc/vconsole.conf`.

Simple change, perhaps this was overlooked before? 