### PR TITLE
test: fix flaky TEST-07-PID1.socket-defer.sh

### DIFF
--- a/test/units/TEST-07-PID1.socket-defer.sh
+++ b/test/units/TEST-07-PID1.socket-defer.sh
@@ -60,7 +60,9 @@ wait_for_start() {
 
 wait_for_stop() {
     timeout 30 bash -c "while systemctl -q is-active '$UNIT_NAME.service'; do sleep .5; done"
-    assert_eq "$(systemctl show "$UNIT_NAME.socket" -P SubState)" "listening"
+    # The socket's SubState transitions from 'running' to 'listening' shortly after the triggered
+    # service becomes inactive, so wait for that transition instead of checking once and racing.
+    timeout 30 bash -c "until [[ \$(systemctl show '$UNIT_NAME.socket' -P SubState) == 'listening' ]]; do sleep .5; done"
 }
 
 # DeferTrigger=no: job mode replace


### PR DESCRIPTION
The socket's SubState transitions from 'running' to 'listening' shortly after the triggered service becomes inactive, so the assert can race and observe the stale 'running' state:

```
[ 1882.425335] systemd[1]: TEST-07-PID1-socket-defer-23279.service: Changed dead -> running
[ 1882.495150] TEST-07-PID1.sh[20535]: ++ systemctl show TEST-07-PID1-socket-defer-23279.socket -P SubState
[ 1882.514239] TEST-07-PID1.sh[20509]: + assert_eq running listening
[ 1882.510529] systemd[1]: TEST-07-PID1-socket-defer-23279.socket: Flushing socket before listening.
[ 1882.510559] systemd[1]: TEST-07-PID1-socket-defer-23279.socket: Changed running -> listening
```

Poll for 30s instead of directly asserting to try and make it more robust

eg: https://github.com/systemd/systemd/actions/runs/25527318098/job/74925761917?pr=41986