### PR TITLE
nsresource: add missing sentinels to dispatch tables 

### DIFF
--- a/src/shared/nsresource.c
+++ b/src/shared/nsresource.c
@@ -372,6 +372,7 @@ int nsresource_add_netif_veth(
         static const sd_json_dispatch_field dispatch_table[] = {
                 { "hostInterfaceName",      SD_JSON_VARIANT_STRING, sd_json_dispatch_string, offsetof(InterfaceParams, host_interface_name),      SD_JSON_MANDATORY },
                 { "namespaceInterfaceName", SD_JSON_VARIANT_STRING, sd_json_dispatch_string, offsetof(InterfaceParams, namespace_interface_name), SD_JSON_MANDATORY },
+                {}
         };
 
         _cleanup_(interface_params_done) InterfaceParams p = {};
@@ -437,6 +438,7 @@ int nsresource_add_netif_tap(
         static const sd_json_dispatch_field dispatch_table[] = {
                 { "hostInterfaceName",       SD_JSON_VARIANT_STRING,        sd_json_dispatch_string, offsetof(InterfaceParams, host_interface_name), SD_JSON_MANDATORY },
                 { "interfaceFileDescriptor", _SD_JSON_VARIANT_TYPE_INVALID, sd_json_dispatch_uint,   offsetof(InterfaceParams, interface_fd_index),  SD_JSON_MANDATORY },
+                {}
         };
 
         _cleanup_(interface_params_done) InterfaceParams p = {};

--- a/src/ssh-generator/ssh-proxy.c
+++ b/src/ssh-generator/ssh-proxy.c
@@ -337,6 +337,7 @@ static int process_machine(const char *machine, const char *port) {
                 { "vSockCid", SD_JSON_VARIANT_UNSIGNED, sd_json_dispatch_uint32,       voffsetof(p, cid),     0                 },
                 { "class",    SD_JSON_VARIANT_STRING,   sd_json_dispatch_const_string, voffsetof(p, class),   SD_JSON_MANDATORY },
                 { "service",  SD_JSON_VARIANT_STRING,   sd_json_dispatch_const_string, voffsetof(p, service), 0                 },
+                {}
         };
 
         r = sd_json_dispatch(result, dispatch_table, SD_JSON_ALLOW_EXTENSIONS, &p);


### PR DESCRIPTION
Otherwise fun things happen:
```
$ build-local-san/test-nsresource
/* test_delegatetap */
Successfully forked off '(sd-mkuserns)' as PID 4098039.
varlink: Setting state idle-client
varlink: Changing state idle-client → calling
json-stream: Sending message: {"method":"io.systemd.NamespaceResource.RegisterUserNamespace","parameters":{"name":"foobar","mangleName":true,"userNamespaceFileDescriptor":0}}
json-stream: Received message: {"parameters":{"name":null}}
varlink: Changing state calling → called
varlink: Changing state called → idle-client
varlink: Changing state idle-client → calling
json-stream: Sending message: {"method":"io.systemd.NamespaceResource.AddNetworkToUserNamespace","parameters":{"userNamespaceFileDescriptor":0,"mode":"tap"}}
json-stream: Received message: {"parameters":{"hostInterfaceName":"ns-4b52cac9c17b","interfaceFileDescriptor":0}}
varlink: Changing state calling → called
varlink: Changing state called → idle-client
=================================================================
==4098038==ERROR: AddressSanitizer: global-buffer-overflow on address 0x7f4a586ef370 at pc 0x7f4a57cb8565 bp 0x7ffd7c9f3930 sp 0x7ffd7c9f3928
READ of size 8 at 0x7f4a586ef370 thread T0
    #0 0x7f4a57cb8564 in sd_json_dispatch_full /home/fsumsal/repos/@systemd/systemd/build-local-san/../src/libsystemd/sd-json/sd-json.c:5195:63
    #1 0x7f4a5770ce5b in nsresource_add_netif_tap /home/fsumsal/repos/@systemd/systemd/build-local-san/../src/shared/nsresource.c:443:13
    #2 0x0000005091b2 in test_delegatetap /home/fsumsal/repos/@systemd/systemd/build-local-san/../src/test/test-nsresource.c:32:38
    #3 0x7f4a578838c7 in run_test_table /home/fsumsal/repos/@systemd/systemd/build-local-san/../src/shared/tests.c:412:33
    #4 0x000000509708 in main /home/fsumsal/repos/@systemd/systemd/build-local-san/../src/test/test-nsresource.c:40:1
    #5 0x7f4a5711b5b4 in __libc_start_call_main (/lib64/libc.so.6+0x35b4) (BuildId: 2b5beec0fd24fe9c9f43eddfdd5facf0b8a1b805)
    #6 0x7f4a5711b667 in __libc_start_main@GLIBC_2.2.5 (/lib64/libc.so.6+0x3667) (BuildId: 2b5beec0fd24fe9c9f43eddfdd5facf0b8a1b805)
    #7 0x00000042b434 in _start (/home/fsumsal/repos/@systemd/systemd/build-local-san/test-nsresource+0x42b434) (BuildId: ca38dacfa9b665de60b1893e5f0e326ea78d5d5c)

0x7f4a586ef370 is located 48 bytes before global variable 'mpol_table' defined in '/home/fsumsal/repos/@systemd/systemd/build-local-san/../src/shared/numa-util.c:179' (0x7f4a586ef3a0) of size 40
0x7f4a586ef370 is located 0 bytes after global variable 'nsresource_add_netif_tap.dispatch_table' defined in '/home/fsumsal/repos/@systemd/systemd/build-local-san/../src/shared/nsresource.c:437' (0x7f4a586ef320) of size 80
SUMMARY: AddressSanitizer: global-buffer-overflow /home/fsumsal/repos/@systemd/systemd/build-local-san/../src/libsystemd/sd-json/sd-json.c:5195:63 in sd_json_dispatch_full
Shadow bytes around the buggy address:
  0x7f4a586ef080: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x7f4a586ef100: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x7f4a586ef180: f9 f9 f9 f9 f9 f9 f9 f9 00 00 00 00 00 00 f9 f9
  0x7f4a586ef200: f9 f9 f9 f9 00 00 00 00 f9 f9 f9 f9 00 00 00 00
  0x7f4a586ef280: f9 f9 f9 f9 00 00 00 00 00 00 00 00 00 00 f9 f9
=>0x7f4a586ef300: f9 f9 f9 f9 00 00 00 00 00 00 00 00 00 00[f9]f9
  0x7f4a586ef380: f9 f9 f9 f9 00 00 00 00 00 f9 f9 f9 f9 f9 f9 f9
  0x7f4a586ef400: 00 00 00 00 00 00 00 00 00 f9 f9 f9 f9 f9 f9 f9
  0x7f4a586ef480: 00 00 00 f9 f9 f9 f9 f9 00 00 00 00 00 00 00 00
  0x7f4a586ef500: 00 00 00 00 00 00 00 00 f9 f9 f9 f9 00 00 00 f9
  0x7f4a586ef580: f9 f9 f9 f9 00 00 00 00 f9 f9 f9 f9 00 00 00 f9
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==4098038==ABORTING
```

Also, do the same thing in ssh-proxy.c where the sentinel was accidentally dropped during the last refactor.