### PR TITLE
mkosi: Drop CPUs= limit

### DIFF
--- a/mkosi/mkosi.conf
+++ b/mkosi/mkosi.conf
@@ -141,7 +141,6 @@ Credentials=
         tty.virtual.tty1.agetty.autologin=root
         tty.virtual.tty1.login.noauth=yes
 RuntimeBuildSources=yes
-CPUs=2
 TPM=yes
 VSock=yes
 KVM=yes


### PR DESCRIPTION
Limiting VMs to 2 cpus was cargo culting without any actual data that this benefits performance. The host OS has a scheduler, let's make use of it and give the VM access to all the CPUs. This doesn't mean they become inaccessible to the host, it just means the VM gets as many virtual CPUs as the host has CPU cores (threads). How they get scheduled is still up to the host OS.