### PR TITLE
binfmt-util: handle ELOOP/EACCES from automount in read-only bind mounts

### DIFF
--- a/src/shared/binfmt-util.c
+++ b/src/shared/binfmt-util.c
@@ -18,6 +18,12 @@ int binfmt_mounted_and_writable(void) {
         fd = RET_NERRNO(open("/proc/sys/fs/binfmt_misc", O_CLOEXEC | O_DIRECTORY | O_PATH));
         if (fd == -ENOENT)
                 return false;
+        /* ELOOP happens when binfmt_misc is an automount point under a read-only bind mount of /proc —
+         * the kernel cannot trigger the automount and returns ELOOP instead. Common in mock/Koji buildroots. */
+        if (fd == -ELOOP || ERRNO_IS_NEG_PRIVILEGE(fd)) {
+                log_debug_errno(fd, "Failed to open /proc/sys/fs/binfmt_misc, ignoring: %m");
+                return false;
+        }
         if (fd < 0)
                 return fd;
 


### PR DESCRIPTION
  When /proc is bind-mounted read-only (as in mock/Koji/CBS buildroots),
  the kernel returns ELOOP when attempting to traverse the binfmt_misc
  automount point. This causes test-binfmt-util to SIGABRT and
  disable_binfmt() to log a spurious warning at shutdown.
  
  binfmt_mounted_and_writable() handles ENOENT but not ELOOP. This adds
  ELOOP and EACCES to the "not available" check.
  
  Context:
  - PR #37004 proposed reverting the test; @bluca suggested graceful handling instead
  - PR #37006 was merged and addressed ELOOP in the xstatfsat() path, but the
    open() call in binfmt_mounted_and_writable() remained unhandled
  - The bug is non-deterministic in build farms because it depends on whether the
    builder host has proc-sys-fs-binfmt_misc.automount active
  
  Root cause: mock bind-mounts host /proc with `rbind` then remounts read-only.
  If the host has binfmt_misc as an automount, the kernel returns ELOOP when
  the chroot tries to traverse it through the read-only bind mount.
  
  Tested in Amazon Linux Koji builds across multiple builder hosts — consistently
  fixes the failure on hosts where it previously reproduced.
  
  Fixes #38070