### PR TITLE
format-table: fix potential segfault

### DIFF
--- a/src/shared/format-table.c
+++ b/src/shared/format-table.c
@@ -1081,12 +1081,12 @@ int table_add_many_internal(Table *t, TableDataType first_type, ...) {
                         break;
 
                 case TABLE_IN_ADDR:
-                        buffer.address = *va_arg(ap, union in_addr_union *);
+                        buffer.address.in = *va_arg(ap, struct in_addr *);
                         data = &buffer.address.in;
                         break;
 
                 case TABLE_IN6_ADDR:
-                        buffer.address = *va_arg(ap, union in_addr_union *);
+                        buffer.address.in6 = *va_arg(ap, struct in6_addr *);
                         data = &buffer.address.in6;
                         break;
 


### PR DESCRIPTION
In format-table.h, TABLE_IN_ADDR is commented as "Takes a union in_addr_union (or a struct in_addr)". However, if we pass struct in_addr to table_add_many(), the function reads more than the size of the struct.