### PR TITLE
job: properly initialize all enum fields

### DIFF
--- a/src/core/job.c
+++ b/src/core/job.c
@@ -41,6 +41,8 @@ Job* job_new_raw(Unit *unit) {
                 .manager = unit->manager,
                 .unit = unit,
                 .type = _JOB_TYPE_INVALID,
+                .state = JOB_WAITING,
+                .result = _JOB_RESULT_INVALID,
         };
 
         return j;

--- a/src/core/job.h
+++ b/src/core/job.h
@@ -106,7 +106,6 @@ typedef struct Job {
 
         JobType type;
         JobState state;
-
         JobResult result;
 
         unsigned run_queue_idx;


### PR DESCRIPTION
This changes the .result field to invalid initially, which arguably makes more sense than "done", which was previously the default.

This is a correctnes fix, and afaics has no effect on the API, since we do not expose this 1:1 as D-Bus property: it's only seen on D-Bus as part of the job completion signal, at which part it is correctly initialized.

Noticed while reviewing: https://github.com/systemd/systemd/pull/41583