### PR TITLE
test: suppress PCR public key auto-loading in TEST-70-TPM2 dditest

### DIFF
--- a/test/units/TEST-70-TPM2.cryptsetup.sh
+++ b/test/units/TEST-70-TPM2.cryptsetup.sh
@@ -223,7 +223,8 @@ Format=ext4
 CopyFiles=/tmp/dditest:/
 Encrypt=tpm2
 EOF
-    PASSWORD=passphrase systemd-repart --tpm2-device-key=/tmp/srk.pub --definitions=/tmp/dditest --empty=create --size=80M /tmp/dditest.raw --tpm2-pcrs=
+    # Use --tpm2-public-key-pcrs= to suppress auto-loading of the system PCR public key
+    PASSWORD=passphrase systemd-repart --tpm2-device-key=/tmp/srk.pub --tpm2-public-key-pcrs= --definitions=/tmp/dditest --empty=create --size=80M /tmp/dditest.raw --tpm2-pcrs=
     DEVICE="$(systemd-dissect --attach /tmp/dditest.raw)"
     udevadm wait --settle --timeout=10 "$DEVICE"p1
     systemd-cryptsetup attach dditest "$DEVICE"p1 - tpm2-device=auto,headless=yes


### PR DESCRIPTION
The dditest block calls systemd-repart with Encrypt=tpm2 but without --tpm2-public-key-pcrs=. Since systemd-stub drops /run/systemd/tpm2-pcr-public-key.pem when booting from a signed UKI systemd-repart auto-loads it and enrolls a signed PCR policy, and then systemd-cryptsetup tpm2-device=auto has no matching signature file, so unlock fails.

--tpm2-public-key= is not enough as the default kicks in then.

Follow-up for cd18656d47710c251a44a8f5f9d616151a909152