### PR TITLE
cryptsetup: added new "wipe" option to wipe fs headers before activating device

### DIFF
--- a/man/crypttab.xml
+++ b/man/crypttab.xml
@@ -73,7 +73,9 @@
       <filename>/etc/cryptsetup-keys.d/</filename> and <filename>/run/cryptsetup-keys.d/</filename>
       directories, if present. Otherwise, the password has to be manually entered during system boot. For
       swap encryption, <filename>/dev/urandom</filename> may be used as key file, resulting in a randomized
-      key.</para>
+      key. Note that if a random device (<filename>/dev/urandom</filename>, <filename>/dev/random</filename>,
+      <filename>/dev/hw_random</filename>, or <filename>/dev/hwrng</filename>) is specified as key file, the
+      <option>wipe</option> option is automatically implied.</para>
 
       <para>If the specified key file path refers to an <constant>AF_UNIX</constant> stream socket in the
       file system, the key is acquired by connecting to the socket and reading it from the connection. This
@@ -1029,6 +1031,26 @@
         <citerefentry><refentrytitle>repart.d</refentrytitle><manvolnum>5</manvolnum></citerefentry>.</para>
 
         <xi:include href="version-info.xml" xpointer="v260"/>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term><option>wipe</option></term>
+        <listitem>
+          <para>
+            If specified, systemd-cryptsetup will attempt to wipe any detected filesystem or superblock signatures
+            from the unlocked device right after it is activated (e.g., before formatting as swap). This is useful for
+            ephemeral encrypted swap, swap pre-filled by <filename>/dev/random</filename> or similar use cases, where random data may
+            otherwise be misdetected as a filesystem signature and as a result block device activation.
+            This option is automatically implied if the key file refers to a random device (i.e.
+            <filename>/dev/urandom</filename>, <filename>/dev/random</filename>, <filename>/dev/hw_random</filename>,
+            or <filename>/dev/hwrng</filename>).
+
+            <warning>
+              The wipe is performed only if the device is not already active.
+            </warning>
+          </para>
+          <xi:include href="version-info.xml" xpointer="v260"/>
         </listitem>
       </varlistentry>
 

--- a/man/crypttab.xml
+++ b/man/crypttab.xml
@@ -73,7 +73,9 @@
       <filename>/etc/cryptsetup-keys.d/</filename> and <filename>/run/cryptsetup-keys.d/</filename>
       directories, if present. Otherwise, the password has to be manually entered during system boot. For
       swap encryption, <filename>/dev/urandom</filename> may be used as key file, resulting in a randomized
-      key.</para>
+      key. Note that if a random device (<filename>/dev/urandom</filename>, <filename>/dev/random</filename>,
+      <filename>/dev/hw_random</filename>, or <filename>/dev/hwrng</filename>) is specified as key file, the
+      <option>wipe</option> option is automatically implied.</para>
 
       <para>If the specified key file path refers to an <constant>AF_UNIX</constant> stream socket in the
       file system, the key is acquired by connecting to the socket and reading it from the connection. This
@@ -1029,6 +1031,26 @@
         <citerefentry><refentrytitle>repart.d</refentrytitle><manvolnum>5</manvolnum></citerefentry>.</para>
 
         <xi:include href="version-info.xml" xpointer="v260"/>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term><option>wipe</option></term>
+        <listitem>
+          <para>
+            If specified, systemd-cryptsetup will attempt to wipe any detected filesystem or superblock signatures
+            from the unlocked device right after it is activated (e.g., before formatting as swap). This is useful for
+            ephemeral encrypted swap, swap pre-filled by <filename>/dev/urandom</filename> or similar use cases, where random data may
+            otherwise be misdetected as a filesystem signature and as a result block device activation.
+            This option is automatically implied if the key file refers to a random device (i.e.
+            <filename>/dev/urandom</filename>, <filename>/dev/random</filename>, <filename>/dev/hw_random</filename>,
+            or <filename>/dev/hwrng</filename>).
+
+            <warning>
+              The wipe is performed only if the device is not already active.
+            </warning>
+          </para>
+          <xi:include href="version-info.xml" xpointer="v262"/>
         </listitem>
       </varlistentry>
 

--- a/src/basic/random-util.c
+++ b/src/basic/random-util.c
@@ -17,6 +17,7 @@
 #include "iovec-util.h"
 #include "log.h"
 #include "parse-util.h"
+#include "path-util.h"
 #include "pidfd-util.h"
 #include "process-util.h"
 #include "random-util.h"
@@ -235,4 +236,15 @@ uint64_t random_u64_range(uint64_t m) {
         } while (x >= UINT64_MAX - remainder);
 
         return x % m;
+}
+
+bool random_is_rng_device(const char *p) {
+        if (!p)
+                return false;
+
+        return PATH_IN_SET(p,
+                           "/dev/urandom",
+                           "/dev/random",
+                           "/dev/hw_random",
+                           "/dev/hwrng");
 }

--- a/src/basic/random-util.h
+++ b/src/basic/random-util.h
@@ -33,3 +33,5 @@ size_t random_pool_size(void);
 int random_write_entropy(int fd, const void *seed, size_t size, bool credit) _nonnull_if_nonzero_(2, 3);
 
 uint64_t random_u64_range(uint64_t max);
+
+bool random_is_rng_device(const char *p);

--- a/src/cryptsetup/cryptsetup-generator.c
+++ b/src/cryptsetup/cryptsetup-generator.c
@@ -18,6 +18,7 @@
 #include "parse-util.h"
 #include "path-util.h"
 #include "proc-cmdline.h"
+#include "random-util.h"
 #include "specifier.h"
 #include "string-util.h"
 #include "strv.h"
@@ -236,11 +237,7 @@ static int print_dependencies(FILE *f, const char* device_path, const char* time
                 /* None, nothing to do */
                 return 0;
 
-        if (PATH_IN_SET(device_path,
-                        "/dev/urandom",
-                        "/dev/random",
-                        "/dev/hw_random",
-                        "/dev/hwrng")) {
+        if (random_is_rng_device(device_path)) {
                 /* RNG device, add random dep */
                 fputs("After=systemd-random-seed.service\n", f);
                 return 0;

--- a/src/cryptsetup/cryptsetup.c
+++ b/src/cryptsetup/cryptsetup.c
@@ -11,6 +11,7 @@
 
 #include "alloc-util.h"
 #include "ask-password-api.h"
+#include "blkid-util.h"
 #include "build.h"
 #include "crypto-util.h"
 #include "cryptsetup-fido2.h"
@@ -25,6 +26,7 @@
 #include "errno-util.h"
 #include "escape.h"
 #include "extract-word.h"
+#include "fd-util.h"
 #include "fileio.h"
 #include "format-table.h"
 #include "fs-util.h"
@@ -43,6 +45,7 @@
 #include "pretty-print.h"
 #include "process-util.h"
 #include "random-util.h"
+#include "stat-util.h"
 #include "string-table.h"
 #include "string-util.h"
 #include "strv.h"
@@ -128,6 +131,7 @@ static char *arg_link_keyring = NULL;
 static char *arg_link_key_type = NULL;
 static char *arg_link_key_description = NULL;
 static char *arg_fixate_volume_key = NULL;
+static bool arg_wipe = false;
 
 STATIC_DESTRUCTOR_REGISTER(arg_cipher, freep);
 STATIC_DESTRUCTOR_REGISTER(arg_hash, freep);
@@ -661,7 +665,9 @@ static int parse_one_option(const char *option) {
                 if (r < 0)
                         return log_oom();
 
-        } else if (!streq(option, "x-initrd.attach"))
+        } else if (streq(option, "wipe"))
+                arg_wipe = true;
+        else if (!streq(option, "x-initrd.attach"))
                 log_warning("Encountered unknown /etc/crypttab option '%s', ignoring.", option);
 
         return 0;
@@ -2598,6 +2604,67 @@ static int discover_key(const char *key_file, const char *volume, TokenType toke
         return r;
 }
 
+static int wipe_fs_superblock(const char *device) {
+#if HAVE_BLKID
+        _cleanup_(blkid_free_probep) blkid_probe probe = NULL;
+        _cleanup_close_ int fd = -EBADF;
+        int r;
+
+        assert(device);
+
+        r = dlopen_libblkid(LOG_ERR);
+        if (r < 0)
+                return r;
+
+        fd = open(device, O_RDWR|O_CLOEXEC|O_NONBLOCK);
+        if (fd < 0)
+                return log_error_errno(errno, "Failed to open device %s: %m", device);
+
+        r = fd_verify_block(fd);
+        if (r < 0)
+                return log_error_errno(r, "Verification that '%s' is actually a block device failed: %m", device);
+
+        probe = sym_blkid_new_probe();
+        if (!probe)
+                return log_oom();
+
+        errno = 0;
+        r = sym_blkid_probe_set_device(probe, fd, /* off= */0, /* size= */0);
+        if (r < 0)
+                return log_error_errno(errno_or_else(EIO), "Failed to allocate device probe for wiping.");
+
+        errno = 0;
+        if (sym_blkid_probe_enable_superblocks(probe, true) < 0 ||
+            sym_blkid_probe_set_superblocks_flags(probe, BLKID_SUBLKS_MAGIC|BLKID_SUBLKS_BADCSUM) < 0 ||
+            sym_blkid_probe_enable_partitions(probe, true) < 0 ||
+            sym_blkid_probe_set_partitions_flags(probe, BLKID_PARTS_MAGIC) < 0)
+                return log_error_errno(errno_or_else(EIO), "Failed to enable superblock and partition probing.");
+
+        /* We have a counter here for robustness not allowing blkid stuck */
+        for (unsigned n = 0;; n++) {
+                if (n >= 5)
+                        return log_error_errno(SYNTHETIC_ERRNO(ENOTRECOVERABLE), "Failed to fully wipe file system signatures after %u attempts, giving up.", n);
+
+                errno = 0;
+                r = sym_blkid_do_probe(probe);
+                if (r < 0)
+                        return log_error_errno(errno_or_else(EIO), "Failed to probe for file systems.");
+                if (r > 0)
+                        break;
+
+                errno = 0;
+                if (sym_blkid_do_wipe(probe, false) < 0)
+                        return log_error_errno(errno_or_else(EIO), "Failed to wipe file system signature.");
+        }
+
+        log_info("Successfully wiped file system and partition signatures from %s.", device);
+        return 0;
+#else
+        return log_error_errno(SYNTHETIC_ERRNO(EOPNOTSUPP),
+                               "Cannot wipe fs and partition signatures, libblkid support is not compiled in.");
+#endif
+}
+
 VERB(verb_attach, "attach", "VOLUME SOURCE-DEVICE [KEY-FILE] [CONFIG]", 3, 5, 0,
      "Attach an encrypted block device");
 static int verb_attach(int argc, char *argv[], uintptr_t _data, void *userdata) {
@@ -2631,6 +2698,11 @@ static int verb_attach(int argc, char *argv[], uintptr_t _data, void *userdata) 
                 r = parse_crypt_config(config);
                 if (r < 0)
                         return r;
+        }
+
+        if (key_file && random_is_rng_device(key_file) && !arg_wipe) {
+                arg_wipe = true;
+                log_info("RNG device is used as key file. Enabling wipe mode.");
         }
 
         log_debug("%s %s ← %s type=%s cipher=%s", __func__,
@@ -2715,7 +2787,7 @@ static int verb_attach(int argc, char *argv[], uintptr_t _data, void *userdata) 
                                         "cryptsetup.luks2-pin");
                         if (r >= 0) {
                                 log_debug("Volume %s activated with a LUKS token.", volume);
-                                return 0;
+                                goto activated;
                         }
 
                         log_debug_errno(r, "Token activation unsuccessful for device %s: %m", sym_crypt_get_device_name(cd));
@@ -2728,114 +2800,127 @@ static int verb_attach(int argc, char *argv[], uintptr_t _data, void *userdata) 
                         return log_error_errno(r, "Failed to load Bitlocker superblock on device %s: %m", sym_crypt_get_device_name(cd));
         }
 
-        bool use_cached_passphrase = true, try_discover_key = !key_file;
-        const char *discovered_key_fn = strjoina(volume, ".key");
-        _cleanup_strv_free_erase_ char **passwords = NULL;
-        for (tries = 0; arg_tries == 0 || tries < arg_tries; tries++) {
-                _cleanup_(iovec_done_erase) struct iovec discovered_key_data = {};
-                const struct iovec *key_data = NULL;
-                TokenType token_type = determine_token_type();
+        {
+                bool use_cached_passphrase = true, try_discover_key = !key_file;
+                const char *discovered_key_fn = strjoina(volume, ".key");
+                _cleanup_strv_free_erase_ char **passwords = NULL;
+                for (tries = 0; arg_tries == 0 || tries < arg_tries; tries++) {
+                        _cleanup_(iovec_done_erase) struct iovec discovered_key_data = {};
+                        const struct iovec *key_data = NULL;
+                        TokenType token_type = determine_token_type();
 
-                log_debug("Beginning attempt %u to unlock.", tries);
+                        log_debug("Beginning attempt %u to unlock.", tries);
 
-                /* When we were able to acquire multiple keys, let's always process them in this order:
-                 *
-                 *    1. A key acquired via PKCS#11 or FIDO2 token, or TPM2 chip
-                 *    2. The configured or discovered key, of which both are exclusive and optional
-                 *    3. The empty password, in case arg_try_empty_password is set
-                 *    4. We enquire the user for a password
-                 */
+                        /* When we were able to acquire multiple keys, let's always process them in this order:
+                        *
+                        *    1. A key acquired via PKCS#11 or FIDO2 token, or TPM2 chip
+                        *    2. The configured or discovered key, of which both are exclusive and optional
+                        *    3. The empty password, in case arg_try_empty_password is set
+                        *    4. We enquire the user for a password
+                        */
 
-                if (try_discover_key) {
-                        r = discover_key(discovered_key_fn, volume, token_type, &discovered_key_data);
-                        if (r < 0)
-                                return r;
-                        if (r > 0)
-                                key_data = &discovered_key_data;
-                }
-
-                if (token_type < 0 && !key_file && !key_data && !passwords) {
-
-                        /* If we have nothing to try anymore, then acquire a new password */
-
-                        if (arg_try_empty_password) {
-                                /* Hmm, let's try an empty password now, but only once */
-                                arg_try_empty_password = false;
-                                key_data = &iovec_empty;
-                        } else {
-                                /* Ask the user for a passphrase or recovery key only as last resort, if we
-                                 * have nothing else to check for */
-                                if (passphrase_type == PASSPHRASE_NONE) {
-                                        passphrase_type = check_registered_passwords(cd);
-                                        if (passphrase_type == PASSPHRASE_NONE)
-                                                return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "No passphrase or recovery key registered.");
-                                }
-
-                                r = get_password(
-                                                volume,
-                                                source,
-                                                until,
-                                                /* ignore_cached= */ !use_cached_passphrase || arg_verify,
-                                                passphrase_type,
-                                                &passwords);
-                                use_cached_passphrase = false;
-                                if (r == -EAGAIN)
-                                        continue;
+                        if (try_discover_key) {
+                                r = discover_key(discovered_key_fn, volume, token_type, &discovered_key_data);
                                 if (r < 0)
                                         return r;
+                                if (r > 0)
+                                        key_data = &discovered_key_data;
                         }
+
+                        if (token_type < 0 && !key_file && !key_data && !passwords) {
+
+                                /* If we have nothing to try anymore, then acquire a new password */
+
+                                if (arg_try_empty_password) {
+                                        /* Hmm, let's try an empty password now, but only once */
+                                        arg_try_empty_password = false;
+                                        key_data = &iovec_empty;
+                                } else {
+                                        /* Ask the user for a passphrase or recovery key only as last resort, if we
+                                        * have nothing else to check for */
+                                        if (passphrase_type == PASSPHRASE_NONE) {
+                                                passphrase_type = check_registered_passwords(cd);
+                                                if (passphrase_type == PASSPHRASE_NONE)
+                                                        return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "No passphrase or recovery key registered.");
+                                        }
+
+                                        r = get_password(
+                                                        volume,
+                                                        source,
+                                                        until,
+                                                        /* ignore_cached= */ !use_cached_passphrase || arg_verify,
+                                                        passphrase_type,
+                                                        &passwords);
+                                        use_cached_passphrase = false;
+                                        if (r == -EAGAIN)
+                                                continue;
+                                        if (r < 0)
+                                                return r;
+                                }
+                        }
+
+                        if (streq_ptr(arg_type, CRYPT_TCRYPT))
+                                r = attach_tcrypt(cd, volume, token_type, key_file, key_data, passwords, flags);
+                        else
+                                r = attach_luks_or_plain_or_bitlk(cd, volume, token_type, key_file, key_data, passwords, flags, until);
+                        if (r >= 0)
+                                break;
+                        if (r != -EAGAIN)
+                                return r;
+
+                        /* Key not correct? Let's try again, but let's invalidate one of the passed fields, so that
+                        * we fall back to the next best thing. */
+
+                        if (token_type == TOKEN_TPM2) {
+                                arg_tpm2_device = mfree(arg_tpm2_device);
+                                arg_tpm2_device_auto = false;
+                                continue;
+                        }
+
+                        if (token_type == TOKEN_FIDO2) {
+                                arg_fido2_device = mfree(arg_fido2_device);
+                                arg_fido2_device_auto = false;
+                                continue;
+                        }
+
+                        if (token_type == TOKEN_PKCS11) {
+                                arg_pkcs11_uri = mfree(arg_pkcs11_uri);
+                                arg_pkcs11_uri_auto = false;
+                                continue;
+                        }
+
+                        if (try_discover_key) {
+                                try_discover_key = false;
+                                continue;
+                        }
+
+                        if (key_file) {
+                                key_file = NULL;
+                                continue;
+                        }
+
+                        if (passwords) {
+                                passwords = strv_free_erase(passwords);
+                                continue;
+                        }
+
+                        log_debug("Prepared for next attempt to unlock.");
                 }
 
-                if (streq_ptr(arg_type, CRYPT_TCRYPT))
-                        r = attach_tcrypt(cd, volume, token_type, key_file, key_data, passwords, flags);
-                else
-                        r = attach_luks_or_plain_or_bitlk(cd, volume, token_type, key_file, key_data, passwords, flags, until);
-                if (r >= 0)
-                        break;
-                if (r != -EAGAIN)
-                        return r;
-
-                /* Key not correct? Let's try again, but let's invalidate one of the passed fields, so that
-                 * we fall back to the next best thing. */
-
-                if (token_type == TOKEN_TPM2) {
-                        arg_tpm2_device = mfree(arg_tpm2_device);
-                        arg_tpm2_device_auto = false;
-                        continue;
-                }
-
-                if (token_type == TOKEN_FIDO2) {
-                        arg_fido2_device = mfree(arg_fido2_device);
-                        arg_fido2_device_auto = false;
-                        continue;
-                }
-
-                if (token_type == TOKEN_PKCS11) {
-                        arg_pkcs11_uri = mfree(arg_pkcs11_uri);
-                        arg_pkcs11_uri_auto = false;
-                        continue;
-                }
-
-                if (try_discover_key) {
-                        try_discover_key = false;
-                        continue;
-                }
-
-                if (key_file) {
-                        key_file = NULL;
-                        continue;
-                }
-
-                if (passwords) {
-                        passwords = strv_free_erase(passwords);
-                        continue;
-                }
-
-                log_debug("Prepared for next attempt to unlock.");
+                if (arg_tries != 0 && tries >= arg_tries)
+                        return log_error_errno(SYNTHETIC_ERRNO(EPERM), "Too many attempts to activate; giving up.");
         }
 
-        if (arg_tries != 0 && tries >= arg_tries)
-                return log_error_errno(SYNTHETIC_ERRNO(EPERM), "Too many attempts to activate; giving up.");
+activated:
+        if (arg_wipe) {
+                _cleanup_free_ char *device = path_join("/dev/mapper/", volume);
+                if (!device)
+                        return log_oom();
+
+                r = wipe_fs_superblock(device);
+                if (r < 0)
+                        return r;
+        }
 
         return 0;
 }

--- a/src/cryptsetup/cryptsetup.c
+++ b/src/cryptsetup/cryptsetup.c
@@ -11,6 +11,7 @@
 
 #include "alloc-util.h"
 #include "ask-password-api.h"
+#include "blkid-util.h"
 #include "build.h"
 #include "crypto-util.h"
 #include "cryptsetup-fido2.h"
@@ -25,6 +26,7 @@
 #include "errno-util.h"
 #include "escape.h"
 #include "extract-word.h"
+#include "fd-util.h"
 #include "fileio.h"
 #include "format-table.h"
 #include "fs-util.h"
@@ -43,6 +45,7 @@
 #include "pretty-print.h"
 #include "process-util.h"
 #include "random-util.h"
+#include "stat-util.h"
 #include "string-table.h"
 #include "string-util.h"
 #include "strv.h"
@@ -128,6 +131,7 @@ static char *arg_link_keyring = NULL;
 static char *arg_link_key_type = NULL;
 static char *arg_link_key_description = NULL;
 static char *arg_fixate_volume_key = NULL;
+static bool arg_wipe = false;
 
 STATIC_DESTRUCTOR_REGISTER(arg_cipher, freep);
 STATIC_DESTRUCTOR_REGISTER(arg_hash, freep);
@@ -661,7 +665,9 @@ static int parse_one_option(const char *option) {
                 if (r < 0)
                         return log_oom();
 
-        } else if (!streq(option, "x-initrd.attach"))
+        } else if (streq(option, "wipe"))
+                arg_wipe = true;
+        else if (!streq(option, "x-initrd.attach"))
                 log_warning("Encountered unknown /etc/crypttab option '%s', ignoring.", option);
 
         return 0;
@@ -2596,6 +2602,66 @@ static int discover_key(const char *key_file, const char *volume, TokenType toke
         return r;
 }
 
+static int wipe_fs_superblock(const char *device) {
+#if HAVE_BLKID
+        _cleanup_(blkid_free_probep) blkid_probe probe = NULL;
+        _cleanup_close_ int fd = -EBADF;
+        int r;
+
+        assert(device);
+
+        r = dlopen_libblkid(LOG_ERR);
+        if (r < 0)
+                return r;
+
+        fd = open(device, O_RDWR|O_CLOEXEC|O_NONBLOCK);
+        if (fd < 0)
+                return log_error_errno(errno, "Failed to open device %s: %m", device);
+
+        r = fd_verify_block(fd);
+        if (r < 0)
+                return log_error_errno(r, "Verification that '%s' is actually a block device failed: %m", device);
+
+        probe = sym_blkid_new_probe();
+        if (!probe)
+                return log_oom();
+
+        errno = 0;
+        r = sym_blkid_probe_set_device(probe, fd, /* off= */0, /* size= */0);
+        if (r < 0)
+                return log_error_errno(errno_or_else(EIO), "Failed to allocate device probe for wiping.");
+
+        errno = 0;
+        if (sym_blkid_probe_enable_superblocks(probe, true) < 0 ||
+            sym_blkid_probe_set_superblocks_flags(probe, BLKID_SUBLKS_MAGIC|BLKID_SUBLKS_BADCSUM) < 0 ||
+            sym_blkid_probe_enable_partitions(probe, true) < 0 ||
+            sym_blkid_probe_set_partitions_flags(probe, BLKID_PARTS_MAGIC) < 0)
+                return log_error_errno(errno_or_else(EIO), "Failed to enable superblock and partition probing.");
+
+        /* We have a counter here for robustness not allowing blkid stuck */
+        for (int i = 5; i > 0; i--) {
+                errno = 0;
+                r = sym_blkid_do_probe(probe);
+                if (r < 0)
+                        return log_error_errno(errno_or_else(EIO), "Failed to probe for file systems.");
+                if (r > 0)
+                        break;
+
+                errno = 0;
+                if (sym_blkid_do_wipe(probe, false) < 0)
+                        return log_error_errno(errno_or_else(EIO), "Failed to wipe file system signature.");
+
+                if (i == 1)
+                        log_info("Not all the disk and partitions fs signatures wiped, continuing.");
+        }
+
+        return 0;
+#else
+        return log_error_errno(SYNTHETIC_ERRNO(EOPNOTSUPP),
+                               "Cannot wipe fs and partition signatures, libblkid support is not compiled in.");
+#endif
+}
+
 VERB(verb_attach, "attach", "VOLUME SOURCE-DEVICE [KEY-FILE] [CONFIG]", 3, 5, 0,
      "Attach an encrypted block device");
 static int verb_attach(int argc, char *argv[], uintptr_t _data, void *userdata) {
@@ -2629,6 +2695,11 @@ static int verb_attach(int argc, char *argv[], uintptr_t _data, void *userdata) 
                 r = parse_crypt_config(config);
                 if (r < 0)
                         return r;
+        }
+
+        if (key_file && random_is_rng_device(key_file) && !arg_wipe) {
+                arg_wipe = true;
+                log_info("RNG device is used as key file. Enabling wipe mode.");
         }
 
         log_debug("%s %s ← %s type=%s cipher=%s", __func__,
@@ -2713,7 +2784,7 @@ static int verb_attach(int argc, char *argv[], uintptr_t _data, void *userdata) 
                                         "cryptsetup.luks2-pin");
                         if (r >= 0) {
                                 log_debug("Volume %s activated with a LUKS token.", volume);
-                                return 0;
+                                goto activated;
                         }
 
                         log_debug_errno(r, "Token activation unsuccessful for device %s: %m", sym_crypt_get_device_name(cd));
@@ -2726,114 +2797,129 @@ static int verb_attach(int argc, char *argv[], uintptr_t _data, void *userdata) 
                         return log_error_errno(r, "Failed to load Bitlocker superblock on device %s: %m", sym_crypt_get_device_name(cd));
         }
 
-        bool use_cached_passphrase = true, try_discover_key = !key_file;
-        const char *discovered_key_fn = strjoina(volume, ".key");
-        _cleanup_strv_free_erase_ char **passwords = NULL;
-        for (tries = 0; arg_tries == 0 || tries < arg_tries; tries++) {
-                _cleanup_(iovec_done_erase) struct iovec discovered_key_data = {};
-                const struct iovec *key_data = NULL;
-                TokenType token_type = determine_token_type();
+        {
+                bool use_cached_passphrase = true, try_discover_key = !key_file;
+                const char *discovered_key_fn = strjoina(volume, ".key");
+                _cleanup_strv_free_erase_ char **passwords = NULL;
+                for (tries = 0; arg_tries == 0 || tries < arg_tries; tries++) {
+                        _cleanup_(iovec_done_erase) struct iovec discovered_key_data = {};
+                        const struct iovec *key_data = NULL;
+                        TokenType token_type = determine_token_type();
 
-                log_debug("Beginning attempt %u to unlock.", tries);
+                        log_debug("Beginning attempt %u to unlock.", tries);
 
-                /* When we were able to acquire multiple keys, let's always process them in this order:
-                 *
-                 *    1. A key acquired via PKCS#11 or FIDO2 token, or TPM2 chip
-                 *    2. The configured or discovered key, of which both are exclusive and optional
-                 *    3. The empty password, in case arg_try_empty_password is set
-                 *    4. We enquire the user for a password
-                 */
+                        /* When we were able to acquire multiple keys, let's always process them in this order:
+                        *
+                        *    1. A key acquired via PKCS#11 or FIDO2 token, or TPM2 chip
+                        *    2. The configured or discovered key, of which both are exclusive and optional
+                        *    3. The empty password, in case arg_try_empty_password is set
+                        *    4. We enquire the user for a password
+                        */
 
-                if (try_discover_key) {
-                        r = discover_key(discovered_key_fn, volume, token_type, &discovered_key_data);
-                        if (r < 0)
-                                return r;
-                        if (r > 0)
-                                key_data = &discovered_key_data;
-                }
-
-                if (token_type < 0 && !key_file && !key_data && !passwords) {
-
-                        /* If we have nothing to try anymore, then acquire a new password */
-
-                        if (arg_try_empty_password) {
-                                /* Hmm, let's try an empty password now, but only once */
-                                arg_try_empty_password = false;
-                                key_data = &iovec_empty;
-                        } else {
-                                /* Ask the user for a passphrase or recovery key only as last resort, if we
-                                 * have nothing else to check for */
-                                if (passphrase_type == PASSPHRASE_NONE) {
-                                        passphrase_type = check_registered_passwords(cd);
-                                        if (passphrase_type == PASSPHRASE_NONE)
-                                                return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "No passphrase or recovery key registered.");
-                                }
-
-                                r = get_password(
-                                                volume,
-                                                source,
-                                                until,
-                                                /* ignore_cached= */ !use_cached_passphrase || arg_verify,
-                                                passphrase_type,
-                                                &passwords);
-                                use_cached_passphrase = false;
-                                if (r == -EAGAIN)
-                                        continue;
+                        if (try_discover_key) {
+                                r = discover_key(discovered_key_fn, volume, token_type, &discovered_key_data);
                                 if (r < 0)
                                         return r;
+                                if (r > 0)
+                                        key_data = &discovered_key_data;
                         }
+
+                        if (token_type < 0 && !key_file && !key_data && !passwords) {
+
+                                /* If we have nothing to try anymore, then acquire a new password */
+
+                                if (arg_try_empty_password) {
+                                        /* Hmm, let's try an empty password now, but only once */
+                                        arg_try_empty_password = false;
+                                        key_data = &iovec_empty;
+                                } else {
+                                        /* Ask the user for a passphrase or recovery key only as last resort, if we
+                                        * have nothing else to check for */
+                                        if (passphrase_type == PASSPHRASE_NONE) {
+                                                passphrase_type = check_registered_passwords(cd);
+                                                if (passphrase_type == PASSPHRASE_NONE)
+                                                        return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "No passphrase or recovery key registered.");
+                                        }
+
+                                        r = get_password(
+                                                        volume,
+                                                        source,
+                                                        until,
+                                                        /* ignore_cached= */ !use_cached_passphrase || arg_verify,
+                                                        passphrase_type,
+                                                        &passwords);
+                                        use_cached_passphrase = false;
+                                        if (r == -EAGAIN)
+                                                continue;
+                                        if (r < 0)
+                                                return r;
+                                }
+                        }
+
+                        if (streq_ptr(arg_type, CRYPT_TCRYPT))
+                                r = attach_tcrypt(cd, volume, token_type, key_file, key_data, passwords, flags);
+                        else
+                                r = attach_luks_or_plain_or_bitlk(cd, volume, token_type, key_file, key_data, passwords, flags, until);
+                        if (r >= 0)
+                                break;
+                        if (r != -EAGAIN)
+                                return r;
+
+                        /* Key not correct? Let's try again, but let's invalidate one of the passed fields, so that
+                        * we fall back to the next best thing. */
+
+                        if (token_type == TOKEN_TPM2) {
+                                arg_tpm2_device = mfree(arg_tpm2_device);
+                                arg_tpm2_device_auto = false;
+                                continue;
+                        }
+
+                        if (token_type == TOKEN_FIDO2) {
+                                arg_fido2_device = mfree(arg_fido2_device);
+                                arg_fido2_device_auto = false;
+                                continue;
+                        }
+
+                        if (token_type == TOKEN_PKCS11) {
+                                arg_pkcs11_uri = mfree(arg_pkcs11_uri);
+                                arg_pkcs11_uri_auto = false;
+                                continue;
+                        }
+
+                        if (try_discover_key) {
+                                try_discover_key = false;
+                                continue;
+                        }
+
+                        if (key_file) {
+                                key_file = NULL;
+                                continue;
+                        }
+
+                        if (passwords) {
+                                passwords = strv_free_erase(passwords);
+                                continue;
+                        }
+
+                        log_debug("Prepared for next attempt to unlock.");
                 }
 
-                if (streq_ptr(arg_type, CRYPT_TCRYPT))
-                        r = attach_tcrypt(cd, volume, token_type, key_file, key_data, passwords, flags);
-                else
-                        r = attach_luks_or_plain_or_bitlk(cd, volume, token_type, key_file, key_data, passwords, flags, until);
-                if (r >= 0)
-                        break;
-                if (r != -EAGAIN)
-                        return r;
-
-                /* Key not correct? Let's try again, but let's invalidate one of the passed fields, so that
-                 * we fall back to the next best thing. */
-
-                if (token_type == TOKEN_TPM2) {
-                        arg_tpm2_device = mfree(arg_tpm2_device);
-                        arg_tpm2_device_auto = false;
-                        continue;
-                }
-
-                if (token_type == TOKEN_FIDO2) {
-                        arg_fido2_device = mfree(arg_fido2_device);
-                        arg_fido2_device_auto = false;
-                        continue;
-                }
-
-                if (token_type == TOKEN_PKCS11) {
-                        arg_pkcs11_uri = mfree(arg_pkcs11_uri);
-                        arg_pkcs11_uri_auto = false;
-                        continue;
-                }
-
-                if (try_discover_key) {
-                        try_discover_key = false;
-                        continue;
-                }
-
-                if (key_file) {
-                        key_file = NULL;
-                        continue;
-                }
-
-                if (passwords) {
-                        passwords = strv_free_erase(passwords);
-                        continue;
-                }
-
-                log_debug("Prepared for next attempt to unlock.");
+                if (arg_tries != 0 && tries >= arg_tries)
+                        return log_error_errno(SYNTHETIC_ERRNO(EPERM), "Too many attempts to activate; giving up.");
         }
 
-        if (arg_tries != 0 && tries >= arg_tries)
-                return log_error_errno(SYNTHETIC_ERRNO(EPERM), "Too many attempts to activate; giving up.");
+activated:
+        if (arg_wipe) {
+                _cleanup_free_ char *device = path_join("/dev/mapper/", volume);
+                if (!device)
+                        return log_oom();
+
+                r = wipe_fs_superblock(device);
+                if (r < 0)
+                        log_warning_errno(r, "Failed to wipe file system and partition signatures from %s: %m", device);
+                else
+                        log_info("Successfully wiped file system and partition signatures from %s.", device);
+        }
 
         return 0;
 }

--- a/test/units/TEST-24-CRYPTSETUP.sh
+++ b/test/units/TEST-24-CRYPTSETUP.sh
@@ -34,17 +34,35 @@ trap at_exit EXIT
 cryptsetup_start_and_check() {
     local expect_fail=0
     local umount_header_and_key=0
+    local check_fs_header=0
+    local expect_no_fs_header=0
     local ec volume unit
+    local blkid_status
 
-    if [[ "${1:?}" == "-f" ]]; then
-        expect_fail=1
-        shift
-    fi
-
-    if [[ "${1:?}" == "-u" ]]; then
-        umount_header_and_key=1
-        shift
-    fi
+    while (($# > 0)); do
+        case "$1" in
+            -f)
+                expect_fail=1
+                shift
+                ;;
+            -u)
+                umount_header_and_key=1
+                shift
+                ;;
+            -h)
+                check_fs_header=1
+                shift
+                ;;
+            -H)
+                expect_no_fs_header=1
+                check_fs_header=1
+                shift
+                ;;
+            *)
+                break
+                ;;
+        esac
+    done
 
     for volume in "$@"; do
         unit="systemd-cryptsetup@$volume.service"
@@ -74,13 +92,34 @@ cryptsetup_start_and_check() {
             udevadm settle --timeout=60
         fi
 
+        ec=0
+        if [[ "$check_fs_header" -ne 0 ]]; then
+            blkid "/dev/mapper/$volume" && blkid_status="succeeded" || blkid_status="failed"
+
+            if [[ "$expect_no_fs_header" -ne 0 && "$blkid_status" == "succeeded" ]]; then
+                echo >&2 "blkid unexpectedly found a fs header on /dev/mapper/$volume"
+                ec=1
+            elif [[ "$expect_no_fs_header" -eq 0 && "$blkid_status" == "failed" ]]; then
+                echo >&2 "blkid failed for /dev/mapper/$volume"
+                ec=1
+            fi
+            if [ "$ec" -eq 0 ]; then
+                echo "[INFO] blkid $blkid_status for /dev/mapper/$volume as expected"
+            fi
+        fi
+
         systemctl status "$unit"
         test -e "/dev/mapper/$volume"
         systemctl stop "$unit"
         test ! -e "/dev/mapper/$volume"
+
+        if [[ "$ec" -ne 0 ]]; then
+            echo >&2 "Test failed for $unit"
+            break
+        fi
     done
 
-    return 0
+    return $ec
 }
 
 # Note: some stuff (especially TPM-related) is already tested by TEST-70-TPM2,
@@ -137,6 +176,15 @@ cryptsetup luksAddKey --batch-mode \
                       --key-slot 8 \
                       "$IMAGE_DETACHED" "$IMAGE_DETACHED_KEYFILE2"
 
+# Add an fs signature to the detached mapping.
+cryptsetup open "$IMAGE_DETACHED" detached_fs_init \
+    --header "$IMAGE_DETACHED_HEADER" \
+    --key-file "$IMAGE_DETACHED_KEYFILE" \
+    --keyfile-offset 32 \
+    --keyfile-size 16
+mkfs.ext4 -F /dev/mapper/detached_fs_init
+cryptsetup close detached_fs_init
+
 # Prepare a couple of dummy devices we'll store a copy of the detached header
 # and one of the keys on to test if systemd-cryptsetup correctly mounts them
 # when necessary
@@ -184,6 +232,7 @@ empty1               $IMAGE_EMPTY    -                               headless=1,
 # This one expects the key to be under /{etc,run}/cryptsetup-keys.d/empty_nokey.key
 empty_nokey          $IMAGE_EMPTY    -                               headless=1
 empty_pkcs11_auto    $IMAGE_EMPTY    -                               headless=1,pkcs11-uri=auto
+empty_urandom        $IMAGE_EMPTY    /dev/urandom                    headless=1,plain,size=256
 
 detached             $IMAGE_DETACHED $IMAGE_DETACHED_KEYFILE         headless=1,header=$IMAGE_DETACHED_HEADER,keyfile-offset=32,keyfile-size=16
 detached_store0      $IMAGE_DETACHED $IMAGE_DETACHED_KEYFILE         headless=1,header=/header:LABEL=header_store,keyfile-offset=32,keyfile-size=16
@@ -198,6 +247,7 @@ detached_slot0       $IMAGE_DETACHED $IMAGE_DETACHED_KEYFILE2        headless=1,
 detached_slot1       $IMAGE_DETACHED $IMAGE_DETACHED_KEYFILE2        headless=1,header=$IMAGE_DETACHED_HEADER,key-slot=8
 detached_slot_fail   $IMAGE_DETACHED $IMAGE_DETACHED_KEYFILE2        headless=1,header=$IMAGE_DETACHED_HEADER,key-slot=0
 detached_nofail      $IMAGE_DETACHED $TMPFS_DETACHED_KEYFILE/keyfile headless=1,header=$TMPFS_DETACHED_HEADER/header,keyfile-offset=32,keyfile-size=16,nofail
+detached_wipe        $IMAGE_DETACHED $IMAGE_DETACHED_KEYFILE         headless=1,header=$IMAGE_DETACHED_HEADER,keyfile-offset=32,keyfile-size=16,wipe
 EOF
 
 # Temporarily drop luks.name=/luks.uuid= from the kernel command line, as it makes
@@ -227,6 +277,8 @@ cryptsetup_start_and_check -f empty_nokey
 mkdir -p /run/cryptsetup-keys.d
 cp "$IMAGE_EMPTY_KEYFILE" /run/cryptsetup-keys.d/empty_nokey.key
 cryptsetup_start_and_check empty_nokey
+# just checking that RNG device can be used as a key file
+cryptsetup_start_and_check empty_urandom
 
 if [[ -d /usr/lib/softhsm/tokens ]]; then
     # Test unlocking with a PKCS#11 token
@@ -327,7 +379,8 @@ cryptsetup_start_and_check -f detached_fail{0..4}
 cryptsetup_start_and_check detached_slot{0..1}
 cryptsetup_start_and_check -f detached_slot_fail
 cryptsetup_start_and_check -u detached_nofail
-
+cryptsetup_start_and_check -h detached
+cryptsetup_start_and_check -H detached_wipe
 systemd-cryptenroll --list-devices
 
 touch /testok

--- a/test/units/TEST-24-CRYPTSETUP.sh
+++ b/test/units/TEST-24-CRYPTSETUP.sh
@@ -34,17 +34,34 @@ trap at_exit EXIT
 cryptsetup_start_and_check() {
     local expect_fail=0
     local umount_header_and_key=0
+    local check_fs_header=0
+    local expect_no_fs_header=0
     local ec volume unit
+    local blkid_status
 
-    if [[ "${1:?}" == "-f" ]]; then
-        expect_fail=1
-        shift
-    fi
-
-    if [[ "${1:?}" == "-u" ]]; then
-        umount_header_and_key=1
-        shift
-    fi
+    while (($# > 0)); do
+        case "$1" in
+            -f)
+                expect_fail=1
+                shift
+                ;;
+            -u)
+                umount_header_and_key=1
+                shift
+                ;;
+            -h)
+                check_fs_header=1
+                shift
+                ;;
+            -H)
+                expect_no_fs_header=1
+                shift
+                ;;
+            *)
+                break
+                ;;
+        esac
+    done
 
     for volume in "$@"; do
         unit="systemd-cryptsetup@$volume.service"
@@ -74,13 +91,34 @@ cryptsetup_start_and_check() {
             udevadm settle --timeout=60
         fi
 
+        ec=0
+        if [[ "$check_fs_header" -ne 0 ]]; then
+            blkid "/dev/mapper/$volume" && blkid_status="succeeded" || blkid_status="failed"
+
+            if [[ "$expect_no_fs_header" -ne 0 && "$blkid_status" == "succeeded" ]]; then
+                echo >&2 "blkid unexpectedly found a fs header on /dev/mapper/$volume"
+                ec=1
+            elif [[ "$expect_no_fs_header" -eq 0 && "$blkid_status" == "failed" ]]; then
+                echo >&2 "blkid failed for /dev/mapper/$volume"
+                ec=1
+            fi
+            if [ "$ec" -eq 0 ]; then
+                echo "[INFO] blkid $blkid_status for /dev/mapper/$volume as expected"
+            fi
+        fi
+
         systemctl status "$unit"
         test -e "/dev/mapper/$volume"
         systemctl stop "$unit"
         test ! -e "/dev/mapper/$volume"
+
+        if [[ "$ec" -ne 0 ]]; then
+            echo >&2 "Test failed for $unit"
+            break
+        fi
     done
 
-    return 0
+    return $ec
 }
 
 # Note: some stuff (especially TPM-related) is already tested by TEST-70-TPM2,
@@ -137,6 +175,15 @@ cryptsetup luksAddKey --batch-mode \
                       --key-slot 8 \
                       "$IMAGE_DETACHED" "$IMAGE_DETACHED_KEYFILE2"
 
+# Add an fs signature to the detached mapping.
+cryptsetup open "$IMAGE_DETACHED" detached_fs_init \
+    --header "$IMAGE_DETACHED_HEADER" \
+    --key-file "$IMAGE_DETACHED_KEYFILE" \
+    --keyfile-offset 32 \
+    --keyfile-size 16
+mkfs.ext4 -F /dev/mapper/detached_fs_init
+cryptsetup close detached_fs_init
+
 # Prepare a couple of dummy devices we'll store a copy of the detached header
 # and one of the keys on to test if systemd-cryptsetup correctly mounts them
 # when necessary
@@ -184,6 +231,7 @@ empty1               $IMAGE_EMPTY    -                               headless=1,
 # This one expects the key to be under /{etc,run}/cryptsetup-keys.d/empty_nokey.key
 empty_nokey          $IMAGE_EMPTY    -                               headless=1
 empty_pkcs11_auto    $IMAGE_EMPTY    -                               headless=1,pkcs11-uri=auto
+empty_urandom        $IMAGE_EMPTY    /dev/urandom                    headless=1,plain,size=256
 
 detached             $IMAGE_DETACHED $IMAGE_DETACHED_KEYFILE         headless=1,header=$IMAGE_DETACHED_HEADER,keyfile-offset=32,keyfile-size=16
 detached_store0      $IMAGE_DETACHED $IMAGE_DETACHED_KEYFILE         headless=1,header=/header:LABEL=header_store,keyfile-offset=32,keyfile-size=16
@@ -198,6 +246,7 @@ detached_slot0       $IMAGE_DETACHED $IMAGE_DETACHED_KEYFILE2        headless=1,
 detached_slot1       $IMAGE_DETACHED $IMAGE_DETACHED_KEYFILE2        headless=1,header=$IMAGE_DETACHED_HEADER,key-slot=8
 detached_slot_fail   $IMAGE_DETACHED $IMAGE_DETACHED_KEYFILE2        headless=1,header=$IMAGE_DETACHED_HEADER,key-slot=0
 detached_nofail      $IMAGE_DETACHED $TMPFS_DETACHED_KEYFILE/keyfile headless=1,header=$TMPFS_DETACHED_HEADER/header,keyfile-offset=32,keyfile-size=16,nofail
+detached_wipe        $IMAGE_DETACHED $IMAGE_DETACHED_KEYFILE         headless=1,header=$IMAGE_DETACHED_HEADER,keyfile-offset=32,keyfile-size=16,wipe
 EOF
 
 # Temporarily drop luks.name=/luks.uuid= from the kernel command line, as it makes
@@ -227,6 +276,8 @@ cryptsetup_start_and_check -f empty_nokey
 mkdir -p /run/cryptsetup-keys.d
 cp "$IMAGE_EMPTY_KEYFILE" /run/cryptsetup-keys.d/empty_nokey.key
 cryptsetup_start_and_check empty_nokey
+# just checking that RNG device can be used as a key file
+cryptsetup_start_and_check empty_urandom
 
 if [[ -d /usr/lib/softhsm/tokens ]]; then
     # Test unlocking with a PKCS#11 token
@@ -269,7 +320,8 @@ cryptsetup_start_and_check -f detached_fail{0..4}
 cryptsetup_start_and_check detached_slot{0..1}
 cryptsetup_start_and_check -f detached_slot_fail
 cryptsetup_start_and_check -u detached_nofail
-
+cryptsetup_start_and_check -h detached
+cryptsetup_start_and_check -H detached_wipe
 systemd-cryptenroll --list-devices
 
 touch /testok


### PR DESCRIPTION
cryptsetup: added new "wipe" option to wipe accidental fs headers signatures if some random data is on disk

This patch tries to cure the issue report in
systemd/systemd#37328


Also I have a script with end-to-end test scenario, but found no place to add it to pipeline, so will just attach it here: [test-jbd-makefs_small.sh](https://github.com/user-attachments/files/27223929/test-jbd-makefs_small.sh)

Fixes: #37328