### PR TITLE
sysupdate: Ensure that end of the MatchPattern is matched correctly

### DIFF
--- a/src/sysupdate/sysupdate-pattern.c
+++ b/src/sysupdate/sysupdate-pattern.c
@@ -426,6 +426,10 @@ int pattern_match(const char *pattern, const char *s, InstanceMetadata *ret) {
                 p = n;
         }
 
+        /* We matched the whole pattern, but if the string continues over the end of the pattern, refuse */
+        if (*p != '\0')
+                goto nope;
+
         if (ret) {
                 *ret = found;
                 found = (InstanceMetadata) INSTANCE_METADATA_NULL;


### PR DESCRIPTION
An error snuck into the pattern parsing of the `MatchPattern` key in the sysupdate transfer files. If there's two files "part1-v2.raw", and "part1-v2.raw.tar" in the source folder, and MatchPattern="part1-@v.raw", sysupdate will incorrectly choose "part1-v2.raw.tar" instead of "part1-v2.raw".

While the pattern matching works perfectly fine, after the full pattern is successfully matched to the string, we don't ensure that the string actually ends when the pattern just did.

This means we can end up choosing a wrong file for the update, if the filename/path happens to start with the same MatchPattern.

Fix it by ensuring the string ends after our match pattern ended.