### PR TITLE
cgtop: make root row default to cgroup sum, '/' toggles to meminfo

### DIFF
--- a/man/systemd-cgtop.xml
+++ b/man/systemd-cgtop.xml
@@ -235,6 +235,25 @@
       </varlistentry>
 
       <varlistentry>
+        <term><option>--root-memory=</option></term>
+
+        <listitem><para>Selects how the root control group row (<literal>/</literal>)
+        reports memory usage. Takes one of <literal>cgroup</literal> or
+        <literal>system</literal>. When <literal>cgroup</literal> (the default)
+        is used, the root row shows the sum of <filename>memory.current</filename>
+        across its direct children, which matches the accounting semantics of
+        every other row in the table. When <literal>system</literal> is used,
+        the root row shows whole-system RAM usage
+        (<literal>MemTotal - MemAvailable</literal> from
+        <filename>/proc/meminfo</filename>), which additionally accounts for
+        kernel slab, vmalloc, page tables, and other memory not attributable to
+        any cgroup. This setting may also be toggled at runtime by pressing the
+        <keycap>/</keycap> key.</para>
+
+        <xi:include href="version-info.xml" xpointer="v261"/></listitem>
+      </varlistentry>
+
+      <varlistentry>
         <term><option>-M <replaceable>MACHINE</replaceable></option></term>
         <term><option>--machine=<replaceable>MACHINE</replaceable></option></term>
 
@@ -301,6 +320,18 @@
         <option>--cpu=</option> command line switch.</para>
 
         <xi:include href="version-info.xml" xpointer="v201"/></listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term><keycap>/</keycap></term>
+
+        <listitem><para>Toggle the root control group row between
+        cgroup-sum accounting (default) and whole-system accounting from
+        <filename>/proc/meminfo</filename>. This setting may also be
+        controlled using the <option>--root-memory=</option> command line
+        switch.</para>
+
+        <xi:include href="version-info.xml" xpointer="v261"/></listitem>
       </varlistentry>
 
       <varlistentry>

--- a/shell-completion/bash/systemd-cgtop
+++ b/shell-completion/bash/systemd-cgtop
@@ -37,7 +37,7 @@ _systemd_cgtop() {
 
     local -A OPTS=(
         [STANDALONE]='-h --help --version -p -t -c -m -i -b --batch -r --raw -k -P'
-        [ARG]='--cpu --depth -M --machine --recursive -n --iterations -d --delay --order'
+        [ARG]='--cpu --depth -M --machine --recursive -n --iterations -d --delay --order --root-memory'
     )
 
     _init_completion || return
@@ -52,6 +52,9 @@ _systemd_cgtop() {
                 ;;
             --order)
                 comps='path tasks cpu memory io'
+                ;;
+            --root-memory)
+                comps='cgroup system'
                 ;;
         esac
         COMPREPLY=( $(compgen -W '$comps' -- "$cur") )

--- a/src/cgtop/cgtop.c
+++ b/src/cgtop/cgtop.c
@@ -73,6 +73,13 @@ typedef enum {
         _CPU_INVALID = -EINVAL,
 } CPUType;
 
+typedef enum RootMemoryMode {
+        ROOT_MEMORY_CGROUP,        /* sum of memory.current over direct children */
+        ROOT_MEMORY_SYSTEM,        /* /proc/meminfo (MemTotal - MemAvailable) */
+        _ROOT_MEMORY_MODE_MAX,
+        _ROOT_MEMORY_MODE_INVALID = -EINVAL,
+} RootMemoryMode;
+
 #define DEFAULT_MAXIMUM_DEPTH 3
 
 static unsigned arg_depth = DEFAULT_MAXIMUM_DEPTH;
@@ -87,6 +94,7 @@ static bool arg_recursive_unset = false;
 static PidsCount arg_count = COUNT_PIDS;
 static Order arg_order = ORDER_CPU;
 static CPUType arg_cpu_type = CPU_PERCENTAGE;
+static RootMemoryMode arg_root_memory_mode = ROOT_MEMORY_CGROUP;
 
 static const char *order_table[_ORDER_MAX] = {
         [ORDER_PATH]   = "path",
@@ -104,6 +112,13 @@ static const char *cpu_type_table[_CPU_MAX] = {
 };
 
 DEFINE_PRIVATE_STRING_TABLE_LOOKUP_FROM_STRING(cpu_type, CPUType);
+
+static const char *root_memory_mode_table[_ROOT_MEMORY_MODE_MAX] = {
+        [ROOT_MEMORY_CGROUP] = "cgroup",
+        [ROOT_MEMORY_SYSTEM] = "system",
+};
+
+DEFINE_PRIVATE_STRING_TABLE_LOOKUP_FROM_STRING(root_memory_mode, RootMemoryMode);
 
 static Group *group_free(Group *g) {
         if (!g)
@@ -325,6 +340,7 @@ static int process(
                 Hashmap *a,
                 Hashmap *b,
                 unsigned iteration,
+                uint64_t *root_children_memory_sum,
                 Group **ret) {
 
         Group *g;
@@ -417,6 +433,14 @@ static int process(
         if (r < 0)
                 return r;
 
+        /* Accumulate depth-1 cgroup memory into the root sum as we go, so
+         * display() can paint the root row in O(1). The caller (refresh()
+         * at depth 0, itself called from loop()) owns the sum and resets
+         * it at the start of each cycle. */
+        if (root_children_memory_sum &&
+            g->memory_valid && !is_root_cgroup(path) && !strchr(path, '/'))
+                *root_children_memory_sum += g->memory;
+
         r = process_io(g, iteration);
         if (r < 0)
                 return r;
@@ -437,6 +461,7 @@ static int refresh(
                 Hashmap *b,
                 unsigned iteration,
                 unsigned depth,
+                uint64_t *root_children_memory_sum,
                 Group **ret) {
 
         _cleanup_closedir_ DIR *d = NULL;
@@ -452,7 +477,7 @@ static int refresh(
                 return 0;
         }
 
-        r = process(path, a, b, iteration, &ours);
+        r = process(path, a, b, iteration, root_children_memory_sum, &ours);
         if (r < 0)
                 return r;
 
@@ -481,7 +506,7 @@ static int refresh(
 
                 path_simplify(p);
 
-                r = refresh(p, a, b, iteration, depth + 1, &child);
+                r = refresh(p, a, b, iteration, depth + 1, root_children_memory_sum, &child);
                 if (r < 0)
                         return r;
                 if (r > 0 &&
@@ -589,7 +614,7 @@ static int group_compare(Group * const *a, Group * const *b) {
         return path_compare(x->path, y->path);
 }
 
-static void display(Hashmap *a) {
+static void display(Hashmap *a, uint64_t root_children_memory_sum) {
         Group *g;
         Group **array;
         signed path_columns;
@@ -661,8 +686,20 @@ static void display(Hashmap *a) {
 
                 g = array[j];
 
-                path = empty_to_root(g->path);
-                ellipsized = ellipsize(path, path_columns, 33);
+                bool is_root = is_root_cgroup(g->path);
+
+                if (is_root) {
+                        if (arg_root_memory_mode == ROOT_MEMORY_CGROUP) {
+                                g->memory = root_children_memory_sum;
+                                g->memory_valid = true;
+                        }
+                        path = arg_root_memory_mode == ROOT_MEMORY_CGROUP
+                                ? "/ *CGROUP USAGE, press / to show WHOLE SYSTEM USAGE*"
+                                : "/ *WHOLE SYSTEM USAGE, press / to show CGROUP USAGE*";
+                } else
+                        path = empty_to_root(g->path);
+
+                ellipsized = ellipsize(path, path_columns, is_root ? 100 : 33);
                 printf("%-*s", path_columns, ellipsized ?: path);
 
                 if (g->n_tasks_valid)
@@ -824,6 +861,15 @@ static int parse_argv(int argc, char *argv[]) {
                                 return log_error_errno(r, "Failed to parse depth parameter '%s': %m", arg);
                         break;
 
+                OPTION_LONG("root-memory", "MODE",
+                            "Root row memory source (cgroup|system, default: cgroup)"):
+                        arg_root_memory_mode = root_memory_mode_from_string(arg);
+                        if (arg_root_memory_mode < 0)
+                                return log_error_errno(arg_root_memory_mode,
+                                                       "Invalid argument to --root-memory=: %s",
+                                                       arg);
+                        break;
+
                 OPTION_COMMON_MACHINE:
                         arg_machine = arg;
                         break;
@@ -853,6 +899,10 @@ static int loop(const char *root) {
         unsigned iteration = 0;
         usec_t last_refresh = 0;
         bool immediate_refresh = false;
+        /* Running sum of memory.current across depth-1 children, filled in by
+         * process() during the refresh() walk and consumed by display() for
+         * the root row when arg_root_memory_mode == ROOT_MEMORY_CGROUP. */
+        uint64_t root_children_memory_sum = 0;
         int r;
 
         a = hashmap_new(&group_hash_ops);
@@ -868,7 +918,10 @@ static int loop(const char *root) {
 
                 if (t >= usec_add(last_refresh, arg_delay) || immediate_refresh) {
 
-                        r = refresh(root, a, b, iteration++, /* depth= */ 0, /* ret= */ NULL);
+                        root_children_memory_sum = 0;
+
+                        r = refresh(root, a, b, iteration++, /* depth= */ 0,
+                                    &root_children_memory_sum, /* ret= */ NULL);
                         if (r < 0)
                                 return log_error_errno(r, "Failed to refresh: %m");
 
@@ -879,7 +932,7 @@ static int loop(const char *root) {
                         immediate_refresh = false;
                 }
 
-                display(b);
+                display(b, root_children_memory_sum);
 
                 if (arg_iterations && iteration >= arg_iterations)
                         return 0;
@@ -939,6 +992,12 @@ static int loop(const char *root) {
                         arg_cpu_type = arg_cpu_type == CPU_TIME ? CPU_PERCENTAGE : CPU_TIME;
                         break;
 
+                case '/':
+                        arg_root_memory_mode = arg_root_memory_mode == ROOT_MEMORY_CGROUP
+                                ? ROOT_MEMORY_SYSTEM : ROOT_MEMORY_CGROUP;
+                        immediate_refresh = true;
+                        break;
+
                 case 'k':
                         arg_count = arg_count != COUNT_ALL_PROCESSES ? COUNT_ALL_PROCESSES : COUNT_PIDS;
                         fprintf(stdout, "\nCounting: %s.", counting_what());
@@ -990,7 +1049,7 @@ static int loop(const char *root) {
                                 "\t<%1$sp%2$s> By path; <%1$st%2$s> By tasks/procs; <%1$sc%2$s> By CPU; <%1$sm%2$s> By memory; <%1$si%2$s> By I/O\n"
                                 "\t<%1$s+%2$s> Inc. delay; <%1$s-%2$s> Dec. delay; <%1$s%%%2$s> Toggle time; <%1$sSPACE%2$s> Refresh\n"
                                 "\t<%1$sP%2$s> Toggle count userspace processes; <%1$sk%2$s> Toggle count all processes\n"
-                                "\t<%1$sr%2$s> Count processes recursively; <%1$sq%2$s> Quit",
+                                "\t<%1$sr%2$s> Count processes recursively; <%1$s/%2$s> Toggle root row (meminfo/cgroup sum); <%1$sq%2$s> Quit",
                                 ansi_highlight(), ansi_normal());
                         fflush(stdout);
                         sleep(3);


### PR DESCRIPTION
TL;DR: cgtop's root row currently reports whole-system RAM from /proc/meminfo, not a cgroup sum, which contradicts the rest of the table. This PR flips the default to cgroup sum and adds / to toggle back to /proc/meminfo.

## Problem

The root row in `systemd-cgtop` currently displays whole-system RAM usage
read from `/proc/meminfo` (`MemTotal - MemAvailable`), not a cgroup sum.
This is a pragmatic fallback — the kernel intentionally does not expose
`memory.current` on the v2 root cgroup (see the existing
`is_root_cgroup()` comment about avoiding "multiple truth about system
state"), so cgtop picks `/proc/meminfo` to fill the gap.

The side effect is that the `/` row answers a different question than
every other row in the table:

- All child rows: "what is this cgroup charged for?" (anon + file +
  sock + shmem attributable to the cgroup).
- Root row: "what is the whole system using?" (includes kernel slab,
  vmalloc, pagetables, zram `mem_used`, and anything not attributable
  to any cgroup).

Concretely, on a typical desktop :

/                         ~10 GB   ← /proc/meminfo (top-like)
user.slice                ~4.6 GB
system.slice              ~0.5 GB
init.scope                ~4 MB
other .mount cgroups      ~1 MB
──────
Σ children                ~5.1 GB  ← the real cgroup total



The ~5 GB delta has no explanation visible in the tool itself, and
users reasonably conclude cgtop is misreporting or that half their RAM
has vanished. The delta is ram that no cgroup can
touch (confirmed by `memory.reclaim` having no effect on it), but
cgtop does not communicate this.

## Change

1. Switch the default accounting for the root row to the sum of
   `memory.current` over its direct children (`user.slice`,
   `system.slice`, `init.scope`, `*.mount`, …). This matches the
   accounting semantics of every other row.

2. Add a `/` interactive key that toggles the root row between the new
   cgroup-sum default and the previous `/proc/meminfo` behaviour. The
   current mode is annotated inline in the root row's Control Group
   cell, along with the toggle key:

/ *CGROUP USAGE, press / to show WHOLE SYSTEM USAGE* ...

or

/ *WHOLE SYSTEM USAGE, press / to show CGROUP USAGE* ...



Ellipsized normally when the terminal is too narrow.

3. Update the interactive help string (`?` / `h`) to list the new
key.

Inside a container (`detect_container() > 0`), `is_root_cgroup()`
already returns false, so none of this applies — the container's `/`
still reads `memory.current` from the namespaced cgroup as before.

## Non-goals

- No new CLI flag. The toggle is runtime-only. Happy to add
`--root-accounting=cgroup|meminfo` if maintainers prefer making it
persistent across invocations.
- No changes to man page yet; feel free to update it
- No new dependencies, no new headers.

## Testing

Built against 260-git, tested on Debian testing (kernel 6.19.14,
cgroup v2 unified hierarchy):

- Default mode: root row shows ~5 GB, matches
`awk '{s+=$1} END{print s}' /sys/fs/cgroup/*/memory.current`.
- After pressing `/`: root row jumps to ~10 GB, matches
`MemTotal - MemAvailable` from `/proc/meminfo`.
- Column alignment preserved at all terminal widths (hint text
ellipsizes with trailing `…` like regular cgroup paths).
- No regression on child rows, sort keys, batch mode, or `-M`
(machine) mode.