### PR TITLE
ssh-proxy: add a missing dispatch table sentinel

### DIFF
--- a/src/ssh-generator/ssh-proxy.c
+++ b/src/ssh-generator/ssh-proxy.c
@@ -337,6 +337,7 @@ static int process_machine(const char *machine, const char *port) {
                 { "vSockCid", SD_JSON_VARIANT_UNSIGNED, sd_json_dispatch_uint32,       voffsetof(p, cid),     0                 },
                 { "class",    SD_JSON_VARIANT_STRING,   sd_json_dispatch_const_string, voffsetof(p, class),   SD_JSON_MANDATORY },
                 { "service",  SD_JSON_VARIANT_STRING,   sd_json_dispatch_const_string, voffsetof(p, service), 0                 },
+                {}
         };
 
         r = sd_json_dispatch(result, dispatch_table, SD_JSON_ALLOW_EXTENSIONS, &p);


### PR DESCRIPTION
Which was accidentally dropped in e6be5fb7200fb02e78e4f27f49a4d734b7b850a0.

Follow-up for e6be5fb7200fb02e78e4f27f49a4d734b7b850a0.