### PR TITLE
Introduce helper functions to parse and build length-prefixed data and TLV data

### DIFF
--- a/src/basic/iovec-wrapper.c
+++ b/src/basic/iovec-wrapper.c
@@ -24,6 +24,22 @@ void iovw_done_free(struct iovec_wrapper *iovw) {
         iovw_done(iovw);
 }
 
+struct iovec_wrapper* iovw_free(struct iovec_wrapper *iovw) {
+        if (!iovw)
+                return NULL;
+
+        iovw_done(iovw);
+        return mfree(iovw);
+}
+
+struct iovec_wrapper* iovw_free_free(struct iovec_wrapper *iovw) {
+        if (!iovw)
+                return NULL;
+
+        iovw_done_free(iovw);
+        return mfree(iovw);
+}
+
 int iovw_compare(const struct iovec_wrapper *a, const struct iovec_wrapper *b) {
         int r;
 

--- a/src/basic/iovec-wrapper.c
+++ b/src/basic/iovec-wrapper.c
@@ -6,6 +6,7 @@
 #include "iovec-util.h"
 #include "iovec-wrapper.h"
 #include "string-util.h"
+#include "unaligned.h"
 
 void iovw_done(struct iovec_wrapper *iovw) {
         assert(iovw);
@@ -301,4 +302,122 @@ char* iovw_to_cstring(const struct iovec_wrapper *iovw) {
 
         assert(!memchr(iov.iov_base, 0, iov.iov_len));
         return TAKE_PTR(iov.iov_base);
+}
+
+int iovec_split(const struct iovec *iov, size_t length_size, struct iovec_wrapper *ret) {
+        int r;
+
+        assert(IN_SET(length_size, 1, 2, 4));
+        assert(ret);
+
+        /* This parses the input iovec as length-prefixed data, and stores the result as iovec_wrapper.
+         * Note, zero-length entries are silently dropped. */
+
+        if (!iovec_is_set(iov)) {
+                *ret = (struct iovec_wrapper) {};
+                return 0;
+        }
+
+        _cleanup_(iovw_done_free) struct iovec_wrapper iovw = {};
+        for (struct iovec i = *iov; iovec_is_set(&i); ) {
+                if (i.iov_len < length_size)
+                        return -EBADMSG;
+
+                size_t len;
+                switch (length_size) {
+                case 1:
+                        len = *(uint8_t*) i.iov_base;
+                        break;
+                case 2:
+                        len = unaligned_read_be16(i.iov_base);
+                        break;
+                case 4:
+                        len = unaligned_read_be32(i.iov_base);
+                        break;
+                default:
+                        assert_not_reached();
+                }
+
+                iovec_inc(&i, length_size);
+
+                if (len == 0)
+                        continue;
+
+                if (i.iov_len < len)
+                        return -EBADMSG;
+
+                r = iovw_extend(&iovw, i.iov_base, len);
+                if (r < 0)
+                        return r;
+
+                iovec_inc(&i, len);
+        }
+
+        *ret = TAKE_STRUCT(iovw);
+        return 0;
+}
+
+int iovw_merge(const struct iovec_wrapper *iovw, size_t length_size, struct iovec *ret) {
+        assert(IN_SET(length_size, 1, 2, 4));
+        assert(ret);
+
+        /* This is the inverse of iovec_split(), and builds a length-prefixed data from iovec_wrapper.
+         * Note, zero-length entries are silently dropped. */
+
+        size_t sz = iovw_size(iovw);
+        if (sz == 0) {
+                *ret = (struct iovec) {};
+                return 0;
+        }
+        if (sz == SIZE_MAX)
+                return -E2BIG;
+
+        if (size_multiply_overflow(length_size, iovw->count))
+                return -E2BIG;
+
+        sz = size_add(sz, iovw->count * length_size);
+        if (sz == SIZE_MAX)
+                return -E2BIG;
+
+        _cleanup_free_ uint8_t *buf = new(uint8_t, sz);
+        if (!buf)
+                return -ENOMEM;
+
+        uint8_t *p = buf;
+        FOREACH_ARRAY(iov, iovw->iovec, iovw->count) {
+                if (iov->iov_len == 0)
+                        continue;
+
+                switch (length_size) {
+                case 1:
+                        if (iov->iov_len > UINT8_MAX)
+                                return -ERANGE;
+
+                        *p = iov->iov_len;
+                        break;
+                case 2:
+                        if (iov->iov_len > UINT16_MAX)
+                                return -ERANGE;
+
+                        unaligned_write_be16(p, iov->iov_len);
+                        break;
+                case 4:
+                        if (iov->iov_len > UINT32_MAX)
+                                return -ERANGE;
+
+                        unaligned_write_be32(p, iov->iov_len);
+                        break;
+                default:
+                        assert_not_reached();
+                }
+                p += length_size;
+
+                p = mempcpy(p, iov->iov_base, iov->iov_len);
+        }
+
+        assert(sz >= (size_t) (p - buf));
+        sz = p - buf;
+
+        *ret = IOVEC_MAKE(TAKE_PTR(buf), sz);
+        return 0;
 }

--- a/src/basic/iovec-wrapper.c
+++ b/src/basic/iovec-wrapper.c
@@ -45,13 +45,12 @@ int iovw_compare(const struct iovec_wrapper *a, const struct iovec_wrapper *b) {
         return CMP(a->count, b->count);
 }
 
-int iovw_put(struct iovec_wrapper *iovw, void *data, size_t len) {
+int iovw_put_full(struct iovec_wrapper *iovw, bool accept_zero, void *data, size_t len) {
         assert(iovw);
+        assert(data || len == 0);
 
-        if (len == 0)
+        if (len == 0 && !accept_zero)
                 return 0;
-
-        assert(data);
 
         if (iovw->count >= IOV_MAX)
                 return -E2BIG;
@@ -63,16 +62,18 @@ int iovw_put(struct iovec_wrapper *iovw, void *data, size_t len) {
         return 1;
 }
 
-int iovw_put_iov(struct iovec_wrapper *iovw, const struct iovec *iov) {
+int iovw_put_iov_full(struct iovec_wrapper *iovw, bool accept_zero, const struct iovec *iov) {
         assert(iovw);
 
         if (!iov)
                 return 0;
 
-        return iovw_put(iovw, iov->iov_base, iov->iov_len);
+        return iovw_put_full(iovw, accept_zero, iov->iov_base, iov->iov_len);
 }
 
-int iovw_put_iovw(struct iovec_wrapper *iovw, const struct iovec_wrapper *source) {
+int iovw_put_iovw_full(struct iovec_wrapper *iovw, bool accept_zero, const struct iovec_wrapper *source) {
+        int r;
+
         assert(iovw);
 
         if (iovw_isempty(source))
@@ -87,24 +88,41 @@ int iovw_put_iovw(struct iovec_wrapper *iovw, const struct iovec_wrapper *source
         if (iovw->count + source->count > IOV_MAX)
                 return -E2BIG;
 
-        if (!GREEDY_REALLOC_APPEND(iovw->iovec, iovw->count, source->iovec, source->count))
-                return -ENOMEM;
+        if (accept_zero) {
+                if (!GREEDY_REALLOC_APPEND(iovw->iovec, iovw->count, source->iovec, source->count))
+                        return -ENOMEM;
+
+                return 0;
+        }
+
+        /* When accept_zero is false, we need to filter zero length iovec in source. */
+        size_t original_count = iovw->count;
+
+        FOREACH_ARRAY(iovec, source->iovec, source->count) {
+                r = iovw_put_iov_full(iovw, accept_zero, iovec);
+                if (r < 0)
+                        goto rollback;
+        }
 
         return 0;
+
+rollback:
+        iovw->count = original_count;
+        return r;
 }
 
-int iovw_consume(struct iovec_wrapper *iovw, void *data, size_t len) {
+int iovw_consume_full(struct iovec_wrapper *iovw, bool accept_zero, void *data, size_t len) {
         /* Move data into iovw or free on error */
         int r;
 
-        r = iovw_put(iovw, data, len);
+        r = iovw_put_full(iovw, accept_zero, data, len);
         if (r <= 0)
                 free(data);
 
         return r;
 }
 
-int iovw_consume_iov(struct iovec_wrapper *iovw, struct iovec *iov) {
+int iovw_consume_iov_full(struct iovec_wrapper *iovw, bool accept_zero, struct iovec *iov) {
         int r;
 
         assert(iovw);
@@ -112,7 +130,7 @@ int iovw_consume_iov(struct iovec_wrapper *iovw, struct iovec *iov) {
         if (!iov)
                 return 0;
 
-        r = iovw_put_iov(iovw, iov);
+        r = iovw_put_iov_full(iovw, accept_zero, iov);
         if (r <= 0)
                 iovec_done(iov);
         else
@@ -123,27 +141,30 @@ int iovw_consume_iov(struct iovec_wrapper *iovw, struct iovec *iov) {
         return r;
 }
 
-int iovw_extend(struct iovec_wrapper *iovw, const void *data, size_t len) {
+int iovw_extend_full(struct iovec_wrapper *iovw, bool accept_zero, const void *data, size_t len) {
+        assert(iovw);
+        assert(data || len == 0);
+
         if (len == 0)
-                return 0;
+                return iovw_put_full(iovw, accept_zero, /* data= */ NULL, /* len= */ 0);
 
         void *c = memdup(data, len);
         if (!c)
                 return -ENOMEM;
 
-        return iovw_consume(iovw, c, len);
+        return iovw_consume_full(iovw, accept_zero, c, len);
 }
 
-int iovw_extend_iov(struct iovec_wrapper *iovw, const struct iovec *iov) {
+int iovw_extend_iov_full(struct iovec_wrapper *iovw, bool accept_zero, const struct iovec *iov) {
         assert(iovw);
 
-        if (!iovec_is_set(iov))
+        if (!iov)
                 return 0;
 
-        return iovw_extend(iovw, iov->iov_base, iov->iov_len);
+        return iovw_extend_full(iovw, accept_zero, iov->iov_base, iov->iov_len);
 }
 
-int iovw_extend_iovw(struct iovec_wrapper *iovw, const struct iovec_wrapper *source) {
+int iovw_extend_iovw_full(struct iovec_wrapper *iovw, bool accept_zero, const struct iovec_wrapper *source) {
         int r;
 
         assert(iovw);
@@ -165,7 +186,7 @@ int iovw_extend_iovw(struct iovec_wrapper *iovw, const struct iovec_wrapper *sou
         size_t original_count = iovw->count;
 
         FOREACH_ARRAY(iovec, source->iovec, source->count) {
-                r = iovw_extend_iov(iovw, iovec);
+                r = iovw_extend_iov_full(iovw, accept_zero, iovec);
                 if (r < 0)
                         goto rollback;
         }
@@ -260,7 +281,7 @@ int iovw_concat(const struct iovec_wrapper *iovw, struct iovec *ret) {
 
         uint8_t *p = buf;
         FOREACH_ARRAY(i, iovw->iovec, iovw->count)
-                p = mempcpy(p, i->iov_base, i->iov_len);
+                p = mempcpy_safe(p, i->iov_base, i->iov_len);
 
         *p = 0;
 

--- a/src/basic/iovec-wrapper.c
+++ b/src/basic/iovec-wrapper.c
@@ -237,7 +237,8 @@ void iovw_rebase(struct iovec_wrapper *iovw, void *old, void *new) {
 }
 
 size_t iovw_size(const struct iovec_wrapper *iovw) {
-        assert(iovw);
+        if (iovw_isempty(iovw))
+                return 0;
 
         return iovec_total_size(iovw->iovec, iovw->count);
 }

--- a/src/basic/iovec-wrapper.h
+++ b/src/basic/iovec-wrapper.h
@@ -11,6 +11,12 @@ struct iovec_wrapper {
 void iovw_done_free(struct iovec_wrapper *iovw);
 void iovw_done(struct iovec_wrapper *iovw);
 
+struct iovec_wrapper* iovw_free(struct iovec_wrapper *iovw);
+DEFINE_TRIVIAL_CLEANUP_FUNC(struct iovec_wrapper*, iovw_free);
+
+struct iovec_wrapper* iovw_free_free(struct iovec_wrapper *iovw);
+DEFINE_TRIVIAL_CLEANUP_FUNC(struct iovec_wrapper*, iovw_free_free);
+
 int iovw_compare(const struct iovec_wrapper *a, const struct iovec_wrapper *b) _pure_;
 static inline bool iovw_equal(const struct iovec_wrapper *a, const struct iovec_wrapper *b) {
         return iovw_compare(a, b) == 0;

--- a/src/basic/iovec-wrapper.h
+++ b/src/basic/iovec-wrapper.h
@@ -68,3 +68,6 @@ void iovw_rebase(struct iovec_wrapper *iovw, void *old, void *new);
 size_t iovw_size(const struct iovec_wrapper *iovw);
 int iovw_concat(const struct iovec_wrapper *iovw, struct iovec *ret);
 char* iovw_to_cstring(const struct iovec_wrapper *iovw);
+
+int iovec_split(const struct iovec *iov, size_t length_size, struct iovec_wrapper *ret);
+int iovw_merge(const struct iovec_wrapper *iovw, size_t length_size, struct iovec *ret);

--- a/src/basic/iovec-wrapper.h
+++ b/src/basic/iovec-wrapper.h
@@ -16,14 +16,38 @@ static inline bool iovw_equal(const struct iovec_wrapper *a, const struct iovec_
         return iovw_compare(a, b) == 0;
 }
 
-int iovw_put(struct iovec_wrapper *iovw, void *data, size_t len);
-int iovw_put_iov(struct iovec_wrapper *iovw, const struct iovec *iov);
-int iovw_put_iovw(struct iovec_wrapper *iovw, const struct iovec_wrapper *source);
-int iovw_consume(struct iovec_wrapper *iovw, void *data, size_t len);
-int iovw_consume_iov(struct iovec_wrapper *iovw, struct iovec *iov);
-int iovw_extend(struct iovec_wrapper *iovw, const void *data, size_t len);
-int iovw_extend_iov(struct iovec_wrapper *iovw, const struct iovec *iov);
-int iovw_extend_iovw(struct iovec_wrapper *iovw, const struct iovec_wrapper *source);
+int iovw_put_full(struct iovec_wrapper *iovw, bool accept_zero, void *data, size_t len);
+static inline int iovw_put(struct iovec_wrapper *iovw, void *data, size_t len) {
+        return iovw_put_full(iovw, false, data, len);
+}
+int iovw_put_iov_full(struct iovec_wrapper *iovw, bool accept_zero, const struct iovec *iov);
+static inline int iovw_put_iov(struct iovec_wrapper *iovw, const struct iovec *iov) {
+        return iovw_put_iov_full(iovw, false, iov);
+}
+int iovw_put_iovw_full(struct iovec_wrapper *iovw, bool accept_zero, const struct iovec_wrapper *source);
+static inline int iovw_put_iovw(struct iovec_wrapper *iovw, const struct iovec_wrapper *source) {
+        return iovw_put_iovw_full(iovw, false, source);
+}
+int iovw_consume_full(struct iovec_wrapper *iovw, bool accept_zero, void *data, size_t len);
+static inline int iovw_consume(struct iovec_wrapper *iovw, void *data, size_t len) {
+        return iovw_consume_full(iovw, false, data, len);
+}
+int iovw_consume_iov_full(struct iovec_wrapper *iovw, bool accept_zero, struct iovec *iov);
+static inline int iovw_consume_iov(struct iovec_wrapper *iovw, struct iovec *iov) {
+        return iovw_consume_iov_full(iovw, false, iov);
+}
+int iovw_extend_full(struct iovec_wrapper *iovw, bool accept_zero, const void *data, size_t len);
+static inline int iovw_extend(struct iovec_wrapper *iovw, const void *data, size_t len) {
+        return iovw_extend_full(iovw, false, data, len);
+}
+int iovw_extend_iov_full(struct iovec_wrapper *iovw, bool accept_zero, const struct iovec *iov);
+static inline int iovw_extend_iov(struct iovec_wrapper *iovw, const struct iovec *iov) {
+        return iovw_extend_iov_full(iovw, false, iov);
+}
+int iovw_extend_iovw_full(struct iovec_wrapper *iovw, bool accept_zero, const struct iovec_wrapper *source);
+static inline int iovw_extend_iovw(struct iovec_wrapper *iovw, const struct iovec_wrapper *source) {
+        return iovw_extend_iovw_full(iovw, false, source);
+}
 
 static inline bool iovw_isempty(const struct iovec_wrapper *iovw) {
         return !iovw || iovw->count == 0;

--- a/src/libsystemd-network/meson.build
+++ b/src/libsystemd-network/meson.build
@@ -37,6 +37,7 @@ libsystemd_network_sources = files(
         'sd-ndisc-router.c',
         'sd-ndisc-router-solicit.c',
         'sd-radv.c',
+        'tlv-util.c',
 )
 
 sources += libsystemd_network_sources
@@ -112,6 +113,9 @@ executables += [
         },
         network_test_template + {
                 'sources' : files('test-sd-dhcp-lease.c'),
+        },
+        network_test_template + {
+                'sources' : files('test-tlv-util.c'),
         },
         network_fuzz_template + {
                 'sources' : files('fuzz-dhcp-client.c'),

--- a/src/libsystemd-network/test-tlv-util.c
+++ b/src/libsystemd-network/test-tlv-util.c
@@ -1,0 +1,207 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include "sd-dhcp-protocol.h"
+
+#include "hashmap.h"
+#include "iovec-util.h"
+#include "iovec-wrapper.h"
+#include "random-util.h"
+#include "tests.h"
+#include "tlv-util.h"
+
+TEST(tlv_constant) {
+        ASSERT_EQ(TLV_TAG_PAD, (uint32_t) SD_DHCP_OPTION_PAD);
+        ASSERT_EQ(TLV_TAG_END, (uint32_t) SD_DHCP_OPTION_END);
+}
+
+TEST(tlv) {
+        _cleanup_(tlv_done) TLV tlv = TLV_INIT(TLV_DHCP4);
+
+        _cleanup_(iovec_done) struct iovec data0 = {}, data1 = {}, data2a = {}, data2b = {}, data3 = {}, data4 = {};
+        ASSERT_OK(random_bytes_allocate_iovec(0, &data0));
+        ASSERT_OK(random_bytes_allocate_iovec(111, &data1));
+        ASSERT_OK(random_bytes_allocate_iovec(123, &data2a));
+        ASSERT_OK(random_bytes_allocate_iovec(321, &data2b));
+        ASSERT_OK(random_bytes_allocate_iovec(333, &data3));
+        ASSERT_OK(random_bytes_allocate_iovec(444, &data4));
+
+        /* tlv_append() */
+        ASSERT_OK(tlv_append(&tlv, 10, data0.iov_len, data0.iov_base));
+        ASSERT_OK(tlv_append(&tlv, 11, data1.iov_len, data1.iov_base));
+        ASSERT_OK(tlv_append(&tlv, 22, data2a.iov_len, data2a.iov_base));
+        ASSERT_OK(tlv_append(&tlv, 22, data2b.iov_len, data2b.iov_base));
+        ASSERT_OK(tlv_append(&tlv, 33, data3.iov_len, data3.iov_base));
+        ASSERT_OK(tlv_append(&tlv, 44, data4.iov_len, data4.iov_base));
+        ASSERT_ERROR(tlv_append(&tlv, 0x00, data4.iov_len, data4.iov_base), EINVAL);
+        ASSERT_ERROR(tlv_append(&tlv, 0xFF, data4.iov_len, data4.iov_base), EINVAL);
+        ASSERT_EQ(hashmap_size(tlv.entries), 5u);
+
+        /* tlv_remove() */
+        tlv_remove(&tlv, 44);
+        ASSERT_EQ(hashmap_size(tlv.entries), 4u);
+        tlv_remove(&tlv, 55);
+        ASSERT_EQ(hashmap_size(tlv.entries), 4u);
+
+        /* tlv_append_tlv() */
+        _cleanup_(tlv_done) TLV tlv_copy = TLV_INIT(TLV_DHCP4);
+        ASSERT_ERROR(tlv_append_tlv(&tlv_copy, &tlv_copy), EINVAL);
+        ASSERT_OK(tlv_append_tlv(&tlv_copy, NULL));
+        ASSERT_OK(tlv_append_tlv(&tlv_copy, &tlv));
+        ASSERT_EQ(hashmap_size(tlv_copy.entries), hashmap_size(tlv.entries));
+
+        /* tlv_isempty() */
+        ASSERT_TRUE(tlv_isempty(NULL));
+        ASSERT_TRUE(tlv_isempty(&TLV_INIT(TLV_DHCP4)));
+        ASSERT_FALSE(tlv_isempty(&tlv));
+
+        /* tlv_contains() */
+        ASSERT_TRUE(tlv_contains(&tlv, 10));
+        ASSERT_TRUE(tlv_contains(&tlv, 11));
+        ASSERT_TRUE(tlv_contains(&tlv, 22));
+        ASSERT_TRUE(tlv_contains(&tlv, 33));
+        ASSERT_FALSE(tlv_contains(&tlv, 44));
+
+        /* tlv_get_all() */
+        struct iovec_wrapper *iovw;
+
+        iovw = ASSERT_NOT_NULL(tlv_get_all(&tlv, 10));
+        ASSERT_EQ(iovw->count, 1u);
+        ASSERT_TRUE(iovec_equal(&iovw->iovec[0], &data0));
+
+        iovw = ASSERT_NOT_NULL(tlv_get_all(&tlv, 11));
+        ASSERT_EQ(iovw->count, 1u);
+        ASSERT_TRUE(iovec_equal(&iovw->iovec[0], &data1));
+
+        iovw = ASSERT_NOT_NULL(tlv_get_all(&tlv, 22));
+        ASSERT_EQ(iovw->count, 3u);
+        ASSERT_TRUE(iovec_equal(&iovw->iovec[0], &data2a));
+        ASSERT_TRUE(iovec_equal(&iovw->iovec[1], &IOVEC_MAKE(data2b.iov_base, UINT8_MAX)));
+        ASSERT_TRUE(iovec_equal(&iovw->iovec[2], &IOVEC_SHIFT(&data2b, UINT8_MAX)));
+
+        iovw = ASSERT_NOT_NULL(tlv_get_all(&tlv, 33));
+        ASSERT_EQ(iovw->count, 2u);
+        ASSERT_TRUE(iovec_equal(&iovw->iovec[0], &IOVEC_MAKE(data3.iov_base, UINT8_MAX)));
+        ASSERT_TRUE(iovec_equal(&iovw->iovec[1], &IOVEC_SHIFT(&data3, UINT8_MAX)));
+
+        ASSERT_NULL(tlv_get_all(&tlv, 44));
+
+        /* tlv_get_full() */
+        struct iovec iov;
+
+        ASSERT_OK(tlv_get(&tlv, 10, &iov));
+        ASSERT_TRUE(iovec_equal(&iov, &data0));
+        ASSERT_OK(tlv_get_full(&tlv, 10, data0.iov_len, &iov));
+        ASSERT_TRUE(iovec_equal(&iov, &data0));
+        ASSERT_ERROR(tlv_get_full(&tlv, 10, 123, &iov), ENODATA);
+
+        ASSERT_OK(tlv_get(&tlv, 11, &iov));
+        ASSERT_TRUE(iovec_equal(&iov, &data1));
+        ASSERT_OK(tlv_get_full(&tlv, 11, data1.iov_len, &iov));
+        ASSERT_TRUE(iovec_equal(&iov, &data1));
+        ASSERT_ERROR(tlv_get_full(&tlv, 11, 123, &iov), ENODATA);
+
+        ASSERT_OK(tlv_get(&tlv, 22, &iov));
+        ASSERT_TRUE(iovec_equal(&iov, &data2a));
+        ASSERT_OK(tlv_get_full(&tlv, 22, data2a.iov_len, &iov));
+        ASSERT_TRUE(iovec_equal(&iov, &data2a));
+        ASSERT_ERROR(tlv_get_full(&tlv, 22, data2b.iov_len, &iov), ENODATA);
+        ASSERT_OK(tlv_get_full(&tlv, 22, UINT8_MAX, &iov));
+        ASSERT_TRUE(iovec_equal(&iov, &IOVEC_MAKE(data2b.iov_base, UINT8_MAX)));
+        ASSERT_OK(tlv_get_full(&tlv, 22, data2b.iov_len - UINT8_MAX, &iov));
+        ASSERT_TRUE(iovec_equal(&iov, &IOVEC_SHIFT(&data2b, UINT8_MAX)));
+
+        ASSERT_OK(tlv_get(&tlv, 33, &iov));
+        ASSERT_TRUE(iovec_equal(&iov, &IOVEC_MAKE(data3.iov_base, UINT8_MAX)));
+        ASSERT_ERROR(tlv_get_full(&tlv, 33, data3.iov_len, &iov), ENODATA);
+        ASSERT_OK(tlv_get_full(&tlv, 33, UINT8_MAX, &iov));
+        ASSERT_TRUE(iovec_equal(&iov, &IOVEC_MAKE(data3.iov_base, UINT8_MAX)));
+        ASSERT_OK(tlv_get_full(&tlv, 33, data3.iov_len - UINT8_MAX, &iov));
+        ASSERT_TRUE(iovec_equal(&iov, &IOVEC_SHIFT(&data3, UINT8_MAX)));
+
+        ASSERT_ERROR(tlv_get(&tlv, 44, NULL), ENODATA);
+
+        /* tlv_get_alloc() */
+        _cleanup_(iovec_done) struct iovec v = {};
+
+        ASSERT_OK(tlv_get_alloc(&tlv, 10, &v));
+        ASSERT_TRUE(iovec_equal(&v, &data0));
+        iovec_done(&v);
+
+        ASSERT_OK(tlv_get_alloc(&tlv, 11, &v));
+        ASSERT_TRUE(iovec_equal(&v, &data1));
+        iovec_done(&v);
+
+        ASSERT_OK(tlv_get_alloc(&tlv, 22, &v));
+        ASSERT_EQ(v.iov_len, data2a.iov_len + data2b.iov_len);
+        ASSERT_EQ(memcmp(v.iov_base, data2a.iov_base, data2a.iov_len), 0);
+        ASSERT_EQ(memcmp((uint8_t*) v.iov_base + data2a.iov_len, data2b.iov_base, data2b.iov_len), 0);
+        iovec_done(&v);
+
+        ASSERT_OK(tlv_get_alloc(&tlv, 33, &v));
+        ASSERT_TRUE(iovec_equal(&v, &data3));
+        iovec_done(&v);
+
+        ASSERT_ERROR(tlv_get_alloc(&tlv, 44, NULL), ENODATA);
+
+        /* tlv_size() */
+        size_t sz = tlv_size(&tlv);
+        /* The tlv contains the 7 entries with a 2-byte header:
+         * tag 10: 1 entry, tag 11: 1 entry, tag 22: 3 entries, tag 33: 2 entries = 7 entries total. */
+        ASSERT_EQ(sz, 7 * 2 + data0.iov_len + data1.iov_len + data2a.iov_len + data2b.iov_len + data3.iov_len + 1);
+
+        /* tlv_build() */
+        ASSERT_OK(tlv_build(&tlv, &v));
+        ASSERT_EQ(v.iov_len, sz);
+        uint8_t *p = v.iov_base;
+        ASSERT_EQ(*p++, 10u);
+        ASSERT_EQ(*p++, data0.iov_len);
+
+        ASSERT_EQ(*p++, 11u);
+        ASSERT_EQ(*p++, data1.iov_len);
+        ASSERT_EQ(memcmp(p, data1.iov_base, data1.iov_len), 0);
+        p += data1.iov_len;
+
+        ASSERT_EQ(*p++, 22u);
+        ASSERT_EQ(*p++, data2a.iov_len);
+        ASSERT_EQ(memcmp(p, data2a.iov_base, data2a.iov_len), 0);
+        p += data2a.iov_len;
+
+        ASSERT_EQ(*p++, 22u);
+        ASSERT_EQ(*p++, UINT8_MAX);
+        ASSERT_EQ(memcmp(p, data2b.iov_base, UINT8_MAX), 0);
+        p += UINT8_MAX;
+
+        ASSERT_EQ(*p++, 22u);
+        ASSERT_EQ(*p++, data2b.iov_len - UINT8_MAX);
+        ASSERT_EQ(memcmp(p, (uint8_t*) data2b.iov_base + UINT8_MAX, data2b.iov_len - UINT8_MAX), 0);
+        p += data2b.iov_len - UINT8_MAX;
+
+        ASSERT_EQ(*p++, 33u);
+        ASSERT_EQ(*p++, UINT8_MAX);
+        ASSERT_EQ(memcmp(p, data3.iov_base, UINT8_MAX), 0);
+        p += UINT8_MAX;
+
+        ASSERT_EQ(*p++, 33u);
+        ASSERT_EQ(*p++, data3.iov_len - UINT8_MAX);
+        ASSERT_EQ(memcmp(p, (uint8_t*) data3.iov_base + UINT8_MAX, data3.iov_len - UINT8_MAX), 0);
+        p += data3.iov_len - UINT8_MAX;
+
+        ASSERT_EQ(*p, 255u);
+
+        /* tlv_new() and tlv_parse() */
+        _cleanup_(tlv_unrefp) TLV *tlv2 = ASSERT_NOT_NULL(tlv_new(TLV_DHCP4 | TLV_TEMPORARY));
+        ASSERT_OK(tlv_parse(tlv2, &v));
+        ASSERT_EQ(hashmap_size(tlv.entries), hashmap_size(tlv2->entries));
+        void *tagp;
+        HASHMAP_FOREACH_KEY(iovw, tagp, tlv.entries) {
+                struct iovec_wrapper *iovw2 = ASSERT_PTR(hashmap_get(tlv2->entries, tagp));
+                ASSERT_TRUE(iovw_equal(iovw, iovw2));
+        }
+
+        /* tlv_build() again, and check the reproducibility. */
+        _cleanup_(iovec_done) struct iovec v2 = {};
+        ASSERT_OK(tlv_build(tlv2, &v2));
+        ASSERT_TRUE(iovec_equal(&v, &v2));
+}
+
+DEFINE_TEST_MAIN(LOG_DEBUG);

--- a/src/libsystemd-network/tlv-util.c
+++ b/src/libsystemd-network/tlv-util.c
@@ -1,0 +1,505 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include "alloc-util.h"
+#include "hashmap.h"
+#include "iovec-util.h"
+#include "iovec-wrapper.h"
+#include "tlv-util.h"
+#include "unaligned.h"
+
+#define TLV_MAX_ENTRIES 4096u
+
+TLVFlag tlv_flags_verify(TLVFlag flags) {
+        assert(IN_SET(flags & _TLV_TAG_MASK, TLV_TAG_U8, TLV_TAG_U16, TLV_TAG_U32));
+        assert(IN_SET(flags & _TLV_LENGTH_MASK, TLV_LENGTH_U8, TLV_LENGTH_U16, TLV_LENGTH_U32));
+
+        /* TLV_PAD and TLV_END are for DHCPv4 options, hence here we assume TLV_TAG_U8 is set. */
+        assert(!FLAGS_SET(flags, TLV_PAD) || FLAGS_SET(flags, TLV_TAG_U8));
+        assert(!FLAGS_SET(flags, TLV_END) || FLAGS_SET(flags, TLV_TAG_U8));
+
+        /* When we requested to append the END tag, then we should understand the END tag on parse. */
+        assert(!FLAGS_SET(flags, TLV_APPEND_END) || FLAGS_SET(flags, TLV_END));
+
+        return flags;
+}
+
+void tlv_done(TLV *tlv) {
+        assert(tlv);
+
+        tlv->entries = hashmap_free(tlv->entries);
+        tlv->n_entries = 0;
+}
+
+static TLV* tlv_free(TLV *tlv) {
+        if (!tlv)
+                return NULL;
+
+        tlv_done(tlv);
+        return mfree(tlv);
+}
+
+DEFINE_TRIVIAL_REF_UNREF_FUNC(TLV, tlv, tlv_free);
+
+TLV* tlv_new(TLVFlag flags) {
+        TLV *tlv = new(TLV, 1);
+        if (!tlv)
+                return NULL;
+
+        *tlv = TLV_INIT(flags);
+        return tlv;
+}
+
+bool tlv_isempty(const TLV *tlv) {
+        return !tlv || hashmap_isempty(tlv->entries);
+}
+
+struct iovec_wrapper* tlv_get_all(const TLV *tlv, uint32_t tag) {
+        assert(tlv);
+        return hashmap_get(tlv->entries, UINT32_TO_PTR(tag));
+}
+
+int tlv_get_full(const TLV *tlv, uint32_t tag, size_t length, struct iovec *ret) {
+        assert(tlv);
+
+        /* Do not free the result iovec, the data is still owned by TLV (or the original input data when
+         * TLV_TEMPORARY is set). */
+
+        struct iovec_wrapper *iovw = tlv_get_all(tlv, tag);
+        if (iovw_isempty(iovw))
+                return -ENODATA;
+
+        /* When multiple entries exist, use the first one matching the length. */
+        FOREACH_ARRAY(iov, iovw->iovec, iovw->count) {
+                if (length != SIZE_MAX && iov->iov_len != length)
+                        continue;
+
+                if (ret)
+                        *ret = *iov;
+                return 0;
+        }
+
+        return -ENODATA;
+}
+
+int tlv_get_alloc(const TLV *tlv, uint32_t tag, struct iovec *ret) {
+        assert(tlv);
+
+        /* Free the result iovec. */
+
+        struct iovec_wrapper *iovw = tlv_get_all(tlv, tag);
+        if (iovw_isempty(iovw))
+                return -ENODATA;
+
+        if (!ret)
+                return 0;
+
+        if (FLAGS_SET(tlv->flags, TLV_MERGE))
+                return iovw_concat(iovw, ret);
+
+        /* When TLV_MERGE is unset, provides the first entry. */
+        if (!iovec_memdup(&iovw->iovec[0], ret))
+                return -ENOMEM;
+
+        return 0;
+}
+
+void tlv_remove(TLV *tlv, uint32_t tag) {
+        assert(tlv);
+
+        struct iovec_wrapper *iovw = hashmap_remove(tlv->entries, UINT32_TO_PTR(tag));
+        if (!iovw)
+                return;
+
+        assert(tlv->n_entries >= iovw->count);
+        tlv->n_entries -= iovw->count;
+
+        if (FLAGS_SET(tlv->flags, TLV_TEMPORARY))
+                iovw_free(iovw);
+        else
+                iovw_free_free(iovw);
+}
+
+DEFINE_PRIVATE_HASH_OPS_WITH_VALUE_DESTRUCTOR(
+                tlv_hash_ops,
+                void,
+                trivial_hash_func,
+                trivial_compare_func,
+                struct iovec_wrapper,
+                iovw_free);
+
+DEFINE_PRIVATE_HASH_OPS_WITH_VALUE_DESTRUCTOR(
+                tlv_hash_ops_free,
+                void,
+                trivial_hash_func,
+                trivial_compare_func,
+                struct iovec_wrapper,
+                iovw_free_free);
+
+static int tlv_append_impl(TLV *tlv, uint32_t tag, size_t length, const void *data) {
+        int r;
+
+        assert(tlv);
+        assert(length == 0 || data);
+
+        if (tlv->n_entries >= TLV_MAX_ENTRIES)
+                return -E2BIG;
+
+        if (FLAGS_SET(tlv->flags, TLV_TEMPORARY)) {
+                struct iovec_wrapper *e = tlv_get_all(tlv, tag);
+                if (e) {
+                        r = iovw_put_full(e, /* accept_zero= */ true, (void*) data, length);
+                        if (r < 0)
+                                return r;
+                } else {
+                        _cleanup_(iovw_freep) struct iovec_wrapper *v = new0(struct iovec_wrapper, 1);
+                        if (!v)
+                                return -ENOMEM;
+
+                        r = iovw_put_full(v, /* accept_zero= */ true, (void*) data, length);
+                        if (r < 0)
+                                return r;
+
+                        r = hashmap_ensure_put(&tlv->entries, &tlv_hash_ops, UINT32_TO_PTR(tag), v);
+                        if (r < 0)
+                                return r;
+
+                        TAKE_PTR(v);
+                }
+        } else {
+                struct iovec_wrapper *e = tlv_get_all(tlv, tag);
+                if (e) {
+                        r = iovw_extend_full(e, /* accept_zero= */ true, data, length);
+                        if (r < 0)
+                                return r;
+                } else {
+                        _cleanup_(iovw_free_freep) struct iovec_wrapper *v = new0(struct iovec_wrapper, 1);
+                        if (!v)
+                                return -ENOMEM;
+
+                        r = iovw_extend_full(v, /* accept_zero= */ true, data, length);
+                        if (r < 0)
+                                return r;
+
+                        r = hashmap_ensure_put(&tlv->entries, &tlv_hash_ops_free, UINT32_TO_PTR(tag), v);
+                        if (r < 0)
+                                return r;
+
+                        TAKE_PTR(v);
+                }
+        }
+
+        tlv->n_entries++;
+        return 0;
+}
+
+int tlv_append(TLV *tlv, uint32_t tag, size_t length, const void *data) {
+        int r;
+
+        assert(tlv);
+        assert(length == 0 || data);
+
+        switch (tlv->flags & _TLV_TAG_MASK) {
+        case TLV_TAG_U8:
+                if (tag > UINT8_MAX)
+                        return -EINVAL;
+                break;
+        case TLV_TAG_U16:
+                if (tag > UINT16_MAX)
+                        return -EINVAL;
+                break;
+        case TLV_TAG_U32:
+                break;
+        default:
+                assert_not_reached();
+        }
+
+        if ((FLAGS_SET(tlv->flags, TLV_PAD) && tag == TLV_TAG_PAD) ||
+            (FLAGS_SET(tlv->flags, TLV_END) && tag == TLV_TAG_END))
+                return -EINVAL;
+
+        size_t max_length;
+        switch (tlv->flags & _TLV_LENGTH_MASK) {
+        case TLV_LENGTH_U8:
+                max_length = UINT8_MAX;
+                break;
+        case TLV_LENGTH_U16:
+                max_length = UINT16_MAX;
+                break;
+        case TLV_LENGTH_U32:
+                max_length = UINT32_MAX;
+                break;
+        default:
+                assert_not_reached();
+        }
+
+        if (FLAGS_SET(tlv->flags, TLV_MERGE)) {
+                /* If TLV_MERGE is set and the length is larger than the allowed maximum, then split the data
+                 * and store them in multiple entries.
+                 *
+                 * Note, if tlv_append_impl() fails below, we do not rollback the entries, hence the caller
+                 * of this function needs to discard the entire data in that case. */
+                const uint8_t *p = data;
+                while (length > max_length) {
+                        r = tlv_append_impl(tlv, tag, max_length, p);
+                        if (r < 0)
+                                return r;
+
+                        p += max_length;
+                        length -= max_length;
+                }
+
+                return tlv_append_impl(tlv, tag, length, p);
+        }
+
+        /* Otherwise, refuse too long data. */
+        if (length > max_length)
+                return -EINVAL;
+
+        return tlv_append_impl(tlv, tag, length, data);
+}
+
+int tlv_append_iov(TLV *tlv, uint32_t tag, const struct iovec *iov) {
+        assert(tlv);
+        assert(iovec_is_valid(iov));
+
+        return tlv_append(tlv, tag, iov ? iov->iov_len : 0, iov ? iov->iov_base : NULL);
+}
+
+int tlv_append_tlv(TLV *tlv, const TLV *source) {
+        int r;
+
+        assert(tlv);
+
+        /* Note, this does not rollback entries on failure, hence the caller of this function needs to
+         * discard the entire data in that case. */
+
+        if (!source)
+                return 0;
+
+        if (source == tlv)
+                return -EINVAL;
+
+        void *tagp;
+        struct iovec_wrapper *iovw;
+        HASHMAP_FOREACH_KEY(iovw, tagp, source->entries) {
+                uint32_t tag = PTR_TO_UINT32(tagp);
+
+                FOREACH_ARRAY(iov, iovw->iovec, iovw->count) {
+                        r = tlv_append(tlv, tag, iov->iov_len, iov->iov_base);
+                        if (r < 0)
+                                return r;
+                }
+        }
+
+        return 0;
+}
+
+int tlv_parse(TLV *tlv, const struct iovec *iov) {
+        int r;
+
+        assert(tlv);
+        assert(iovec_is_valid(iov));
+
+        /* Note, this does not rollback entries on failure, hence the caller of this function needs to
+         * discard the entire data in that case. */
+
+        if (!iovec_is_set(iov))
+                return 0;
+
+        for (struct iovec i = *iov; iovec_is_set(&i); ) {
+                uint32_t tag;
+                switch (tlv->flags & _TLV_TAG_MASK) {
+                case TLV_TAG_U8:
+                        if (i.iov_len < sizeof(uint8_t))
+                                return -EBADMSG;
+                        tag = *(uint8_t*) i.iov_base;
+                        iovec_inc(&i, sizeof(uint8_t));
+                        break;
+                case TLV_TAG_U16:
+                        if (i.iov_len < sizeof(uint16_t))
+                                return -EBADMSG;
+                        tag = unaligned_read_be16(i.iov_base);
+                        iovec_inc(&i, sizeof(uint16_t));
+                        break;
+                case TLV_TAG_U32:
+                        if (i.iov_len < sizeof(uint32_t))
+                                return -EBADMSG;
+                        tag = unaligned_read_be32(i.iov_base);
+                        iovec_inc(&i, sizeof(uint32_t));
+                        break;
+                default:
+                        assert_not_reached();
+                }
+
+                if (FLAGS_SET(tlv->flags, TLV_PAD) && tag == TLV_TAG_PAD)
+                        continue;
+                if (FLAGS_SET(tlv->flags, TLV_END) && tag == TLV_TAG_END)
+                        break;
+
+                size_t len;
+                switch (tlv->flags & _TLV_LENGTH_MASK) {
+                case TLV_LENGTH_U8:
+                        if (i.iov_len < sizeof(uint8_t))
+                                return -EBADMSG;
+                        len = *(uint8_t*) i.iov_base;
+                        iovec_inc(&i, sizeof(uint8_t));
+                        break;
+                case TLV_LENGTH_U16:
+                        if (i.iov_len < sizeof(uint16_t))
+                                return -EBADMSG;
+                        len = unaligned_read_be16(i.iov_base);
+                        iovec_inc(&i, sizeof(uint16_t));
+                        break;
+                case TLV_LENGTH_U32:
+                        if (i.iov_len < sizeof(uint32_t))
+                                return -EBADMSG;
+                        len = unaligned_read_be32(i.iov_base);
+                        iovec_inc(&i, sizeof(uint32_t));
+                        break;
+                default:
+                        assert_not_reached();
+                }
+
+                if (i.iov_len < len)
+                        return -EBADMSG;
+
+                r = tlv_append_impl(tlv, tag, len, i.iov_base);
+                if (r < 0)
+                        return r;
+
+                iovec_inc(&i, len);
+        }
+
+        return 0;
+}
+
+size_t tlv_size(const TLV *tlv) {
+        assert(tlv);
+
+        size_t header_sz;
+        switch (tlv->flags & _TLV_TAG_MASK) {
+        case TLV_TAG_U8:
+                header_sz = sizeof(uint8_t);
+                break;
+        case TLV_TAG_U16:
+                header_sz = sizeof(uint16_t);
+                break;
+        case TLV_TAG_U32:
+                header_sz = sizeof(uint32_t);
+                break;
+        default:
+                assert_not_reached();
+        }
+
+        switch (tlv->flags & _TLV_LENGTH_MASK) {
+        case TLV_LENGTH_U8:
+                header_sz += sizeof(uint8_t);
+                break;
+        case TLV_LENGTH_U16:
+                header_sz += sizeof(uint16_t);
+                break;
+        case TLV_LENGTH_U32:
+                header_sz += sizeof(uint32_t);
+                break;
+        default:
+                assert_not_reached();
+        }
+
+        size_t sz = FLAGS_SET(tlv->flags, TLV_APPEND_END);
+
+        struct iovec_wrapper *iovw;
+        HASHMAP_FOREACH(iovw, tlv->entries) {
+                if (size_multiply_overflow(header_sz, iovw->count))
+                        return SIZE_MAX;
+
+                sz = size_add(sz, size_add(header_sz * iovw->count, iovw_size(iovw)));
+        }
+
+        return sz;
+}
+
+int tlv_build(const TLV *tlv, struct iovec *ret) {
+        int r;
+
+        assert(tlv);
+        assert(ret);
+
+        size_t sz = tlv_size(tlv);
+        if (sz == SIZE_MAX)
+                return -ENOBUFS;
+
+        _cleanup_free_ uint8_t *buf = new(uint8_t, sz);
+        if (!buf)
+                return -ENOMEM;
+
+        /* Sort by tags, for reproducibility. */
+        _cleanup_free_ void **sorted = NULL;
+        size_t n;
+        r = hashmap_dump_keys_sorted(tlv->entries, &sorted, &n);
+        if (r < 0)
+                return r;
+
+        uint8_t *p = buf;
+        FOREACH_ARRAY(tagp, sorted, n) {
+                uint32_t tag = PTR_TO_UINT32(*tagp);
+                struct iovec_wrapper *iovw = ASSERT_PTR(tlv_get_all(tlv, tag));
+
+                if ((FLAGS_SET(tlv->flags, TLV_PAD) && tag == TLV_TAG_PAD) ||
+                    (FLAGS_SET(tlv->flags, TLV_END) && tag == TLV_TAG_END))
+                        return -EINVAL;
+
+                FOREACH_ARRAY(iov, iovw->iovec, iovw->count) {
+                        switch (tlv->flags & _TLV_TAG_MASK) {
+                        case TLV_TAG_U8:
+                                if (tag > UINT8_MAX)
+                                        return -EINVAL;
+                                *p++ = tag;
+                                break;
+                        case TLV_TAG_U16:
+                                if (tag > UINT16_MAX)
+                                        return -EINVAL;
+                                unaligned_write_be16(p, tag);
+                                p += sizeof(uint16_t);
+                                break;
+                        case TLV_TAG_U32:
+                                unaligned_write_be32(p, tag);
+                                p += sizeof(uint32_t);
+                                break;
+                        default:
+                                assert_not_reached();
+                        }
+
+                        switch (tlv->flags & _TLV_LENGTH_MASK) {
+                        case TLV_LENGTH_U8:
+                                if (iov->iov_len > UINT8_MAX)
+                                        return -EINVAL;
+                                *p++ = iov->iov_len;
+                                break;
+                        case TLV_LENGTH_U16:
+                                if (iov->iov_len > UINT16_MAX)
+                                        return -EINVAL;
+                                unaligned_write_be16(p, iov->iov_len);
+                                p += sizeof(uint16_t);
+                                break;
+                        case TLV_LENGTH_U32:
+                                if (iov->iov_len > UINT32_MAX)
+                                        return -EINVAL;
+                                unaligned_write_be32(p, iov->iov_len);
+                                p += sizeof(uint32_t);
+                                break;
+                        default:
+                                assert_not_reached();
+                        }
+
+                        p = mempcpy_safe(p, iov->iov_base, iov->iov_len);
+                }
+        }
+
+        if (FLAGS_SET(tlv->flags, TLV_APPEND_END))
+                *p++ = TLV_TAG_END;
+
+        assert(sz == (size_t) (p - buf));
+
+        *ret = IOVEC_MAKE(TAKE_PTR(buf), sz);
+        return 0;
+}

--- a/src/libsystemd-network/tlv-util.h
+++ b/src/libsystemd-network/tlv-util.h
@@ -1,0 +1,82 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#pragma once
+
+#include "sd-forward.h"
+
+#define TLV_TAG_PAD UINT32_C(0)
+#define TLV_TAG_END UINT32_C(0xFF)
+
+typedef enum TLVFlag {
+        TLV_TAG_U8       = 1 << 0,
+        TLV_TAG_U16      = 1 << 1,
+        TLV_TAG_U32      = 1 << 2,
+        _TLV_TAG_MASK    = TLV_TAG_U8 | TLV_TAG_U16 | TLV_TAG_U32,
+        TLV_LENGTH_U8    = 1 << 3,
+        TLV_LENGTH_U16   = 1 << 4,
+        TLV_LENGTH_U32   = 1 << 5,
+        _TLV_LENGTH_MASK = TLV_LENGTH_U8 | TLV_LENGTH_U16 | TLV_LENGTH_U32,
+        TLV_PAD          = 1 << 6,  /* If set, tag == 0 is a pad, and does not have the length field. */
+        TLV_END          = 1 << 7,  /* If set, tag == 0xFF is a sign of the end of the sequence. */
+        TLV_APPEND_END   = 1 << 8,  /* If set, append the END tag at the end of the sequence on build. */
+        TLV_MERGE        = 1 << 9,  /* If set, tlv_get_alloc() merges them, and tlv_append() split long data. */
+        TLV_TEMPORARY    = 1 << 10, /* If set, tlv_append() and tlv_parse() do not copy the data. */
+
+        /* DHCPv4 options. */
+        TLV_DHCP4        = TLV_TAG_U8 | TLV_LENGTH_U8 | TLV_PAD | TLV_END | TLV_APPEND_END | TLV_MERGE,
+        /* Used for DHCPv4 sub-options, e.g.
+         * DHCPv4 Vendor Specific Information sub-option (43),
+         * DHCPv4 Relay Agent Information sub-option (82), or
+         * DHCPv4 Vendor-Identifying Vendor Specific Information sub-sub-option (125).
+         * Note that the PAD is not mentioned in RFC, but some implementations use it, hence let's gracefully
+         * handle it. Also note that the END tag is prohibited in most options, but we also gracefully handle
+         * it on parse, but of course do not append it on build. */
+        TLV_DHCP4_SUBOPTION
+                         = TLV_TAG_U8 | TLV_LENGTH_U8 | TLV_PAD | TLV_END,
+        /* DHCPv4 Vendor-Identifying Vendor Class sub-option (124) and
+         * DHCPv4 Vendor-Identifying Vendor Specific Information sub-option (125).
+         * The tag is called 'enterprise-number', and in uint32. */
+        TLV_DHCP4_VENDOR_IDENTIFYING_OPTION
+                         = TLV_TAG_U32 | TLV_LENGTH_U8 | TLV_MERGE,
+} TLVFlag;
+
+typedef struct TLV {
+        unsigned n_ref;
+        TLVFlag flags;
+        unsigned n_entries;
+        Hashmap *entries;
+} TLV;
+
+#define TLV_INIT(f)                             \
+        (TLV) {                                 \
+                .n_ref = 1,                     \
+                .flags = tlv_flags_verify(f),   \
+        }
+
+TLVFlag tlv_flags_verify(TLVFlag flags);
+
+void tlv_done(TLV *tlv);
+TLV* tlv_ref(TLV *p);
+TLV* tlv_unref(TLV *p);
+DEFINE_TRIVIAL_CLEANUP_FUNC(TLV*, tlv_unref);
+TLV* tlv_new(TLVFlag flags);
+
+bool tlv_isempty(const TLV *tlv);
+
+struct iovec_wrapper* tlv_get_all(const TLV *tlv, uint32_t tag);
+static inline bool tlv_contains(const TLV *tlv, uint32_t tag) {
+        return tlv_get_all(tlv, tag);
+}
+int tlv_get_full(const TLV *tlv, uint32_t tag, size_t length, struct iovec *ret);
+static inline int tlv_get(const TLV *tlv, uint32_t tag, struct iovec *ret) {
+        return tlv_get_full(tlv, tag, SIZE_MAX, ret);
+}
+int tlv_get_alloc(const TLV *tlv, uint32_t tag, struct iovec *ret);
+
+void tlv_remove(TLV *tlv, uint32_t tag);
+int tlv_append(TLV *tlv, uint32_t tag, size_t length, const void *data);
+int tlv_append_iov(TLV *tlv, uint32_t tag, const struct iovec *iov);
+int tlv_append_tlv(TLV *tlv, const TLV *source);
+
+int tlv_parse(TLV *tlv, const struct iovec *iov);
+size_t tlv_size(const TLV *tlv);
+int tlv_build(const TLV *tlv, struct iovec *ret);

--- a/src/test/test-iovec-wrapper.c
+++ b/src/test/test-iovec-wrapper.c
@@ -5,6 +5,7 @@
 #include "alloc-util.h"
 #include "iovec-util.h"
 #include "iovec-wrapper.h"
+#include "random-util.h"
 #include "tests.h"
 
 TEST(iovw_compare) {
@@ -504,6 +505,198 @@ TEST(iovw_to_cstring) {
         s = iovw_to_cstring(&iovw);
         ASSERT_NOT_NULL(s);
         ASSERT_STREQ(s, "foo/bar");
+}
+
+TEST(iovw_merge_and_iovec_split) {
+        _cleanup_(iovw_done_free) struct iovec_wrapper iovw = {}, iovw2 = {};
+        _cleanup_(iovec_done) struct iovec v = {}, v2 = {};
+        uint8_t *p;
+
+        struct iovec
+                a = IOVEC_MAKE_STRING("aaa"),
+                b = IOVEC_MAKE_STRING("bbbb"),
+                c = IOVEC_MAKE_STRING("ccccc");
+
+        /* single entry */
+        ASSERT_OK(iovw_extend_iov(&iovw, &a));
+
+        ASSERT_OK(iovw_merge(&iovw, sizeof(uint8_t), &v));
+        ASSERT_EQ(v.iov_len, 1 + a.iov_len);
+        p = ASSERT_NOT_NULL(v.iov_base);
+        ASSERT_EQ(*p++, a.iov_len);
+        ASSERT_EQ(memcmp(p, a.iov_base, a.iov_len), 0);
+        p += a.iov_len;
+        ASSERT_OK(iovec_split(&v, sizeof(uint8_t), &iovw2));
+        ASSERT_TRUE(iovw_equal(&iovw, &iovw2));
+
+        iovec_done(&v);
+        iovw_done_free(&iovw2);
+
+        ASSERT_OK(iovw_merge(&iovw, sizeof(uint16_t), &v));
+        ASSERT_EQ(v.iov_len, sizeof(uint16_t) + a.iov_len);
+        p = ASSERT_NOT_NULL(v.iov_base);
+        ASSERT_EQ(*p++, 0);
+        ASSERT_EQ(*p++, a.iov_len);
+        ASSERT_EQ(memcmp(p, a.iov_base, a.iov_len), 0);
+        p += a.iov_len;
+        ASSERT_OK(iovec_split(&v, sizeof(uint16_t), &iovw2));
+        ASSERT_TRUE(iovw_equal(&iovw, &iovw2));
+
+        iovec_done(&v);
+        iovw_done_free(&iovw2);
+
+        ASSERT_OK(iovw_merge(&iovw, sizeof(uint32_t), &v));
+        ASSERT_EQ(v.iov_len, sizeof(uint32_t) + a.iov_len);
+        p = ASSERT_NOT_NULL(v.iov_base);
+        ASSERT_EQ(*p++, 0);
+        ASSERT_EQ(*p++, 0);
+        ASSERT_EQ(*p++, 0);
+        ASSERT_EQ(*p++, a.iov_len);
+        ASSERT_EQ(memcmp(p, a.iov_base, a.iov_len), 0);
+        p += a.iov_len;
+        ASSERT_OK(iovec_split(&v, sizeof(uint32_t), &iovw2));
+        ASSERT_TRUE(iovw_equal(&iovw, &iovw2));
+
+        iovec_done(&v);
+        iovw_done_free(&iovw2);
+
+        /* multiple entries */
+        ASSERT_OK(iovw_extend_iov(&iovw, &b));
+        ASSERT_OK(iovw_extend_iov(&iovw, &c));
+
+        ASSERT_OK(iovw_merge(&iovw, sizeof(uint8_t), &v));
+        ASSERT_EQ(v.iov_len, 3 + a.iov_len + b.iov_len + c.iov_len);
+        p = ASSERT_NOT_NULL(v.iov_base);
+        ASSERT_EQ(*p++, a.iov_len);
+        ASSERT_EQ(memcmp(p, a.iov_base, a.iov_len), 0);
+        p += a.iov_len;
+        ASSERT_EQ(*p++, b.iov_len);
+        ASSERT_EQ(memcmp(p, b.iov_base, b.iov_len), 0);
+        p += b.iov_len;
+        ASSERT_EQ(*p++, c.iov_len);
+        ASSERT_EQ(memcmp(p, c.iov_base, c.iov_len), 0);
+        ASSERT_OK(iovec_split(&v, sizeof(uint8_t), &iovw2));
+        ASSERT_TRUE(iovw_equal(&iovw, &iovw2));
+
+        iovec_done(&v);
+        iovw_done_free(&iovw2);
+
+        ASSERT_OK(iovw_merge(&iovw, sizeof(uint16_t), &v));
+        ASSERT_EQ(v.iov_len, 3 * sizeof(uint16_t) + a.iov_len + b.iov_len + c.iov_len);
+        p = ASSERT_NOT_NULL(v.iov_base);
+        ASSERT_EQ(*p++, 0);
+        ASSERT_EQ(*p++, a.iov_len);
+        ASSERT_EQ(memcmp(p, a.iov_base, a.iov_len), 0);
+        p += a.iov_len;
+        ASSERT_EQ(*p++, 0);
+        ASSERT_EQ(*p++, b.iov_len);
+        ASSERT_EQ(memcmp(p, b.iov_base, b.iov_len), 0);
+        p += b.iov_len;
+        ASSERT_EQ(*p++, 0);
+        ASSERT_EQ(*p++, c.iov_len);
+        ASSERT_EQ(memcmp(p, c.iov_base, c.iov_len), 0);
+        ASSERT_OK(iovec_split(&v, sizeof(uint16_t), &iovw2));
+        ASSERT_TRUE(iovw_equal(&iovw, &iovw2));
+
+        iovec_done(&v);
+        iovw_done_free(&iovw2);
+
+        ASSERT_OK(iovw_merge(&iovw, sizeof(uint32_t), &v));
+        ASSERT_EQ(v.iov_len, 3 * sizeof(uint32_t) + a.iov_len + b.iov_len + c.iov_len);
+        p = ASSERT_NOT_NULL(v.iov_base);
+        ASSERT_EQ(*p++, 0);
+        ASSERT_EQ(*p++, 0);
+        ASSERT_EQ(*p++, 0);
+        ASSERT_EQ(*p++, a.iov_len);
+        ASSERT_EQ(memcmp(p, a.iov_base, a.iov_len), 0);
+        p += a.iov_len;
+        ASSERT_EQ(*p++, 0);
+        ASSERT_EQ(*p++, 0);
+        ASSERT_EQ(*p++, 0);
+        ASSERT_EQ(*p++, b.iov_len);
+        ASSERT_EQ(memcmp(p, b.iov_base, b.iov_len), 0);
+        p += b.iov_len;
+        ASSERT_EQ(*p++, 0);
+        ASSERT_EQ(*p++, 0);
+        ASSERT_EQ(*p++, 0);
+        ASSERT_EQ(*p++, c.iov_len);
+        ASSERT_EQ(memcmp(p, c.iov_base, c.iov_len), 0);
+        ASSERT_OK(iovec_split(&v, sizeof(uint32_t), &iovw2));
+        ASSERT_TRUE(iovw_equal(&iovw, &iovw2));
+
+        iovec_done(&v);
+        iovw_done_free(&iovw2);
+
+        /* with empty entries */
+        _cleanup_(iovw_done) struct iovec_wrapper with_empty = {
+                .iovec = ASSERT_PTR(new0(struct iovec, 6)),
+                .count = 6,
+        };
+        with_empty.iovec[0] = a;
+        with_empty.iovec[2] = b;
+        with_empty.iovec[4] = c;
+        ASSERT_OK(iovw_merge(&iovw, sizeof(uint8_t), &v));
+        ASSERT_OK(iovw_merge(&with_empty, sizeof(uint8_t), &v2));
+        ASSERT_TRUE(iovec_equal(&v, &v2));
+
+        iovec_done(&v);
+        iovec_done(&v2);
+
+        size_t sz = 6 + a.iov_len + b.iov_len + c.iov_len;
+        _cleanup_free_ uint8_t *buf = ASSERT_PTR(new(uint8_t, sz));
+        p = buf;
+        *p++ = a.iov_len;
+        p = mempcpy(p, a.iov_base, a.iov_len);
+        *p++ = 0;
+        *p++ = b.iov_len;
+        p = mempcpy(p, b.iov_base, b.iov_len);
+        *p++ = 0;
+        *p++ = c.iov_len;
+        p = mempcpy(p, c.iov_base, c.iov_len);
+        *p++ = 0;
+        ASSERT_OK(iovec_split(&IOVEC_MAKE(buf, sz), sizeof(uint8_t), &iovw2));
+        ASSERT_TRUE(iovw_equal(&iovw, &iovw2));
+
+        iovw_done_free(&iovw2);
+
+        /* truncated */
+        ASSERT_OK(iovw_merge(&iovw, sizeof(uint8_t), &v));
+        ASSERT_ERROR(iovec_split(&IOVEC_MAKE(v.iov_base, v.iov_len - 1), sizeof(uint8_t), &iovw2), EBADMSG);
+
+        iovec_done(&v);
+
+        /* too long */
+        _cleanup_(iovec_done) struct iovec large = {};
+        ASSERT_OK(random_bytes_allocate_iovec(256, &large));
+        ASSERT_ERROR(iovw_merge(&(struct iovec_wrapper) { .iovec = &large, .count = 1, }, sizeof(uint8_t), &v), ERANGE);
+        ASSERT_OK(iovw_merge(&(struct iovec_wrapper) { .iovec = &large, .count = 1, }, sizeof(uint16_t), &v));
+        ASSERT_OK(iovec_split(&v, sizeof(uint16_t), &iovw2));
+        ASSERT_EQ(iovw2.count, 1u);
+        ASSERT_TRUE(iovec_equal(&iovw2.iovec[0], &large));
+
+        iovec_done(&v);
+        iovw_done_free(&iovw2);
+
+        /* No entry */
+        ASSERT_OK(iovw_merge(&(struct iovec_wrapper) {}, sizeof(uint8_t), &v));
+        ASSERT_FALSE(iovec_is_set(&v));
+
+        ASSERT_OK(iovw_merge(NULL, sizeof(uint8_t), &v));
+        ASSERT_FALSE(iovec_is_set(&v));
+
+        ASSERT_OK(iovec_split(&(struct iovec) {}, sizeof(uint8_t), &iovw2));
+        ASSERT_TRUE(iovw_isempty(&iovw2));
+
+        ASSERT_OK(iovec_split(NULL, sizeof(uint8_t), &iovw2));
+        ASSERT_TRUE(iovw_isempty(&iovw2));
+
+        /* empty entry only */
+        ASSERT_OK(iovw_merge(&(struct iovec_wrapper) { .iovec = &(struct iovec) {}, .count = 1, }, sizeof(uint8_t), &v));
+        ASSERT_FALSE(iovec_is_set(&v));
+
+        ASSERT_OK(iovec_split(&IOVEC_MAKE("", 1), sizeof(uint8_t), &iovw2));
+        ASSERT_TRUE(iovw_isempty(&iovw2));
+
 }
 
 DEFINE_TEST_MAIN(LOG_INFO);

--- a/src/test/test-iovec-wrapper.c
+++ b/src/test/test-iovec-wrapper.c
@@ -393,6 +393,8 @@ TEST(iovw_size) {
         ASSERT_OK(iovw_put(&iovw, (char*) "efghij", 6));
         ASSERT_OK(iovw_put(&iovw, (char*) "kl", 2));
         ASSERT_EQ(iovw_size(&iovw), 12U);
+
+        ASSERT_EQ(iovw_size(NULL), 0U);
 }
 
 TEST(iovw_concat) {

--- a/src/test/test-iovec-wrapper.c
+++ b/src/test/test-iovec-wrapper.c
@@ -82,6 +82,12 @@ TEST(iovw_put) {
         ASSERT_EQ(memcmp(iovw.iovec[1].iov_base, "barbar", 6), 0);
         ASSERT_EQ(iovw.iovec[2].iov_len, 1U);
         ASSERT_EQ(memcmp(iovw.iovec[2].iov_base, "q", 1), 0);
+
+        ASSERT_OK(iovw_put_full(&iovw, /* accept_zero= */ false, NULL, 0));
+        ASSERT_EQ(iovw.count, 3U);
+        ASSERT_OK(iovw_put_full(&iovw, /* accept_zero= */ true, NULL, 0));
+        ASSERT_EQ(iovw.count, 4U);
+        ASSERT_TRUE(iovec_equal(&iovw.iovec[3], &(struct iovec) {}));
 }
 
 TEST(iovw_put_iov) {
@@ -100,6 +106,12 @@ TEST(iovw_put_iov) {
         ASSERT_TRUE(iovec_equal(&iovw.iovec[0], &IOVEC_MAKE_STRING("aaa")));
         ASSERT_TRUE(iovec_equal(&iovw.iovec[1], &IOVEC_MAKE_STRING("bbb")));
         ASSERT_TRUE(iovec_equal(&iovw.iovec[2], &IOVEC_MAKE_STRING("ccc")));
+
+        ASSERT_OK(iovw_put_iov_full(&iovw, /* accept_zero= */ false, &(struct iovec) {}));
+        ASSERT_EQ(iovw.count, 3U);
+        ASSERT_OK(iovw_put_iov_full(&iovw, /* accept_zero= */ true, &(struct iovec) {}));
+        ASSERT_EQ(iovw.count, 4U);
+        ASSERT_TRUE(iovec_equal(&iovw.iovec[3], &(struct iovec) {}));
 }
 
 TEST(iovw_put_iovw) {
@@ -113,7 +125,8 @@ TEST(iovw_put_iovw) {
         ASSERT_OK(iovw_put_iov(&source, &IOVEC_MAKE_STRING("aaa")));
         ASSERT_OK(iovw_put_iov(&source, &IOVEC_MAKE_STRING("bbb")));
         ASSERT_OK(iovw_put_iov(&source, &IOVEC_MAKE_STRING("ccc")));
-        ASSERT_EQ(source.count, 3U);
+        ASSERT_OK(iovw_put_iov_full(&source, /* accept_zero= */ true, &(struct iovec) {}));
+        ASSERT_EQ(source.count, 4U);
 
         /* Pre-seed target with one entry to check that append adds on top rather than replacing */
         ASSERT_OK(iovw_put_iov(&target, &IOVEC_MAKE_STRING("xxx")));
@@ -136,10 +149,24 @@ TEST(iovw_put_iovw) {
         ASSERT_PTR_EQ(target.iovec[5].iov_base, source.iovec[2].iov_base);
 
         /* Source is unchanged */
-        ASSERT_EQ(source.count, 3U);
+        ASSERT_EQ(source.count, 4U);
         ASSERT_TRUE(iovec_equal(&source.iovec[0], &IOVEC_MAKE_STRING("aaa")));
         ASSERT_TRUE(iovec_equal(&source.iovec[1], &IOVEC_MAKE_STRING("bbb")));
         ASSERT_TRUE(iovec_equal(&source.iovec[2], &IOVEC_MAKE_STRING("ccc")));
+        ASSERT_TRUE(iovec_equal(&source.iovec[3], &(struct iovec) {}));
+
+        ASSERT_OK(iovw_put_iovw_full(&target, /* accept_zero= */ true, &source));
+        ASSERT_EQ(target.count, 10U);
+        ASSERT_TRUE(iovec_equal(&target.iovec[0], &IOVEC_MAKE_STRING("xxx")));
+        ASSERT_TRUE(iovec_equal(&target.iovec[1], &IOVEC_MAKE_STRING("yyy")));
+        ASSERT_TRUE(iovec_equal(&target.iovec[2], &IOVEC_MAKE_STRING("zzz")));
+        ASSERT_TRUE(iovec_equal(&target.iovec[3], &IOVEC_MAKE_STRING("aaa")));
+        ASSERT_TRUE(iovec_equal(&target.iovec[4], &IOVEC_MAKE_STRING("bbb")));
+        ASSERT_TRUE(iovec_equal(&target.iovec[5], &IOVEC_MAKE_STRING("ccc")));
+        ASSERT_TRUE(iovec_equal(&target.iovec[6], &IOVEC_MAKE_STRING("aaa")));
+        ASSERT_TRUE(iovec_equal(&target.iovec[7], &IOVEC_MAKE_STRING("bbb")));
+        ASSERT_TRUE(iovec_equal(&target.iovec[8], &IOVEC_MAKE_STRING("ccc")));
+        ASSERT_TRUE(iovec_equal(&target.iovec[9], &(struct iovec) {}));
 
         /* Cannot pass the same objects */
         ASSERT_ERROR(iovw_put_iovw(&target, &target), EINVAL);
@@ -169,6 +196,12 @@ TEST(iovw_extend) {
         /* Mutating the caller's buffer does not affect what's stored */
         memset(buf, 'X', sizeof buf);
         ASSERT_EQ(memcmp(iovw.iovec[0].iov_base, "one", 3), 0);
+
+        ASSERT_OK(iovw_extend_full(&iovw, /* accept_zero= */ false, NULL, 0));
+        ASSERT_EQ(iovw.count, 2U);
+        ASSERT_OK(iovw_extend_full(&iovw, /* accept_zero= */ true, NULL, 0));
+        ASSERT_EQ(iovw.count, 3U);
+        ASSERT_TRUE(iovec_equal(&iovw.iovec[2], &(struct iovec) {}));
 }
 
 TEST(iovw_extend_iov) {
@@ -186,6 +219,12 @@ TEST(iovw_extend_iov) {
         ASSERT_TRUE(iovec_equal(&iovw.iovec[0], &IOVEC_MAKE_STRING("aaa")));
         ASSERT_TRUE(iovec_equal(&iovw.iovec[1], &IOVEC_MAKE_STRING("bbb")));
         ASSERT_TRUE(iovec_equal(&iovw.iovec[2], &IOVEC_MAKE_STRING("ccc")));
+
+        ASSERT_OK(iovw_extend_iov_full(&iovw, /* accept_zero= */ false, &(struct iovec) {}));
+        ASSERT_EQ(iovw.count, 3U);
+        ASSERT_OK(iovw_extend_iov_full(&iovw, /* accept_zero= */ true, &(struct iovec) {}));
+        ASSERT_EQ(iovw.count, 4U);
+        ASSERT_TRUE(iovec_equal(&iovw.iovec[3], &(struct iovec) {}));
 }
 
 TEST(iovw_extend_iovw) {
@@ -199,7 +238,8 @@ TEST(iovw_extend_iovw) {
 
         ASSERT_OK(iovw_put(&source, (char*) "one", 3));
         ASSERT_OK(iovw_put(&source, (char*) "twotwo", 6));
-        ASSERT_EQ(source.count, 2U);
+        ASSERT_OK(iovw_put_full(&source, /* accept_zero= */ true, NULL, 0));
+        ASSERT_EQ(source.count, 3U);
 
         /* Pre-seed target with one entry to check that append adds on top rather than replacing */
         char *seed = strdup("zero");
@@ -218,8 +258,17 @@ TEST(iovw_extend_iovw) {
         ASSERT_EQ(target.iovec[2].iov_len, 6U);
         ASSERT_EQ(memcmp(target.iovec[2].iov_base, "twotwo", 6), 0);
 
+        ASSERT_OK(iovw_extend_iovw_full(&target, /* accept_zero= */ true, &source));
+        ASSERT_EQ(target.count, 6U);
+        ASSERT_TRUE(iovec_equal(&target.iovec[0], &IOVEC_MAKE_STRING("zero")));
+        ASSERT_TRUE(iovec_equal(&target.iovec[1], &IOVEC_MAKE_STRING("one")));
+        ASSERT_TRUE(iovec_equal(&target.iovec[2], &IOVEC_MAKE_STRING("twotwo")));
+        ASSERT_TRUE(iovec_equal(&target.iovec[3], &IOVEC_MAKE_STRING("one")));
+        ASSERT_TRUE(iovec_equal(&target.iovec[4], &IOVEC_MAKE_STRING("twotwo")));
+        ASSERT_TRUE(iovec_equal(&target.iovec[5], &(struct iovec) {}));
+
         /* Source is unchanged */
-        ASSERT_EQ(source.count, 2U);
+        ASSERT_EQ(source.count, 3U);
 
         /* Cannot pass the same objects */
         ASSERT_ERROR(iovw_extend_iovw(&target, &target), EINVAL);
@@ -240,6 +289,16 @@ TEST(iovw_consume) {
         char *q = ASSERT_NOT_NULL(strdup(""));
         ASSERT_OK_ZERO(iovw_consume(&iovw, q, 0));
         ASSERT_EQ(iovw.count, 1U);
+
+        ASSERT_OK(iovw_consume_full(&iovw, /* accept_zero= */ false, NULL, 0));
+        ASSERT_EQ(iovw.count, 1U);
+        ASSERT_OK(iovw_consume_full(&iovw, /* accept_zero= */ true, NULL, 0));
+        ASSERT_EQ(iovw.count, 2U);
+        ASSERT_TRUE(iovec_equal(&iovw.iovec[1], &(struct iovec) {}));
+        q = ASSERT_NOT_NULL(strdup(""));
+        ASSERT_OK(iovw_consume_full(&iovw, /* accept_zero= */ true, q, 0));
+        ASSERT_EQ(iovw.count, 3U);
+        ASSERT_TRUE(iovec_equal(&iovw.iovec[2], &(struct iovec) {}));
 }
 
 TEST(iovw_consume_iov) {
@@ -270,6 +329,19 @@ TEST(iovw_consume_iov) {
         /* zero length iovec is also freed */
         ASSERT_NULL(iov.iov_base);
         ASSERT_EQ(iov.iov_len, 0U);
+
+        ASSERT_OK(iovw_consume_iov_full(&iovw, /* accept_zero= */ false, &(struct iovec) {}));
+        ASSERT_EQ(iovw.count, 1U);
+        ASSERT_OK(iovw_consume_iov_full(&iovw, /* accept_zero= */ true, &(struct iovec) {}));
+        ASSERT_EQ(iovw.count, 2U);
+        ASSERT_TRUE(iovec_equal(&iovw.iovec[1], &(struct iovec) {}));
+        iov = (struct iovec) {
+                .iov_base = ASSERT_NOT_NULL(strdup("")),
+                .iov_len = 0,
+        };
+        ASSERT_OK(iovw_consume_iov_full(&iovw, /* accept_zero= */ true, &iov));
+        ASSERT_EQ(iovw.count, 3U);
+        ASSERT_TRUE(iovec_equal(&iovw.iovec[2], &(struct iovec) {}));
 }
 
 TEST(iovw_isempty) {


### PR DESCRIPTION
These are currently not used yet, but will be used later in parsing/building network packets like DHCP message.