### PR TITLE
journal-file: refresh fstat before failing on bounds check in journal_file_verify_header()

### DIFF
--- a/src/libsystemd/sd-journal/journal-file.c
+++ b/src/libsystemd/sd-journal/journal-file.c
@@ -551,6 +551,7 @@ static bool hash_table_is_valid(uint64_t offset, uint64_t size, uint64_t header_
 
 static int journal_file_verify_header(JournalFile *f) {
         uint64_t arena_size, header_size;
+        int r;
 
         assert(f);
         assert(f->header);
@@ -590,8 +591,19 @@ static int journal_file_verify_header(JournalFile *f) {
 
         arena_size = le64toh(READ_NOW(f->header->arena_size));
 
-        if (UINT64_MAX - header_size < arena_size || header_size + arena_size > (uint64_t) f->last_stat.st_size)
+        if (UINT64_MAX - header_size < arena_size)
                 return -ENODATA;
+        if (header_size + arena_size > (uint64_t) f->last_stat.st_size) {
+                /* The cached stat may be older than the header read above. The writer extends the file
+                 * before bumping arena_size, so refreshing the stat once and re-checking should be
+                 * sufficient to tell a transient race apart from actual corruption. */
+                r = journal_file_fstat(f);
+                if (r < 0)
+                        return r;
+
+                if (header_size + arena_size > (uint64_t) f->last_stat.st_size)
+                        return -ENODATA;
+        }
 
         uint64_t tail_object_offset = le64toh(f->header->tail_object_offset);
         if (!offset_is_valid(tail_object_offset, header_size, UINT64_MAX))
@@ -694,7 +706,6 @@ static int journal_file_verify_header(JournalFile *f) {
         if (journal_file_writable(f)) {
                 sd_id128_t machine_id;
                 uint8_t state;
-                int r;
 
                 r = sd_id128_get_machine(&machine_id);
                 if (ERRNO_IS_NEG_MACHINE_ID_UNSET(r)) /* Gracefully handle the machine ID not being initialized yet */

--- a/src/libsystemd/sd-journal/journal-file.c
+++ b/src/libsystemd/sd-journal/journal-file.c
@@ -542,6 +542,7 @@ static bool hash_table_is_valid(uint64_t offset, uint64_t size, uint64_t header_
 
 static int journal_file_verify_header(JournalFile *f) {
         uint64_t arena_size, header_size;
+        int r;
 
         assert(f);
         assert(f->header);
@@ -583,6 +584,17 @@ static int journal_file_verify_header(JournalFile *f) {
 
         if (UINT64_MAX - header_size < arena_size)
                 return -ENODATA;
+        if (header_size + arena_size > (uint64_t) f->last_stat.st_size) {
+                /* The cached stat may be older than the header read above. The writer extends the file
+                 * before bumping arena_size, so refreshing the stat once and re-checking should be
+                 * sufficient to tell a transient race apart from actual corruption. */
+                r = journal_file_fstat(f);
+                if (r < 0)
+                        return r;
+
+                if (header_size + arena_size > (uint64_t) f->last_stat.st_size)
+                        return -ENODATA;
+        }
 
         uint64_t file_size = (uint64_t) f->last_stat.st_size;
 
@@ -714,7 +726,6 @@ static int journal_file_verify_header(JournalFile *f) {
         if (journal_file_writable(f)) {
                 sd_id128_t machine_id;
                 uint8_t state;
-                int r;
 
                 r = sd_id128_get_machine(&machine_id);
                 if (ERRNO_IS_NEG_MACHINE_ID_UNSET(r)) /* Gracefully handle the machine ID not being initialized yet */

--- a/test/units/TEST-04-JOURNAL.journalctl-varlink.sh
+++ b/test/units/TEST-04-JOURNAL.journalctl-varlink.sh
@@ -5,26 +5,6 @@ set -o pipefail
 
 VARLINK_SOCKET="/run/systemd/io.systemd.JournalAccess"
 
-# Wrapper around varlinkctl that retries up to 3 times when the server returns
-# NoEntries to avoid spurious flaky failures
-varlinkctl_get_entries() {
-    local output rc
-    for _ in 1 2 3; do
-        output="$(varlinkctl call --more "$VARLINK_SOCKET" io.systemd.JournalAccess.GetEntries "$@" 2>&1)" && rc=0 || rc=$?
-        if [[ $rc -eq 0 ]]; then
-            printf '%s\n' "$output"
-            return 0
-        fi
-        if ! grep -q 'io.systemd.JournalAccess.NoEntries' <<<"$output"; then
-            printf '%s\n' "$output" >&2
-            return $rc
-        fi
-        journalctl --sync || true
-    done
-    printf '%s\n' "$output" >&2
-    return $rc
-}
-
 # ensure the varlink basics work
 varlinkctl list-interfaces "$VARLINK_SOCKET" | grep io.systemd.JournalAccess
 varlinkctl introspect "$VARLINK_SOCKET" | grep "method GetEntries("
@@ -36,18 +16,18 @@ systemd-cat -t "$TAG" -p warning echo "varlink-test-warning"
 journalctl --sync
 
 # most basic call works
-varlinkctl_get_entries '{}' | jq --seq .
+varlinkctl call --more "$VARLINK_SOCKET" io.systemd.JournalAccess.GetEntries '{}' | jq --seq .
 # validate the JSON has some basic properties (similar to journalctls json output)
-varlinkctl_get_entries '{}' | jq --seq '.entry | {MESSAGE, PRIORITY, _UID}'
+varlinkctl call --more "$VARLINK_SOCKET" io.systemd.JournalAccess.GetEntries '{}' | jq --seq '.entry | {MESSAGE, PRIORITY, _UID}'
 
 # check that default limit works (100), we don't know how many entries we have so we just check
 # bounds
-ENTRIES=$(varlinkctl_get_entries '{}' | wc -l)
+ENTRIES=$(varlinkctl call --more "$VARLINK_SOCKET" io.systemd.JournalAccess.GetEntries '{}' | wc -l)
 test "$ENTRIES" -gt 0
 test "$ENTRIES" -le 100
 
 # check explicit limit
-ENTRIES=$(varlinkctl_get_entries '{"limit": 3}' | wc -l)
+ENTRIES=$(varlinkctl call --more "$VARLINK_SOCKET" io.systemd.JournalAccess.GetEntries '{"limit": 3}' | wc -l)
 test "$ENTRIES" -le 3
 
 # check unit filter: use transient units to get deterministic results
@@ -58,16 +38,16 @@ systemd-run --unit="$UNIT_NAME_2" --wait bash -c 'echo hello-from-varlink-test-2
 journalctl --sync
 
 # single unit filter
-SINGLE_OUTPUT="$(varlinkctl_get_entries "{\"units\": [\"$UNIT_NAME_1\"]}")"
+SINGLE_OUTPUT="$(varlinkctl call --more "$VARLINK_SOCKET" io.systemd.JournalAccess.GetEntries "{\"units\": [\"$UNIT_NAME_1\"]}")"
 grep "hello-from-varlink-test-1" >/dev/null <<<"$SINGLE_OUTPUT"
 (! grep "hello-from-varlink-test-2" >/dev/null <<<"$SINGLE_OUTPUT")
 # multi unit filter
-MULTI_OUTPUT="$(varlinkctl_get_entries "{\"units\": [\"$UNIT_NAME_1\", \"$UNIT_NAME_2\"]}")"
+MULTI_OUTPUT="$(varlinkctl call --more "$VARLINK_SOCKET" io.systemd.JournalAccess.GetEntries "{\"units\": [\"$UNIT_NAME_1\", \"$UNIT_NAME_2\"]}")"
 grep "hello-from-varlink-test-1" >/dev/null <<<"$MULTI_OUTPUT"
 grep "hello-from-varlink-test-2" >/dev/null <<<"$MULTI_OUTPUT"
 
 # check priority filter: priority 4 (warning) should include our warning message
-varlinkctl_get_entries '{"priority": 4, "limit": 1000}' | grep "varlink-test-warning" >/dev/null
+varlinkctl call --more "$VARLINK_SOCKET" io.systemd.JournalAccess.GetEntries '{"priority": 4, "limit": 1000}' | grep "varlink-test-warning" >/dev/null
 # check priority filter: priority 3 (error) should NOT include our warning (priority 4)
 (! varlinkctl call --more "$VARLINK_SOCKET" io.systemd.JournalAccess.GetEntries '{"priority": 3, "limit": 1000}' | grep "varlink-test-warning")
 


### PR DESCRIPTION
There seems to be a race condition where the writer extends the file
before bumping header->arena_size. A reader in journal_file_open() caches
f->last_stat.st_size early, then later reads arena_size from the header in
journal_file_verify_header(): if the writer interleaves between those two
reads, the cached st_size is stale and the bounds check spuriously returns
-ENODATA, causing add_any_file() to silently drop the active journal file.

Refresh the stat once and re-check before giving up, which is what
journal_file_move_to() a bit below already does.