### PR TITLE
networkd: fix route race condition at startup

### DIFF
--- a/src/network/networkd-json.c
+++ b/src/network/networkd-json.c
@@ -278,7 +278,8 @@ static int route_append_json(Route *route, bool serializing, sd_json_variant **a
                         SD_JSON_BUILD_PAIR_UNSIGNED("Flags", route->flags),
                         JSON_BUILD_PAIR_UNSIGNED_NON_ZERO("NextHopID", route->nexthop_id),
                         SD_JSON_BUILD_PAIR_STRING("ConfigSource", network_config_source_to_string(route->source)),
-                        JSON_BUILD_PAIR_IN_ADDR_WITH_STRING_NON_NULL("ConfigProvider", route->family, &route->provider));
+                        JSON_BUILD_PAIR_IN_ADDR_WITH_STRING_NON_NULL("ConfigProvider", route->family, &route->provider),
+                        JSON_BUILD_PAIR_FINITE_USEC("LifetimeUSec", route->lifetime_usec));
         if (r < 0)
                 return r;
 
@@ -322,7 +323,6 @@ static int route_append_json(Route *route, bool serializing, sd_json_variant **a
                                 JSON_BUILD_PAIR_UNSIGNED_NON_ZERO("MTU", route_metric_get(&route->metric, RTAX_MTU)),
                                 SD_JSON_BUILD_PAIR_UNSIGNED("Preference", route->pref),
                                 SD_JSON_BUILD_PAIR_STRING("FlagsString", strempty(flags)),
-                                JSON_BUILD_PAIR_FINITE_USEC("LifetimeUSec", route->lifetime_usec),
                                 SD_JSON_BUILD_PAIR_STRING("ConfigState", state));
                 if (r < 0)
                         return r;

--- a/src/network/networkd-route.c
+++ b/src/network/networkd-route.c
@@ -307,7 +307,7 @@ int route_new_static(Network *network, const char *filename, unsigned section_li
         return 0;
 }
 
-static int route_attach(Manager *manager, Route *route) {
+int route_attach(Manager *manager, Route *route) {
         int r;
 
         assert(manager);

--- a/src/network/networkd-route.h
+++ b/src/network/networkd-route.h
@@ -78,6 +78,7 @@ DECLARE_TRIVIAL_REF_UNREF_FUNC(Route, route);
 DEFINE_SECTION_CLEANUP_FUNCTIONS(Route, route_unref);
 
 void route_detach(Route *route);
+int route_attach(Manager *manager, Route *route);
 
 int route_new(Route **ret);
 int route_new_static(Network *network, const char *filename, unsigned section_line, Route **ret);

--- a/src/network/networkd-serialize.c
+++ b/src/network/networkd-serialize.c
@@ -348,6 +348,7 @@ static int manager_deserialize_route(Manager *manager, sd_json_variant *v) {
                 /* config */
                 { "ConfigSource",                  SD_JSON_VARIANT_STRING,        json_dispatch_network_config_source, offsetof(RouteParam, route.source),                             SD_JSON_MANDATORY                 },
                 { "ConfigProvider",                SD_JSON_VARIANT_ARRAY,         json_dispatch_byte_array_iovec,      offsetof(RouteParam, provider),                                 0                                 },
+                { "LifetimeUSec",                  _SD_JSON_VARIANT_TYPE_INVALID, sd_json_dispatch_uint64,             offsetof(RouteParam, route.lifetime_usec),                      0                                 },
                 {},
         };
 
@@ -356,7 +357,9 @@ static int manager_deserialize_route(Manager *manager, sd_json_variant *v) {
         assert(manager);
         assert(v);
 
-        _cleanup_(route_param_done) RouteParam p = {};
+        _cleanup_(route_param_done) RouteParam p = {
+                .route.lifetime_usec = USEC_INFINITY,
+        };
         r = sd_json_dispatch(v, dispatch_table, SD_JSON_ALLOW_EXTENSIONS, &p);
         if (r < 0)
                 return log_debug_errno(r, "Failed to dispatch route from json variant: %m");
@@ -406,6 +409,8 @@ static int manager_deserialize_route(Manager *manager, sd_json_variant *v) {
         memcpy_safe(&p.route.src, p.src.iov_base, p.src.iov_len);
         memcpy_safe(&p.route.prefsrc, p.prefsrc.iov_base, p.prefsrc.iov_len);
         memcpy_safe(&p.route.nexthop.gw, p.gw.iov_base, p.gw.iov_len);
+        /* The route may be duplicated below, so first assemble all serialized fields into p.route. */
+        memcpy_safe(&p.route.provider, p.provider.iov_base, p.provider.iov_len);
 
         p.route.metric.n_metrics = p.metrics.iov_len / sizeof(uint32_t);
         p.route.metric.metrics = new(uint32_t, p.route.metric.n_metrics);
@@ -417,15 +422,38 @@ static int manager_deserialize_route(Manager *manager, sd_json_variant *v) {
         Route *route;
         r = route_get(manager, &p.route, &route);
         if (r < 0) {
-                log_route_debug(&p.route, "Cannot find deserialized", manager);
-                return 0; /* Already removed? */
+                _cleanup_(route_unrefp) Route *dup = NULL;
+
+                if (manager->manage_foreign_routes || p.route.source != NETWORK_CONFIG_SOURCE_NDISC) {
+                        log_route_debug(&p.route, "Cannot find deserialized", manager);
+                        return 0; /* Already removed? */
+                }
+
+                /* With ManageForeignRoutes=no, NDisc routes are not enumerated on restart. Still remember
+                 * deserialized NDisc routes, as they are needed to keep their nexthop in use. */
+                r = route_dup(&p.route, NULL, &dup);
+                if (r < 0)
+                        return r;
+
+                r = route_attach(manager, dup);
+                if (r < 0)
+                        return r;
+
+                route_enter_configured(dup);
+                route_attach_to_nexthop(dup);
+                log_route_debug(dup, "Deserialized", manager);
+
+                TAKE_PTR(dup);
+                return 0;
         }
 
         if (route->source != NETWORK_CONFIG_SOURCE_FOREIGN)
                 return 0; /* Huh?? Already deserialized?? */
 
+        /* Restore networkd-only metadata that cannot be recovered from route enumeration. */
         route->source = p.route.source;
-        memcpy_safe(&route->provider, p.provider.iov_base, p.provider.iov_len);
+        route->provider = p.route.provider;
+        route->lifetime_usec = p.route.lifetime_usec;
 
         log_route_debug(route, "Deserialized", manager);
         return 0;

--- a/test/test-network/conf/25-ipv6-prefix-veth-keep-configuration.network
+++ b/test/test-network/conf/25-ipv6-prefix-veth-keep-configuration.network
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+[Match]
+Name=veth99
+
+[Network]
+IPv6AcceptRA=yes
+KeepConfiguration=yes
+
+[IPv6AcceptRA]
+UseDNS=no
+UseDomains=no

--- a/test/test-network/conf/25-veth-peer-radvd.network
+++ b/test/test-network/conf/25-veth-peer-radvd.network
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+[Match]
+Name=veth-peer
+
+[Network]
+IPv6AcceptRA=no
+IPv6Forwarding=yes

--- a/test/test-network/conf/radvd/solicited-only.conf
+++ b/test/test-network/conf/radvd/solicited-only.conf
@@ -1,0 +1,16 @@
+interface veth-peer
+{
+        AdvSendAdvert on;
+        UnicastOnly on;
+        AdvRASolicitedUnicast on;
+        AdvDefaultLifetime 1800;
+        RemoveAdvOnExit off;
+
+        prefix 2002:da8:4051:0::/64
+        {
+                AdvOnLink on;
+                AdvAutonomous on;
+                AdvPreferredLifetime 1000;
+                AdvValidLifetime 2100;
+        };
+};

--- a/test/test-network/systemd-networkd-tests.py
+++ b/test/test-network/systemd-networkd-tests.py
@@ -7172,6 +7172,63 @@ class NetworkdRATests(unittest.TestCase, Utilities):
         networkctl_reload()
         self.check_router_preference('01', 100, 'high', 300, 'low')
 
+    @unittest.skipUnless(
+        radvd_check_config('solicited-only.conf'),
+        "radvd doesn't support solicited-only RA config",
+    )
+    def test_ndisc_restart_with_manage_foreign_routes_no(self):
+        ndisc_default_route_regex = (
+            r'default (nhid [0-9]+ )?via fe80::1034:56ff:fe78:9abd proto ra\b'
+        )
+
+        copy_networkd_conf_dropin('networkd-manage-foreign-routes-no.conf')
+        copy_network_unit('25-veth.netdev',
+                          '25-veth-peer-radvd.network',
+                          '25-ipv6-prefix-veth-keep-configuration.network')
+        start_networkd()
+        self.wait_online('veth-peer:degraded')
+
+        results = []
+        start_radvd(config_file='solicited-only.conf')
+        networkctl_reconfigure('veth99')
+        self.wait_route('veth99', ndisc_default_route_regex, ipv='-6', timeout_sec=10)
+        self.wait_online('veth99:routable', 'veth-peer:degraded', timeout='10s', setup_timeout=10)
+
+        for i in range(6):
+            print(f'### Restart systemd-networkd.service ({i + 1}/6)')
+            restart_networkd()
+            is_configured = self.wait_operstate('veth99',
+                                                operstate='routable',
+                                                setup_state='configured',
+                                                setup_timeout=10,
+                                                fail_assert=False)
+            routes = check_output('ip -6 route show dev veth99')
+            has_default_route = re.search(
+                f'^{ndisc_default_route_regex}',
+                routes,
+                re.MULTILINE,
+            ) is not None
+            status = networkctl_status('veth99')
+            state = re.search(r'^\s*State:\s*(.*)$', status, re.MULTILINE).group(1)
+
+            print(
+                f'### NDisc restart {i + 1}: '
+                f'default_route={has_default_route}, configured={is_configured}, state={state}'
+            )
+            if not (has_default_route and is_configured):
+                print('### ip -6 route show dev veth99')
+                print(routes)
+                print('### networkctl status veth99')
+                print(status)
+
+            results.append((has_default_route, is_configured, state))
+
+        print(f'### NDisc restart results: {results}')
+        self.assertTrue(
+            all(has_default_route and is_configured for has_default_route, is_configured, _state in results),
+            results,
+        )
+
     def _test_ndisc_vs_static_route(self, manage_foreign_nexthops):
         if not manage_foreign_nexthops:
             copy_networkd_conf_dropin('networkd-manage-foreign-nexthops-no.conf')


### PR DESCRIPTION
Fix a route race condition causing the interface to stay stuck in `configuring` state when `systemd-networkd` restarts and `ManageForeignRoutes` is set to no.

Preserve serialized NDisc route state across networkd restarts and restore the route association when the matching kernel route was flagged as foreign.

- Serialize `LifetimeUSec` for routes so NDisc route lifetime information is available during state restoration.
- Restore serialized route lifetime/provider when deserializing routes.
- Attach deserialized NDisc routes to their provider/nexthop when the route is in the kernel but absent from networkd's managed route set.
- Make `route_attach()` available to deserialization code so restored routes can be reconnected to their NDisc provider.

Background: On restart, networkd can read existing RA-created nexthops and routes. With `ManageForeignRoutes=no`, those kernel routes may be flagged as foreign rather than inserted into networkd's managed route set. If a new RA arrives immediately in response to the initial Router Solicitation, networkd may match it against the partially restored/removing NDisc object, remove or ignore the old association, and still consider the RA processing path satisfied.

That leaves NDisc waiting for SLAAC routes that networkd no longer has a valid managed object for. Since the RA was received, networkd does not keep soliciting indefinitely, so the link can remain without a usable default route until a later unsolicited RA arrives. This may cause packet loss after restart and, with solicited-only RA behavior, alternating between `configured` + usable and `configuring` + unusable across restarts.

Add a regression test using radvd in solicited-only mode to exercise the restart path without relying on unsolicited RAs.

Fixes #40510