### PR TITLE
meson: don't use Python module for host Python

### DIFF
--- a/.github/workflows/build-test.sh
+++ b/.github/workflows/build-test.sh
@@ -156,8 +156,8 @@ if [ -n "$bpftool_dir" ]; then
 fi
 
 if [[ -n "$CUSTOM_PYTHON" ]]; then
-    # If CUSTOM_PYTHON is set we need to pull jinja2 from pip, as a local interpreter is used
-    pip3 install --user --break-system-packages jinja2
+    # If CUSTOM_PYTHON is set we need to pull dependencies from pip, as a local interpreter is used
+    pip3 install --user --break-system-packages jinja2 pefile
 fi
 
 $CC --version

--- a/meson.build
+++ b/meson.build
@@ -1686,7 +1686,7 @@ if have and efi_arch == 'x64' and cc.links('''
         efi_cpu_family_alt = 'x86'
 endif
 
-want_ukify = pymod.find_installation('python3', required: get_option('ukify'), modules : ['pefile']).found()
+want_ukify = get_option('ukify').allowed()
 conf.set10('ENABLE_UKIFY', want_ukify)
 
 #####################################################################


### PR DESCRIPTION
Checking for pefile required that module to be made available for the Python used to build systemd, even though it's only used at runtime, potentially via a different Python installation.

Furthermore, Meson's Python module doesn't do the right thing when cross compiling and looking up a Python for the host system, so this would end up uselessly checking whether the build Python had the pefile module, which is not needed.  Even if it were made to check the host Python using find_program, it still relies on being able to run its Python, which in a cross scenario it probably wouldn't be able to do.

All in all, this check does more harm than good, and prevents building ukify in valid configurations, so remove it.