### PR TITLE
hwdb: sensor: add accel mount matrix for GPD WIN 5

### DIFF
--- a/hwdb.d/60-sensor.hwdb
+++ b/hwdb.d/60-sensor.hwdb
@@ -515,6 +515,7 @@ sensor:modalias:acpi:KIOX000A:*:dmi:bvnAmericanMegatrendsInc.:bvr5.11:bd03/20/20
 sensor:modalias:acpi:KIOX000A:*:dmi:bvnAmericanMegatrendsInc.:bvr5.11:bd05/25/2017:*:svnDefaultstring:pnDefaultstring:pvrDefaultstring:rvnAMICorporation:rnDefaultstring:rvrDefaultstring:cvnDefaultstring:ct3:cvrDefaultstring:*
  ACCEL_LOCATION=base
 
+sensor:modalias:acpi:BMI0160:*:dmi:*:svnGPD:pnG1618-05:*    # WIN 5
 sensor:modalias:acpi:BMI0160:*:dmi:*:svnGPD:pnG1619-04:*    # Win Max 2
  ACCEL_MOUNT_MATRIX=0, -1, 0; -1, 0, 0; 0, 0, 1
 


### PR DESCRIPTION
The GPD WIN 5 (DMI `G1618-05`) ships a BMI0160 accelerometer mounted the same way as on the Win Max 2 (`G1619-04`), so this entry reuses the same mount matrix.

Without it, `iio-sensor-proxy` reports `AccelerometerOrientation = 'normal'` regardless of how the device is held, which breaks auto-rotation on compositors that listen to it.

Verified on a real G1618-05:
- raw acceleration `(+1g, 0, 0)` ↔ matrix ↔ panel normal
- raw `(0, -1g, ~-0.4g)` ↔ matrix ↔ left-up (landscape, left up)
- `monitor-sensor` and the `net.hadess.SensorProxy` D-Bus property both follow physical orientation transitions after applying the matrix.