### PR TITLE
systemd-cat does not connect the standard *input* of a process to the journal

### DIFF
--- a/man/systemd-cat.xml
+++ b/man/systemd-cat.xml
@@ -37,9 +37,9 @@
     <title>Description</title>
 
     <para><command>systemd-cat</command> may be used to connect the
-    standard input and output of a process to the journal, or as a
-    filter tool in a shell pipeline to pass the output the previous
-    pipeline element generates to the journal.</para>
+    standard output and error output of a command to the journal, or
+    as a filter tool in a shell pipeline to pass the output the
+    previous pipeline element generates to the journal.</para>
 
     <para>If no parameter is passed, <command>systemd-cat</command>
     will write everything it reads from standard input (stdin) to the


### PR DESCRIPTION
The first paragraph of the description of the systemd-cat utility incorrectly referred to stdin when it obviously meant stderr: the other fd that it connects to the journal via a unix(7) domain socket, as clarified in the following paragraphs.

I've also replaced "process" with "command" as in that mode, systemd-cat executes a file and does not spawn a process.