### PR TITLE
firstboot,sysinstall,hostnamed: always show FANCY_NAME=

### DIFF
--- a/src/basic/os-util.c
+++ b/src/basic/os-util.c
@@ -3,10 +3,12 @@
 #include <stdlib.h>
 
 #include "alloc-util.h"
+#include "ansi-color.h"
 #include "chase.h"
 #include "dirent-util.h"
 #include "env-file.h"
 #include "errno-util.h"
+#include "escape.h"
 #include "fd-util.h"
 #include "fs-util.h"
 #include "glyph-util.h"
@@ -511,4 +513,47 @@ const char* os_release_pretty_name(const char *pretty_name, const char *name) {
 
         return empty_to_null(pretty_name) ?:
                 empty_to_null(name) ?: "Linux";
+}
+
+char *unescape_fancy_name(char **fancy_name) {
+        assert(fancy_name);
+
+        /* Checks if the fancy name is valid, unescapes if it is, nullifies it if not */
+
+        _cleanup_free_ char *unescaped_fancy_name = NULL;
+
+        if (isempty(*fancy_name))
+                goto clear;
+
+        /* We undo one level of C escapes on this */
+        ssize_t n = cunescape(*fancy_name, /* flags= */ 0, &unescaped_fancy_name);
+        if (n < 0) {
+                log_debug_errno((int) n, "Failed to unescape FANCY_NAME= string, suppressing: %m");
+                goto clear;
+        }
+
+        if (!utf8_is_valid(unescaped_fancy_name)) {
+                log_debug("Unescaped FANCY_NAME= string is not valid UTF-8, suppressing.");
+                goto clear;
+        }
+
+        free_and_replace(*fancy_name, unescaped_fancy_name);
+        return *fancy_name;
+
+clear:
+        *fancy_name = mfree(*fancy_name);
+        return NULL;
+}
+
+bool use_fancy_name(const char *fancy_name) {
+
+        /* Decides whether to show the specified fancy name */
+
+        if (isempty(fancy_name))
+                return false;
+
+        if (!colors_enabled())
+                return false;
+
+        return emoji_enabled() || ascii_is_valid(fancy_name);
 }

--- a/src/basic/os-util.h
+++ b/src/basic/os-util.h
@@ -55,3 +55,6 @@ int load_os_release_pairs_with_prefix(const char *root, const char *prefix, char
 int os_release_support_ended(const char *support_end, bool quiet, usec_t *ret_eol);
 
 const char* os_release_pretty_name(const char *pretty_name, const char *name);
+
+bool use_fancy_name(const char *fancy_name);
+char *unescape_fancy_name(char **fancy_name);

--- a/src/firstboot/firstboot.c
+++ b/src/firstboot/firstboot.c
@@ -103,7 +103,7 @@ STATIC_DESTRUCTOR_REGISTER(arg_kernel_cmdline, freep);
 STATIC_DESTRUCTOR_REGISTER(arg_image_policy, image_policy_freep);
 
 static void print_welcome(int rfd, sd_varlink **mute_console_link) {
-        _cleanup_free_ char *pretty_name = NULL, *os_name = NULL, *ansi_color = NULL;
+        _cleanup_free_ char *pretty_name = NULL, *os_name = NULL, *ansi_color = NULL, *fancy_name = NULL;
         static bool done = false;
         const char *pn, *ac;
         int r;
@@ -133,6 +133,7 @@ static void print_welcome(int rfd, sd_varlink **mute_console_link) {
 
         r = parse_os_release_at(rfd,
                                 "PRETTY_NAME", &pretty_name,
+                                "FANCY_NAME", &fancy_name,
                                 "NAME", &os_name,
                                 "ANSI_COLOR", &ansi_color);
         if (r < 0)
@@ -142,7 +143,9 @@ static void print_welcome(int rfd, sd_varlink **mute_console_link) {
         pn = os_release_pretty_name(pretty_name, os_name);
         ac = isempty(ansi_color) ? "0" : ansi_color;
 
-        if (colors_enabled())
+        if (use_fancy_name(unescape_fancy_name(&fancy_name)))
+                printf(ANSI_HIGHLIGHT "Welcome to " ANSI_NORMAL "%s" ANSI_HIGHLIGHT "!" ANSI_NORMAL "\n", fancy_name);
+        else if (colors_enabled())
                 printf(ANSI_HIGHLIGHT "Welcome to " ANSI_NORMAL "\x1B[%sm%s" ANSI_HIGHLIGHT "!" ANSI_NORMAL "\n", ac, pn);
         else
                 printf("Welcome to %s!\n", pn);

--- a/src/hostname/hostnamectl.c
+++ b/src/hostname/hostnamectl.c
@@ -23,13 +23,13 @@
 #include "log.h"
 #include "main-func.h"
 #include "options.h"
+#include "os-util.h"
 #include "parse-argument.h"
 #include "polkit-agent.h"
 #include "pretty-print.h"
 #include "runtime-scope.h"
 #include "string-util.h"
 #include "time-util.h"
-#include "utf8.h"
 #include "verbs.h"
 
 static bool arg_ask_password = true;
@@ -236,7 +236,7 @@ static int print_status_info(StatusInfo *i) {
                         return table_log_add_error(r);
         }
 
-        if (!isempty(i->os_fancy_name) && (emoji_enabled() || ascii_is_valid(i->os_fancy_name)) && colors_enabled()) {
+        if (use_fancy_name(i->os_fancy_name)) {
                 r = table_add_many(table,
                                    TABLE_FIELD, "Operating System",
                                    TABLE_STRING_WITH_ANSI, i->os_fancy_name,

--- a/src/hostname/hostnamed.c
+++ b/src/hostname/hostnamed.c
@@ -22,7 +22,6 @@
 #include "device-private.h"
 #include "env-file.h"
 #include "env-util.h"
-#include "escape.h"
 #include "extract-word.h"
 #include "fileio.h"
 #include "hashmap.h"
@@ -230,20 +229,7 @@ static void context_read_os_release(Context *c) {
         if (free_and_strdup(&c->data[PROP_OS_PRETTY_NAME], os_release_pretty_name(os_pretty_name, os_name)) < 0)
                 log_oom();
 
-        if (!isempty(os_fancy_name)) {
-                _cleanup_free_ char *unescaped = NULL;
-
-                /* We undo one level of C escapes on this */
-                ssize_t l = cunescape(os_fancy_name, /* flags= */ 0, &unescaped);
-                if (l < 0) {
-                        log_warning_errno(l, "Failed to unescape fancy OS name, ignoring: %m");
-                        os_fancy_name = mfree(os_fancy_name);
-                } else if (!utf8_is_valid(unescaped)) {
-                        log_warning("Unescaped fancy OS name contains invalid UTF-8, ignoring.");
-                        os_fancy_name = mfree(os_fancy_name);
-                } else
-                        free_and_replace(os_fancy_name, unescaped);
-        }
+        unescape_fancy_name(&os_fancy_name);
 
         if (isempty(os_fancy_name)) {
                 free(os_fancy_name); /* free if empty string */

--- a/src/shared/prompt-util.c
+++ b/src/shared/prompt-util.c
@@ -12,6 +12,7 @@
 #include "parse-util.h"
 #include "pretty-print.h"
 #include "prompt-util.h"
+#include "stdio-util.h"
 #include "string-util.h"
 #include "strv.h"
 #include "terminal-util.h"
@@ -234,11 +235,12 @@ int chrome_show(
 
         _cleanup_free_ char *b = NULL, *ansi_color_reverse = NULL;
         if (!bottom) {
-                _cleanup_free_ char *pretty_name = NULL, *os_name = NULL, *ansi_color = NULL, *documentation_url = NULL;
+                _cleanup_free_ char *pretty_name = NULL, *os_name = NULL, *ansi_color = NULL, *documentation_url = NULL, *fancy_name = NULL;
 
                 r = parse_os_release(
                                 /* root= */ NULL,
                                 "PRETTY_NAME",        &pretty_name,
+                                "FANCY_NAME",         &fancy_name,
                                 "NAME",               &os_name,
                                 "ANSI_COLOR",         &ansi_color,
                                 "ANSI_COLOR_REVERSE", &ansi_color_reverse,
@@ -258,7 +260,11 @@ int chrome_show(
                         free_and_replace(ansi_color_reverse, j);
                 }
 
-                if (asprintf(&b, "\x1B[0;%sm %s %s", c, m, ansi_color_reverse ?: ANSI_COLOR_CHROME) < 0)
+                if (use_fancy_name(unescape_fancy_name(&fancy_name)))
+                        b = asprintf_safe("\x1B[0;%sm \x1B[0m%s\x1B[0;%sm %s", c, fancy_name, c, ansi_color_reverse ?: ANSI_COLOR_CHROME);
+                else
+                        b = asprintf_safe("\x1B[0;%sm %s %s", c, m, ansi_color_reverse ?: ANSI_COLOR_CHROME);
+                if (!b)
                         return log_oom_debug();
 
                 if (documentation_url) {

--- a/src/sysinstall/sysinstall.c
+++ b/src/sysinstall/sysinstall.c
@@ -214,7 +214,7 @@ static int parse_argv(int argc, char *argv[]) {
 }
 
 static int print_welcome(sd_varlink **mute_console_link) {
-        _cleanup_free_ char *pretty_name = NULL, *os_name = NULL, *ansi_color = NULL;
+        _cleanup_free_ char *pretty_name = NULL, *os_name = NULL, *ansi_color = NULL, *fancy_name = NULL;
         const char *pn, *ac;
         int r;
 
@@ -229,6 +229,7 @@ static int print_welcome(sd_varlink **mute_console_link) {
         r = parse_os_release(
                         /* root= */ NULL,
                         "PRETTY_NAME", &pretty_name,
+                        "FANCY_NAME",  &fancy_name,
                         "NAME",        &os_name,
                         "ANSI_COLOR",  &ansi_color);
         if (r < 0)
@@ -238,7 +239,9 @@ static int print_welcome(sd_varlink **mute_console_link) {
         pn = os_release_pretty_name(pretty_name, os_name);
         ac = isempty(ansi_color) ? "0" : ansi_color;
 
-        if (colors_enabled())
+        if (use_fancy_name(unescape_fancy_name(&fancy_name)))
+                printf(ANSI_HIGHLIGHT "Welcome to the " ANSI_NORMAL "%s" ANSI_HIGHLIGHT " Installer!" ANSI_NORMAL "\n", fancy_name);
+        else if (colors_enabled())
                 printf(ANSI_HIGHLIGHT "Welcome to the " ANSI_NORMAL "\x1B[%sm%s" ANSI_HIGHLIGHT " Installer!" ANSI_NORMAL "\n", ac, pn);
         else
                 printf("Welcome to the %s Installer!\n", pn);


### PR DESCRIPTION
This makes sure that whenever we want to show the OS name we can show the fancy name. Thus this moves the escaping/validation of the fancy name out of hostnamed into generic code, and then makes use of it in sysinstall,firstboot,prompt-util.