### PR TITLE
core: when figuring out whether to create orphanage units, consult vt…

### DIFF
--- a/src/core/manager-serialize.c
+++ b/src/core/manager-serialize.c
@@ -270,8 +270,8 @@ static int manager_synthesize_orphaned_unit(
                                          "Cannot synthesize unit for '%s' (overridden by alias to '%s'): invalid unit type. Skipping stale state.",
                                          original_name, canonical_name);
 
-        /* Only transition units that track external resources, forget internal ones (eg: timers) */
-        if (!IN_SET(t, UNIT_SERVICE, UNIT_SCOPE, UNIT_MOUNT, UNIT_AUTOMOUNT))
+        /* Only transition units that track external resources and can be renamed/know aliases, forget internal ones (eg: timers) */
+        if (!unit_vtable[t]->track_orphaned)
                 return log_warning_errno(SYNTHETIC_ERRNO(EOPNOTSUPP),
                                          "Cannot synthesize unit for '%s' (overridden by alias to '%s'): unsupported unit type. Skipping stale state.",
                                          original_name, canonical_name);

--- a/src/core/mount.c
+++ b/src/core/mount.c
@@ -2509,6 +2509,8 @@ const UnitVTable mount_vtable = {
         .can_transient = true,
         .can_fail = true,
         .exclude_from_switch_root_serialization = true,
+        .notify_plymouth = true,
+        .track_orphaned = true,
 
         .init = mount_init,
         .load = mount_load,
@@ -2576,6 +2578,4 @@ const UnitVTable mount_vtable = {
         },
 
         .test_startable = mount_test_startable,
-
-        .notify_plymouth = true,
 };

--- a/src/core/scope.c
+++ b/src/core/scope.c
@@ -744,6 +744,7 @@ const UnitVTable scope_vtable = {
         .can_fail = true,
         .once_only = true,
         .can_set_managed_oom = true,
+        .track_orphaned = true,
 
         .init = scope_init,
         .load = scope_load,

--- a/src/core/service.c
+++ b/src/core/service.c
@@ -6149,6 +6149,8 @@ const UnitVTable service_vtable = {
         .can_delegate = true,
         .can_fail = true,
         .can_set_managed_oom = true,
+        .notify_plymouth = true,
+        .track_orphaned = true,
 
         .init = service_init,
         .done = service_done,
@@ -6212,8 +6214,6 @@ const UnitVTable service_vtable = {
         },
 
         .test_startable = service_test_startable,
-
-        .notify_plymouth = true,
 
         .audit_start_message_type = AUDIT_SERVICE_START,
         .audit_stop_message_type = AUDIT_SERVICE_STOP,

--- a/src/core/socket.c
+++ b/src/core/socket.c
@@ -3726,6 +3726,7 @@ const UnitVTable socket_vtable = {
         .can_transient = true,
         .can_trigger = true,
         .can_fail = true,
+        .track_orphaned = true,
 
         .init = socket_init,
         .done = socket_done,

--- a/src/core/swap.c
+++ b/src/core/swap.c
@@ -1616,6 +1616,7 @@ const UnitVTable swap_vtable = {
         .private_section = "Swap",
 
         .can_fail = true,
+        .track_orphaned = true,
 
         .init = swap_init,
         .load = swap_load,

--- a/src/core/unit.h
+++ b/src/core/unit.h
@@ -771,6 +771,10 @@ typedef struct UnitVTable {
         /* If true, we'll notify a surrounding VMM/container manager about this unit becoming available */
         bool notify_supervisor;
 
+        /* If true, we'll synthesize an 'orphaned' unit if a unit becomes an alias of another unit during a
+         * reload cycle, but still has resources assigned to it */
+        bool track_orphaned;
+
         /* The audit events to generate on start + stop (or 0 if none shall be generated) */
         int audit_start_message_type;
         int audit_stop_message_type;


### PR DESCRIPTION
…able instead of allowlist

As per https://github.com/systemd/systemd/pull/41986#pullrequestreview-4281939586

This also corrects the list of unit types a bit:

1. this removes the mount/automount unit type from the list, since for these types we do not allow aliases/renaming anyway.

2. this adds socket + swap units to the list, since they can change name, and for both of them we actually do fork off processes hence track resources.

Follow-up for: #41986