### PR TITLE
network/address: drop duplicated address earlier

### DIFF
--- a/src/network/networkd-address.c
+++ b/src/network/networkd-address.c
@@ -2478,6 +2478,9 @@ int network_drop_invalid_addresses(Network *network) {
                 assert(r > 0);
         }
 
+        /* Detach duplicated entries now. */
+        duplicated_addresses = set_free(duplicated_addresses);
+
         r = network_adjust_dhcp_server(network, &addresses);
         if (r < 0)
                 return r;


### PR DESCRIPTION
network_adjust_dhcp_server() searches network->addresses_by_section, hence without this change, an address entry picked by network_adjust_dhcp_server() may be detached and freed by the cleanup function.