### PR TITLE
repart: raise log level to LOG_ERR if dlopen_fdisk() fails

### DIFF
--- a/src/repart/repart.c
+++ b/src/repart/repart.c
@@ -11218,7 +11218,7 @@ static int run(int argc, char *argv[]) {
         if (r <= 0)
                 return r;
 
-        r = dlopen_fdisk(LOG_DEBUG);
+        r = dlopen_fdisk(LOG_ERR);
         if (r < 0)
                 return r;
 


### PR DESCRIPTION
libfdisk is required by systemd-repart and it silently exits if dlopen fails (unless the debug log level is set):

```
$ SYSTEMD_LOG_LEVEL=debug systemd-repart
Shared library 'libfdisk.so.1' is not available: libfdisk.so.1: cannot open shared object file: No such file or directory
$ echo $?
1
```

Follow-up for d49f3f287a0bf72b5b473980cf435f0c0c2413d0