### PR TITLE
dhcp-message: introduce dhcp_message_{payload,packet}_size()

### DIFF
--- a/src/libsystemd-network/dhcp-message.c
+++ b/src/libsystemd-network/dhcp-message.c
@@ -1428,6 +1428,18 @@ int dhcp_message_parse(
         return 0;
 }
 
+size_t dhcp_message_payload_size(sd_dhcp_message *message) {
+        assert(message);
+
+        return MAX(size_add(sizeof(DHCPMessageHeader), tlv_size(&message->options)), BOOTP_MESSAGE_SIZE);
+}
+
+size_t dhcp_message_packet_size(sd_dhcp_message *message) {
+        assert(message);
+
+        return size_add(sizeof(struct iphdr) + sizeof(struct udphdr), dhcp_message_payload_size(message));
+}
+
 int dhcp_message_build(sd_dhcp_message *message, struct iovec_wrapper *ret) {
         int r;
 

--- a/src/libsystemd-network/dhcp-message.h
+++ b/src/libsystemd-network/dhcp-message.h
@@ -89,6 +89,9 @@ int dhcp_message_parse(
                 const struct hw_addr_data *hw_addr,
                 sd_dhcp_message **ret);
 
+size_t dhcp_message_payload_size(sd_dhcp_message *message);
+size_t dhcp_message_packet_size(sd_dhcp_message *message);
+
 int dhcp_message_build(sd_dhcp_message *message, struct iovec_wrapper *ret);
 
 int dhcp_message_build_json(sd_dhcp_message *message, sd_json_variant **ret);

--- a/src/libsystemd-network/test-dhcp-message.c
+++ b/src/libsystemd-network/test-dhcp-message.c
@@ -212,6 +212,7 @@ static void verify_send_udp(sd_dhcp_message *message, uint32_t xid, const struct
                 .msg_iovlen = 1,
         };
         ssize_t len = ASSERT_OK_ERRNO(recvmsg_safe(socket_fd[1], &msg, MSG_DONTWAIT));
+        ASSERT_EQ((size_t) len, dhcp_message_payload_size(message));
 
         _cleanup_(sd_dhcp_message_unrefp) sd_dhcp_message *m = NULL;
         ASSERT_OK(dhcp_message_parse(
@@ -255,6 +256,7 @@ static void verify_send_raw(sd_dhcp_message *message, uint32_t xid, const struct
                 .msg_iovlen = 1,
         };
         ssize_t len = ASSERT_OK_ERRNO(recvmsg_safe(socket_fd[1], &msg, MSG_DONTWAIT));
+        ASSERT_EQ((size_t) len, dhcp_message_packet_size(message));
 
         struct iovec payload;
         ASSERT_OK(udp_packet_verify(
@@ -497,6 +499,7 @@ TEST(dhcp_message) {
 
         _cleanup_(iovec_done) struct iovec joined = {};
         ASSERT_OK(iovw_concat(&iovw, &joined));
+        ASSERT_EQ(joined.iov_len, dhcp_message_payload_size(m));
 
         _cleanup_(sd_dhcp_message_unrefp) sd_dhcp_message *m2 = NULL;
         ASSERT_OK(dhcp_message_parse(


### PR DESCRIPTION
These are currently unused, but will be used later. Preparation for later changes.