### PR TITLE
meson: move systemd-sysupdate to /usr/bin/

### DIFF
--- a/src/sysupdate/meson.build
+++ b/src/sysupdate/meson.build
@@ -21,7 +21,7 @@ systemd_updatectl_sources = files(
 )
 
 executables += [
-        libexec_template + {
+        executable_template + {
                 'name' : 'systemd-sysupdate',
                 'public' : true,
                 'conditions' : ['ENABLE_SYSUPDATE'],
@@ -56,4 +56,11 @@ if conf.get('ENABLE_SYSUPDATED') == 1
                      install_dir : dbussystemservicedir)
         install_data('org.freedesktop.sysupdate1.policy',
                      install_dir : polkitpolicydir)
+endif
+
+if conf.get('ENABLE_SYSUPDATE') == 1
+        # symlink for backwards compatibility after rename
+        install_symlink('systemd-sysupdate',
+                        pointing_to : libexecdir_to_bin / 'systemd-sysupdate',
+                        install_dir : libexecdir)
 endif

--- a/test/units/TEST-72-SYSUPDATE.sh
+++ b/test/units/TEST-72-SYSUPDATE.sh
@@ -5,7 +5,7 @@
 set -eux
 set -o pipefail
 
-SYSUPDATE=/lib/systemd/systemd-sysupdate
+SYSUPDATE=/usr/bin/systemd-sysupdate
 SYSUPDATED=/lib/systemd/systemd-sysupdated
 SECTOR_SIZES=(512 4096)
 WORKDIR="$(mktemp -d /var/tmp/test-72-XXXXXX)"

--- a/units/meson.build
+++ b/units/meson.build
@@ -785,7 +785,7 @@ units = [
           'symlinks' : ['system-install.target.wants/'],
         },
         {
-          'file' : 'systemd-sysupdate-reboot.service.in',
+          'file' : 'systemd-sysupdate-reboot.service',
           'conditions' : ['ENABLE_SYSUPDATE'],
         },
         {
@@ -793,7 +793,7 @@ units = [
           'conditions' : ['ENABLE_SYSUPDATE'],
         },
         {
-          'file' : 'systemd-sysupdate.service.in',
+          'file' : 'systemd-sysupdate.service',
           'conditions' : ['ENABLE_SYSUPDATE'],
         },
         {

--- a/units/systemd-sysupdate-reboot.service
+++ b/units/systemd-sysupdate-reboot.service
@@ -14,7 +14,7 @@ ConditionVirtualization=!container
 
 [Service]
 Type=oneshot
-ExecStart={{LIBEXECDIR}}/systemd-sysupdate reboot
+ExecStart=systemd-sysupdate reboot
 
 [Install]
 Also=systemd-sysupdate-reboot.timer

--- a/units/systemd-sysupdate.service
+++ b/units/systemd-sysupdate.service
@@ -17,7 +17,7 @@ ConditionVirtualization=!container
 [Service]
 Type=simple
 NotifyAccess=main
-ExecStart={{LIBEXECDIR}}/systemd-sysupdate update
+ExecStart=systemd-sysupdate update
 CapabilityBoundingSet=CAP_CHOWN CAP_FOWNER CAP_FSETID CAP_MKNOD CAP_SETFCAP CAP_SYS_ADMIN CAP_SETPCAP CAP_DAC_OVERRIDE CAP_LINUX_IMMUTABLE
 NoNewPrivileges=yes
 MemoryDenyWriteExecute=yes


### PR DESCRIPTION
Let's make systemd-sysupdate easy to call. It was added in 2021 and it's around to stay and not "experimental" in any way.