### PR TITLE
cryptsetup: avoid a segfault when a keyfile is passed along with a TPM device

### DIFF
--- a/src/cryptsetup/cryptsetup.c
+++ b/src/cryptsetup/cryptsetup.c
@@ -2060,7 +2060,7 @@ static int attach_luks_or_plain_or_bitlk_by_tpm2(
                                         /* pcrlock_path= */ NULL,
                                         /* primary_alg= */ 0,
                                         key_file, arg_keyfile_size, arg_keyfile_offset,
-                                        key_data, /* n_blobs= */ 1,
+                                        key_data, /* n_blobs= */ iovec_is_set(key_data) ? 1 : 0,
                                         /* policy_hash= */ NULL, /* we don't know the policy hash */
                                         /* n_policy_hash= */ 0,
                                         /* salt= */ NULL,

--- a/src/shared/tpm2-util.c
+++ b/src/shared/tpm2-util.c
@@ -5804,6 +5804,7 @@ int tpm2_unseal(Tpm2Context *c,
         int r;
 
         assert(n_blobs > 0);
+        assert(blobs);
         assert(iovec_is_valid(pubkey));
         assert(ret_secret);
 

--- a/test/units/TEST-70-TPM2.cryptsetup.sh
+++ b/test/units/TEST-70-TPM2.cryptsetup.sh
@@ -57,8 +57,9 @@ IMAGE="$(mktemp /tmp/systemd-cryptsetup-XXX.IMAGE)"
 
 truncate -s 20M "$IMAGE"
 echo -n passphrase >/tmp/passphrase
+echo -n wrong_passphrase >/tmp/wrong_passphrase
 # Change file mode to avoid "/tmp/passphrase has 0644 mode that is too permissive" messages
-chmod 0600 /tmp/passphrase
+chmod 0600 /tmp/passphrase /tmp/wrong_passphrase
 cryptsetup luksFormat -q --pbkdf pbkdf2 --pbkdf-force-iterations 1000 --use-urandom "$IMAGE" /tmp/passphrase
 
 # Unlocking via keyfile
@@ -237,4 +238,11 @@ EOF
     rmdir /tmp/dditest
 fi
 
-rm -f "$IMAGE" "$PRIMARY"
+# Key file can contain a TPM blob but in case it doesn't fallback should also work.
+systemd-cryptsetup attach test-volume "$IMAGE" /tmp/passphrase tpm2-device=auto,headless=1
+systemd-cryptsetup detach test-volume
+
+# Negative test: invalid passphrase should not work.
+(! systemd-cryptsetup attach test-volume "$IMAGE" /tmp/wrong_passphrase tpm2-device=auto,headless=1)
+
+rm -f "$IMAGE" "$PRIMARY" /tmp/passphrase /tmp/wrong_passphrase


### PR DESCRIPTION
A segfault is observed when both key_file and tpm2-device are simultaneously passed to systemd-cryptsetup, e.g.

```
  systemd-cryptsetup attach test_data /vol /my-pass tpm2-device=auto
```

The crash appears after commit 5c6aad9 but the flaw in the logic was pre-existing. 

Fixes #41867