### PR TITLE
sd-json,user-record: store the strv size when extending it

### DIFF
--- a/src/libsystemd/sd-json/json-util.c
+++ b/src/libsystemd/sd-json/json-util.c
@@ -291,6 +291,7 @@ int json_dispatch_path(const char *name, sd_json_variant *variant, sd_json_dispa
 int json_dispatch_strv_path(const char *name, sd_json_variant *variant, sd_json_dispatch_flags_t flags, void *userdata) {
         _cleanup_strv_free_ char **n = NULL;
         char ***l = ASSERT_PTR(userdata);
+        size_t s = 0;
         int r;
 
         assert(variant);
@@ -310,7 +311,7 @@ int json_dispatch_strv_path(const char *name, sd_json_variant *variant, sd_json_
                 if (r < 0)
                         return r;
 
-                r = strv_extend(&n, a);
+                r = strv_extend_with_size(&n, &s, a);
                 if (r < 0)
                         return json_log_oom(variant, flags);
         }

--- a/src/libsystemd/sd-json/sd-json.c
+++ b/src/libsystemd/sd-json/sd-json.c
@@ -5663,6 +5663,7 @@ _public_ int sd_json_dispatch_strv(const char *name, sd_json_variant *variant, s
         _cleanup_strv_free_ char **l = NULL;
         char ***s = userdata;
         sd_json_variant *e;
+        size_t n = 0;
         int r;
 
         assert_return(variant, -EINVAL);
@@ -5696,7 +5697,7 @@ _public_ int sd_json_dispatch_strv(const char *name, sd_json_variant *variant, s
                 if ((flags & SD_JSON_STRICT) && !string_is_safe(sd_json_variant_string(e), STRING_ALLOW_EMPTY|STRING_ALLOW_GLOBS))
                         return json_log(e, flags, SYNTHETIC_ERRNO(EINVAL), "JSON field '%s' contains unsafe characters, refusing.", strna(name));
 
-                r = strv_extend(&l, sd_json_variant_string(e));
+                r = strv_extend_with_size(&l, &n, sd_json_variant_string(e));
                 if (r < 0)
                         return json_log(e, flags, r, "Failed to append array element: %m");
         }

--- a/src/shared/user-record.c
+++ b/src/shared/user-record.c
@@ -518,6 +518,7 @@ static int json_dispatch_locales(const char *name, sd_json_variant *variant, sd_
         char ***l = userdata;
         const char *locale;
         sd_json_variant *e;
+        size_t s = 0;
         int r;
 
         if (sd_json_variant_is_null(variant)) {
@@ -536,7 +537,7 @@ static int json_dispatch_locales(const char *name, sd_json_variant *variant, sd_
                 if (!locale_is_valid(locale))
                         return json_log(variant, flags, SYNTHETIC_ERRNO(EINVAL), "JSON field '%s' is not an array of valid locales.", strna(name));
 
-                r = strv_extend(&n, locale);
+                r = strv_extend_with_size(&n, &s, locale);
                 if (r < 0)
                         return json_log_oom(variant, flags);
         }
@@ -593,6 +594,7 @@ static int json_dispatch_weight(const char *name, sd_json_variant *variant, sd_j
 int json_dispatch_user_group_list(const char *name, sd_json_variant *variant, sd_json_dispatch_flags_t flags, void *userdata) {
         char ***list = ASSERT_PTR(userdata);
         _cleanup_strv_free_ char **l = NULL;
+        size_t s = 0;
         int r;
 
         if (!sd_json_variant_is_array(variant))
@@ -606,7 +608,7 @@ int json_dispatch_user_group_list(const char *name, sd_json_variant *variant, sd
                 if (!valid_user_group_name(sd_json_variant_string(e), FLAGS_SET(flags, SD_JSON_RELAX) ? VALID_USER_RELAX : 0))
                         return json_log(e, flags, SYNTHETIC_ERRNO(EINVAL), "JSON array element is not a valid user/group name: %s", sd_json_variant_string(e));
 
-                r = strv_extend(&l, sd_json_variant_string(e));
+                r = strv_extend_with_size(&l, &s, sd_json_variant_string(e));
                 if (r < 0)
                         return json_log(e, flags, r, "Failed to append array element: %m");
         }


### PR DESCRIPTION
So strv_push_with_size() doesn't have to recalculate the size every time.