### PR TITLE
sysupdate: mkdir_parents CurrentSymlink= path

### DIFF
--- a/src/sysupdate/sysupdate-transfer.c
+++ b/src/sysupdate/sysupdate-transfer.c
@@ -1750,6 +1750,10 @@ int transfer_install_instance(
                         if (r < 0)
                                 return log_error_errno(r, "Failed to make symlink path '%s' relative to '%s': %m", link_target, parent);
 
+                        r = mkdir_parents(link_path, 0755);
+                        if (r < 0)
+                                return log_error_errno(r, "Failed to create directory for current symlink '%s': %m", link_path);
+
                         r = symlink_atomic(relative, link_path);
                         if (r < 0)
                                 return log_error_errno(r, "Failed to update current symlink '%s' %s '%s': %m",


### PR DESCRIPTION
This was missing in the CurrentSymlink= creation path, and leads to
partially-broken update installs.

Signed-off-by: Aleksa Sarai <aleksa@amutable.com>