### PR TITLE
hwdb: Add correct keyboard mapping for touchpad_toggle event on msi GS66 stealth

### DIFF
--- a/hwdb.d/60-keyboard.hwdb
+++ b/hwdb.d/60-keyboard.hwdb
@@ -1605,6 +1605,10 @@ evdev:atkbd:dmi:bvn*:bvr*:bd*:svnMicro-Star*:pn*:*
 evdev:atkbd:dmi:bvn*:bvr*:bd*:svnMICRO-STAR*:pnGF63*:*
  KEYBOARD_KEY_85=touchpad_toggle                        # Toggle touchpad, sends meta+ctrl+toggle
 
+# MSI GS66 Stealth toggles touchpad using Fn+F3 where the keyboard key is 76
+evdev:atkbd:dmi:bvn*:bvr*:bd*:svnMICRO-STAR*:pn*Stealth GS66*:*
+ KEYBOARD_KEY_76=touchpad_toggle                        # Toggle touchpad
+
 evdev:atkbd:dmi:bvn*:bvr*:bd*:svnMICRO-STAR*:pnGE60*:*
 evdev:atkbd:dmi:bvn*:bvr*:bd*:svnMICRO-STAR*:pnGE70*:*
  KEYBOARD_KEY_c2=ejectcd


### PR DESCRIPTION
To enable/disable touchpad using fn+F3 on the MSI GS66 Stealth, it uses scan code 0x76, but it was producing code 194 (KEY_F24), rather than the correct code 530 (KEY_TOUCHPAD_TOGGLE).

0x76 is already mapped to touchpad_toggle on MSI Prestige and Modern models, but it was not working by default on the GS66 stealth.


**Model info:**
MSI GS66 Stealth 12UE (i7-12700h)
Product name: GS66 Stealth 12UE

**udevadm info /dev/input/event3 output:**

```
P: /devices/platform/i8042/serio0/input/input53/event3
M: event3
R: 3
J: c13:67
U: input
D: c 13:67
N: input/event3
L: 0
S: input/by-path/platform-i8042-serio-0-event-kbd
E: DEVPATH=/devices/platform/i8042/serio0/input/input53/event3
E: DEVNAME=/dev/input/event3
E: MAJOR=13
E: MINOR=67
E: SUBSYSTEM=input
E: USEC_INITIALIZED=2532782297
E: KEYBOARD_KEY_9c=enter
E: KEYBOARD_KEY_76=touchpad_toggle
E: KEYBOARD_KEY_91=config
E: KEYBOARD_KEY_a0=mute
E: KEYBOARD_KEY_ae=volumedown
E: KEYBOARD_KEY_b0=volumeup
E: KEYBOARD_KEY_b2=www
E: KEYBOARD_KEY_c2=ejectcd
E: KEYBOARD_KEY_df=sleep
E: KEYBOARD_KEY_e2=bluetooth
E: KEYBOARD_KEY_e4=touchpad_toggle
E: KEYBOARD_KEY_ec=email
E: KEYBOARD_KEY_ee=camera
E: KEYBOARD_KEY_f1=micmute
E: KEYBOARD_KEY_f2=rotate_display
E: KEYBOARD_KEY_f6=wlan
E: KEYBOARD_KEY_f7=brightnessdown
E: KEYBOARD_KEY_f8=brightnessup
E: KEYBOARD_KEY_f9=search
E: ID_INPUT=1
E: ID_INPUT_KEY=1
E: ID_INPUT_KEYBOARD=1
E: ID_BUS=i8042
E: ID_SERIAL=noserial
E: ID_PATH=platform-i8042-serio-0
E: ID_PATH_TAG=platform-i8042-serio-0
E: ID_INTEGRATION=internal
E: LIBINPUT_DEVICE_GROUP=11/1/1:isa0060/serio0
E: DEVLINKS=/dev/input/by-path/platform-i8042-serio-0-event-kbd
E: TAGS=:power-switch:
E: CURRENT_TAGS=:power-switch:
```