### PR TITLE
cryptsetup: Invalidate ineffective try_discover_key before trying

### DIFF
--- a/src/cryptsetup/cryptsetup.c
+++ b/src/cryptsetup/cryptsetup.c
@@ -2755,6 +2755,8 @@ static int verb_attach(int argc, char *argv[], uintptr_t _data, void *userdata) 
                                 return r;
                         if (r > 0)
                                 key_data = &discovered_key_data;
+                        else
+                                try_discover_key = false;
                 }
 
                 if (token_type < 0 && !key_file && !key_data && !passwords) {

--- a/src/cryptsetup/cryptsetup.c
+++ b/src/cryptsetup/cryptsetup.c
@@ -2738,6 +2738,8 @@ static int verb_attach(int argc, char *argv[], void *userdata) {
                                 return r;
                         if (r > 0)
                                 key_data = &discovered_key_data;
+                        else
+                                try_discover_key = false;
                 }
 
                 if (token_type < 0 && !key_file && !key_data && !passwords) {


### PR DESCRIPTION
A single incorrect password attempt from the user would be tried twice, because the first failed try would think it was the try_discover_key method that failed, and would invalidate that instead of the actual failed password. This resulted in the user being prompted one fewer time than they should be.

Fixes #38495