### PR TITLE
nspawn: fix EPERM when using --private-users with --network-namespace-path

### DIFF
--- a/src/nspawn/nspawn.c
+++ b/src/nspawn/nspawn.c
@@ -4408,6 +4408,10 @@ static int outer_child(
         if (notify_fd < 0)
                 return notify_fd;
 
+        /* Join the external netns first, before dropping outer's CAP_SYS_ADMIN capability. */
+        if (arg_network_namespace_path && setns(netns_fd, CLONE_NEWNET) < 0)
+                return log_error_errno(errno, "Failed to join network namespace: %m");
+
         pid_t pid = raw_clone(SIGCHLD|CLONE_NEWNS|
                         arg_clone_ns_flags |
                         (IN_SET(arg_userns_mode, USER_NAMESPACE_FIXED, USER_NAMESPACE_PICK) ? CLONE_NEWUSER : 0) |
@@ -4422,9 +4426,6 @@ static int outer_child(
 
                 /* The inner child has all namespaces that are requested, so that we all are owned by the
                  * user if user namespaces are turned on. */
-
-                if (arg_network_namespace_path && setns(netns_fd, CLONE_NEWNET) < 0)
-                        return log_error_errno(errno, "Failed to join network namespace: %m");
 
                 if (arg_userns_mode == USER_NAMESPACE_MANAGED) {
                         /* In managed usernamespace operation, sysfs + procfs are special, we'll have to

--- a/src/nspawn/nspawn.c
+++ b/src/nspawn/nspawn.c
@@ -4408,6 +4408,13 @@ static int outer_child(
         if (notify_fd < 0)
                 return notify_fd;
 
+        /* Join the external network namespace first, while we are still in the parent's
+         * user namespace and have CAP_SYS_ADMIN there. Once we clone with CLONE_NEWUSER,
+         * the child will be in a new user namespace, lacking the capabilities in the
+         * parent user namespace required to join its network namespace. */
+        if (arg_network_namespace_path && setns(netns_fd, CLONE_NEWNET) < 0)
+                return log_error_errno(errno, "Failed to join network namespace: %m");
+
         pid_t pid = raw_clone(SIGCHLD|CLONE_NEWNS|
                         arg_clone_ns_flags |
                         (IN_SET(arg_userns_mode, USER_NAMESPACE_FIXED, USER_NAMESPACE_PICK) ? CLONE_NEWUSER : 0) |
@@ -4422,9 +4429,6 @@ static int outer_child(
 
                 /* The inner child has all namespaces that are requested, so that we all are owned by the
                  * user if user namespaces are turned on. */
-
-                if (arg_network_namespace_path && setns(netns_fd, CLONE_NEWNET) < 0)
-                        return log_error_errno(errno, "Failed to join network namespace: %m");
 
                 if (arg_userns_mode == USER_NAMESPACE_MANAGED) {
                         /* In managed usernamespace operation, sysfs + procfs are special, we'll have to

--- a/test/units/TEST-13-NSPAWN.nspawn.sh
+++ b/test/units/TEST-13-NSPAWN.nspawn.sh
@@ -1185,6 +1185,21 @@ matrix_run_one() {
                        ip a | grep -v -E '^1: lo.*UP'
     ip netns del nspawn_test
 
+    # test --network-namespace-path works when combined with --private-users=pick
+    ip netns add nspawn_test
+    ip netns exec nspawn_test ip link add foo type dummy
+
+    if [[ "$IS_USERNS_SUPPORTED" == "yes" && "$api_vfs_writable" == "no" ]]; then
+        SYSTEMD_NSPAWN_USE_CGNS="$use_cgns" SYSTEMD_NSPAWN_API_VFS_WRITABLE="$api_vfs_writable" \
+            systemd-nspawn --register=no \
+                           --directory="$root" \
+                           --private-users=pick \
+                           --network-namespace-path=/run/netns/nspawn_test \
+                           ip link show dev foo
+    fi
+
+    ip netns del nspawn_test
+
     rm -fr "$root"
 
     return 0


### PR DESCRIPTION
This PR fixes a bug where systemd-nspawn fails to start when both `--private-users` and `--network-namespace-path` are specified.

# The Problem:
The nspawn performs the following sequence:
1. Outer child called `raw_clone()` with `CLONE_NEWUSER`.
2. Inner child was spawned into a new User Namespace.
3. Inner child then attempted to call `setns()` to join the external network namespace provided via `--network-namespace-path` triggering kernel permission error.

Fixes #36363

# The Fix
The current implementation uses an ordering that prevents `--private-users` from working with `--network-namespace-path` due to kernel `setns()` permission constraints.

The fix involves shifting the `setns()` call to the outer child, immediately before the `raw_clone()` call.
This alignment also matches the logic described in the inner child's comments, which assume the network namespace is already present upon entry (if following `arg_network_namespace_path` condition).



# Verification

Tested on Arch Linux.

Builded and tested locally, without mkosi since the fix is straightforward.
```bash
meson setup build
ninja -C build systemd-nspawn
```

```bash
[engi@engix99 systemd]$ sudo ./build/systemd-nspawn --ephemeral -D / --private-users=pick --network-namespace-path=/var/run/netns/test-ns /bin/sh
Note: in a future version of systemd-nspawn the default set of permitted socket address families will be restricted to AF_INET, AF_INET6 and AF_UNIX. Use --restrict-address-families= to configure the set of permitted socket address families, or set RestrictAddressFamilies= in a .nspawn file.
░ Spawning container engix99-b3e557cf9a120628 on /.#snapshot.22f2c3b38d992587.
░ Press Ctrl-] three times within 1s to kill container; two times followed by r
░ to reboot container; two times followed by p to poweroff container.
Selected user namespace base 432865280 and range 65536.
sh-5.3# ip addr
1: lo: <LOOPBACK> mtu 65536 qdisc noop state DOWN group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
sh-5.3# ls -l /proc/self/ns/net
lrwxrwxrwx 1 root root 0 Apr 27 16:38 /proc/self/ns/net -> 'net:[4026533616]'
sh-5.3#
exit
Container engix99-b3e557cf9a120628 exited successfully.
Failed to unregister machine in system context, ignoring: No such device or address
```

Host's
```bash
[engi@engix99 ~]$ ls -l /proc/self/ns/net
lrwxrwxrwx 1 engi engi 0 Apr 27 16:38 /proc/self/ns/net -> 'net:[4026531833]'
```

Current systemd behaviour
```bash
[engi@engix99 systemd]$ sudo systemd-nspawn --ephemeral -D / --private-users=pick --network-namespace-path=/var/run/netns/test-ns /bin/sh
░ Spawning container engix99-ba96189ae6ce1b74 on /.#snapshot.4e4a5adc6aa8bc61.
░ Press Ctrl-] three times within 1s to kill container; two times followed by r
░ to reboot container; two times followed by p to poweroff container.
Selected user namespace base 537526272 and range 65536.
Failed to join network namespace: Operation not permitted
Child died too early.
[engi@engix99 systemd]$
```

```
systemd 260 (260.1-2-arch)
+PAM +AUDIT -SELINUX +APPARMOR -IMA +IPE +SMACK +SECCOMP +GCRYPT +GNUTLS +OPENSSL +ACL +BLKID +CURL +ELFUTILS +FIDO2 +IDN2 +KMOD +LIBCRYPTSETUP +LIBCRYPTSETUP_PLUGINS +LIBFDISK +PCRE2 +PWQUALITY +P11KIT +QRENCODE +TPM2 +BZIP2 +LZ4 +XZ +ZLIB +ZSTD +BPF_FRAMEWORK +BTF +XKBCOMMON +UTMP +LIBARCHIVE
```