### PR TITLE
semaphore: stop deleting all apt sources

### DIFF
--- a/.semaphore/semaphore-runner.sh
+++ b/.semaphore/semaphore-runner.sh
@@ -68,8 +68,8 @@ EOF
 for phase in "${PHASES[@]}"; do
     case "$phase" in
         SETUP)
-            # remove semaphore repos, some of them don't work and cause error messages
-            sudo rm -rf /etc/apt/sources.list.d/*
+            # remove chrome repo, we don't need it
+            sudo rm -rf /etc/apt/sources.list.d/google-chrome.sources
 
             # enable backports for latest LXC
             echo "deb http://archive.ubuntu.com/ubuntu $UBUNTU_RELEASE-backports main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list.d/backports.list


### PR DESCRIPTION
The image configuration was changed and the main sources are now in a drop-in apt sources files too, so deleting the whole drop-in directory breaks installing packages. Just delete the disabled ones and chrome.