### PR TITLE
fundamental: drop now-unused macro

### DIFF
--- a/src/fundamental/cleanup-fundamental.h
+++ b/src/fundamental/cleanup-fundamental.h
@@ -45,14 +45,6 @@
 #define DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_MACRO(type, macro, empty)      \
         DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_MACRO_RENAME(type, macro, macro##p, empty)
 
-/* Clean up a NULL-terminated array by dropping all the items in it (up to the first NULL).
- * The array itself is not deallocated. */
-#define DEFINE_ARRAY_DONE_FUNC(type, helper)                    \
-        void helper ## _many(type (*p)[]) {                     \
-                for (type *t = *ASSERT_PTR(p); *t; t++)         \
-                        *t = helper(*t);                        \
-        }
-
 /* Clean up an array of pointers to objects by dropping all the items in it.
  * The size of the array is passed in as a parameter, so NULL items may appear in the middle of the array.
  * Free the array itself afterwards. */


### PR DESCRIPTION
Followup for 9d2f5b4611a47b9e5a31296cea70c2d8c6c86bbb.