### PR TITLE
mkosi: update debian commit reference to a6d0098d1086e93291248e1d7d0360563c0bb41d

### DIFF
--- a/mkosi/mkosi.pkgenv/mkosi.conf.d/debian-ubuntu.conf
+++ b/mkosi/mkosi.pkgenv/mkosi.conf.d/debian-ubuntu.conf
@@ -9,5 +9,5 @@ Environment=
         GIT_URL=https://salsa.debian.org/systemd-team/systemd.git
         GIT_SUBDIR=debian
         GIT_BRANCH=debian/master
-        GIT_COMMIT=94af257c72ac3e9bf20e324ff31c3bd5d8197f0e
+        GIT_COMMIT=1302f123d9ab65bbaff5d95935eabfd659456550
         PKG_SUBDIR=debian


### PR DESCRIPTION
* a6d0098d10 Install new files for upstream build
* ce07fd7616 d/t/boot-and-services: use coreutils tunable in apparmor test (LP: #2125614)