### PR TITLE
import: Trust subkeys included in signature

### DIFF
--- a/README
+++ b/README
@@ -270,6 +270,8 @@ REQUIREMENTS:
                 NOTE: If using dbus < 1.9.18, you should override the default
                 policy directory (--with-dbuspolicydir=/etc/dbus-1/system.d).
         polkit (optional)
+        gnupg >= 2.4 optional (for signature verification in: importctl,
+                               systemd-sysupdate)
 
         To build in directory build/:
           meson setup build/ && ninja -C build/

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -508,6 +508,16 @@ is suppressed by default.
   operation. If not set, defaults to true. If disabled installation of images
   will be quicker, but not as safe.
 
+`systemd-importd`/`systemd-pull` and `systemd-sysupdate`:
+
+* `$SYSTEMD_OPENPGP_KEYRING` — takes an absolute path to an OpenPGP keyring
+  file. If set and non-empty, signature verification on download uses this
+  keyring instead of the default `/etc/systemd/import-pubring.pgp` and
+  `/usr/lib/systemd/import-pubring.pgp` keyrings.
+  Useful when running unprivileged in the user context, with custom transfer
+  definitions (e.g. `systemd-sysupdate --definitions=…`), or for testing.
+  Has no effect when signature verification is disabled.
+
 `systemd-dissect`, `systemd-nspawn` and all other tools that may operate on
 disk images with `--image=` or similar:
 

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -503,6 +503,16 @@ is suppressed by default.
   operation. If not set, defaults to true. If disabled installation of images
   will be quicker, but not as safe.
 
+`systemd-import`/`systemd-importd`/`systemd-pull` and `systemd-sysupdate`:
+
+* `$SYSTEMD_OPENPGP_KEYRING` — takes an absolute path to an OpenPGP keyring
+  file. If set and non-empty, signature verification on download uses this
+  keyring instead of the default `/etc/systemd/import-pubring.pgp` and
+  `/usr/lib/systemd/import-pubring.pgp` keyrings.
+  Useful when running unprivileged in the user context, with custom transfer
+  definitions (e.g. `systemd-sysupdate --definitions=…`), or for testing.
+  Has no effect when signature verification is disabled.
+
 `systemd-dissect`, `systemd-nspawn` and all other tools that may operate on
 disk images with `--image=` or similar:
 

--- a/man/systemd-sysupdate.xml
+++ b/man/systemd-sysupdate.xml
@@ -311,6 +311,18 @@
       </varlistentry>
 
       <varlistentry>
+        <term><option>--keyring=</option></term>
+
+        <listitem><para>Takes a path to an OpenPGP keyring file. When specified, this keyring
+        is used to verify the signature on the <filename>SHA256SUMS</filename> manifest, instead of the
+        default <filename>/etc/systemd/import-pubring.pgp</filename> and
+        <filename>/usr/lib/systemd/import-pubring.pgp</filename> keyrings. This only has effect when
+        verification is enabled with <varname>Verify=</varname>/<option>--verify=</option>.</para>
+
+        <xi:include href="version-info.xml" xpointer="v261"/></listitem>
+      </varlistentry>
+
+      <varlistentry>
         <term><option>--reboot</option></term>
 
         <listitem><para>When used in combination with the <command>update</command> commands and a new version is

--- a/src/import/pull-common.c
+++ b/src/import/pull-common.c
@@ -431,7 +431,8 @@ static bool gpg_supports_auto_key_import(void) {
 
 static int verify_gpg(
                 const struct iovec *payload,
-                const struct iovec *signature) {
+                const struct iovec *signature,
+                const char *keyring_override) {
 
         _cleanup_close_pair_ int gpg_pipe[2] = EBADF_PAIR;
         _cleanup_(rm_rf_physical_and_freep) char *gpg_home = NULL;
@@ -503,9 +504,11 @@ static int verify_gpg(
 
                 cmd[k++] = strjoina("--homedir=", gpg_home);
 
+                if (keyring_override)
+                        cmd[k++] = strjoina("--keyring=", keyring_override);
                 /* We add the user keyring only to the command line arguments, if it's around since gpg fails
                  * otherwise. */
-                if (access(USER_KEYRING_PATH, F_OK) >= 0)
+                else if (access(USER_KEYRING_PATH, F_OK) >= 0)
                         cmd[k++] = "--keyring=" USER_KEYRING_PATH;
                 else if (access(USER_KEYRING_PATH_LEGACY, F_OK) >= 0)
                         cmd[k++] = "--keyring=" USER_KEYRING_PATH_LEGACY;
@@ -557,6 +560,7 @@ finish:
 }
 
 int pull_verify(ImportVerify verify,
+                const char *keyring_override,
                 PullJob *main_job,
                 PullJob *checksum_job,
                 PullJob *signature_job,
@@ -626,7 +630,7 @@ int pull_verify(ImportVerify verify,
                 return log_error_errno(SYNTHETIC_ERRNO(EBADMSG),
                                        "Signature is empty, cannot verify.");
 
-        return verify_gpg(&verify_job->payload, &signature_job->payload);
+        return verify_gpg(&verify_job->payload, &signature_job->payload, keyring_override);
 }
 
 int verification_style_from_url(const char *url, VerificationStyle *ret) {

--- a/src/import/pull-common.c
+++ b/src/import/pull-common.c
@@ -401,6 +401,34 @@ static int verify_one(PullJob *checksum_job, PullJob *job) {
         return 1;
 }
 
+/* --auto-key-import requires a newer gpg. We probe support at runtime by
+ * passing the flag before --version so that gpg will parse it and report failure
+ * if not supported, otherwise it will continue with --version and exit with 0. */
+static bool gpg_supports_auto_key_import(void) {
+        int r;
+
+        _cleanup_(pidref_done_sigkill_wait) PidRef pidref = PIDREF_NULL;
+        r = pidref_safe_fork_full(
+                        "(gpg-probe)",
+                        /* stdio_fds= */ NULL,
+                        /* except_fds= */ NULL, /* n_except_fds= */ 0,
+                        FORK_RESET_SIGNALS|FORK_CLOSE_ALL_FDS|FORK_DEATHSIG_SIGTERM|FORK_REARRANGE_STDIO|FORK_RLIMIT_NOFILE_SAFE,
+                        &pidref);
+        if (r < 0) {
+                log_debug_errno(r, "Failed to fork gpg probe process, continuing assuming --auto-key-import is not supported: %m");
+                return false;
+        }
+        if (r == 0) {
+                execlp("gpg2", "gpg2", "--auto-key-import", "--no-options", "--version", (char*) NULL);
+                execlp("gpg", "gpg", "--auto-key-import", "--no-options", "--version", (char*) NULL);
+                _exit(EXIT_FAILURE);
+        }
+
+        r = pidref_wait_for_terminate_and_check("gpg-probe", &pidref, /* flags= */ 0);
+        pidref_done(&pidref);
+        return r == EXIT_SUCCESS;
+}
+
 static int verify_gpg(
                 const struct iovec *payload,
                 const struct iovec *signature) {
@@ -455,6 +483,8 @@ static int verify_gpg(
                         "--no-auto-check-trustdb",
                         "--batch",
                         "--trust-model=always",
+                        NULL, /* --auto-key-import (newer gpg only) */
+                        NULL, /* --import-options=... (paired with --auto-key-import) */
                         NULL, /* --homedir= */
                         NULL, /* --keyring= */
                         NULL, /* --verify */
@@ -462,7 +492,12 @@ static int verify_gpg(
                         NULL, /* dash */
                         NULL  /* trailing NULL */
                 };
-                size_t k = ELEMENTSOF(cmd) - 6;
+                size_t k = ELEMENTSOF(cmd) - 8;
+
+                if (gpg_supports_auto_key_import()) {
+                        cmd[k++] = "--auto-key-import";
+                        cmd[k++] = "--import-options=merge-only,import-clean";
+                }
 
                 /* Child */
 

--- a/src/import/pull-common.c
+++ b/src/import/pull-common.c
@@ -409,10 +409,18 @@ static int verify_gpg(
         _cleanup_(rm_rf_physical_and_freep) char *gpg_home = NULL;
         char sig_file_path[] = "/tmp/sigXXXXXX";
         _cleanup_(pidref_done_sigkill_wait) PidRef pidref = PIDREF_NULL;
+        const char *keyring_override;
         int r;
 
         assert(iovec_is_valid(payload));
         assert(iovec_is_valid(signature));
+
+        /* Support using a custom keyring, see docs/ENVIRONMENT.md. */
+        keyring_override = empty_to_null(secure_getenv("SYSTEMD_OPENPGP_KEYRING"));
+        if (keyring_override && !(path_is_absolute(keyring_override) && path_is_normalized(keyring_override)))
+                return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
+                                       "$SYSTEMD_OPENPGP_KEYRING must be an absolute, normalized path, got '%s'.",
+                                       keyring_override);
 
         r = pipe2(gpg_pipe, O_CLOEXEC);
         if (r < 0)
@@ -468,9 +476,11 @@ static int verify_gpg(
 
                 cmd[k++] = strjoina("--homedir=", gpg_home);
 
-                /* We add the user keyring only to the command line arguments, if it's around since gpg fails
-                 * otherwise. */
-                if (access(USER_KEYRING_PATH, F_OK) >= 0)
+                if (keyring_override)
+                        cmd[k++] = strjoina("--keyring=", keyring_override);
+                else if (access(USER_KEYRING_PATH, F_OK) >= 0) /* We add the user keyring only to the
+                                                                * command line arguments, if it's around
+                                                                * since gpg fails otherwise. */
                         cmd[k++] = "--keyring=" USER_KEYRING_PATH;
                 else if (access(USER_KEYRING_PATH_LEGACY, F_OK) >= 0)
                         cmd[k++] = "--keyring=" USER_KEYRING_PATH_LEGACY;

--- a/src/import/pull-common.c
+++ b/src/import/pull-common.c
@@ -455,6 +455,8 @@ static int verify_gpg(
                         "--no-auto-check-trustdb",
                         "--batch",
                         "--trust-model=always",
+                        "--auto-key-import",
+                        "--import-options=merge-only,import-clean",
                         NULL, /* --homedir= */
                         NULL, /* --keyring= */
                         NULL, /* --verify */

--- a/src/import/pull-common.c
+++ b/src/import/pull-common.c
@@ -5,6 +5,7 @@
 #include "sd-id128.h"
 
 #include "alloc-util.h"
+#include "copy.h"
 #include "dirent-util.h"
 #include "escape.h"
 #include "fd-util.h"
@@ -409,7 +410,8 @@ static int verify_gpg(
         _cleanup_(rm_rf_physical_and_freep) char *gpg_home = NULL;
         char sig_file_path[] = "/tmp/sigXXXXXX";
         _cleanup_(pidref_done_sigkill_wait) PidRef pidref = PIDREF_NULL;
-        const char *keyring_override;
+        _cleanup_free_ char *keyring_copy = NULL;
+        const char *keyring_override, *keyring_source;
         int r;
 
         assert(iovec_is_valid(payload));
@@ -446,6 +448,31 @@ static int verify_gpg(
                 goto finish;
         }
 
+        if (keyring_override)
+                keyring_source = keyring_override;
+        else if (access(USER_KEYRING_PATH, F_OK) >= 0)
+                keyring_source = USER_KEYRING_PATH;
+        else if (access(USER_KEYRING_PATH_LEGACY, F_OK) >= 0)
+                keyring_source = USER_KEYRING_PATH_LEGACY;
+        else
+                keyring_source = VENDOR_KEYRING_PATH;
+
+        /* For whatever reason gpg --auto-key-import writes the key material embedded in the signature
+         * (the signing subkey) back into the keyring it verifies against instead of just using it
+         * temporarily. Verify against a throwaway copy in the tmp home so we never write to the
+         * original keyring. */
+        keyring_copy = path_join(gpg_home, "keyring.gpg");
+        if (!keyring_copy) {
+                r = log_oom();
+                goto finish;
+        }
+
+        r = copy_file(keyring_source, keyring_copy, 0, 0600, /* copy_flags= */ 0);
+        if (r < 0) {
+                log_error_errno(r, "Failed to copy keyring '%s': %m", keyring_source);
+                goto finish;
+        }
+
         r = pidref_safe_fork_full(
                         "(gpg)",
                         (int[]) { gpg_pipe[0], -EBADF, STDERR_FILENO },
@@ -463,6 +490,8 @@ static int verify_gpg(
                         "--no-auto-check-trustdb",
                         "--batch",
                         "--trust-model=always",
+                        "--auto-key-import",
+                        "--import-options=merge-only,import-clean",
                         NULL, /* --homedir= */
                         NULL, /* --keyring= */
                         NULL, /* --verify */
@@ -475,18 +504,7 @@ static int verify_gpg(
                 /* Child */
 
                 cmd[k++] = strjoina("--homedir=", gpg_home);
-
-                if (keyring_override)
-                        cmd[k++] = strjoina("--keyring=", keyring_override);
-                else if (access(USER_KEYRING_PATH, F_OK) >= 0) /* We add the user keyring only to the
-                                                                * command line arguments, if it's around
-                                                                * since gpg fails otherwise. */
-                        cmd[k++] = "--keyring=" USER_KEYRING_PATH;
-                else if (access(USER_KEYRING_PATH_LEGACY, F_OK) >= 0)
-                        cmd[k++] = "--keyring=" USER_KEYRING_PATH_LEGACY;
-                else
-                        cmd[k++] = "--keyring=" VENDOR_KEYRING_PATH;
-
+                cmd[k++] = strjoina("--keyring=", keyring_copy);
                 cmd[k++] = "--verify";
                 if (signature) {
                         cmd[k++] = sig_file_path;

--- a/src/import/pull-common.c
+++ b/src/import/pull-common.c
@@ -409,10 +409,18 @@ static int verify_gpg(
         _cleanup_(rm_rf_physical_and_freep) char *gpg_home = NULL;
         char sig_file_path[] = "/tmp/sigXXXXXX";
         _cleanup_(pidref_done_sigkill_wait) PidRef pidref = PIDREF_NULL;
+        const char *keyring_override;
         int r;
 
         assert(iovec_is_valid(payload));
         assert(iovec_is_valid(signature));
+
+        /* Support using a custom keyring, see docs/ENVIRONMENT.md. */
+        keyring_override = empty_to_null(getenv("SYSTEMD_OPENPGP_KEYRING"));
+        if (keyring_override && !path_is_absolute(keyring_override))
+                return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
+                                       "$SYSTEMD_OPENPGP_KEYRING must be an absolute path, got '%s'.",
+                                       keyring_override);
 
         r = pipe2(gpg_pipe, O_CLOEXEC);
         if (r < 0)
@@ -470,9 +478,11 @@ static int verify_gpg(
 
                 cmd[k++] = strjoina("--homedir=", gpg_home);
 
-                /* We add the user keyring only to the command line arguments, if it's around since gpg fails
-                 * otherwise. */
-                if (access(USER_KEYRING_PATH, F_OK) >= 0)
+                if (keyring_override)
+                        cmd[k++] = strjoina("--keyring=", keyring_override);
+                else if (access(USER_KEYRING_PATH, F_OK) >= 0) /* We add the user keyring only to the
+                                                                * command line arguments, if it's around
+                                                                * since gpg fails otherwise. */
                         cmd[k++] = "--keyring=" USER_KEYRING_PATH;
                 else if (access(USER_KEYRING_PATH_LEGACY, F_OK) >= 0)
                         cmd[k++] = "--keyring=" USER_KEYRING_PATH_LEGACY;

--- a/src/import/pull-common.h
+++ b/src/import/pull-common.h
@@ -46,6 +46,7 @@ int pull_make_verification_jobs(
 
 int pull_verify(
                 ImportVerify verify,
+                const char *keyring_override, /* may be NULL */
                 PullJob *main_job,
                 PullJob *checksum_job,
                 PullJob *signature_job,

--- a/src/import/pull-raw.c
+++ b/src/import/pull-raw.c
@@ -39,6 +39,7 @@ typedef struct RawPull {
         ImportFlags flags;
         ImportVerify verify;
         char *image_root;
+        char *keyring_override;
 
         uint64_t offset;
 
@@ -99,6 +100,7 @@ RawPull* raw_pull_unref(RawPull *p) {
         free(p->roothash_signature_path);
         free(p->verity_path);
         free(p->image_root);
+        free(p->keyring_override);
         free(p->local);
 
         return mfree(p);
@@ -582,6 +584,7 @@ static void raw_pull_job_on_finished(PullJob *j) {
                 raw_pull_report_progress(p, RAW_VERIFYING);
 
                 r = pull_verify(p->verify,
+                                p->keyring_override,
                                 p->raw_job,
                                 p->checksum_job,
                                 p->signature_job,
@@ -823,6 +826,7 @@ int raw_pull_start(
                 uint64_t size_max,
                 ImportFlags flags,
                 ImportVerify verify,
+                const char *keyring_override,
                 const struct iovec *checksum) {
 
         int r;
@@ -847,6 +851,10 @@ int raw_pull_start(
                 return -EBUSY;
 
         r = free_and_strdup(&p->local, local);
+        if (r < 0)
+                return r;
+
+        r = free_and_strdup(&p->keyring_override, keyring_override);
         if (r < 0)
                 return r;
 

--- a/src/import/pull-raw.h
+++ b/src/import/pull-raw.h
@@ -14,4 +14,4 @@ RawPull* raw_pull_unref(RawPull *p);
 
 DEFINE_TRIVIAL_CLEANUP_FUNC(RawPull*, raw_pull_unref);
 
-int raw_pull_start(RawPull *p, const char *url, const char *local, uint64_t offset, uint64_t size_max, ImportFlags flags, ImportVerify verify, const struct iovec *checksum);
+int raw_pull_start(RawPull *p, const char *url, const char *local, uint64_t offset, uint64_t size_max, ImportFlags flags, ImportVerify verify, const char *keyring_override /* may be NULL */, const struct iovec *checksum);

--- a/src/import/pull-tar.c
+++ b/src/import/pull-tar.c
@@ -47,6 +47,7 @@ typedef struct TarPull {
         ImportFlags flags;
         ImportVerify verify;
         char *image_root;
+        char *keyring_override;
 
         PullJob *tar_job;
         PullJob *checksum_job;
@@ -96,6 +97,7 @@ TarPull* tar_pull_unref(TarPull *p) {
         free(p->final_path);
         free(p->settings_path);
         free(p->image_root);
+        free(p->keyring_override);
         free(p->local);
 
         safe_close(p->tree_fd);
@@ -496,6 +498,7 @@ static void tar_pull_job_on_finished(PullJob *j) {
 
                 clear_progress_bar(/* prefix= */ NULL);
                 r = pull_verify(p->verify,
+                                p->keyring_override,
                                 p->tar_job,
                                 p->checksum_job,
                                 p->signature_job,
@@ -728,6 +731,7 @@ int tar_pull_start(
                 const char *local,
                 ImportFlags flags,
                 ImportVerify verify,
+                const char *keyring_override,
                 const struct iovec *checksum) {
 
         int r;
@@ -750,6 +754,10 @@ int tar_pull_start(
                 return -EBUSY;
 
         r = free_and_strdup(&p->local, local);
+        if (r < 0)
+                return r;
+
+        r = free_and_strdup(&p->keyring_override, keyring_override);
         if (r < 0)
                 return r;
 

--- a/src/import/pull-tar.h
+++ b/src/import/pull-tar.h
@@ -14,4 +14,4 @@ TarPull* tar_pull_unref(TarPull *p);
 
 DEFINE_TRIVIAL_CLEANUP_FUNC(TarPull*, tar_pull_unref);
 
-int tar_pull_start(TarPull *p, const char *url, const char *local, ImportFlags flags, ImportVerify verify, const struct iovec *checksum);
+int tar_pull_start(TarPull *p, const char *url, const char *local, ImportFlags flags, ImportVerify verify, const char *keyring_override /* may be NULL */, const struct iovec *checksum);

--- a/src/import/pull.c
+++ b/src/import/pull.c
@@ -34,6 +34,7 @@
 
 static char *arg_image_root = NULL;
 static ImportVerify arg_verify = IMPORT_VERIFY_SIGNATURE;
+static char *arg_keyring_override = NULL;
 static ImportFlags arg_import_flags = IMPORT_PULL_SETTINGS | IMPORT_PULL_ROOTHASH | IMPORT_PULL_ROOTHASH_SIGNATURE | IMPORT_PULL_VERITY | IMPORT_BTRFS_SUBVOL | IMPORT_BTRFS_QUOTA | IMPORT_CONVERT_QCOW2 | IMPORT_SYNC;
 static uint64_t arg_offset = UINT64_MAX, arg_size_max = UINT64_MAX;
 static struct iovec arg_checksum = {};
@@ -42,6 +43,7 @@ static RuntimeScope arg_runtime_scope = _RUNTIME_SCOPE_INVALID;
 
 STATIC_DESTRUCTOR_REGISTER(arg_checksum, iovec_done);
 STATIC_DESTRUCTOR_REGISTER(arg_image_root, freep);
+STATIC_DESTRUCTOR_REGISTER(arg_keyring_override, freep);
 
 static int normalize_local(const char *local, const char *url, char **ret) {
         _cleanup_free_ char *ll = NULL;
@@ -169,6 +171,7 @@ static int verb_tar(int argc, char *argv[], uintptr_t _data, void *userdata) {
                         normalized,
                         arg_import_flags & IMPORT_PULL_FLAGS_MASK_TAR,
                         arg_verify,
+                        arg_keyring_override,
                         &arg_checksum);
         if (r < 0)
                 return log_error_errno(r, "Failed to pull image: %m");
@@ -239,6 +242,7 @@ static int verb_raw(int argc, char *argv[], uintptr_t _data, void *userdata) {
                         arg_size_max,
                         arg_import_flags & IMPORT_PULL_FLAGS_MASK_RAW,
                         arg_verify,
+                        arg_keyring_override,
                         &arg_checksum);
         if (r < 0)
                 return log_error_errno(r, "Failed to pull image: %m");
@@ -381,6 +385,13 @@ static int parse_argv(int argc, char *argv[], char ***ret_args) {
 
                 OPTION_LONG("image-root", "PATH", "Image root directory"):
                         r = parse_path_argument(opts.arg, /* suppress_root= */ false, &arg_image_root);
+                        if (r < 0)
+                                return r;
+                        break;
+
+                OPTION_LONG("keyring", "PATH",
+                            "Use the specified keyring for signature verification"):
+                        r = parse_path_argument(opts.arg, /* suppress_root= */ false, &arg_keyring_override);
                         if (r < 0)
                                 return r;
                         break;

--- a/src/sysupdate/sysupdate-resource.c
+++ b/src/sysupdate/sysupdate-resource.c
@@ -323,6 +323,7 @@ static int resource_load_from_blockdev(Resource *rr) {
 static int download_manifest(
                 const char *url,
                 bool verify_signature,
+                const char *keyring_override, /* may be NULL */
                 char **ret_buffer,
                 size_t *ret_size) {
 
@@ -365,6 +366,7 @@ static int download_manifest(
                         "raw",
                         "--direct",                        /* just download the specified URL, don't download anything else */
                         "--verify", verify_signature ? "signature" : "no", /* verify the manifest file */
+                        strjoina("--keyring=", keyring_override ?: ""), /* empty value means using the default keyring */
                         suffixed_url,
                         "-",                               /* write to stdout */
                         NULL
@@ -471,6 +473,7 @@ static int process_magic_file(
 static int resource_load_from_web(
                 Resource *rr,
                 bool verify,
+                const char *keyring_override, /* may be NULL */
                 Hashmap **web_cache) {
 
         size_t manifest_size = 0, left = 0;
@@ -492,7 +495,7 @@ static int resource_load_from_web(
         } else {
                 log_debug("Manifest web cache miss for %s.", rr->path);
 
-                r = download_manifest(rr->path, verify, &buf, &manifest_size);
+                r = download_manifest(rr->path, verify, keyring_override, &buf, &manifest_size);
                 if (r < 0)
                         return r;
 
@@ -625,7 +628,7 @@ static int instance_cmp(Instance *const*a, Instance *const*b) {
         return path_compare((*a)->path, (*b)->path);
 }
 
-int resource_load_instances(Resource *rr, bool verify, Hashmap **web_cache) {
+int resource_load_instances(Resource *rr, bool verify, const char *keyring_override, Hashmap **web_cache) {
         int r;
 
         assert(rr);
@@ -648,7 +651,7 @@ int resource_load_instances(Resource *rr, bool verify, Hashmap **web_cache) {
 
         case RESOURCE_URL_FILE:
         case RESOURCE_URL_TAR:
-                r = resource_load_from_web(rr, verify, web_cache);
+                r = resource_load_from_web(rr, verify, keyring_override, web_cache);
                 break;
 
         default:

--- a/src/sysupdate/sysupdate-resource.h
+++ b/src/sysupdate/sysupdate-resource.h
@@ -89,7 +89,7 @@ typedef struct Resource {
 
 void resource_destroy(Resource *rr);
 
-int resource_load_instances(Resource *rr, bool verify, Hashmap **web_cache);
+int resource_load_instances(Resource *rr, bool verify, const char *keyring_override /* may be NULL */, Hashmap **web_cache);
 
 Instance* resource_find_instance(Resource *rr, const char *version);
 

--- a/src/sysupdate/sysupdate.c
+++ b/src/sysupdate/sysupdate.c
@@ -50,6 +50,7 @@ static int arg_verify = -1;
 static ImagePolicy *arg_image_policy = NULL;
 static bool arg_offline = false;
 char *arg_transfer_source = NULL;
+static char *arg_keyring_override = NULL;
 
 STATIC_DESTRUCTOR_REGISTER(arg_definitions, freep);
 STATIC_DESTRUCTOR_REGISTER(arg_root, freep);
@@ -57,6 +58,7 @@ STATIC_DESTRUCTOR_REGISTER(arg_image, freep);
 STATIC_DESTRUCTOR_REGISTER(arg_component, freep);
 STATIC_DESTRUCTOR_REGISTER(arg_image_policy, image_policy_freep);
 STATIC_DESTRUCTOR_REGISTER(arg_transfer_source, freep);
+STATIC_DESTRUCTOR_REGISTER(arg_keyring_override, freep);
 
 const Specifier specifier_table[] = {
         COMMON_SYSTEM_SPECIFIERS,
@@ -270,6 +272,7 @@ static int context_load_installed_instances(Context *c) {
                 r = resource_load_instances(
                                 &t->target,
                                 arg_verify >= 0 ? arg_verify : t->verify,
+                                arg_keyring_override,
                                 &c->web_cache);
                 if (r < 0)
                         return r;
@@ -281,6 +284,7 @@ static int context_load_installed_instances(Context *c) {
                 r = resource_load_instances(
                                 &t->target,
                                 arg_verify >= 0 ? arg_verify : t->verify,
+                                arg_keyring_override,
                                 &c->web_cache);
                 if (r < 0)
                         return r;
@@ -302,6 +306,7 @@ static int context_load_available_instances(Context *c) {
                 r = resource_load_instances(
                                 &t->source,
                                 arg_verify >= 0 ? arg_verify : t->verify,
+                                arg_keyring_override,
                                 &c->web_cache);
                 if (r < 0)
                         return r;
@@ -1958,6 +1963,13 @@ static int parse_argv(int argc, char *argv[], char ***remaining_args) {
                         arg_verify = b;
                         break;
                 }
+
+                OPTION_LONG("keyring", "PATH",
+                            "Use the specified keyring for signature verification"):
+                        r = parse_path_argument(opts.arg, /* suppress_root= */ false, &arg_keyring_override);
+                        if (r < 0)
+                                return r;
+                        break;
 
                 OPTION_LONG("reboot", NULL,
                             "Reboot after updating to newer version"):

--- a/test/units/TEST-72-SYSUPDATE.sh
+++ b/test/units/TEST-72-SYSUPDATE.sh
@@ -43,12 +43,22 @@ Environment=SYSTEMD_XBOOTLDR_PATH=${SYSTEMD_XBOOTLDR_PATH}
 EOF
 systemctl daemon-reload
 
+SIGTEST_GPGHOME=
+SIGTEST_OTHERHOME=
+
 at_exit() {
     set +e
 
     losetup -n --output NAME --associated "$BACKING_FILE" | while read -r loop_dev; do
         losetup --detach "$loop_dev"
     done
+
+    if [ "$SIGTEST_GPGHOME" != "" ]; then
+        gpgconf --homedir "$SIGTEST_GPGHOME" --kill all 2>/dev/null
+    fi
+    if [ "$SIGTEST_OTHERHOME" != "" ]; then
+        gpgconf --homedir "$SIGTEST_OTHERHOME" --kill all 2>/dev/null
+    fi
 
     rm -rf "$WORKDIR"
 }
@@ -467,5 +477,94 @@ EOF
     rm "$BACKING_FILE"
 done
 done
+
+test_signature_verification() {
+    if ! command -v gpg >/dev/null; then
+        echo "gpg not available, skipping signature verification test"
+        return 0
+    fi
+
+    if ! gpg --include-key-block --version >/dev/null 2>&1; then
+        echo "gpg version too old, skipping signature verification test"
+        return 0
+    fi
+
+    local sigdir="$WORKDIR/sigtest-source"
+    local defdir="$WORKDIR/sigtest-defs"
+    local gpghome="$WORKDIR/sigtest-gpghome"
+    local other_home="$WORKDIR/sigtest-otherhome"
+    local target="$WORKDIR/sigtest-target"
+    local keyring="$WORKDIR/sigtest-keyring"
+    local top_fpr
+
+    SIGTEST_GPGHOME="$gpghome"
+    SIGTEST_OTHERHOME="$other_home"
+
+    mkdir -p "$sigdir" "$defdir" "$gpghome" "$other_home" "$target"
+    chmod 700 "$gpghome" "$other_home"
+
+    GNUPGHOME="$gpghome" gpg --batch --pinentry-mode loopback --passphrase '' \
+        --quick-gen-key 'Test Key <test@example.com>' rsa2048 cert,sign never
+    top_fpr="$(GNUPGHOME="$gpghome" gpg --list-keys --with-colons \
+        | grep -m1 '^fpr:' | cut -d: -f10)"
+    test "$top_fpr" != ""
+
+    GNUPGHOME="$gpghome" gpg --export --output "$keyring"
+
+    dd if=/dev/urandom of="$sigdir/payload-v1.raw" bs=1024 count=8 status=none
+    (cd "$sigdir" && sha256sum payload-v1.raw > SHA256SUMS)
+    GNUPGHOME="$gpghome" gpg --batch --pinentry-mode loopback --passphrase '' \
+        --detach-sign --include-key-block --yes \
+        --output "$sigdir/SHA256SUMS.gpg" "$sigdir/SHA256SUMS"
+
+    cat >"$defdir/01-sigtest.transfer" <<EOF
+[Source]
+Type=url-file
+Path=file://$sigdir
+MatchPattern=payload-@v.raw
+
+[Target]
+Type=regular-file
+Path=$target
+MatchPattern=payload-@v.raw
+InstancesMax=3
+EOF
+
+    "$SYSUPDATE" --definitions="$defdir" --keyring="$keyring" check-new
+    "$SYSUPDATE" --definitions="$defdir" --keyring="$keyring" update
+    cmp "$sigdir/payload-v1.raw" "$target/payload-v1.raw"
+
+    # Negative test: Sign with a key not in the keyring
+    GNUPGHOME="$other_home" gpg --batch --pinentry-mode loopback --passphrase '' \
+        --quick-gen-key 'Other Key <other@example.com>' rsa2048 cert,sign never
+    dd if=/dev/urandom of="$sigdir/payload-v2.raw" bs=1024 count=8 status=none
+    (cd "$sigdir" && sha256sum payload-v1.raw payload-v2.raw > SHA256SUMS)
+    GNUPGHOME="$other_home" gpg --batch --pinentry-mode loopback --passphrase '' \
+        --detach-sign --include-key-block --yes \
+        --output "$sigdir/SHA256SUMS.gpg" "$sigdir/SHA256SUMS"
+    (! "$SYSUPDATE" --definitions="$defdir" --keyring="$keyring" update)
+    test ! -f "$target/payload-v2.raw"
+
+    # Sub key test: Add a sub key the client does not have and rely on gpg
+    # --auto-key-import to get it from the signature.
+    GNUPGHOME="$gpghome" gpg --batch --pinentry-mode loopback --passphrase '' \
+        --quick-add-key "$top_fpr" rsa2048 sign 1y
+    # Make it so that only the sub key is available for signing to avoid having
+    # to select it by fingerprint.
+    GNUPGHOME="$gpghome" gpg --batch --pinentry-mode loopback --passphrase '' \
+        --output "$WORKDIR/sigtest-subkey-secret.gpg" \
+        --export-secret-subkeys
+    GNUPGHOME="$gpghome" gpg --batch --pinentry-mode loopback --passphrase '' \
+        --yes --delete-secret-keys "$top_fpr"
+    GNUPGHOME="$gpghome" gpg --batch --pinentry-mode loopback --passphrase '' \
+        --import "$WORKDIR/sigtest-subkey-secret.gpg"
+    GNUPGHOME="$gpghome" gpg --batch --pinentry-mode loopback --passphrase '' \
+        --detach-sign --include-key-block --yes \
+        --output "$sigdir/SHA256SUMS.gpg" "$sigdir/SHA256SUMS"
+    "$SYSUPDATE" --definitions="$defdir" --keyring="$keyring" update
+    cmp "$sigdir/payload-v2.raw" "$target/payload-v2.raw"
+}
+
+test_signature_verification
 
 touch /testok

--- a/test/units/TEST-72-SYSUPDATE.sh
+++ b/test/units/TEST-72-SYSUPDATE.sh
@@ -56,6 +56,9 @@ EOF
 
 systemctl daemon-reload
 
+SIGTEST_GPGHOME=
+SIGTEST_OTHERHOME=
+
 at_exit() {
     set +e
 
@@ -66,6 +69,13 @@ at_exit() {
     losetup -n --output NAME --associated "$BACKING_FILE" | while read -r loop_dev; do
         losetup --detach "$loop_dev"
     done
+
+    if [ "$SIGTEST_GPGHOME" != "" ]; then
+        gpgconf --homedir "$SIGTEST_GPGHOME" --kill all 2>/dev/null
+    fi
+    if [ "$SIGTEST_OTHERHOME" != "" ]; then
+        gpgconf --homedir "$SIGTEST_OTHERHOME" --kill all 2>/dev/null
+    fi
 
     rm -rf "$WORKDIR"
 }
@@ -1080,5 +1090,106 @@ systemctl daemon-reload
 rm -rf "$CONFIGDIR" "$WORKDIR/blobs"
 rm -f "$WORKDIR/source/notifytest-v1.bin" "$WORKDIR/source/SHA256SUMS" \
       "$WORKDIR/notify-recorder.py" "$NOTIFY_LOG"
+
+test_signature_verification() {
+    if ! command -v gpg >/dev/null; then
+        echo "gpg not available, skipping signature verification test"
+        return 0
+    fi
+
+    # Checking for --auto-key-import is not enough because the merge-only/import-clean guarantee we rely on
+    # only works correctly with gpg 2.4
+    local gpg_version gpg_rest
+    gpg_version="$(gpg --version | sed -n '1p' | awk '{print $NF}')"
+    gpg_rest="${gpg_version#*.}"
+    if [ "${gpg_version%%.*}" -lt 2 ] || { [ "${gpg_version%%.*}" -eq 2 ] && [ "${gpg_rest%%.*}" -lt 4 ]; }; then
+        echo "gpg $gpg_version too old (need >= 2.4), skipping signature verification test"
+        return 0
+    fi
+
+    local sigdir="$WORKDIR/sigtest-source"
+    local defdir="$WORKDIR/sigtest-defs"
+    local gpghome="$WORKDIR/sigtest-gpghome"
+    local other_home="$WORKDIR/sigtest-otherhome"
+    local target="$WORKDIR/sigtest-target"
+    local keyring="$WORKDIR/sigtest-keyring"
+    local top_fpr keys
+
+    SIGTEST_GPGHOME="$gpghome"
+    SIGTEST_OTHERHOME="$other_home"
+
+    mkdir -p "$sigdir" "$defdir" "$gpghome" "$other_home" "$target"
+    chmod 700 "$gpghome" "$other_home"
+
+    GNUPGHOME="$gpghome" gpg --batch --pinentry-mode loopback --passphrase '' \
+        --quick-gen-key 'Test Key <test@example.com>' rsa2048 cert,sign never
+    # Capture gpg output first, then grep from a here-string to avoid grep -m1 causing a SIGPIPE
+    keys="$(GNUPGHOME="$gpghome" gpg --list-keys --with-colons)"
+    top_fpr="$(grep -m1 '^fpr:' <<< "$keys" | cut -d: -f10)"
+    test "$top_fpr" != ""
+
+    GNUPGHOME="$gpghome" gpg --export --output "$keyring"
+
+    dd if=/dev/urandom of="$sigdir/payload-v1.raw" bs=1024 count=8 status=none
+    (cd "$sigdir" && sha256sum payload-v1.raw > SHA256SUMS)
+    GNUPGHOME="$gpghome" gpg --batch --pinentry-mode loopback --passphrase '' \
+        --detach-sign --include-key-block --yes \
+        --output "$sigdir/SHA256SUMS.gpg" "$sigdir/SHA256SUMS"
+
+    cat >"$defdir/01-sigtest.transfer" <<EOF
+[Source]
+Type=url-file
+Path=file://$sigdir
+MatchPattern=payload-@v.raw
+
+[Target]
+Type=regular-file
+Path=$target
+MatchPattern=payload-@v.raw
+InstancesMax=3
+EOF
+
+    SYSTEMD_OPENPGP_KEYRING="$keyring" "$SYSUPDATE" --definitions="$defdir" check-new
+    SYSTEMD_OPENPGP_KEYRING="$keyring" "$SYSUPDATE" --definitions="$defdir" update
+    cmp "$sigdir/payload-v1.raw" "$target/payload-v1.raw"
+
+    # Negative test: Sign with a key not in the keyring
+    GNUPGHOME="$other_home" gpg --batch --pinentry-mode loopback --passphrase '' \
+        --quick-gen-key 'Other Key <other@example.com>' rsa2048 cert,sign never
+    dd if=/dev/urandom of="$sigdir/payload-v2.raw" bs=1024 count=8 status=none
+    (cd "$sigdir" && sha256sum payload-v1.raw payload-v2.raw > SHA256SUMS)
+    GNUPGHOME="$other_home" gpg --batch --pinentry-mode loopback --passphrase '' \
+        --detach-sign --include-key-block --yes \
+        --output "$sigdir/SHA256SUMS.gpg" "$sigdir/SHA256SUMS"
+    if SYSTEMD_OPENPGP_KEYRING="$keyring" "$SYSUPDATE" --definitions="$defdir" update; then
+        echo "ERROR: accepted an update signed by a key not in the keyring" >&2
+        exit 1
+    fi
+    if [ -f "$target/payload-v2.raw" ]; then
+        echo "ERROR: payload-v2 should not have been installed" >&2
+        exit 1
+    fi
+
+    # Sub key test: Add a sub key the client does not have and rely on gpg
+    # --auto-key-import to get it from the signature.
+    GNUPGHOME="$gpghome" gpg --batch --pinentry-mode loopback --passphrase '' \
+        --quick-add-key "$top_fpr" rsa2048 sign 1y
+    # Make it so that only the sub key is available for signing to avoid having
+    # to select it by fingerprint.
+    GNUPGHOME="$gpghome" gpg --batch --pinentry-mode loopback --passphrase '' \
+        --output "$WORKDIR/sigtest-subkey-secret.gpg" \
+        --export-secret-subkeys
+    GNUPGHOME="$gpghome" gpg --batch --pinentry-mode loopback --passphrase '' \
+        --yes --delete-secret-keys "$top_fpr"
+    GNUPGHOME="$gpghome" gpg --batch --pinentry-mode loopback --passphrase '' \
+        --import "$WORKDIR/sigtest-subkey-secret.gpg"
+    GNUPGHOME="$gpghome" gpg --batch --pinentry-mode loopback --passphrase '' \
+        --detach-sign --include-key-block --yes \
+        --output "$sigdir/SHA256SUMS.gpg" "$sigdir/SHA256SUMS"
+    SYSTEMD_OPENPGP_KEYRING="$keyring" "$SYSUPDATE" --definitions="$defdir" update
+    cmp "$sigdir/payload-v2.raw" "$target/payload-v2.raw"
+}
+
+test_signature_verification
 
 touch /testok

--- a/test/units/TEST-72-SYSUPDATE.sh
+++ b/test/units/TEST-72-SYSUPDATE.sh
@@ -43,12 +43,22 @@ Environment=SYSTEMD_XBOOTLDR_PATH=${SYSTEMD_XBOOTLDR_PATH}
 EOF
 systemctl daemon-reload
 
+SIGTEST_GPGHOME=
+SIGTEST_OTHERHOME=
+
 at_exit() {
     set +e
 
     losetup -n --output NAME --associated "$BACKING_FILE" | while read -r loop_dev; do
         losetup --detach "$loop_dev"
     done
+
+    if [ "$SIGTEST_GPGHOME" != "" ]; then
+        gpgconf --homedir "$SIGTEST_GPGHOME" --kill all 2>/dev/null
+    fi
+    if [ "$SIGTEST_OTHERHOME" != "" ]; then
+        gpgconf --homedir "$SIGTEST_OTHERHOME" --kill all 2>/dev/null
+    fi
 
     rm -rf "$WORKDIR"
 }
@@ -604,5 +614,94 @@ cmp "$WORKDIR/source/tiny-v1.bin" "$WORKDIR/blobs/tiny-v1.bin"
 rm "$CONFIGDIR/01-tiny-url.transfer"
 rm "$WORKDIR/source/tiny-v1.bin"
 rm "$WORKDIR/source/SHA256SUMS"
+
+test_signature_verification() {
+    if ! command -v gpg >/dev/null; then
+        echo "gpg not available, skipping signature verification test"
+        return 0
+    fi
+
+    if ! gpg --include-key-block --version >/dev/null 2>&1; then
+        echo "gpg version too old, skipping signature verification test"
+        return 0
+    fi
+
+    local sigdir="$WORKDIR/sigtest-source"
+    local defdir="$WORKDIR/sigtest-defs"
+    local gpghome="$WORKDIR/sigtest-gpghome"
+    local other_home="$WORKDIR/sigtest-otherhome"
+    local target="$WORKDIR/sigtest-target"
+    local keyring="$WORKDIR/sigtest-keyring"
+    local top_fpr
+
+    SIGTEST_GPGHOME="$gpghome"
+    SIGTEST_OTHERHOME="$other_home"
+
+    mkdir -p "$sigdir" "$defdir" "$gpghome" "$other_home" "$target"
+    chmod 700 "$gpghome" "$other_home"
+
+    GNUPGHOME="$gpghome" gpg --batch --pinentry-mode loopback --passphrase '' \
+        --quick-gen-key 'Test Key <test@example.com>' rsa2048 cert,sign never
+    top_fpr="$(GNUPGHOME="$gpghome" gpg --list-keys --with-colons \
+        | grep -m1 '^fpr:' | cut -d: -f10)"
+    test "$top_fpr" != ""
+
+    GNUPGHOME="$gpghome" gpg --export --output "$keyring"
+
+    dd if=/dev/urandom of="$sigdir/payload-v1.raw" bs=1024 count=8 status=none
+    (cd "$sigdir" && sha256sum payload-v1.raw > SHA256SUMS)
+    GNUPGHOME="$gpghome" gpg --batch --pinentry-mode loopback --passphrase '' \
+        --detach-sign --include-key-block --yes \
+        --output "$sigdir/SHA256SUMS.gpg" "$sigdir/SHA256SUMS"
+
+    cat >"$defdir/01-sigtest.transfer" <<EOF
+[Source]
+Type=url-file
+Path=file://$sigdir
+MatchPattern=payload-@v.raw
+
+[Target]
+Type=regular-file
+Path=$target
+MatchPattern=payload-@v.raw
+InstancesMax=3
+EOF
+
+    SYSTEMD_OPENPGP_KEYRING="$keyring" "$SYSUPDATE" --definitions="$defdir" check-new
+    SYSTEMD_OPENPGP_KEYRING="$keyring" "$SYSUPDATE" --definitions="$defdir" update
+    cmp "$sigdir/payload-v1.raw" "$target/payload-v1.raw"
+
+    # Negative test: Sign with a key not in the keyring
+    GNUPGHOME="$other_home" gpg --batch --pinentry-mode loopback --passphrase '' \
+        --quick-gen-key 'Other Key <other@example.com>' rsa2048 cert,sign never
+    dd if=/dev/urandom of="$sigdir/payload-v2.raw" bs=1024 count=8 status=none
+    (cd "$sigdir" && sha256sum payload-v1.raw payload-v2.raw > SHA256SUMS)
+    GNUPGHOME="$other_home" gpg --batch --pinentry-mode loopback --passphrase '' \
+        --detach-sign --include-key-block --yes \
+        --output "$sigdir/SHA256SUMS.gpg" "$sigdir/SHA256SUMS"
+    (! SYSTEMD_OPENPGP_KEYRING="$keyring" "$SYSUPDATE" --definitions="$defdir" update)
+    test ! -f "$target/payload-v2.raw"
+
+    # Sub key test: Add a sub key the client does not have and rely on gpg
+    # --auto-key-import to get it from the signature.
+    GNUPGHOME="$gpghome" gpg --batch --pinentry-mode loopback --passphrase '' \
+        --quick-add-key "$top_fpr" rsa2048 sign 1y
+    # Make it so that only the sub key is available for signing to avoid having
+    # to select it by fingerprint.
+    GNUPGHOME="$gpghome" gpg --batch --pinentry-mode loopback --passphrase '' \
+        --output "$WORKDIR/sigtest-subkey-secret.gpg" \
+        --export-secret-subkeys
+    GNUPGHOME="$gpghome" gpg --batch --pinentry-mode loopback --passphrase '' \
+        --yes --delete-secret-keys "$top_fpr"
+    GNUPGHOME="$gpghome" gpg --batch --pinentry-mode loopback --passphrase '' \
+        --import "$WORKDIR/sigtest-subkey-secret.gpg"
+    GNUPGHOME="$gpghome" gpg --batch --pinentry-mode loopback --passphrase '' \
+        --detach-sign --include-key-block --yes \
+        --output "$sigdir/SHA256SUMS.gpg" "$sigdir/SHA256SUMS"
+    SYSTEMD_OPENPGP_KEYRING="$keyring" "$SYSUPDATE" --definitions="$defdir" update
+    cmp "$sigdir/payload-v2.raw" "$target/payload-v2.raw"
+}
+
+test_signature_verification
 
 touch /testok


### PR DESCRIPTION
- import: Trust subkeys included in signature
    
    With gpg sub keys one can rotate signing keys while having a stable
    trust anchor. So far one still had to ship the sub key out of band but
    a newer gpg has the option to include the sub key in the signature and
    import it automatically. This is safe if we only allow importing a sub
    key signed by the top key we already have in the key ring.
    Add the --auto-key-import argument to gpg to import subkeys but also
    set --import-options=merge-only,import-clean to restrict what we import
    to only be sub keys signed by the top key we have in the keyring and
    discard any irrelevant parts.
- import: Support env var to override gpg keyring
    
    By default there is a fixed keyring in /usr or /etc. But when running
    systemd-pull unprivileged in the user context or with a custom transfer
    definition as in systemd-sysupdate --definitions=./... (e.g., for local
    ParticleOS updates) it is limiting to require that all keys have to be
    part of the OS keyring or otherwise no verification can be used. Also,
    for testing it is valuable to point it at a different keyring.
    Add a SYSTEMD_OPENPGP_KEYRING env var where the omission or empty
    assignment sticks to the current behavior of the global OS keyrings but
    a keyring path given will take precedence. While an env var can leak
    down the process tree and is more difficult to secure for being the
    trust anchor the advantage is that one can directly specify it in the
    service unit as drop-in instead of having to patch the command
    invocation. Anyway it's a niche use case and thus not part of the man
    page.