### PR TITLE
A couple of sanitizer-related tweaks

### DIFF
--- a/mkosi/mkosi.sanitizers/mkosi.postinst
+++ b/mkosi/mkosi.sanitizers/mkosi.postinst
@@ -9,13 +9,17 @@ if [[ ! -f "$BUILDROOT/$LIBSYSTEMD" ]]; then
     exit 0
 fi
 
-# ASAN and syscall filters aren't compatible with each other.
+# ASAN and syscall filters aren't compatible with each other. Also, drop any memory limits
+# as these are quite unpredictable when running under sanitizers.
 find "$BUILDROOT"/usr "$BUILDROOT"/etc -name '*.service' -type f | while read -r unit; do
-    if grep -q -e MemoryDeny -e SystemCall "$unit" ; then
+    if grep -q -e MemoryDeny -e MemoryMax -e MemoryHigh -e MemorySwapMax -e SystemCall "$unit" ; then
         mkdir -p "$unit.d"
         cat > "$unit.d/sanitizer-compat.conf" <<EOF
 [Service]
 MemoryDenyWriteExecute=no
+MemoryMax=
+MemoryHigh=
+MemorySwapMax=
 SystemCallFilter=
 EOF
     fi

--- a/mkosi/mkosi.sanitizers/mkosi.postinst
+++ b/mkosi/mkosi.sanitizers/mkosi.postinst
@@ -56,6 +56,7 @@ wrap=(
     dbus-broker-launch
     dbus-daemon
     delv
+    dfuzzer
     dhcpd
     dig
     dnf
@@ -70,6 +71,7 @@ wrap=(
     groups
     id
     integritysetup
+    iscsiadm
     iscsid
     keymgr
     knotc
@@ -79,12 +81,15 @@ wrap=(
     login
     ls
     lsblk
+    lsns
     lsof
     lvm
     mdadm
     mkfs.btrfs
+    mkfs.ext4
     mksquashfs
     mount
+    mountpoint
     multipath
     multipathd
     nvme
@@ -98,8 +103,12 @@ wrap=(
     stat
     stress-ng
     su
+    swapoff
+    swapon
     tar
     tgtd
+    # The tpm2 tools (tpm2_readpublic, tpm2_pcrextend, ...) all are symlinks to tpm2
+    tpm2
     umount
     unix_chkpwd
     useradd

--- a/mkosi/mkosi.sanitizers/mkosi.postinst
+++ b/mkosi/mkosi.sanitizers/mkosi.postinst
@@ -140,8 +140,11 @@ for bin in "${wrap[@]}"; do
 # Preload the ASan runtime DSO, otherwise ASan will complain
 export LD_PRELOAD="$ASAN_RT_PATH"
 # Disable LSan to speed things up, since we don't care about leak reports
-# from 'external' binaries
-export ASAN_OPTIONS=detect_leaks=$enable_lsan
+# from 'external' binaries. In addition, disable quarantine (for use-after-free
+# detection) and malloc stack frame collection as we don't care about these in
+# 'external' binaries either, and they just unnecessarily hog up memory & cpu
+# cycles.
+export ASAN_OPTIONS=detect_leaks=$enable_lsan:quarantine_size_mb=0:malloc_context_size=0
 # Set argv[0] to the original binary name without the ".orig" suffix
 exec -a "\$0" -- "${target}.orig" "\$@"
 EOF

--- a/mkosi/mkosi.sanitizers/mkosi.postinst
+++ b/mkosi/mkosi.sanitizers/mkosi.postinst
@@ -11,7 +11,7 @@ fi
 
 # ASAN and syscall filters aren't compatible with each other. Also, drop any memory limits
 # as these are quite unpredictable when running under sanitizers.
-find "$BUILDROOT"/usr "$BUILDROOT"/etc -name '*.service' -type f | while read -r unit; do
+find "$BUILDROOT"/{etc,usr/lib}/systemd/system/ -name '*.service' -type f | while read -r unit; do
     if grep -q -e MemoryDeny -e MemoryMax -e MemoryHigh -e MemorySwapMax -e SystemCall "$unit" ; then
         mkdir -p "$unit.d"
         cat > "$unit.d/sanitizer-compat.conf" <<EOF

--- a/test/integration-tests/integration-test-wrapper.py
+++ b/test/integration-tests/integration-test-wrapper.py
@@ -142,7 +142,19 @@ def process_sanitizer_report(args: argparse.Namespace, journal_file: Path) -> bo
     fatal_end = re.compile(r'==[0-9]+==HINT:\s+\w+Sanitizer')
 
     # 'Standard' errors:
-    standard_begin = re.compile(r'([0-9]+: runtime error|==[0-9]+==.+?\w+Sanitizer)')
+    #
+    # TODO: there's currently a bug in LLVM 22 due to which certain systemd
+    # units can throw the following warning:
+    # [ 3366.747202] systemd-oomd[93]: ==93==WARNING: ptrace appears to be blocked (is seccomp enabled?).
+    #                LeakSanitizer may hang.
+    # [ 3366.747202] systemd-oomd[93]: ==93==Child exited with signal 15.
+    #
+    # which is then picked up by the following regex and causes the test to
+    # fail. Let's, temporarily, exclude this warning from the regex to mitigate
+    # this.
+    #
+    # See: https://github.com/llvm/llvm-project/issues/193714
+    standard_begin = re.compile(r'([0-9]+: runtime error|==[0-9]+==(?!WARNING: ptrace).+?\w+Sanitizer)')
     standard_end = re.compile(r'SUMMARY:\s+(\w+)Sanitizer')
 
     # extract COMM

--- a/test/units/TEST-07-PID1.user-namespace-path.sh
+++ b/test/units/TEST-07-PID1.user-namespace-path.sh
@@ -6,15 +6,6 @@ set -o pipefail
 # shellcheck source=test/units/util.sh
 . "$(dirname "$0")"/util.sh
 
-# When sanitizers are used, export LD_PRELOAD with the sanitizers path,
-# lsns doesn't work otherwise.
-if [ -f /usr/lib/systemd/systemd-asan-env ]; then
-    # shellcheck source=/dev/null
-    . /usr/lib/systemd/systemd-asan-env
-    export LD_PRELOAD
-    export ASAN_OPTIONS
-fi
-
 # Only reuse the user namespace
 systemd-run --unit=oldservice --property=Type=exec --property=PrivateUsers=true sleep 3600
 OLD_PID=$(systemctl show oldservice -p MainPID | awk -F= '{print $2}')


### PR DESCRIPTION
The sanitizer job was FUBAR on Fedora Rawhide (and RHEL 10 to some extent) due to several changes:
  - latest LLVM (v22) introduced a change that occasionally generates a false-positive warning when running with sanitizers
  - several tools had to be "ASan-wrapped" because:
    - util-linux started linking against libsystemd which propagated to other tools depending on its shared libraries (like libmount)
    - libssh started depending on libfido2, which depends on libudev; this then translated to an interesting depedency chain where tpm2 utils got a dependency on libudev through libcurl -> libssh -> libfido2
  - polkit added MemoryMax= to its service file, which is incompatible with ASan-runs (at least with the current limits)

See the commits for more detailed descriptions.

Also, one note: the santizer job is currently still FUBAR on Fedora Rawhide (or, more specifically, the TEST-50-DISSECT and TEST-58-REPART), because mkfs.erofs also gained a dependency on libudev (through libcurl, see above), but the wrapping currently doesn't work as it also depends on libqpl which is linked with libtsan (which is incompatible with other sanitizers). This is currently tracked in https://bugzilla.redhat.com/show_bug.cgi?id=2461146