### PR TITLE
test: make TEST-64 mdadm_lvm cleanup robust against reruns

### DIFF
--- a/test/units/TEST-64-UDEV-STORAGE.sh
+++ b/test/units/TEST-64-UDEV-STORAGE.sh
@@ -1333,6 +1333,12 @@ testcase_mdadm_lvm() {
     helper_check_device_units
     # Cleanup
     lvm vgchange -an "$vgroup"
+    # Wipe the LVM signature off the MD device, otherwise the underlying disks
+    # still hold the PV header at the same offset. If the VM is restarted (e.g.
+    # the test gets re-run because of a reboot), mdadm --create with the same
+    # UUID would expose the same data and udev would auto-trigger
+    # lvm-activate-${vgroup}.service, racing with the test's pvcreate.
+    wipefs --all "$raid_dev"
     mdadm -v --stop "$raid_dev"
 
     # Clear superblocks to make the MD device will not be restarted even if the VM is restarted.
@@ -1340,6 +1346,10 @@ testcase_mdadm_lvm() {
     udevadm settle --timeout=30
     # shellcheck disable=SC2046
     mdadm -v --zero-superblock --force $(readlink -f "${devices[@]}")
+    # Also wipe any leftover signatures from the underlying disks for the same
+    # reason as above.
+    # shellcheck disable=SC2046
+    wipefs --all $(readlink -f "${devices[@]}")
     udevadm settle --timeout=30
 
     # Check if all expected symlinks were removed after the cleanup


### PR DESCRIPTION
mdadm --zero-superblock only wipes the MD metadata on the underlying disks, not the LVM PV header that lives in the array data area. When the VM is restarted and the test re-creates the array with the same UUID, /dev/md127 exposes the old data including the LVM PV header, so udev's 69-lvm.rules auto-triggers lvm-activate-mdlvm_vg.service which races with the test's own pvcreate for exclusive access on /dev/md127.

Wipe the LVM signature off the MD device (and the underlying disks as a belt-and-braces measure) to avoid the race on re-run, fixing failures when the VM is rebooted instead of shut down.

Co-developed-by: Claude Opus 4.7 <noreply@anthropic.com>