### PR TITLE
report: add pid1 metrics in a separate Varlink service

### DIFF
--- a/src/basic/fileio.c
+++ b/src/basic/fileio.c
@@ -895,23 +895,11 @@ int script_get_shebang_interpreter(const char *path, char **ret) {
         return 0;
 }
 
-int get_proc_field(const char *path, const char *key, char **ret) {
-        _cleanup_fclose_ FILE *f = NULL;
+static int get_proc_field_from_stream(FILE *f, const char *key, char **ret) {
         int r;
 
-        /* Retrieve one field from a file like /proc/self/status. "key" matches the beginning of the line
-         * and should not include whitespace or the delimiter (':').
-         * Whitespaces after the ':' will be skipped. Only the first element is returned
-         * (i.e. for /proc/meminfo line "MemTotal: 1024 kB" -> return "1024"). */
-
-        assert(path);
+        assert(f);
         assert(key);
-
-        r = fopen_unlocked(path, "re", &f);
-        if (r == -ENOENT && proc_mounted() == 0)
-                return -ENOSYS;
-        if (r < 0)
-                return r;
 
         for (;;) {
                  _cleanup_free_ char *line = NULL;
@@ -935,6 +923,84 @@ int get_proc_field(const char *path, const char *key, char **ret) {
                          return 0;
                  }
         }
+}
+
+int get_proc_field(const char *path, const char *key, char **ret) {
+        _cleanup_fclose_ FILE *f = NULL;
+        int r;
+
+        /* Retrieve one field from a file like /proc/self/status. "key" matches the beginning of the line
+         * and should not include whitespace or the delimiter (':').
+         * Whitespaces after the ':' will be skipped. Only the first element is returned
+         * (i.e. for /proc/meminfo line "MemTotal: 1024 kB" -> return "1024"). */
+
+        assert(path);
+        assert(key);
+
+        r = fopen_unlocked(path, "re", &f);
+        if (r == -ENOENT && proc_mounted() == 0)
+                return -ENOSYS;
+        if (r < 0)
+                return r;
+
+        return get_proc_field_from_stream(f, key, ret);
+}
+
+int get_proc_field_from_fd(int fd, const char *key, char **ret) {
+        _cleanup_close_ int dup_fd = -EBADF;
+        _cleanup_fclose_ FILE *f = NULL;
+        int r;
+
+        /* Like get_proc_field(), but reads from an already-open fd instead of opening a path. The caller
+         * retains ownership of fd; the helper dup()s it internally so the fd's read position is not
+         * disturbed and the helper can be called repeatedly with different keys. The dup'd fd is rewound to
+         * offset 0 before reading, which for /proc seq_files regenerates the snapshot.
+         *
+         * The intended use is to open a /proc file while privileged and then read fields from it after a
+         * subsequent drop_privileges(): the kernel's lookup-time access check has already been passed, and
+         * reads from the original file description survive the privilege change. */
+
+        assert(fd >= 0);
+        assert(key);
+
+        dup_fd = fcntl(fd, F_DUPFD_CLOEXEC, 3);
+        if (dup_fd < 0)
+                return -errno;
+
+        if (lseek(dup_fd, 0, SEEK_SET) < 0)
+                return -errno;
+
+        r = take_fdopen_unlocked(&dup_fd, "r", &f);
+        if (r < 0)
+                return r;
+
+        return get_proc_field_from_stream(f, key, ret);
+}
+
+int read_one_line_from_fd(int fd, char **ret) {
+        _cleanup_close_ int dup_fd = -EBADF;
+        _cleanup_fclose_ FILE *f = NULL;
+        int r;
+
+        /* Like read_one_line_file(), but reads from an already-open fd. Caller retains ownership of fd;
+         * the helper dup()s internally and rewinds the dup to offset 0. See get_proc_field_from_fd() for
+         * the rationale. */
+
+        assert(fd >= 0);
+        assert(ret);
+
+        dup_fd = fcntl(fd, F_DUPFD_CLOEXEC, 3);
+        if (dup_fd < 0)
+                return -errno;
+
+        if (lseek(dup_fd, 0, SEEK_SET) < 0)
+                return -errno;
+
+        r = take_fdopen_unlocked(&dup_fd, "r", &f);
+        if (r < 0)
+                return r;
+
+        return read_line(f, LONG_LINE_MAX, ret);
 }
 
 DIR* xopendirat(int dir_fd, const char *path, int flags) {

--- a/src/basic/fileio.h
+++ b/src/basic/fileio.h
@@ -92,6 +92,8 @@ int verify_file_at(int dir_fd, const char *fn, const char *blob, bool accept_ext
 int script_get_shebang_interpreter(const char *path, char **ret);
 
 int get_proc_field(const char *path, const char *key, char **ret);
+int get_proc_field_from_fd(int fd, const char *key, char **ret);
+int read_one_line_from_fd(int fd, char **ret);
 
 DIR* xopendirat(int dir_fd, const char *path, int flags);
 

--- a/src/report/meson.build
+++ b/src/report/meson.build
@@ -25,4 +25,11 @@ executables += [
                         'report-cgroup-server.c',
                 ),
         },
+        libexec_template + {
+                'name' : 'systemd-report-pid1',
+                'sources' : files(
+                        'report-pid1.c',
+                        'report-pid1-server.c',
+                ),
+        },
 ]

--- a/src/report/report-pid1-server.c
+++ b/src/report/report-pid1-server.c
@@ -1,0 +1,128 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include "sd-varlink.h"
+
+#include "alloc-util.h"
+#include "ansi-color.h"
+#include "build.h"
+#include "capability-util.h"
+#include "fd-util.h"
+#include "format-table.h"
+#include "log.h"
+#include "main-func.h"
+#include "options.h"
+#include "report-pid1.h"
+#include "user-util.h"
+#include "varlink-io.systemd.Metrics.h"
+#include "varlink-util.h"
+
+static int vl_server(void) {
+        _cleanup_(sd_varlink_server_unrefp) sd_varlink_server *vs = NULL;
+        _cleanup_free_ Pid1Context *ctx = NULL;
+        _cleanup_close_ int stat_fd = -EBADF, status_fd = -EBADF;
+        int r;
+
+        ctx = new0(Pid1Context, 1);
+        if (!ctx)
+                return log_oom();
+
+        /* Do the privileged collection now: count /proc/1/fd (root-only) and open /proc/1/stat and
+         * /proc/1/status so the subsequent reads survive the privilege drop. The snapshot is served for
+         * the lifetime of this (short-lived, Accept=yes) process; per-source errors are recorded in ctx
+         * and callbacks skip emission for any source that failed. */
+        pid1_context_collect_privileged(ctx, &stat_fd, &status_fd);
+
+        /* Drop to nobody before touching anything remote-reachable. Everything below this line — parsing
+         * the /proc fds, JSON building, Varlink dispatch — runs unprivileged. */
+        r = drop_privileges(UID_NOBODY, GID_NOBODY, /* keep_capabilities= */ 0);
+        if (r < 0)
+                return log_error_errno(r, "Failed to drop privileges to nobody: %m");
+
+        pid1_context_collect_unprivileged(ctx, TAKE_FD(stat_fd), TAKE_FD(status_fd));
+
+        r = varlink_server_new(&vs, SD_VARLINK_SERVER_INHERIT_USERDATA, ctx);
+        if (r < 0)
+                return log_error_errno(r, "Failed to allocate Varlink server: %m");
+
+        r = sd_varlink_server_add_interface(vs, &vl_interface_io_systemd_Metrics);
+        if (r < 0)
+                return log_error_errno(r, "Failed to add Varlink interface: %m");
+
+        r = sd_varlink_server_bind_method_many(
+                        vs,
+                        "io.systemd.Metrics.List",     vl_method_list_metrics,
+                        "io.systemd.Metrics.Describe", vl_method_describe_metrics);
+        if (r < 0)
+                return log_error_errno(r, "Failed to bind Varlink methods: %m");
+
+        r = sd_varlink_server_loop_auto(vs);
+        if (r < 0)
+                return log_error_errno(r, "Failed to run Varlink event loop: %m");
+
+        return 0;
+}
+
+static int help(void) {
+        _cleanup_(table_unrefp) Table *options = NULL;
+        int r;
+
+        r = option_parser_get_help_table(&options);
+        if (r < 0)
+                return r;
+
+        printf("%s [OPTIONS...]\n"
+               "\n%sReport PID1 resource metrics.%s\n"
+               "\n%sOptions:%s\n",
+               program_invocation_short_name,
+               ansi_highlight(),
+               ansi_normal(),
+               ansi_underline(),
+               ansi_normal());
+
+        return table_print_or_warn(options);
+}
+
+static int parse_argv(int argc, char *argv[]) {
+        int r;
+
+        assert(argc >= 0);
+        assert(argv);
+
+        OptionParser state = { argc, argv };
+
+        FOREACH_OPTION(&state, c, /* ret_a= */ NULL, /* on_error= */ return c)
+                switch (c) {
+                OPTION_COMMON_HELP:
+                        return help();
+
+                OPTION_COMMON_VERSION:
+                        return version();
+                }
+
+        if (state.optind < argc)
+                return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
+                                       "This program takes no arguments.");
+
+        r = sd_varlink_invocation(SD_VARLINK_ALLOW_ACCEPT);
+        if (r < 0)
+                return log_error_errno(r, "Failed to check if invoked in Varlink mode: %m");
+        if (r == 0)
+                return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
+                                       "This program can only run as a Varlink service.");
+
+        return 1;
+}
+
+static int run(int argc, char *argv[]) {
+        int r;
+
+        log_setup();
+
+        r = parse_argv(argc, argv);
+        if (r <= 0)
+                return r;
+
+        return vl_server();
+}
+
+DEFINE_MAIN_FUNCTION(run);

--- a/src/report/report-pid1.c
+++ b/src/report/report-pid1.c
@@ -1,0 +1,308 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include <dirent.h>
+#include <fcntl.h>
+
+#include "sd-json.h"
+#include "sd-varlink.h"
+
+#include "alloc-util.h"
+#include "dirent-util.h"
+#include "errno-util.h"
+#include "fd-util.h"
+#include "fileio.h"
+#include "log.h"
+#include "metrics.h"
+#include "parse-util.h"
+#include "report-pid1.h"
+#include "string-util.h"
+#include "time-util.h"
+
+static int pid1_count_fds(uint64_t *ret) {
+        _cleanup_closedir_ DIR *d = NULL;
+        uint64_t n = 0;
+
+        assert(ret);
+
+        d = opendir("/proc/1/fd");
+        if (!d)
+                return -errno;
+
+        FOREACH_DIRENT(de, d, return -errno)
+                n++;
+
+        *ret = n;
+        return 0;
+}
+
+static int pid1_parse_stat_cpu_times(int stat_fd, uint64_t *ret_utime_jiffies, uint64_t *ret_stime_jiffies) {
+        _cleanup_free_ char *line = NULL;
+        const char *p;
+        unsigned long utime, stime;
+        int r;
+
+        assert(stat_fd >= 0);
+        assert(ret_utime_jiffies);
+        assert(ret_stime_jiffies);
+
+        r = read_one_line_from_fd(stat_fd, &line);
+        if (r < 0)
+                return r;
+
+        /* The comm field is enclosed in () but does not escape any () inside, so skip past the last ')'. */
+        p = strrchr(line, ')');
+        if (!p)
+                return -EIO;
+        p++;
+
+        if (sscanf(p, " "
+                   "%*c "  /* state */
+                   "%*u "  /* ppid */
+                   "%*u "  /* pgrp */
+                   "%*u "  /* session */
+                   "%*u "  /* tty_nr */
+                   "%*u "  /* tpgid */
+                   "%*u "  /* flags */
+                   "%*u "  /* minflt */
+                   "%*u "  /* cminflt */
+                   "%*u "  /* majflt */
+                   "%*u "  /* cmajflt */
+                   "%lu "  /* utime */
+                   "%lu ", /* stime */
+                   &utime, &stime) != 2)
+                return -EIO;
+
+        *ret_utime_jiffies = utime;
+        *ret_stime_jiffies = stime;
+        return 0;
+}
+
+static int pid1_parse_memory_bytes(int status_fd, uint64_t *ret) {
+        _cleanup_free_ char *s = NULL;
+        uint64_t v;
+        int r;
+
+        assert(status_fd >= 0);
+        assert(ret);
+
+        r = get_proc_field_from_fd(status_fd, "VmRSS", &s);
+        if (r < 0)
+                return r;
+
+        r = safe_atou64(s, &v);
+        if (r < 0)
+                return r;
+
+        if (!MUL_ASSIGN_SAFE(&v, U64_KB))
+                return -EOVERFLOW;
+
+        *ret = v;
+        return 0;
+}
+
+static int pid1_parse_threads(int status_fd, uint64_t *ret) {
+        _cleanup_free_ char *s = NULL;
+        int n, r;
+
+        assert(status_fd >= 0);
+        assert(ret);
+
+        r = get_proc_field_from_fd(status_fd, "Threads", &s);
+        if (r < 0)
+                return r;
+
+        r = safe_atoi(s, &n);
+        if (r < 0)
+                return r;
+        if (n < 0)
+                return -EINVAL;
+
+        *ret = (uint64_t) n;
+        return 0;
+}
+
+void pid1_context_collect_privileged(Pid1Context *ctx, int *ret_stat_fd, int *ret_status_fd) {
+        int r;
+
+        assert(ctx);
+        assert(ret_stat_fd);
+        assert(ret_status_fd);
+
+        /* Count /proc/1/fd now — this must happen while privileged (mode 0500, root-owned), and the result
+         * is a single number so there is no fd to carry across the privilege drop. */
+        r = pid1_count_fds(&ctx->fd_count);
+        if (r < 0) {
+                ctx->fd_result = r;
+                log_debug_errno(r, "Failed to count /proc/1/fd, skipping FD metric: %m");
+        } else
+                ctx->fd_result = 1;
+
+        /* Open /proc/1/stat and /proc/1/status now, while we still have root (and therefore satisfy any
+         * ProtectProc=hidepid check). The actual parsing happens in _unprivileged() from these fds; the
+         * kernel's access check is already passed at open(). */
+        *ret_stat_fd = RET_NERRNO(open("/proc/1/stat", O_RDONLY|O_CLOEXEC));
+        if (*ret_stat_fd < 0) {
+                ctx->stat_result = *ret_stat_fd;
+                log_debug_errno(*ret_stat_fd, "Failed to open /proc/1/stat, skipping CPU metrics: %m");
+        }
+
+        *ret_status_fd = RET_NERRNO(open("/proc/1/status", O_RDONLY|O_CLOEXEC));
+        if (*ret_status_fd < 0) {
+                ctx->memory_result = *ret_status_fd;
+                ctx->threads_result = *ret_status_fd;
+                log_debug_errno(*ret_status_fd,
+                                "Failed to open /proc/1/status, skipping memory and tasks metrics: %m");
+        }
+}
+
+void pid1_context_collect_unprivileged(Pid1Context *ctx, int stat_fd, int status_fd) {
+        _cleanup_close_ int _stat_fd = stat_fd, _status_fd = status_fd;
+        int r;
+
+        assert(ctx);
+
+        if (_stat_fd >= 0) {
+                r = pid1_parse_stat_cpu_times(_stat_fd, &ctx->utime_jiffies, &ctx->stime_jiffies);
+                if (r < 0) {
+                        ctx->stat_result = r;
+                        log_debug_errno(r, "Failed to parse /proc/1/stat, skipping CPU metrics: %m");
+                } else
+                        ctx->stat_result = 1;
+        }
+
+        if (_status_fd >= 0) {
+                r = pid1_parse_memory_bytes(_status_fd, &ctx->memory_bytes);
+                if (r < 0) {
+                        ctx->memory_result = r;
+                        log_debug_errno(r, "Failed to parse VmRSS, skipping memory metric: %m");
+                } else
+                        ctx->memory_result = 1;
+
+                r = pid1_parse_threads(_status_fd, &ctx->threads);
+                if (r < 0) {
+                        ctx->threads_result = r;
+                        log_debug_errno(r, "Failed to parse Threads, skipping tasks metric: %m");
+                } else
+                        ctx->threads_result = 1;
+        }
+}
+
+static int cpu_time_build_json(MetricFamilyContext *context, void *userdata) {
+        Pid1Context *ctx = ASSERT_PTR(userdata);
+        int r;
+
+        assert(context);
+
+        if (ctx->stat_result != 1)
+                return 0;
+
+        {
+                _cleanup_(sd_json_variant_unrefp) sd_json_variant *fields = NULL;
+
+                r = sd_json_buildo(&fields, SD_JSON_BUILD_PAIR_STRING("mode", "user"));
+                if (r < 0)
+                        return r;
+
+                r = metric_build_send_unsigned(
+                                context,
+                                /* object= */ NULL,
+                                jiffies_to_usec(ctx->utime_jiffies) * NSEC_PER_USEC,
+                                fields);
+                if (r < 0)
+                        return r;
+        }
+
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *fields = NULL;
+
+        r = sd_json_buildo(&fields, SD_JSON_BUILD_PAIR_STRING("mode", "kernel"));
+        if (r < 0)
+                return r;
+
+        return metric_build_send_unsigned(
+                        context,
+                        /* object= */ NULL,
+                        jiffies_to_usec(ctx->stime_jiffies) * NSEC_PER_USEC,
+                        fields);
+}
+
+static int fd_count_build_json(MetricFamilyContext *context, void *userdata) {
+        Pid1Context *ctx = ASSERT_PTR(userdata);
+
+        assert(context);
+
+        if (ctx->fd_result != 1)
+                return 0;
+
+        return metric_build_send_unsigned(
+                        context,
+                        /* object= */ NULL,
+                        ctx->fd_count,
+                        /* fields= */ NULL);
+}
+
+static int memory_usage_build_json(MetricFamilyContext *context, void *userdata) {
+        Pid1Context *ctx = ASSERT_PTR(userdata);
+
+        assert(context);
+
+        if (ctx->memory_result != 1)
+                return 0;
+
+        return metric_build_send_unsigned(
+                        context,
+                        /* object= */ NULL,
+                        ctx->memory_bytes,
+                        /* fields= */ NULL);
+}
+
+static int tasks_build_json(MetricFamilyContext *context, void *userdata) {
+        Pid1Context *ctx = ASSERT_PTR(userdata);
+
+        assert(context);
+
+        if (ctx->threads_result != 1)
+                return 0;
+
+        return metric_build_send_unsigned(
+                        context,
+                        /* object= */ NULL,
+                        ctx->threads,
+                        /* fields= */ NULL);
+}
+
+static const MetricFamily pid1_metric_family_table[] = {
+        /* Keep metrics ordered alphabetically */
+        {
+                .name = METRIC_IO_SYSTEMD_PID1_PREFIX "CpuTime",
+                .description = "PID1 CPU time in nanoseconds, split by mode (user or kernel)",
+                .type = METRIC_FAMILY_TYPE_COUNTER,
+                .generate = cpu_time_build_json,
+        },
+        {
+                .name = METRIC_IO_SYSTEMD_PID1_PREFIX "FDCount",
+                .description = "PID1 open file descriptor count",
+                .type = METRIC_FAMILY_TYPE_GAUGE,
+                .generate = fd_count_build_json,
+        },
+        {
+                .name = METRIC_IO_SYSTEMD_PID1_PREFIX "MemoryUsage",
+                .description = "PID1 resident memory usage in bytes",
+                .type = METRIC_FAMILY_TYPE_GAUGE,
+                .generate = memory_usage_build_json,
+        },
+        {
+                .name = METRIC_IO_SYSTEMD_PID1_PREFIX "Tasks",
+                .description = "PID1 thread count",
+                .type = METRIC_FAMILY_TYPE_GAUGE,
+                .generate = tasks_build_json,
+        },
+        {}
+};
+
+int vl_method_describe_metrics(sd_varlink *link, sd_json_variant *parameters, sd_varlink_method_flags_t flags, void *userdata) {
+        return metrics_method_describe(pid1_metric_family_table, link, parameters, flags, userdata);
+}
+
+int vl_method_list_metrics(sd_varlink *link, sd_json_variant *parameters, sd_varlink_method_flags_t flags, void *userdata) {
+        return metrics_method_list(pid1_metric_family_table, link, parameters, flags, userdata);
+}

--- a/src/report/report-pid1.h
+++ b/src/report/report-pid1.h
@@ -1,0 +1,46 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#pragma once
+
+#include "shared-forward.h"
+
+#define METRIC_IO_SYSTEMD_PID1_PREFIX "io.systemd.PID1."
+
+/* Snapshot of PID1 data read from /proc/1 at startup.
+ *
+ * Each *_result field is:
+ *   0  = source not yet collected (matches new0() zero-init),
+ *   1  = collected successfully,
+ *   <0 = collection failed with this -errno.
+ *
+ * Callbacks emit only when the field is 1. This leaves zero-init meaning
+ * "uncollected", so skipping the collect calls cannot silently produce
+ * zero-valued metrics. */
+typedef struct Pid1Context {
+        uint64_t utime_jiffies;
+        uint64_t stime_jiffies;
+        uint64_t memory_bytes;
+        uint64_t fd_count;
+        uint64_t threads;
+        int stat_result;
+        int memory_result;
+        int fd_result;
+        int threads_result;
+} Pid1Context;
+
+/* Collection is split into two phases so the privilege drop can happen between them:
+ *
+ *  1. pid1_context_collect_privileged() runs as root and handles the pieces
+ *     that require privilege — counting /proc/1/fd (mode 0500, root-owned)
+ *     and opening /proc/1/stat and /proc/1/status past the ProtectProc=
+ *     hidepid check. The two fds are returned to the caller.
+ *
+ *  2. pid1_context_collect_unprivileged() parses those fds and can therefore
+ *     run after drop_privileges(). It takes ownership of both fds and closes
+ *     them before returning. Reads from the already-open file descriptions
+ *     succeed regardless of current credentials because the kernel's access
+ *     check ran at open() time. */
+void pid1_context_collect_privileged(Pid1Context *ctx, int *ret_stat_fd, int *ret_status_fd);
+void pid1_context_collect_unprivileged(Pid1Context *ctx, int stat_fd, int status_fd);
+
+int vl_method_list_metrics(sd_varlink *link, sd_json_variant *parameters, sd_varlink_method_flags_t flags, void *userdata);
+int vl_method_describe_metrics(sd_varlink *link, sd_json_variant *parameters, sd_varlink_method_flags_t flags, void *userdata);

--- a/test/units/TEST-74-AUX-UTILS.report.sh
+++ b/test/units/TEST-74-AUX-UTILS.report.sh
@@ -37,6 +37,25 @@ varlinkctl list-methods /run/systemd/report/io.systemd.CGroup
 varlinkctl --more call /run/systemd/report/io.systemd.CGroup io.systemd.Metrics.List {}
 varlinkctl --more call /run/systemd/report/io.systemd.CGroup io.systemd.Metrics.Describe {}
 
+# test io.systemd.PID1 Metrics
+systemctl start systemd-report-pid1.socket
+varlinkctl info /run/systemd/report/io.systemd.PID1
+varlinkctl list-methods /run/systemd/report/io.systemd.PID1
+varlinkctl --more call /run/systemd/report/io.systemd.PID1 io.systemd.Metrics.List {}
+varlinkctl --more call /run/systemd/report/io.systemd.PID1 io.systemd.Metrics.Describe {}
+
+# Confirm all four metric families are advertised by Describe and that
+# every one produces a value via List. CpuTime is additionally split by
+# mode (user, kernel) via the "fields" sub-object of each List reply.
+PID1_DESCRIBE=$(varlinkctl --more call /run/systemd/report/io.systemd.PID1 io.systemd.Metrics.Describe {})
+PID1_LIST=$(varlinkctl --more call /run/systemd/report/io.systemd.PID1 io.systemd.Metrics.List {})
+for m in CpuTime FDCount MemoryUsage Tasks; do
+    echo "$PID1_DESCRIBE" | grep >/dev/null "\"io.systemd.PID1.$m\""
+    echo "$PID1_LIST"     | grep >/dev/null "\"io.systemd.PID1.$m\""
+done
+echo "$PID1_LIST" | grep >/dev/null '"mode"[[:space:]]*:[[:space:]]*"user"'
+echo "$PID1_LIST" | grep >/dev/null '"mode"[[:space:]]*:[[:space:]]*"kernel"'
+
 # test io.systemd.Network Metrics
 varlinkctl info /run/systemd/report/io.systemd.Network
 varlinkctl list-methods /run/systemd/report/io.systemd.Network

--- a/units/meson.build
+++ b/units/meson.build
@@ -726,6 +726,8 @@ units = [
         },
         { 'file' : 'systemd-report-cgroup.socket' },
         { 'file' : 'systemd-report-cgroup@.service.in' },
+        { 'file' : 'systemd-report-pid1.socket' },
+        { 'file' : 'systemd-report-pid1@.service.in' },
         {
           'file' : 'systemd-resolved.service.in',
           'conditions' : ['ENABLE_RESOLVE'],

--- a/units/systemd-report-pid1.socket
+++ b/units/systemd-report-pid1.socket
@@ -1,0 +1,25 @@
+#  SPDX-License-Identifier: LGPL-2.1-or-later
+#
+#  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+
+[Unit]
+Description=PID1 Report Varlink Socket
+DefaultDependencies=no
+Before=sockets.target shutdown.target
+Conflicts=shutdown.target
+
+[Socket]
+ListenStream=/run/systemd/report/io.systemd.PID1
+FileDescriptorName=varlink
+SocketMode=0666
+Accept=yes
+MaxConnectionsPerSource=16
+RemoveOnStop=yes
+
+[Install]
+WantedBy=sockets.target

--- a/units/systemd-report-pid1@.service.in
+++ b/units/systemd-report-pid1@.service.in
@@ -1,0 +1,55 @@
+#  SPDX-License-Identifier: LGPL-2.1-or-later
+#
+#  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+
+[Unit]
+Description=PID1 Report Service
+DefaultDependencies=no
+Conflicts=shutdown.target
+Before=shutdown.target
+
+[Service]
+# Starts as root to read /proc/1/fd/ (mode 0500, owned by root), then calls
+# drop_privileges() to become nobody with zero capabilities before entering
+# the Varlink event loop. CAP_SETUID and CAP_SETGID are needed for the
+# setresuid()/setresgid() transition; CAP_SETPCAP is needed for the
+# subsequent prctl(PR_CAPBSET_DROP) calls that clear the bounding set.
+# All three are dropped along with every other cap in that same
+# drop_privileges() call.
+CapabilityBoundingSet=CAP_SETUID CAP_SETGID CAP_SETPCAP
+DeviceAllow=
+IPAddressDeny=any
+KeyringMode=private
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+NoNewPrivileges=yes
+PrivateDevices=yes
+PrivateIPC=yes
+PrivateNetwork=yes
+PrivateTmp=disconnected
+ProcSubset=pid
+ProtectClock=yes
+ProtectControlGroups=yes
+ProtectHome=yes
+ProtectHostname=yes
+ProtectKernelLogs=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+ProtectProc=invisible
+ProtectSystem=strict
+ReadWritePaths=
+RestrictAddressFamilies=AF_UNIX
+RestrictNamespaces=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+RuntimeMaxSec=1min
+SystemCallArchitectures=native
+SystemCallErrorNumber=EPERM
+SystemCallFilter=@system-service
+UMask=0077
+ExecStart={{LIBEXECDIR}}/systemd-report-pid1


### PR DESCRIPTION
Add systemd-report-pid1, a new Varlink service that exposes four PID1 resource metrics under the io.systemd.PID1.* namespace:
    
* CpuTime (counter, ns) -- from /proc/1/stat utime/stime, split via a "mode" field (user or kernel)
* FDCount (gauge) -- entries in /proc/1/fd/
* MemoryUsage (gauge, bytes) -- from /proc/1/status VmRSS
* Tasks (gauge) -- from /proc/1/status Threads
    
The metrics describe PID1's own resource footprint, but the collector deliberately lives outside PID1, similarly to systemd-report-cgroup.

The daemon has to been run as root to read /proc/1/fd. To minimize the attack surface we drop privileges as early as possible. We also set up the unit to enable all hardening knobs and minimize exposed capabilities.
