### PR TITLE
iovec-util: introduce iovec_done_and_memdup()

### DIFF
--- a/src/basic/iovec-util.c
+++ b/src/basic/iovec-util.c
@@ -129,6 +129,21 @@ struct iovec* iovec_memdup(const struct iovec *source, struct iovec *ret) {
         return ret;
 }
 
+int iovec_done_and_memdup(struct iovec *iovec, const struct iovec *source) {
+        assert(iovec);
+
+        if (iovec_equal(iovec, source))
+                return 0;
+
+        struct iovec copy;
+        if (!iovec_memdup(source, &copy))
+                return -ENOMEM;
+
+        iovec_done(iovec);
+        *iovec = copy;
+        return 1;
+}
+
 struct iovec* iovec_append(struct iovec *iovec, const struct iovec *append) {
         assert(iovec_is_valid(iovec));
 

--- a/src/basic/iovec-util.h
+++ b/src/basic/iovec-util.h
@@ -43,5 +43,6 @@ static inline bool iovec_equal(const struct iovec *a, const struct iovec *b) {
 }
 
 struct iovec* iovec_memdup(const struct iovec *source, struct iovec *ret);
+int iovec_done_and_memdup(struct iovec *iovec, const struct iovec *source);
 
 struct iovec* iovec_append(struct iovec *iovec, const struct iovec *append);

--- a/src/test/test-iovec-util.c
+++ b/src/test/test-iovec-util.c
@@ -163,4 +163,29 @@ TEST(iovec_make_byte) {
         ASSERT_EQ(memcmp_nn(x.iov_base, x.iov_len, "x", 1), 0);
 }
 
+TEST(iovec_done_and_memdup) {
+        _cleanup_(iovec_done) struct iovec iov = {};
+
+        ASSERT_OK_ZERO(iovec_done_and_memdup(&iov, NULL));
+        ASSERT_TRUE(!iovec_is_set(&iov));
+        ASSERT_OK_ZERO(iovec_done_and_memdup(&iov, &(struct iovec) {}));
+        ASSERT_TRUE(!iovec_is_set(&iov));
+        ASSERT_OK_POSITIVE(iovec_done_and_memdup(&iov, &IOVEC_MAKE_STRING("aaa")));
+        ASSERT_TRUE(iovec_equal(&iov, &IOVEC_MAKE_STRING("aaa")));
+        ASSERT_OK_POSITIVE(iovec_done_and_memdup(&iov, &IOVEC_MAKE_STRING("bbbbb")));
+        ASSERT_TRUE(iovec_equal(&iov, &IOVEC_MAKE_STRING("bbbbb")));
+        ASSERT_OK_POSITIVE(iovec_done_and_memdup(&iov, NULL));
+        ASSERT_TRUE(!iovec_is_set(&iov));
+        ASSERT_OK_POSITIVE(iovec_done_and_memdup(&iov, &IOVEC_MAKE_STRING("ccc")));
+        ASSERT_TRUE(iovec_equal(&iov, &IOVEC_MAKE_STRING("ccc")));
+        ASSERT_OK_POSITIVE(iovec_done_and_memdup(&iov, &(struct iovec) {}));
+        ASSERT_TRUE(!iovec_is_set(&iov));
+        ASSERT_OK_ZERO(iovec_done_and_memdup(&iov, &iov));
+        ASSERT_TRUE(!iovec_is_set(&iov));
+        ASSERT_OK_POSITIVE(iovec_done_and_memdup(&iov, &IOVEC_MAKE_STRING("ddd")));
+        ASSERT_TRUE(iovec_equal(&iov, &IOVEC_MAKE_STRING("ddd")));
+        ASSERT_OK_ZERO(iovec_done_and_memdup(&iov, &iov));
+        ASSERT_TRUE(iovec_equal(&iov, &IOVEC_MAKE_STRING("ddd")));
+}
+
 DEFINE_TEST_MAIN(LOG_INFO);


### PR DESCRIPTION
It is similar to free_and_strdup(), but for struct iovec.