### PR TITLE
hwdb/keyboard: Map f21 key on Wareus B15

### DIFF
--- a/hwdb.d/60-keyboard.hwdb
+++ b/hwdb.d/60-keyboard.hwdb
@@ -2186,6 +2186,7 @@ evdev:name:SIPODEV USB Composite Device:dmi:bvn*:bvr*:bd*:svnVIOS:pnLTH17:*
 # Wareus B15 (8AD5A)
 evdev:atkbd:dmi:bvn*:bvr*:bd*:svnWareus*:pnB15*:*
  KEYBOARD_KEY_55=fn
+ KEYBOARD_KEY_c1=f21
 
 ###########################################################
 # WeiHeng


### PR DESCRIPTION
Addition to PR https://github.com/systemd/systemd/pull/41181 Plasma-workspace OSD notifications about turning the touchpad on and off are guided by f21. When this match is specified, KDE notifies on this laptop that the on/off switch of the touchpad state is pressed.
Fix dmesg:
atkbd serio0: Unknown key pressed (translated set 2, code 0xc1 on isa0060/serio0).

fn+f7 == 0xc1 == switch of the touchpad state on/off