### PR TITLE
core,test: decouple service and device default timeouts

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -321,8 +321,29 @@ conf.set10('MEMORY_ACCOUNTING_DEFAULT',                       memory_accounting_
 conf.set('STATUS_UNIT_FORMAT_DEFAULT',                        'STATUS_UNIT_FORMAT_' + status_unit_format_default.to_upper())
 conf.set_quoted('STATUS_UNIT_FORMAT_DEFAULT_STR',             status_unit_format_default)
 
-conf.set('DEFAULT_TIMEOUT_SEC',                               get_option('default-timeout-sec'))
-conf.set('DEFAULT_USER_TIMEOUT_SEC',                          get_option('default-user-timeout-sec'))
+default_timeout_sec = get_option('default-timeout-sec')
+
+# Parse a multiplier string of the form "N" or "N/D" into [numerator, denominator].
+foreach mult_opt : ['default-user-timeout-multiplier', 'default-device-timeout-multiplier']
+        mult_str = get_option(mult_opt)
+        if mult_str.contains('/')
+                mult_parts = mult_str.split('/')
+                mult_numer = mult_parts[0].to_int()
+                mult_denom = mult_parts[1].to_int()
+        else
+                mult_numer = mult_str.to_int()
+                mult_denom = 1
+        endif
+        if mult_opt == 'default-user-timeout-multiplier'
+                user_timeout_sec = default_timeout_sec * mult_numer / mult_denom
+        else
+                device_timeout_sec = default_timeout_sec * mult_numer / mult_denom
+        endif
+endforeach
+
+conf.set('DEFAULT_TIMEOUT_SEC',                               default_timeout_sec)
+conf.set('DEFAULT_USER_TIMEOUT_SEC',                          user_timeout_sec)
+conf.set('DEFAULT_DEVICE_TIMEOUT_SEC',                        device_timeout_sec)
 conf.set('UPDATE_HELPER_USER_TIMEOUT_SEC',                    get_option('update-helper-user-timeout-sec'))
 
 conf.set10('ENABLE_FIRST_BOOT_FULL_PRESET',                   get_option('first-boot-full-preset'))

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -209,10 +209,12 @@ option('dbussystemservicedir', type : 'string',
        description : 'D-Bus system service directory')
 option('dbus-interfaces-dir', type : 'string',
        description : 'export D-Bus introspection XML as standalone files')
-option('default-timeout-sec', type : 'integer', value : 90,
+option('default-timeout-sec', type : 'integer', value : 30,
        description : 'default timeout for system unit start/stop')
-option('default-user-timeout-sec', type : 'integer', value : 90,
-       description : 'default timeout for user unit start/stop')
+option('default-user-timeout-multiplier', type : 'string', value : '2',
+       description : 'user-manager timeout multiplier (× default-timeout-sec); integer "N" or fraction "N/D"')
+option('default-device-timeout-multiplier', type : 'string', value : '6',
+       description : 'device-unit timeout multiplier (× default-timeout-sec); integer "N" or fraction "N/D"')
 option('pkgconfigdatadir', type : 'string', value : '',
        description : 'directory for arch-independent pkg-config files')
 option('pkgconfiglibdir', type : 'string', value : '',

--- a/src/basic/constants.h
+++ b/src/basic/constants.h
@@ -12,10 +12,11 @@
 /* Timeout for user confirmation on the console */
 #define DEFAULT_CONFIRM_USEC (30*USEC_PER_SEC)
 
-/* We use an extra-long timeout for the reload. This is because a reload or reexec means generators are rerun
- * which are timed out after DEFAULT_TIMEOUT_USEC. Let's use twice that time here, so that the generators can
- * have their timeout, and for everything else there's the same time budget in place. */
-#define DAEMON_RELOAD_TIMEOUT_SEC (DEFAULT_TIMEOUT_USEC * 2)
+/* daemon-reload/-reexec is a multi-step pipeline (re-run every
+ * generator, reload every unit, rebuild all jobs); align with the
+ * device-timeout patience multiplier (6×) rather than the
+ * fail-fast service multiplier (1×). */
+#define DAEMON_RELOAD_TIMEOUT_SEC (DEFAULT_TIMEOUT_USEC * 6)
 
 #define DEFAULT_START_LIMIT_INTERVAL (10*USEC_PER_SEC)
 #define DEFAULT_START_LIMIT_BURST 5

--- a/src/core/system.conf.in
+++ b/src/core/system.conf.in
@@ -50,7 +50,8 @@
 #DefaultTimeoutStartSec={{DEFAULT_TIMEOUT_SEC}}s
 #DefaultTimeoutStopSec={{DEFAULT_TIMEOUT_SEC}}s
 #DefaultTimeoutAbortSec=
-#DefaultDeviceTimeoutSec={{DEFAULT_TIMEOUT_SEC}}s
+# Generous so device enumeration tolerates virt, slow/old/failing hardware.
+#DefaultDeviceTimeoutSec={{DEFAULT_DEVICE_TIMEOUT_SEC}}s
 #DefaultRestartSec=100ms
 #DefaultStartLimitIntervalSec=10s
 #DefaultStartLimitBurst=5


### PR DESCRIPTION
Hello, the 90s default for DefaultDeviceTimeoutSec proves too aggressive for integration tests running in slow environments (TCG emulation, or newer distros where initrd startup is pushed later by additional TPM/udev/early-setup work). TEST-86-MULTI-PROFILE-UKI in particular consistently fails at ~89s with "Timed out waiting for device dev-gpt\x2dauto\x2droot.device" before userspace udev has had time to enumerate partitions.

Raise the default to 300s via integration_test_template's cmdline. This is inherited by every integration test but has no effect on runs where devices appear quickly (the larger timeout is only ever hit when something is genuinely slow).

Reproduces cleanly with TEST_NO_KVM=1 meson test ... TEST-86-...: FAIL before (~89s), PASS after (~25min within the 30min default test budget). KVM path unchanged (~125-170s).

May mitigate similar failure signatures on other flaky tests sharing the VM+TPM profile (see #39553, #38241, #39548).