### PR TITLE
Improve error logging for fstat failure

### DIFF
--- a/src/mountfsd/mountwork.c
+++ b/src/mountfsd/mountwork.c
@@ -1362,7 +1362,7 @@ static int vl_method_make_directory(
 
         struct stat parent_stat;
         if (fstat(parent_fd, &parent_stat) < 0)
-                return r;
+                return log_debug_errno(errno, "Failed to fstat parent directory fd: %m");
 
         r = stat_verify_directory(&parent_stat);
         if (r < 0)


### PR DESCRIPTION
Small hygiene fix.  r must be >= 0 as per the prior statement (otherwise we would have returned).  This is really only going to be r == 0, which means return r; is return 0;  I'm updating this to use log_debug_errno

No bug or issue, again small hygiene fix.