### PR TITLE
meson: drop vestigial libgpg-error dependency

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1184,22 +1184,14 @@ libqrencode = dependency('libqrencode',
 libqrencode_cflags = libqrencode.partial_dependency(includes: true, compile_args: true)
 conf.set10('HAVE_QRENCODE', libqrencode.found())
 
-feature = get_option('gcrypt')
 libgcrypt = dependency('libgcrypt',
-                       required : feature)
-libgpg_error = dependency('gpg-error',
-                          required : feature)
-
-have = libgcrypt.found() and libgpg_error.found()
-if not have
-        # link to neither of the libs if one is not found
-        libgcrypt = []
-        libgpg_error = []
-        libgcrypt_cflags = []
-else
+                       required : get_option('gcrypt'))
+conf.set10('HAVE_GCRYPT', libgcrypt.found())
+if libgcrypt.found()
         libgcrypt_cflags = libgcrypt.partial_dependency(includes: true, compile_args: true)
+else
+        libgcrypt_cflags = []
 endif
-conf.set10('HAVE_GCRYPT', have)
 
 libgnutls = dependency('gnutls',
                        version : '>= 3.1.4',


### PR DESCRIPTION
libgpg-error was added in 2017 (commit 76c8741060, Michael Biebl) to gate HAVE_GCRYPT on its presence because src/resolve referenced libgpg-error directly at the time. That usage is long gone — no source file references any gpg-error API today — so the dependency only served to fail HAVE_GCRYPT detection when gpg-error-dev wasn't installed.

libgcrypt's pkg-config Requires already pulls in the gpg-error headers (via the transitive #include <gpg-error.h> in <gcrypt.h>), so dropping the dep doesn't break compilation.