### PR TITLE
network/can: only send CAN.RestartSec if set

### DIFF
--- a/src/network/networkd-can.c
+++ b/src/network/networkd-can.c
@@ -89,17 +89,19 @@ int can_set_netlink_message(Link *link, sd_netlink_message *m) {
                         return r;
         }
 
-        uint64_t restart_ms;
-
-        if (link->network->can_restart_us == USEC_INFINITY)
-                restart_ms = 0;
-        else
-                restart_ms = DIV_ROUND_UP(link->network->can_restart_us, USEC_PER_MSEC);
-
-        log_link_debug(link, "Setting restart = %s", FORMAT_TIMESPAN(restart_ms * 1000, MSEC_PER_SEC));
-        r = sd_netlink_message_append_u32(m, IFLA_CAN_RESTART_MS, restart_ms);
-        if (r < 0)
-                return r;
+        if (link->network->can_restart_us_set) {
+                uint64_t restart_ms;
+        
+                if (link->network->can_restart_us == USEC_INFINITY)
+                        restart_ms = 0;
+                else
+                        restart_ms = DIV_ROUND_UP(link->network->can_restart_us, USEC_PER_MSEC);
+        
+                log_link_debug(link, "Setting restart = %s", FORMAT_TIMESPAN(restart_ms * 1000, MSEC_PER_SEC));
+                r = sd_netlink_message_append_u32(m, IFLA_CAN_RESTART_MS, restart_ms);
+                if (r < 0)
+                        return r;
+        }
 
         if (link->network->can_control_mode_mask != 0) {
                 struct can_ctrlmode cm = {
@@ -219,7 +221,8 @@ int config_parse_can_restart_usec(
                 void *data,
                 void *userdata) {
 
-        usec_t usec, *restart_usec = ASSERT_PTR(data);
+        Network *network = ASSERT_PTR(userdata);
+        usec_t usec;
         int r;
 
         assert(filename);
@@ -240,7 +243,8 @@ int config_parse_can_restart_usec(
                 return 0;
         }
 
-        *restart_usec = usec;
+        network->can_restart_us_set = true;
+        network->can_restart_us = usec;
         return 0;
 }
 

--- a/src/network/networkd-network-gperf.gperf
+++ b/src/network/networkd-network-gperf.gperf
@@ -481,7 +481,7 @@ CAN.DataPropagationSegment,                      config_parse_uint32,           
 CAN.DataPhaseBufferSegment1,                     config_parse_uint32,                            0,                                      offsetof(Network, can_data_phase_buffer_segment_1)
 CAN.DataPhaseBufferSegment2,                     config_parse_uint32,                            0,                                      offsetof(Network, can_data_phase_buffer_segment_2)
 CAN.DataSyncJumpWidth,                           config_parse_uint32,                            0,                                      offsetof(Network, can_data_sync_jump_width)
-CAN.RestartSec,                                  config_parse_can_restart_usec,                  0,                                      offsetof(Network, can_restart_us)
+CAN.RestartSec,                                  config_parse_can_restart_usec,                  0,                                      0
 CAN.Loopback,                                    config_parse_can_control_mode,                  CAN_CTRLMODE_LOOPBACK,                  0
 CAN.ListenOnly,                                  config_parse_can_control_mode,                  CAN_CTRLMODE_LISTENONLY,                0
 CAN.TripleSampling,                              config_parse_can_control_mode,                  CAN_CTRLMODE_3_SAMPLES,                 0

--- a/src/network/networkd-network.h
+++ b/src/network/networkd-network.h
@@ -319,6 +319,7 @@ typedef struct Network {
         uint32_t can_data_phase_buffer_segment_2;
         uint32_t can_data_sync_jump_width;
         usec_t can_restart_us;
+        bool can_restart_us_set;
         uint32_t can_control_mode_mask;
         uint32_t can_control_mode_flags;
         uint16_t can_termination;


### PR DESCRIPTION
Always sending a value unconditionally breaks compatibility with CAN adapter that don't support automatic restarting. This restores previous behavior: If RestartSec is not set, don't add it to the netlink message.

This code is a previous implementation of #37824 by @rzblue. Commit [`30cc182`](https://github.com/systemd/systemd/commit/30cc182f6855853de06deace27e042cc7df5789d) to be exact.

Problem description (copied from what I wrote in #37824):

>Hi!
>From what I can tell this completely break systemd-networkd compatibility with USB to CAN adapters, that don't support `CAN_RESTART_MS`.
>
>I currently have this systemd network configuration:
>```ini
>[Match]
>Name=can*
>
>[Link]
>RequiredForOnline=no
>
>[Network]
>
>[CAN]
>BitRate=1M
>```
>
>Which is failing with:
>```
>λ networkctl status can0
>● 3: can0
>               Link File: /nix/store/fy4qc11zglik99wwypmll8agwfcdmkph-systemd-258.5/lib/systemd/network/99-default.link
>            Network File: /etc/systemd/network/25-can0.network
>                   State: off (failed)
>            Online state: unknown
>                    Type: can
>                    Kind: can
>                    Path: platform-3f980000.usb-usb-0:1.5:1.0
>                  Driver: gs_usb
>                  Vendor: OpenMoko, Inc.
>                   Model: Geschwister Schneider CAN adapter
>                     MTU: 16
>                   QDisc: noop
>Number of Queues (Tx/Rx): 1/1
>       Activation Policy: up
>     Required For Online: no
>
>May 06 16:35:00 nixos-artillery-genius systemd-networkd[9505]: can0: Failed
>May 06 16:35:00 nixos-artillery-genius systemd-networkd[9505]: can0: Trying to reconfigure the interface.
>May 06 16:35:00 nixos-artillery-genius systemd-networkd[9505]: can0: Reconfiguring with /etc/systemd/network/25-can0.network.
>May 06 16:35:00 nixos-artillery-genius systemd-networkd[9505]: can0: Failed to set CAN interface configurations: Device doesn't support restart from Bus Off. Operation not supported
>May 06 16:35:00 nixos-artillery-genius systemd-networkd[9505]: can0: Failed
>May 06 16:35:00 nixos-artillery-genius systemd-networkd[9505]: can0: Trying to reconfigure the interface.
>May 06 16:35:00 nixos-artillery-genius systemd-networkd[9505]: can0: Reconfiguring with /etc/systemd/network/25-can0.network.
>May 06 16:35:00 nixos-artillery-genius systemd-networkd[9505]: can0: Failed to set CAN interface configurations: Device doesn't support restart from Bus Off. Operation not supported
>May 06 16:35:00 nixos-artillery-genius systemd-networkd[9505]: can0: Failed
>May 06 16:35:00 nixos-artillery-genius systemd-networkd[9505]: can0: The interface entered the failed state frequently, refusing to reconfigure it automatically.
>```
>
>I'm using a cheap [UCAN](https://wiki.fysetc.com/docs/UCAN) USB to CAN adapter, which seems to run [canable-fw](https://github.com/normaldotcom/canable-fw) firmware (slcan). This adapter is pretty common in the 3dprinter community, were CAN is used to communicate between the main 3d printer host board (normally a raspberry pi running klipper) and the toolhead.
>
>This specific change doesn't seem to affect many of these people yet though, as it's relatively new and probably hasn't reached the commonly used raspberry pi images yet.
>
>I have found a bunch of reports of people using `RestartSec=<non-zero-value>` though, resulting in the same error:
><img width="2150" height="1347" alt="image" src="https://github.com/user-attachments/assets/b4aee86d-4d50-4388-840c-c91136daaaa6" />
>
>(This is from the Voron Design discord server.)
>
>So my question is @rzblue, @yuwata:
>What does this change actually solve? In it's current form, it seems to break more things than fix them.
>
>I think this should be (atleast partially) reverted.
>What about using the previous condition from [here](https://github.com/systemd/systemd/pull/37824#discussion_r2144226676)?
>
>`if (link->network->can_restart_us_set) {` Shouldn't this result in no message being sent if `RestartSec` is not set?