### PR TITLE
man: clarify that ExecCondition= skip triggers SuccessAction=

### DIFF
--- a/man/systemd.service.xml
+++ b/man/systemd.service.xml
@@ -457,6 +457,15 @@
         signal, etc.), the unit will be considered failed (and remaining commands will be skipped). Exit code of 0 or
         those matching <varname>SuccessExitStatus=</varname> will continue execution to the next commands.</para>
 
+        <para>Note that an <varname>ExecCondition=</varname> skip is <emphasis>not</emphasis> equivalent to a
+        unit-level <varname>Condition…=</varname> or <varname>Assert…=</varname> check failing. Because
+        <varname>ExecCondition=</varname> runs as part of the activation transition, a skip causes the unit to
+        transition from <constant>active</constant> to <constant>inactive</constant>, and consequently
+        <varname>SuccessAction=</varname> (see
+        <citerefentry><refentrytitle>systemd.unit</refentrytitle><manvolnum>5</manvolnum></citerefentry>) will be
+        honored. By contrast, <varname>Condition…=</varname> directives in the <literal>[Unit]</literal> section
+        prevent activation entirely and therefore do not trigger <varname>SuccessAction=</varname>.</para>
+
         <para>The same recommendations about not running long-running processes in <varname>ExecStartPre=</varname>
         also applies to <varname>ExecCondition=</varname>. <varname>ExecCondition=</varname> will also run the commands
         in <varname>ExecStopPost=</varname>, as part of stopping the service, in the case of any non-zero or abnormal

--- a/man/systemd.unit.xml
+++ b/man/systemd.unit.xml
@@ -1115,6 +1115,16 @@
         allowed. In user mode, only <option>none</option>, <option>exit</option>, and
         <option>exit-force</option> are allowed. Both options default to <option>none</option>.</para>
 
+        <para>These actions are tied to the unit's state transitions and fire only when the unit actually
+        transitions out of an <constant>active</constant> or <constant>activating</constant> state. As a
+        consequence, <varname>Condition…=</varname> and <varname>Assert…=</varname> directives that fail do
+        <emphasis>not</emphasis> trigger <varname>SuccessAction=</varname> or
+        <varname>FailureAction=</varname>: they prevent activation in the first place, so no state transition
+        occurs. By contrast, the <varname>ExecCondition=</varname> directive in
+        <citerefentry><refentrytitle>systemd.service</refentrytitle><manvolnum>5</manvolnum></citerefentry>
+        runs as part of activation, so an <varname>ExecCondition=</varname> skip <emphasis>will</emphasis>
+        trigger <varname>SuccessAction=</varname>.</para>
+
         <para>If <option>none</option> is set, no action will be triggered. <option>reboot</option> causes a
         reboot following the normal shutdown procedure (i.e. equivalent to <command>systemctl
         reboot</command>).  <option>reboot-force</option> causes a forced reboot which will terminate all


### PR DESCRIPTION
The current docs for `ExecCondition=` describe its exit-code-based skip behavior but don't mention the interaction with `SuccessAction=`/`FailureAction=`. The asymmetry with `Condition…=` / `Assert…=` directives — which prevent activation entirely and therefore do **not** trigger `SuccessAction=` — has tripped users up (#42035).

This is a doc-only change: no functional behavior is altered.

- `man/systemd.service.xml`: in the `ExecCondition=` block, note that a skip causes `active → inactive` and so `SuccessAction=` is honored.
- `man/systemd.unit.xml`: in the `SuccessAction=` / `FailureAction=` block, explain the state-transition tie-in and contrast `Condition…=` (no trigger) with `ExecCondition=` (does trigger).

Verified by rebuilding both man pages locally (`meson compile -C build man/systemd.service.5 man/systemd.unit.5`) and inspecting the rendered groff output.

Closes: #42035