### PR TITLE
shared/pager: enable support for more(1) secure mode at build-time

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -635,6 +635,12 @@ sed    = find_program('sed')
 sh     = find_program('sh')
 stat   = find_program('stat')
 
+more_pager = find_program('more',
+                      version : '>= 2.42',
+                      required : false)
+have = more_pager.found()
+conf.set10('HAVE_SECURE_MORE_PAGER', have)
+
 ln_s = ln.full_path() + ' -frsT -- "${DESTDIR:-}@0@" "${DESTDIR:-}@1@"'
 
 # If -Dxxx-path option is found, use that. Otherwise, use the default from the

--- a/src/shared/pager.c
+++ b/src/shared/pager.c
@@ -21,6 +21,12 @@
 #include "strv.h"
 #include "terminal-util.h"
 
+#if HAVE_SECURE_MORE_PAGER
+#define SECURE_MORE_PAGER       "more",
+#else
+#define SECURE_MORE_PAGER
+#endif /* HAVE_SECURE_MORE_PAGER */
+
 static PidRef pager_pidref = PIDREF_NULL;
 
 static int stored_stdout = -1;
@@ -236,7 +242,7 @@ void pager_open(PagerFlags flags) {
 
                 for (unsigned i = 0; i < ELEMENTSOF(pagers); i++) {
                         /* Only less, more (and our trivial fallback) implement secure mode right now. */
-                        if (use_secure_mode && !STR_IN_SET(pagers[i], "less", "more", "(built-in)"))
+                        if (use_secure_mode && !STR_IN_SET(pagers[i], "less", SECURE_MORE_PAGER "(built-in)" ))
                                 continue;
 
                         r = loop_write(exe_name_pipe[1], pagers[i], strlen(pagers[i]) + 1);


### PR DESCRIPTION
Commit 81d23b58 added more(1) (from util-linux) to the list of trusted pagers, as it supports a secure mode similar to less(1) ever since util-linux version 2.42. This same version was used to bump the baseline runtime requirement of util-linux. However, this can cause security issues in cases where the literal version requirement is not respected and an older util-linux version is installed on the system. The least we can do is to enforce a version check at build time and turn support on/off depending on the installed version.

Note that this only affects the list of trusted pagers, more(1) remains available for output when no secure pager is required, as determined by the pager selection logic.

The behavior changes as follows:

Systems with more(1) version < 2.42:

    Usable only when no trusted pager is needed or SYSTEMD_PAGERSECURE=0

Systems with more(1) version >= 2.42

    Usable in all cases

Addresses: 81d23b58

------

Following the discussion with @bluca [here](https://github.com/systemd/systemd/pull/41503#issuecomment-4389060491).