### PR TITLE
curl-util: fix clang-tidy warnings

### DIFF
--- a/src/shared/curl-util.h
+++ b/src/shared/curl-util.h
@@ -33,8 +33,8 @@ extern DLSYM_PROTOTYPE(curl_slist_free_all);
 typedef int (*curl_finished_t)(CurlSlot *slot, CURL *curl, CURLcode code, void *userdata);
 
 int curl_glue_new(CurlGlue **glue, sd_event *event);
-CurlGlue* curl_glue_ref(CurlGlue *glue);
-CurlGlue* curl_glue_unref(CurlGlue *glue);
+CurlGlue* curl_glue_ref(CurlGlue *p);
+CurlGlue* curl_glue_unref(CurlGlue *p);
 
 DEFINE_TRIVIAL_CLEANUP_FUNC(CurlGlue*, curl_glue_unref);
 
@@ -62,8 +62,8 @@ int curl_glue_perform_async(
 CURL* curl_slot_get_easy(CurlSlot *slot);
 CurlGlue* curl_slot_get_glue(CurlSlot *slot);
 
-CurlSlot* curl_slot_ref(CurlSlot *slot);
-CurlSlot* curl_slot_unref(CurlSlot *slot);
+CurlSlot* curl_slot_ref(CurlSlot *p);
+CurlSlot* curl_slot_unref(CurlSlot *p);
 
 DEFINE_TRIVIAL_CLEANUP_FUNC(CurlSlot*, curl_slot_unref);
 


### PR DESCRIPTION
```
496/2798 clang-tidy - systemd:clang-tidy-curl-util.c                                 FAIL            0.18s   exit status 1
>>> MALLOC_PERTURB_=3 MSAN_OPTIONS=halt_on_error=1:abort_on_error=1:print_summary=1:print_stacktrace=1 MESON_TEST_ITERATION=1 ASAN_OPTIONS=halt_on_error=1:abort_on_error=1:print_summary=1 UBSAN_OPTIONS=halt_on_error=1:abort_on_error=1:print_summary=1:print_stacktrace=1 /usr/sbin/clang-tidy -p /home/runner/work/systemd/systemd/build /home/runner/work/systemd/systemd/build/../src/shared/curl-util.c
――――――――――――――――――――――――――――――――――――― ✀  ――――――――――――――――――――――――――――――――――――― 4 warnings generated.
../src/shared/curl-util.h:36:11: error: function 'curl_glue_ref' has a definition with different parameter names [readability-inconsistent-declaration-parameter-name,-warnings-as-errors]
   36 | CurlGlue* curl_glue_ref(CurlGlue *glue);
      |           ^
../src/shared/curl-util.c:336:1: note: the definition seen here
  336 | DEFINE_TRIVIAL_REF_UNREF_FUNC(CurlGlue, curl_glue, curl_glue_free);
      | ^
../src/basic/cleanup-util.h:73:9: note: expanded from macro 'DEFINE_TRIVIAL_REF_UNREF_FUNC'
   73 |         DEFINE_TRIVIAL_REF_FUNC(type, name);                    \
      |         ^
../src/basic/cleanup-util.h:59:9: note: expanded from macro 'DEFINE_TRIVIAL_REF_FUNC'
   59 |         _DEFINE_TRIVIAL_REF_FUNC(type, name,)
      |         ^
../src/basic/cleanup-util.h:32:21: note: expanded from macro '_DEFINE_TRIVIAL_REF_FUNC'
note: expanded from here
   32 |         scope type *name##_ref(type *p) {                                               \
      |                     ^
../src/shared/curl-util.h:36:11: note: differing parameters are named here: ('glue'), in definition: ('p')
   36 | CurlGlue* curl_glue_ref(CurlGlue *glue);
      |           ^                       ~~~~
      |                                   p
../src/shared/curl-util.h:37:11: error: function 'curl_glue_unref' has a definition with different parameter names [readability-inconsistent-declaration-parameter-name,-warnings-as-errors]
   37 | CurlGlue* curl_glue_unref(CurlGlue *glue);
      |           ^
../src/shared/curl-util.c:336:1: note: the definition seen here
  336 | DEFINE_TRIVIAL_REF_UNREF_FUNC(CurlGlue, curl_glue, curl_glue_free);
      | ^
../src/basic/cleanup-util.h:74:9: note: expanded from macro 'DEFINE_TRIVIAL_REF_UNREF_FUNC'
   74 |         DEFINE_TRIVIAL_UNREF_FUNC(type, name, free_func);
      |         ^
../src/basic/cleanup-util.h:66:9: note: expanded from macro 'DEFINE_TRIVIAL_UNREF_FUNC'
   66 |         _DEFINE_TRIVIAL_UNREF_FUNC(type, name, free_func,)
      |         ^
../src/basic/cleanup-util.h:46:21: note: expanded from macro '_DEFINE_TRIVIAL_UNREF_FUNC'
note: expanded from here
   46 |         scope type *name##_unref(type *p) {                                             \
      |                     ^
../src/shared/curl-util.h:37:11: note: differing parameters are named here: ('glue'), in definition: ('p')
   37 | CurlGlue* curl_glue_unref(CurlGlue *glue);
      |           ^                         ~~~~
      |                                     p
../src/shared/curl-util.h:65:11: error: function 'curl_slot_ref' has a definition with different parameter names [readability-inconsistent-declaration-parameter-name,-warnings-as-errors]
   65 | CurlSlot* curl_slot_ref(CurlSlot *slot);
      |           ^
../src/shared/curl-util.c:105:1: note: the definition seen here
  105 | DEFINE_TRIVIAL_REF_UNREF_FUNC(CurlSlot, curl_slot, curl_slot_free);
      | ^
../src/basic/cleanup-util.h:73:9: note: expanded from macro 'DEFINE_TRIVIAL_REF_UNREF_FUNC'
   73 |         DEFINE_TRIVIAL_REF_FUNC(type, name);                    \
      |         ^
../src/basic/cleanup-util.h:59:9: note: expanded from macro 'DEFINE_TRIVIAL_REF_FUNC'
   59 |         _DEFINE_TRIVIAL_REF_FUNC(type, name,)
      |         ^
../src/basic/cleanup-util.h:32:21: note: expanded from macro '_DEFINE_TRIVIAL_REF_FUNC'
note: expanded from here
   32 |         scope type *name##_ref(type *p) {                                               \
      |                     ^
../src/shared/curl-util.h:65:11: note: differing parameters are named here: ('slot'), in definition: ('p')
   65 | CurlSlot* curl_slot_ref(CurlSlot *slot);
      |           ^                       ~~~~
      |                                   p
../src/shared/curl-util.h:66:11: error: function 'curl_slot_unref' has a definition with different parameter names [readability-inconsistent-declaration-parameter-name,-warnings-as-errors]
   66 | CurlSlot* curl_slot_unref(CurlSlot *slot);
      |           ^
../src/shared/curl-util.c:105:1: note: the definition seen here
  105 | DEFINE_TRIVIAL_REF_UNREF_FUNC(CurlSlot, curl_slot, curl_slot_free);
      | ^
../src/basic/cleanup-util.h:74:9: note: expanded from macro 'DEFINE_TRIVIAL_REF_UNREF_FUNC'
   74 |         DEFINE_TRIVIAL_UNREF_FUNC(type, name, free_func);
      |         ^
../src/basic/cleanup-util.h:66:9: note: expanded from macro 'DEFINE_TRIVIAL_UNREF_FUNC'
   66 |         _DEFINE_TRIVIAL_UNREF_FUNC(type, name, free_func,)
      |         ^
../src/basic/cleanup-util.h:46:21: note: expanded from macro '_DEFINE_TRIVIAL_UNREF_FUNC'
note: expanded from here
   46 |         scope type *name##_unref(type *p) {                                             \
      |                     ^
../src/shared/curl-util.h:66:11: note: differing parameters are named here: ('slot'), in definition: ('p')
   66 | CurlSlot* curl_slot_unref(CurlSlot *slot);
      |           ^                         ~~~~
      |                                     p
```

Follow-up for 87cec65cae656f6ac2e702bd60dad6dd4fdae636