### PR TITLE
test-oomd: fix flakiness under sanitizers

### DIFF
--- a/src/oom/test-oomd-util.c
+++ b/src/oom/test-oomd-util.c
@@ -291,7 +291,7 @@ TEST(oomd_cgroup_context_acquire_and_insert) {
         ASSERT_EQ(ctx->memory_low, 0u);
         ASSERT_EQ(ctx->swap_usage, 0u);
         ASSERT_EQ(ctx->last_pgscan, 0u);
-        ASSERT_EQ(ctx->pgscan, 0u);
+        ASSERT_LT(ctx->pgscan, 10u);
         ASSERT_NULL(ctx = oomd_cgroup_context_unref(ctx));
 
         ASSERT_OK(oomd_cgroup_context_acquire("", &ctx));


### PR DESCRIPTION
The test asserts that pgscan is 0, but under sanitizers this sometimes fails and shows up as 1. We cannot control what the kernel scans, and with sanitizers the runtime can be slow enough it's possible that the kernel does a pass on the cgroup of the unit test. Instead of asserting that it's 0, assert that it's between 0 and 9, which seems a reasonable range.

Fixes https://github.com/systemd/systemd/issues/37710