### PR TITLE
mkosi: Make sure mkosi.clangd maps to mkosi/mkosi.tools

### DIFF
--- a/mkosi/mkosi.clangd
+++ b/mkosi/mkosi.clangd
@@ -13,5 +13,5 @@ exec "${SPAWN[@]}" \
         clangd \
             --compile-commands-dir=build \
             --path-mappings="\
-$(pwd)/mkosi.tools/usr/include=/usr/include" \
+$(pwd)/mkosi/mkosi.tools/usr/include=/usr/include" \
             "$@"


### PR DESCRIPTION
The tools tree is now stored in mkosi/mkosi.tools, so update the script to match.