### PR TITLE
sd-boot related work from #41543 (add "extra" stanza to bls type 1)

### DIFF
--- a/man/systemd-stub.xml
+++ b/man/systemd-stub.xml
@@ -291,6 +291,14 @@
     by <command>systemd-creds encrypt -T</command> (see
     <citerefentry><refentrytitle>systemd-creds</refentrytitle><manvolnum>1</manvolnum></citerefentry> for
     details); in case of the system extension images by using signed Verity images.</para>
+
+    <para>Note that earlier components of the boot process might register additional initrds, and thus
+    additional "companion" resources such as system extensions, configuration extensions and credentials for
+    consumption by the kernel and OS eventually booted. For example,
+    <citerefentry><refentrytitle>systemd-boot</refentrytitle><manvolnum>7</manvolnum></citerefentry> does
+    this for resources configured in UAPI.1 Type #1 <literal>extra</literal>
+    lines. <filename>systemd-stub</filename> will combine any resources provided that way with the companion
+    file resources it acquires itself.</para>
   </refsect1>
 
   <refsect1>

--- a/src/boot/boot.c
+++ b/src/boot/boot.c
@@ -120,6 +120,7 @@ typedef struct BootEntry {
         char16_t *options;
         bool options_implied; /* If true, these options are implied if we invoke the PE binary without any parameters (as in: UKI). If false we must specify these options explicitly. */
         char16_t **initrd;
+        char16_t **extras;
         char16_t key;
         EFI_STATUS (*call)(const struct BootEntry *entry, EFI_FILE *root_dir, EFI_HANDLE parent_image);
         int tries_done;
@@ -424,6 +425,8 @@ static void print_status(Config *config, char16_t *loaded_image_path) {
                         printf("           url: %ls\n", entry->url);
                 STRV_FOREACH(initrd, entry->initrd)
                         printf("        initrd: %ls\n", *initrd);
+                STRV_FOREACH(extra, entry->extras)
+                        printf("         extra: %ls\n", *extra);
                 if (entry->devicetree)
                         printf("    devicetree: %ls\n", entry->devicetree);
                 if (entry->options)
@@ -1047,6 +1050,7 @@ static BootEntry* boot_entry_free(BootEntry *entry) {
         free(entry->devicetree);
         free(entry->options);
         strv_free(entry->initrd);
+        strv_free(entry->extras);
         free(entry->directory);
         free(entry->current_name);
         free(entry->next_name);
@@ -1363,7 +1367,7 @@ static void boot_entry_add_type1(
 
         _cleanup_(boot_entry_freep) BootEntry *entry = NULL;
         char *line;
-        size_t pos = 0, n_initrd = 0;
+        size_t pos = 0, n_initrd = 0, n_extras = 0;
         char *key, *value;
         EFI_STATUS err;
 
@@ -1491,6 +1495,14 @@ static void boot_entry_add_type1(
                                 (n_initrd + 2) * sizeof(uint16_t *));
                         entry->initrd[n_initrd++] = xstr8_to_path(value);
                         entry->initrd[n_initrd] = NULL;
+
+                } else if (streq8(key, "extra")) {
+                        entry->extras = xrealloc(
+                                entry->extras,
+                                n_extras == 0 ? 0 : (n_extras + 1) * sizeof(uint16_t *),
+                                (n_extras + 2) * sizeof(uint16_t *));
+                        entry->extras[n_extras++] = xstr8_to_path(value);
+                        entry->extras[n_extras] = NULL;
 
                 } else if (streq8(key, "options")) {
                         _cleanup_free_ char16_t *new = NULL;

--- a/src/boot/boot.c
+++ b/src/boot/boot.c
@@ -3,6 +3,7 @@
 #include "bcd.h"
 #include "bootspec-fundamental.h"
 #include "console.h"
+#include "cpio.h"
 #include "device-path-util.h"
 #include "devicetree.h"
 #include "drivers.h"
@@ -37,6 +38,9 @@
 #include "util.h"
 #include "version.h"
 #include "vmm.h"
+
+/* Safety margin, refuse larger extra files (this is not load bearing, only a safety net for robustness reasons). */
+#define EXTRA_SIZE_MAX (1024U * 1024U * 1536U)
 
 /* Magic string for recognizing our own binaries */
 #define SD_MAGIC "#### LoaderInfo: systemd-boot " GIT_VERSION " ####"
@@ -2581,7 +2585,9 @@ static EFI_STATUS initrd_prepare(
         assert(ret_initrd_pages);
         assert(ret_initrd_size);
 
-        if (entry->type != LOADER_LINUX || strv_isempty(entry->initrd)) {
+        assert(entry->type == LOADER_LINUX);
+
+        if (strv_isempty(entry->initrd)) {
                 *ret_options = NULL;
                 *ret_initrd_pages = (Pages) {};
                 *ret_initrd_size = 0;
@@ -2682,6 +2688,174 @@ static EFI_STATUS initrd_prepare(
         *ret_options = TAKE_PTR(options);
         *ret_initrd_pages = TAKE_STRUCT(pages);
         *ret_initrd_size = size;
+        return EFI_SUCCESS;
+}
+
+static EFI_STATUS load_extras(
+                EFI_FILE *root,
+                const BootEntry *entry,
+                Pages *ret_initrd_pages,
+                size_t *ret_initrd_size) {
+
+        EFI_STATUS err;
+
+        assert(root);
+        assert(entry);
+        assert(ret_initrd_pages);
+        assert(ret_initrd_size);
+
+        assert(IN_SET(entry->type, LOADER_UKI, LOADER_UKI_URL));
+
+        _cleanup_(iovec_done) struct iovec previous_initrd = {}, confext_initrd = {}, sysext_initrd = {}, credential_initrd = {};
+
+        const struct ExtraResourceInfo {
+                const char16_t *suffix;
+                const CpioTarget *target;
+                struct iovec *iovec;
+                const char16_t *tpm_description;
+        } table[] = {
+                { u".cred",        &cpio_target_credentials, &credential_initrd, u"Entry credentials initrd"             },
+                { u".sysext.raw",  &cpio_target_sysext,      &sysext_initrd,     u"Entry system extension initrd"        },
+                { u".confext.raw", &cpio_target_confext,     &confext_initrd,    u"Entry configuration extension initrd" },
+        };
+
+        if (strv_isempty(entry->extras))
+                goto nothing;
+
+        uint32_t inode = 1; /* inode counter, so that each item gets a new inode */
+        unsigned n = 0;
+
+        STRV_FOREACH(i, entry->extras) {
+                _cleanup_file_close_ EFI_FILE *handle = NULL;
+                err = root->Open(root, &handle, *i, EFI_FILE_MODE_READ, /* Attributes= */ 0);
+                if (err != EFI_SUCCESS) {
+                        log_warning_status(err, "Failed to open extra file '%ls', ignoring: %m", *i);
+                        continue;
+                }
+
+                _cleanup_free_ EFI_FILE_INFO *info = NULL;
+                err = get_file_info(handle, &info, /* ret_size= */ NULL);
+                if (err != EFI_SUCCESS) {
+                        log_warning_status(err, "Failed to get information about file '%ls', ignoring: %m", *i);
+                        continue;
+                }
+
+                if (FLAGS_SET(info->Attribute, EFI_FILE_DIRECTORY)) {
+                        log_warning("Extra file '%ls' is a directory, ignoring.", *i);
+                        continue;
+                }
+
+                if (info->FileSize == 0) {
+                        log_warning("Extra file '%ls' is empty, ignoring.", *i);
+                        continue;
+                }
+                if (info->FileSize > EXTRA_SIZE_MAX) {
+                        log_warning("Extra file '%ls' is larger than allowed extra file size, ignoring.", *i);
+                        continue;
+                }
+
+                if (!is_ascii(info->FileName)) {
+                        log_warning("Extra file name '%ls' is not valid ASCII, ignoring.", *i);
+                        continue;
+                }
+                if (strlen16(info->FileName) > 255) { /* Max filename size on Linux */
+                        log_warning("Filename '%ls' too long, ignoring.", *i);
+                        continue;
+                }
+
+                const struct ExtraResourceInfo *x = NULL;
+                FOREACH_ELEMENT(j, table) {
+                        if (endswith_no_case(info->FileName, j->suffix)) {
+                                x = j;
+                                break;
+                        }
+                }
+                if (!x) {
+                        log_warning("Unrecognized type of extra file '%ls', ignoring.", info->FileName);
+                        continue;
+                }
+
+                _cleanup_free_ char *content = NULL;
+                size_t contentsize = 0;  /* avoid false maybe-uninitialized warning */
+                err = file_handle_read(handle, /* offset= */ 0, info->FileSize, &content, &contentsize);
+                if (err != EFI_SUCCESS) {
+                        log_warning_status(err, "Failed to read '%ls', ignoring: %m", *i);
+                        continue;
+                }
+
+                /* Generate the leading directory inodes right before adding the first files to the
+                 * archive. Otherwise the cpio archive cannot be unpacked, since the leading dirs won't
+                 * exist. Note that we potentially do redundant work here: a prior iteration might already
+                 * have created the prefix for us, but to simplify this we regenerate it anyway. It's very
+                 * little data, and simplifies the implementation here a lot. */
+                err = pack_cpio_prefix(x->target, &inode, &x->iovec->iov_base, &x->iovec->iov_len);
+                if (err != EFI_SUCCESS)
+                        return log_error_status(err, "Failed to pack cpio prefix '%s': %m", x->target->directory);
+
+                err = pack_cpio_one(
+                                info->FileName,
+                                content, contentsize,
+                                x->target,
+                                &inode,
+                                &x->iovec->iov_base, &x->iovec->iov_len);
+                if (err != EFI_SUCCESS)
+                        return log_error_status(err, "Failed to pack cpio file '%ls': %m", info->FileName);
+
+                n++;
+        }
+
+        if (n == 0) /* Nothing actually loaded */
+                goto nothing;
+
+        FOREACH_ELEMENT(x, table) {
+                if (x->iovec->iov_len <= 0)
+                        continue;
+
+                err = pack_cpio_trailer(&x->iovec->iov_base, &x->iovec->iov_len);
+                if (err != EFI_SUCCESS)
+                        return log_error_status(err, "Failed to pack cpio trailer: %m");
+
+                err = tpm_log_ipl_event(
+                                x->target->tpm_pcr,
+                                POINTER_TO_PHYSICAL_ADDRESS(x->iovec->iov_base),
+                                x->iovec->iov_len,
+                                x->tpm_description,
+                                /* ret_measured= */ NULL);
+                if (err != EFI_SUCCESS)
+                        return log_error_status(
+                                        err,
+                                        "Unable to add cpio TPM measurement for PCR %u (%ls): %m",
+                                        x->target->tpm_pcr,
+                                        x->tpm_description);
+        }
+
+        /* Be nice: pick up any previously registered initrds and prepend them to what we are generating here */
+        err = initrd_read_previous(&previous_initrd);
+        if (err == EFI_NOT_FOUND)
+                log_debug_status(err, "No previous initrd installed.");
+        else if (err != EFI_SUCCESS)
+                log_warning_status(err, "Failed to read previously registered initrd, ignoring.");
+        else
+                log_debug("Successfully loaded previously installed initrd (%zu bytes).", previous_initrd.iov_len);
+
+        err = combine_initrds(
+                        (const struct iovec[]) {
+                                previous_initrd,
+                                credential_initrd,
+                                sysext_initrd,
+                                confext_initrd,
+                        },
+                        /* n_initrds= */ 4,
+                        ret_initrd_pages,
+                        ret_initrd_size);
+        if (err != EFI_SUCCESS)
+                return log_error_status(err, "Failed to combine previous with extra initrds: %m");
+
+        return EFI_SUCCESS;
+
+nothing:
+        *ret_initrd_pages = (Pages) {};
+        *ret_initrd_size = 0;
         return EFI_SUCCESS;
 }
 
@@ -2833,15 +3007,11 @@ static EFI_STATUS call_image_start(
                 return log_error_status(err, "Error loading EFI binary %ls: %m", entry->loader);
         }
 
-        _cleanup_(cleanup_initrd) EFI_HANDLE initrd_handle = NULL;
         _cleanup_free_ char16_t *options_initrd = NULL;
-        _cleanup_pages_ Pages initrd_pages = {};
+        _cleanup_pages_ Pages initrd_pages = {};                        /* Note: please keep order intact: these pages should be released after the initrd handle is released */
+        _cleanup_(cleanup_initrd) EFI_HANDLE initrd_handle = NULL;
         size_t initrd_size = 0;
         if (image_root) {
-                err = initrd_prepare(image_root, entry, &options_initrd, &initrd_pages, &initrd_size);
-                if (err != EFI_SUCCESS)
-                        return log_error_status(err, "Error preparing initrd: %m");
-
                 /* DTBs are loaded by the kernel before ExitBootServices(), and they can be used to map and
                  * assign arbitrary memory ranges, so skip them when secure boot is enabled as the DTB here
                  * is unverified. */
@@ -2851,9 +3021,35 @@ static EFI_STATUS call_image_start(
                                 return log_error_status(err, "Error loading %ls: %m", entry->devicetree);
                 }
 
+                switch (entry->type) {
+
+                case LOADER_LINUX:
+                        /* For traditional Linux we follow 'initrd' links, because that's how things worked in the good old days */
+                        err = initrd_prepare(image_root, entry, &options_initrd, &initrd_pages, &initrd_size);
+                        if (err != EFI_SUCCESS)
+                                return log_error_status(err, "Error preparing initrd: %m");
+
+                        break;
+
+                case LOADER_UKI:
+                case LOADER_UKI_URL:
+                        /* For modern UKIs we'll not bother with 'initrd', but we'll instead support 'extra'
+                         * for loading credentials, sysext and confext. */
+
+                        err = load_extras(image_root, entry, &initrd_pages, &initrd_size);
+                        if (err != EFI_SUCCESS)
+                                return err; /* load_extras() logs on its own */
+                        break;
+
+                default:
+                        ;
+                }
+
                 err = initrd_register(&IOVEC_MAKE(PHYSICAL_ADDRESS_TO_POINTER(initrd_pages.addr), initrd_size), &initrd_handle);
                 if (err != EFI_SUCCESS)
                         return log_error_status(err, "Error registering initrd: %m");
+
+                /* NB: the initrd pages remain in our possession, we will free them if executing the image fails below */
         }
 
         EFI_LOADED_IMAGE_PROTOCOL *loaded_image;

--- a/src/boot/cpio.c
+++ b/src/boot/cpio.c
@@ -406,7 +406,7 @@ EFI_STATUS pack_cpio(
 
                 err = file_read(extra_dir, items[i], 0, 0, &content, &contentsize);
                 if (err != EFI_SUCCESS) {
-                        log_error_status(err, "Failed to read %ls, ignoring: %m", items[i]);
+                        log_warning_status(err, "Failed to read %ls, ignoring: %m", items[i]);
                         continue;
                 }
 

--- a/src/boot/cpio.c
+++ b/src/boot/cpio.c
@@ -5,6 +5,7 @@
 #include "iovec-util-fundamental.h"
 #include "measure.h"
 #include "string-util-fundamental.h"
+#include "tpm2-pcr.h"
 #include "util.h"
 
 static char *write_cpio_word(char *p, uint32_t v) {
@@ -306,7 +307,6 @@ EFI_STATUS pack_cpio(
                 const char16_t *match_suffix,
                 const char16_t *exclude_suffix,
                 const CpioTarget *target,
-                uint32_t tpm_pcr,
                 const char16_t *tpm_description,
                 struct iovec *ret_buffer,
                 bool *ret_measured) {
@@ -425,12 +425,16 @@ EFI_STATUS pack_cpio(
                 return log_error_status(err, "Failed to pack cpio trailer: %m");
 
         err = tpm_log_ipl_event(
-                        tpm_pcr, POINTER_TO_PHYSICAL_ADDRESS(buffer), buffer_size, tpm_description, ret_measured);
+                        target->tpm_pcr,
+                        POINTER_TO_PHYSICAL_ADDRESS(buffer),
+                        buffer_size,
+                        tpm_description,
+                        ret_measured);
         if (err != EFI_SUCCESS)
                 return log_error_status(
                                 err,
-                                "Unable to add cpio TPM measurement for PCR %u (%ls), ignoring: %m",
-                                tpm_pcr,
+                                "Unable to add cpio TPM measurement for PCR %u (%ls): %m",
+                                target->tpm_pcr,
                                 tpm_description);
 
         *ret_buffer = IOVEC_MAKE(TAKE_PTR(buffer), buffer_size);
@@ -450,7 +454,6 @@ EFI_STATUS pack_cpio_literal(
                 size_t data_size,
                 const CpioTarget *target,
                 const char16_t *target_filename,
-                uint32_t tpm_pcr,
                 const char16_t *tpm_description,
                 struct iovec *ret_buffer,
                 bool *ret_measured) {
@@ -486,12 +489,16 @@ EFI_STATUS pack_cpio_literal(
                 return log_error_status(err, "Failed to pack cpio trailer: %m");
 
         err = tpm_log_ipl_event(
-                        tpm_pcr, POINTER_TO_PHYSICAL_ADDRESS(buffer), buffer_size, tpm_description, ret_measured);
+                        target->tpm_pcr,
+                        POINTER_TO_PHYSICAL_ADDRESS(buffer),
+                        buffer_size,
+                        tpm_description,
+                        ret_measured);
         if (err != EFI_SUCCESS)
                 return log_error_status(
                                 err,
-                                "Unable to add cpio TPM measurement for PCR %u (%ls), ignoring: %m",
-                                tpm_pcr,
+                                "Unable to add cpio TPM measurement for PCR %u (%ls): %m",
+                                target->tpm_pcr,
                                 tpm_description);
 
         *ret_buffer = IOVEC_MAKE(TAKE_PTR(buffer), buffer_size);
@@ -506,46 +513,54 @@ const CpioTarget cpio_target_credentials = {
         .directory = ".extra/credentials",
         .dir_mode = 0500,
         .access_mode = 0400,
+        .tpm_pcr = TPM2_PCR_KERNEL_CONFIG,
 };
 
 const CpioTarget cpio_target_global_credentials = {
         .directory = ".extra/global_credentials",
         .dir_mode = 0500,
         .access_mode = 0400,
+        .tpm_pcr = TPM2_PCR_KERNEL_CONFIG,
 };
 
 const CpioTarget cpio_target_sysext = {
         .directory = ".extra/sysext",
         .dir_mode = 0555,
         .access_mode = 0444,
+        .tpm_pcr = TPM2_PCR_SYSEXTS,
 };
 
 const CpioTarget cpio_target_global_sysext = {
         .directory = ".extra/global_sysext",
         .dir_mode = 0555,
         .access_mode = 0444,
+        .tpm_pcr = TPM2_PCR_SYSEXTS,
 };
 
 const CpioTarget cpio_target_confext = {
         .directory = ".extra/confext",
         .dir_mode = 0555,
         .access_mode = 0444,
+        .tpm_pcr = TPM2_PCR_KERNEL_CONFIG,
 };
 
 const CpioTarget cpio_target_global_confext = {
         .directory = ".extra/global_confext",
         .dir_mode = 0555,
         .access_mode = 0444,
+        .tpm_pcr = TPM2_PCR_KERNEL_CONFIG,
 };
 
 const CpioTarget cpio_target_meta = {
         .directory = ".extra",
         .dir_mode = 0555,
         .access_mode = 0444,
+        .tpm_pcr = UINT32_MAX,
 };
 
 const CpioTarget cpio_target_meta_secret = {
         .directory = ".extra",
         .dir_mode = 0555,
         .access_mode = 0400,
+        .tpm_pcr = UINT32_MAX,
 };

--- a/src/boot/cpio.h
+++ b/src/boot/cpio.h
@@ -8,6 +8,7 @@ typedef struct CpioTarget {
         const char *directory; /* Path to directory where to place resources */
         uint32_t dir_mode;     /* Access mode for the directory */
         uint32_t access_mode;  /* Access mode for the files in the directory */
+        uint32_t tpm_pcr;      /* Where to measure this data into */
 } CpioTarget;
 
 EFI_STATUS pack_cpio_one(
@@ -35,7 +36,6 @@ EFI_STATUS pack_cpio(
                 const char16_t *match_suffix,
                 const char16_t *exclude_suffix,
                 const CpioTarget *target,
-                uint32_t tpm_pcr,
                 const char16_t *tpm_description,
                 struct iovec *ret_buffer,
                 bool *ret_measured);
@@ -45,7 +45,6 @@ EFI_STATUS pack_cpio_literal(
                 size_t data_size,
                 const CpioTarget *target,
                 const char16_t *target_filename,
-                uint32_t tpm_pcr,
                 const char16_t *tpm_description,
                 struct iovec *ret_buffer,
                 bool *ret_measured);

--- a/src/boot/meson.build
+++ b/src/boot/meson.build
@@ -309,6 +309,7 @@ endif
 libefi_sources = files(
         'chid.c',
         'console.c',
+        'cpio.c',
         'device-path-util.c',
         'devicetree.c',
         'drivers.c',
@@ -341,7 +342,6 @@ systemd_boot_sources = files(
 
 stub_sources = files(
         'boot-secret.c',
-        'cpio.c',
         'linux.c',
         'splash.c',
         'stub.c',

--- a/src/boot/stub.c
+++ b/src/boot/stub.c
@@ -819,7 +819,6 @@ static void generate_sidecar_initrds(
                       u".cred",
                       /* exclude_suffix= */ NULL,
                       &cpio_target_credentials,
-                      /* tpm_pcr= */ TPM2_PCR_KERNEL_CONFIG,
                       u"Credentials initrd",
                       initrds + INITRD_CREDENTIAL,
                       &m) == EFI_SUCCESS)
@@ -830,7 +829,6 @@ static void generate_sidecar_initrds(
                       u".cred",
                       /* exclude_suffix= */ NULL,
                       &cpio_target_global_credentials,
-                      /* tpm_pcr= */ TPM2_PCR_KERNEL_CONFIG,
                       u"Global credentials initrd",
                       initrds + INITRD_GLOBAL_CREDENTIAL,
                       &m) == EFI_SUCCESS)
@@ -841,7 +839,6 @@ static void generate_sidecar_initrds(
                       u".raw",         /* ideally we'd pick up only *.sysext.raw here, but for compat we pick up *.raw instead … */
                       u".confext.raw", /* … but then exclude *.confext.raw again */
                       &cpio_target_sysext,
-                      /* tpm_pcr= */ TPM2_PCR_SYSEXTS,
                       u"System extension initrd",
                       initrds + INITRD_SYSEXT,
                       &m) == EFI_SUCCESS)
@@ -852,7 +849,6 @@ static void generate_sidecar_initrds(
                       u".raw", /* as above */
                       u".confext.raw",
                       &cpio_target_global_sysext,
-                      /* tpm_pcr= */ TPM2_PCR_SYSEXTS,
                       u"Global system extension initrd",
                       initrds + INITRD_GLOBAL_SYSEXT,
                       &m) == EFI_SUCCESS)
@@ -863,7 +859,6 @@ static void generate_sidecar_initrds(
                       u".confext.raw",
                       /* exclude_suffix= */ NULL,
                       &cpio_target_confext,
-                      /* tpm_pcr= */ TPM2_PCR_KERNEL_CONFIG,
                       u"Configuration extension initrd",
                       initrds + INITRD_CONFEXT,
                       &m) == EFI_SUCCESS)
@@ -874,7 +869,6 @@ static void generate_sidecar_initrds(
                       u".confext.raw",
                       /* exclude_suffix= */ NULL,
                       &cpio_target_global_confext,
-                      /* tpm_pcr= */ TPM2_PCR_KERNEL_CONFIG,
                       u"Global configuration extension initrd",
                       initrds + INITRD_GLOBAL_CONFEXT,
                       &m) == EFI_SUCCESS)
@@ -926,7 +920,6 @@ static void generate_embedded_initrds(
                                 sections[t->section].memory_size,
                                 &cpio_target_meta,
                                 t->filename,
-                                /* tpm_pcr= */ UINT32_MAX,
                                 /* tpm_description= */ NULL,
                                 initrds + t->initrd_index,
                                 /* ret_measured= */ NULL);
@@ -948,7 +941,6 @@ static void generate_boot_secret_initrd(
                         BOOT_SECRET_SIZE,
                         &cpio_target_meta_secret,
                         u"boot-secret",
-                        /* tpm_pcr= */ UINT32_MAX,
                         /* tpm_description= */ NULL,
                         initrds + INITRD_BOOT_SECRET,
                         /* ret_measured= */ NULL);


### PR DESCRIPTION
This implements the "extra" stanza for type 1 entries in systemd-boot, see:

https://github.com/uapi-group/specifications/commit/bde167a46c866c44e1240120695f70f0bf70aadc

It comes with a really thorough test suite matching our currently level of testing of systemd-boot (read: there is none, I ask you to trust me, Claude, and your review on this one)...

Split out of #41543 