### PR TITLE
test: start systemd-report-basic.socket again

### DIFF
--- a/test/units/TEST-74-AUX-UTILS.report.sh
+++ b/test/units/TEST-74-AUX-UTILS.report.sh
@@ -51,7 +51,8 @@ varlinkctl --more call /run/systemd/report/io.systemd.Network io.systemd.Metrics
 varlinkctl --more call /run/systemd/report/io.systemd.Network io.systemd.Metrics.Describe {}
 
 # test io.systemd.Basic Metrics
-[[ "$(systemctl is-enabled systemd-report-basic.socket)" == enabled ]]
+# ensure the socket is running, as some distros don't enable it by default
+systemctl start systemd-report-basic.socket
 varlinkctl info /run/systemd/report/io.systemd.Basic
 varlinkctl list-methods /run/systemd/report/io.systemd.Basic
 varlinkctl --more call /run/systemd/report/io.systemd.Basic io.systemd.Metrics.List {}


### PR DESCRIPTION
SUSE uses a different preset, so don't just assert in the test, instead just start the socket in case it is not enabled

```
TEST-74-AUX-UTILS.sh[1594]: ++ systemctl is-enabled systemd-report-basic.socket
TEST-74-AUX-UTILS.sh[1540]: + [[ disabled == enabled ]]
TEST-74-AUX-UTILS.sh[120]: + echo 'Subtest /usr/lib/systemd/tests/testdata/units/TEST-74-AUX-UTILS.report.sh failed'
```

Follow-up for 4409e52494d803426a365b6636a66fd2dfc70b62