### PR TITLE
shared: drop redundant cryptsetup_enable_logging(NULL) calls

### DIFF
--- a/src/growfs/growfs.c
+++ b/src/growfs/growfs.c
@@ -93,10 +93,6 @@ static int maybe_resize_underlying_device(
         assert(mountfd >= 0);
         assert(mountpath);
 
-#if HAVE_LIBCRYPTSETUP
-        cryptsetup_enable_logging(NULL);
-#endif
-
         r = get_block_device_harder_fd(mountfd, &devno);
         if (r < 0)
                 return log_error_errno(r, "Failed to determine underlying block device of \"%s\": %m",

--- a/src/home/homework.c
+++ b/src/home/homework.c
@@ -2005,8 +2005,6 @@ static int run(int argc, char *argv[]) {
 
         log_setup();
 
-        cryptsetup_enable_logging(NULL);
-
         umask(0022);
 
         if (argc < 2 || argc > 3)

--- a/src/repart/repart.c
+++ b/src/repart/repart.c
@@ -11222,10 +11222,6 @@ static int run(int argc, char *argv[]) {
         if (r < 0)
                 return r;
 
-#if HAVE_LIBCRYPTSETUP
-        cryptsetup_enable_logging(NULL);
-#endif
-
         if (arg_varlink)
                 return vl_server();
 

--- a/src/shared/cryptsetup-util.c
+++ b/src/shared/cryptsetup-util.c
@@ -133,10 +133,6 @@ int cryptsetup_set_minimal_pbkdf(struct crypt_device *cd) {
 
         /* Sets a minimal PKBDF in case we already have a high entropy key. */
 
-        r = dlopen_cryptsetup(LOG_DEBUG);
-        if (r < 0)
-                return r;
-
         r = sym_crypt_set_pbkdf_type(cd, &minimal_pbkdf);
         if (r < 0)
                 return r;
@@ -163,10 +159,6 @@ int cryptsetup_get_token_as_json(
          *      -ENOENT → token doesn't exist
          * -EMEDIUMTYPE → "verify_type" specified and doesn't match token's type
          */
-
-        r = dlopen_cryptsetup(LOG_DEBUG);
-        if (r < 0)
-                return r;
 
         r = sym_crypt_token_json_get(cd, idx, &text);
         if (r < 0)
@@ -196,10 +188,6 @@ int cryptsetup_get_token_as_json(
 int cryptsetup_add_token_json(struct crypt_device *cd, sd_json_variant *v) {
         _cleanup_free_ char *text = NULL;
         int r;
-
-        r = dlopen_cryptsetup(LOG_DEBUG);
-        if (r < 0)
-                return r;
 
         r = sd_json_variant_format(v, 0, &text);
         if (r < 0)


### PR DESCRIPTION
These were only used to implicitly load libcryptsetup at startup. dlopen_cryptsetup() now calls cryptsetup_enable_logging(NULL) itself, and every code path that uses libcryptsetup calls dlopen_cryptsetup() before doing so, so the upfront calls are no longer needed.