### PR TITLE
units: pull in basic.target rather than sysinit.target from system-in…

### DIFF
--- a/units/system-install.target
+++ b/units/system-install.target
@@ -10,6 +10,6 @@
 [Unit]
 Description=System Installer
 Documentation=man:systemd-sysinstall(8)
-Requires=sysinit.target
-After=sysinit.target
+Requires=basic.target
+After=basic.target
 AllowIsolate=yes


### PR DESCRIPTION
…stall.target

Many of our services are nowadays implemented via socket activation, and hence require sockets.target to be active to be accessible. One of them is mute-console.socket, which we typically want to use from systemd-firstboot.service, systemd-sysinstall.service and other related services. Hence let's pull in basic.target rather than sysinit.target from system-install.target since it pulls sockets.target in too.

Effectively, this doesn't change much except for pulling in a bunch more sockets, and frankly going for sysinit.target was really a bug to begin width.