### PR TITLE
sd-bus: store the strv size when extending it

### DIFF
--- a/src/core/dbus-manager.c
+++ b/src/core/dbus-manager.c
@@ -971,6 +971,10 @@ static int method_list_units_by_names(sd_bus_message *message, void *userdata, s
         if (r < 0)
                 return r;
 
+        if (strv_length(units) > MAX(hashmap_size(m->units), (unsigned) MANAGER_MAX_NAMES / 2))
+                return sd_bus_error_set(reterr_error, SD_BUS_ERROR_LIMITS_EXCEEDED,
+                                        "Too many unit names requested.");
+
         r = sd_bus_message_new_method_return(message, &reply);
         if (r < 0)
                 return r;

--- a/src/libsystemd/sd-bus/bus-message.c
+++ b/src/libsystemd/sd-bus/bus-message.c
@@ -4331,6 +4331,7 @@ int bus_message_get_blob(sd_bus_message *m, void **buffer, size_t *sz) {
 _public_ int sd_bus_message_read_strv_extend(sd_bus_message *m, char ***l) {
         char type;
         const char *contents, *s;
+        size_t n;
         int r;
 
         assert(m);
@@ -4347,9 +4348,10 @@ _public_ int sd_bus_message_read_strv_extend(sd_bus_message *m, char ***l) {
         if (r <= 0)
                 return r;
 
+        n = strv_length(*l);
         /* sd_bus_message_read_basic() does content validation for us. */
         while ((r = sd_bus_message_read_basic(m, *contents, &s)) > 0) {
-                r = strv_extend(l, s);
+                r = strv_extend_with_size(l, &n, s);
                 if (r < 0)
                         return r;
         }


### PR DESCRIPTION
So strv_push_with_size() doesn't have to recalculate the size every time.

---

I'm not completely sure about both the naming (the name suggests the limit applies to all IPC calls, but it's currently used only in a single place) and the actual limit (the method is not used by anything in our code, AFAIK, so the conservative limit should be fine) in the second commit, so any suggestions are more than welcome.