### PR TITLE
blockdev-util: Drop name argument from BLKPG functions

### DIFF
--- a/src/repart/repart.c
+++ b/src/repart/repart.c
@@ -5206,7 +5206,7 @@ static int partition_target_prepare(
                                   part_node, nr,
                                   p->offset, NATURAL_ALIGNMENT(p->offset),
                                   size, NATURAL_ALIGNMENT(size));
-                        r = block_device_add_partition(whole_fd, part_node, nr, p->offset, size);
+                        r = block_device_add_partition(whole_fd, nr, p->offset, size);
                         if (r < 0)
                                 return log_error_errno(r, "Failed to create new partition '%s': %m", part_node);
 
@@ -5215,7 +5215,7 @@ static int partition_target_prepare(
                         dev_fd = open(part_node, O_RDWR|O_CLOEXEC|O_NOCTTY);
                         if (dev_fd < 0) {
                                 r = -errno;
-                                int q = block_device_remove_partition(whole_fd, part_node, nr);
+                                int q = block_device_remove_partition(whole_fd, nr);
                                 if (q < 0)
                                         log_warning_errno(q, "Error while removing block device partition '%s', ignoring: %m", part_node);
                                 return log_error_errno(r, "Failed to open new partition '%s': %m", part_node);
@@ -5225,7 +5225,7 @@ static int partition_target_prepare(
 
                         b = new(BlockPartition, 1);
                         if (!b) {
-                                r = block_device_remove_partition(whole_fd, part_node, nr);
+                                r = block_device_remove_partition(whole_fd, nr);
                                 if (r < 0)
                                         log_warning_errno(r, "Error while removing block device partition '%s', ignoring: %m", part_node);
 

--- a/src/shared/blockdev-util.c
+++ b/src/shared/blockdev-util.c
@@ -642,15 +642,9 @@ int path_get_whole_disk(const char *path, bool backing, dev_t *ret) {
         return fd_get_whole_disk(fd, backing, ret);
 }
 
-int block_device_add_partition(
-                int fd,
-                const char *name,
-                int nr,
-                uint64_t start,
-                uint64_t size) {
+int block_device_add_partition(int fd, int nr, uint64_t start, uint64_t size) {
 
         assert(fd >= 0);
-        assert(name);
         assert(nr > 0);
 
         struct blkpg_partition bp = {
@@ -665,21 +659,12 @@ int block_device_add_partition(
                 .datalen = sizeof(bp),
         };
 
-        if (strlen(name) >= sizeof(bp.devname))
-                return -EINVAL;
-
-        strcpy(bp.devname, name);
-
         return RET_NERRNO(ioctl(fd, BLKPG, &ba));
 }
 
-int block_device_remove_partition(
-                int fd,
-                const char *name,
-                int nr) {
+int block_device_remove_partition(int fd, int nr) {
 
         assert(fd >= 0);
-        assert(name);
         assert(nr > 0);
 
         struct blkpg_partition bp = {
@@ -691,11 +676,6 @@ int block_device_remove_partition(
                 .data = &bp,
                 .datalen = sizeof(bp),
         };
-
-        if (strlen(name) >= sizeof(bp.devname))
-                return -EINVAL;
-
-        strcpy(bp.devname, name);
 
         return RET_NERRNO(ioctl(fd, BLKPG, &ba));
 }
@@ -824,7 +804,7 @@ int block_device_remove_all_partitions(sd_device *dev, int fd) {
                 if (r < 0 && r != -ENOENT)
                         log_debug_errno(r, "Failed to forget btrfs device %s, ignoring: %m", devname);
 
-                r = block_device_remove_partition(fd, devname, nr);
+                r = block_device_remove_partition(fd, nr);
                 if (r == -ENODEV) {
                         log_debug("Kernel removed partition %s before us, ignoring", devname);
                         continue;

--- a/src/shared/blockdev-util.h
+++ b/src/shared/blockdev-util.h
@@ -45,8 +45,8 @@ int path_is_encrypted(const char *path);
 int fd_get_whole_disk(int fd, bool backing, dev_t *ret);
 int path_get_whole_disk(const char *path, bool backing, dev_t *ret);
 
-int block_device_add_partition(int fd, const char *name, int nr, uint64_t start, uint64_t size);
-int block_device_remove_partition(int fd, const char *name, int nr);
+int block_device_add_partition(int fd, int nr, uint64_t start, uint64_t size);
+int block_device_remove_partition(int fd, int nr);
 int block_device_resize_partition(int fd, int nr, uint64_t start, uint64_t size);
 int partition_enumerator_new(sd_device *dev, sd_device_enumerator **ret);
 int block_device_remove_all_partitions(sd_device *dev, int fd);

--- a/src/shared/dissect-image.c
+++ b/src/shared/dissect-image.c
@@ -1278,7 +1278,7 @@ static int dissect_image(
                  * partition already existent. */
 
                 if (FLAGS_SET(flags, DISSECT_IMAGE_ADD_PARTITION_DEVICES)) {
-                        r = block_device_add_partition(fd, node, nr, (uint64_t) start * 512, (uint64_t) size * 512);
+                        r = block_device_add_partition(fd, nr, (uint64_t) start * 512, (uint64_t) size * 512);
                         if (r < 0) {
                                 if (r != -EBUSY)
                                         return log_debug_errno(r, "BLKPG_ADD_PARTITION failed: %m");

--- a/src/shared/reread-partition-table.c
+++ b/src/shared/reread-partition-table.c
@@ -179,7 +179,7 @@ static int process_partition(
                  * just to make a point. */
                 partition = sd_device_unref(partition);
 
-                r = block_device_remove_partition(fd, subnode, nr);
+                r = block_device_remove_partition(fd, nr);
                 if (r < 0)
                         return log_device_debug_errno(d, r, "Failed to remove kernel partition device '%s' in order to recreate it: %m", subnode);
 
@@ -189,7 +189,7 @@ static int process_partition(
 
         log_device_debug(d, "Adding partition %i...", nr);
 
-        r = block_device_add_partition(fd, subnode, nr, (uint64_t) start * 512U, (uint64_t) size * 512U);
+        r = block_device_add_partition(fd, nr, (uint64_t) start * 512U, (uint64_t) size * 512U);
         if (r < 0)
                 return log_device_debug_errno(d, r, "Failed to add kernel partition device %i to partition table values: %m", nr);
 
@@ -228,7 +228,7 @@ static int remove_partitions(sd_device *d, int fd, sd_device_enumerator *e, Set 
 
                 log_device_debug(partition, "Kernel knows partition %u which we didn't find, removing.", nr);
 
-                r = block_device_remove_partition(fd, devname, (int) nr);
+                r = block_device_remove_partition(fd, (int) nr);
                 if (r < 0) /* NB: when logging we use the parent device below, after all the partition device ceased existing by now, most likely */
                         RET_GATHER(ret, log_device_debug_errno(d, r, "Failed to remove kernel partition device '%s' that vanished from partition table: %m", devname));
                 else  {


### PR DESCRIPTION
We don't use it, the kernel ignores it, let's just drop
the argument. Saves callers from having to ensure the name
they pass in fits in the 64 char buffer.
