### PR TITLE
core: ensure all types from execute.h start with Exec

### DIFF
--- a/src/core/dbus-execute.c
+++ b/src/core/dbus-execute.c
@@ -58,7 +58,7 @@ static BUS_DEFINE_PROPERTY_GET_ENUM(property_get_private_bpf, private_bpf, Priva
 static BUS_DEFINE_PROPERTY_GET_ENUM(property_get_protect_home, protect_home, ProtectHome);
 static BUS_DEFINE_PROPERTY_GET_ENUM(property_get_protect_system, protect_system, ProtectSystem);
 static BUS_DEFINE_PROPERTY_GET_ENUM(property_get_personality, personality, unsigned long);
-static BUS_DEFINE_PROPERTY_GET_ENUM(property_get_memory_thp, memory_thp, MemoryTHP);
+static BUS_DEFINE_PROPERTY_GET_ENUM(property_get_exec_memory_thp, exec_memory_thp, ExecMemoryTHP);
 static BUS_DEFINE_PROPERTY_GET(property_get_ioprio, "i", ExecContext, exec_context_get_effective_ioprio);
 static BUS_DEFINE_PROPERTY_GET(property_get_mount_apivfs, "b", ExecContext, exec_context_get_effective_mount_apivfs);
 static BUS_DEFINE_PROPERTY_GET(property_get_bind_log_sockets, "b", ExecContext, exec_context_get_effective_bind_log_sockets);
@@ -1002,7 +1002,7 @@ static int property_get_exec_quota(sd_bus *bus,
                 void *userdata,
                 sd_bus_error *reterr_error) {
 
-        QuotaLimit *q = ASSERT_PTR(userdata);
+        ExecQuotaLimit *q = ASSERT_PTR(userdata);
 
         assert(bus);
         assert(reply);
@@ -1399,7 +1399,7 @@ const sd_bus_vtable bus_exec_vtable[] = {
         SD_BUS_PROPERTY("BPFDelegatePrograms", "s", property_get_bpf_delegate_programs, offsetof(ExecContext, bpf_delegate_programs), SD_BUS_VTABLE_PROPERTY_CONST),
         SD_BUS_PROPERTY("BPFDelegateAttachments", "s", property_get_bpf_delegate_attachments, offsetof(ExecContext, bpf_delegate_attachments), SD_BUS_VTABLE_PROPERTY_CONST),
         SD_BUS_PROPERTY("MemoryKSM", "b", bus_property_get_tristate, offsetof(ExecContext, memory_ksm), SD_BUS_VTABLE_PROPERTY_CONST),
-        SD_BUS_PROPERTY("MemoryTHP", "s", property_get_memory_thp, offsetof(ExecContext, memory_thp), SD_BUS_VTABLE_PROPERTY_CONST),
+        SD_BUS_PROPERTY("MemoryTHP", "s", property_get_exec_memory_thp, offsetof(ExecContext, memory_thp), SD_BUS_VTABLE_PROPERTY_CONST),
         SD_BUS_PROPERTY("UserNamespacePath", "s", NULL, offsetof(ExecContext, user_namespace_path), SD_BUS_VTABLE_PROPERTY_CONST),
         SD_BUS_PROPERTY("NetworkNamespacePath", "s", NULL, offsetof(ExecContext, network_namespace_path), SD_BUS_VTABLE_PROPERTY_CONST),
         SD_BUS_PROPERTY("IPCNamespacePath", "s", NULL, offsetof(ExecContext, ipc_namespace_path), SD_BUS_VTABLE_PROPERTY_CONST),
@@ -1444,7 +1444,7 @@ static int property_get_quota_usage(
         else
                 assert_not_reached();
 
-        const QuotaLimit *q;
+        const ExecQuotaLimit *q;
         q = &c->directories[dt].exec_quota;
 
         if (q->quota_enforce || q->quota_accounting) {
@@ -1842,7 +1842,7 @@ static BUS_DEFINE_SET_TRANSIENT_PARSE_PTR(bpf_delegate_commands, uint64_t, bpf_d
 static BUS_DEFINE_SET_TRANSIENT_PARSE_PTR(bpf_delegate_maps, uint64_t, bpf_delegate_maps_from_string);
 static BUS_DEFINE_SET_TRANSIENT_PARSE_PTR(bpf_delegate_programs, uint64_t, bpf_delegate_programs_from_string);
 static BUS_DEFINE_SET_TRANSIENT_PARSE_PTR(bpf_delegate_attachments, uint64_t, bpf_delegate_attachments_from_string);
-static BUS_DEFINE_SET_TRANSIENT_PARSE(memory_thp, MemoryTHP, memory_thp_from_string);
+static BUS_DEFINE_SET_TRANSIENT_PARSE(exec_memory_thp, ExecMemoryTHP, exec_memory_thp_from_string);
 BUS_DEFINE_SET_TRANSIENT_PARSE(exec_preserve_mode, ExecPreserveMode, exec_preserve_mode_from_string);
 static BUS_DEFINE_SET_TRANSIENT_PARSE_PTR(personality, unsigned long, parse_personality);
 static BUS_DEFINE_SET_TRANSIENT_TO_STRING_ALLOC(secure_bits, "i", int32_t, int, "%" PRIi32, secure_bits_to_string_alloc_with_check);
@@ -2341,7 +2341,7 @@ int bus_exec_context_set_transient_property(
                 return bus_set_transient_tristate(u, name, &c->memory_ksm, message, flags, reterr_error);
 
         if (streq(name, "MemoryTHP"))
-                return bus_set_transient_memory_thp(u, name, &c->memory_thp, message, flags, reterr_error);
+                return bus_set_transient_exec_memory_thp(u, name, &c->memory_thp, message, flags, reterr_error);
 
         if (streq(name, "UtmpIdentifier"))
                 return bus_set_transient_string(u, name, &c->utmp_id, message, flags, reterr_error);

--- a/src/core/exec-invoke.c
+++ b/src/core/exec-invoke.c
@@ -2762,7 +2762,7 @@ static int create_many_symlinks(const char *root, const char *source, char **sym
         return 0;
 }
 
-static int set_exec_storage_quota(int fd, uint32_t proj_id, const QuotaLimit *ql) {
+static int set_exec_storage_quota(int fd, uint32_t proj_id, const ExecQuotaLimit *ql) {
         int r;
         uint64_t block_limit = 0, inode_limit = 0;
 
@@ -2852,7 +2852,7 @@ static int apply_exec_quotas(
                 const char *target_dir,
                 const char *cgroup_path,
                 ExecDirectoryType type,
-                const QuotaLimit *ql,
+                const ExecQuotaLimit *ql,
                 uint32_t *exec_dt_proj_id, /* in/out */
                 bool *already_enforced) {  /* in/out */
 
@@ -4872,23 +4872,23 @@ static int setup_delegated_namespaces(
         return 0;
 }
 
-static int set_memory_thp(MemoryTHP thp) {
+static int set_memory_thp(ExecMemoryTHP thp) {
         int r;
 
         switch (thp) {
 
-        case MEMORY_THP_INHERIT:
+        case EXEC_MEMORY_THP_INHERIT:
                 return 0;
 
-        case MEMORY_THP_DISABLE:
+        case EXEC_MEMORY_THP_DISABLE:
                 r = RET_NERRNO(prctl(PR_SET_THP_DISABLE, 1, 0, 0, 0));
                 break;
 
-        case MEMORY_THP_MADVISE:
+        case EXEC_MEMORY_THP_MADVISE:
                 r = RET_NERRNO(prctl(PR_SET_THP_DISABLE, 1, PR_THP_DISABLE_EXCEPT_ADVISED, 0, 0));
                 break;
 
-        case MEMORY_THP_SYSTEM:
+        case EXEC_MEMORY_THP_SYSTEM:
                 r = RET_NERRNO(prctl(PR_SET_THP_DISABLE, 0, 0, 0, 0));
                 break;
 
@@ -5711,11 +5711,11 @@ int exec_invoke(
         r = set_memory_thp(context->memory_thp);
         if (r == -EOPNOTSUPP)
                 log_debug_errno(r, "Setting MemoryTHP=%s is not supported, ignoring.",
-                                memory_thp_to_string(context->memory_thp));
+                                exec_memory_thp_to_string(context->memory_thp));
         else if (r < 0) {
                 *exit_status = EXIT_MEMORY_THP;
                 return log_error_errno(r, "Failed to set MemoryTHP=%s: %m",
-                                       memory_thp_to_string(context->memory_thp));
+                                       exec_memory_thp_to_string(context->memory_thp));
         }
 
 #if ENABLE_UTMP

--- a/src/core/execute-serialize.c
+++ b/src/core/execute-serialize.c
@@ -1698,7 +1698,7 @@ static int exec_context_serialize(const ExecContext *c, FILE *f) {
         if (r < 0)
                 return r;
 
-        r = serialize_item(f, "exec-context-memory-thp", memory_thp_to_string(c->memory_thp));
+        r = serialize_item(f, "exec-context-memory-thp", exec_memory_thp_to_string(c->memory_thp));
         if (r < 0)
                 return r;
 
@@ -2643,7 +2643,7 @@ static int exec_context_deserialize(ExecContext *c, FILE *f) {
                         if (r < 0)
                                 return r;
                 } else if ((val = startswith(l, "exec-context-memory-thp="))) {
-                        c->memory_thp = memory_thp_from_string(val);
+                        c->memory_thp = exec_memory_thp_from_string(val);
                         if (c->memory_thp < 0)
                                 return c->memory_thp;
                 } else if ((val = startswith(l, "exec-context-private-tmp="))) {

--- a/src/core/execute.c
+++ b/src/core/execute.c
@@ -1143,7 +1143,7 @@ void exec_context_dump(const ExecContext *c, FILE* f, const char *prefix) {
                 prefix, protect_hostname_to_string(c->protect_hostname), c->private_hostname ? ":" : "", strempty(c->private_hostname),
                 prefix, protect_proc_to_string(c->protect_proc),
                 prefix, proc_subset_to_string(c->proc_subset),
-                prefix, memory_thp_to_string(c->memory_thp),
+                prefix, exec_memory_thp_to_string(c->memory_thp),
                 prefix, private_bpf_to_string(c->private_bpf));
 
         if (c->private_bpf == PRIVATE_BPF_YES) {
@@ -3146,11 +3146,11 @@ static const char* const exec_keyring_mode_table[_EXEC_KEYRING_MODE_MAX] = {
 
 DEFINE_STRING_TABLE_LOOKUP(exec_keyring_mode, ExecKeyringMode);
 
-static const char* const memory_thp_table[_MEMORY_THP_MAX] = {
-        [MEMORY_THP_INHERIT] = "inherit",
-        [MEMORY_THP_DISABLE] = "disable",
-        [MEMORY_THP_MADVISE] = "madvise",
-        [MEMORY_THP_SYSTEM]  = "system",
+static const char* const exec_memory_thp_table[_EXEC_MEMORY_THP_MAX] = {
+        [EXEC_MEMORY_THP_INHERIT] = "inherit",
+        [EXEC_MEMORY_THP_DISABLE] = "disable",
+        [EXEC_MEMORY_THP_MADVISE] = "madvise",
+        [EXEC_MEMORY_THP_SYSTEM]  = "system",
 };
 
-DEFINE_STRING_TABLE_LOOKUP(memory_thp, MemoryTHP);
+DEFINE_STRING_TABLE_LOOKUP(exec_memory_thp, ExecMemoryTHP);

--- a/src/core/execute.h
+++ b/src/core/execute.h
@@ -73,23 +73,23 @@ typedef enum ExecKeyringMode {
         _EXEC_KEYRING_MODE_INVALID = -EINVAL,
 } ExecKeyringMode;
 
-typedef enum MemoryTHP {
+typedef enum ExecMemoryTHP {
         /*
          * Inherit default from process that starts systemd, i.e. do not make
          * any PR_SET_THP_DISABLE call.
          */
-        MEMORY_THP_INHERIT,
-        MEMORY_THP_DISABLE, /* Disable THPs completely for the process */
-        MEMORY_THP_MADVISE, /* Disable THPs for the process except when madvised */
+        EXEC_MEMORY_THP_INHERIT,
+        EXEC_MEMORY_THP_DISABLE, /* Disable THPs completely for the process */
+        EXEC_MEMORY_THP_MADVISE, /* Disable THPs for the process except when madvised */
         /*
          * Use system default THP setting. this can be used when the process that
          * starts systemd has already disabled THPs via PR_SET_THP_DISABLE, and we
          * want to restore the system default THP setting at process invocation time.
          */
-        MEMORY_THP_SYSTEM,
-        _MEMORY_THP_MAX,
-        _MEMORY_THP_INVALID = -EINVAL,
-} MemoryTHP;
+        EXEC_MEMORY_THP_SYSTEM,
+        _EXEC_MEMORY_THP_MAX,
+        _EXEC_MEMORY_THP_INVALID = -EINVAL,
+} ExecMemoryTHP;
 
 /* Contains start and exit information about an executed command.  */
 typedef struct ExecStatus {
@@ -154,12 +154,12 @@ static inline bool EXEC_DIRECTORY_TYPE_SHALL_CHOWN(ExecDirectoryType t) {
         return t >= 0 && t < _EXEC_DIRECTORY_TYPE_MAX && t != EXEC_DIRECTORY_CONFIGURATION;
 }
 
-typedef struct QuotaLimit {
+typedef struct ExecQuotaLimit {
         uint64_t quota_absolute; /* absolute quota in bytes; if UINT64_MAX relative quota configured, see below */
         uint32_t quota_scale;    /* relative quota to backend size, scaled to 0…UINT32_MAX */
         bool quota_enforce;
         bool quota_accounting;
-} QuotaLimit;
+} ExecQuotaLimit;
 
 typedef struct ExecDirectoryItem {
         char *path;
@@ -172,7 +172,7 @@ typedef struct ExecDirectory {
         mode_t mode;
         size_t n_items;
         ExecDirectoryItem *items;
-        QuotaLimit exec_quota;
+        ExecQuotaLimit exec_quota;
 } ExecDirectory;
 
 typedef enum ExecCleanMask {
@@ -332,7 +332,7 @@ typedef struct ExecContext {
         int mount_apivfs;
         int bind_log_sockets;
         int memory_ksm;
-        MemoryTHP memory_thp;
+        ExecMemoryTHP memory_thp;
         PrivateTmp private_tmp;     /* Those are not independent parameters, but are calculated from */
         PrivateTmp private_var_tmp; /* other parameters in unit_patch_contexts(). */
 
@@ -636,7 +636,7 @@ DECLARE_STRING_TABLE_LOOKUP(exec_directory_type_mode, ExecDirectoryType);
 
 DECLARE_STRING_TABLE_LOOKUP(exec_resource_type, ExecDirectoryType);
 
-DECLARE_STRING_TABLE_LOOKUP(memory_thp, MemoryTHP);
+DECLARE_STRING_TABLE_LOOKUP(exec_memory_thp, ExecMemoryTHP);
 
 bool exec_needs_mount_namespace(const ExecContext *context, const ExecParameters *params);
 bool exec_needs_network_namespace(const ExecContext *context);

--- a/src/core/load-fragment-gperf.gperf.in
+++ b/src/core/load-fragment-gperf.gperf.in
@@ -196,7 +196,7 @@
 {% endif %}
 {{type}}.ProtectHostname,                     config_parse_protect_hostname,                      0,                                  offsetof({{type}}, exec_context)
 {{type}}.MemoryKSM,                           config_parse_tristate,                              0,                                  offsetof({{type}}, exec_context.memory_ksm)
-{{type}}.MemoryTHP,                           config_parse_memory_thp,                            0,                                  offsetof({{type}}, exec_context.memory_thp)
+{{type}}.MemoryTHP,                           config_parse_exec_memory_thp,                       0,                                  offsetof({{type}}, exec_context.memory_thp)
 {%- endmacro -%}
 
 {%- macro KILL_CONTEXT_CONFIG_ITEMS(type) -%}

--- a/src/core/load-fragment.c
+++ b/src/core/load-fragment.c
@@ -166,7 +166,7 @@ DEFINE_CONFIG_PARSE_PTR(config_parse_bpf_delegate_commands, bpf_delegate_command
 DEFINE_CONFIG_PARSE_PTR(config_parse_bpf_delegate_maps, bpf_delegate_maps_from_string, uint64_t);
 DEFINE_CONFIG_PARSE_PTR(config_parse_bpf_delegate_programs, bpf_delegate_programs_from_string, uint64_t);
 DEFINE_CONFIG_PARSE_PTR(config_parse_bpf_delegate_attachments, bpf_delegate_attachments_from_string, uint64_t);
-DEFINE_CONFIG_PARSE_ENUM(config_parse_memory_thp, memory_thp, MemoryTHP);
+DEFINE_CONFIG_PARSE_ENUM(config_parse_exec_memory_thp, exec_memory_thp, ExecMemoryTHP);
 
 bool contains_instance_specifier_superset(const char *s) {
         const char *p, *q;
@@ -4532,7 +4532,7 @@ int config_parse_exec_quota(
                 void *data,
                 void *userdata) {
 
-        QuotaLimit *quota_limit = ASSERT_PTR(data);
+        ExecQuotaLimit *quota_limit = ASSERT_PTR(data);
         uint64_t quota_absolute = UINT64_MAX;
         uint32_t quota_scale = UINT32_MAX;
         int r;

--- a/src/core/load-fragment.h
+++ b/src/core/load-fragment.h
@@ -169,7 +169,7 @@ CONFIG_PARSER_PROTOTYPE(config_parse_cgroup_nft_set);
 CONFIG_PARSER_PROTOTYPE(config_parse_mount_node);
 CONFIG_PARSER_PROTOTYPE(config_parse_concurrency_max);
 CONFIG_PARSER_PROTOTYPE(config_parse_bind_network_interface);
-CONFIG_PARSER_PROTOTYPE(config_parse_memory_thp);
+CONFIG_PARSER_PROTOTYPE(config_parse_exec_memory_thp);
 
 /* gperf prototypes */
 const struct ConfigPerfItem* load_fragment_gperf_lookup(const char *key, GPERF_LEN_TYPE length);

--- a/src/core/varlink-execute.c
+++ b/src/core/varlink-execute.c
@@ -352,7 +352,7 @@ static int ioprio_class_build_json(sd_json_variant **ret, const char *name, void
 static int exec_dir_build_json(sd_json_variant **ret, const char *name, void *userdata) {
         _cleanup_(sd_json_variant_unrefp) sd_json_variant *v = NULL;
         ExecDirectory *exec_dir = ASSERT_PTR(userdata);
-        const QuotaLimit *quota = &exec_dir->exec_quota;
+        const ExecQuotaLimit *quota = &exec_dir->exec_quota;
         int r;
 
         assert(ret);
@@ -881,7 +881,7 @@ int unit_exec_context_build_json(sd_json_variant **ret, const char *name, void *
                         SD_JSON_BUILD_PAIR_INTEGER("IOSchedulingPriority", ioprio_prio_data(exec_context_get_effective_ioprio(c))),
 
                         JSON_BUILD_PAIR_TRISTATE_NON_NULL("MemoryKSM", c->memory_ksm),
-                        JSON_BUILD_PAIR_ENUM("MemoryTHP", memory_thp_to_string(c->memory_thp)),
+                        JSON_BUILD_PAIR_ENUM("MemoryTHP", exec_memory_thp_to_string(c->memory_thp)),
 
                         /* Sandboxing */
                         JSON_BUILD_PAIR_ENUM("ProtectSystem", protect_system_to_string(c->protect_system)),

--- a/src/test/test-varlink-idl-unit.c
+++ b/src/test/test-varlink-idl-unit.c
@@ -20,7 +20,7 @@ TEST(unit_enums_idl) {
         TEST_IDL_ENUM(ExecUtmpMode, exec_utmp_mode, vl_type_ExecUtmpMode);
         TEST_IDL_ENUM(ExecPreserveMode, exec_preserve_mode, vl_type_ExecPreserveMode);
         TEST_IDL_ENUM(ExecKeyringMode, exec_keyring_mode, vl_type_ExecKeyringMode);
-        TEST_IDL_ENUM(MemoryTHP, memory_thp, vl_type_MemoryTHP);
+        TEST_IDL_ENUM(ExecMemoryTHP, exec_memory_thp, vl_type_MemoryTHP);
         TEST_IDL_ENUM(ProtectProc, protect_proc, vl_type_ProtectProc);
         TEST_IDL_ENUM(ProcSubset, proc_subset, vl_type_ProcSubset);
         TEST_IDL_ENUM(ProtectSystem, protect_system, vl_type_ProtectSystem);


### PR DESCRIPTION
Until very recently all types defined by execute.h started with "Exec" in the name. I think that was useful, since it made clear that the types are associated with the ExecContext infrastructure. Let's hence restore this.

(If we every move these types out of execute.h we should drop the "Exec" prefix again. But today is not that day.)

No real code changes, just dumb renaming.