### PR TITLE
Fix crash and lost nested mounts for systemd-sysext

### DIFF
--- a/src/shared/mount-util.c
+++ b/src/shared/mount-util.c
@@ -1838,11 +1838,35 @@ int get_sub_mounts(const char *prefix, SubMount **ret_mounts, size_t *ret_n_moun
                         continue;
                 }
 
-                mount_fd = RET_NERRNO(open_tree(AT_FDCWD, path, OPEN_TREE_CLONE|OPEN_TREE_CLOEXEC|AT_RECURSIVE));
-                if (mount_fd == -ENOENT) /* The path may be hidden by another over-mount or already unmounted. */
-                        continue;
-                if (mount_fd < 0)
-                        return log_debug_errno(mount_fd, "Failed to open subtree of mounted filesystem '%s': %m", path);
+                /* If possible on a newer kernel, use MS_PRIVATE to decouple it from the original mount.
+                 * Otherwise MNT_DETACH of the source path could propagate through and unmount the
+                 * just-moved nested children at the destination (relevant for preserving nested mounts
+                 * under sysext hierarchies). */
+                static bool mount_attr_unsupported = false;
+
+                if (!mount_attr_unsupported) {
+                        mount_fd = open_tree_attr_with_fallback(
+                                        AT_FDCWD, path,
+                                        OPEN_TREE_CLONE|OPEN_TREE_CLOEXEC|AT_RECURSIVE,
+                                        &(struct mount_attr) { .propagation = MS_PRIVATE });
+                        if (mount_fd == -ENOENT) /* The path may be hidden by another over-mount or already unmounted. */
+                                continue;
+                        if (mount_fd < 0 && ERRNO_IS_NEG_NOT_SUPPORTED(mount_fd)) {
+                                /* On a kernel older than 5.12 without mount_setattr() we do the regular
+                                 * clone. Nested mounts under sysext and similar cases may get lost. */
+                                log_debug_errno(mount_fd, "mount_setattr() not supported, falling back to plain open_tree() without MS_PRIVATE: %m");
+                                mount_attr_unsupported = true;
+                        } else if (mount_fd < 0)
+                                return log_debug_errno(mount_fd, "Failed to open subtree of mounted filesystem '%s': %m", path);
+                }
+
+                if (mount_attr_unsupported) {
+                        mount_fd = RET_NERRNO(open_tree(AT_FDCWD, path, OPEN_TREE_CLONE|OPEN_TREE_CLOEXEC|AT_RECURSIVE));
+                        if (mount_fd == -ENOENT)
+                                continue;
+                        if (mount_fd < 0)
+                                return log_debug_errno(mount_fd, "Failed to open subtree of mounted filesystem '%s': %m", path);
+                }
 
                 p = strdup(path);
                 if (!p)

--- a/src/shared/mount-util.c
+++ b/src/shared/mount-util.c
@@ -1754,21 +1754,36 @@ DEFINE_ARRAY_FREE_FUNC(sub_mount_array_free, SubMount, sub_mount_clear);
 static int sub_mount_compare(const SubMount *a, const SubMount *b) {
         assert(a);
         assert(b);
-        assert(a->path);
-        assert(b->path);
+
+        /* sub_mount_drop() creates NULL paths which we order to the end so that after the sort we can
+         * truncate the array. Done manually because path_compare() orders NULL before non-NULL. */
+        if (!a->path || !b->path)
+                return CMP(!a->path, !b->path);
 
         return path_compare(a->path, b->path);
 }
 
-static void sub_mount_drop(SubMount *s, size_t n) {
-        assert(s || n == 0);
+static void sub_mount_drop(SubMount *s, size_t *n) {
+        assert(n);
+        assert(s || *n == 0);
 
-        for (size_t m = 0, i = 1; i < n; i++) {
+        /* Works on a sorted array. Drops mounts that are covered by the preceding entry's recursive
+         * open_tree() clone, clearing the slot in place. Then sorts again for the NULL paths to be shifted
+         * past the kept count. */
+
+        size_t kept = *n > 0;
+        for (size_t m = 0, i = 1; i < *n; i++)
                 if (path_startswith(s[i].path, s[m].path))
                         sub_mount_clear(s + i);
-                else
+                else {
                         m = i;
-        }
+                        kept++;
+                }
+
+        if (kept < *n)
+                typesafe_qsort(s, *n, sub_mount_compare);
+
+        *n = kept;
 }
 #endif
 
@@ -1843,7 +1858,7 @@ int get_sub_mounts(const char *prefix, SubMount **ret_mounts, size_t *ret_n_moun
         }
 
         typesafe_qsort(mounts, n, sub_mount_compare);
-        sub_mount_drop(mounts, n);
+        sub_mount_drop(mounts, &n);
 
         *ret_mounts = TAKE_PTR(mounts);
         *ret_n_mounts = n;

--- a/src/shared/mount-util.c
+++ b/src/shared/mount-util.c
@@ -1840,11 +1840,36 @@ int get_sub_mounts(const char *prefix, SubMount **ret_mounts, size_t *ret_n_moun
                         continue;
                 }
 
-                mount_fd = RET_NERRNO(open_tree(AT_FDCWD, path, OPEN_TREE_CLONE|OPEN_TREE_CLOEXEC|AT_RECURSIVE));
-                if (mount_fd == -ENOENT) /* The path may be hidden by another over-mount or already unmounted. */
-                        continue;
-                if (mount_fd < 0)
-                        return log_debug_errno(mount_fd, "Failed to open subtree of mounted filesystem '%s': %m", path);
+                /* If possible on a newer kernel, use MS_PRIVATE to decouple it from the original
+                 * mount. Otherwise MNT_DETACH of the source path could propagate through and
+                 * unmount the just-moved nested children at the destination (relevant for
+                 * preserving nested mounts under sysext hierarchies). */
+                static bool mount_attr_unsupported = false;
+
+                if (!mount_attr_unsupported) {
+                        mount_fd = open_tree_attr_with_fallback(
+                                        AT_FDCWD, path,
+                                        OPEN_TREE_CLONE|OPEN_TREE_CLOEXEC|AT_RECURSIVE,
+                                        &(struct mount_attr) { .propagation = MS_PRIVATE });
+                        if (mount_fd == -ENOENT) /* The path may be hidden by another over-mount or already unmounted. */
+                                continue;
+                        if (mount_fd < 0 && ERRNO_IS_NEG_NOT_SUPPORTED(mount_fd)) {
+                                /* On a kernel older than 5.12 without mount_setattr() we do the
+                                 * regular clone. Nested mounts under sysext and similar cases
+                                 * may get lost. */
+                                log_debug_errno(mount_fd, "open_tree_attr() not supported, falling back to plain open_tree() without MS_PRIVATE: %m");
+                                mount_attr_unsupported = true;
+                        } else if (mount_fd < 0)
+                                return log_debug_errno(mount_fd, "Failed to open subtree of mounted filesystem '%s': %m", path);
+                }
+
+                if (mount_attr_unsupported) {
+                        mount_fd = RET_NERRNO(open_tree(AT_FDCWD, path, OPEN_TREE_CLONE|OPEN_TREE_CLOEXEC|AT_RECURSIVE));
+                        if (mount_fd == -ENOENT)
+                                continue;
+                        if (mount_fd < 0)
+                                return log_debug_errno(mount_fd, "Failed to open subtree of mounted filesystem '%s': %m", path);
+                }
 
                 p = strdup(path);
                 if (!p)

--- a/src/shared/mount-util.c
+++ b/src/shared/mount-util.c
@@ -1754,21 +1754,38 @@ DEFINE_ARRAY_FREE_FUNC(sub_mount_array_free, SubMount, sub_mount_clear);
 static int sub_mount_compare(const SubMount *a, const SubMount *b) {
         assert(a);
         assert(b);
-        assert(a->path);
-        assert(b->path);
+
+        /* sub_mount_drop() creates NULL paths which we order to the end so that after the sort we can
+         * truncate the array. */
+        if (!a->path)
+                return b->path ? 1 : 0;
+        if (!b->path)
+                return -1;
 
         return path_compare(a->path, b->path);
 }
 
-static void sub_mount_drop(SubMount *s, size_t n) {
-        assert(s || n == 0);
+static void sub_mount_drop(SubMount *s, size_t *n) {
+        assert(n);
+        assert(s || *n == 0);
 
-        for (size_t m = 0, i = 1; i < n; i++) {
+        /* Works on a sorted array. Drops mounts that are covered by the preceding entry's recursive
+         * open_tree() clone, clearing the slot in place. Then sorts again for the NULL paths to be shifted
+         * past the kept count. */
+
+        size_t kept = *n > 0;
+        for (size_t m = 0, i = 1; i < *n; i++)
                 if (path_startswith(s[i].path, s[m].path))
                         sub_mount_clear(s + i);
-                else
+                else {
                         m = i;
-        }
+                        kept++;
+                }
+
+        if (kept < *n)
+                typesafe_qsort(s, *n, sub_mount_compare);
+
+        *n = kept;
 }
 #endif
 
@@ -1843,7 +1860,7 @@ int get_sub_mounts(const char *prefix, SubMount **ret_mounts, size_t *ret_n_moun
         }
 
         typesafe_qsort(mounts, n, sub_mount_compare);
-        sub_mount_drop(mounts, n);
+        sub_mount_drop(mounts, &n);
 
         *ret_mounts = TAKE_PTR(mounts);
         *ret_n_mounts = n;

--- a/src/sysext/sysext.c
+++ b/src/sysext/sysext.c
@@ -480,9 +480,13 @@ static int move_submounts(const char *src, const char *dst) {
                 if (child_fd < 0)
                         return log_error_errno(errno, "Failed to pin mountpoint %s: %m", t);
 
-                r = mount_follow_verbose(LOG_ERR, m->path, FORMAT_PROC_FD_PATH(child_fd), /* fstype= */ NULL, MS_BIND|MS_REC, /* options= */ NULL);
+                /* Instead of a bind mount we attach the detached clone produced by
+                 * open_tree_attr_with_fallback() from get_sub_mounts() because that has no propagation
+                 * relationship with the original anymore and the MNT_DETACH below won't propagate for
+                 * nested mounts. */
+                r = RET_NERRNO(move_mount(m->mount_fd, "", child_fd, "", MOVE_MOUNT_F_EMPTY_PATH|MOVE_MOUNT_T_EMPTY_PATH));
                 if (r < 0)
-                        return r;
+                        return log_error_errno(r, "Failed to move mount '%s' to '%s': %m", m->path, t);
 
                 (void) umount_verbose(LOG_WARNING, m->path, MNT_DETACH);
         }

--- a/src/sysext/sysext.c
+++ b/src/sysext/sysext.c
@@ -404,9 +404,13 @@ static int move_submounts(const char *src, const char *dst) {
                 if (child_fd < 0)
                         return log_error_errno(errno, "Failed to pin mountpoint %s: %m", t);
 
-                r = mount_follow_verbose(LOG_ERR, m->path, FORMAT_PROC_FD_PATH(child_fd), /* fstype= */ NULL, MS_BIND|MS_REC, /* options= */ NULL);
+                /* Instead of a bind mount we attach the detached clone produced by
+                 * open_tree_attr_with_fallback() from get_sub_mounts() because that has no propagation
+                 * relationship with the original anymore and the MNT_DETACH below won't propagate for
+                 * nested mounts. */
+                r = RET_NERRNO(move_mount(m->mount_fd, "", child_fd, "", MOVE_MOUNT_F_EMPTY_PATH|MOVE_MOUNT_T_EMPTY_PATH));
                 if (r < 0)
-                        return r;
+                        return log_error_errno(r, "Failed to move mount %s to %s: %m", m->path, t);
 
                 (void) umount_verbose(LOG_WARNING, m->path, MNT_DETACH);
         }

--- a/src/test/test-mount-util.c
+++ b/src/test/test-mount-util.c
@@ -490,6 +490,51 @@ TEST(bind_mount_submounts) {
         }
 }
 
+TEST(get_sub_mounts) {
+        _cleanup_(rm_rf_physical_and_freep) char *a = NULL;
+        int r;
+
+        CHECK_PRIV;
+
+        assert_se(mkdtemp_malloc(NULL, &a) >= 0);
+
+        r = ASSERT_OK(pidref_safe_fork("(get-sub-mounts)", FORK_COMMON_FLAGS, NULL));
+        if (r == 0) {
+                _cleanup_free_ char *outer = NULL, *inner = NULL;
+                SubMount *mounts = NULL;
+                size_t n = 0;
+
+                CLEANUP_ARRAY(mounts, n, sub_mount_array_free);
+
+                /* Reproduces the layout that triggered the assertion crash in systemd-sysext on
+                 * Flatcar (https://github.com/flatcar/Flatcar/issues/2111): a mount nested inside
+                 * another mount under a sysext hierarchy. The dedup pass must keep only the outer
+                 * entry (the inner is covered by the outer's recursive open_tree() clone) and
+                 * compact the array — leaving NULL entries behind would crash the consumer. */
+
+                assert_se(outer = path_join(a, "outer"));
+                assert_se(mkdir(outer, 0755) >= 0);
+                ASSERT_OK(mount_nofollow_verbose(LOG_INFO, "tmpfs", outer, "tmpfs", 0, NULL));
+
+                assert_se(inner = path_join(outer, "inner"));
+                assert_se(mkdir(inner, 0755) >= 0);
+                ASSERT_OK(mount_nofollow_verbose(LOG_INFO, "tmpfs", inner, "tmpfs", 0, NULL));
+
+                ASSERT_OK(get_sub_mounts(a, &mounts, &n));
+
+                /* Only the outer entry should survive dedup; the inner is implied by the outer's
+                 * recursive clone. */
+                ASSERT_EQ(n, 1u);
+                ASSERT_NOT_NULL(mounts[0].path);
+                ASSERT_STREQ(mounts[0].path, outer);
+                ASSERT_OK(mounts[0].mount_fd);
+
+                ASSERT_OK(umount_recursive(a, 0));
+
+                _exit(EXIT_SUCCESS);
+        }
+}
+
 TEST(path_is_network_fs_harder) {
         _cleanup_close_ int dir_fd = -EBADF;
         int r;

--- a/src/test/test-mount-util.c
+++ b/src/test/test-mount-util.c
@@ -490,6 +490,55 @@ TEST(bind_mount_submounts) {
         }
 }
 
+TEST(get_sub_mounts) {
+        _cleanup_(rm_rf_physical_and_freep) char *a = NULL;
+        int r;
+
+        CHECK_PRIV;
+
+        ASSERT_OK(mkdtemp_malloc(NULL, &a));
+
+        r = ASSERT_OK(pidref_safe_fork("(get-sub-mounts)", FORK_COMMON_FLAGS, NULL));
+        if (r == 0) {
+                SubMount *mounts = NULL;
+                size_t n = 0;
+
+                CLEANUP_ARRAY(mounts, n, sub_mount_array_free);
+
+                /* Reproduces the layout that triggered the assertion crash in systemd-sysext on
+                 * Flatcar (https://github.com/flatcar/Flatcar/issues/2111): a mount nested inside
+                 * another mount under a sysext hierarchy. The dedup pass must keep only the outer
+                 * entry (the inner is covered by the outer's recursive open_tree() clone) and
+                 * compact the array — leaving NULL entries behind would crash the consumer. */
+
+                _cleanup_free_ char *outer = ASSERT_NOT_NULL(path_join(a, "outer"));
+                ASSERT_OK_ERRNO(mkdir(outer, 0755));
+                ASSERT_OK(mount_nofollow_verbose(LOG_INFO, "tmpfs", outer, "tmpfs", 0, NULL));
+
+                _cleanup_free_ char *inner = ASSERT_NOT_NULL(path_join(outer, "inner"));
+                ASSERT_OK_ERRNO(mkdir(inner, 0755));
+                ASSERT_OK(mount_nofollow_verbose(LOG_INFO, "tmpfs", inner, "tmpfs", 0, NULL));
+
+                r = get_sub_mounts(a, &mounts, &n);
+                if (r == -EOPNOTSUPP) {
+                        log_tests_skipped("libmount support not compiled in");
+                        _exit(EXIT_SUCCESS);
+                }
+                ASSERT_OK(r);
+
+                /* Only the outer entry should survive dedup; the inner is implied by the outer's
+                 * recursive clone. */
+                ASSERT_EQ(n, 1u);
+                ASSERT_NOT_NULL(mounts[0].path);
+                ASSERT_STREQ(mounts[0].path, outer);
+                ASSERT_OK(mounts[0].mount_fd);
+
+                ASSERT_OK(umount_recursive(a, 0));
+
+                _exit(EXIT_SUCCESS);
+        }
+}
+
 TEST(path_is_network_fs_harder) {
         _cleanup_close_ int dir_fd = -EBADF;
         int r;

--- a/test/units/TEST-50-DISSECT.sysext.sh
+++ b/test/units/TEST-50-DISSECT.sysext.sh
@@ -1675,6 +1675,57 @@ run_systemd_sysext "$fake_root" unmerge
 extension_verify_after_unmerge "$fake_root" "$hierarchy" -h
 )
 
+( init_trap
+: "Nested tmpfs submounts under the hierarchy survive merge/refresh/unmerge round-trip"
+fake_root=${roots_dir:+"$roots_dir/nested-submounts"}
+hierarchy=/opt
+
+# Don't run the test if the inner mount won't be preserved due to an old kernel
+if ! systemd-analyze compare-versions "$(uname -r)" ge 5.12; then
+    echo >&2 "Kernel too old for mount_setattr (need >= 5.12), skipping nested submount test"
+    exit 0
+fi
+
+prepare_root "$fake_root" "$hierarchy"
+prepare_extension_image "$fake_root" "$hierarchy"
+prepare_hierarchy "$fake_root" "$hierarchy"
+
+# Two tmpfs mounts, one nested in the hierarchy under the other. Reproduces the nested mount layout from
+# https://github.com/flatcar/Flatcar/issues/2111 and verifies that we preserve nested mounts across merge,
+# refresh, and unmerge.
+outer_mp="$fake_root$hierarchy/outer"
+inner_mp="$outer_mp/inner"
+mkdir -p "$outer_mp"
+mount -t tmpfs tmpfs "$outer_mp"
+prepend_trap "umount -l ${outer_mp@Q} 2>/dev/null || true"
+mkdir -p "$inner_mp"
+mount -t tmpfs tmpfs "$inner_mp"
+prepend_trap "umount -l ${inner_mp@Q} 2>/dev/null || true"
+touch "$outer_mp/outer-marker"
+touch "$inner_mp/inner-marker"
+
+run_systemd_sysext "$fake_root" merge
+extension_verify_after_merge "$fake_root" "$hierarchy" -e -h
+mountpoint "$outer_mp"
+mountpoint "$inner_mp"
+test -f "$outer_mp/outer-marker"
+test -f "$inner_mp/inner-marker"
+
+run_systemd_sysext "$fake_root" refresh --always-refresh=yes
+extension_verify_after_merge "$fake_root" "$hierarchy" -e -h
+mountpoint "$outer_mp"
+mountpoint "$inner_mp"
+test -f "$outer_mp/outer-marker"
+test -f "$inner_mp/inner-marker"
+
+run_systemd_sysext "$fake_root" unmerge
+extension_verify_after_unmerge "$fake_root" "$hierarchy" -h
+mountpoint "$outer_mp"
+mountpoint "$inner_mp"
+test -f "$outer_mp/outer-marker"
+test -f "$inner_mp/inner-marker"
+)
+
 } # End of run_sysext_tests
 
 

--- a/test/units/TEST-50-DISSECT.sysext.sh
+++ b/test/units/TEST-50-DISSECT.sysext.sh
@@ -1863,6 +1863,57 @@ if systemctl --quiet is-active "$ext_unit"; then
 fi
 )
 
+( init_trap
+: "Nested tmpfs submounts under the hierarchy survive merge/refresh/unmerge round-trip"
+fake_root=${roots_dir:+"$roots_dir/nested-submounts"}
+hierarchy=/opt
+
+# Don't run the test if the inner mount won't be preserved due to an old kernel
+if ! systemd-analyze compare-versions "$(uname -r)" ge 5.12; then
+    echo >&2 "Kernel too old for mount_setattr (need >= 5.12), skipping nested submount test"
+    exit 0
+fi
+
+prepare_root "$fake_root" "$hierarchy"
+prepare_extension_image "$fake_root" "$hierarchy"
+prepare_hierarchy "$fake_root" "$hierarchy"
+
+# Two tmpfs mounts, one nested in the hierarchy under the other. Reproduces the nested mount layout from
+# https://github.com/flatcar/Flatcar/issues/2111 and verifies that we preserve nested mounts across merge,
+# refresh, and unmerge.
+outer_mp="$fake_root$hierarchy/outer"
+inner_mp="$outer_mp/inner"
+mkdir -p "$outer_mp"
+mount -t tmpfs tmpfs "$outer_mp"
+prepend_trap "umount -l ${outer_mp@Q} 2>/dev/null || true"
+mkdir -p "$inner_mp"
+mount -t tmpfs tmpfs "$inner_mp"
+prepend_trap "umount -l ${inner_mp@Q} 2>/dev/null || true"
+touch "$outer_mp/outer-marker"
+touch "$inner_mp/inner-marker"
+
+run_systemd_sysext "$fake_root" merge
+extension_verify_after_merge "$fake_root" "$hierarchy" -e -h
+mountpoint "$outer_mp"
+mountpoint "$inner_mp"
+test -f "$outer_mp/outer-marker"
+test -f "$inner_mp/inner-marker"
+
+run_systemd_sysext "$fake_root" refresh --always-refresh=yes
+extension_verify_after_merge "$fake_root" "$hierarchy" -e -h
+mountpoint "$outer_mp"
+mountpoint "$inner_mp"
+test -f "$outer_mp/outer-marker"
+test -f "$inner_mp/inner-marker"
+
+run_systemd_sysext "$fake_root" unmerge
+extension_verify_after_unmerge "$fake_root" "$hierarchy" -h
+mountpoint "$outer_mp"
+mountpoint "$inner_mp"
+test -f "$outer_mp/outer-marker"
+test -f "$inner_mp/inner-marker"
+)
+
 } # End of run_sysext_tests
 
 


### PR DESCRIPTION
- mount-util: Compact list of sub mounts after dropping
    
    When nested mounts appear under a sysext hierarchy like this:
      mkdir -p /opt/trigger/
      mount -t tmpfs tmpfs /opt/trigger
      mkdir -p /opt/trigger/inner
      mount -t tmpfs tmpfs /opt/trigger/inner
    Then systemd-sysext merge will hit an assertion reported in
    https://github.com/flatcar/Flatcar/issues/2111 because when it iterates
    over the list of sub mounts it doesn't expect entries with NULL in the
    path from the dropped entries.
    Instead of having to deal with entries with path NULL, better fill the
    holes from dropping by moving the next element forward and then
    reducing the list length.
- mount-util/sysext: Clone sub mounts as private to preserve nested ones
    
    When nested mounts appear like mentioned above,
    systemd-sysext merge will lose the inner mount because it uses a
    regular bind mount with propagation and then unmounts the source,
    unmounting all children with it which propagates.
    To solve this, clone the sub mount with MS_PRIVATE to decouple sub
    mounts from the original mount. Then attach the cloned mount instead of
    doing regular bind mounts. For old kernels we still attach the cloned
    mount but we fallback to cloning without MS_PRIVATE. This change also
    affects mount_private_apivfs which is used for private /proc, /sys, and
    cgroupfs but I think it makes sense there, too, instead of only doing
    mount_setattr for sysext alone.