### PR TITLE
mountpoint-util: don't treat ZFS file systems as blockdev-backed

### DIFF
--- a/src/basic/mountpoint-util.c
+++ b/src/basic/mountpoint-util.c
@@ -410,7 +410,9 @@ bool fstype_is_blockdev_backed(const char *fstype) {
         if (x)
                 fstype = x;
 
-        return !STR_IN_SET(fstype, "9p", "overlay") && !fstype_is_network(fstype) && !fstype_is_api_vfs(fstype);
+        return !STR_IN_SET(fstype, "9p", "overlay", "zfs")
+                        && !fstype_is_network(fstype)
+                        && !fstype_is_api_vfs(fstype);
 }
 
 bool fstype_is_ro(const char *fstype) {


### PR DESCRIPTION
ZFS file systems aren't directly backed by block devices. Instead, they are mounted by naming a dataset, which is a concept defined on ZFS's own storage pool architecture.

If `fstype_is_blockdev_backed` identifies a ZFS file system as to be backed by a block device, this will cause `systemd-mount` to try to chase the dataset name as a file system path (e.g., `rpool/my/dataset`), which will fail. That, in turn, prevents a user from generating transient mount units with systemd-mount.

With this patch, `systemd-mount` can be used to mount ZFS file systems that have their `mountpoint` property set to `legacy` (manual mount, as preferred on distributions like NixOS).

<details>
<summary>The following test script (expecting root permissions, running on a ZFS-enabled host, and using Nix to build systemd) documents the old and new behavior:</summary>

```
#! /usr/bin/env bash

set -x

TMP_DIR="$(mktemp -d /tmp/systemd-mount-zfs-test-XXXX)"
ZFS_POOL_NAME="$(basename "$TMP_DIR")"

# Sanity check: make sure no pool with ZFS_POOL_NAME exists; we must not delete
# any existing pools:
if ! (zpool list "$ZFS_POOL_NAME" 2>&1 | grep "no such pool"); then
    echo "ZFS pool $ZFS_POOL_NAME exists, refusing..." >&2
    exit 1
fi

cleanup() {
    echo "Cleaning up..." >&2
    umount "$TMP_DIR/mnt"
    rm -rf "$TMP_DIR"
    zpool export "$ZFS_POOL_NAME"
}
trap cleanup EXIT SIGINT SIGTERM

# Create a new ZFS pool to test on:
truncate -s 100M "$TMP_DIR/disk.img"
zpool create "$ZFS_POOL_NAME" "$TMP_DIR/disk.img"

# Create a dataset with legacy mounting and a mount target:
zfs create -o mountpoint=legacy "$ZFS_POOL_NAME/test-dataset"
mkdir "$TMP_DIR/mnt"

# Try mounting with unpatched systemd-mount, and assert the "Failed to chase
# path" error:
OUT="$(systemd-mount -t zfs "$ZFS_POOL_NAME/test-dataset" "$TMP_DIR/mnt" 2>&1)"
if [ $? -eq 0 ] || [[ "$OUT" != *"Failed to chase path"* ]]; then
    echo "Unpatched systemd-mount unexpectedly did not error: $OUT" >&2
    exit 1
fi

# Try mounting with patched systemd-mount (which we build using Nix), and then
# assert that a transient mount unit is successfully defined:
PATCHED_SYSTEMD="$(nix-build --no-out-link -E '
  with import (builtins.fetchTarball {
    # nixos-unstable as of 2026-04-30T19:45:37.000Z
    url = "https://github.com/NixOS/nixpkgs/archive/15f4ee454b1dce334612fa6843b3e05cf546efab.tar.gz";
    sha256 = "sha256-Ad49moKWeXtKBJNy2ebiTQUEgdLyvGmTeykAQ9xM+Z4=";
  }) {};
  pkgs.systemd.overrideAttrs (oldAttrs: {
    patches = (oldAttrs.patches or []) ++ [
      ./0001-mountpoint-util-don-t-treat-ZFS-file-systems-as-bloc.patch
    ];
  })
')"

OUT="$(\
  $PATCHED_SYSTEMD/bin/systemd-mount \
    -t zfs "$ZFS_POOL_NAME/test-dataset" "$TMP_DIR/mnt" 2>&1)"
if [ $? -ne 0 ]; then
    echo "Mounting with patched systemd-mount failed!" >&2
    exit 1
fi

UNIT_NAME="$(echo "$OUT" | sed -E 's/^Started unit (.*) for mount point:.*$/\1/')"
systemctl status "$UNIT_NAME"
```

</details>