### PR TITLE
hwdb: Add missing Steelseries Arctis Pro Wireless

### DIFF
--- a/hwdb.d/70-sound-card.hwdb
+++ b/hwdb.d/70-sound-card.hwdb
@@ -55,6 +55,7 @@ usb:v1038p2216*
 usb:v1038p2236*
 usb:v1038p12C2*
 usb:v1038p1290*
+usb:v1038p1294*
 usb:v1038p12EC*
 usb:v1038p2269*
 usb:v1038p226D*


### PR DESCRIPTION
The Hub for these headsets uses the following
USB entries:

Bus 007 Device 002: ID 0451:2036 Texas Instruments, Inc. TUSB2036 Hub
Bus 007 Device 003: ID 1038:1290 SteelSeries ApS Arctis Pro Wireless
Bus 007 Device 004: ID 1038:1294 SteelSeries ApS Arctis Pro Wireless

Validated the changes using the `/etc/udev/hwdb.d/71-sound-card-local.hwdb` entry

<img width="560" height="108" alt="imagen" src="https://github.com/user-attachments/assets/57f0b0bb-0148-4487-8f4f-08decb547f3d" />
