### PR TITLE
test: make varlink StartTransient checks compatible with jq 1.6

### DIFF
--- a/test/units/TEST-26-SYSTEMCTL.sh
+++ b/test/units/TEST-26-SYSTEMCTL.sh
@@ -552,32 +552,35 @@ result=$(varlinkctl call "$MANAGER_SOCKET" io.systemd.Unit.StartTransient \
 echo "$result" | grep '"context"' >/dev/null
 
 # Streaming with notifyJobChanges: should get intermediate state updates and a final result
+# Note: use --slurp + any() rather than 'select() -e' because in jq 1.6 (shipped on
+# CentOS 9) -e checks only the last input record's output, so a select() that filters
+# out the trailing record makes jq exit non-zero even when earlier records match.
 defer_transient_cleanup varlink-transient-test3.service
 result=$(varlinkctl call --more "$MANAGER_SOCKET" io.systemd.Unit.StartTransient \
     '{"context":{"ID":"varlink-transient-test3.service","Service":{"Type":"oneshot","ExecStart":[{"path":"/bin/true"}]}},"notifyJobChanges":true}')
-printf '%s' "$result" | jq --seq -e 'select(.job.State == "waiting")' >/dev/null
-printf '%s' "$result" | jq --seq -e 'select(.job.Result == "done")' >/dev/null
+printf '%s' "$result" | jq --seq --slurp -e 'any(.[]; .job.State == "waiting")' >/dev/null
+printf '%s' "$result" | jq --seq --slurp -e 'any(.[]; .job.Result == "done")' >/dev/null
 
 # Fire-and-forget: --more without notify flags should return immediately with context+runtime
 defer_transient_cleanup varlink-transient-fireforget.service
 result=$(varlinkctl call --more "$MANAGER_SOCKET" io.systemd.Unit.StartTransient \
     '{"context":{"ID":"varlink-transient-fireforget.service","Service":{"Type":"oneshot","ExecStart":[{"path":"/bin/true"}]}}}')
-printf '%s' "$result" | jq --seq -e 'select(.context)' >/dev/null
-printf '%s' "$result" | jq --seq -e 'select(.runtime)' >/dev/null
+printf '%s' "$result" | jq --seq --slurp -e 'any(.[]; .context)' >/dev/null
+printf '%s' "$result" | jq --seq --slurp -e 'any(.[]; .runtime)' >/dev/null
 
 # Streaming with notifyUnitChanges: should get unit state change notifications
 defer_transient_cleanup varlink-transient-unitnotify.service
 result=$(varlinkctl call --more "$MANAGER_SOCKET" io.systemd.Unit.StartTransient \
     '{"context":{"ID":"varlink-transient-unitnotify.service","Service":{"Type":"oneshot","ExecStart":[{"path":"/bin/true"}]}},"notifyUnitChanges":true}')
-printf '%s' "$result" | jq --seq -e 'select(.runtime.ActiveState)' >/dev/null
+printf '%s' "$result" | jq --seq --slurp -e 'any(.[]; .runtime.ActiveState)' >/dev/null
 
 # Streaming with both notifyJobChanges and notifyUnitChanges
 defer_transient_cleanup varlink-transient-both.service
 result=$(varlinkctl call --more "$MANAGER_SOCKET" io.systemd.Unit.StartTransient \
     '{"context":{"ID":"varlink-transient-both.service","Service":{"Type":"oneshot","ExecStart":[{"path":"/bin/true"}]}},"notifyJobChanges":true,"notifyUnitChanges":true}')
-printf '%s' "$result" | jq --seq -e 'select(.job.State)' >/dev/null
-printf '%s' "$result" | jq --seq -e 'select(.runtime.ActiveState)' >/dev/null
-printf '%s' "$result" | jq --seq -e 'select(.job.Result == "done")' >/dev/null
+printf '%s' "$result" | jq --seq --slurp -e 'any(.[]; .job.State)' >/dev/null
+printf '%s' "$result" | jq --seq --slurp -e 'any(.[]; .runtime.ActiveState)' >/dev/null
+printf '%s' "$result" | jq --seq --slurp -e 'any(.[]; .job.Result == "done")' >/dev/null
 
 # prepare for the error case below: create a long-running service, then try to create it again while it's active
 defer_transient_cleanup varlink-transient-exists.service
@@ -589,7 +592,7 @@ timeout 10 bash -c 'until systemctl is-active varlink-transient-exists.service; 
 defer_transient_cleanup varlink-transient-multi.service
 result=$(varlinkctl call --more "$MANAGER_SOCKET" io.systemd.Unit.StartTransient \
     '{"context":{"ID":"varlink-transient-multi.service","Service":{"Type":"oneshot","ExecStart":[{"path":"/bin/true"},{"path":"/bin/true"}]}},"notifyJobChanges":true}')
-printf '%s' "$result" | jq --seq -e 'select(.job.Result == "done")' >/dev/null
+printf '%s' "$result" | jq --seq --slurp -e 'any(.[]; .job.Result == "done")' >/dev/null
 
 # Transient service with Description and RemainAfterExit
 defer_transient_cleanup varlink-transient-desc.service


### PR DESCRIPTION
The new "varlinkctl --more StartTransient" subtest pipes a JSON-SEQ stream of multiple records into "jq --seq -e ...". CentOS 9 ships jq 1.6, where -e only inspects the last input record's output: when the trailing record (the final reply) doesn't match the "select()" filter, jq exits non-zero even though earlier records match, so the test fails.

Use --slurp which collapses the records into an array first and returns a single bool.

Follow-up for 1cde1cc3bab595fe7b4e2befbfa08a01a172db0f