### PR TITLE
chase: open host root with O_PATH

### DIFF
--- a/src/basic/chase.c
+++ b/src/basic/chase.c
@@ -278,7 +278,7 @@ int chaseat(int dir_fd, const char *path, ChaseFlags flags, char **ret_path, int
                         goto success;
                 }
 
-                _dir_fd = open("/", O_DIRECTORY|O_RDONLY|O_CLOEXEC);
+                _dir_fd = open("/", O_DIRECTORY|O_PATH|O_CLOEXEC);
                 if (_dir_fd < 0)
                         return -errno;
 


### PR DESCRIPTION
`chaseat()` in `v260-stable` falls back to opening `/` when resolving from the host root and the `open_tree()` shortcut cannot be used. That currently opens `/` as a regular directory fd, so libudev sysfs enumeration can fail under sandboxes such as Landlock or AppArmor profiles that allow the relevant `/sys` paths but intentionally do not grant read access to `/`.

This keeps the generic `chase()` path intact and changes only the root anchor fd to `O_PATH`, which is enough for path walking and does not require read permission on `/`.

Fixes #41630.

Validation:

- `meson setup /tmp/systemd-v260-pr42012-build -Dtests=false -Dman=disabled -Dmode=developer`
- `ninja -C /tmp/systemd-v260-pr42012-build libudev`
- `meson setup /tmp/systemd-v260-tests-build -Dman=disabled -Dmode=developer`
- `ninja -C /tmp/systemd-v260-tests-build test-chase`
- `/tmp/systemd-v260-tests-build/test-chase`
- `LD_LIBRARY_PATH=/tmp/systemd-v260-base-build strace -f -e trace=openat lsusb`: baseline `v260-stable` had 457 `openat(..., "/", ...)` calls without `O_PATH` on my machine.
- `LD_LIBRARY_PATH=/tmp/systemd-v260-pr42012-build strace -f -e trace=openat lsusb`: patched build printed the same 34 `lsusb` lines and had 0 `openat(..., "/", ...)` calls without `O_PATH`.
