### PR TITLE
hwdb/keyboard: fix KP_Enter on Clevo PA70ES

### DIFF
--- a/hwdb.d/60-keyboard.hwdb
+++ b/hwdb.d/60-keyboard.hwdb
@@ -344,6 +344,15 @@ evdev:atkbd:dmi:bvn*:bvr*:bd*:svn*BenQ*:pn*Joybook*R22*:*
 # Clevo
 ###########################################################
 
+# Clevo PA70ES (Avell C73)
+# The ITE keyboard controller firmware (version 0xAB83) is shared with
+# the X+ piccolo. The piccolo rule (below) matches by input device ID
+# and remaps KP_Enter to Enter since the piccolo has no numpad and its
+# main Enter sends the wrong scan code. The PA70ES has a real numpad,
+# so the remap breaks KP_Enter. This restores the correct mapping.
+evdev:atkbd:dmi:bvn*:bvr*:bd*:svnNotebook:pnPA70ES:*
+ KEYBOARD_KEY_9c=kpenter
+
 evdev:atkbd:dmi:bvn*:bvr*:bd*:svnNotebook:pnW65_67SZ:*
  KEYBOARD_KEY_a0=!mute
  KEYBOARD_KEY_a2=!playpause


### PR DESCRIPTION
The ITE keyboard controller firmware (version `0xAB83`) is shared
between the Clevo PA70ES and the X+ piccolo series.

The piccolo's hwdb rule added in #41456 matches by input device ID
(`evdev:input:b0011v0001p0001eAB83*`) and remaps scan code `0x9c`
(KP_Enter) to Enter, since the piccolo has no numpad and its main
Enter key sends the wrong scan code.

The Clevo PA70ES has a real numpad. The piccolo rule matches it
because both laptops use the same ITE controller firmware, which
breaks KP_Enter on the PA70ES.

This PR adds a DMI-specific override that restores `KEY_KPENTER`
for `0x9c` on the PA70ES. The existing Clevo section already uses
`svnNotebook` for DMI matching.

### Evidence

```
$ cat /sys/class/input/event4/device/id/version
ab83

$ udevadm info /dev/input/event4 | grep KEYBOARD_KEY_9c
E: KEYBOARD_KEY_9c=enter

$ cat /sys/class/dmi/id/sys_vendor
Notebook

$ cat /sys/class/dmi/id/product_name
PA70ES
```

### Suggestion

The piccolo rule should ideally be narrowed to use DMI matching
instead of input device ID to avoid catching other laptops with
the same ITE controller firmware. The `eAB83` version identifies
the ITE keyboard controller, not a specific laptop model.

Cc: @eworm-de (author of #41456)