### PR TITLE
blockdev-list: fix per-element leak in block_device_array_free()

### DIFF
--- a/src/shared/blockdev-list.c
+++ b/src/shared/blockdev-list.c
@@ -27,7 +27,7 @@ void block_device_done(BlockDevice *d) {
 void block_device_array_free(BlockDevice *d, size_t n_devices) {
 
         FOREACH_ARRAY(i, d, n_devices)
-                block_device_done(d);
+                block_device_done(i);
 
         free(d);
 }


### PR DESCRIPTION
FOREACH_ARRAY declares 'i' as the iterator but the body passed 'd' (the array base) to block_device_done(). Since mfree() leaves the field NULL after the first call, element 0 is freed repeatedly while elements 1..N-1 leak their node, symlinks strv, model, vendor and subsystem.

The bug predates the sanitizer-instrumented callers. PR #41776's new systemd-storage-block daemon runs blockdev_list() under ASan/LSan in TEST-87-AUX-UTILS-VM and exposes it (15 allocs / 804 bytes leaked per ListVolumes request). The fix also benefits repart and blockdev_list's internal CLEANUP_ARRAY cleanup.

Follow-up for 9f6b2745eaa15be80568fde2a44d0a10ed6eb2a1