### PR TITLE
boot: fix off-by-one truncation when reading efivars

### DIFF
--- a/src/boot/efi-efivars.c
+++ b/src/boot/efi-efivars.c
@@ -106,7 +106,7 @@ EFI_STATUS efivar_get_str16(const EFI_GUID *vendor, const char16_t *name, char16
         val = xmalloc(size + sizeof(char16_t));
 
         memcpy(val, buf, size);
-        val[size / sizeof(char16_t) - 1] = 0; /* NUL terminate */
+        val[size / sizeof(char16_t)] = 0; /* NUL terminate */
 
         *ret = val;
         return EFI_SUCCESS;


### PR DESCRIPTION
'val' is allocated as 'size + 1', so the NUL terminator must be written to 'size', rather than 'size - 1'.

Follow-up for fab82756462fd0ce82836e3d95721954d7ab2527