### PR TITLE
Add Blockstream Jade+ to hardware wallets list

### DIFF
--- a/hwdb.d/70-hardware-wallets.hwdb
+++ b/hwdb.d/70-hardware-wallets.hwdb
@@ -32,6 +32,10 @@ usb:v10C4pEA60*
 usb:v1A86p55D4*
  ID_HARDWARE_WALLET=1
 
+# Jade Plus
+usb:v303Ap4001*
+ ID_HARDWARE_WALLET=1
+
 ################
 # Coinkite Hardware Wallets
 ################


### PR DESCRIPTION
Updating the hardware list to include this entry https://github.com/bitcoin-core/HWI/commit/4d17ae6e4e9d669a30f7df0e4dbc2781d4ed531d .