### PR TITLE
resolve: enforce the search domain limit earlier 

### DIFF
--- a/src/resolve/resolved-link-bus.c
+++ b/src/resolve/resolved-link-bus.c
@@ -321,7 +321,7 @@ int bus_link_method_set_domains(sd_bus_message *message, void *userdata, sd_bus_
         if (r < 0)
                 return r;
 
-        for (;;) {
+        for (unsigned n_names = 0;; n_names++) {
                 _cleanup_free_ char *prefixed = NULL;
                 const char *name;
                 int route_only;
@@ -339,6 +339,8 @@ int bus_link_method_set_domains(sd_bus_message *message, void *userdata, sd_bus_
                         return sd_bus_error_setf(error, SD_BUS_ERROR_INVALID_ARGS, "Invalid search domain %s", name);
                 if (!route_only && dns_name_is_root(name))
                         return sd_bus_error_set(error, SD_BUS_ERROR_INVALID_ARGS, "Root domain is not suitable as search domain");
+                if (n_names >= LINK_SEARCH_DOMAINS_MAX)
+                        return sd_bus_error_set(error, SD_BUS_ERROR_LIMITS_EXCEEDED, "Too many search domains per link");
 
                 if (route_only) {
                         prefixed = strjoin("~", name);

--- a/src/resolve/resolved-link-bus.c
+++ b/src/resolve/resolved-link-bus.c
@@ -683,6 +683,9 @@ int bus_link_method_set_dnssec_negative_trust_anchors(sd_bus_message *message, v
         if (r < 0)
                 return r;
 
+        if (strv_length(ntas) > LINK_NEGATIVE_TRUST_ANCHORS_MAX)
+                return sd_bus_error_set(error, SD_BUS_ERROR_LIMITS_EXCEEDED, "Too many negative trust anchors per link");
+
         STRV_FOREACH(i, ntas) {
                 r = dns_name_is_valid(*i);
                 if (r < 0)

--- a/src/resolve/resolved-link.h
+++ b/src/resolve/resolved-link.h
@@ -11,6 +11,7 @@
 
 #define LINK_SEARCH_DOMAINS_MAX 1024
 #define LINK_DNS_SERVERS_MAX 256
+#define LINK_NEGATIVE_TRUST_ANCHORS_MAX 2048
 
 typedef struct LinkAddress {
         Link *link;


### PR DESCRIPTION
The search domain limit is already enforced by dns_search_domain_new(),
but in this case it's way too late. Let's enforce it during the first
loop to avoid unnecessary parsing.

---

Also, set a similar limit for NTAs - introduce a new constant, since there's no pre-existing limit. I pulled the value from a thin air since there's (AFAIK) no mandated maximum/minimum for NTAs, but given they're supposed to be a manual and _temporary_ workarounds, hopefully 2K of NTAs will be more than enough (if not, please yell).

Also note: the newly added error messages don't have the trailing "." and similarly the newly introduced constant doesn't have the "u" suffix to match the style of the surrounding code (and I didn't want to fix the surrounding code to make the diff minimal). If this is not desirable, please also yell.