### PR TITLE
oomctl: add missing assert flagged by coccinelle

### DIFF
--- a/src/oom/oomctl.c
+++ b/src/oom/oomctl.c
@@ -89,6 +89,7 @@ static int verb_dump_state(int argc, char *argv[], uintptr_t _data, void *userda
 static int parse_argv(int argc, char *argv[], char ***ret_args) {
         assert(argc >= 0);
         assert(argv);
+        assert(ret_args);
 
         OptionParser state = { argc, argv };
         const char *arg;


### PR DESCRIPTION
```
FAIL: check-pointer-deref.cocci found issues in /home/runner/work/systemd/systemd/src/oom/: diff -u -p /home/runner/work/systemd/systemd/src/oom/oomctl.c /tmp/nothing/oomctl.c --- /home/runner/work/systemd/systemd/src/oom/oomctl.c +++ /tmp/nothing/oomctl.c
@@ -107,7 +107,6 @@ static int parse_argv(int argc, char *ar
                         break;
                 }

-        *ret_args = option_parser_get_args(&state);
         return 1;
 }

Coccinelle check(s) failed. For each flagged dereference, either:
  - Add assert(param)/ASSERT_PTR(param) at the top of the function (if the parameter must not be NULL)
  - Add an if (param) guard before the dereference (if NULL is valid)
  - Add POINTER_MAY_BE_NULL(param) if NULL is okay for param
```

Follow-up for 143af68ee15607aced66e9f5aba55899b3f4e505