### PR TITLE
mkosi: trim verity.sig json files to remove NUL padding before passing to jq

### DIFF
--- a/mkosi/mkosi.pkgenv/mkosi.conf.d/debian-ubuntu.conf
+++ b/mkosi/mkosi.pkgenv/mkosi.conf.d/debian-ubuntu.conf
@@ -9,5 +9,5 @@ Environment=
         GIT_URL=https://salsa.debian.org/systemd-team/systemd.git
         GIT_SUBDIR=debian
         GIT_BRANCH=debian/master
-        GIT_COMMIT=23ef56be0050f78be704f288ed1ce30ace47cbfe
+        GIT_COMMIT=94af257c72ac3e9bf20e324ff31c3bd5d8197f0e
         PKG_SUBDIR=debian

--- a/mkosi/mkosi.postinst.chroot
+++ b/mkosi/mkosi.postinst.chroot
@@ -27,8 +27,9 @@ mountpoint -q /etc/resolv.conf && umount /etc/resolv.conf
 rm -f /etc/resolv.conf
 
 for f in "$BUILDROOT"/usr/share/*.verity.sig; do
-    jq --join-output '.rootHash' "$f" >"${f%.verity.sig}.roothash"
-    jq --join-output '.signature' "$f" | base64 --decode >"${f%.verity.sig}.roothash.p7s"
+    # jq started refusing input with NUL bytes padding
+    strings "$f" | jq --join-output '.rootHash' >"${f%.verity.sig}.roothash"
+    strings "$f" | jq --join-output '.signature' | base64 --decode >"${f%.verity.sig}.roothash.p7s"
 done
 
 # We want /var/log/journal to be created on first boot so it can be created with the right chattr settings by


### PR DESCRIPTION
jq started rejecting input that has NUL bytes to fix some security issues,
so we need to trim the verity.sig json files, which are spat out with
the NUL bytes padding from the GPT partition content.

```
‣  Running postinstall script /home/runner/work/systemd/systemd/mkosi/mkosi.postinst.chroot…
jq: parse error: Invalid numeric literal at EOF at line 1, column 16384
‣ "/work/postinst final" returned non-zero exit code 5.
```

https://github.com/jqlang/jq/commit/6374ae0bcdfe33a18eb0ae6db28493b1f34a0a5b