### PR TITLE
util-linux: Drop required version back to v2.27.1

### DIFF
--- a/README
+++ b/README
@@ -264,9 +264,9 @@ REQUIREMENTS:
         During runtime, you need the following additional
         dependencies:
 
-        util-linux >= v2.41 required (including but not limited to: mount,
-                                      umount, swapon, swapoff, sulogin,
-                                      agetty, fsck)
+        util-linux >= v2.27.1 required (including but not limited to: mount,
+                                        umount, swapon, swapoff, sulogin,
+                                        agetty, fsck)
         dbus >= 1.4.0 (strictly speaking optional, but recommended)
                 NOTE: If using dbus < 1.9.18, you should override the default
                 policy directory (--with-dbuspolicydir=/etc/dbus-1/system.d).


### PR DESCRIPTION
It was bumped in a40d93400759c8eb46a2ec8702735bde2333812a but this is hardly load bearing stuff so let's document the version we actually require rather than the version that makes a hardly load bearing feature work properly, especially since v2.41 is extremely new and requiring distributions to have that is just unrealistic.

This doesn't actually change anything materially except documentation, but it keeps us honest about depending on stuff from newer util-linux because we happen to document reliance on an extremely new version.