### PR TITLE
journal: stop dropping AUDIT_LOGIN records

### DIFF
--- a/man/journald.conf.xml
+++ b/man/journald.conf.xml
@@ -497,6 +497,13 @@
         unit <literal>systemd-journald-audit.socket</literal> can be disabled and, in this case, this setting
         is without effect.</para>
 
+        <para>Audit records with a type below <constant>AUDIT_FIRST_USER_MSG</constant> (1100) are dropped,
+        with the exception of <constant>AUDIT_USER</constant> (1005) and <constant>AUDIT_LOGIN</constant>
+        (1006). The 1000–1099 range is otherwise reserved for audit-netlink control messages (rule
+        management, daemon configuration) which are not log-worthy. Records of type
+        <constant>AUDIT_LOGIN</constant> carry the loginuid (AUID) transition for new sessions and are
+        required to attribute later actions back to a user.</para>
+
         <xi:include href="version-info.xml" xpointer="v246"/>
         </listitem>
       </varlistentry>

--- a/src/journal/journald-audit.c
+++ b/src/journal/journald-audit.c
@@ -457,8 +457,13 @@ void manager_process_audit_message(
         if (IN_SET(nl->nlmsg_type, NLMSG_NOOP, NLMSG_ERROR))
                 return;
 
-        /* Except AUDIT_USER, all messages below AUDIT_FIRST_USER_MSG are control messages, let's ignore those */
-        if (nl->nlmsg_type < AUDIT_FIRST_USER_MSG && nl->nlmsg_type != AUDIT_USER)
+        /* AUDIT_USER (deprecated) and AUDIT_LOGIN (loginuid transition) are events allocated in the
+         * 1000-1099 range that is otherwise reserved for audit netlink control messages (rule
+         * management, daemon configuration). All other types in that range are control messages we
+         * should ignore. */
+        if (nl->nlmsg_type < AUDIT_FIRST_USER_MSG &&
+            nl->nlmsg_type != AUDIT_USER &&
+            nl->nlmsg_type != AUDIT_LOGIN)
                 return;
 
         process_audit_string(m, nl->nlmsg_type, NLMSG_DATA(nl), nl->nlmsg_len - ALIGN(sizeof(struct nlmsghdr)));


### PR DESCRIPTION
## Background

`manager_process_audit_message()` in `src/journal/journald-audit.c` filters out every audit-netlink message whose type is below `AUDIT_FIRST_USER_MSG` (1100), with a single carve-out for `AUDIT_USER` (1005):

```c
/* Except AUDIT_USER, all messages below AUDIT_FIRST_USER_MSG are control messages, let's ignore those */
if (nl->nlmsg_type < AUDIT_FIRST_USER_MSG && nl->nlmsg_type != AUDIT_USER)
        return;
```

The 1000-1099 range is documented in linux-audit's [`message-dictionary-ranges.txt`](https://github.com/linux-audit/audit-documentation/blob/main/specs/messages/message-dictionary-ranges.txt) as commands to the audit system (rule management, daemon configuration). Journald is right to ignore those. But two values in that range are events, not commands:

```c
#define AUDIT_USER   1005   /* Message from userspace -- deprecated */
#define AUDIT_LOGIN  1006   /* Define the login id and information */
```

(`<linux/audit.h>`)

## The bug

The filter is asymmetric. `AUDIT_USER` (deprecated, kept for back-compat) is exempted; `AUDIT_LOGIN` is not. As a result `systemd-journald` silently drops every `AUDIT_LOGIN` record on every running system. `AUDIT_LOGIN` is the record auditd emits for the loginuid (AUID) transition that turns an anonymous netlink/PAM session into an attributable one. Without it, later AVC and syscall records the journal does collect cannot be tied back to a real user.

Verifiable on any host running `auditd`:

```
# auditd writes LOGIN events:
$ sudo grep -c 'type=LOGIN' /var/log/audit/audit.log
42

# journald sees zero of them:
$ journalctl -t audit | grep -c LOGIN
0
```

## The fix

Extend the carve-out to include `AUDIT_LOGIN`, and document the type-range filter behavior in `journald.conf(5)` so operators know what is and isn't forwarded.

## Verification

- `meson compile -C build systemd-journald` — clean
- `meson test -C build -v test-audit-type test-audit-util test-journald-syslog test-journald-tables test-journald-config` — 5/5 pass
- `meson compile -C build man/journald.conf.5` — man page renders cleanly with the new paragraph

---

Co-developed-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>