### PR TITLE
ci: switch SUSE mkosi mirror to cdn.o.o

### DIFF
--- a/.github/workflows/mkosi.yml
+++ b/.github/workflows/mkosi.yml
@@ -226,6 +226,15 @@ jobs:
           RAM=4G
           EOF
 
+          # Preferred for cloud/CIs
+          if [ ${{ matrix.distro }} = opensuse ]; then
+              tee -a mkosi/mkosi.local.conf <<EOF
+
+          [Distribution]
+          Mirror=https://cdn.opensuse.org/
+          EOF
+          fi
+
       - name: Generate secure boot key
         run: mkosi --debug genkey
 


### PR DESCRIPTION
The cdn mirror is preferred by SUSE for clouds/CIs. There have been issues with some mirrors, which fail to download from GHA quite often lately, so hopefully this will make it reliable again.