### PR TITLE
mkosi: drop libucontext again

### DIFF
--- a/mkosi/mkosi.conf.d/arch/mkosi.conf
+++ b/mkosi/mkosi.conf.d/arch/mkosi.conf
@@ -29,7 +29,6 @@ Packages=
         iproute
         iputils
         knot
-        libucontext
         liburing
         linux
         man-db

--- a/mkosi/mkosi.conf.d/centos-fedora/mkosi.conf
+++ b/mkosi/mkosi.conf.d/centos-fedora/mkosi.conf
@@ -44,7 +44,6 @@ Packages=
         knot
         libcap-ng-utils
         libmicrohttpd
-        libucontext
         liburing
         man-db
         nmap-ncat

--- a/mkosi/mkosi.images/build/mkosi.conf.d/arch/mkosi.conf
+++ b/mkosi/mkosi.images/build/mkosi.conf.d/arch/mkosi.conf
@@ -10,4 +10,3 @@ Packages=
         diffutils
         erofs-utils
         git
-        libucontext

--- a/mkosi/mkosi.images/build/mkosi.conf.d/centos-fedora/mkosi.conf
+++ b/mkosi/mkosi.images/build/mkosi.conf.d/centos-fedora/mkosi.conf
@@ -12,6 +12,5 @@ Packages=
         git-core
         libasan
         libubsan
-        libucontext-devel
         rpm-build
         which

--- a/mkosi/mkosi.tools.conf/mkosi.conf.d/arch.conf
+++ b/mkosi/mkosi.tools.conf/mkosi.conf.d/arch.conf
@@ -10,7 +10,6 @@ Packages=
         clang-tools-extra
         github-cli
         lcov
-        libucontext
         liburing
         musl
         mypy

--- a/mkosi/mkosi.tools.conf/mkosi.conf.d/centos-fedora.conf
+++ b/mkosi/mkosi.tools.conf/mkosi.conf.d/centos-fedora.conf
@@ -12,6 +12,5 @@ Packages=
         rpm-build
         libasan
         libubsan
-        libucontext-devel
         liburing-devel
         compiler-rt


### PR DESCRIPTION
Turns out it's possible to implement fibers without unnecessary system calls and without ucontext.h so there's no need for libucontext anymore, so drop it from the package list.