### PR TITLE
nss-myhostname: fix maybe-uninitialized warning

### DIFF
--- a/src/nss-myhostname/nss-myhostname.c
+++ b/src/nss-myhostname/nss-myhostname.c
@@ -39,7 +39,7 @@ enum nss_status _nss_myhostname_gethostbyname4_r(
         _cleanup_free_ char *hn = NULL;
         const char *canonical = NULL;
         int n_addresses = 0;
-        uint32_t local_address_ipv4;
+        uint32_t local_address_ipv4 = 0;
         size_t l, idx, ms;
         char *r_name;
 


### PR DESCRIPTION
In resolute with gcc 15.2.0:

```
472s ../src/nss-myhostname/nss-myhostname.c: In function ‘_nss_myhostname_gethostbyname4_r’: 472s ../src/nss-myhostname/nss-myhostname.c:132:44: error: ‘local_address_ipv4’ may be used uninitialized [-Werror=maybe-uninitialized]
472s   132 |                 *(uint32_t*) r_tuple->addr = local_address_ipv4;
472s       |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~
472s ../src/nss-myhostname/nss-myhostname.c:42:18: note: ‘local_address_ipv4’ was declared here
472s    42 |         uint32_t local_address_ipv4;
472s       |                  ^~~~~~~~~~~~~~~~~~
```