### PR TITLE
vmspawn: Use builtin vdagent instead of spicevmc

### DIFF
--- a/src/vmspawn/vmspawn.c
+++ b/src/vmspawn/vmspawn.c
@@ -2965,9 +2965,9 @@ static int run_virtual_machine(int kvm_device_fd, int vhost_device_fd) {
                         return r;
 
                 r = qemu_config_section(config_file, "chardev", "vdagent",
-                                        "backend", "spicevmc",
-                                        "debug", "0",
-                                        "name", "vdagent");
+                                        "backend", "qemu-vdagent",
+                                        "clipboard", "on",
+                                        "debug", "0");
                 if (r < 0)
                         return r;
 


### PR DESCRIPTION
The builtin one also makes the clipboard and such work. spicevmc is only required for remote desktop use cases, so let's use the  builtin one instead.