### PR TITLE
socket-util: extend the buffer in sockaddr_union to make it consistent with hw_addr_data

### DIFF
--- a/src/basic/basic-forward.h
+++ b/src/basic/basic-forward.h
@@ -153,3 +153,7 @@ typedef struct SocketAddress SocketAddress;
 
 /* MAX_ERRNO is defined as 4095 in linux/err.h. We use the same value here. */
 #define ERRNO_MAX               4095
+
+/* This is MAX_ADDR_LEN as defined in linux/netdevice.h, but net/if_arp.h
+ * defines a macro of the same name with a much lower size. */
+#define HW_ADDR_MAX_SIZE 32

--- a/src/basic/ether-addr-util.h
+++ b/src/basic/ether-addr-util.h
@@ -7,10 +7,6 @@
 
 #include "basic-forward.h"
 
-/* This is MAX_ADDR_LEN as defined in linux/netdevice.h, but net/if_arp.h
- * defines a macro of the same name with a much lower size. */
-#define HW_ADDR_MAX_SIZE 32
-
 struct hw_addr_data {
         size_t length;
         union {

--- a/src/basic/socket-util.c
+++ b/src/basic/socket-util.c
@@ -3,6 +3,8 @@
 #include <fcntl.h>
 #include <linux/if.h>
 #include <linux/if_arp.h>
+#include <linux/if_ether.h>
+#include <linux/if_infiniband.h>
 #include <linux/pkt_sched.h>
 #include <mqueue.h>
 #include <net/if.h>

--- a/src/basic/socket-util.h
+++ b/src/basic/socket-util.h
@@ -1,8 +1,6 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 #pragma once
 
-#include <linux/if_ether.h>
-#include <linux/if_infiniband.h>
 #include <linux/if_packet.h>
 #include <linux/netlink.h>
 #include <linux/vm_sockets.h>
@@ -29,8 +27,8 @@ union sockaddr_union {
         struct sockaddr_ll ll;
         struct sockaddr_vm vm;
 
-        /* Ensure there is enough space to store Infiniband addresses */
-        uint8_t ll_buffer[offsetof(struct sockaddr_ll, sll_addr) + CONST_MAX(ETH_ALEN, INFINIBAND_ALEN)];
+        /* Ensure there is enough space to store an arbitrary hardware address, e.g. Infiniband */
+        uint8_t ll_buffer[offsetof(struct sockaddr_ll, sll_addr) + HW_ADDR_MAX_SIZE];
 
         /* Ensure there is enough space after the AF_UNIX sun_path for one more NUL byte, just to be sure that the path
          * component is always followed by at least one NUL byte. */

--- a/src/libsystemd-network/lldp-network.c
+++ b/src/libsystemd-network/lldp-network.c
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
 #include <linux/filter.h>
+#include <linux/if_ether.h>
 
 #include "fd-util.h"
 #include "lldp-network.h"


### PR DESCRIPTION
Concerned by Claude:
https://github.com/systemd/systemd/pull/42119#discussion_r3251133516