### PR TITLE
tree-wide: drop 4th option from FOREACH_OPTION()

### DIFF
--- a/src/ac-power/ac-power.c
+++ b/src/ac-power/ac-power.c
@@ -44,8 +44,9 @@ static int parse_argv(int argc, char *argv[]) {
         OptionParser state = { argc, argv };
         const char *arg;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
+
                 OPTION_COMMON_HELP:
                         return help();
 

--- a/src/ask-password/ask-password.c
+++ b/src/ask-password/ask-password.c
@@ -76,8 +76,9 @@ static int parse_argv(int argc, char *argv[]) {
         OptionParser state = { argc, argv };
         const char *arg;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
+
                 OPTION_COMMON_HELP:
                         return help();
 

--- a/src/battery-check/battery-check.c
+++ b/src/battery-check/battery-check.c
@@ -83,7 +83,7 @@ static int parse_argv(int argc, char *argv[]) {
 
         OptionParser state = { argc, argv };
 
-        FOREACH_OPTION(&state, c, /* ret_a= */ NULL, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, /* ret_a= */ NULL)
                 switch (c) {
 
                 OPTION_COMMON_HELP:

--- a/src/binfmt/binfmt.c
+++ b/src/binfmt/binfmt.c
@@ -142,8 +142,9 @@ static int parse_argv(int argc, char *argv[], char ***ret_args) {
         OptionParser state = { argc, argv };
         const char *arg;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
+
                 OPTION_COMMON_HELP:
                         return help();
 

--- a/src/bless-boot/bless-boot.c
+++ b/src/bless-boot/bless-boot.c
@@ -82,8 +82,9 @@ static int parse_argv(int argc, char *argv[], char ***ret_args) {
         OptionParser state = { argc, argv };
         const char *arg;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
+
                 OPTION_COMMON_HELP:
                         return help();
 

--- a/src/bless-boot/boot-check-no-failures.c
+++ b/src/bless-boot/boot-check-no-failures.c
@@ -46,7 +46,7 @@ static int parse_argv(int argc, char *argv[]) {
 
         OptionParser state = { argc, argv };
 
-        FOREACH_OPTION(&state, c, /* ret_a= */ NULL, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, /* ret_a= */ NULL)
                 switch (c) {
 
                 OPTION_COMMON_HELP:

--- a/src/bootctl/bootctl.c
+++ b/src/bootctl/bootctl.c
@@ -419,7 +419,7 @@ static int parse_argv(int argc, char *argv[], char ***ret_args) {
         OptionParser state = { argc, argv };
         const char *arg;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
 
                 OPTION_GROUP("Block Device Discovery Commands"): {}

--- a/src/cgls/cgls.c
+++ b/src/cgls/cgls.c
@@ -73,7 +73,7 @@ static int parse_argv(int argc, char *argv[]) {
         const char *arg;
         int r;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
 
                 OPTION_COMMON_HELP:

--- a/src/cgtop/cgtop.c
+++ b/src/cgtop/cgtop.c
@@ -723,7 +723,7 @@ static int parse_argv(int argc, char *argv[]) {
         const char *arg;
         int r;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
 
                 OPTION_COMMON_HELP:

--- a/src/core/executor.c
+++ b/src/core/executor.c
@@ -65,7 +65,7 @@ static int parse_argv(int argc, char *argv[]) {
         OptionParser state = { argc, argv };
         const char *arg;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
 
                 OPTION_COMMON_HELP:

--- a/src/creds/creds.c
+++ b/src/creds/creds.c
@@ -827,7 +827,7 @@ static int parse_argv(int argc, char *argv[], char ***ret_args) {
         const char *arg;
         int r;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
 
                 OPTION_COMMON_HELP:

--- a/src/cryptenroll/cryptenroll.c
+++ b/src/cryptenroll/cryptenroll.c
@@ -280,7 +280,7 @@ static int parse_argv(int argc, char *argv[]) {
         const char *arg;
         int r;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
 
                 OPTION_COMMON_HELP:

--- a/src/cryptsetup/cryptsetup.c
+++ b/src/cryptsetup/cryptsetup.c
@@ -2508,7 +2508,7 @@ static int parse_argv(int argc, char *argv[], char ***ret_args) {
         OptionParser state = { argc, argv };
         const char *arg;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
 
                 OPTION_COMMON_HELP:

--- a/src/delta/delta.c
+++ b/src/delta/delta.c
@@ -521,7 +521,7 @@ static int parse_argv(int argc, char *argv[], char ***ret_args) {
         const char *arg;
         int r;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
 
                 OPTION_COMMON_HELP:

--- a/src/detect-virt/detect-virt.c
+++ b/src/detect-virt/detect-virt.c
@@ -56,7 +56,7 @@ static int parse_argv(int argc, char *argv[]) {
         OptionParser state = { argc, argv };
         const char *arg;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
                 OPTION_COMMON_HELP:
                         return help();

--- a/src/dissect/dissect.c
+++ b/src/dissect/dissect.c
@@ -234,7 +234,7 @@ static int parse_argv(int argc, char *argv[]) {
         const Option *current;
         const char *arg;
 
-        FOREACH_OPTION_FULL(&state, c, &current, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_FULL(&state, c, &current, &arg)
                 switch (c) {
 
                 OPTION_COMMON_NO_PAGER:
@@ -512,6 +512,9 @@ static int parse_argv(int argc, char *argv[]) {
                 OPTION_LONG("shift", NULL, "Shift UID range to selected base"):
                         arg_action = ACTION_SHIFT;
                         break;
+
+                OPTION_ERROR:
+                        return c;
                 }
 
         if (system_scope_requested || user_scope_requested)

--- a/src/escape/escape-tool.c
+++ b/src/escape/escape-tool.c
@@ -59,7 +59,7 @@ static int parse_argv(int argc, char *argv[], char ***ret_args) {
         OptionParser state = { argc, argv };
         const char *arg;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
 
                 OPTION_COMMON_HELP:

--- a/src/factory-reset/factory-reset-tool.c
+++ b/src/factory-reset/factory-reset-tool.c
@@ -73,8 +73,9 @@ static int parse_argv(int argc, char *argv[], char ***ret_args) {
         OptionParser state = { argc, argv };
         const char *arg;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
+
                 OPTION_COMMON_HELP:
                         return help();
 

--- a/src/firstboot/firstboot.c
+++ b/src/firstboot/firstboot.c
@@ -1271,7 +1271,7 @@ static int parse_argv(int argc, char *argv[]) {
         const char *arg;
         int r;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
 
                 OPTION_COMMON_HELP:

--- a/src/growfs/growfs.c
+++ b/src/growfs/growfs.c
@@ -163,7 +163,7 @@ static int parse_argv(int argc, char *argv[]) {
         OptionParser state = { argc, argv };
         const char *arg;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
 
                 OPTION_COMMON_HELP:

--- a/src/hibernate-resume/hibernate-resume.c
+++ b/src/hibernate-resume/hibernate-resume.c
@@ -58,7 +58,7 @@ static int parse_argv(int argc, char *argv[], char ***ret_args) {
         OptionParser state = { argc, argv };
         const char *arg;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
 
                 OPTION_COMMON_HELP:

--- a/src/hostname/hostnamectl.c
+++ b/src/hostname/hostnamectl.c
@@ -768,7 +768,7 @@ static int parse_argv(int argc, char *argv[], char ***ret_args) {
         OptionParser state = { argc, argv };
         const char *arg;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
                 OPTION_COMMON_HELP:
                         return help();

--- a/src/hwdb/hwdb.c
+++ b/src/hwdb/hwdb.c
@@ -84,7 +84,7 @@ static int parse_argv(int argc, char *argv[], char ***ret_args) {
         OptionParser state = { argc, argv };
         const char *arg;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
 
                 OPTION_COMMON_HELP:

--- a/src/id128/id128.c
+++ b/src/id128/id128.c
@@ -240,8 +240,9 @@ static int parse_argv(int argc, char *argv[], char ***ret_args) {
         OptionParser state = { argc, argv };
         const char *arg;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
+
                 OPTION_COMMON_HELP:
                         return help();
 

--- a/src/imds/imds-tool.c
+++ b/src/imds/imds-tool.c
@@ -85,7 +85,7 @@ static int parse_argv(int argc, char *argv[]) {
         OptionParser state = { argc, argv };
         const char *arg;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
 
                 OPTION_COMMON_HELP:

--- a/src/imds/imdsd.c
+++ b/src/imds/imdsd.c
@@ -2252,7 +2252,7 @@ static int parse_argv(int argc, char *argv[]) {
         OptionParser state = { argc, argv };
         const char *arg;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
 
                 OPTION_COMMON_HELP:

--- a/src/import/export.c
+++ b/src/import/export.c
@@ -241,7 +241,7 @@ static int parse_argv(int argc, char *argv[], char ***ret_args) {
         OptionParser state = { argc, argv };
         const char *arg;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
 
                 OPTION_COMMON_HELP:

--- a/src/import/import-fs.c
+++ b/src/import/import-fs.c
@@ -317,7 +317,7 @@ static int parse_argv(int argc, char *argv[], char ***ret_args) {
         const char *arg;
         int r;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
 
                 OPTION_COMMON_HELP:

--- a/src/import/import.c
+++ b/src/import/import.c
@@ -320,7 +320,7 @@ static int parse_argv(int argc, char *argv[], char ***ret_args) {
         OptionParser state = { argc, argv };
         const char *arg;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
 
                 OPTION_COMMON_HELP:

--- a/src/import/importctl.c
+++ b/src/import/importctl.c
@@ -1116,7 +1116,7 @@ static int parse_argv(int argc, char *argv[], char ***ret_args) {
         OptionParser state = { argc, argv };
         const char *arg;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
 
                 OPTION_COMMON_HELP:

--- a/src/import/pull.c
+++ b/src/import/pull.c
@@ -367,7 +367,7 @@ static int parse_argv(int argc, char *argv[], char ***ret_args) {
         OptionParser state = { argc, argv };
         const char *arg;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
 
                 OPTION_COMMON_HELP:

--- a/src/journal-remote/journal-gatewayd.c
+++ b/src/journal-remote/journal-gatewayd.c
@@ -1122,7 +1122,7 @@ static int parse_argv(int argc, char *argv[]) {
         const char *arg;
         int r;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
 
                 OPTION_COMMON_HELP:

--- a/src/journal-remote/journal-remote-main.c
+++ b/src/journal-remote/journal-remote-main.c
@@ -908,7 +908,7 @@ static int parse_argv(int argc, char *argv[]) {
         OptionParser state = { argc, argv };
         const char *arg;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
 
                 OPTION_COMMON_HELP:

--- a/src/journal/bsod.c
+++ b/src/journal/bsod.c
@@ -251,7 +251,7 @@ static int parse_argv(int argc, char *argv[]) {
         const char *arg;
         int r;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
 
                 OPTION_COMMON_HELP:

--- a/src/journal/cat.c
+++ b/src/journal/cat.c
@@ -63,7 +63,7 @@ static int parse_argv(int argc, char *argv[], char ***ret_args) {
         const char *arg;
         int r;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
 
                 OPTION_COMMON_HELP:

--- a/src/keyutil/keyutil.c
+++ b/src/keyutil/keyutil.c
@@ -91,7 +91,7 @@ static int parse_argv(int argc, char *argv[], char ***ret_args) {
         const char *arg;
         int r;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
 
                 OPTION_COMMON_HELP:

--- a/src/libsystemd-network/test-ndisc-send.c
+++ b/src/libsystemd-network/test-ndisc-send.c
@@ -81,7 +81,7 @@ static int parse_argv(int argc, char *argv[]) {
         OptionParser state = { argc, argv };
         const char *arg;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
 
                 OPTION_COMMON_VERSION:

--- a/src/libsystemd/sd-journal/test-journal-append.c
+++ b/src/libsystemd/sd-journal/test-journal-append.c
@@ -154,7 +154,7 @@ int main(int argc, char *argv[]) {
         OptionParser state = { argc, argv };
         const char *arg;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
 
                 OPTION_COMMON_HELP: {

--- a/src/libudev/test-libudev.c
+++ b/src/libudev/test-libudev.c
@@ -431,7 +431,7 @@ static int parse_args(int argc, char *argv[], const char **syspath, const char *
         OptionParser state = { argc, argv };
         const char *arg;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
 
                 OPTION_COMMON_HELP:

--- a/src/login/inhibit.c
+++ b/src/login/inhibit.c
@@ -204,7 +204,7 @@ static int parse_argv(int argc, char *argv[], char ***remaining_args) {
         const char *arg;
         int r;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
 
                 OPTION_COMMON_HELP:

--- a/src/machine-id-setup/machine-id-setup-main.c
+++ b/src/machine-id-setup/machine-id-setup-main.c
@@ -79,7 +79,7 @@ static int parse_argv(int argc, char *argv[]) {
         const char *arg;
         int r;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
 
                 OPTION_COMMON_HELP:

--- a/src/measure/measure-tool.c
+++ b/src/measure/measure-tool.c
@@ -141,7 +141,7 @@ static int parse_argv(int argc, char *argv[], char ***ret_args) {
         const char *arg;
         int r;
 
-        FOREACH_OPTION_FULL(&state, c, &opt, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_FULL(&state, c, &opt, &arg)
                 switch (c) {
 
                 OPTION_COMMON_HELP:
@@ -307,6 +307,9 @@ static int parse_argv(int argc, char *argv[], char ***ret_args) {
                         if (r < 0)
                                 return r;
                         break;
+
+                OPTION_ERROR:
+                        return c;
                 }
 
         if (arg_public_key && arg_certificate)

--- a/src/modules-load/modules-load.c
+++ b/src/modules-load/modules-load.c
@@ -361,7 +361,7 @@ static int parse_argv(int argc, char *argv[], char ***ret_args) {
 
         OptionParser state = { argc, argv };
 
-        FOREACH_OPTION(&state, c, /* arg= */ NULL, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, /* arg= */ NULL)
                 switch (c) {
 
                 OPTION_COMMON_HELP:

--- a/src/mute-console/mute-console.c
+++ b/src/mute-console/mute-console.c
@@ -64,7 +64,7 @@ static int parse_argv(int argc, char *argv[]) {
         const char *arg;
         int r;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
 
                 OPTION_COMMON_HELP:

--- a/src/network/generator/network-generator-main.c
+++ b/src/network/generator/network-generator-main.c
@@ -175,7 +175,7 @@ static int parse_argv(int argc, char *argv[], char ***ret_args) {
         OptionParser state = { argc, argv };
         const char *arg;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
 
                 OPTION_COMMON_HELP:

--- a/src/notify/notify.c
+++ b/src/notify/notify.c
@@ -156,7 +156,7 @@ static int parse_argv(int argc, char *argv[], char ***ret_args) {
         OptionParser state = { argc, argv };
         const char *arg;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
 
                 OPTION_COMMON_HELP:

--- a/src/nspawn/nspawn.c
+++ b/src/nspawn/nspawn.c
@@ -606,7 +606,7 @@ static int parse_argv(int argc, char *argv[]) {
         const Option *opt;
         const char *arg;
 
-        FOREACH_OPTION_FULL(&state, c, &opt, &arg, /* on_error= */ return c) {
+        FOREACH_OPTION_FULL(&state, c, &opt, &arg) {
                 switch (c) {
 
                 OPTION_COMMON_HELP:
@@ -1441,6 +1441,9 @@ static int parse_argv(int argc, char *argv[]) {
                 OPTION_LONG("system", NULL, "Run in the system service manager scope"):
                         arg_runtime_scope = RUNTIME_SCOPE_SYSTEM;
                         break;
+
+                OPTION_ERROR:
+                        return c;
                 }
         }
 

--- a/src/oom/oomctl.c
+++ b/src/oom/oomctl.c
@@ -94,7 +94,7 @@ static int parse_argv(int argc, char *argv[], char ***ret_args) {
         OptionParser state = { argc, argv };
         const char *arg;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
 
                 OPTION_COMMON_HELP:

--- a/src/oom/oomd.c
+++ b/src/oom/oomd.c
@@ -54,7 +54,7 @@ static int parse_argv(int argc, char *argv[]) {
         OptionParser state = { argc, argv };
         const char *arg;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
 
                 OPTION_COMMON_HELP:

--- a/src/path/path-tool.c
+++ b/src/path/path-tool.c
@@ -207,7 +207,7 @@ static int parse_argv(int argc, char *argv[], char ***ret_args) {
         OptionParser state = { argc, argv };
         const char *arg;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
 
                 OPTION_COMMON_HELP:

--- a/src/pcrextend/pcrextend.c
+++ b/src/pcrextend/pcrextend.c
@@ -85,7 +85,7 @@ static int parse_argv(int argc, char *argv[], char ***ret_args) {
         const char *arg;
         int r;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
 
                 OPTION_COMMON_HELP:

--- a/src/pcrlock/pcrlock.c
+++ b/src/pcrlock/pcrlock.c
@@ -5194,7 +5194,7 @@ static int parse_argv(int argc, char *argv[], char ***ret_args) {
         bool auto_location = true;
         int r;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
 
                 OPTION_COMMON_HELP:

--- a/src/ptyfwd/ptyfwd-tool.c
+++ b/src/ptyfwd/ptyfwd-tool.c
@@ -66,7 +66,7 @@ static int parse_argv(int argc, char *argv[], char ***remaining_args) {
         const char *arg;
         int r;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
 
                 OPTION_COMMON_HELP:

--- a/src/random-seed/random-seed-tool.c
+++ b/src/random-seed/random-seed-tool.c
@@ -353,7 +353,7 @@ static int parse_argv(int argc, char *argv[]) {
         const char *arg;
         int r;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
 
                 OPTION_COMMON_HELP:

--- a/src/repart/repart.c
+++ b/src/repart/repart.c
@@ -9689,7 +9689,7 @@ static int parse_argv(int argc, char *argv[]) {
         bool auto_public_key_pcr_mask = true, auto_pcrlock = true;
         int r;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
 
                 OPTION_GROUP("Options"): {}

--- a/src/report/report-basic-server.c
+++ b/src/report/report-basic-server.c
@@ -59,7 +59,7 @@ static int parse_argv(int argc, char *argv[]) {
 
         OptionParser state = { argc, argv };
 
-        FOREACH_OPTION(&state, c, /* ret_a= */ NULL, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, /* ret_a= */ NULL)
                 switch (c) {
                 OPTION_COMMON_HELP:
                         return help();

--- a/src/report/report.c
+++ b/src/report/report.c
@@ -988,8 +988,9 @@ static int parse_argv(int argc, char *argv[], char ***ret_args) {
         OptionParser state = { argc, argv };
         const char *arg;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
+
                 OPTION_COMMON_HELP:
                         return help();
 

--- a/src/sbsign/sbsign.c
+++ b/src/sbsign/sbsign.c
@@ -97,7 +97,7 @@ static int parse_argv(int argc, char *argv[], char ***ret_args) {
         const char *arg;
         int r;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
 
                 OPTION_COMMON_HELP:

--- a/src/shared/options.c
+++ b/src/shared/options.c
@@ -74,23 +74,46 @@ int option_parse(
                 const Option **ret_option,
                 const char **ret_arg) {
 
+        /* We define this one early, since we use goto below, and need to guarantee its initialization */
+        _cleanup_free_ char *_optname = NULL;  /* allocated option name */
+        int r;
+
+        assert(state);
+
         /* Check and initialize */
-        if (state->optind == 0) {
+        switch (state->state) {
+
+        case OPTION_PARSER_INIT:
                 assert(state->mode >= 0 && state->mode < _OPTION_PARSER_MODE_MAX);
 
-                if (state->argc < 1)
-                        return log_error_errno(SYNTHETIC_ERRNO(EUCLEAN), "argv cannot be empty");
+                if (state->argc < 1) {
+                        r = log_error_errno(SYNTHETIC_ERRNO(EUCLEAN), "argv cannot be empty");
+                        goto fail;
+                }
 
                 assert_se((size_t) state->argc == strv_length(state->argv)); /* Make sure argc/argv are consistent */
-
                 state->optind = state->positional_offset = 1;
+                state->state = OPTION_PARSER_RUNNING;
+                break;
+
+        case OPTION_PARSER_RUNNING:
+        case OPTION_PARSER_STOPPING:
+                break;
+
+        case OPTION_PARSER_DONE:
+                goto done;
+
+        case OPTION_PARSER_FAILED:
+                return log_error_errno(SYNTHETIC_ERRNO(ESTALE), "Option parser failed before, refusing.");
+
+        default:
+                assert_not_reached();
         }
 
         /* Look for the next option */
 
         const Option *option = NULL;  /* initialization to appease gcc 13 */
         const char *optname = NULL, *optval = NULL;
-        _cleanup_free_ char *_optname = NULL;  /* allocated option name */
         bool separate_optval = false;
         bool handling_positional_arg = false;
 
@@ -98,27 +121,27 @@ int option_parse(
                 /* Handle non-option parameters */
                 for (;;) {
                         if (state->optind == state->argc)
-                                return 0;
+                                goto done;
 
                         if (streq(state->argv[state->optind], "--")) {
                                 /* No more options. Move "--" before positional args so that
                                  * the list of positional args is clean. */
                                 shift_arg(state->argv, state->positional_offset++, state->optind++);
-                                state->parsing_stopped = true;
+                                goto done;
                         }
 
-                        if (state->parsing_stopped)
-                                return 0;
+                        /* If we are in OPTION_PARSER_STOPPING state we only wanted to read one more "--" if
+                         * there is one, nothing else, hence it's time to say goodbye now. */
+                        if (state->state == OPTION_PARSER_STOPPING)
+                                goto done;
 
                         if (state->argv[state->optind][0] == '-' &&
                             state->argv[state->optind][1] != '\0')
                                 /* Looks like we found an option parameter */
                                 break;
 
-                        if (state->mode == OPTION_PARSER_STOP_AT_FIRST_NONOPTION) {
-                                state->parsing_stopped = true;
-                                return 0;
-                        }
+                        if (state->mode == OPTION_PARSER_STOP_AT_FIRST_NONOPTION)
+                                goto done;
 
                         if (state->mode == OPTION_PARSER_RETURN_POSITIONAL_ARGS) {
                                 handling_positional_arg = true;
@@ -149,8 +172,10 @@ int option_parse(
                         char *eq = strchr(state->argv[state->optind], '=');
                         if (eq) {
                                 optname = _optname = strndup(state->argv[state->optind], eq - state->argv[state->optind]);
-                                if (!_optname)
-                                        return log_oom();
+                                if (!_optname) {
+                                        r = log_oom();
+                                        goto fail;
+                                }
 
                                 /* joined argument */
                                 optval = eq + 1;
@@ -163,12 +188,16 @@ int option_parse(
 
                         for (option = options;; option++) {
                                 if (option >= options_end) {
-                                        if (n_partial_matches == 0)
-                                                return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
-                                                                       "%s: unrecognized option '%s'",
-                                                                       program_invocation_short_name, optname);
-                                        if (n_partial_matches > 1)
-                                                return partial_match_error(options, options_end, optname, n_partial_matches);
+                                        if (n_partial_matches == 0) {
+                                                r = log_error_errno(SYNTHETIC_ERRNO(EINVAL),
+                                                                    "%s: unrecognized option '%s'",
+                                                                    program_invocation_short_name, optname);
+                                                goto fail;
+                                        }
+                                        if (n_partial_matches > 1) {
+                                                r = partial_match_error(options, options_end, optname, n_partial_matches);
+                                                goto fail;
+                                        }
 
                                         /* just one partial — good */
                                         option = last_partial;
@@ -197,15 +226,19 @@ int option_parse(
         if (state->short_option_offset > 0) {
                 char optchar = state->argv[state->optind][state->short_option_offset];
 
-                if (asprintf(&_optname, "-%c", optchar) < 0)
-                        return log_oom();
+                if (asprintf(&_optname, "-%c", optchar) < 0) {
+                        r = log_oom();
+                        goto fail;
+                }
                 optname = _optname;
 
                 for (option = options;; option++) {
-                        if (option >= options_end)
-                                return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
-                                                       "%s: unrecognized option '%s'",
-                                                       program_invocation_short_name, optname);
+                        if (option >= options_end) {
+                                r = log_error_errno(SYNTHETIC_ERRNO(EINVAL),
+                                                    "%s: unrecognized option '%s'",
+                                                    program_invocation_short_name, optname);
+                                goto fail;
+                        }
 
                         if (option_is_metadata(option) || optchar != option->short_code)
                                 continue;
@@ -227,15 +260,19 @@ int option_parse(
 
         assert(option);
 
-        if (!handling_positional_arg && optval && !option_takes_arg(option))
-                return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
-                                       "%s: option '%s' doesn't allow an argument",
-                                       program_invocation_short_name, optname);
+        if (!handling_positional_arg && optval && !option_takes_arg(option)) {
+                r = log_error_errno(SYNTHETIC_ERRNO(EINVAL),
+                                    "%s: option '%s' doesn't allow an argument",
+                                    program_invocation_short_name, optname);
+                goto fail;
+        }
         if (!handling_positional_arg && !optval && option_arg_required(option)) {
-                if (!state->argv[state->optind + 1])
-                        return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
-                                               "%s: option '%s' requires an argument",
-                                               program_invocation_short_name, optname);
+                if (!state->argv[state->optind + 1]) {
+                        r = log_error_errno(SYNTHETIC_ERRNO(EINVAL),
+                                            "%s: option '%s' requires an argument",
+                                            program_invocation_short_name, optname);
+                        goto fail;
+                }
                 optval = state->argv[state->optind + 1];
                 separate_optval = true;
         }
@@ -254,7 +291,7 @@ int option_parse(
         }
 
         if (FLAGS_SET(option->flags, OPTION_STOPS_PARSING))
-                state->parsing_stopped = true;
+                state->state = OPTION_PARSER_STOPPING;
 
         if (ret_option)
                 /* Return the matched Option structure to allow the caller to "know" what was matched */
@@ -267,6 +304,20 @@ int option_parse(
                 assert(!optval);
 
         return option->id;
+
+done:
+        state->state = OPTION_PARSER_DONE;
+        if (ret_option)
+                *ret_option = NULL;
+        if (ret_arg)
+                *ret_arg = NULL;
+        return 0;
+
+fail:
+        /* Invalidate the object for good on the first error */
+        assert(r < 0);
+        state->state = OPTION_PARSER_FAILED;
+        return r;
 }
 
 char* option_parser_next_arg(const OptionParser *state) {
@@ -299,7 +350,7 @@ char** option_parser_get_args(const OptionParser *state) {
          * original argv array, so it must not be freed or modified. */
 
         assert(state->optind > 0);
-        assert(state->optind == state->argc || state->parsing_stopped);
+        assert(state->state == OPTION_PARSER_DONE);
         assert(state->positional_offset <= state->argc);
 
         return state->argv + state->positional_offset;
@@ -307,7 +358,7 @@ char** option_parser_get_args(const OptionParser *state) {
 
 size_t option_parser_get_n_args(const OptionParser *state) {
         assert(state->optind > 0);
-        assert(state->optind == state->argc || state->parsing_stopped);
+        assert(state->state == OPTION_PARSER_DONE);
         assert(state->positional_offset <= state->argc);
 
         return state->argc - state->positional_offset;

--- a/src/shared/options.c
+++ b/src/shared/options.c
@@ -78,8 +78,10 @@ int option_parse(
         if (state->optind == 0) {
                 assert(state->mode >= 0 && state->mode < _OPTION_PARSER_MODE_MAX);
 
-                if (state->argc < 1 || strv_isempty(state->argv))
+                if (state->argc < 1)
                         return log_error_errno(SYNTHETIC_ERRNO(EUCLEAN), "argv cannot be empty");
+
+                assert_se((size_t) state->argc == strv_length(state->argv)); /* Make sure argc/argv are consistent */
 
                 state->optind = state->positional_offset = 1;
         }

--- a/src/shared/options.h
+++ b/src/shared/options.h
@@ -109,6 +109,9 @@ typedef struct Option {
                     "Allows the certificate to be loaded from an OpenSSL provider " \
                     "(file, provider:PROVIDER)")
 
+#define OPTION_ERROR \
+        case INT_MIN ... -1
+
 /* This is magically mapped to the beginning and end of the section */
 extern const Option __start_SYSTEMD_OPTIONS[];
 extern const Option __stop_SYSTEMD_OPTIONS[];
@@ -158,16 +161,21 @@ int option_parse(
                 const Option **ret_option,
                 const char **ret_arg);
 
-/* Iterate over options. */
-#define FOREACH_OPTION_FULL(parser, opt, ret_o, ret_a, on_error) \
-        for (int opt; (opt = option_parse(ALIGN_PTR(__start_SYSTEMD_OPTIONS), __stop_SYSTEMD_OPTIONS, parser, ret_o, ret_a)) != 0; ) \
-                if (opt < 0) {                                                  \
-                        on_error;                                               \
-                        break;                                                  \
-                } else
+/* Iterate over options. Don't forget to handle OPTION_ERROR! */
+#define FOREACH_OPTION_FULL(parser, opt, ret_o, ret_a) \
+        for (int opt; (opt = option_parse(ALIGN_PTR(__start_SYSTEMD_OPTIONS), __stop_SYSTEMD_OPTIONS, (parser), (ret_o), (ret_a))) != 0; ) \
 
-#define FOREACH_OPTION(parser, opt, ret_a, on_error) \
-        FOREACH_OPTION_FULL(parser, opt, /* ret_o= */ NULL, ret_a, on_error)
+/* Same, but doesn't return the Option pointer. And again, don't forget to handle OPTION_ERROR! */
+#define FOREACH_OPTION(parser, opt, ret_a) \
+        FOREACH_OPTION_FULL((parser), opt, /* ret_o= */ NULL, (ret_a))
+
+/* Just like FOREACH_OPTION(), but returns from the current function on error with the error code. No need to
+ * handle OPTION_ERROR here! */
+#define FOREACH_OPTION_OR_RETURN(parser, opt, ret_a)                   \
+        FOREACH_OPTION_FULL((parser), opt, /* ret_o= */ NULL, (ret_a)) \
+                if (opt < 0)                                           \
+                        return opt;                                    \
+                else
 
 char* option_parser_next_arg(const OptionParser *state);
 char* option_parser_consume_next_arg(OptionParser *state);

--- a/src/shared/options.h
+++ b/src/shared/options.h
@@ -127,14 +127,22 @@ typedef enum OptionParserMode {
         _OPTION_PARSER_MODE_MAX,
 } OptionParserMode;
 
+typedef enum OptionParserState {
+        OPTION_PARSER_INIT,
+        OPTION_PARSER_RUNNING,
+        OPTION_PARSER_STOPPING, /* We processed an option with OPTION_STOPS_PARSING, and will eat up one more "--", but not more */
+        OPTION_PARSER_DONE,     /* Option parsing completed (could be because we reached the end, or because "--" was fully processed, or because we hit a terminating option) */
+        OPTION_PARSER_FAILED,   /* We encountered a parse error, and terminated option parsing. */
+        _OPTION_PARSER_MAX,
+} OptionParserState;
+
 typedef struct OptionParser {
         /* Those three should stay first so that it's possible to initialize the struct as { argc, argv }
          * or { argc, argv, mode }. */
         int argc;                     /* The original argc. */
         char **argv;                  /* The argv array, possibly reordered. */
         OptionParserMode mode;
-
-        bool parsing_stopped;         /* We processed "--" or an option that terminates option parsing. */
+        OptionParserState state;
         int optind;                   /* Position of the parameter being handled.
                                        * 0 → option parsing hasn't been started yet. */
         int short_option_offset;      /* Set when we're parsing an argument with one or more short options.

--- a/src/shared/options.h
+++ b/src/shared/options.h
@@ -115,7 +115,7 @@ extern const Option __stop_SYSTEMD_OPTIONS[];
 
 typedef enum OptionParserMode {
         /* The default mode. This is the implicit default and doesn't have to be specified. */
-        OPTION_PARSER_NORMAL = 0,
+        OPTION_PARSER_NORMAL,
 
         /* Same as "+…" for getopt_long — only parse options before the first positional argument. */
         OPTION_PARSER_STOP_AT_FIRST_NONOPTION,

--- a/src/shutdown/shutdown.c
+++ b/src/shutdown/shutdown.c
@@ -67,7 +67,7 @@ static int parse_argv(int argc, char *argv[]) {
         const char *arg;
         int r;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
 
                 OPTION_COMMON_LOG_LEVEL:

--- a/src/sleep/sleep.c
+++ b/src/sleep/sleep.c
@@ -731,7 +731,7 @@ static int parse_argv(int argc, char *argv[], char ***ret_args) {
 
         OptionParser state = { argc, argv };
 
-        FOREACH_OPTION(&state, c, /* arg= */ NULL, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, /* arg= */ NULL)
                 switch (c) {
 
                 OPTION_COMMON_HELP:

--- a/src/socket-activate/socket-activate.c
+++ b/src/socket-activate/socket-activate.c
@@ -359,7 +359,7 @@ static int parse_argv(int argc, char *argv[], char ***remaining_args) {
         const char *arg;
         int r;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
 
                 OPTION_COMMON_HELP:

--- a/src/socket-proxy/socket-proxyd.c
+++ b/src/socket-proxy/socket-proxyd.c
@@ -424,7 +424,7 @@ static int parse_argv(int argc, char *argv[]) {
         const char *arg;
         int r;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
 
                 OPTION_COMMON_HELP:

--- a/src/ssh-generator/ssh-issue.c
+++ b/src/ssh-generator/ssh-issue.c
@@ -164,7 +164,7 @@ static int parse_argv(int argc, char *argv[], char ***ret_args) {
         const char *arg, *verb = NULL;
         int r;
 
-        FOREACH_OPTION_FULL(&state, c, &opt, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_FULL(&state, c, &opt, &arg)
                 switch (c) {
 
                 OPTION_COMMON_HELP:
@@ -192,6 +192,9 @@ static int parse_argv(int argc, char *argv[], char ***ret_args) {
 
                         arg_issue_stdout = false;
                         break;
+
+                OPTION_ERROR:
+                        return c;
                 }
 
         if (!arg_issue_path && !arg_issue_stdout) {

--- a/src/stdio-bridge/stdio-bridge.c
+++ b/src/stdio-bridge/stdio-bridge.c
@@ -50,7 +50,7 @@ static int parse_argv(int argc, char *argv[]) {
         const char *arg;
         int r;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
 
                 OPTION_COMMON_HELP:

--- a/src/storagetm/storagetm.c
+++ b/src/storagetm/storagetm.c
@@ -81,7 +81,7 @@ static int parse_argv(int argc, char *argv[]) {
         const char *arg;
         int r;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
 
                 OPTION_COMMON_HELP:

--- a/src/sysctl/sysctl.c
+++ b/src/sysctl/sysctl.c
@@ -363,7 +363,7 @@ static int parse_argv(int argc, char *argv[], char ***remaining_args) {
         OptionParser state = { argc, argv };
         const char *arg;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
 
                 OPTION_COMMON_HELP:

--- a/src/sysupdate/sysupdate.c
+++ b/src/sysupdate/sysupdate.c
@@ -1866,7 +1866,7 @@ static int parse_argv(int argc, char *argv[], char ***remaining_args) {
         const char *arg;
         int r;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
 
                 OPTION_COMMON_HELP:

--- a/src/sysupdate/updatectl.c
+++ b/src/sysupdate/updatectl.c
@@ -1690,7 +1690,7 @@ static int parse_argv(int argc, char *argv[], char ***ret_args) {
         OptionParser state = { argc, argv };
         const char *arg;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
 
                 OPTION_LONG("reboot", NULL, "Reboot after updating to newer version"):

--- a/src/sysusers/sysusers.c
+++ b/src/sysusers/sysusers.c
@@ -2104,7 +2104,7 @@ static int parse_argv(int argc, char *argv[], char ***ret_args) {
         OptionParser state = { argc, argv };
         const char *arg;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
 
                 OPTION_COMMON_CAT_CONFIG:

--- a/src/test/test-chase-manual.c
+++ b/src/test/test-chase-manual.c
@@ -41,7 +41,7 @@ static int parse_argv(int argc, char *argv[], char ***ret_args) {
         const Option *opt;
         const char *arg;
 
-        FOREACH_OPTION_FULL(&state, c, &opt, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_FULL(&state, c, &opt, &arg)
                 switch (c) {
 
                 OPTION_COMMON_HELP:
@@ -66,6 +66,9 @@ static int parse_argv(int argc, char *argv[], char ***ret_args) {
                 OPTION_LONG_DATA("warn",           NULL, CHASE_WARN,           "Emit a warning on error"):
                         arg_flags |= opt->data;
                         break;
+
+                OPTION_ERROR:
+                        return c;
                 }
 
         *ret_args = option_parser_get_args(&state);

--- a/src/test/test-options.c
+++ b/src/test/test-options.c
@@ -760,23 +760,27 @@ static void test_macros_parse_one(
         const Option *opt;
         const char *arg;
 
-        FOREACH_OPTION_FULL(&state, c, &opt, &arg, ASSERT_TRUE(false)) {
-                log_debug("%c %s: %s=%s",
-                          opt->short_code != 0 ? opt->short_code : ' ',
-                          opt->long_code ?: "",
-                          strnull(opt->metavar), strnull(arg));
+        FOREACH_OPTION_FULL(&state, c, &opt, &arg) {
+                if (c < 0)
+                        log_debug_errno(c, "Got failure: %m");
+                else {
+                        log_debug("%c %s: %s=%s",
+                                  opt->short_code != 0 ? opt->short_code : ' ',
+                                  opt->long_code ?: "",
+                                  strnull(opt->metavar), strnull(arg));
 
-                ASSERT_LT(i, n_entries);
-                if (entries[i].long_code)
-                        ASSERT_TRUE(streq_ptr(opt->long_code, entries[i].long_code));
-                if (entries[i].short_code != 0)
-                        ASSERT_EQ(opt->short_code, entries[i].short_code);
-                ASSERT_TRUE(streq_ptr(arg, entries[i].argument));
+                        ASSERT_LT(i, n_entries);
+                        if (entries[i].long_code)
+                                ASSERT_TRUE(streq_ptr(opt->long_code, entries[i].long_code));
+                        if (entries[i].short_code != 0)
+                                ASSERT_EQ(opt->short_code, entries[i].short_code);
+                        ASSERT_TRUE(streq_ptr(arg, entries[i].argument));
 
-                if (streq_ptr(entries[i].long_code, "optional2"))
-                        ASSERT_EQ(opt->data, 666u);
-                else
-                        ASSERT_EQ(opt->data, 0u);
+                        if (streq_ptr(entries[i].long_code, "optional2"))
+                                ASSERT_EQ(opt->data, 666u);
+                        else
+                                ASSERT_EQ(opt->data, 0u);
+                }
 
                 i++;
 
@@ -820,9 +824,13 @@ static void test_macros_parse_one(
                 OPTION_POSITIONAL:
                         break;
 
+                OPTION_ERROR:
+                        log_error_errno(c, "Unexpected error: %m");
+                        assert_not_reached();
+
                 default:
                         log_error("Unexpected option id: %d", c);
-                        ASSERT_TRUE(false);
+                        assert_not_reached();
                 }
         }
 

--- a/src/timedate/timedatectl.c
+++ b/src/timedate/timedatectl.c
@@ -951,7 +951,7 @@ static int parse_argv(int argc, char *argv[], char ***ret_args) {
         const Option *current;
         const char *arg;
 
-        FOREACH_OPTION_FULL(&state, c, &current, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_FULL(&state, c, &current, &arg)
                 switch (c) {
                 OPTION_COMMON_HELP:
                         return help();
@@ -1006,6 +1006,9 @@ static int parse_argv(int argc, char *argv[], char ***ret_args) {
                 OPTION('a', "all", NULL, "Show all properties, including empty ones"):
                         SET_FLAG(arg_print_flags, BUS_PRINT_PROPERTY_SHOW_EMPTY, true);
                         break;
+
+                OPTION_ERROR:
+                        return c;
                 }
 
         *ret_args = option_parser_get_args(&state);

--- a/src/tmpfiles/test-offline-passwd.c
+++ b/src/tmpfiles/test-offline-passwd.c
@@ -46,7 +46,7 @@ static int parse_argv(int argc, char *argv[], char ***ret_args) {
         OptionParser state = { argc, argv };
         const char *arg;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
 
                 OPTION('r', "root", "PATH", "Operate on an alternate filesystem root"):

--- a/src/tmpfiles/tmpfiles.c
+++ b/src/tmpfiles/tmpfiles.c
@@ -4190,7 +4190,7 @@ static int parse_argv(int argc, char *argv[], char ***ret_args) {
         OptionParser state = { argc, argv };
         const char *arg;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
 
                 OPTION_LONG("create", NULL, "Create and adjust files and directories"):

--- a/src/tpm2-setup/tpm2-clear.c
+++ b/src/tpm2-setup/tpm2-clear.c
@@ -52,7 +52,7 @@ static int parse_argv(int argc, char *argv[]) {
 
         OptionParser state = { argc, argv };
 
-        FOREACH_OPTION(&state, c, /* ret_a= */ NULL, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, /* ret_a= */ NULL)
                 switch (c) {
 
                 OPTION_COMMON_HELP:

--- a/src/tpm2-setup/tpm2-setup.c
+++ b/src/tpm2-setup/tpm2-setup.c
@@ -79,7 +79,7 @@ static int parse_argv(int argc, char *argv[]) {
         OptionParser state = { argc, argv };
         const char *arg;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
 
                 OPTION_COMMON_HELP:

--- a/src/tty-ask-password-agent/tty-ask-password-agent.c
+++ b/src/tty-ask-password-agent/tty-ask-password-agent.c
@@ -476,7 +476,7 @@ static int parse_argv(int argc, char *argv[]) {
         const char *arg;
         int r;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
 
                 OPTION_COMMON_HELP:

--- a/src/update-done/update-done.c
+++ b/src/update-done/update-done.c
@@ -99,7 +99,7 @@ static int parse_argv(int argc, char *argv[]) {
         OptionParser state = { argc, argv };
         const char *arg;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
                 OPTION_COMMON_HELP:
                         return help();

--- a/src/validatefs/validatefs.c
+++ b/src/validatefs/validatefs.c
@@ -67,7 +67,7 @@ static int parse_argv(int argc, char *argv[]) {
         OptionParser state = { argc, argv };
         const char *arg;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
                 OPTION_COMMON_HELP:
                         return help();

--- a/src/varlinkctl/varlinkctl.c
+++ b/src/varlinkctl/varlinkctl.c
@@ -127,7 +127,7 @@ static int parse_argv(int argc, char *argv[], char ***ret_args) {
         OptionParser state = { argc, argv };
         const char *arg;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
 
                 OPTION_COMMON_HELP:

--- a/src/vmspawn/vmspawn.c
+++ b/src/vmspawn/vmspawn.c
@@ -329,7 +329,7 @@ static int parse_argv(int argc, char *argv[]) {
         const Option *current;
         const char *arg;
 
-        FOREACH_OPTION_FULL(&state, c, &current, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_FULL(&state, c, &current, &arg)
                 switch (c) {
 
                 OPTION_COMMON_HELP:
@@ -888,6 +888,9 @@ static int parse_argv(int argc, char *argv[]) {
                         if (r < 0)
                                 return r;
                         break;
+
+                OPTION_ERROR:
+                        return c;
                 }
 
         /* Drop duplicate --bind-user= and --bind-user-group= entries */

--- a/src/vpick/vpick-tool.c
+++ b/src/vpick/vpick-tool.c
@@ -102,7 +102,7 @@ static int parse_argv(int argc, char *argv[], char ***ret_args) {
         OptionParser state = { argc, argv };
         const char *arg;
 
-        FOREACH_OPTION(&state, c, &arg, /* on_error= */ return c)
+        FOREACH_OPTION_OR_RETURN(&state, c, &arg)
                 switch (c) {
 
                 OPTION('B', "basename", "BASENAME", "Look for specified basename"):


### PR DESCRIPTION
let' handle errors instead via a switch case, like all other cases.

I am really not a fan of embedding actual code in macro arguments, hence let's try something that is a lot more readable.