### PR TITLE
dns-question: limit the number of questions per query

### DIFF
--- a/src/shared/dns-question.c
+++ b/src/shared/dns-question.c
@@ -608,6 +608,9 @@ int dns_json_dispatch_question(const char *name, sd_json_variant *variant, sd_js
         if (!sd_json_variant_is_array(variant))
                 return json_log(variant, flags, SYNTHETIC_ERRNO(EINVAL), "JSON field '%s' is not an array.", strna(name));
 
+        if (sd_json_variant_elements(variant) > DNS_QUESTION_ITEMS_MAX)
+                return json_log(variant, flags, SYNTHETIC_ERRNO(E2BIG), "Too many questions in a single query.");
+
         _cleanup_(dns_question_unrefp) DnsQuestion *nq = NULL;
         nq = dns_question_new(sd_json_variant_elements(variant));
         if (!nq)

--- a/src/shared/dns-question.h
+++ b/src/shared/dns-question.h
@@ -5,6 +5,8 @@
 
 #include "shared-forward.h"
 
+#define DNS_QUESTION_ITEMS_MAX 128U
+
 /* A simple array of resource keys */
 
 typedef enum DnsQuestionFlags {


### PR DESCRIPTION
Let's cap the number of question each query can have to something reasonable - 128 questions per query should be more than enough for any real-world scenario.