### PR TITLE
man: EnvironmentFile= honors %h, not \$HOME

### DIFF
--- a/man/systemd.exec.xml
+++ b/man/systemd.exec.xml
@@ -3294,6 +3294,10 @@ SystemCallErrorNumber=EPERM</programlisting>
         If the empty string is assigned to this option, the list of files to read is reset, all prior assignments
         have no effect.</para>
 
+        <para>Note that shell variables such as <literal>$HOME</literal> are not expanded in this path.
+        Use <literal>%</literal>-specifiers instead; for example, <literal>%h</literal> expands to the
+        user's home directory.</para>
+
         <para>The files listed with this directive will be read shortly before the process is executed (more
         specifically, after all processes from a previous unit state terminated. This means you can generate these
         files in one unit state, and read it with this option in the next. The files are read from the file


### PR DESCRIPTION
Fixes #38580

Add a note to EnvironmentFile= docs that shell variables like $HOME are not
expanded - use %h instead.