### PR TITLE
sd-varlink: fix wedged state after call setup failure

### DIFF
--- a/src/libsystemd/sd-varlink/sd-varlink.c
+++ b/src/libsystemd/sd-varlink/sd-varlink.c
@@ -1715,14 +1715,18 @@ static int varlink_call_internal(sd_varlink *v, sd_json_variant *request) {
 
         while (v->state == VARLINK_CALLING) {
                 r = sd_varlink_process(v);
-                if (r < 0)
+                if (r < 0) {
+                        v->n_pending--;
                         return r;
+                }
                 if (r > 0)
                         continue;
 
                 r = sd_varlink_wait(v, USEC_INFINITY);
-                if (r < 0)
+                if (r < 0) {
+                        v->n_pending--;
                         return r;
+                }
         }
 
         switch (v->state) {
@@ -1733,9 +1737,11 @@ static int varlink_call_internal(sd_varlink *v, sd_json_variant *request) {
 
         case VARLINK_PENDING_DISCONNECT:
         case VARLINK_DISCONNECTED:
+                v->n_pending--;
                 return varlink_log_errno(v, SYNTHETIC_ERRNO(ECONNRESET), "Connection was closed.");
 
         case VARLINK_PENDING_TIMEOUT:
+                v->n_pending--;
                 return varlink_log_errno(v, SYNTHETIC_ERRNO(ETIME), "Connection timed out.");
 
         default:


### PR DESCRIPTION
Fix a state accounting bug where varlink_call_internal() can leave n_pending incremented after an error, causing later calls on the same sd_varlink object to fail even though no pending call remains.

Addresses #41883 

**NOTE:** As noted in the PR bug found using the N184 scanning suite.  This was also used to help with the PR and suggested fix.

https://github.com/MillaFleurs/N184
