### PR TITLE
Implement Path/Scope/Swap/Timer Context/Runtime for `io.systemd.Unit.List`

### DIFF
--- a/src/core/meson.build
+++ b/src/core/meson.build
@@ -75,6 +75,7 @@ libcore_sources = files(
         'varlink-mount.c',
         'varlink-path.c',
         'varlink-scope.c',
+        'varlink-swap.c',
         'varlink-unit.c',
 )
 

--- a/src/core/meson.build
+++ b/src/core/meson.build
@@ -76,6 +76,7 @@ libcore_sources = files(
         'varlink-path.c',
         'varlink-scope.c',
         'varlink-swap.c',
+        'varlink-timer.c',
         'varlink-unit.c',
 )
 

--- a/src/core/meson.build
+++ b/src/core/meson.build
@@ -74,6 +74,7 @@ libcore_sources = files(
         'varlink-metrics.c',
         'varlink-mount.c',
         'varlink-path.c',
+        'varlink-scope.c',
         'varlink-unit.c',
 )
 

--- a/src/core/meson.build
+++ b/src/core/meson.build
@@ -73,6 +73,7 @@ libcore_sources = files(
         'varlink-manager.c',
         'varlink-metrics.c',
         'varlink-mount.c',
+        'varlink-path.c',
         'varlink-unit.c',
 )
 

--- a/src/core/varlink-path.c
+++ b/src/core/varlink-path.c
@@ -1,0 +1,48 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include "sd-json.h"
+
+#include "json-util.h"
+#include "path.h"
+#include "varlink-path.h"
+
+static int path_specs_build_json(sd_json_variant **ret, const char *name, void *userdata) {
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *v = NULL;
+        PathSpec *specs = userdata;
+        int r;
+
+        assert(ret);
+
+        LIST_FOREACH(spec, k, specs) {
+                r = sd_json_variant_append_arraybo(
+                                &v,
+                                JSON_BUILD_PAIR_ENUM("type", path_type_to_string(k->type)),
+                                SD_JSON_BUILD_PAIR_STRING("path", k->path));
+                if (r < 0)
+                        return r;
+        }
+
+        *ret = TAKE_PTR(v);
+        return 0;
+}
+
+int path_context_build_json(sd_json_variant **ret, const char *name, void *userdata) {
+        Path *p = ASSERT_PTR(PATH(userdata));
+        Unit *trigger = UNIT_TRIGGER(UNIT(p));
+
+        return sd_json_buildo(
+                        ASSERT_PTR(ret),
+                        JSON_BUILD_PAIR_CALLBACK_NON_NULL("Paths", path_specs_build_json, p->specs),
+                        JSON_BUILD_PAIR_STRING_NON_EMPTY("Unit", trigger ? trigger->id : NULL),
+                        SD_JSON_BUILD_PAIR_BOOLEAN("MakeDirectory", p->make_directory),
+                        SD_JSON_BUILD_PAIR_UNSIGNED("DirectoryMode", p->directory_mode),
+                        JSON_BUILD_PAIR_RATELIMIT("TriggerLimit", &p->trigger_limit));
+}
+
+int path_runtime_build_json(sd_json_variant **ret, const char *name, void *userdata) {
+        Path *p = ASSERT_PTR(PATH(userdata));
+
+        return sd_json_buildo(
+                        ASSERT_PTR(ret),
+                        JSON_BUILD_PAIR_ENUM("Result", path_result_to_string(p->result)));
+}

--- a/src/core/varlink-path.h
+++ b/src/core/varlink-path.h
@@ -1,0 +1,7 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#pragma once
+
+#include "core-forward.h"
+
+int path_context_build_json(sd_json_variant **ret, const char *name, void *userdata);
+int path_runtime_build_json(sd_json_variant **ret, const char *name, void *userdata);

--- a/src/core/varlink-scope.c
+++ b/src/core/varlink-scope.c
@@ -1,0 +1,26 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include "sd-json.h"
+
+#include "json-util.h"
+#include "scope.h"
+#include "varlink-scope.h"
+
+int scope_context_build_json(sd_json_variant **ret, const char *name, void *userdata) {
+        Scope *s = ASSERT_PTR(SCOPE(userdata));
+
+        return sd_json_buildo(
+                        ASSERT_PTR(ret),
+                        JSON_BUILD_PAIR_ENUM("OOMPolicy", oom_policy_to_string(s->oom_policy)),
+                        JSON_BUILD_PAIR_FINITE_USEC("RuntimeMaxUSec", s->runtime_max_usec),
+                        JSON_BUILD_PAIR_FINITE_USEC("RuntimeRandomizedExtraUSec", s->runtime_rand_extra_usec),
+                        JSON_BUILD_PAIR_FINITE_USEC("TimeoutStopUSec", s->timeout_stop_usec));
+}
+
+int scope_runtime_build_json(sd_json_variant **ret, const char *name, void *userdata) {
+        Scope *s = ASSERT_PTR(SCOPE(userdata));
+
+        return sd_json_buildo(
+                        ASSERT_PTR(ret),
+                        JSON_BUILD_PAIR_ENUM("Result", scope_result_to_string(s->result)));
+}

--- a/src/core/varlink-scope.h
+++ b/src/core/varlink-scope.h
@@ -1,0 +1,7 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#pragma once
+
+#include "core-forward.h"
+
+int scope_context_build_json(sd_json_variant **ret, const char *name, void *userdata);
+int scope_runtime_build_json(sd_json_variant **ret, const char *name, void *userdata);

--- a/src/core/varlink-swap.c
+++ b/src/core/varlink-swap.c
@@ -1,0 +1,35 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include "sd-json.h"
+
+#include "json-util.h"
+#include "swap.h"
+#include "user-util.h"
+#include "varlink-common.h"
+#include "varlink-swap.h"
+
+int swap_context_build_json(sd_json_variant **ret, const char *name, void *userdata) {
+        Swap *s = ASSERT_PTR(SWAP(userdata));
+
+        return sd_json_buildo(
+                        ASSERT_PTR(ret),
+                        SD_JSON_BUILD_PAIR_STRING("What", s->what),
+                        JSON_BUILD_PAIR_INTEGER_NON_NEGATIVE("Priority", swap_get_priority(s)),
+                        JSON_BUILD_PAIR_STRING_NON_EMPTY("Options", swap_get_options(s)),
+                        JSON_BUILD_PAIR_FINITE_USEC("TimeoutUSec", s->timeout_usec),
+                        JSON_BUILD_PAIR_CALLBACK_NON_NULL("ExecActivate", exec_command_build_json, &s->exec_command[SWAP_EXEC_ACTIVATE]),
+                        JSON_BUILD_PAIR_CALLBACK_NON_NULL("ExecDeactivate", exec_command_build_json, &s->exec_command[SWAP_EXEC_DEACTIVATE]));
+}
+
+int swap_runtime_build_json(sd_json_variant **ret, const char *name, void *userdata) {
+        Unit *u = ASSERT_PTR(userdata);
+        Swap *s = ASSERT_PTR(SWAP(u));
+
+        return sd_json_buildo(
+                        ASSERT_PTR(ret),
+                        SD_JSON_BUILD_PAIR_CONDITION(pidref_is_set(&s->control_pid), "ControlPID", JSON_BUILD_PIDREF(&s->control_pid)),
+                        JSON_BUILD_PAIR_ENUM("Result", swap_result_to_string(s->result)),
+                        JSON_BUILD_PAIR_ENUM("CleanResult", swap_result_to_string(s->clean_result)),
+                        SD_JSON_BUILD_PAIR_CONDITION(uid_is_valid(u->ref_uid), "UID", SD_JSON_BUILD_UNSIGNED(u->ref_uid)),
+                        SD_JSON_BUILD_PAIR_CONDITION(gid_is_valid(u->ref_gid), "GID", SD_JSON_BUILD_UNSIGNED(u->ref_gid)));
+}

--- a/src/core/varlink-swap.h
+++ b/src/core/varlink-swap.h
@@ -1,0 +1,7 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#pragma once
+
+#include "core-forward.h"
+
+int swap_context_build_json(sd_json_variant **ret, const char *name, void *userdata);
+int swap_runtime_build_json(sd_json_variant **ret, const char *name, void *userdata);

--- a/src/core/varlink-timer.c
+++ b/src/core/varlink-timer.c
@@ -1,0 +1,77 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include "sd-json.h"
+
+#include "calendarspec.h"
+#include "json-util.h"
+#include "timer.h"
+#include "varlink-timer.h"
+
+static int timers_build_json(sd_json_variant **ret, const char *name, void *userdata) {
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *v = NULL;
+        TimerValue *values = userdata;
+        int r;
+
+        assert(ret);
+
+        LIST_FOREACH(value, value, values) {
+                _cleanup_free_ char *base_name = NULL;
+
+                base_name = timer_base_to_usec_string(value->base);
+                if (!base_name)
+                        return -ENOMEM;
+
+                if (value->base == TIMER_CALENDAR) {
+                        _cleanup_free_ char *calendar = NULL;
+
+                        r = calendar_spec_to_string(value->calendar_spec, &calendar);
+                        if (r < 0)
+                                return log_debug_errno(r, "Failed to convert calendar spec into string: %m");
+
+                        r = sd_json_variant_append_arraybo(
+                                        &v,
+                                        JSON_BUILD_PAIR_ENUM("base", base_name),
+                                        SD_JSON_BUILD_PAIR_STRING("calendar", calendar));
+                } else
+                        r = sd_json_variant_append_arraybo(
+                                        &v,
+                                        JSON_BUILD_PAIR_ENUM("base", base_name),
+                                        SD_JSON_BUILD_PAIR_UNSIGNED("usec", value->value));
+                if (r < 0)
+                        return r;
+        }
+
+        *ret = TAKE_PTR(v);
+        return 0;
+}
+
+int timer_context_build_json(sd_json_variant **ret, const char *name, void *userdata) {
+        Timer *t = ASSERT_PTR(TIMER(userdata));
+        Unit *trigger = UNIT_TRIGGER(UNIT(t));
+
+        return sd_json_buildo(
+                        ASSERT_PTR(ret),
+                        JSON_BUILD_PAIR_CALLBACK_NON_NULL("Timers", timers_build_json, t->values),
+                        JSON_BUILD_PAIR_STRING_NON_EMPTY("Unit", trigger ? trigger->id : NULL),
+                        SD_JSON_BUILD_PAIR_BOOLEAN("OnClockChange", t->on_clock_change),
+                        SD_JSON_BUILD_PAIR_BOOLEAN("OnTimezoneChange", t->on_timezone_change),
+                        JSON_BUILD_PAIR_FINITE_USEC("AccuracyUSec", t->accuracy_usec),
+                        JSON_BUILD_PAIR_FINITE_USEC("RandomizedDelayUSec", t->random_delay_usec),
+                        JSON_BUILD_PAIR_FINITE_USEC("RandomizedOffsetUSec", t->random_offset_usec),
+                        SD_JSON_BUILD_PAIR_BOOLEAN("FixedRandomDelay", t->fixed_random_delay),
+                        SD_JSON_BUILD_PAIR_BOOLEAN("Persistent", t->persistent),
+                        SD_JSON_BUILD_PAIR_BOOLEAN("WakeSystem", t->wake_system),
+                        SD_JSON_BUILD_PAIR_BOOLEAN("RemainAfterElapse", t->remain_after_elapse),
+                        SD_JSON_BUILD_PAIR_BOOLEAN("DeferReactivation", t->defer_reactivation));
+}
+
+int timer_runtime_build_json(sd_json_variant **ret, const char *name, void *userdata) {
+        Timer *t = ASSERT_PTR(TIMER(userdata));
+
+        return sd_json_buildo(
+                        ASSERT_PTR(ret),
+                        JSON_BUILD_PAIR_ENUM("Result", timer_result_to_string(t->result)),
+                        JSON_BUILD_PAIR_FINITE_USEC("NextElapseUSecRealtime", t->next_elapse_realtime),
+                        JSON_BUILD_PAIR_FINITE_USEC("NextElapseUSecMonotonic", timer_next_elapse_monotonic(t)),
+                        JSON_BUILD_PAIR_DUAL_TIMESTAMP_NON_NULL("LastTriggerUSec", &t->last_trigger));
+}

--- a/src/core/varlink-timer.h
+++ b/src/core/varlink-timer.h
@@ -1,0 +1,7 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#pragma once
+
+#include "core-forward.h"
+
+int timer_context_build_json(sd_json_variant **ret, const char *name, void *userdata);
+int timer_runtime_build_json(sd_json_variant **ret, const char *name, void *userdata);

--- a/src/core/varlink-unit.c
+++ b/src/core/varlink-unit.c
@@ -29,6 +29,7 @@
 #include "varlink-execute.h"
 #include "varlink-kill.h"
 #include "varlink-mount.h"
+#include "varlink-path.h"
 #include "varlink-unit.h"
 #include "varlink-util.h"
 
@@ -162,6 +163,7 @@ static int unit_context_build_json(sd_json_variant **ret, const char *name, void
         static const sd_json_build_callback_t unit_type_callbacks[_UNIT_TYPE_MAX] = {
                 [UNIT_AUTOMOUNT] = automount_context_build_json,
                 [UNIT_MOUNT]     = mount_context_build_json,
+                [UNIT_PATH]      = path_context_build_json,
                 [UNIT_SERVICE]   = service_context_build_json,
         };
 
@@ -328,6 +330,7 @@ static int unit_runtime_build_json(sd_json_variant **ret, const char *name, void
         static const sd_json_build_callback_t unit_type_callbacks[_UNIT_TYPE_MAX] = {
                 [UNIT_AUTOMOUNT] = automount_runtime_build_json,
                 [UNIT_MOUNT]     = mount_runtime_build_json,
+                [UNIT_PATH]      = path_runtime_build_json,
         };
 
         return sd_json_buildo(

--- a/src/core/varlink-unit.c
+++ b/src/core/varlink-unit.c
@@ -31,6 +31,7 @@
 #include "varlink-mount.h"
 #include "varlink-path.h"
 #include "varlink-scope.h"
+#include "varlink-swap.h"
 #include "varlink-unit.h"
 #include "varlink-util.h"
 
@@ -167,6 +168,7 @@ static int unit_context_build_json(sd_json_variant **ret, const char *name, void
                 [UNIT_PATH]      = path_context_build_json,
                 [UNIT_SCOPE]     = scope_context_build_json,
                 [UNIT_SERVICE]   = service_context_build_json,
+                [UNIT_SWAP]      = swap_context_build_json,
         };
 
         return sd_json_buildo(
@@ -334,6 +336,7 @@ static int unit_runtime_build_json(sd_json_variant **ret, const char *name, void
                 [UNIT_MOUNT]     = mount_runtime_build_json,
                 [UNIT_PATH]      = path_runtime_build_json,
                 [UNIT_SCOPE]     = scope_runtime_build_json,
+                [UNIT_SWAP]      = swap_runtime_build_json,
         };
 
         return sd_json_buildo(

--- a/src/core/varlink-unit.c
+++ b/src/core/varlink-unit.c
@@ -32,6 +32,7 @@
 #include "varlink-path.h"
 #include "varlink-scope.h"
 #include "varlink-swap.h"
+#include "varlink-timer.h"
 #include "varlink-unit.h"
 #include "varlink-util.h"
 
@@ -169,6 +170,7 @@ static int unit_context_build_json(sd_json_variant **ret, const char *name, void
                 [UNIT_SCOPE]     = scope_context_build_json,
                 [UNIT_SERVICE]   = service_context_build_json,
                 [UNIT_SWAP]      = swap_context_build_json,
+                [UNIT_TIMER]     = timer_context_build_json,
         };
 
         return sd_json_buildo(
@@ -337,6 +339,7 @@ static int unit_runtime_build_json(sd_json_variant **ret, const char *name, void
                 [UNIT_PATH]      = path_runtime_build_json,
                 [UNIT_SCOPE]     = scope_runtime_build_json,
                 [UNIT_SWAP]      = swap_runtime_build_json,
+                [UNIT_TIMER]     = timer_runtime_build_json,
         };
 
         return sd_json_buildo(

--- a/src/core/varlink-unit.c
+++ b/src/core/varlink-unit.c
@@ -30,6 +30,7 @@
 #include "varlink-kill.h"
 #include "varlink-mount.h"
 #include "varlink-path.h"
+#include "varlink-scope.h"
 #include "varlink-unit.h"
 #include "varlink-util.h"
 
@@ -164,6 +165,7 @@ static int unit_context_build_json(sd_json_variant **ret, const char *name, void
                 [UNIT_AUTOMOUNT] = automount_context_build_json,
                 [UNIT_MOUNT]     = mount_context_build_json,
                 [UNIT_PATH]      = path_context_build_json,
+                [UNIT_SCOPE]     = scope_context_build_json,
                 [UNIT_SERVICE]   = service_context_build_json,
         };
 
@@ -331,6 +333,7 @@ static int unit_runtime_build_json(sd_json_variant **ret, const char *name, void
                 [UNIT_AUTOMOUNT] = automount_runtime_build_json,
                 [UNIT_MOUNT]     = mount_runtime_build_json,
                 [UNIT_PATH]      = path_runtime_build_json,
+                [UNIT_SCOPE]     = scope_runtime_build_json,
         };
 
         return sd_json_buildo(

--- a/src/shared/varlink-idl-common.c
+++ b/src/shared/varlink-idl-common.c
@@ -99,6 +99,12 @@ SD_VARLINK_DEFINE_ENUM_TYPE(
                 SD_VARLINK_DEFINE_ENUM_VALUE(kill));
 
 SD_VARLINK_DEFINE_ENUM_TYPE(
+                OOMPolicy,
+                SD_VARLINK_DEFINE_ENUM_VALUE(continue),
+                SD_VARLINK_DEFINE_ENUM_VALUE(stop),
+                SD_VARLINK_DEFINE_ENUM_VALUE(kill));
+
+SD_VARLINK_DEFINE_ENUM_TYPE(
                 EmergencyAction,
                 SD_VARLINK_DEFINE_ENUM_VALUE(none),
                 SD_VARLINK_DEFINE_ENUM_VALUE(exit),

--- a/src/shared/varlink-idl-common.h
+++ b/src/shared/varlink-idl-common.h
@@ -12,4 +12,5 @@ extern const sd_varlink_symbol vl_type_ExecCommand;
 extern const sd_varlink_symbol vl_type_ExecOutputType;
 extern const sd_varlink_symbol vl_type_CGroupPressureWatch;
 extern const sd_varlink_symbol vl_type_ManagedOOMMode;
+extern const sd_varlink_symbol vl_type_OOMPolicy;
 extern const sd_varlink_symbol vl_type_EmergencyAction;

--- a/src/shared/varlink-io.systemd.Manager.c
+++ b/src/shared/varlink-io.systemd.Manager.c
@@ -15,12 +15,6 @@ SD_VARLINK_DEFINE_ENUM_TYPE(
                 SD_VARLINK_DEFINE_ENUM_VALUE(auto),
                 SD_VARLINK_DEFINE_ENUM_VALUE(null));
 
-SD_VARLINK_DEFINE_ENUM_TYPE(
-                OOMPolicy,
-                SD_VARLINK_DEFINE_ENUM_VALUE(continue),
-                SD_VARLINK_DEFINE_ENUM_VALUE(stop),
-                SD_VARLINK_DEFINE_ENUM_VALUE(kill));
-
 static SD_VARLINK_DEFINE_STRUCT_TYPE(
                 LogLevelStruct,
                 SD_VARLINK_FIELD_COMMENT("'console' target log level"),

--- a/src/shared/varlink-io.systemd.Manager.h
+++ b/src/shared/varlink-io.systemd.Manager.h
@@ -6,4 +6,3 @@
 extern const sd_varlink_interface vl_interface_io_systemd_Manager;
 
 extern const sd_varlink_symbol vl_type_LogTarget;
-extern const sd_varlink_symbol vl_type_OOMPolicy;

--- a/src/shared/varlink-io.systemd.Unit.c
+++ b/src/shared/varlink-io.systemd.Unit.c
@@ -1081,6 +1081,70 @@ static SD_VARLINK_DEFINE_STRUCT_TYPE(
                 SD_VARLINK_FIELD_COMMENT("Reference GID"),
                 SD_VARLINK_DEFINE_FIELD(GID, SD_VARLINK_INT, SD_VARLINK_NULLABLE));
 
+/* TimerContext
+ * https://www.freedesktop.org/software/systemd/man/latest/systemd.timer.html */
+SD_VARLINK_DEFINE_ENUM_TYPE(
+                TimerBase,
+                SD_VARLINK_DEFINE_ENUM_VALUE(OnActiveUSec),
+                SD_VARLINK_DEFINE_ENUM_VALUE(OnBootUSec),
+                SD_VARLINK_DEFINE_ENUM_VALUE(OnStartupUSec),
+                SD_VARLINK_DEFINE_ENUM_VALUE(OnUnitActiveUSec),
+                SD_VARLINK_DEFINE_ENUM_VALUE(OnUnitInactiveUSec),
+                SD_VARLINK_DEFINE_ENUM_VALUE(OnCalendar));
+
+static SD_VARLINK_DEFINE_STRUCT_TYPE(
+                TimerSpec,
+                SD_VARLINK_FIELD_COMMENT("Timer base type"),
+                SD_VARLINK_DEFINE_FIELD_BY_TYPE(base, TimerBase, 0),
+                SD_VARLINK_FIELD_COMMENT("Timer value in microseconds (for monotonic timers)"),
+                SD_VARLINK_DEFINE_FIELD(usec, SD_VARLINK_INT, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("Calendar specification string (for calendar timers)"),
+                SD_VARLINK_DEFINE_FIELD(calendar, SD_VARLINK_STRING, SD_VARLINK_NULLABLE));
+
+static SD_VARLINK_DEFINE_STRUCT_TYPE(
+                TimerContext,
+                SD_VARLINK_FIELD_COMMENT("https://www.freedesktop.org/software/systemd/man/"PROJECT_VERSION_STR"/systemd.timer.html#OnActiveSec="),
+                SD_VARLINK_DEFINE_FIELD_BY_TYPE(Timers, TimerSpec, SD_VARLINK_ARRAY|SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("https://www.freedesktop.org/software/systemd/man/"PROJECT_VERSION_STR"/systemd.timer.html#Unit="),
+                SD_VARLINK_DEFINE_FIELD(Unit, SD_VARLINK_STRING, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("https://www.freedesktop.org/software/systemd/man/"PROJECT_VERSION_STR"/systemd.timer.html#OnClockChange="),
+                SD_VARLINK_DEFINE_FIELD(OnClockChange, SD_VARLINK_BOOL, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("https://www.freedesktop.org/software/systemd/man/"PROJECT_VERSION_STR"/systemd.timer.html#OnClockChange="),
+                SD_VARLINK_DEFINE_FIELD(OnTimezoneChange, SD_VARLINK_BOOL, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("https://www.freedesktop.org/software/systemd/man/"PROJECT_VERSION_STR"/systemd.timer.html#AccuracySec="),
+                SD_VARLINK_DEFINE_FIELD(AccuracyUSec, SD_VARLINK_INT, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("https://www.freedesktop.org/software/systemd/man/"PROJECT_VERSION_STR"/systemd.timer.html#RandomizedDelaySec="),
+                SD_VARLINK_DEFINE_FIELD(RandomizedDelayUSec, SD_VARLINK_INT, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("https://www.freedesktop.org/software/systemd/man/"PROJECT_VERSION_STR"/systemd.timer.html#RandomizedOffsetSec="),
+                SD_VARLINK_DEFINE_FIELD(RandomizedOffsetUSec, SD_VARLINK_INT, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("https://www.freedesktop.org/software/systemd/man/"PROJECT_VERSION_STR"/systemd.timer.html#FixedRandomDelay="),
+                SD_VARLINK_DEFINE_FIELD(FixedRandomDelay, SD_VARLINK_BOOL, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("https://www.freedesktop.org/software/systemd/man/"PROJECT_VERSION_STR"/systemd.timer.html#Persistent="),
+                SD_VARLINK_DEFINE_FIELD(Persistent, SD_VARLINK_BOOL, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("https://www.freedesktop.org/software/systemd/man/"PROJECT_VERSION_STR"/systemd.timer.html#WakeSystem="),
+                SD_VARLINK_DEFINE_FIELD(WakeSystem, SD_VARLINK_BOOL, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("https://www.freedesktop.org/software/systemd/man/"PROJECT_VERSION_STR"/systemd.timer.html#RemainAfterElapse="),
+                SD_VARLINK_DEFINE_FIELD(RemainAfterElapse, SD_VARLINK_BOOL, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("https://www.freedesktop.org/software/systemd/man/"PROJECT_VERSION_STR"/systemd.timer.html#DeferReactivation="),
+                SD_VARLINK_DEFINE_FIELD(DeferReactivation, SD_VARLINK_BOOL, SD_VARLINK_NULLABLE));
+
+SD_VARLINK_DEFINE_ENUM_TYPE(
+                TimerResult,
+                SD_VARLINK_DEFINE_ENUM_VALUE(success),
+                SD_VARLINK_DEFINE_ENUM_VALUE(resources),
+                SD_VARLINK_DEFINE_ENUM_VALUE(start_limit_hit));
+
+static SD_VARLINK_DEFINE_STRUCT_TYPE(
+                TimerRuntime,
+                SD_VARLINK_FIELD_COMMENT("Result of timer operation"),
+                SD_VARLINK_DEFINE_FIELD_BY_TYPE(Result, TimerResult, 0),
+                SD_VARLINK_FIELD_COMMENT("Next elapse time in realtime clock"),
+                SD_VARLINK_DEFINE_FIELD(NextElapseUSecRealtime, SD_VARLINK_INT, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("Next elapse time in monotonic clock"),
+                SD_VARLINK_DEFINE_FIELD(NextElapseUSecMonotonic, SD_VARLINK_INT, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("Last time the timer triggered"),
+                SD_VARLINK_DEFINE_FIELD_BY_TYPE(LastTriggerUSec, Timestamp, SD_VARLINK_NULLABLE));
+
 /* Service-specific types */
 
 /* Keep in sync with service_type_table[] in src/core/service.c */
@@ -1279,7 +1343,9 @@ static SD_VARLINK_DEFINE_STRUCT_TYPE(
                 SD_VARLINK_FIELD_COMMENT("The scope context of the unit"),
                 SD_VARLINK_DEFINE_FIELD_BY_TYPE(Scope, ScopeContext, SD_VARLINK_NULLABLE),
                 SD_VARLINK_FIELD_COMMENT("The swap context of the unit"),
-                SD_VARLINK_DEFINE_FIELD_BY_TYPE(Swap, SwapContext, SD_VARLINK_NULLABLE));
+                SD_VARLINK_DEFINE_FIELD_BY_TYPE(Swap, SwapContext, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("The timer context of the unit"),
+                SD_VARLINK_DEFINE_FIELD_BY_TYPE(Timer, TimerContext, SD_VARLINK_NULLABLE));
 
 static SD_VARLINK_DEFINE_STRUCT_TYPE(
                 ActivationDetails,
@@ -1459,7 +1525,9 @@ static SD_VARLINK_DEFINE_STRUCT_TYPE(
                 SD_VARLINK_FIELD_COMMENT("The scope runtime of the unit"),
                 SD_VARLINK_DEFINE_FIELD_BY_TYPE(Scope, ScopeRuntime, SD_VARLINK_NULLABLE),
                 SD_VARLINK_FIELD_COMMENT("The swap runtime of the unit"),
-                SD_VARLINK_DEFINE_FIELD_BY_TYPE(Swap, SwapRuntime, SD_VARLINK_NULLABLE));
+                SD_VARLINK_DEFINE_FIELD_BY_TYPE(Swap, SwapRuntime, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("The timer runtime of the unit"),
+                SD_VARLINK_DEFINE_FIELD_BY_TYPE(Timer, TimerRuntime, SD_VARLINK_NULLABLE));
 
 static SD_VARLINK_DEFINE_METHOD_FULL(
                 List,
@@ -1633,6 +1701,11 @@ SD_VARLINK_DEFINE_INTERFACE(
                 &vl_type_SwapContext,
                 &vl_type_SwapResult,
                 &vl_type_SwapRuntime,
+                &vl_type_TimerBase,
+                &vl_type_TimerSpec,
+                &vl_type_TimerContext,
+                &vl_type_TimerResult,
+                &vl_type_TimerRuntime,
 
                 /* UnitContext enums */
                 &vl_type_CollectMode,

--- a/src/shared/varlink-io.systemd.Unit.c
+++ b/src/shared/varlink-io.systemd.Unit.c
@@ -1041,6 +1041,46 @@ static SD_VARLINK_DEFINE_STRUCT_TYPE(
                 SD_VARLINK_FIELD_COMMENT("Result of scope operation"),
                 SD_VARLINK_DEFINE_FIELD_BY_TYPE(Result, ScopeResult, 0));
 
+/* SwapContext
+ * https://www.freedesktop.org/software/systemd/man/latest/systemd.swap.html */
+static SD_VARLINK_DEFINE_STRUCT_TYPE(
+                SwapContext,
+                SD_VARLINK_FIELD_COMMENT("https://www.freedesktop.org/software/systemd/man/"PROJECT_VERSION_STR"/systemd.swap.html#What="),
+                SD_VARLINK_DEFINE_FIELD(What, SD_VARLINK_STRING, 0),
+                SD_VARLINK_FIELD_COMMENT("https://www.freedesktop.org/software/systemd/man/"PROJECT_VERSION_STR"/systemd.swap.html#Priority="),
+                SD_VARLINK_DEFINE_FIELD(Priority, SD_VARLINK_INT, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("https://www.freedesktop.org/software/systemd/man/"PROJECT_VERSION_STR"/systemd.swap.html#Options="),
+                SD_VARLINK_DEFINE_FIELD(Options, SD_VARLINK_STRING, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("https://www.freedesktop.org/software/systemd/man/"PROJECT_VERSION_STR"/systemd.swap.html#TimeoutSec="),
+                SD_VARLINK_DEFINE_FIELD(TimeoutUSec, SD_VARLINK_INT, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("Activate command"),
+                SD_VARLINK_DEFINE_FIELD_BY_TYPE(ExecActivate, ExecCommand, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("Deactivate command"),
+                SD_VARLINK_DEFINE_FIELD_BY_TYPE(ExecDeactivate, ExecCommand, SD_VARLINK_NULLABLE));
+
+SD_VARLINK_DEFINE_ENUM_TYPE(
+                SwapResult,
+                SD_VARLINK_DEFINE_ENUM_VALUE(success),
+                SD_VARLINK_DEFINE_ENUM_VALUE(resources),
+                SD_VARLINK_DEFINE_ENUM_VALUE(timeout),
+                SD_VARLINK_DEFINE_ENUM_VALUE(exit_code),
+                SD_VARLINK_DEFINE_ENUM_VALUE(signal),
+                SD_VARLINK_DEFINE_ENUM_VALUE(core_dump),
+                SD_VARLINK_DEFINE_ENUM_VALUE(start_limit_hit));
+
+static SD_VARLINK_DEFINE_STRUCT_TYPE(
+                SwapRuntime,
+                SD_VARLINK_FIELD_COMMENT("PID of the current swap control process"),
+                SD_VARLINK_DEFINE_FIELD_BY_TYPE(ControlPID, ProcessId, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("Result of swap operation"),
+                SD_VARLINK_DEFINE_FIELD_BY_TYPE(Result, SwapResult, 0),
+                SD_VARLINK_FIELD_COMMENT("Result of cleaning operation"),
+                SD_VARLINK_DEFINE_FIELD_BY_TYPE(CleanResult, SwapResult, 0),
+                SD_VARLINK_FIELD_COMMENT("Reference UID"),
+                SD_VARLINK_DEFINE_FIELD(UID, SD_VARLINK_INT, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("Reference GID"),
+                SD_VARLINK_DEFINE_FIELD(GID, SD_VARLINK_INT, SD_VARLINK_NULLABLE));
+
 /* Service-specific types */
 
 /* Keep in sync with service_type_table[] in src/core/service.c */
@@ -1237,7 +1277,9 @@ static SD_VARLINK_DEFINE_STRUCT_TYPE(
                 SD_VARLINK_FIELD_COMMENT("The path context of the unit"),
                 SD_VARLINK_DEFINE_FIELD_BY_TYPE(Path, PathContext, SD_VARLINK_NULLABLE),
                 SD_VARLINK_FIELD_COMMENT("The scope context of the unit"),
-                SD_VARLINK_DEFINE_FIELD_BY_TYPE(Scope, ScopeContext, SD_VARLINK_NULLABLE));
+                SD_VARLINK_DEFINE_FIELD_BY_TYPE(Scope, ScopeContext, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("The swap context of the unit"),
+                SD_VARLINK_DEFINE_FIELD_BY_TYPE(Swap, SwapContext, SD_VARLINK_NULLABLE));
 
 static SD_VARLINK_DEFINE_STRUCT_TYPE(
                 ActivationDetails,
@@ -1415,7 +1457,9 @@ static SD_VARLINK_DEFINE_STRUCT_TYPE(
                 SD_VARLINK_FIELD_COMMENT("The path runtime of the unit"),
                 SD_VARLINK_DEFINE_FIELD_BY_TYPE(Path, PathRuntime, SD_VARLINK_NULLABLE),
                 SD_VARLINK_FIELD_COMMENT("The scope runtime of the unit"),
-                SD_VARLINK_DEFINE_FIELD_BY_TYPE(Scope, ScopeRuntime, SD_VARLINK_NULLABLE));
+                SD_VARLINK_DEFINE_FIELD_BY_TYPE(Scope, ScopeRuntime, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("The swap runtime of the unit"),
+                SD_VARLINK_DEFINE_FIELD_BY_TYPE(Swap, SwapRuntime, SD_VARLINK_NULLABLE));
 
 static SD_VARLINK_DEFINE_METHOD_FULL(
                 List,
@@ -1586,6 +1630,9 @@ SD_VARLINK_DEFINE_INTERFACE(
                 &vl_type_ScopeContext,
                 &vl_type_ScopeResult,
                 &vl_type_ScopeRuntime,
+                &vl_type_SwapContext,
+                &vl_type_SwapResult,
+                &vl_type_SwapRuntime,
 
                 /* UnitContext enums */
                 &vl_type_CollectMode,

--- a/src/shared/varlink-io.systemd.Unit.c
+++ b/src/shared/varlink-io.systemd.Unit.c
@@ -1016,6 +1016,31 @@ static SD_VARLINK_DEFINE_STRUCT_TYPE(
                 SD_VARLINK_FIELD_COMMENT("Result of path operation"),
                 SD_VARLINK_DEFINE_FIELD_BY_TYPE(Result, PathResult, 0));
 
+/* ScopeContext
+ * https://www.freedesktop.org/software/systemd/man/latest/systemd.scope.html */
+static SD_VARLINK_DEFINE_STRUCT_TYPE(
+                ScopeContext,
+                SD_VARLINK_FIELD_COMMENT("https://www.freedesktop.org/software/systemd/man/"PROJECT_VERSION_STR"/systemd.scope.html#OOMPolicy="),
+                SD_VARLINK_DEFINE_FIELD_BY_TYPE(OOMPolicy, OOMPolicy, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("https://www.freedesktop.org/software/systemd/man/"PROJECT_VERSION_STR"/systemd.scope.html#RuntimeMaxSec="),
+                SD_VARLINK_DEFINE_FIELD(RuntimeMaxUSec, SD_VARLINK_INT, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("https://www.freedesktop.org/software/systemd/man/"PROJECT_VERSION_STR"/systemd.scope.html#RuntimeRandomizedExtraSec="),
+                SD_VARLINK_DEFINE_FIELD(RuntimeRandomizedExtraUSec, SD_VARLINK_INT, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("https://www.freedesktop.org/software/systemd/man/"PROJECT_VERSION_STR"/systemd.scope.html#TimeoutStopSec="),
+                SD_VARLINK_DEFINE_FIELD(TimeoutStopUSec, SD_VARLINK_INT, SD_VARLINK_NULLABLE));
+
+SD_VARLINK_DEFINE_ENUM_TYPE(
+                ScopeResult,
+                SD_VARLINK_DEFINE_ENUM_VALUE(success),
+                SD_VARLINK_DEFINE_ENUM_VALUE(resources),
+                SD_VARLINK_DEFINE_ENUM_VALUE(timeout),
+                SD_VARLINK_DEFINE_ENUM_VALUE(oom_kill));
+
+static SD_VARLINK_DEFINE_STRUCT_TYPE(
+                ScopeRuntime,
+                SD_VARLINK_FIELD_COMMENT("Result of scope operation"),
+                SD_VARLINK_DEFINE_FIELD_BY_TYPE(Result, ScopeResult, 0));
+
 /* Service-specific types */
 
 /* Keep in sync with service_type_table[] in src/core/service.c */
@@ -1210,7 +1235,9 @@ static SD_VARLINK_DEFINE_STRUCT_TYPE(
                 SD_VARLINK_FIELD_COMMENT("The mount context of the unit"),
                 SD_VARLINK_DEFINE_FIELD_BY_TYPE(Mount, MountContext, SD_VARLINK_NULLABLE),
                 SD_VARLINK_FIELD_COMMENT("The path context of the unit"),
-                SD_VARLINK_DEFINE_FIELD_BY_TYPE(Path, PathContext, SD_VARLINK_NULLABLE));
+                SD_VARLINK_DEFINE_FIELD_BY_TYPE(Path, PathContext, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("The scope context of the unit"),
+                SD_VARLINK_DEFINE_FIELD_BY_TYPE(Scope, ScopeContext, SD_VARLINK_NULLABLE));
 
 static SD_VARLINK_DEFINE_STRUCT_TYPE(
                 ActivationDetails,
@@ -1386,7 +1413,9 @@ static SD_VARLINK_DEFINE_STRUCT_TYPE(
                 SD_VARLINK_FIELD_COMMENT("The mount runtime of the unit"),
                 SD_VARLINK_DEFINE_FIELD_BY_TYPE(Mount, MountRuntime, SD_VARLINK_NULLABLE),
                 SD_VARLINK_FIELD_COMMENT("The path runtime of the unit"),
-                SD_VARLINK_DEFINE_FIELD_BY_TYPE(Path, PathRuntime, SD_VARLINK_NULLABLE));
+                SD_VARLINK_DEFINE_FIELD_BY_TYPE(Path, PathRuntime, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("The scope runtime of the unit"),
+                SD_VARLINK_DEFINE_FIELD_BY_TYPE(Scope, ScopeRuntime, SD_VARLINK_NULLABLE));
 
 static SD_VARLINK_DEFINE_METHOD_FULL(
                 List,
@@ -1553,6 +1582,10 @@ SD_VARLINK_DEFINE_INTERFACE(
                 &vl_type_PathContext,
                 &vl_type_PathResult,
                 &vl_type_PathRuntime,
+                &vl_type_OOMPolicy,
+                &vl_type_ScopeContext,
+                &vl_type_ScopeResult,
+                &vl_type_ScopeRuntime,
 
                 /* UnitContext enums */
                 &vl_type_CollectMode,

--- a/src/shared/varlink-io.systemd.Unit.c
+++ b/src/shared/varlink-io.systemd.Unit.c
@@ -973,6 +973,49 @@ static SD_VARLINK_DEFINE_STRUCT_TYPE(
                 SD_VARLINK_FIELD_COMMENT("Remount command"),
                 SD_VARLINK_DEFINE_FIELD_BY_TYPE(ExecRemount, ExecCommand, SD_VARLINK_NULLABLE));
 
+/* PathContext
+ * https://www.freedesktop.org/software/systemd/man/latest/systemd.path.html */
+SD_VARLINK_DEFINE_ENUM_TYPE(
+                PathType,
+                SD_VARLINK_DEFINE_ENUM_VALUE(PathExists),
+                SD_VARLINK_DEFINE_ENUM_VALUE(PathExistsGlob),
+                SD_VARLINK_DEFINE_ENUM_VALUE(DirectoryNotEmpty),
+                SD_VARLINK_DEFINE_ENUM_VALUE(PathChanged),
+                SD_VARLINK_DEFINE_ENUM_VALUE(PathModified));
+
+static SD_VARLINK_DEFINE_STRUCT_TYPE(
+                PathSpec,
+                SD_VARLINK_FIELD_COMMENT("Path spec type"),
+                SD_VARLINK_DEFINE_FIELD_BY_TYPE(type, PathType, 0),
+                SD_VARLINK_FIELD_COMMENT("Path"),
+                SD_VARLINK_DEFINE_FIELD(path, SD_VARLINK_STRING, 0));
+
+static SD_VARLINK_DEFINE_STRUCT_TYPE(
+                PathContext,
+                SD_VARLINK_FIELD_COMMENT("https://www.freedesktop.org/software/systemd/man/"PROJECT_VERSION_STR"/systemd.path.html#PathExists="),
+                SD_VARLINK_DEFINE_FIELD_BY_TYPE(Paths, PathSpec, SD_VARLINK_ARRAY|SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("https://www.freedesktop.org/software/systemd/man/"PROJECT_VERSION_STR"/systemd.path.html#Unit="),
+                SD_VARLINK_DEFINE_FIELD(Unit, SD_VARLINK_STRING, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("https://www.freedesktop.org/software/systemd/man/"PROJECT_VERSION_STR"/systemd.path.html#MakeDirectory="),
+                SD_VARLINK_DEFINE_FIELD(MakeDirectory, SD_VARLINK_BOOL, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("https://www.freedesktop.org/software/systemd/man/"PROJECT_VERSION_STR"/systemd.path.html#DirectoryMode="),
+                SD_VARLINK_DEFINE_FIELD(DirectoryMode, SD_VARLINK_INT, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("https://www.freedesktop.org/software/systemd/man/"PROJECT_VERSION_STR"/systemd.path.html#TriggerLimitIntervalSec="),
+                SD_VARLINK_DEFINE_FIELD_BY_TYPE(TriggerLimit, RateLimit, SD_VARLINK_NULLABLE));
+
+SD_VARLINK_DEFINE_ENUM_TYPE(
+                PathResult,
+                SD_VARLINK_DEFINE_ENUM_VALUE(success),
+                SD_VARLINK_DEFINE_ENUM_VALUE(resources),
+                SD_VARLINK_DEFINE_ENUM_VALUE(start_limit_hit),
+                SD_VARLINK_DEFINE_ENUM_VALUE(unit_start_limit_hit),
+                SD_VARLINK_DEFINE_ENUM_VALUE(trigger_limit_hit));
+
+static SD_VARLINK_DEFINE_STRUCT_TYPE(
+                PathRuntime,
+                SD_VARLINK_FIELD_COMMENT("Result of path operation"),
+                SD_VARLINK_DEFINE_FIELD_BY_TYPE(Result, PathResult, 0));
+
 /* Service-specific types */
 
 /* Keep in sync with service_type_table[] in src/core/service.c */
@@ -1165,7 +1208,9 @@ static SD_VARLINK_DEFINE_STRUCT_TYPE(
                 SD_VARLINK_FIELD_COMMENT("The automount context of the unit"),
                 SD_VARLINK_DEFINE_FIELD_BY_TYPE(Automount, AutomountContext, SD_VARLINK_NULLABLE),
                 SD_VARLINK_FIELD_COMMENT("The mount context of the unit"),
-                SD_VARLINK_DEFINE_FIELD_BY_TYPE(Mount, MountContext, SD_VARLINK_NULLABLE));
+                SD_VARLINK_DEFINE_FIELD_BY_TYPE(Mount, MountContext, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("The path context of the unit"),
+                SD_VARLINK_DEFINE_FIELD_BY_TYPE(Path, PathContext, SD_VARLINK_NULLABLE));
 
 static SD_VARLINK_DEFINE_STRUCT_TYPE(
                 ActivationDetails,
@@ -1339,7 +1384,9 @@ static SD_VARLINK_DEFINE_STRUCT_TYPE(
                 SD_VARLINK_FIELD_COMMENT("The automount runtime of the unit"),
                 SD_VARLINK_DEFINE_FIELD_BY_TYPE(Automount, AutomountRuntime, SD_VARLINK_NULLABLE),
                 SD_VARLINK_FIELD_COMMENT("The mount runtime of the unit"),
-                SD_VARLINK_DEFINE_FIELD_BY_TYPE(Mount, MountRuntime, SD_VARLINK_NULLABLE));
+                SD_VARLINK_DEFINE_FIELD_BY_TYPE(Mount, MountRuntime, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("The path runtime of the unit"),
+                SD_VARLINK_DEFINE_FIELD_BY_TYPE(Path, PathRuntime, SD_VARLINK_NULLABLE));
 
 static SD_VARLINK_DEFINE_METHOD_FULL(
                 List,
@@ -1501,6 +1548,11 @@ SD_VARLINK_DEFINE_INTERFACE(
                 &vl_type_MountContext,
                 &vl_type_MountResult,
                 &vl_type_MountRuntime,
+                &vl_type_PathType,
+                &vl_type_PathSpec,
+                &vl_type_PathContext,
+                &vl_type_PathResult,
+                &vl_type_PathRuntime,
 
                 /* UnitContext enums */
                 &vl_type_CollectMode,

--- a/src/shared/varlink-io.systemd.Unit.h
+++ b/src/shared/varlink-io.systemd.Unit.h
@@ -34,6 +34,8 @@ extern const sd_varlink_symbol vl_type_PathType;
 extern const sd_varlink_symbol vl_type_PathResult;
 extern const sd_varlink_symbol vl_type_ScopeResult;
 extern const sd_varlink_symbol vl_type_SwapResult;
+extern const sd_varlink_symbol vl_type_TimerBase;
+extern const sd_varlink_symbol vl_type_TimerResult;
 extern const sd_varlink_symbol vl_type_CollectMode;
 extern const sd_varlink_symbol vl_type_JobMode;
 extern const sd_varlink_symbol vl_type_ServiceType;

--- a/src/shared/varlink-io.systemd.Unit.h
+++ b/src/shared/varlink-io.systemd.Unit.h
@@ -32,6 +32,7 @@ extern const sd_varlink_symbol vl_type_AutomountResult;
 extern const sd_varlink_symbol vl_type_MountResult;
 extern const sd_varlink_symbol vl_type_PathType;
 extern const sd_varlink_symbol vl_type_PathResult;
+extern const sd_varlink_symbol vl_type_ScopeResult;
 extern const sd_varlink_symbol vl_type_CollectMode;
 extern const sd_varlink_symbol vl_type_JobMode;
 extern const sd_varlink_symbol vl_type_ServiceType;

--- a/src/shared/varlink-io.systemd.Unit.h
+++ b/src/shared/varlink-io.systemd.Unit.h
@@ -33,6 +33,7 @@ extern const sd_varlink_symbol vl_type_MountResult;
 extern const sd_varlink_symbol vl_type_PathType;
 extern const sd_varlink_symbol vl_type_PathResult;
 extern const sd_varlink_symbol vl_type_ScopeResult;
+extern const sd_varlink_symbol vl_type_SwapResult;
 extern const sd_varlink_symbol vl_type_CollectMode;
 extern const sd_varlink_symbol vl_type_JobMode;
 extern const sd_varlink_symbol vl_type_ServiceType;

--- a/src/shared/varlink-io.systemd.Unit.h
+++ b/src/shared/varlink-io.systemd.Unit.h
@@ -30,6 +30,8 @@ extern const sd_varlink_symbol vl_type_MountPropagationFlag;
 extern const sd_varlink_symbol vl_type_KillMode;
 extern const sd_varlink_symbol vl_type_AutomountResult;
 extern const sd_varlink_symbol vl_type_MountResult;
+extern const sd_varlink_symbol vl_type_PathType;
+extern const sd_varlink_symbol vl_type_PathResult;
 extern const sd_varlink_symbol vl_type_CollectMode;
 extern const sd_varlink_symbol vl_type_JobMode;
 extern const sd_varlink_symbol vl_type_ServiceType;

--- a/src/test/test-varlink-idl-unit.c
+++ b/src/test/test-varlink-idl-unit.c
@@ -6,6 +6,7 @@
 #include "kill.h"
 #include "mount.h"
 #include "numa-util.h"
+#include "path.h"
 #include "process-util.h"
 #include "service.h"
 #include "tests.h"
@@ -62,6 +63,12 @@ TEST(unit_enums_idl) {
 
         /* ServiceContext enums */
         TEST_IDL_ENUM(ServiceType, service_type, vl_type_ServiceType);
+
+        /* PathContext enums */
+        TEST_IDL_ENUM(PathType, path_type, vl_type_PathType);
+
+        /* PathRuntime enums */
+        TEST_IDL_ENUM(PathResult, path_result, vl_type_PathResult);
 
         /* UnitContext enums */
         TEST_IDL_ENUM(CollectMode, collect_mode, vl_type_CollectMode);

--- a/src/test/test-varlink-idl-unit.c
+++ b/src/test/test-varlink-idl-unit.c
@@ -8,7 +8,9 @@
 #include "numa-util.h"
 #include "path.h"
 #include "process-util.h"
+#include "scope.h"
 #include "service.h"
+#include "swap.h"
 #include "tests.h"
 #include "test-varlink-idl-util.h"
 #include "unit.h"
@@ -69,6 +71,9 @@ TEST(unit_enums_idl) {
 
         /* PathRuntime enums */
         TEST_IDL_ENUM(PathResult, path_result, vl_type_PathResult);
+
+        /* ScopeRuntime enums */
+        TEST_IDL_ENUM(ScopeResult, scope_result, vl_type_ScopeResult);
 
         /* UnitContext enums */
         TEST_IDL_ENUM(CollectMode, collect_mode, vl_type_CollectMode);

--- a/src/test/test-varlink-idl-unit.c
+++ b/src/test/test-varlink-idl-unit.c
@@ -13,6 +13,7 @@
 #include "swap.h"
 #include "tests.h"
 #include "test-varlink-idl-util.h"
+#include "timer.h"
 #include "unit.h"
 #include "varlink-idl-common.h"
 #include "varlink-io.systemd.Unit.h"
@@ -77,6 +78,16 @@ TEST(unit_enums_idl) {
 
         /* SwapRuntime enums */
         TEST_IDL_ENUM(SwapResult, swap_result, vl_type_SwapResult);
+
+        /* TimerContext enums */
+        for (TimerBase b = 0; b < _TIMER_BASE_MAX; b++) {
+                _cleanup_free_ char *s = timer_base_to_usec_string(b);
+                assert_se(s);
+                test_enum_to_string_name(s, &vl_type_TimerBase);
+        }
+
+        /* TimerRuntime enums */
+        TEST_IDL_ENUM(TimerResult, timer_result, vl_type_TimerResult);
 
         /* UnitContext enums */
         TEST_IDL_ENUM(CollectMode, collect_mode, vl_type_CollectMode);

--- a/src/test/test-varlink-idl-unit.c
+++ b/src/test/test-varlink-idl-unit.c
@@ -75,6 +75,9 @@ TEST(unit_enums_idl) {
         /* ScopeRuntime enums */
         TEST_IDL_ENUM(ScopeResult, scope_result, vl_type_ScopeResult);
 
+        /* SwapRuntime enums */
+        TEST_IDL_ENUM(SwapResult, swap_result, vl_type_SwapResult);
+
         /* UnitContext enums */
         TEST_IDL_ENUM(CollectMode, collect_mode, vl_type_CollectMode);
         TEST_IDL_ENUM(EmergencyAction, emergency_action, vl_type_EmergencyAction);

--- a/test/units/TEST-74-AUX-UTILS.varlinkctl.sh
+++ b/test/units/TEST-74-AUX-UTILS.varlinkctl.sh
@@ -252,6 +252,12 @@ test -n "$path_id"
 path_params=$(jq -cn --arg name "$path_id" '{name: $name}')
 varlinkctl call /run/systemd/io.systemd.Manager io.systemd.Unit.List "$path_params" | jq -e '.context.Path'
 varlinkctl call /run/systemd/io.systemd.Manager io.systemd.Unit.List "$path_params" | jq -e '.runtime.Path'
+# test for ScopeContext/Runtime
+scope_id=$(varlinkctl call --collect /run/systemd/io.systemd.Manager io.systemd.Unit.List '{}' | jq -r '.[] | select(.context.Type == "scope" and .runtime.LoadState == "loaded") .context.ID' | grep -v null | tail -n 1)
+test -n "$scope_id"
+scope_params=$(jq -cn --arg name "$scope_id" '{name: $name}')
+varlinkctl call /run/systemd/io.systemd.Manager io.systemd.Unit.List "$scope_params" | jq -e '.context.Scope'
+varlinkctl call /run/systemd/io.systemd.Manager io.systemd.Unit.List "$scope_params" | jq -e '.runtime.Scope'
 
 # test io.systemd.Metrics
 varlinkctl info /run/systemd/report/io.systemd.Manager

--- a/test/units/TEST-74-AUX-UTILS.varlinkctl.sh
+++ b/test/units/TEST-74-AUX-UTILS.varlinkctl.sh
@@ -233,7 +233,7 @@ varlinkctl call /run/systemd/io.systemd.Manager io.systemd.Unit.List "{\"invocat
 # test for KillContext
 varlinkctl call /run/systemd/io.systemd.Manager io.systemd.Unit.List '{"pid": {"pid": 0}}' | jq -e '.context.Kill'
 # test for AutomountContext/Runtime
-automount_id=$(varlinkctl call --collect /run/systemd/io.systemd.Manager io.systemd.Unit.List '{}' | jq -r '.[] | select(.context.Type == "automount" and .runtime.LoadState == "loaded") .context.ID' | grep -v null | tail -n 1)
+automount_id=$(varlinkctl call --collect /run/systemd/io.systemd.Manager io.systemd.Unit.List '{}' | jq -r '.[] | select(.context.Type == "automount" and .runtime.LoadState == "loaded") .context.ID // empty' | tail -n 1)
 test -n "$automount_id"
 # Use jq to JSON-encode the unit name as it may contain backslash escapes (e.g. \x2d) that
 # are not valid JSON escape sequences and would be rejected by varlinkctl's JSON parser.
@@ -241,19 +241,19 @@ automount_params=$(jq -cn --arg name "$automount_id" '{name: $name}')
 varlinkctl call /run/systemd/io.systemd.Manager io.systemd.Unit.List "$automount_params" | jq -e '.context.Automount'
 varlinkctl call /run/systemd/io.systemd.Manager io.systemd.Unit.List "$automount_params" | jq -e '.runtime.Automount'
 # test for MountContext/Runtime
-mount_id=$(varlinkctl call --collect /run/systemd/io.systemd.Manager io.systemd.Unit.List '{}' | jq -r '.[] | select(.context.Type == "mount" and .runtime.LoadState == "loaded") .context.ID' | grep -v null | tail -n 1)
+mount_id=$(varlinkctl call --collect /run/systemd/io.systemd.Manager io.systemd.Unit.List '{}' | jq -r '.[] | select(.context.Type == "mount" and .runtime.LoadState == "loaded") .context.ID // empty' | tail -n 1)
 test -n "$mount_id"
 mount_params=$(jq -cn --arg name "$mount_id" '{name: $name}')
 varlinkctl call /run/systemd/io.systemd.Manager io.systemd.Unit.List "$mount_params" | jq -e '.context.Mount'
 varlinkctl call /run/systemd/io.systemd.Manager io.systemd.Unit.List "$mount_params" | jq -e '.runtime.Mount'
 # test for PathContext/Runtime
-path_id=$(varlinkctl call --collect /run/systemd/io.systemd.Manager io.systemd.Unit.List '{}' | jq -r '.[] | select(.context.Type == "path" and .runtime.LoadState == "loaded") .context.ID' | grep -v null | tail -n 1)
+path_id=$(varlinkctl call --collect /run/systemd/io.systemd.Manager io.systemd.Unit.List '{}' | jq -r '.[] | select(.context.Type == "path" and .runtime.LoadState == "loaded") .context.ID // empty' | tail -n 1)
 test -n "$path_id"
 path_params=$(jq -cn --arg name "$path_id" '{name: $name}')
 varlinkctl call /run/systemd/io.systemd.Manager io.systemd.Unit.List "$path_params" | jq -e '.context.Path'
 varlinkctl call /run/systemd/io.systemd.Manager io.systemd.Unit.List "$path_params" | jq -e '.runtime.Path'
 # test for ScopeContext/Runtime
-scope_id=$(varlinkctl call --collect /run/systemd/io.systemd.Manager io.systemd.Unit.List '{}' | jq -r '.[] | select(.context.Type == "scope" and .runtime.LoadState == "loaded") .context.ID' | grep -v null | tail -n 1)
+scope_id=$(varlinkctl call --collect /run/systemd/io.systemd.Manager io.systemd.Unit.List '{}' | jq -r '.[] | select(.context.Type == "scope" and .runtime.LoadState == "loaded") .context.ID // empty' | tail -n 1)
 test -n "$scope_id"
 scope_params=$(jq -cn --arg name "$scope_id" '{name: $name}')
 varlinkctl call /run/systemd/io.systemd.Manager io.systemd.Unit.List "$scope_params" | jq -e '.context.Scope'
@@ -266,7 +266,7 @@ if test -n "$swap_id"; then
     varlinkctl call /run/systemd/io.systemd.Manager io.systemd.Unit.List "$swap_params" | jq -e '.runtime.Swap'
 fi
 # test for TimerContext/Runtime
-timer_id=$(varlinkctl call --collect /run/systemd/io.systemd.Manager io.systemd.Unit.List '{}' | jq -r '.[] | select(.context.Type == "timer" and .runtime.LoadState == "loaded") .context.ID' | grep -v null | tail -n 1)
+timer_id=$(varlinkctl call --collect /run/systemd/io.systemd.Manager io.systemd.Unit.List '{}' | jq -r '.[] | select(.context.Type == "timer" and .runtime.LoadState == "loaded") .context.ID // empty' | tail -n 1)
 test -n "$timer_id"
 timer_params=$(jq -cn --arg name "$timer_id" '{name: $name}')
 varlinkctl call /run/systemd/io.systemd.Manager io.systemd.Unit.List "$timer_params" | jq -e '.context.Timer'

--- a/test/units/TEST-74-AUX-UTILS.varlinkctl.sh
+++ b/test/units/TEST-74-AUX-UTILS.varlinkctl.sh
@@ -265,6 +265,12 @@ if test -n "$swap_id"; then
     varlinkctl call /run/systemd/io.systemd.Manager io.systemd.Unit.List "$swap_params" | jq -e '.context.Swap'
     varlinkctl call /run/systemd/io.systemd.Manager io.systemd.Unit.List "$swap_params" | jq -e '.runtime.Swap'
 fi
+# test for TimerContext/Runtime
+timer_id=$(varlinkctl call --collect /run/systemd/io.systemd.Manager io.systemd.Unit.List '{}' | jq -r '.[] | select(.context.Type == "timer" and .runtime.LoadState == "loaded") .context.ID' | grep -v null | tail -n 1)
+test -n "$timer_id"
+timer_params=$(jq -cn --arg name "$timer_id" '{name: $name}')
+varlinkctl call /run/systemd/io.systemd.Manager io.systemd.Unit.List "$timer_params" | jq -e '.context.Timer'
+varlinkctl call /run/systemd/io.systemd.Manager io.systemd.Unit.List "$timer_params" | jq -e '.runtime.Timer'
 
 # test io.systemd.Metrics
 varlinkctl info /run/systemd/report/io.systemd.Manager

--- a/test/units/TEST-74-AUX-UTILS.varlinkctl.sh
+++ b/test/units/TEST-74-AUX-UTILS.varlinkctl.sh
@@ -246,6 +246,12 @@ test -n "$mount_id"
 mount_params=$(jq -cn --arg name "$mount_id" '{name: $name}')
 varlinkctl call /run/systemd/io.systemd.Manager io.systemd.Unit.List "$mount_params" | jq -e '.context.Mount'
 varlinkctl call /run/systemd/io.systemd.Manager io.systemd.Unit.List "$mount_params" | jq -e '.runtime.Mount'
+# test for PathContext/Runtime
+path_id=$(varlinkctl call --collect /run/systemd/io.systemd.Manager io.systemd.Unit.List '{}' | jq -r '.[] | select(.context.Type == "path" and .runtime.LoadState == "loaded") .context.ID' | grep -v null | tail -n 1)
+test -n "$path_id"
+path_params=$(jq -cn --arg name "$path_id" '{name: $name}')
+varlinkctl call /run/systemd/io.systemd.Manager io.systemd.Unit.List "$path_params" | jq -e '.context.Path'
+varlinkctl call /run/systemd/io.systemd.Manager io.systemd.Unit.List "$path_params" | jq -e '.runtime.Path'
 
 # test io.systemd.Metrics
 varlinkctl info /run/systemd/report/io.systemd.Manager

--- a/test/units/TEST-74-AUX-UTILS.varlinkctl.sh
+++ b/test/units/TEST-74-AUX-UTILS.varlinkctl.sh
@@ -258,6 +258,13 @@ test -n "$scope_id"
 scope_params=$(jq -cn --arg name "$scope_id" '{name: $name}')
 varlinkctl call /run/systemd/io.systemd.Manager io.systemd.Unit.List "$scope_params" | jq -e '.context.Scope'
 varlinkctl call /run/systemd/io.systemd.Manager io.systemd.Unit.List "$scope_params" | jq -e '.runtime.Scope'
+# test for SwapContext/Runtime (swap units may not be present on all systems)
+swap_id=$(varlinkctl call --collect /run/systemd/io.systemd.Manager io.systemd.Unit.List '{}' | jq -r '.[] | select(.context.Type == "swap" and .runtime.LoadState == "loaded") .context.ID // empty' | tail -n 1)
+if test -n "$swap_id"; then
+    swap_params=$(jq -cn --arg name "$swap_id" '{name: $name}')
+    varlinkctl call /run/systemd/io.systemd.Manager io.systemd.Unit.List "$swap_params" | jq -e '.context.Swap'
+    varlinkctl call /run/systemd/io.systemd.Manager io.systemd.Unit.List "$swap_params" | jq -e '.runtime.Swap'
+fi
 
 # test io.systemd.Metrics
 varlinkctl info /run/systemd/report/io.systemd.Manager


### PR DESCRIPTION
The PR implements the following objects + tests for io.systemd.Unit.List:
* PathContext
* PathRuntime
* ScopeContext
* ScopeRuntime
* SwapContext
* SwapRuntime
* TimerContext
* TimerRuntime

It's a continuation of the following PRs:
* https://github.com/systemd/systemd/pull/37432
* https://github.com/systemd/systemd/pull/37646
* https://github.com/systemd/systemd/pull/38032
* https://github.com/systemd/systemd/pull/38212
* https://github.com/systemd/systemd/pull/39391