### PR TITLE
ukify: resolve relative devicetree paths from /usr/lib/modules

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -42,6 +42,12 @@ CHANGES WITH 261 in spe:
           Affected enum types: ExecInputType, ExecOutputType, ProtectHome,
           CGroupController, CollectMode, EmergencyAction, JobMode.
 
+        * ukify now resolves relative DeviceTree=/--devicetree= and
+          DeviceTreeAuto=/--devicetree-auto= paths under
+          /usr/lib/modules/<kernel-version>/dtb/. Absolute paths continue to be
+          used as-is. For relative paths, the kernel version must be specified
+          explicitly or autodetectable from the kernel image.
+
         * It was discovered that some of the events systemd-stub measures to
           the TPM were not also measured to the hardware CC registers (e.g.
           Intel TDX RTMRs) via EFI_CC_MEASUREMENT_PROTOCOL. In particular,

--- a/NEWS
+++ b/NEWS
@@ -20,6 +20,15 @@ CHANGES WITH 262:
           have been provided. This clears the way for a new
           "systemd-sysupdate@.service" unit for varlink activation of sysupdate.
 
+        * ukify now resolves relative DeviceTree=/--devicetree= and
+          DeviceTreeAuto=/--devicetree-auto= paths using kernel-install's
+          devicetree lookup paths, prioritizing $KERNEL_INSTALL_CONF_ROOT when
+          set. Absolute paths continue to be used as-is.
+          Previously, relative paths were passed through unchanged and thus
+          resolved relative to the caller's current working directory. For
+          relative paths, the kernel version must be specified explicitly or
+          autodetectable from the kernel image.
+
         * TPM-sealed credentials are now pinned to the TPM's SRK. This prevents
           MITM interposer attacks from stealing the decrypted credentials by
           ensuring that communication with the TPM is protected by a private key

--- a/man/ukify.xml
+++ b/man/ukify.xml
@@ -422,7 +422,10 @@
 
           <listitem><para>The devicetree description (the <literal>.dtb</literal> section). The argument is a
           path to a compiled binary DeviceTree file. If not specified, the section will not be present.
-          </para>
+          Absolute paths are used as-is. Relative paths are resolved under
+          <filename>/usr/lib/modules/<replaceable>VERSION</replaceable>/dtb/</filename>. The kernel version
+          must be specified with <varname>Uname=</varname>/<option>--uname=</option> or autodetectable from
+          the kernel image for relative paths to work.</para>
 
           <xi:include href="version-info.xml" xpointer="v253"/></listitem>
         </varlistentry>
@@ -432,7 +435,9 @@
           <term><option>--devicetree-auto=<replaceable>PATH</replaceable></option></term>
 
           <listitem><para>Zero or more automatically selectable DeviceTree files. In the configuration file, items are separated by
-          whitespace. Each DeviceTree will be in a separate <literal>.dtbauto</literal> section.</para>
+          whitespace. Each DeviceTree will be in a separate <literal>.dtbauto</literal> section. Absolute and
+          relative paths are handled as described for <varname>DeviceTree=</varname>/<option>--devicetree=</option>
+          above.</para>
 
           <xi:include href="version-info.xml" xpointer="v257"/></listitem>
         </varlistentry>

--- a/man/ukify.xml
+++ b/man/ukify.xml
@@ -447,7 +447,15 @@
 
           <listitem><para>The devicetree description (the <literal>.dtb</literal> section). The argument is a
           path to a compiled binary DeviceTree file. If not specified, the section will not be present.
-          </para>
+          Absolute paths are used as-is. Relative paths are resolved by looking under
+          <filename>$KERNEL_INSTALL_CONF_ROOT</filename> when set, followed by
+          <filename>/usr/lib/firmware/<replaceable>VERSION</replaceable>/device-tree/</filename>,
+          <filename>/usr/lib/linux-image-<replaceable>VERSION</replaceable>/</filename>, and
+          <filename>/usr/lib/modules/<replaceable>VERSION</replaceable>/dtb/</filename>, in that order.
+          The last location is used as the fallback when reporting a missing relative path. The kernel
+          version must be specified with
+          <varname>Uname=</varname>/<option>--uname=</option> or autodetectable from the kernel image for
+          relative paths to work.</para>
 
           <xi:include href="version-info.xml" xpointer="v253"/></listitem>
         </varlistentry>
@@ -457,7 +465,9 @@
           <term><option>--devicetree-auto=<replaceable>PATH</replaceable></option></term>
 
           <listitem><para>Zero or more automatically selectable DeviceTree files. In the configuration file, items are separated by
-          whitespace. Each DeviceTree will be in a separate <literal>.dtbauto</literal> section.</para>
+          whitespace. Each DeviceTree will be in a separate <literal>.dtbauto</literal> section. Absolute and
+          relative paths are handled as described for <varname>DeviceTree=</varname>/<option>--devicetree=</option>
+          above.</para>
 
           <xi:include href="version-info.xml" xpointer="v257"/></listitem>
         </varlistentry>

--- a/src/ukify/test/test_ukify.py
+++ b/src/ukify/test/test_ukify.py
@@ -64,6 +64,11 @@ if build_root and (
 ).exists():
     arg_tools += ['--stub', p]
 
+
+def module_dtb_path(uname, path):
+    return pathlib.Path('/usr/lib/modules') / uname / 'dtb' / path
+
+
 def systemd_measure():
     opts = ukify.create_parser().parse_args(arg_tools)
     return ukify.find_tool('systemd-measure', opts=opts)
@@ -103,6 +108,7 @@ def test_apply_config(tmp_path):
                   6 7 8
         OSRelease = @some/path1
         DeviceTree = some/path2
+        DeviceTreeAuto = auto/path1 auto/path2
         Splash = some/path3
         Uname = 1.2.3
         EFIArch=arm
@@ -131,6 +137,7 @@ def test_apply_config(tmp_path):
     assert ns.cmdline == '1 2 3 4 5\n6 7 8'
     assert ns.os_release == '@some/path1'
     assert ns.devicetree == pathlib.Path('some/path2')
+    assert ns.devicetree_auto == [pathlib.Path('auto/path1'), pathlib.Path('auto/path2')]
     assert ns.splash == pathlib.Path('some/path3')
     assert ns.efi_arch == 'arm'
     assert ns.stub == pathlib.Path('some/path4')
@@ -153,7 +160,11 @@ def test_apply_config(tmp_path):
                          pathlib.Path('initrd3')]
     assert ns.cmdline == '1 2 3 4 5 6 7 8'
     assert ns.os_release == pathlib.Path('some/path1')
-    assert ns.devicetree == pathlib.Path('some/path2')
+    assert ns.devicetree == module_dtb_path('1.2.3', 'some/path2')
+    assert ns.devicetree_auto == [
+        module_dtb_path('1.2.3', 'auto/path1'),
+        module_dtb_path('1.2.3', 'auto/path2'),
+    ]
     assert ns.splash == pathlib.Path('some/path3')
     assert ns.efi_arch == 'arm'
     assert ns.stub == pathlib.Path('some/path4')
@@ -179,11 +190,14 @@ def test_parse_args_minimal():
                                pathlib.Path('/usr/lib/os-release'))
 
 def test_parse_args_many_deprecated():
+    uname = '1.2.3'
+
     opts = ukify.parse_args(
         ['/ARG1', '///ARG2', '/ARG3 WITH SPACE',
          '--cmdline=a b c',
          '--os-release=K1=V1\nK2=V2',
          '--devicetree=DDDDTTTT',
+         '--devicetree-auto=AAAADDDDTTTT',
          '--splash=splash',
          '--pcrpkey=PATH',
          '--uname=1.2.3',
@@ -205,10 +219,11 @@ def test_parse_args_many_deprecated():
     assert opts.initrd == [pathlib.Path('/ARG2'), pathlib.Path('/ARG3 WITH SPACE')]
     assert opts.cmdline == 'a b c'
     assert opts.os_release == 'K1=V1\nK2=V2'
-    assert opts.devicetree == pathlib.Path('DDDDTTTT')
+    assert opts.devicetree == module_dtb_path(uname, 'DDDDTTTT')
+    assert opts.devicetree_auto == [module_dtb_path(uname, 'AAAADDDDTTTT')]
     assert opts.splash == pathlib.Path('splash')
     assert opts.pcrpkey == pathlib.Path('PATH')
-    assert opts.uname == '1.2.3'
+    assert opts.uname == uname
     assert opts.stub == pathlib.Path('STUBPATH')
     assert opts.pcr_private_keys == ['PKEY1']
     assert opts.pcr_public_keys == ['PKEY2']
@@ -222,6 +237,8 @@ def test_parse_args_many_deprecated():
     assert opts.measure is False
 
 def test_parse_args_many():
+    uname = '1.2.3'
+
     opts = ukify.parse_args(
         ['build',
          '--linux=/ARG1',
@@ -230,6 +247,7 @@ def test_parse_args_many():
          '--cmdline=a b c',
          '--os-release=K1=V1\nK2=V2',
          '--devicetree=DDDDTTTT',
+         '--devicetree-auto=AAAADDDDTTTT',
          '--splash=splash',
          '--pcrpkey=PATH',
          '--uname=1.2.3',
@@ -253,10 +271,11 @@ def test_parse_args_many():
     assert opts.initrd == [pathlib.Path('/ARG2'), pathlib.Path('/ARG3 WITH SPACE')]
     assert opts.cmdline == 'a b c'
     assert opts.os_release == 'K1=V1\nK2=V2'
-    assert opts.devicetree == pathlib.Path('DDDDTTTT')
+    assert opts.devicetree == module_dtb_path(uname, 'DDDDTTTT')
+    assert opts.devicetree_auto == [module_dtb_path(uname, 'AAAADDDDTTTT')]
     assert opts.splash == pathlib.Path('splash')
     assert opts.pcrpkey == pathlib.Path('PATH')
-    assert opts.uname == '1.2.3'
+    assert opts.uname == uname
     assert opts.stub == pathlib.Path('STUBPATH')
     assert opts.pcr_private_keys == ['PKEY1']
     assert opts.pcr_public_keys == ['PKEY2']
@@ -294,6 +313,8 @@ def test_parse_sections():
     assert opts.sections[1].measure is False
 
 def test_config_priority(tmp_path):
+    uname = '1.2.3'
+
     config = tmp_path / 'config1.conf'
     # config: use pesign and give certdir + certname
     config.write_text(textwrap.dedent(
@@ -361,10 +382,10 @@ def test_config_priority(tmp_path):
                            pathlib.Path('/ARG3 WITH SPACE')]
     assert opts.cmdline == 'a b c'
     assert opts.os_release == 'K1=V1\nK2=V2'
-    assert opts.devicetree == pathlib.Path('DDDDTTTT')
+    assert opts.devicetree == module_dtb_path(uname, 'DDDDTTTT')
     assert opts.splash == pathlib.Path('splash')
     assert opts.pcrpkey == pathlib.Path('PATH')
-    assert opts.uname == '1.2.3'
+    assert opts.uname == uname
     assert opts.stub == pathlib.Path('STUBPATH')
     assert opts.pcr_private_keys == ['PKEY1', 'some/path7']
     assert opts.pcr_public_keys == ['PKEY2', 'some/path8']

--- a/src/ukify/test/test_ukify.py
+++ b/src/ukify/test/test_ukify.py
@@ -65,6 +65,10 @@ if (
     arg_tools += ['--stub', p]
 
 
+def module_dtb_path(uname, path):
+    return pathlib.Path('/usr/lib/modules') / uname / 'dtb' / path
+
+
 def systemd_measure():
     opts = ukify.create_parser().parse_args(arg_tools)
     return ukify.find_tool('systemd-measure', opts=opts)
@@ -111,6 +115,7 @@ def test_apply_config(tmp_path):
                   6 7 8
         OSRelease = @some/path1
         DeviceTree = some/path2
+        DeviceTreeAuto = auto/path1 auto/path2
         Splash = some/path3
         Uname = 1.2.3
         EFIArch=arm
@@ -143,6 +148,7 @@ def test_apply_config(tmp_path):
     assert ns.cmdline == '1 2 3 4 5\n6 7 8'
     assert ns.os_release == '@some/path1'
     assert ns.devicetree == pathlib.Path('some/path2')
+    assert ns.devicetree_auto == [pathlib.Path('auto/path1'), pathlib.Path('auto/path2')]
     assert ns.splash == pathlib.Path('some/path3')
     assert ns.efi_arch == 'arm'
     assert ns.stub == pathlib.Path('some/path4')
@@ -167,7 +173,11 @@ def test_apply_config(tmp_path):
     ]
     assert ns.cmdline == '1 2 3 4 5 6 7 8'
     assert ns.os_release == pathlib.Path('some/path1')
-    assert ns.devicetree == pathlib.Path('some/path2')
+    assert ns.devicetree == module_dtb_path('1.2.3', 'some/path2')
+    assert ns.devicetree_auto == [
+        module_dtb_path('1.2.3', 'auto/path1'),
+        module_dtb_path('1.2.3', 'auto/path2'),
+    ]
     assert ns.splash == pathlib.Path('some/path3')
     assert ns.efi_arch == 'arm'
     assert ns.stub == pathlib.Path('some/path4')
@@ -197,6 +207,8 @@ def test_parse_args_minimal():
 
 
 def test_parse_args_many_deprecated():
+    uname = '1.2.3'
+
     opts = ukify.parse_args(
         [
             '/ARG1',
@@ -205,6 +217,7 @@ def test_parse_args_many_deprecated():
             '--cmdline=a b c',
             '--os-release=K1=V1\nK2=V2',
             '--devicetree=DDDDTTTT',
+            '--devicetree-auto=AAAADDDDTTTT',
             '--splash=splash',
             '--pcrpkey=PATH',
             '--uname=1.2.3',
@@ -227,10 +240,11 @@ def test_parse_args_many_deprecated():
     assert opts.initrd == [pathlib.Path('/ARG2'), pathlib.Path('/ARG3 WITH SPACE')]
     assert opts.cmdline == 'a b c'
     assert opts.os_release == 'K1=V1\nK2=V2'
-    assert opts.devicetree == pathlib.Path('DDDDTTTT')
+    assert opts.devicetree == module_dtb_path(uname, 'DDDDTTTT')
+    assert opts.devicetree_auto == [module_dtb_path(uname, 'AAAADDDDTTTT')]
     assert opts.splash == pathlib.Path('splash')
     assert opts.pcrpkey == pathlib.Path('PATH')
-    assert opts.uname == '1.2.3'
+    assert opts.uname == uname
     assert opts.stub == pathlib.Path('STUBPATH')
     assert opts.pcr_private_keys == ['PKEY1']
     assert opts.pcr_public_keys == ['PKEY2']
@@ -245,6 +259,8 @@ def test_parse_args_many_deprecated():
 
 
 def test_parse_args_many():
+    uname = '1.2.3'
+
     opts = ukify.parse_args(
         [
             'build',
@@ -254,6 +270,7 @@ def test_parse_args_many():
             '--cmdline=a b c',
             '--os-release=K1=V1\nK2=V2',
             '--devicetree=DDDDTTTT',
+            '--devicetree-auto=AAAADDDDTTTT',
             '--splash=splash',
             '--pcrpkey=PATH',
             '--uname=1.2.3',
@@ -278,10 +295,11 @@ def test_parse_args_many():
     assert opts.initrd == [pathlib.Path('/ARG2'), pathlib.Path('/ARG3 WITH SPACE')]
     assert opts.cmdline == 'a b c'
     assert opts.os_release == 'K1=V1\nK2=V2'
-    assert opts.devicetree == pathlib.Path('DDDDTTTT')
+    assert opts.devicetree == module_dtb_path(uname, 'DDDDTTTT')
+    assert opts.devicetree_auto == [module_dtb_path(uname, 'AAAADDDDTTTT')]
     assert opts.splash == pathlib.Path('splash')
     assert opts.pcrpkey == pathlib.Path('PATH')
-    assert opts.uname == '1.2.3'
+    assert opts.uname == uname
     assert opts.stub == pathlib.Path('STUBPATH')
     assert opts.pcr_private_keys == ['PKEY1']
     assert opts.pcr_public_keys == ['PKEY2']
@@ -294,6 +312,115 @@ def test_parse_args_many():
     assert opts.output == pathlib.Path('OUTPUT')
     assert opts.measure is False
     assert opts.policy_digest is False
+
+
+def test_parse_args_devicetree_autodetects_uname(monkeypatch):
+    def scrape(filename, opts=None):
+        assert filename == pathlib.Path('/ARG1')
+        return '1.2.3'
+
+    monkeypatch.setattr(ukify.Uname, 'scrape', scrape)
+
+    opts = ukify.parse_args(
+        [
+            'build',
+            '--linux=/ARG1',
+            '--devicetree=DDDDTTTT',
+            '--devicetree-auto=AAAADDDDTTTT',
+        ]
+    )
+
+    assert opts.uname == '1.2.3'
+    assert opts.devicetree == module_dtb_path('1.2.3', 'DDDDTTTT')
+    assert opts.devicetree_auto == [module_dtb_path('1.2.3', 'AAAADDDDTTTT')]
+
+
+def test_parse_args_devicetree_autodetect_failure(monkeypatch):
+    def scrape(filename, opts=None):
+        assert filename == pathlib.Path('/ARG1')
+        return None
+
+    monkeypatch.setattr(ukify.Uname, 'scrape', scrape)
+
+    with pytest.raises(ValueError, match='Kernel version unknown'):
+        ukify.parse_args(
+            [
+                'build',
+                '--linux=/ARG1',
+                '--devicetree=DDDDTTTT',
+            ]
+        )
+
+
+def test_parse_args_devicetree_absolute_passthrough():
+    opts = ukify.parse_args(
+        [
+            'build',
+            '--linux=/ARG1',
+            '--uname=1.2.3',
+            '--devicetree=/DDDDTTTT',
+            '--devicetree-auto=/AAAADDDDTTTT',
+        ]
+    )
+
+    assert opts.devicetree == pathlib.Path('/DDDDTTTT')
+    assert opts.devicetree_auto == [pathlib.Path('/AAAADDDDTTTT')]
+
+
+def test_parse_args_devicetree_empty_uname():
+    with pytest.raises(ValueError, match='Kernel version unknown'):
+        ukify.parse_args(
+            [
+                'build',
+                '--linux=/ARG1',
+                '--uname=',
+                '--devicetree=DDDDTTTT',
+            ]
+        )
+
+
+def test_parse_args_devicetree_invalid_uname():
+    with pytest.raises(ValueError, match='Invalid kernel version'):
+        ukify.parse_args(
+            [
+                'build',
+                '--linux=/ARG1',
+                '--uname=..',
+                '--devicetree=DDDDTTTT',
+            ]
+        )
+
+    with pytest.raises(ValueError, match='Invalid kernel version'):
+        ukify.parse_args(
+            [
+                'build',
+                '--linux=/ARG1',
+                '--uname=.',
+                '--devicetree=DDDDTTTT',
+            ]
+        )
+
+
+def test_parse_args_devicetree_rejects_parent_path():
+    with pytest.raises(ValueError, match='must name a file'):
+        ukify.parse_args(
+            [
+                'build',
+                '--linux=/ARG1',
+                '--uname=1.2.3',
+                '--devicetree=../DDDDTTTT',
+            ]
+        )
+
+    with pytest.raises(ValueError, match='must name a file'):
+        ukify.parse_args(
+            [
+                'build',
+                '--linux=/ARG1',
+                '--uname=1.2.3',
+                '--devicetree=.',
+            ]
+        )
 
 
 def test_parse_sections():
@@ -323,6 +450,8 @@ def test_parse_sections():
 
 
 def test_config_priority(tmp_path):
+    uname = '1.2.3'
+
     config = tmp_path / 'config1.conf'
     # config: use pesign and give certdir + certname
     config.write_text(
@@ -397,10 +526,10 @@ def test_config_priority(tmp_path):
     ]
     assert opts.cmdline == 'a b c'
     assert opts.os_release == 'K1=V1\nK2=V2'
-    assert opts.devicetree == pathlib.Path('DDDDTTTT')
+    assert opts.devicetree == module_dtb_path(uname, 'DDDDTTTT')
     assert opts.splash == pathlib.Path('splash')
     assert opts.pcrpkey == pathlib.Path('PATH')
-    assert opts.uname == '1.2.3'
+    assert opts.uname == uname
     assert opts.stub == pathlib.Path('STUBPATH')
     assert opts.pcr_private_keys == ['PKEY1', 'some/path7']
     assert opts.pcr_public_keys == ['PKEY2', 'some/path8']

--- a/src/ukify/test/test_ukify.py
+++ b/src/ukify/test/test_ukify.py
@@ -65,6 +65,22 @@ if (
     arg_tools += ['--stub', p]
 
 
+def module_dtb_path(uname, path):
+    return pathlib.Path('/usr/lib/modules') / uname / 'dtb' / path
+
+
+def firmware_dtb_path(uname, path):
+    return pathlib.Path('/usr/lib/firmware') / uname / 'device-tree' / path
+
+
+def linux_image_dtb_path(uname, path):
+    return pathlib.Path('/usr/lib') / f'linux-image-{uname}' / path
+
+
+def conf_root_dtb_path(root, path):
+    return pathlib.Path(root) / path
+
+
 def systemd_measure():
     opts = ukify.create_parser().parse_args(arg_tools)
     return ukify.find_tool('systemd-measure', opts=opts)
@@ -111,6 +127,7 @@ def test_apply_config(tmp_path):
                   6 7 8
         OSRelease = @some/path1
         DeviceTree = some/path2
+        DeviceTreeAuto = auto/path1 auto/path2
         Splash = some/path3
         Uname = 1.2.3
         EFIArch=arm
@@ -143,6 +160,7 @@ def test_apply_config(tmp_path):
     assert ns.cmdline == '1 2 3 4 5\n6 7 8'
     assert ns.os_release == '@some/path1'
     assert ns.devicetree == pathlib.Path('some/path2')
+    assert ns.devicetree_auto == [pathlib.Path('auto/path1'), pathlib.Path('auto/path2')]
     assert ns.splash == pathlib.Path('some/path3')
     assert ns.efi_arch == 'arm'
     assert ns.stub == pathlib.Path('some/path4')
@@ -168,6 +186,7 @@ def test_apply_config(tmp_path):
     assert ns.cmdline == '1 2 3 4 5 6 7 8'
     assert ns.os_release == pathlib.Path('some/path1')
     assert ns.devicetree == pathlib.Path('some/path2')
+    assert ns.devicetree_auto == [pathlib.Path('auto/path1'), pathlib.Path('auto/path2')]
     assert ns.splash == pathlib.Path('some/path3')
     assert ns.efi_arch == 'arm'
     assert ns.stub == pathlib.Path('some/path4')
@@ -205,6 +224,7 @@ def test_parse_args_many_deprecated():
             '--cmdline=a b c',
             '--os-release=K1=V1\nK2=V2',
             '--devicetree=DDDDTTTT',
+            '--devicetree-auto=AAAADDDDTTTT',
             '--splash=splash',
             '--pcrpkey=PATH',
             '--uname=1.2.3',
@@ -228,6 +248,7 @@ def test_parse_args_many_deprecated():
     assert opts.cmdline == 'a b c'
     assert opts.os_release == 'K1=V1\nK2=V2'
     assert opts.devicetree == pathlib.Path('DDDDTTTT')
+    assert opts.devicetree_auto == [pathlib.Path('AAAADDDDTTTT')]
     assert opts.splash == pathlib.Path('splash')
     assert opts.pcrpkey == pathlib.Path('PATH')
     assert opts.uname == '1.2.3'
@@ -254,6 +275,7 @@ def test_parse_args_many():
             '--cmdline=a b c',
             '--os-release=K1=V1\nK2=V2',
             '--devicetree=DDDDTTTT',
+            '--devicetree-auto=AAAADDDDTTTT',
             '--splash=splash',
             '--pcrpkey=PATH',
             '--uname=1.2.3',
@@ -281,6 +303,7 @@ def test_parse_args_many():
     assert opts.cmdline == 'a b c'
     assert opts.os_release == 'K1=V1\nK2=V2'
     assert opts.devicetree == pathlib.Path('DDDDTTTT')
+    assert opts.devicetree_auto == [pathlib.Path('AAAADDDDTTTT')]
     assert opts.splash == pathlib.Path('splash')
     assert opts.pcrpkey == pathlib.Path('PATH')
     assert opts.uname == '1.2.3'
@@ -297,6 +320,420 @@ def test_parse_args_many():
     assert opts.measure is False
     assert opts.policy_digest is False
     assert opts.sign_initrd_pcrs is False
+
+
+def test_parse_args_devicetree_autodetects_uname(monkeypatch):
+    def scrape(filename, opts=None):
+        assert filename == pathlib.Path('/ARG1')
+        return '1.2.3'
+
+    monkeypatch.setattr(ukify.Uname, 'scrape', scrape)
+
+    opts = ukify.parse_args(
+        [
+            'build',
+            '--linux=/ARG1',
+            '--devicetree=DDDDTTTT',
+            '--devicetree-auto=AAAADDDDTTTT',
+        ]
+    )
+
+    assert opts.uname == '1.2.3'
+    assert opts.devicetree == pathlib.Path('DDDDTTTT')
+    assert opts.devicetree_auto == [pathlib.Path('AAAADDDDTTTT')]
+
+
+def test_parse_args_devicetree_autodetect_failure_warns(monkeypatch, capsys):
+    def scrape(filename, opts=None):
+        assert filename == pathlib.Path('/ARG1')
+        return None
+
+    monkeypatch.setattr(ukify.Uname, 'scrape', scrape)
+
+    opts = ukify.parse_args(
+        [
+            'build',
+            '--linux=/ARG1',
+            '--devicetree=DDDDTTTT',
+        ]
+    )
+
+    assert opts.uname is None
+    assert opts.devicetree == pathlib.Path('DDDDTTTT')
+    assert 'Kernel version unknown, cannot resolve relative DeviceTree paths' in capsys.readouterr().err
+
+
+def test_main_devicetree_autodetect_failure_raises(monkeypatch):
+    monkeypatch.setattr(ukify.Uname, 'scrape', lambda filename, opts=None: None)
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        [
+            'ukify',
+            'build',
+            '--linux=/ARG1',
+            '--devicetree=DDDDTTTT',
+        ],
+    )
+
+    with pytest.raises(ValueError, match='Kernel version unknown'):
+        ukify.main()
+
+
+def test_parse_args_devicetree_absolute_passthrough():
+    opts = ukify.parse_args(
+        [
+            'build',
+            '--linux=/ARG1',
+            '--uname=..',
+            '--devicetree=/DDDDTTTT',
+            '--devicetree-auto=/AAAADDDDTTTT',
+        ]
+    )
+
+    assert opts.devicetree == pathlib.Path('/DDDDTTTT')
+    assert opts.devicetree_auto == [pathlib.Path('/AAAADDDDTTTT')]
+
+
+def test_resolve_devicetree_path_searches_kernel_install_locations(monkeypatch):
+    uname = '1.2.3'
+    monkeypatch.delenv('KERNEL_INSTALL_CONF_ROOT', raising=False)
+
+    def is_file(self):
+        return self == linux_image_dtb_path(uname, 'DDDDTTTT')
+
+    monkeypatch.setattr(pathlib.Path, 'is_file', is_file)
+
+    resolved = ukify.resolve_devicetree_path(pathlib.Path('DDDDTTTT'), uname, check_exists=True)
+    assert resolved == linux_image_dtb_path(uname, 'DDDDTTTT')
+
+
+def test_resolve_devicetree_path_prefers_firmware_location(monkeypatch):
+    uname = '1.2.3'
+    monkeypatch.delenv('KERNEL_INSTALL_CONF_ROOT', raising=False)
+
+    def is_file(self):
+        return self in (
+            firmware_dtb_path(uname, 'DDDDTTTT'),
+            linux_image_dtb_path(uname, 'DDDDTTTT'),
+            module_dtb_path(uname, 'DDDDTTTT'),
+        )
+
+    monkeypatch.setattr(pathlib.Path, 'is_file', is_file)
+
+    resolved = ukify.resolve_devicetree_path(pathlib.Path('DDDDTTTT'), uname, check_exists=True)
+    assert resolved == firmware_dtb_path(uname, 'DDDDTTTT')
+
+
+def test_resolve_devicetree_path_prefers_kernel_install_conf_root(monkeypatch, tmp_path):
+    uname = '1.2.3'
+    root = tmp_path / 'kernel'
+
+    def is_file(self):
+        return self in (
+            conf_root_dtb_path(root, 'DDDDTTTT'),
+            firmware_dtb_path(uname, 'DDDDTTTT'),
+            linux_image_dtb_path(uname, 'DDDDTTTT'),
+            module_dtb_path(uname, 'DDDDTTTT'),
+        )
+
+    monkeypatch.setenv('KERNEL_INSTALL_CONF_ROOT', os.fspath(root))
+    monkeypatch.setattr(pathlib.Path, 'is_file', is_file)
+
+    resolved = ukify.resolve_devicetree_path(pathlib.Path('DDDDTTTT'), uname, check_exists=True)
+    assert resolved == conf_root_dtb_path(root, 'DDDDTTTT')
+
+
+def test_resolve_devicetree_path_conf_root_precedes_default_locations(monkeypatch, tmp_path):
+    uname = '1.2.3'
+    root = tmp_path / 'kernel'
+
+    monkeypatch.setenv('KERNEL_INSTALL_CONF_ROOT', os.fspath(root))
+    monkeypatch.setattr(pathlib.Path, 'is_file', lambda path: path == module_dtb_path(uname, 'DDDDTTTT'))
+
+    resolved = ukify.resolve_devicetree_path(pathlib.Path('DDDDTTTT'), uname, check_exists=True)
+    assert resolved == module_dtb_path(uname, 'DDDDTTTT')
+
+
+def test_resolve_devicetree_path_rejects_symlink_outside_search_directory(monkeypatch, tmp_path):
+    uname = '1.2.3'
+    root = tmp_path / 'kernel'
+    outside = tmp_path / 'outside.dtb'
+    root.mkdir()
+    outside.touch()
+    (root / 'DDDDTTTT').symlink_to(outside)
+
+    monkeypatch.setenv('KERNEL_INSTALL_CONF_ROOT', os.fspath(root))
+
+    with pytest.raises(FileNotFoundError):
+        ukify.resolve_devicetree_path(pathlib.Path('DDDDTTTT'), uname, check_exists=True)
+
+
+def test_resolve_devicetree_path_prefers_linux_image_location_over_modules(monkeypatch):
+    uname = '1.2.3'
+    monkeypatch.delenv('KERNEL_INSTALL_CONF_ROOT', raising=False)
+
+    def is_file(self):
+        return self in (
+            linux_image_dtb_path(uname, 'DDDDTTTT'),
+            module_dtb_path(uname, 'DDDDTTTT'),
+        )
+
+    monkeypatch.setattr(pathlib.Path, 'is_file', is_file)
+
+    resolved = ukify.resolve_devicetree_path(pathlib.Path('DDDDTTTT'), uname, check_exists=True)
+    assert resolved == linux_image_dtb_path(uname, 'DDDDTTTT')
+
+
+def test_resolve_devicetree_path_missing_uses_module_fallback(monkeypatch):
+    uname = '1.2.3'
+    monkeypatch.delenv('KERNEL_INSTALL_CONF_ROOT', raising=False)
+
+    monkeypatch.setattr(pathlib.Path, 'is_file', lambda path: False)
+
+    with pytest.raises(
+        FileNotFoundError,
+        match=re.escape(f'DeviceTree file {module_dtb_path(uname, "DDDDTTTT")} not found'),
+    ):
+        ukify.resolve_devicetree_path(pathlib.Path('DDDDTTTT'), uname, check_exists=True)
+
+
+def test_resolve_devicetree_options_searches_after_parse_args(monkeypatch):
+    uname = '1.2.3'
+    monkeypatch.delenv('KERNEL_INSTALL_CONF_ROOT', raising=False)
+
+    opts = ukify.parse_args(
+        [
+            'build',
+            '--linux=/ARG1',
+            '--uname=1.2.3',
+            '--devicetree=DDDDTTTT',
+            '--devicetree-auto=AAAADDDDTTTT',
+        ]
+    )
+
+    assert opts.devicetree == pathlib.Path('DDDDTTTT')
+    assert opts.devicetree_auto == [pathlib.Path('AAAADDDDTTTT')]
+
+    def is_file(self):
+        return self in (
+            firmware_dtb_path(uname, 'DDDDTTTT'),
+            firmware_dtb_path(uname, 'AAAADDDDTTTT'),
+        )
+
+    monkeypatch.setattr(pathlib.Path, 'is_file', is_file)
+
+    ukify.resolve_devicetree_options(opts, check_exists=True)
+    assert opts.devicetree == firmware_dtb_path(uname, 'DDDDTTTT')
+    assert opts.devicetree_auto == [firmware_dtb_path(uname, 'AAAADDDDTTTT')]
+
+
+def test_main_resolves_devicetree_options_after_finalize(monkeypatch):
+    uname = '1.2.3'
+    captured_opts = []
+    monkeypatch.delenv('KERNEL_INSTALL_CONF_ROOT', raising=False)
+
+    def is_file(self):
+        return self == firmware_dtb_path(uname, 'DDDDTTTT')
+
+    def check_inputs(opts):
+        assert opts.devicetree == firmware_dtb_path(uname, 'DDDDTTTT')
+
+    def make_uki(opts):
+        captured_opts.append(opts)
+
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        [
+            'ukify',
+            'build',
+            '--linux=/ARG1',
+            '--uname=1.2.3',
+            '--devicetree=DDDDTTTT',
+        ],
+    )
+    monkeypatch.setattr(pathlib.Path, 'is_file', is_file)
+    monkeypatch.setattr(ukify, 'check_inputs', check_inputs)
+    monkeypatch.setattr(ukify, 'make_uki', make_uki)
+
+    ukify.main()
+
+    assert captured_opts[0].devicetree == firmware_dtb_path(uname, 'DDDDTTTT')
+
+
+def test_parse_args_devicetree_unknown_uname_ignores_non_build(capsys):
+    opts = ukify.parse_args(
+        [
+            'inspect',
+            '/ARG1',
+            '--devicetree=DDDDTTTT',
+        ]
+    )
+
+    assert opts.devicetree == pathlib.Path('DDDDTTTT')
+    assert 'Kernel version unknown, cannot resolve relative DeviceTree paths' not in capsys.readouterr().err
+
+
+def test_main_build_summary_devicetree_unknown_uname_does_not_raise(monkeypatch, capsys):
+    resolve_calls = []
+    resolve_devicetree_options = ukify.resolve_devicetree_options
+
+    def resolve_devicetree_options_wrapper(opts, check_exists=False):
+        resolve_calls.append(check_exists)
+        assert not check_exists
+        resolve_devicetree_options(opts, check_exists)
+
+    monkeypatch.setattr(ukify.Uname, 'scrape', lambda filename, opts=None: None)
+    monkeypatch.setattr(ukify, 'resolve_devicetree_options', resolve_devicetree_options_wrapper)
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        [
+            'ukify',
+            'build',
+            '--summary',
+            '--linux=/ARG1',
+            '--devicetree=DDDDTTTT',
+        ],
+    )
+
+    ukify.main()
+    assert resolve_calls == [False]
+    captured = capsys.readouterr()
+    out = captured.out
+    assert "'summary': True" in out
+    assert "PosixPath('DDDDTTTT')" in out
+    assert captured.err.count('Kernel version unknown, cannot resolve relative DeviceTree paths') == 1
+
+
+def test_main_build_summary_devicetree_resolves_known_uname(monkeypatch, capsys):
+    monkeypatch.delenv('KERNEL_INSTALL_CONF_ROOT', raising=False)
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        [
+            'ukify',
+            'build',
+            '--summary',
+            '--linux=/ARG1',
+            '--uname=1.2.3',
+            '--devicetree=DDDDTTTT',
+        ],
+    )
+
+    ukify.main()
+    out = capsys.readouterr().out
+    assert "'summary': True" in out
+    assert "PosixPath('/usr/lib/modules/1.2.3/dtb/DDDDTTTT')" in out
+
+
+def test_main_build_summary_autodetects_uname(monkeypatch, capsys):
+    monkeypatch.setattr(ukify.Uname, 'scrape', lambda filename, opts=None: '1.2.3')
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        [
+            'ukify',
+            'build',
+            '--summary',
+            '--linux=/ARG1',
+        ],
+    )
+
+    ukify.main()
+    assert "'uname': '1.2.3'" in capsys.readouterr().out
+
+
+def test_main_devicetree_empty_uname_raises(monkeypatch):
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        [
+            'ukify',
+            'build',
+            '--linux=/ARG1',
+            '--uname=',
+            '--devicetree=DDDDTTTT',
+        ],
+    )
+
+    with pytest.raises(ValueError, match='Kernel version unknown'):
+        ukify.main()
+
+
+def test_parse_args_devicetree_invalid_uname():
+    opts = ukify.parse_args(
+        [
+            'build',
+            '--linux=/ARG1',
+            '--uname=1.2.3+test',
+            '--devicetree=DDDDTTTT',
+        ]
+    )
+    assert opts.uname == '1.2.3+test'
+
+    with pytest.raises(ValueError, match='Invalid kernel version'):
+        ukify.parse_args(
+            [
+                'build',
+                '--linux=/ARG1',
+                '--uname=..',
+                '--devicetree=DDDDTTTT',
+            ]
+        )
+
+    with pytest.raises(ValueError, match='Invalid kernel version'):
+        ukify.parse_args(
+            [
+                'build',
+                '--linux=/ARG1',
+                '--uname=.',
+                '--devicetree=DDDDTTTT',
+            ]
+        )
+
+    with pytest.raises(ValueError, match='Invalid kernel version'):
+        ukify.parse_args(
+            [
+                'build',
+                '--linux=/ARG1',
+                '--uname=/',
+                '--devicetree=DDDDTTTT',
+            ]
+        )
+
+
+def test_parse_args_devicetree_rejects_invalid_relative_paths():
+    with pytest.raises(ValueError, match='Invalid DeviceTree path'):
+        ukify.parse_args(
+            [
+                'build',
+                '--linux=/ARG1',
+                '--uname=1.2.3',
+                '--devicetree=../DDDDTTTT',
+            ]
+        )
+
+    with pytest.raises(ValueError, match='Invalid DeviceTree path'):
+        ukify.parse_args(
+            [
+                'build',
+                '--linux=/ARG1',
+                '--uname=1.2.3',
+                '--devicetree=.',
+            ]
+        )
+
+    with pytest.raises(ValueError, match='Invalid DeviceTree path'):
+        ukify.parse_args(
+            [
+                'build',
+                '--linux=/ARG1',
+                '--uname=1.2.3',
+                '--devicetree-auto=../AAAADDDDTTTT',
+            ]
+        )
 
 
 def test_parse_sections():
@@ -326,6 +763,8 @@ def test_parse_sections():
 
 
 def test_config_priority(tmp_path):
+    uname = '1.2.3'
+
     config = tmp_path / 'config1.conf'
     # config: use pesign and give certdir + certname
     config.write_text(
@@ -403,7 +842,7 @@ def test_config_priority(tmp_path):
     assert opts.devicetree == pathlib.Path('DDDDTTTT')
     assert opts.splash == pathlib.Path('splash')
     assert opts.pcrpkey == pathlib.Path('PATH')
-    assert opts.uname == '1.2.3'
+    assert opts.uname == uname
     assert opts.stub == pathlib.Path('STUBPATH')
     assert opts.pcr_private_keys == ['PKEY1', 'some/path7']
     assert opts.pcr_public_keys == ['PKEY2', 'some/path8']

--- a/src/ukify/ukify.py
+++ b/src/ukify/ukify.py
@@ -923,6 +923,37 @@ def join_initrds(initrds: list[Path]) -> Union[Path, bytes, None]:
     return b''.join(seq)
 
 
+def resolve_devicetree_path(path: Path, uname: str, check_exists: bool = False) -> Path:
+    resolved = path if path.is_absolute() else Path('/usr/lib/modules') / uname / 'dtb' / path
+
+    if check_exists and not resolved.exists():
+        raise FileNotFoundError(f'DeviceTree file {resolved} not found')
+
+    return resolved
+
+
+def resolve_devicetree_options(
+    opts: Union[argparse.Namespace, UkifyConfig], check_exists: bool = False
+) -> None:
+    if opts.uname is None:
+        has_relative_devicetree = (
+            (opts.devicetree is not None and not opts.devicetree.is_absolute())
+            or any(not path.is_absolute() for path in opts.devicetree_auto)
+        )
+        if has_relative_devicetree:
+            message = 'Kernel version unknown, cannot resolve relative DeviceTree paths'
+            if check_exists:
+                raise ValueError(message)
+            print(message, file=sys.stderr)
+        return
+
+    if opts.devicetree is not None:
+        opts.devicetree = resolve_devicetree_path(opts.devicetree, opts.uname, check_exists)
+    opts.devicetree_auto = [
+        resolve_devicetree_path(path, opts.uname, check_exists) for path in opts.devicetree_auto
+    ]
+
+
 T = TypeVar('T')
 
 
@@ -1357,6 +1388,8 @@ def make_uki(opts: UkifyConfig) -> None:
     if opts.uname is None and linux is not None:
         print('Kernel version not specified, starting autodetection 😖.', file=sys.stderr)
         opts.uname = Uname.scrape(linux, opts=opts)
+
+    resolve_devicetree_options(opts, check_exists=True)
 
     uki = UKI(opts.join_pcrsig if opts.join_pcrsig else opts.stub)
     initrd = join_initrds(opts.initrd)
@@ -2433,6 +2466,8 @@ def finalize_options(opts: argparse.Namespace) -> None:
 
     if opts.efi_arch is None:
         opts.efi_arch = guess_efi_arch()
+
+    resolve_devicetree_options(opts)
 
     if opts.stub is None and not opts.join_pcrsig:
         if opts.linux is not None:

--- a/src/ukify/ukify.py
+++ b/src/ukify/ukify.py
@@ -320,6 +320,9 @@ class UkifyConfig:
         return cls(**{k: v for k, v in vars(ns).items() if k in inspect.signature(cls).parameters})
 
 
+UkifyOptions = Union[argparse.Namespace, UkifyConfig]
+
+
 class Uname:
     # This class is here purely as a namespace for the functions
 
@@ -333,7 +336,7 @@ class Uname:
     TEXT_PATTERN = rb'Linux version (?P<version>\d\.\S+) \('
 
     @classmethod
-    def scrape_x86(cls, filename: Path, opts: Optional[UkifyConfig] = None) -> str:
+    def scrape_x86(cls, filename: Path, opts: Optional[UkifyOptions] = None) -> str:
         # Based on https://gitlab.archlinux.org/archlinux/mkinitcpio/mkinitcpio/-/blob/master/functions#L136
         # and https://docs.kernel.org/arch/x86/boot.html#the-real-mode-kernel-header
         with open(filename, 'rb') as f:
@@ -353,7 +356,7 @@ class Uname:
         return m.group('version')
 
     @classmethod
-    def scrape_elf(cls, filename: Path, opts: Optional[UkifyConfig] = None) -> str:
+    def scrape_elf(cls, filename: Path, opts: Optional[UkifyOptions] = None) -> str:
         readelf = find_tool('readelf', opts=opts)
 
         cmd = [
@@ -375,7 +378,7 @@ class Uname:
         return text.rstrip('\0')
 
     @classmethod
-    def scrape_generic(cls, filename: Path, opts: Optional[UkifyConfig] = None) -> str:
+    def scrape_generic(cls, filename: Path, opts: Optional[UkifyOptions] = None) -> str:
         # import libarchive
         # libarchive-c fails with
         # ArchiveError: Unrecognized archive format (errno=84, retcode=-30, archive_p=94705420454656)
@@ -389,7 +392,7 @@ class Uname:
         return m.group('version').decode()
 
     @classmethod
-    def scrape(cls, filename: Path, opts: Optional[UkifyConfig] = None) -> Optional[str]:
+    def scrape(cls, filename: Path, opts: Optional[UkifyOptions] = None) -> Optional[str]:
         for func in (cls.scrape_x86, cls.scrape_elf, cls.scrape_generic):
             try:
                 version = func(filename, opts=opts)
@@ -707,7 +710,7 @@ def check_cert_and_keys_nonexistent(opts: UkifyConfig) -> None:
 def find_tool(
     name: str,
     fallback: Optional[str] = None,
-    opts: Optional[UkifyConfig] = None,
+    opts: Optional[UkifyOptions] = None,
     msg: str = 'Tool {name} not installed!',
 ) -> Union[str, Path]:
     if opts and opts.tools:
@@ -921,6 +924,50 @@ def join_initrds(initrds: list[Path]) -> Union[Path, bytes, None]:
         seq += [initrd, padding]
 
     return b''.join(seq)
+
+
+def has_relative_devicetree(opts: UkifyOptions) -> bool:
+    return (opts.devicetree is not None and not opts.devicetree.is_absolute()) or any(
+        not path.is_absolute() for path in opts.devicetree_auto
+    )
+
+
+def resolve_devicetree_path(path: Path, uname: str, check_exists: bool = False) -> Path:
+    uname_parts = Path(uname).parts
+    if len(uname_parts) != 1 or uname_parts[0] in ('.', '..'):
+        raise ValueError(f'Invalid kernel version {uname!r}')
+
+    if path.is_absolute():
+        resolved = path
+    else:
+        if not path.parts or '.' in path.parts or '..' in path.parts:
+            raise ValueError(f'Relative DeviceTree path {path} must name a file below the dtb directory')
+        resolved = Path('/usr/lib/modules') / uname / 'dtb' / path
+
+    if check_exists and not resolved.is_file():
+        raise FileNotFoundError(f'DeviceTree file {resolved} not found')
+
+    return resolved
+
+
+def resolve_devicetree_options(
+    opts: UkifyOptions,
+    check_exists: bool = False,
+    strict_uname: bool = False,
+) -> None:
+    if not opts.uname:
+        if has_relative_devicetree(opts):
+            message = 'Kernel version unknown, cannot resolve relative DeviceTree paths'
+            if strict_uname or check_exists:
+                raise ValueError(message)
+            print(message, file=sys.stderr)
+        return
+
+    if opts.devicetree is not None:
+        opts.devicetree = resolve_devicetree_path(opts.devicetree, opts.uname, check_exists)
+    opts.devicetree_auto = [
+        resolve_devicetree_path(path, opts.uname, check_exists) for path in opts.devicetree_auto
+    ]
 
 
 T = TypeVar('T')
@@ -1355,7 +1402,7 @@ def make_uki(opts: UkifyConfig) -> None:
             linux = Path(linux_signed.name)
 
     if opts.uname is None and linux is not None:
-        print('Kernel version not specified, starting autodetection 😖.', file=sys.stderr)
+        print('Kernel version not specified, autodetecting from the kernel image.', file=sys.stderr)
         opts.uname = Uname.scrape(linux, opts=opts)
 
     uki = UKI(opts.join_pcrsig if opts.join_pcrsig else opts.stub)
@@ -2434,6 +2481,12 @@ def finalize_options(opts: argparse.Namespace) -> None:
     if opts.efi_arch is None:
         opts.efi_arch = guess_efi_arch()
 
+    if opts.uname is None and opts.linux is not None and has_relative_devicetree(opts):
+        print('Kernel version not specified, autodetecting from the kernel image.', file=sys.stderr)
+        opts.uname = Uname.scrape(opts.linux, opts=opts)
+
+    resolve_devicetree_options(opts, strict_uname=opts.verb == 'build')
+
     if opts.stub is None and not opts.join_pcrsig:
         if opts.linux is not None:
             opts.stub = Path(f'/usr/lib/systemd/boot/efi/linux{opts.efi_arch}.efi.stub')
@@ -2550,6 +2603,7 @@ def main() -> None:
         # TODO: replace pprint() with some fancy formatting.
         pprint.pprint(vars(opts))
     elif opts.verb == 'build':
+        resolve_devicetree_options(opts, check_exists=True)
         check_inputs(opts)
         make_uki(opts)
     elif opts.verb == 'genkey':

--- a/src/ukify/ukify.py
+++ b/src/ukify/ukify.py
@@ -37,6 +37,7 @@ import re
 import shlex
 import shutil
 import socket
+import string
 import struct
 import subprocess
 import sys
@@ -322,6 +323,9 @@ class UkifyConfig:
         return cls(**{k: v for k, v in vars(ns).items() if k in inspect.signature(cls).parameters})
 
 
+UkifyOptions = Union[argparse.Namespace, UkifyConfig]
+
+
 class Uname:
     # This class is here purely as a namespace for the functions
 
@@ -335,7 +339,7 @@ class Uname:
     TEXT_PATTERN = rb'Linux version (?P<version>\d\.\S+) \('
 
     @classmethod
-    def scrape_x86(cls, filename: Path, opts: Optional[UkifyConfig] = None) -> str:
+    def scrape_x86(cls, filename: Path, opts: Optional[UkifyOptions] = None) -> str:
         # Based on https://gitlab.archlinux.org/archlinux/mkinitcpio/mkinitcpio/-/blob/master/functions#L136
         # and https://docs.kernel.org/arch/x86/boot.html#the-real-mode-kernel-header
         with open(filename, 'rb') as f:
@@ -355,7 +359,7 @@ class Uname:
         return m.group('version')
 
     @classmethod
-    def scrape_elf(cls, filename: Path, opts: Optional[UkifyConfig] = None) -> str:
+    def scrape_elf(cls, filename: Path, opts: Optional[UkifyOptions] = None) -> str:
         readelf = find_tool('readelf', opts=opts)
 
         cmd = [
@@ -377,7 +381,7 @@ class Uname:
         return text.rstrip('\0')
 
     @classmethod
-    def scrape_generic(cls, filename: Path, opts: Optional[UkifyConfig] = None) -> str:
+    def scrape_generic(cls, filename: Path, opts: Optional[UkifyOptions] = None) -> str:
         # import libarchive
         # libarchive-c fails with
         # ArchiveError: Unrecognized archive format (errno=84, retcode=-30, archive_p=94705420454656)
@@ -391,7 +395,7 @@ class Uname:
         return m.group('version').decode()
 
     @classmethod
-    def scrape(cls, filename: Path, opts: Optional[UkifyConfig] = None) -> Optional[str]:
+    def scrape(cls, filename: Path, opts: Optional[UkifyOptions] = None) -> Optional[str]:
         for func in (cls.scrape_x86, cls.scrape_elf, cls.scrape_generic):
             try:
                 version = func(filename, opts=opts)
@@ -716,7 +720,7 @@ def check_cert_and_keys_nonexistent(opts: UkifyConfig) -> None:
 def find_tool(
     name: str,
     fallback: Optional[str] = None,
-    opts: Optional[UkifyConfig] = None,
+    opts: Optional[UkifyOptions] = None,
     msg: str = 'Tool {name} not installed!',
 ) -> Union[str, Path]:
     if opts and opts.tools:
@@ -948,6 +952,88 @@ def join_initrds(initrds: list[Path]) -> Union[Path, bytes, None]:
         seq += [initrd, padding]
 
     return b''.join(seq)
+
+
+def has_relative_devicetree(opts: UkifyOptions) -> bool:
+    return (opts.devicetree is not None and not opts.devicetree.is_absolute()) or any(
+        not path.is_absolute() for path in opts.devicetree_auto
+    )
+
+
+def devicetree_search_paths(uname: str) -> tuple[Path, ...]:
+    paths = (
+        Path('/usr/lib/firmware') / uname / 'device-tree',
+        Path(f'/usr/lib/linux-image-{uname}'),
+        Path('/usr/lib/modules') / uname / 'dtb',
+    )
+
+    return (Path(root), *paths) if (root := os.getenv('KERNEL_INSTALL_CONF_ROOT')) else paths
+
+
+def validate_uname(uname: str) -> None:
+    if not (uname and uname[0] != '.' and set(uname) <= set(string.ascii_letters + string.digits + '._+-#')):
+        raise ValueError(f'Invalid kernel version {uname!r}')
+
+
+def validate_devicetree_path(path: Path) -> None:
+    if not path.is_absolute() and (not path.parts or '..' in path.parts):
+        raise ValueError(f'Invalid DeviceTree path {path!r}')
+
+
+def resolve_devicetree_path(
+    path: Path,
+    uname: str,
+    check_exists: bool = False,
+) -> Path:
+    if path.is_absolute():
+        resolved = path
+    else:
+        for directory in devicetree_search_paths(uname):
+            resolved = directory / path
+            if resolved.is_file() and resolved.resolve().is_relative_to(directory.resolve()):
+                check_exists = False
+                break
+
+    if check_exists and not resolved.is_file():
+        raise FileNotFoundError(f'DeviceTree file {resolved} not found')
+
+    return resolved
+
+
+def validate_devicetree_options(opts: UkifyOptions) -> None:
+    if not opts.uname:
+        return
+
+    if has_relative_devicetree(opts):
+        validate_uname(opts.uname)
+
+    for path in [*([opts.devicetree] if opts.devicetree else []), *opts.devicetree_auto]:
+        validate_devicetree_path(path)
+
+
+def resolve_devicetree_options(
+    opts: UkifyOptions,
+    check_exists: bool = False,
+) -> None:
+    if not opts.uname:
+        if has_relative_devicetree(opts):
+            message = 'Kernel version unknown, cannot resolve relative DeviceTree paths'
+            if check_exists:
+                raise ValueError(message)
+            print(message, file=sys.stderr)
+        return
+
+    if opts.devicetree is not None:
+        opts.devicetree = resolve_devicetree_path(opts.devicetree, opts.uname, check_exists)
+    opts.devicetree_auto = [
+        resolve_devicetree_path(path, opts.uname, check_exists) for path in opts.devicetree_auto
+    ]
+
+
+def autodetect_uname(opts: UkifyOptions, linux: Optional[Path]) -> None:
+    if opts.uname is None and linux is not None:
+        print('Kernel version not specified, autodetecting from the kernel image.', file=sys.stderr)
+        opts.uname = Uname.scrape(linux, opts=opts)
 
 
 T = TypeVar('T')
@@ -1381,9 +1467,7 @@ def make_uki(opts: UkifyConfig) -> None:
             signtool.sign(os.fspath(linux), os.fspath(Path(linux_signed.name)), opts=opts)
             linux = Path(linux_signed.name)
 
-    if opts.uname is None and linux is not None:
-        print('Kernel version not specified, starting autodetection 😖.', file=sys.stderr)
-        opts.uname = Uname.scrape(linux, opts=opts)
+    autodetect_uname(opts, linux)
 
     uki = UKI(opts.join_pcrsig if opts.join_pcrsig else opts.stub)
     initrd = join_initrds(opts.initrd)
@@ -2530,6 +2614,17 @@ def finalize_options(opts: argparse.Namespace) -> None:
     if opts.efi_arch is None:
         opts.efi_arch = guess_efi_arch()
 
+    if opts.verb == 'build':
+        if opts.summary or has_relative_devicetree(opts):
+            autodetect_uname(opts, opts.linux)
+
+        if not opts.uname:
+            resolve_devicetree_options(opts)
+        else:
+            validate_devicetree_options(opts)
+    else:
+        validate_devicetree_options(opts)
+
     if opts.stub is None and not opts.join_pcrsig:
         if opts.linux is not None:
             opts.stub = Path(f'/usr/lib/systemd/boot/efi/linux{opts.efi_arch}.efi.stub')
@@ -2643,9 +2738,12 @@ def parse_args(args: Optional[list[str]] = None) -> argparse.Namespace:
 def main() -> None:
     opts = UkifyConfig.from_namespace(parse_args())
     if opts.summary:
+        if opts.uname:
+            resolve_devicetree_options(opts)
         # TODO: replace pprint() with some fancy formatting.
         pprint.pprint(vars(opts))
     elif opts.verb == 'build':
+        resolve_devicetree_options(opts, check_exists=True)
         check_inputs(opts)
         make_uki(opts)
     elif opts.verb == 'genkey':


### PR DESCRIPTION
UKI configurations may refer to device tree blobs by their path relative to the kernel module directory. This matches how distributions install DTBs under /usr/lib/modules/<uname>/dtb/.

Until now, ukify passed those relative paths through unchanged for both DeviceTree and DeviceTreeAuto. This made such configurations depend on the caller's current working directory. It also made values from uki.conf fail even though the kernel version is already known explicitly, or can be autodetected from the kernel image.

Resolve relative DeviceTree and DeviceTreeAuto entries against /uisr/lib/modules/<uname>/dtb/ once the kernel release is known. Absolute paths keep their existing behaviour, and the resolution is applied to both command-line options and values loaded from uki.conf.