### PR TITLE
clang-tidy: Drop unknown gcc compiler args

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -70,6 +70,7 @@ CheckOptions:
     ^getmntent$,mnt_table_next_fs(),libmount parser should be used instead
 '
   misc-header-include-cycle.IgnoredFilesList: 'glib-2.0'
+RemovedArgs: ['-fwide-exec-charset=UCS2', '-maccumulate-outgoing-args']
 WarningsAsErrors: '*'
 ExcludeHeaderFilterRegex: 'blkid\.h|gmessages\.h|gstring\.h'
 HeaderFileExtensions:


### PR DESCRIPTION
clang-tidy recently gained support to allow dropping compiler args from the entries parsed from the compilation database. Let's make use of this to drop the two compiler args we use with gcc that clang doesn't support so we can run clang-tidy on meson build trees configured to use gcc without getting tons of false positives.