### PR TITLE
boot: Correct EFI version check for warning suppression

### DIFF
--- a/src/boot/efi.h
+++ b/src/boot/efi.h
@@ -184,6 +184,8 @@ typedef uint64_t EFI_PHYSICAL_ADDRESS;
 #define EFI_PAGE_SIZE 4096U
 #define EFI_SIZE_TO_PAGES(s) (((s) + 0xFFFU) >> 12U)
 
+#define EFI_2_10_SYSTEM_TABLE_REVISION  ((2U << 16) | (10U))
+
 /* These are common enough to warrant forward declaration. We also give them a
  * shorter name for convenience. */
 typedef struct EFI_FILE_PROTOCOL EFI_FILE;

--- a/src/boot/linux.c
+++ b/src/boot/linux.c
@@ -252,7 +252,7 @@ EFI_STATUS linux_exec(
                 if (err != EFI_SUCCESS)
                         /* Only warn if the UEFI should have support in the first place (version >= 2.10) */
                         log_full(err,
-                                 ST->Hdr.Revision >= ((2U << 16) | 100U) ? LOG_WARNING : LOG_DEBUG,
+                                 ST->Hdr.Revision >= EFI_2_10_SYSTEM_TABLE_REVISION ? LOG_WARNING : LOG_DEBUG,
                                  "No EFI_MEMORY_ATTRIBUTE_PROTOCOL found, skipping NX_COMPAT support.");
         }
 


### PR DESCRIPTION
The boot stub suppresses EFI_MEMORY_ATTRIBUTE_PROTOCOL not found warning if the UEFI version is earlier than 2.10, except that there is a typo such that 2.100 was compared against instead.

This is discovered on Qualcomm's UEFI implementation where they do enforce NX bits but does not support EFI_MEMORY_ATTRIBUTE_PROTOCOL.