### PR TITLE
TEST-64-UDEV-STORAGE: Drop number of nvme devices to 12

### DIFF
--- a/test/integration-tests/TEST-64-UDEV-STORAGE/meson.build
+++ b/test/integration-tests/TEST-64-UDEV-STORAGE/meson.build
@@ -176,23 +176,23 @@ udev_storage_tests += udev_storage_test_template + {
 cmdline = []
 qemu_args = []
 
-foreach i : range(20)
+foreach i : range(12)
         cmdline += [f'--drive=nvme@i@:1M::']
 endforeach
 
-foreach i : range(5)
+foreach i : range(3)
         qemu_args += ['-device', f'nvme,drive=nvme@i@,serial=deadbeef@i@,max_ioqpairs=8']
 endforeach
 
-foreach i : range(5, 10)
+foreach i : range(3, 6)
         qemu_args += ['-device', f'"nvme,drive=nvme@i@,serial=    deadbeef  @i@   ,max_ioqpairs=8"']
 endforeach
 
-foreach i : range(10, 15)
+foreach i : range(6, 9)
         qemu_args += ['-device', f'"nvme,drive=nvme@i@,serial=    dead/beef/@i@   ,max_ioqpairs=8"']
 endforeach
 
-foreach i : range(15, 20)
+foreach i : range(9, 12)
         qemu_args += ['-device', f'"nvme,drive=nvme@i@,serial=dead/../../beef/@i@,max_ioqpairs=8"']
 endforeach
 

--- a/test/units/TEST-64-UDEV-STORAGE.sh
+++ b/test/units/TEST-64-UDEV-STORAGE.sh
@@ -178,7 +178,7 @@ testcase_nvme_basic() {
     local expected_symlinks=()
     local i
 
-    for i in {0..4}; do
+    for i in {0..2}; do
         expected_symlinks+=(
             # both replace mode provides the same devlink
             /dev/disk/by-id/nvme-QEMU_NVMe_Ctrl_deadbeef"$i"
@@ -186,7 +186,7 @@ testcase_nvme_basic() {
             /dev/disk/by-id/nvme-QEMU_NVMe_Ctrl_deadbeef"$i"_1
         )
     done
-    for i in {5..9}; do
+    for i in {3..5}; do
         expected_symlinks+=(
             # old replace mode
             /dev/disk/by-id/nvme-QEMU_NVMe_Ctrl__deadbeef_"$i"
@@ -196,7 +196,7 @@ testcase_nvme_basic() {
             /dev/disk/by-id/nvme-QEMU_NVMe_Ctrl_____deadbeef__"$i"_1
         )
     done
-    for i in {10..14}; do
+    for i in {6..8}; do
         expected_symlinks+=(
             # old replace mode does not provide devlink, as serial contains "/"
             # newer replace mode
@@ -205,7 +205,7 @@ testcase_nvme_basic() {
             /dev/disk/by-id/nvme-QEMU_NVMe_Ctrl_____dead_beef_"$i"_1
         )
     done
-    for i in {15..19}; do
+    for i in {9..11}; do
         expected_symlinks+=(
             # old replace mode does not provide devlink, as serial contains "/"
             # newer replace mode
@@ -222,7 +222,7 @@ testcase_nvme_basic() {
     test ! -e /dev/disk/by-id/nvme-QEMU_NVMe_Ctrl_deadbeef
 
     lsblk --noheadings | grep "^nvme"
-    [[ "$(lsblk --noheadings | grep -c "^nvme")" -ge 20 ]]
+    [[ "$(lsblk --noheadings | grep -c "^nvme")" -ge 12 ]]
 }
 
 testcase_nvme_subsystem() {


### PR DESCRIPTION
qemu by default only has 30 PCI slots and with vmspawn now reserving
some of those for its hotplug features, we go over the limit for the 
nvme test.

Let's drop the number of nvme devices to 12 to fix the conflict.
