### PR TITLE
60-sensor.hwdb iio/accel fix for Advan Evo-X 13

### DIFF
--- a/hwdb.d/60-sensor.hwdb
+++ b/hwdb.d/60-sensor.hwdb
@@ -114,7 +114,7 @@ sensor:modalias:acpi:BMA250E:*:dmi:*:svnAcer:*:rnAigner:*       # Iconia Tab 8W 
 #########################################
 
 sensor:modalias:acpi:NSA2513:*:dmi*:svnADVAN*:pn1301:*          # Evo-X 13 (Intel N150)
- ACCEL_MOUNT_MATRIX=-1,0,0;0,-1,0;0,0,1
+ ACCEL_MOUNT_MATRIX=-1, 0, 0; 0, -1, 0; 0, 0, 1
 
 #########################################
 # Aquarius

--- a/hwdb.d/60-sensor.hwdb
+++ b/hwdb.d/60-sensor.hwdb
@@ -110,6 +110,13 @@ sensor:modalias:acpi:BMA250E:*:dmi:*:svnAcer:*:rnAigner:*       # Iconia Tab 8W 
  ACCEL_MOUNT_MATRIX=1, 0, 0; 0, -1, 0; 0, 0, 1
 
 #########################################
+# Advan
+#########################################
+
+sensor:modalias:acpi:NSA2513:*:dmi*:svnADVAN*:pn1301:*          # Evo-X 13 (Intel N150)
+ ACCEL_MOUNT_MATRIX=-1,0,0;0,-1,0;0,0,1
+
+#########################################
 # Aquarius
 #########################################
 


### PR DESCRIPTION
Added fix for Advan Evo-X 13 2-in-1 laptop

Relevant output of `udevadm info --export-db`
```
P: /devices/pci0000:00/0000:00:15.2/i2c_designware.3/i2c-2/i2c-NSA2513:00/iio:device0
M: iio:device0
R: 0
J: +iio:iio:device0
U: iio
T: iio_device
E: DEVPATH=/devices/pci0000:00/0000:00:15.2/i2c_designware.3/i2c-2/i2c-NSA2513:00/iio:device0
E: DEVTYPE=iio_device
E: SUBSYSTEM=iio
E: USEC_INITIALIZED=5462149
E: ACCEL_MOUNT_MATRIX=-1,0,0;0,-1,0;0,0,1
E: IIO_SENSOR_PROXY_TYPE=iio-poll-accel
E: SYSTEMD_WANTS=iio-sensor-proxy.service
E: TAGS=:systemd:
E: CURRENT_TAGS=:systemd:
```