### PR TITLE
Revert "resolve: refuse traffic from the local host only for queries"

### DIFF
--- a/src/resolve/resolved-mdns.c
+++ b/src/resolve/resolved-mdns.c
@@ -413,6 +413,14 @@ static int on_mdns_packet(sd_event_source *s, int fd, uint32_t revents, void *us
         if (r <= 0)
                 return r;
 
+        /* Refuse traffic from the local host, to avoid query loops. However, allow legacy mDNS
+         * unicast queries through anyway (we never send those ourselves, hence no risk).
+         * i.e. check for the source port nr. */
+        if (p->sender_port == MDNS_PORT && manager_packet_from_local_address(m, p)) {
+                log_debug("Got mDNS UDP packet from local host, ignoring.");
+                return 0;
+        }
+
         scope = manager_find_scope(m, p);
         if (!scope) {
                 log_debug("Got mDNS UDP packet on unknown scope. Ignoring.");
@@ -529,14 +537,6 @@ static int on_mdns_packet(sd_event_source *s, int fd, uint32_t revents, void *us
                 if (unsolicited_packet)
                         mdns_notify_browsers_unsolicited_updates(m, p->answer, p->family);
         } else if (dns_packet_validate_query(p) > 0)  {
-                /* Refuse traffic from the local host, to avoid query loops. However, allow legacy mDNS
-                 * unicast queries through anyway (we never send those ourselves, hence no risk).
-                 * i.e. check for the source port nr. */
-                if (p->sender_port == MDNS_PORT && manager_packet_from_local_address(m, p)) {
-                        log_debug("Got mDNS UDP packet from local host, ignoring.");
-                        return 0;
-                }
-
                 log_debug("Got mDNS query packet for id %u", DNS_PACKET_ID(p));
 
                 r = mdns_scope_process_query(scope, p);


### PR DESCRIPTION
## Summary

Backport of [`658e5ac0`](https://github.com/systemd/systemd/commit/658e5ac06f80ee2078b034f7cc483204d7f91c5e) (on `main`, 2026-03-25) to **v258-stable**.

`v258-stable` carries the cherry-pick of `e6fd7a3f` ("resolve: refuse traffic from the local host only for queries"), which moved the `manager_packet_from_local_address()` filter from the top of `on_mdns_packet()` into the `else if (dns_packet_validate_query(p) > 0)` branch — leaving the reply path unguarded against looped-back multicast. `main` reverted this; `v258-stable` did not.

The issue reporter in #42072 is running systemd 258.7, so this backport is what fixes their case directly.

## Why this is needed

From `658e5ac0`'s commit message:

> When a service unregisters (e.g. on process restart), `manager_refresh_rrs()` clears and re-adds all RRs in PROBING state, which sends a multicast announcement (QR=1). The kernel reflects this back to resolved's own socket. Because the local-address check was moved inside the query-only branch by the reverted commit, the reply path in `on_mdns_packet()` is now unguarded. The looped-back announcement matches the pending probe transaction and completes it with `DNS_TRANSACTION_SUCCESS`. Since the zone item is still in PROBING state (not ESTABLISHED), `dns_zone_item_notify()` sets `we_lost=true` and calls `dns_zone_item_conflict()`, which invokes `manager_next_hostname()` and renames the hostname.

This matches the symptom in #42072.

## Verification

- `git cherry-pick -x 658e5ac0` onto `v258-stable` applied with a trivial 3-way merge (surrounding lines differ from main; the moved block is byte-identical).
- Resulting `git diff` against `v258-stable` is the same 8-add / 8-delete shape as the original revert.

## Related

- Issue: #42072
- Original revert on main: `658e5ac0`
- Companion backports: #42107 (v259-stable), #42108 (v260-stable).