### PR TITLE
ci/alpine: do not install util-linux-login

### DIFF
--- a/.github/workflows/unit-tests-musl.yml
+++ b/.github/workflows/unit-tests-musl.yml
@@ -92,7 +92,6 @@ jobs:
             tpm2-tss-tcti-device
             tzdata
             util-linux-dev
-            util-linux-login
             util-linux-misc
             utmps-dev
             valgrind-dev


### PR DESCRIPTION
For some reasons, after util-linux is bumped from 2.41.4-r0 to 2.42-r0, the 'su' command from util-linux-login seems to not correctly run commands in https://github.com/jirutka/setup-alpine/blob/v1.4.1/alpine.sh and causes the following spurious failure:
```
2026-05-15T21:19:15.6539432Z ##[group]Set up user runner
2026-05-15T21:19:15.6981963Z /bin/sh: line 0: ��: not found
2026-05-15T21:19:15.6982503Z /bin/sh: line 1: ␡ELF␂␁␁␃: not found
2026-05-15T21:19:15.6985788Z /bin/sh: line 10: ␒␐␆␒B␈␒�␄␒y␄␒�␁␒␞␇␒:␁␒�␃␒�␄␒@␁␒9␈␒?␆␒␚␈␒x: not found
2026-05-15T21:19:15.7010731Z /bin/sh: line 33: can't open ␂␒-␂␒�: no such file
2026-05-15T21:19:15.7016026Z /bin/sh: line 33: syntax error: unexpected word (expecting ")")
2026-05-15T21:19:15.7049583Z
2026-05-15T21:19:15.7050199Z ␛[1;31mError occurred at line 338:␛[0m
2026-05-15T21:19:15.7050830Z   335 | 		echo 'permit nopass keepenv $SUDO_USER' | tee /etc/doas.d/root.conf
2026-05-15T21:19:15.7051287Z   336 | 	fi
2026-05-15T21:19:15.7051549Z   337 | SHELL
2026-05-15T21:19:15.7052039Z ␛[1;31m> 338 | abin/"$INPUT_SHELL_NAME" --root /.setup.sh␛[0m
2026-05-15T21:19:15.7052506Z   339 |
2026-05-15T21:19:15.7052796Z   340 | rm .setup.sh
2026-05-15T21:19:15.7053172Z   341 | endgroup
2026-05-15T21:19:15.7096322Z ##[error]Error occurred at line 338: abin/"$INPUT_SHELL_NAME" --root /.setup.sh (see the job log for more information)
2026-05-15T21:19:15.7101400Z ##[error]Process completed with exit code 1.
```
Let's not install the package. It seems no command provided by the package is used.