### PR TITLE
test: fix flaky testcase_15_wait_online_dns in TEST-75-RESOLVED

### DIFF
--- a/test/units/TEST-75-RESOLVED.sh
+++ b/test/units/TEST-75-RESOLVED.sh
@@ -1421,7 +1421,7 @@ testcase_15_wait_online_dns() {
         /usr/lib/systemd/systemd-networkd-wait-online --timeout=0 --dns --interface=dns0
 
     # Wait until it blocks waiting for updated DNS config
-    timeout 30 bash -c "journalctl -b -u $unit -f | grep -m1 'dns0: No.*DNS server is accessible'" >/dev/null
+    timeout 30 bash -c "until journalctl -b -u $unit --grep 'dns0: No.*DNS server is accessible' >/dev/null 2>&1; do sleep 0.5; done"
 
     # Update the global configuration. Restart rather than reload systemd-resolved so that
     # systemd-networkd-wait-online has to re-connect to the varlink service.


### PR DESCRIPTION
The test used `timeout 30 bash -c "journalctl -b -u $unit -f | grep -m1 ..."` to wait for systemd-networkd-wait-online to log that no DNS server is accessible. The expected message is actually emitted ~1s after the unit starts, but `grep -m1` exiting doesn't tear down `journalctl -f`: journalctl only notices the closed pipe on its next write, which may never happen for an otherwise idle unit. The pipeline therefore hangs until the 30s timeout fires, eventually causing the test to fail.

Replace the follow+pipe with a polling `journalctl --grep` loop, which exits cleanly as soon as the message lands in the journal.

Logs from the failing run:

```
  [ 2650.871441] systemd-networkd-wait-online[2190]: dns0: No DNS configuration yet
  [ 2651.723180] systemd-networkd-wait-online[2190]: dns0: No DNS server is accessible.
  [ 2680.909048] systemd-networkd-wait-online[2190]: json-stream: Got POLLHUP from socket.
  [ 2680.909092] systemd-networkd-wait-online[2190]: DNS configuration monitor disconnected, reconnecting...
  [ 2680.914368] systemd-networkd-wait-online[2190]: Failed to connect to io.systemd.Resolve.Monitor: Connection refused
  [ 2681.966674] systemd-networkd-wait-online[2190]: dns0: No DNS server is accessible.
  [ 2681.969527] systemd-networkd-wait-online[2190]: Failed to connect to io.systemd.Resolve.Monitor: Connection refused
  [ 2682.077032] systemd[1]: Stopping wait-online-dns-0f9e4f6d-8b34-4cff-b2da-03612ca731e8.service - [systemd-run] /usr/lib/systemd/systemd-networkd-wait-online --timeout=0 --dns --interface=dns0...
```

https://github.com/systemd/systemd/actions/runs/25377660774/job/74417031349?pr=41897

Co-developed-by: Claude Opus 4.7 <noreply@anthropic.com>