### PR TITLE
TEST-67-INTEGRITY: pre-load crypto modules and skip unsupported algorithms

### DIFF
--- a/test/units/TEST-67-INTEGRITY.sh
+++ b/test/units/TEST-67-INTEGRITY.sh
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 set -euxo pipefail
 
-. /etc/os-release
-
 DM_NAME="integrity_test"
 DM_NODE="/dev/mapper/${DM_NAME}"
 DM_SERVICE="systemd-integritysetup@${DM_NAME}.service"
@@ -119,16 +117,23 @@ EOF
 }
 
 for a in crc32c crc32 xxhash64 sha1 sha256; do
-    if [[ "$a" == crc32 && "${ID_LIKE:-}" == alpine ]]; then
-        # crc32 is not supported on alpine/postmarketos ??
-        # --------
-        # [   22.419458] TEST-67-INTEGRITY.sh[3085]: + integritysetup format /dev/loop0 --batch-mode -I crc32 ''
-        # [   22.433168] kernel: device-mapper: table: 253:0: integrity: Invalid internal hash (-ENOENT)
-        # [   22.433220] TEST-67-INTEGRITY.sh[3475]: device-mapper: reload ioctl on temporary-cryptsetup-6b3b80ef-6854-4102-8239-6360f15af0c3 (253:0) failed: No such file or directory
-        # [   22.433220] TEST-67-INTEGRITY.sh[3475]: Cannot format integrity for device /dev/loop0.
-        # [   22.433835] kernel: device-mapper: ioctl: error adding target to table
-        # --------
-        continue;
+    # dm-integrity uses crypto_alloc_shash() which triggers request_module()
+    # for the underlying hash algorithm when needed. That auto-load has been
+    # observed to fail flakily in some test environments, leading to errors
+    # like:
+    #   kernel: device-mapper: table: NNN:N: integrity: Invalid internal hash (-ENOENT)
+    #   integritysetup: Cannot format integrity for device /dev/loopN.
+    # Try to load the kernel module ahead of time to avoid that. Failure is
+    # acceptable here: the algorithm might be built-in (no module to load) or
+    # genuinely unsupported, in which case the next check will skip it.
+    modprobe -q "crypto-$a" || :
+
+    # Some algorithms are not supported on certain platforms (e.g. crc32 is
+    # missing on Alpine/postmarketOS). Skip them at runtime to avoid spurious
+    # failures.
+    if ! grep -q -E "^name\s+: $a\$" /proc/crypto; then
+        echo "Algorithm '$a' is not supported on this system, skipping."
+        continue
     fi
 
     test_one "$a" 0


### PR DESCRIPTION
The test occasionally fails on GHA CI when formatting with xxhash64 because dm-integrity's crypto_alloc_shash() -> request_module() path flakily fails to load the algorithm:

```
[   29.172664] TEST-67-INTEGRITY.sh[447]: + for a in crc32c crc32 xxhash64 sha1 sha256
[   29.172664] TEST-67-INTEGRITY.sh[447]: + [[ xxhash64 == crc32 ]]
[   29.172664] TEST-67-INTEGRITY.sh[447]: + test_one xxhash64 0
[   29.172664] TEST-67-INTEGRITY.sh[447]: + integritysetup format /dev/loop0 --batch-mode -I xxhash64 ''
[   29.223383] TEST-67-INTEGRITY.sh[1220]: device-mapper: reload ioctl on temporary-cryptsetup-fa8bebe3-1d87-4796-91e8-abc02c487bb5 (254:0) failed: No such file or directory
[   29.226916] kernel: device-mapper: table: 254:0: integrity: Invalid internal hash (-ENOENT)
[   29.227415] kernel: device-mapper: ioctl: error adding target to table
[   29.231586] TEST-67-INTEGRITY.sh[1220]: Cannot format integrity for device /dev/loop0.
```

Preload each algorithm's crypto module before use, and skip algorithms that are not registered in /proc/crypto.

eg: https://github.com/systemd/systemd/actions/runs/25642687733/job/75265735368?pr=42016