### PR TITLE
man: clarify that /etc/verity.d only parses certificates with the .crt extension

### DIFF
--- a/man/kernel-command-line.xml
+++ b/man/kernel-command-line.xml
@@ -711,8 +711,8 @@
         <term><varname>systemd.allow_userspace_verity=</varname></term>
 
         <listitem><para>Takes a boolean argument. Controls whether disk images that are Verity protected may
-        be authenticated in userspace signature checks via <filename>/etc/verity.d/</filename> (and related
-        directories) public key drop-ins, or whether in-kernel signature checking only. Defaults to
+        be authenticated in userspace signature checks via <filename>/etc/verity.d/*.crt</filename> (and
+        related directories) public key drop-ins, or whether in-kernel signature checking only. Defaults to
         on.</para>
 
         <xi:include href="version-info.xml" xpointer="v256"/></listitem>

--- a/man/systemd-mountfsd.service.xml
+++ b/man/systemd-mountfsd.service.xml
@@ -45,7 +45,7 @@
       <filename>/usr/lib/</filename> it is assumed to be trusted.</para></listitem>
 
       <listitem><para>If the disk image contains a Verity enabled disk image, along with a signature
-      partition with a key in the kernel keyring or in <filename>/etc/verity.d/</filename> (and related
+      partition with a key in the kernel keyring or in <filename>/etc/verity.d/*.crt</filename> (and related
       directories) the disk image is considered trusted.</para></listitem>
     </orderedlist>
 

--- a/src/shared/dissect-image.c
+++ b/src/shared/dissect-image.c
@@ -3072,7 +3072,7 @@ static int validate_signature_userspace(const VeritySettings *verity, const char
                 return 0;
         }
         if (!b) {
-                log_debug("Userspace dm-verity signature authentication disabled via systemd.allow_userspace_verity= kernel command line variable.");
+                log_debug("Userspace dm-verity signature authentication disabled via systemd.allow_userspace_verity= kernel command line option.");
                 return 0;
         }
 


### PR DESCRIPTION
Exposed in the dracut testsuite while adding tests for sysexts:

```
[    2.972948] localhost (sd-merge)[510]: Validation of dm-verity signature failed via the kernel, trying userspace validation instead: Required key not available
[    2.972993] localhost (sd-merge)[510]: Skipping file '/etc/verity.d/dracut.pem', suffix is not '.crt'.
[    2.973045] localhost (sd-merge)[510]: No userspace dm-verity certificates found.
```

https://github.com/systemd/systemd/blob/658e5ac06f80ee2078b034f7cc483204d7f91c5e/src/shared/dissect-image.c#L3093