### PR TITLE
opensuse mkosi: user and group bin needed for a test

### DIFF
--- a/mkosi/mkosi.conf.d/opensuse/mkosi.conf
+++ b/mkosi/mkosi.conf.d/opensuse/mkosi.conf
@@ -84,6 +84,7 @@ Packages=
         softhsm
         squashfs
         stress-ng
+        system-user-bin
         tgt
         timezone
         tpm2.0-tools


### PR DESCRIPTION
* Fix the test TEST-02-UNITTESTS for openSUSE environment.