### PR TITLE
test: make TEST-70-TPM2 and TEST-86-MULTI-PROFILE-UKI robust against reruns

### DIFF
--- a/test/integration-tests/TEST-70-TPM2/meson.build
+++ b/test/integration-tests/TEST-70-TPM2/meson.build
@@ -10,5 +10,8 @@ integration_tests += [
                 'vm' : true,
                 'firmware' : 'auto',
                 'tpm' : true,
+                'cmdline' : integration_test_template['cmdline'] + [
+                        'systemd.default_device_timeout_sec=300',
+                ],
         },
 ]

--- a/test/integration-tests/TEST-86-MULTI-PROFILE-UKI/meson.build
+++ b/test/integration-tests/TEST-86-MULTI-PROFILE-UKI/meson.build
@@ -7,5 +7,8 @@ integration_tests += [
                 'vm' : true,
                 'firmware' : 'auto',
                 'tpm' : true,
+                'cmdline' : integration_test_template['cmdline'] + [
+                        'systemd.default_device_timeout_sec=300',
+                ],
         },
 ]

--- a/test/units/TEST-70-TPM2.creds.sh
+++ b/test/units/TEST-70-TPM2.creds.sh
@@ -5,6 +5,12 @@ set -o pipefail
 
 export SYSTEMD_LOG_LEVEL=debug
 
+at_exit() {
+	rm -f /tmp/testdata /tmp/testdata.encrypted
+}
+
+trap at_exit EXIT
+
 # Ensure that sandboxing doesn't stop creds from being accessible
 echo "test" >/tmp/testdata
 systemd-creds encrypt /tmp/testdata /tmp/testdata.encrypted --with-key=tpm2
@@ -12,5 +18,3 @@ systemd-creds encrypt /tmp/testdata /tmp/testdata.encrypted --with-key=tpm2
 systemd-run -p PrivateDevices=yes -p LoadCredentialEncrypted=testdata.encrypted:/tmp/testdata.encrypted --pipe --wait systemd-creds cat testdata.encrypted | cmp - /tmp/testdata
 # SetCredentialEncrypted
 systemd-run -p PrivateDevices=yes -p SetCredentialEncrypted=testdata.encrypted:"$(cat /tmp/testdata.encrypted)" --pipe --wait systemd-creds cat testdata.encrypted | cmp - /tmp/testdata
-
-rm -f /tmp/testdata

--- a/test/units/TEST-70-TPM2.cryptenroll.sh
+++ b/test/units/TEST-70-TPM2.cryptenroll.sh
@@ -11,6 +11,12 @@ cryptenroll_wipe_and_check() {(
     grep -qE "Wiped slot [[:digit:]]+" /tmp/cryptenroll.out
 )}
 
+at_exit() {
+    rm -f "${IMAGE:-}" /tmp/cryptenroll.out /tmp/password
+}
+
+trap at_exit EXIT
+
 # There is an external issue with libcryptsetup on ppc64 that hits 95% of Ubuntu ppc64 test runs, so skip it
 if [[ "$(uname -m)" == "ppc64le" ]]; then
     echo "Skipping systemd-cryptenroll tests on ppc64le, see https://github.com/systemd/systemd/issues/27716"

--- a/test/units/TEST-70-TPM2.cryptsetup.sh
+++ b/test/units/TEST-70-TPM2.cryptsetup.sh
@@ -31,10 +31,23 @@ tpm_check_failure_with_wrong_pin() {
 }
 
 at_exit() {
+    set +e
+
+    umount /tmp/dditest.mnt
+    systemd-cryptsetup detach test-volume
+    systemd-cryptsetup detach dditest
+
     # Evict the TPM primary key that we persisted
     if [[ -n "${PERSISTENT_HANDLE:-}" ]]; then
         tpm2_evictcontrol -c "$PERSISTENT_HANDLE"
     fi
+
+    if [[ -n "${DEVICE:-}" ]]; then
+        systemd-dissect --detach "$DEVICE"
+    fi
+
+    rm -rf /tmp/dditest /tmp/dditest.mnt
+    rm -f /tmp/dditest.raw "${IMAGE:-}" "${PRIMARY:-}" /tmp/passphrase /tmp/pcr.dat /tmp/srk.pub /tmp/srk2.pub
 }
 
 trap at_exit EXIT

--- a/test/units/TEST-70-TPM2.measure.sh
+++ b/test/units/TEST-70-TPM2.measure.sh
@@ -14,6 +14,31 @@ if [[ ! -x "${SD_MEASURE:?}" ]]; then
     exit 0
 fi
 
+at_exit() {
+    set +e
+
+    systemd-cryptsetup detach test-volume2
+    rm -f "${IMAGE:-}" \
+        /tmp/passphrase \
+        /tmp/pcrsign-private.pem \
+        /tmp/pcrsign-public.pem \
+        /tmp/pcrsign.sig \
+        /tmp/pcrsign.sig2 \
+        /tmp/pcrsign.sig3 \
+        /tmp/pcrsign.sig4 \
+        /tmp/pcrsign.sig5 \
+        /tmp/pcrsign.sig6 \
+        /tmp/pcrsign.sig7 \
+        /tmp/pcrtestdata \
+        /tmp/pcrtestdata.encrypted \
+        /tmp/result \
+        /tmp/result.json \
+        /tmp/tpmdata1 \
+        /tmp/tpmdata2
+}
+
+trap at_exit EXIT
+
 IMAGE="$(mktemp /tmp/systemd-measure-XXX.image)"
 
 echo HALLO >/tmp/tpmdata1

--- a/test/units/TEST-70-TPM2.nvpcr.sh
+++ b/test/units/TEST-70-TPM2.nvpcr.sh
@@ -21,7 +21,7 @@ at_exit() {
     fi
 
     rm -rf /run/nvpcr /tmp/nvpcr
-    rm -f /var/tmp/nvpcr.raw /run/verity.d/test-79-nvpcr.crt
+    rm -f /var/tmp/nvpcr.raw /run/verity.d/test-70-nvpcr.crt /run/systemd/nvpcr/test.anchor
 }
 
 trap at_exit EXIT

--- a/test/units/TEST-70-TPM2.pcrextend.sh
+++ b/test/units/TEST-70-TPM2.pcrextend.sh
@@ -19,6 +19,16 @@ at_exit() {
         # Dump the event log on fail, to make debugging a bit easier
         jq --seq --slurp </run/log/systemd/tpm2-measure.log
     fi
+
+    set +e
+
+    if [[ -e /etc/machine-id.save ]]; then
+        mv /etc/machine-id.save /etc/machine-id
+    fi
+
+    rm -rf /run/systemd/system/systemd-pcrextend.socket.d
+    systemctl daemon-reload
+    rm -f /tmp/oldpcr16 /tmp/oldpcr15 /tmp/newpcr16 /tmp/newpcr15
 }
 
 trap at_exit EXIT

--- a/test/units/TEST-70-TPM2.pcrlock.sh
+++ b/test/units/TEST-70-TPM2.pcrlock.sh
@@ -23,7 +23,26 @@ at_exit() {
         [[ -e /run/log/systemd/tpm2-measure.log ]] && jq --seq --slurp </run/log/systemd/tpm2-measure.log
     fi
 
-    return 0
+    set +e
+
+    systemd-cryptsetup detach pcrlock
+
+    if [[ -x "${SD_PCRLOCK:-}" ]]; then
+        "$SD_PCRLOCK" remove-policy
+        "$SD_PCRLOCK" unlock-firmware-config
+        "$SD_PCRLOCK" unlock-gpt
+        "$SD_PCRLOCK" unlock-machine-id
+        "$SD_PCRLOCK" unlock-file-system
+        "$SD_PCRLOCK" unlock-raw --pcrlock=/var/lib/pcrlock.d/910-test70.pcrlock
+        "$SD_PCRLOCK" unlock-raw --pcrlock=/var/lib/pcrlock.d/920-test70.pcrlock
+    fi
+
+    rm -rf /tmp/fakexbootldr /var/lib/pcrlock.d/123-empty.pcrlock.d /run/systemd/system/systemd-pcrlock.socket.d
+    if [[ -n "${img:-}" ]]; then
+        rm -f "$img" "$img".private.pem "$img".public.pem "$img".pcrsign
+    fi
+    rm -f /tmp/borked /tmp/pcrlockpwd /var/lib/systemd/pcrlock.json /var/lib/systemd/pcrlock.json.gone
+    systemctl daemon-reload
 }
 
 trap at_exit EXIT

--- a/test/units/TEST-86-MULTI-PROFILE-UKI.sh
+++ b/test/units/TEST-86-MULTI-PROFILE-UKI.sh
@@ -64,6 +64,9 @@ elif [[ "$ID" == "profile1" ]]; then
 elif [[ "$ID" == "profile2" ]]; then
     grep testprofile2=1 /proc/cmdline
     rm /root/encrypted.raw
+    # Reset the default boot entry so a subsequent re-run of the test does not
+    # boot straight back into @profile2 (where encrypted.raw is now gone) and fail.
+    bootctl set-default ""
 else
     exit 1
 fi


### PR DESCRIPTION
These tests leave a lot of state around, and when the test is re-run, for example due to the qemu bug that makes a VM reboot instead of shutting down, it fails.