### PR TITLE
repart: hide read-only block devices from candidates

### DIFF
--- a/src/repart/repart.c
+++ b/src/repart/repart.c
@@ -9896,7 +9896,13 @@ static int parse_argv(int argc, char *argv[]) {
 
                 OPTION_LONG("list-devices", NULL,
                             "List candidate block devices to operate on"):
-                        r = blockdev_list(BLOCKDEV_LIST_REQUIRE_PARTITION_SCANNING|BLOCKDEV_LIST_SHOW_SYMLINKS|BLOCKDEV_LIST_IGNORE_ZRAM, /* ret_devices= */ NULL, /* ret_n_devices= */ NULL);
+                        r = blockdev_list(
+                                        BLOCKDEV_LIST_SHOW_SYMLINKS|
+                                        BLOCKDEV_LIST_REQUIRE_PARTITION_SCANNING|
+                                        BLOCKDEV_LIST_IGNORE_ZRAM|
+                                        BLOCKDEV_LIST_IGNORE_READ_ONLY,
+                                        /* ret_devices= */ NULL,
+                                        /* ret_n_devices= */ NULL);
                         if (r < 0)
                                 return r;
 
@@ -10876,6 +10882,7 @@ static int vl_method_list_candidate_devices(
                         BLOCKDEV_LIST_REQUIRE_PARTITION_SCANNING|
                         BLOCKDEV_LIST_IGNORE_ZRAM|
                         BLOCKDEV_LIST_METADATA|
+                        BLOCKDEV_LIST_IGNORE_READ_ONLY|
                         (p.ignore_empty ? BLOCKDEV_LIST_IGNORE_EMPTY : 0)|
                         (p.ignore_root ? BLOCKDEV_LIST_IGNORE_ROOT : 0),
                         &l,

--- a/src/shared/blockdev-list.c
+++ b/src/shared/blockdev-list.c
@@ -188,6 +188,20 @@ int blockdev_list(BlockDevListFlags flags, BlockDevice **ret_devices, size_t *re
                         }
                 }
 
+                int ro = -1;
+                if (FLAGS_SET(flags, BLOCKDEV_LIST_IGNORE_READ_ONLY) || FLAGS_SET(flags, BLOCKDEV_LIST_METADATA)) {
+                        r = device_get_sysattr_bool(dev, "ro");
+                        if (r < 0)
+                                log_device_debug_errno(dev, r, "Failed to acquire read-only flag of device '%s', ignoring: %m", node);
+                        else
+                                ro = r;
+
+                        if (ro > 0 && FLAGS_SET(flags, BLOCKDEV_LIST_IGNORE_READ_ONLY)) {
+                                log_device_debug(dev, "Device '%s' is read-only, skipping.", node);
+                                continue;
+                        }
+                }
+
                 _cleanup_strv_free_ char **list = NULL;
                 if (FLAGS_SET(flags, BLOCKDEV_LIST_SHOW_SYMLINKS)) {
                         FOREACH_DEVICE_DEVLINK(dev, sl)
@@ -198,17 +212,10 @@ int blockdev_list(BlockDevListFlags flags, BlockDevice **ret_devices, size_t *re
                 }
 
                 _cleanup_free_ char *model = NULL, *vendor = NULL, *subsystem = NULL;
-                int ro = -1;
                 if (FLAGS_SET(flags, BLOCKDEV_LIST_METADATA)) {
                         (void) blockdev_get_prop(dev, "ID_MODEL_FROM_DATABASE", "ID_MODEL", &model);
                         (void) blockdev_get_prop(dev, "ID_VENDOR_FROM_DATABASE", "ID_VENDOR", &vendor);
                         (void) blockdev_get_subsystem(dev, &subsystem);
-
-                        r = device_get_sysattr_bool(dev, "ro");
-                        if (r < 0)
-                                log_device_debug_errno(dev, r, "Failed to acquire read-only flag of device '%s', ignoring: %m", node);
-                        else
-                                ro = r;
                 }
 
                 if (ret_devices) {

--- a/src/shared/blockdev-list.h
+++ b/src/shared/blockdev-list.h
@@ -11,6 +11,7 @@ typedef enum BlockDevListFlags {
         BLOCKDEV_LIST_IGNORE_ROOT                = 1 << 4, /* Ignore the block device we are currently booted from */
         BLOCKDEV_LIST_IGNORE_EMPTY               = 1 << 5, /* Ignore disks of zero size (usually drives without a medium) */
         BLOCKDEV_LIST_METADATA                   = 1 << 6, /* Fill in model, vendor, subsystem, read_only */
+        BLOCKDEV_LIST_IGNORE_READ_ONLY           = 1 << 7, /* Ignore read-only block devices */
 } BlockDevListFlags;
 
 typedef struct BlockDevice {


### PR DESCRIPTION
If they are read-only they are no candidates, since we cannot write to them.