### PR TITLE
resolved: add options for bypassing hook queries

### DIFF
--- a/man/nss-resolve.xml
+++ b/man/nss-resolve.xml
@@ -152,6 +152,19 @@
         <xi:include href="version-info.xml" xpointer="v260"/></listitem>
       </varlistentry>
     </variablelist>
+
+    <variablelist class='environment-variables'>
+      <varlistentry>
+        <term><varname>$SYSTEMD_NSS_RESOLVE_HOOKS</varname></term>
+
+        <listitem><para>Takes a boolean argument. When false, answers will be returned without querying
+        systemd-resolved hooks.
+        <citerefentry><refentrytitle>systemd-resolved</refentrytitle><manvolnum>8</manvolnum></citerefentry>.
+        </para>
+
+        <xi:include href="version-info.xml" xpointer="v261"/></listitem>
+      </varlistentry>
+    </variablelist>
   </refsect1>
 
   <refsect1>

--- a/man/nss-resolve.xml
+++ b/man/nss-resolve.xml
@@ -152,6 +152,19 @@
         <xi:include href="version-info.xml" xpointer="v260"/></listitem>
       </varlistentry>
     </variablelist>
+
+    <variablelist class='environment-variables'>
+      <varlistentry>
+        <term><varname>$SYSTEMD_NSS_RESOLVE_HOOKS</varname></term>
+
+        <listitem><para>Takes a boolean argument. When false, answers will be returned without querying
+        <citerefentry><refentrytitle>systemd-resolved</refentrytitle><manvolnum>8</manvolnum></citerefentry>
+        hooks.
+        </para>
+
+        <xi:include href="version-info.xml" xpointer="v261"/></listitem>
+      </varlistentry>
+    </variablelist>
   </refsect1>
 
   <refsect1>

--- a/man/resolvectl.xml
+++ b/man/resolvectl.xml
@@ -438,6 +438,17 @@
       </varlistentry>
 
       <varlistentry>
+        <term><option>--hooks=<replaceable>BOOL</replaceable></option></term>
+
+        <listitem><para>Takes a boolean parameter; used in conjunction with <command>query</command>.
+        If true (the default), lookups are sent to local services that implement
+        <filename>io.systemd.Resolve.Hook</filename> before querying the network.
+        If false, hooks are bypassed for this request.</para>
+
+        <xi:include href="version-info.xml" xpointer="v261"/></listitem>
+      </varlistentry>
+
+      <varlistentry>
         <term><option>--search=<replaceable>BOOL</replaceable></option></term>
 
         <listitem><para>Takes a boolean parameter. If true (the default), any specified single-label

--- a/man/resolved.conf.xml
+++ b/man/resolved.conf.xml
@@ -429,6 +429,16 @@ DNSStubListenerExtra=udp:[2001:db8:0:f102::13]:9953</programlisting>
         <xi:include href="version-info.xml" xpointer="v254"/>
         </listitem>
       </varlistentry>
+
+      <varlistentry>
+        <term><varname>QueryHooks=</varname></term>
+        <listitem><para>Takes a boolean argument. If <literal>yes</literal> (the default),
+        <command>systemd-resolved</command> will query hooks, i.e. local services that implement
+        <filename>io.systemd.Resolve.Hook</filename>, when handling local name resolultion requests.
+        </para>
+
+        <xi:include href="version-info.xml" xpointer="v261"/></listitem>
+      </varlistentry>
     </variablelist>
   </refsect1>
 

--- a/man/resolved.conf.xml
+++ b/man/resolved.conf.xml
@@ -429,6 +429,17 @@ DNSStubListenerExtra=udp:[2001:db8:0:f102::13]:9953</programlisting>
         <xi:include href="version-info.xml" xpointer="v254"/>
         </listitem>
       </varlistentry>
+
+      <varlistentry>
+        <term><varname>QueryHooks=</varname></term>
+        <listitem><para>Takes a boolean argument. If <literal>yes</literal> (the default),
+        <command>systemd-resolved</command> will query hooks, i.e. local services that implement
+        <filename>io.systemd.Resolve.Hook</filename>, when handling local name resolution requests.
+        If <literal>no</literal>, the hooks will be bypassed for all requests.
+        </para>
+
+        <xi:include href="version-info.xml" xpointer="v261"/></listitem>
+      </varlistentry>
     </variablelist>
   </refsect1>
 

--- a/shell-completion/bash/resolvectl
+++ b/shell-completion/bash/resolvectl
@@ -38,7 +38,8 @@ _resolvectl() {
         [STANDALONE]='-h --help --version -4 -6 --legend=no --cname=no
                       --validate=no --synthesize=no --cache=no --relax-single-label=no --zone=no
                       --trust-anchor=no --network=no --service-address=no
-                      --service-txt=no --search=no --stale-data=no --no-pager --no-ask-password'
+                      --service-txt=no --search=no --stale-data=no --no-pager --no-ask-password
+                      --hooks=no'
         [ARG]='-t --type -c --class -i --interface -p --protocol --raw --json'
     )
     local -A VERBS=(

--- a/shell-completion/zsh/_resolvectl
+++ b/shell-completion/zsh/_resolvectl
@@ -91,6 +91,7 @@ _arguments \
     '--zone=[Do not allow response from locally registered mDNS/LLMNR records]:BOOL:(yes no)' \
     '--trust-anchor=[Do not allow response from local trust anchor]:BOOL:(yes no)' \
     '--network=[Do not allow response from network]:BOOL:(yes no)' \
+    '--hooks=[Do not query hooks]:BOOL:(yes no)' \
     '--search=[Do not use search domains]:BOOL:(yes no)' \
     '--raw=[Dump the answer as binary data]:RAW:(payload packet)' \
     '--json=[Output as JSON]:JSON:(pretty short off)' \

--- a/src/nss-resolve/nss-resolve.c
+++ b/src/nss-resolve/nss-resolve.c
@@ -188,7 +188,8 @@ static uint64_t query_flags(void) {
                 query_flag("SYSTEMD_NSS_RESOLVE_CACHE", 0, SD_RESOLVED_NO_CACHE) |
                 query_flag("SYSTEMD_NSS_RESOLVE_ZONE", 0, SD_RESOLVED_NO_ZONE) |
                 query_flag("SYSTEMD_NSS_RESOLVE_TRUST_ANCHOR", 0, SD_RESOLVED_NO_TRUST_ANCHOR) |
-                query_flag("SYSTEMD_NSS_RESOLVE_NETWORK", 0, SD_RESOLVED_NO_NETWORK);
+                query_flag("SYSTEMD_NSS_RESOLVE_NETWORK", 0, SD_RESOLVED_NO_NETWORK) |
+                query_flag("SYSTEMD_NSS_RESOLVE_HOOKS", 0, SD_RESOLVED_NO_HOOKS);
 }
 
 static int query_ifindex(void) {

--- a/src/resolve/resolvectl.c
+++ b/src/resolve/resolvectl.c
@@ -3642,6 +3642,7 @@ static int native_parse_argv(int argc, char *argv[]) {
                 ARG_JSON,
                 ARG_STALE_DATA,
                 ARG_RELAX_SINGLE_LABEL,
+                ARG_HOOKS,
         };
 
         static const struct option options[] = {
@@ -3668,6 +3669,7 @@ static int native_parse_argv(int argc, char *argv[]) {
                 { "json",                  required_argument, NULL, ARG_JSON                  },
                 { "stale-data",            required_argument, NULL, ARG_STALE_DATA            },
                 { "relax-single-label",    required_argument, NULL, ARG_RELAX_SINGLE_LABEL    },
+                { "hooks",                 required_argument, NULL, ARG_HOOKS                 },
                 {}
         };
 
@@ -3878,6 +3880,13 @@ static int native_parse_argv(int argc, char *argv[]) {
 
                 case 'j':
                         arg_json_format_flags = SD_JSON_FORMAT_PRETTY_AUTO|SD_JSON_FORMAT_COLOR_AUTO;
+                        break;
+
+                case ARG_HOOKS:
+                        r = parse_boolean_argument("--hooks=", optarg, NULL);
+                        if (r < 0)
+                                return r;
+                        SET_FLAG(arg_flags, SD_RESOLVED_NO_HOOKS, r == 0);
                         break;
 
                 case '?':

--- a/src/resolve/resolvectl.c
+++ b/src/resolve/resolvectl.c
@@ -3285,6 +3285,7 @@ static int native_help(void) {
                "     --trust-anchor=BOOL       Allow response from local trust anchor (default:\n"
                "                               yes)\n"
                "     --network=BOOL            Allow response from network (default: yes)\n"
+               "     --hooks=BOOL              Allow response from hooks (default: yes)\n"
                "     --search=BOOL             Use search domains for single-label names (default:\n"
                "                               yes)\n"
                "     --raw[=payload|packet]    Dump the answer as binary data\n"
@@ -3642,6 +3643,7 @@ static int native_parse_argv(int argc, char *argv[]) {
                 ARG_JSON,
                 ARG_STALE_DATA,
                 ARG_RELAX_SINGLE_LABEL,
+                ARG_HOOKS,
         };
 
         static const struct option options[] = {
@@ -3668,6 +3670,7 @@ static int native_parse_argv(int argc, char *argv[]) {
                 { "json",                  required_argument, NULL, ARG_JSON                  },
                 { "stale-data",            required_argument, NULL, ARG_STALE_DATA            },
                 { "relax-single-label",    required_argument, NULL, ARG_RELAX_SINGLE_LABEL    },
+                { "hooks",                 required_argument, NULL, ARG_HOOKS                 },
                 {}
         };
 
@@ -3878,6 +3881,13 @@ static int native_parse_argv(int argc, char *argv[]) {
 
                 case 'j':
                         arg_json_format_flags = SD_JSON_FORMAT_PRETTY_AUTO|SD_JSON_FORMAT_COLOR_AUTO;
+                        break;
+
+                case ARG_HOOKS:
+                        r = parse_boolean_argument("--hooks=", optarg, NULL);
+                        if (r < 0)
+                                return r;
+                        SET_FLAG(arg_flags, SD_RESOLVED_NO_HOOKS, r == 0);
                         break;
 
                 case '?':

--- a/src/resolve/resolved-dns-query.c
+++ b/src/resolve/resolved-dns-query.c
@@ -1630,6 +1630,7 @@ int validate_and_mangle_query_flags(
                        SD_RESOLVED_NO_NETWORK|
                        SD_RESOLVED_NO_STALE|
                        SD_RESOLVED_RELAX_SINGLE_LABEL|
+                       SD_RESOLVED_NO_HOOKS|
                        ok))
                 return -EINVAL;
 

--- a/src/resolve/resolved-gperf.gperf
+++ b/src/resolve/resolved-gperf.gperf
@@ -37,3 +37,4 @@ Resolve.DNSStubListenerExtra,      config_parse_dns_stub_listener_extra, 0,     
 Resolve.CacheFromLocalhost,        config_parse_bool,                    0,                   offsetof(Manager, cache_from_localhost)
 Resolve.StaleRetentionSec,         config_parse_sec,                     0,                   offsetof(Manager, stale_retention_usec)
 Resolve.RefuseRecordTypes,         config_parse_record_types,            0,                   offsetof(Manager, refuse_record_types)
+Resolve.QueryHooks,                config_parse_bool,                    0,                   offsetof(Manager, do_query_hooks)

--- a/src/resolve/resolved-hook.c
+++ b/src/resolve/resolved-hook.c
@@ -815,7 +815,7 @@ int manager_hook_query(
         assert(m);
         assert(ret);
 
-        if (!use_hooks()) {
+        if (!m->do_query_hooks || !use_hooks()) {
                 *ret = NULL;
                 return 0; /* no relevant hooks, continue immediately */
         }

--- a/src/resolve/resolved-hook.c
+++ b/src/resolve/resolved-hook.c
@@ -12,6 +12,7 @@
 #include "iovec-util.h"
 #include "json-util.h"
 #include "ratelimit.h"
+#include "resolved-dns-query.h"
 #include "resolved-hook.h"
 #include "resolved-manager.h"
 #include "set.h"
@@ -815,7 +816,8 @@ int manager_hook_query(
         assert(m);
         assert(ret);
 
-        if (!m->do_query_hooks || !use_hooks()) {
+        DnsQuery *q = ASSERT_PTR(userdata);
+        if (FLAGS_SET(q->flags, SD_RESOLVED_NO_HOOKS) || !m->do_query_hooks || !use_hooks()) {
                 *ret = NULL;
                 return 0; /* no relevant hooks, continue immediately */
         }

--- a/src/resolve/resolved-hook.c
+++ b/src/resolve/resolved-hook.c
@@ -12,6 +12,7 @@
 #include "iovec-util.h"
 #include "json-util.h"
 #include "ratelimit.h"
+#include "resolved-dns-query.h"
 #include "resolved-hook.h"
 #include "resolved-manager.h"
 #include "set.h"
@@ -807,15 +808,16 @@ int manager_hook_query(
                 DnsQuestion *question_idna,
                 DnsQuestion *question_utf8,
                 HookCompleteCallback complete_cb,
-                void *userdata,
+                DnsQuery *q,
                 HookQuery **ret) {
 
         int r;
 
         assert(m);
+        assert(q);
         assert(ret);
 
-        if (!m->do_query_hooks || !use_hooks()) {
+        if (FLAGS_SET(q->flags, SD_RESOLVED_NO_HOOKS) || !m->do_query_hooks || !use_hooks()) {
                 *ret = NULL;
                 return 0; /* no relevant hooks, continue immediately */
         }
@@ -858,7 +860,7 @@ int manager_hook_query(
                                 .question_utf8 = dns_question_ref(question_utf8),
                                 .answer_rcode = -1,
                                 .complete = complete_cb,
-                                .userdata = userdata,
+                                .userdata = q,
                         };
                 }
 

--- a/src/resolve/resolved-hook.h
+++ b/src/resolve/resolved-hook.h
@@ -5,6 +5,6 @@
 
 typedef void (HookCompleteCallback)(HookQuery *q, int rcode, DnsAnswer *answer, void *userdata);
 
-int manager_hook_query(Manager *m, DnsQuestion *question_idna, DnsQuestion *question_utf8, HookCompleteCallback complete_cb, void *userdata, HookQuery **ret);
+int manager_hook_query(Manager *m, DnsQuestion *question_idna, DnsQuestion *question_utf8, HookCompleteCallback complete_cb, DnsQuery *q, HookQuery **ret);
 
 HookQuery* hook_query_free(HookQuery *hq);

--- a/src/resolve/resolved-manager.c
+++ b/src/resolve/resolved-manager.c
@@ -644,6 +644,7 @@ static void manager_set_defaults(Manager *m) {
         m->stale_retention_usec = 0;
         m->refuse_record_types = set_free(m->refuse_record_types);
         m->resolv_conf_stat = (struct stat) {};
+        m->do_query_hooks = true;
 }
 
 static int manager_dispatch_reload_signal(sd_event_source *s, const struct signalfd_siginfo *si, void *userdata) {

--- a/src/resolve/resolved-manager.h
+++ b/src/resolve/resolved-manager.h
@@ -168,6 +168,7 @@ typedef struct Manager {
 
         Hashmap *hooks;
         struct stat hook_stat;
+        bool do_query_hooks;
 } Manager;
 
 /* Manager */

--- a/src/resolve/resolved.conf.in
+++ b/src/resolve/resolved.conf.in
@@ -43,3 +43,4 @@
 #ResolveUnicastSingleLabel=no
 #StaleRetentionSec=0
 #RefuseRecordTypes=
+#QueryHooks=yes

--- a/src/shared/resolved-def.h
+++ b/src/shared/resolved-def.h
@@ -83,6 +83,9 @@
 /* Output: Result was answered by hook */
 #define SD_RESOLVED_FROM_HOOK       (UINT64_C(1) << 27)
 
+/* Input: Don't query hooks for this request */
+#define SD_RESOLVED_NO_HOOKS        (UINT64_C(1) << 28)
+
 #define SD_RESOLVED_LLMNR           (SD_RESOLVED_LLMNR_IPV4|SD_RESOLVED_LLMNR_IPV6)
 #define SD_RESOLVED_MDNS            (SD_RESOLVED_MDNS_IPV4|SD_RESOLVED_MDNS_IPV6)
 #define SD_RESOLVED_PROTOCOLS_ALL   (SD_RESOLVED_MDNS|SD_RESOLVED_LLMNR|SD_RESOLVED_DNS)


### PR DESCRIPTION
There are various reasons why an admin may want to disable hook queries, but the only way to do that right now is to set `SYSTEMD_RESOLVED_HOOK=0` in `systemd-resolved.service`'s environment. Hence, changing this requires a reloading unit state and restarting resolved.

Add a new option to `resolved.conf` to enable/disable hook queries at the manager level. And, add a flag `SD_RESOLVED_NO_HOOKS` to provide a way to do this on per-query basis, similar to existing flags.