### PR TITLE
test: make TEST-07-PID1.user-namespace-path more robust

### DIFF
--- a/test/units/TEST-07-PID1.user-namespace-path.sh
+++ b/test/units/TEST-07-PID1.user-namespace-path.sh
@@ -7,10 +7,10 @@ set -o pipefail
 . "$(dirname "$0")"/util.sh
 
 # Only reuse the user namespace
-systemd-run --unit=oldservice --property=Type=exec --property=PrivateUsers=true sleep 3600
+systemd-run --unit=oldservice --property=Type=notify --property=NotifyAccess=all --property=PrivateUsers=true bash -c 'systemd-notify --ready; exec sleep 3600'
 OLD_PID=$(systemctl show oldservice -p MainPID | awk -F= '{print $2}')
 
-systemd-run --unit=newservice --property=Type=exec --property=UserNamespacePath=/proc/"$OLD_PID"/ns/user --property=PrivateNetwork=true sleep 3600
+systemd-run --unit=newservice --property=Type=notify --property=NotifyAccess=all --property=UserNamespacePath=/proc/"$OLD_PID"/ns/user --property=PrivateNetwork=true bash -c 'systemd-notify --ready; exec sleep 3600'
 NEW_PID=$(systemctl show newservice -p MainPID | awk -F= '{print $2}')
 
 assert_neq "$(lsns -p "$OLD_PID" -o NS -t net -n)" "$(lsns -p "$NEW_PID" -o NS -t net -n)"
@@ -19,10 +19,10 @@ assert_eq "$(lsns -p "$OLD_PID" -o NS -t user -n)" "$(lsns -p "$NEW_PID" -o NS -
 systemctl stop oldservice newservice
 
 # Reuse the user and network namespaces
-systemd-run --unit=oldservice --property=Type=exec --property=PrivateUsers=true --property=PrivateNetwork=true sleep 3600
+systemd-run --unit=oldservice --property=Type=notify --property=NotifyAccess=all --property=PrivateUsers=true --property=PrivateNetwork=true bash -c 'systemd-notify --ready; exec sleep 3600'
 OLD_PID=$(systemctl show oldservice -p MainPID | awk -F= '{print $2}')
 
-systemd-run --unit=newservice --property=Type=exec --property=UserNamespacePath=/proc/"$OLD_PID"/ns/user --property=NetworkNamespacePath=/proc/"$OLD_PID"/ns/net sleep 3600
+systemd-run --unit=newservice --property=Type=notify --property=NotifyAccess=all --property=UserNamespacePath=/proc/"$OLD_PID"/ns/user --property=NetworkNamespacePath=/proc/"$OLD_PID"/ns/net bash -c 'systemd-notify --ready; exec sleep 3600'
 NEW_PID=$(systemctl show newservice -p MainPID | awk -F= '{print $2}')
 
 assert_eq "$(lsns -p "$OLD_PID" -o NS -t net -n)" "$(lsns -p "$NEW_PID" -o NS -t net -n)"
@@ -31,10 +31,10 @@ assert_eq "$(lsns -p "$OLD_PID" -o NS -t user -n)" "$(lsns -p "$NEW_PID" -o NS -
 systemctl stop oldservice newservice
 
 # Delegate the network namespace
-systemd-run --unit=oldservice --property=Type=exec --property=PrivateUsers=true sleep 3600
+systemd-run --unit=oldservice --property=Type=notify --property=NotifyAccess=all --property=PrivateUsers=true bash -c 'systemd-notify --ready; exec sleep 3600'
 OLD_PID=$(systemctl show oldservice -p MainPID | awk -F= '{print $2}')
 
-systemd-run --unit=newservice --property=Type=exec --property=UserNamespacePath=/proc/"$OLD_PID"/ns/user --property=DelegateNamespaces=net --property=PrivateNetwork=true sleep 3600
+systemd-run --unit=newservice --property=Type=notify --property=NotifyAccess=all --property=UserNamespacePath=/proc/"$OLD_PID"/ns/user --property=DelegateNamespaces=net --property=PrivateNetwork=true bash -c 'systemd-notify --ready; exec sleep 3600'
 NEW_PID=$(systemctl show newservice -p MainPID | awk -F= '{print $2}')
 
 assert_neq "$(lsns -p "$OLD_PID" -o NS -t net -n)" "$(lsns -p "$NEW_PID" -o NS -t net -n)"


### PR DESCRIPTION
The test occasionally fails because lsns returns empty output for the transient unit, even though the process is running. e.g.:

```
    [ 1843.556046] TEST-07-PID1.sh[8560]: + systemd-run --unit=newservice --property=Type=exec --property=UserNamespacePath=/proc/8608/ns/user --property=NetworkNamespacePath=/proc/8608/ns/net sleep 3600
    [ 1844.205927] TEST-07-PID1.sh[8616]: ++ systemctl show newservice -p MainPID
    [ 1844.221425] TEST-07-PID1.sh[8618]: ++ lsns -p 8608 -o NS -t net -n
    [ 1844.229653] TEST-07-PID1.sh[8619]: ++ lsns -p 8614 -o NS -t net -n
    [ 1844.235563] TEST-07-PID1.sh[8620]: FAIL: expected: '' actual: '4026532522'
```

This could be a race, so switch to Type=notify to try and make it more robust.

eg: https://github.com/systemd/systemd/actions/runs/25485775345/job/74780837128?pr=41974