### PR TITLE
sd-json: limit the number of env variables to something reasonable 

### DIFF
--- a/src/libsystemd/sd-json/json-util.c
+++ b/src/libsystemd/sd-json/json-util.c
@@ -653,6 +653,9 @@ int json_dispatch_strv_environment(const char *name, sd_json_variant *variant, s
         if (!sd_json_variant_is_array(variant))
                 return json_log(variant, flags, SYNTHETIC_ERRNO(EINVAL), "JSON field '%s' is not an array.", strna(name));
 
+        if (sd_json_variant_elements(variant) > ENVIRONMENT_ASSIGNMENTS_MAX)
+                return json_log(variant, flags, SYNTHETIC_ERRNO(E2BIG), "Too many environment variable assignments.");
+
         sd_json_variant *i;
         JSON_VARIANT_ARRAY_FOREACH(i, variant) {
                 const char *e;

--- a/src/libsystemd/sd-json/json-util.h
+++ b/src/libsystemd/sd-json/json-util.h
@@ -9,6 +9,8 @@
 #include "sd-forward.h"
 #include "string-util.h"        /* IWYU pragma: keep */
 
+#define ENVIRONMENT_ASSIGNMENTS_MAX 1024U
+
 #define JSON_VARIANT_REPLACE(v, q)        \
         do {                              \
                 typeof(v)* _v = &(v);     \


### PR DESCRIPTION
Let's start with 1024, as that should be plenty for all sane use cases.