### PR TITLE
units: order networkd resolve hook After=network-pre.target

### DIFF
--- a/units/systemd-networkd-resolve-hook.socket
+++ b/units/systemd-networkd-resolve-hook.socket
@@ -12,6 +12,7 @@ Description=Network Management Resolve Hook Socket
 Documentation=man:systemd-networkd.service(8)
 ConditionCapability=CAP_NET_ADMIN
 DefaultDependencies=no
+After=network-pre.target
 Before=sockets.target shutdown.target
 Conflicts=shutdown.target
 


### PR DESCRIPTION
Without this, the socket is available well before systemd-networkd.service is able to start, because of its own After=network-pre.target ordering. Then, if resolved handles queries before network-pre.target, it will hang waiting for networkd to reply to hook queries.

This is currently happening in the wild with cloud-init.