### PR TITLE
logind: zero-initialize dispatch struct in vl_method_release_session()

### DIFF
--- a/src/login/logind-varlink.c
+++ b/src/login/logind-varlink.c
@@ -310,7 +310,7 @@ static int vl_method_release_session(sd_varlink *link, sd_json_variant *paramete
 
         struct {
                 const char *id;
-        } p;
+        } p = {};
 
         static const sd_json_dispatch_field dispatch_table[] = {
                 { "Id", SD_JSON_VARIANT_STRING, sd_json_dispatch_const_string, voffsetof(p, id), 0 },


### PR DESCRIPTION
The local struct passed to sd_varlink_dispatch() was not zero-initialized. Since sd_json_dispatch_full() does not call handlers for absent optional fields, p.id could be left indeterminate when the client omits the Id parameter, leading to use of uninitialized memory.

spun out of #41561