### PR TITLE
vmspawn: Attach a USB keyboard in GUI mode

### DIFF
--- a/src/vmspawn/vmspawn.c
+++ b/src/vmspawn/vmspawn.c
@@ -2978,6 +2978,23 @@ static int run_virtual_machine(int kvm_device_fd, int vhost_device_fd) {
                 if (r < 0)
                         return r;
 
+                /* Attach a USB xHCI controller and a USB keyboard. We prefer USB over the implicit PS/2
+                 * keyboard so that EDK2's UsbKbDxe driver runs, which registers the default HII keyboard
+                 * layout package — the PS/2 driver does not. That makes
+                 * EFI_HII_DATABASE_PROTOCOL.GetKeyboardLayout() return a usable layout, which systemd-boot
+                 * then exports via the LoaderKeyboardLayout EFI variable, which is useful for testing that
+                 * codepath actually works. */
+                r = qemu_config_section(config_file, "device", "xhci0",
+                                        "driver", "qemu-xhci");
+                if (r < 0)
+                        return r;
+
+                r = qemu_config_section(config_file, "device", "usb-kbd0",
+                                        "driver", "usb-kbd",
+                                        "bus", "xhci0.0");
+                if (r < 0)
+                        return r;
+
                 break;
 
         case CONSOLE_HEADLESS:


### PR DESCRIPTION
EDK2's UsbKbDxe is the only driver that registers a default HII keyboard layout via the HII database protocol; the PS/2 driver does not. Adding a USB xHCI controller and usb-kbd in CONSOLE_GUI mode gives us a layout to query, which systemd-boot exports through the LoaderKeyboardLayout EFI variable — useful for exercising that codepath end-to-end.