### PR TITLE
test: add missing varlink IDL enum tests for Job and ServiceType

### DIFF
--- a/src/shared/varlink-io.systemd.Unit.c
+++ b/src/shared/varlink-io.systemd.Unit.c
@@ -976,7 +976,7 @@ static SD_VARLINK_DEFINE_STRUCT_TYPE(
 /* Service-specific types */
 
 /* Keep in sync with service_type_table[] in src/core/service.c */
-static SD_VARLINK_DEFINE_ENUM_TYPE(
+SD_VARLINK_DEFINE_ENUM_TYPE(
                 ServiceType,
                 SD_VARLINK_DEFINE_ENUM_VALUE(simple),
                 SD_VARLINK_DEFINE_ENUM_VALUE(exec),

--- a/src/shared/varlink-io.systemd.Unit.h
+++ b/src/shared/varlink-io.systemd.Unit.h
@@ -32,3 +32,4 @@ extern const sd_varlink_symbol vl_type_AutomountResult;
 extern const sd_varlink_symbol vl_type_MountResult;
 extern const sd_varlink_symbol vl_type_CollectMode;
 extern const sd_varlink_symbol vl_type_JobMode;
+extern const sd_varlink_symbol vl_type_ServiceType;

--- a/src/test/meson.build
+++ b/src/test/meson.build
@@ -491,10 +491,13 @@ executables += [
                 'conditions' : ['ENABLE_UTMP'],
         },
         core_test_template + {
-                'sources' : files('test-varlink-idl-unit.c'),
+                'sources' : files('test-varlink-idl-job.c'),
         },
         core_test_template + {
                 'sources' : files('test-varlink-idl-manager.c'),
+        },
+        core_test_template + {
+                'sources' : files('test-varlink-idl-unit.c'),
         },
         test_template + {
                 'sources' : files('test-varlink-idl-machine.c'),

--- a/src/test/test-varlink-idl-job.c
+++ b/src/test/test-varlink-idl-job.c
@@ -1,0 +1,14 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include "job.h"
+#include "tests.h"
+#include "test-varlink-idl-util.h"
+#include "varlink-io.systemd.Job.h"
+
+TEST(job_enums_idl) {
+        TEST_IDL_ENUM(JobType, job_type, vl_type_JobType);
+        TEST_IDL_ENUM(JobState, job_state, vl_type_JobState);
+        TEST_IDL_ENUM(JobResult, job_result, vl_type_JobResult);
+}
+
+DEFINE_TEST_MAIN(LOG_DEBUG);

--- a/src/test/test-varlink-idl-unit.c
+++ b/src/test/test-varlink-idl-unit.c
@@ -7,6 +7,7 @@
 #include "mount.h"
 #include "numa-util.h"
 #include "process-util.h"
+#include "service.h"
 #include "tests.h"
 #include "test-varlink-idl-util.h"
 #include "unit.h"
@@ -58,6 +59,9 @@ TEST(unit_enums_idl) {
 
         /* MountRuntime enums */
         TEST_IDL_ENUM(MountResult, mount_result, vl_type_MountResult);
+
+        /* ServiceContext enums */
+        TEST_IDL_ENUM(ServiceType, service_type, vl_type_ServiceType);
 
         /* UnitContext enums */
         TEST_IDL_ENUM(CollectMode, collect_mode, vl_type_CollectMode);


### PR DESCRIPTION
PR #41583 (io.systemd.Unit.StartTransient) introduced several new varlink IDL enum types without corresponding enum consistency tests:

- JobType, JobState, JobResult in the new io.systemd.Job interface
- ServiceType in the Unit interface's ServiceContext

Add a new test-varlink-idl-job test file covering all three Job enums, and add ServiceType coverage to the existing test-varlink-idl-unit test. Export vl_type_ServiceType (was static) so it can be referenced from the test.

Co-developed-by: Claude Opus 4.6 <noreply@anthropic.com>