### PR TITLE
logind: keep lingering users at startup-time GC

### DIFF
--- a/src/login/logind-user.c
+++ b/src/login/logind-user.c
@@ -763,8 +763,14 @@ bool user_may_gc(User *u, bool drop_not_started) {
 
         /* Is this a user that shall stay around forever ("linger")? Before we say "no" to GC'ing for lingering users, let's check
          * if any of the three units that we maintain for this user is still around. If none of them is,
-         * there's no need to keep this user around even if lingering is enabled. */
-        if (user_check_linger_file(u) > 0 && user_unit_active(u))
+         * there's no need to keep this user around even if lingering is enabled.
+         *
+         * Exception: at startup-time GC (drop_not_started=false) the per-user units have not yet been
+         * started by manager_startup(), so requiring user_unit_active() here would unconditionally GC
+         * every lingering user before we get a chance to user_start() them. That breaks after a
+         * soft-reboot, where /run/systemd/users is preserved and feeds lingering users into the GC
+         * queue (cold boot is unaffected because /run is empty). See #41789. */
+        if (user_check_linger_file(u) > 0 && (!drop_not_started || user_unit_active(u)))
                 return false;
 
         /* Check if our job is still pending */


### PR DESCRIPTION
## Summary

Fixes #41789 — after `systemctl soft-reboot`, `user@UID.service` for lingering users is not started (works fine after hardware reboot).

## Root cause

`manager_startup()` runs `manager_gc(m, /* drop_not_started= */ false)` before iterating `m->users` to call `user_start()`. The linger guard inside `user_may_gc()` requires `user_unit_active()` to be true to keep a user — but at this point the per-user units have not been started yet, so any lingering user that ended up in the `user_gc_queue` is freed before `user_start()` ever runs.

The asymmetry between cold boot and soft-reboot:

- **Cold boot:** `/run/systemd/users` is empty. Lingering users come in only via `manager_enumerate_linger_users()` in `src/login/logind.c`, which does **not** call `user_add_to_gc_queue()`. They never enter the GC queue → `manager_gc` is a no-op for them → `user_start()` runs normally.
- **Soft-reboot:** `/run` is tmpfs and survives. `/run/systemd/users/UID` files persist, so `manager_enumerate_users()` finds them and **explicitly** calls `user_add_to_gc_queue(u)` (`logind.c:356`). On the next `manager_gc(m, false)`, `user_may_gc()` sees `user_unit_active() == false` (units aren't up yet) → returns true → `user_stop()` + `user_finalize()` + `user_free()` → user_start() iterates a hashmap with that user already gone.

## Fix

Special-case the startup-time GC in `user_may_gc()`:

```c
if (user_check_linger_file(u) > 0 && (!drop_not_started || user_unit_active(u)))
        return false;
```

- `drop_not_started == false` (only caller: `manager_startup` → `manager_gc(m, false)`): the predicate degenerates to "linger file exists", so we always keep lingering users at startup. `user_start()` is about to run and will queue the right jobs.
- `drop_not_started == true` (event-loop `manager_gc(m, true)` at `logind.c:1331`): unchanged — still requires `user_unit_active()` so we don't hold on to records for lingering users whose units genuinely died.

The earlier `if (drop_not_started && !u->started) return true;` clause handles never-started users in steady-state separately; the new condition only ever loosens behavior at startup.

## Verification

- `meson test -C build -v test-login-shared test-login-tables test-login-util test-login` — all pass.
- Reasoning verified by an independent pass over `manager_enumerate_users`, `manager_enumerate_linger_users`, `manager_startup`, `manager_gc`, `user_may_gc`, `user_start`, `user_unit_active`. No leak: orphan-linger users without a user record fail earlier at `manager_add_user_by_uid`; users that survive startup but whose units never become active are caught by the unchanged steady-state branch.

## Follow-up (not in this PR)

An integration regression test under `TEST-82-SOFTREBOOT` (enable linger on a user, soft-reboot, assert `user@UID.service` active) would be a useful guard against future regressions. Happy to send that as a separate PR if there's interest.

Closes: #41789