### PR TITLE
units: enable systemd-report-basic.socket by default

### DIFF
--- a/presets/90-systemd.preset
+++ b/presets/90-systemd.preset
@@ -31,6 +31,7 @@ enable systemd-networkd.service
 enable systemd-networkd-wait-online.service
 enable systemd-nsresourced.socket
 enable systemd-pstore.service
+enable systemd-report-basic.socket
 enable systemd-resolved.service
 enable systemd-sysext.service
 enable systemd-timesyncd.service

--- a/test/units/TEST-74-AUX-UTILS.report.sh
+++ b/test/units/TEST-74-AUX-UTILS.report.sh
@@ -51,7 +51,7 @@ varlinkctl --more call /run/systemd/report/io.systemd.Network io.systemd.Metrics
 varlinkctl --more call /run/systemd/report/io.systemd.Network io.systemd.Metrics.Describe {}
 
 # test io.systemd.Basic Metrics
-systemctl start systemd-report-basic.socket
+[[ "$(systemctl is-enabled systemd-report-basic.socket)" == enabled ]]
 varlinkctl info /run/systemd/report/io.systemd.Basic
 varlinkctl list-methods /run/systemd/report/io.systemd.Basic
 varlinkctl --more call /run/systemd/report/io.systemd.Basic io.systemd.Metrics.List {}


### PR DESCRIPTION
In https://github.com/systemd/systemd/pull/41688 we merged metrics and facts for systemd-report. However while some metric sources are enabled by default (like `io.systemd.{Manager,Network}`) the `io.systemd.Basic` service is not enabled by default.

This commit changes this and enables it by default.

We could also enable the systemd-report-cgroup.socket but that sends a lot more data not sure that is a good default.