### PR TITLE
nsresourced: handle recycled user namespace inode in worker and manager

### DIFF
--- a/src/nsresourced/nsresourced-manager.c
+++ b/src/nsresourced/nsresourced-manager.c
@@ -360,6 +360,25 @@ static void manager_release_userns_by_inode(Manager *m, uint64_t inode) {
                 log_full_errno(r == -ENOENT ? LOG_DEBUG : LOG_WARNING, r,
                                "Failed to find userns for inode %" PRIu64 ", ignoring: %m", inode);
 
+        /* The kernel reuses user namespace inodes, and our BPF death notification can race with a worker
+         * reusing this inode for a freshly registered user namespace. If the registry entry carries a
+         * kernel namespace ID and that namespace is still alive, the entry has been replaced and we must
+         * not touch any of the state, otherwise we'd tear down the brand-new namespace's BPF rules, fdstore
+         * entry and registry files. */
+        if (userns_info && userns_info->userns_id != 0) {
+                _cleanup_close_ int probe_fd = namespace_open_by_id(userns_info->userns_id);
+                if (probe_fd >= 0) {
+                        log_debug("Skipping release of user namespace inode %" PRIu64 ": registry entry refers to a still-alive namespace (id %" PRIu64 "), entry was replaced after a recycled inode.",
+                                  inode, userns_info->userns_id);
+                        return;
+                }
+                if (probe_fd != -ESTALE &&
+                    !ERRNO_IS_NEG_PRIVILEGE(probe_fd) &&
+                    !ERRNO_IS_NEG_NOT_SUPPORTED(probe_fd))
+                        log_debug_errno(probe_fd, "Failed to probe liveness of user namespace %" PRIu64 " (id %" PRIu64 "), proceeding with release: %m",
+                                        inode, userns_info->userns_id);
+        }
+
         if (DEBUG_LOGGING) {
                 if (userns_info && uid_is_valid(userns_info->start_uid))
                         log_debug("Removing user namespace mapping %" PRIu64 " for UID " UID_FMT ".", inode, userns_info->start_uid);

--- a/src/nsresourced/nsresourcework.c
+++ b/src/nsresourced/nsresourcework.c
@@ -641,8 +641,41 @@ static int allocate_now(
         r = userns_registry_inode_exists(registry_dir_fd, info->userns_inode);
         if (r < 0)
                 return r;
-        if (r > 0)
-                return -EDEADLK;
+        if (r > 0) {
+                /* The kernel reuses user namespace inodes, so it can happen that an inode arrives here that
+                 * we've previously registered, before our BPF kprobe handler in the manager process got a
+                 * chance to release it. If the existing registry entry carries a kernel namespace ID that
+                 * differs from ours, the old namespace is gone and the inode has been recycled, so clean up
+                 * the stale entry and continue. Otherwise (matching IDs, or no ID recorded), treat it as a
+                 * real collision. */
+                _cleanup_(userns_info_freep) UserNamespaceInfo *existing = NULL;
+
+                r = userns_registry_load_by_userns_inode(registry_dir_fd, info->userns_inode, &existing);
+                if (r < 0)
+                        return log_debug_errno(r, "Failed to load existing registry entry for user namespace inode %" PRIu64 ": %m", info->userns_inode);
+
+                if (info->userns_id == 0 || existing->userns_id == 0 || existing->userns_id == info->userns_id)
+                        return -EDEADLK;
+
+                log_debug("Registry entry for user namespace inode %" PRIu64 " refers to a different namespace (id %" PRIu64 " vs %" PRIu64 "), cleaning up stale entry.",
+                          info->userns_inode, existing->userns_id, info->userns_id);
+
+                /* The stale entry's BPF rules will be replaced by our own below. The fdstore entry uses the
+                 * inode as its FDNAME, so the manager will replace it when we send our own FDSTORE
+                 * notification. We still have to clean up the cgroups and netifs that were delegated to the
+                 * previous namespace, plus the registry files themselves. */
+                r = userns_info_remove_cgroups(existing);
+                if (r < 0)
+                        log_debug_errno(r, "Failed to remove cgroups of stale user namespace entry, ignoring: %m");
+
+                r = userns_info_remove_netifs(existing);
+                if (r < 0)
+                        log_debug_errno(r, "Failed to remove netifs of stale user namespace entry, ignoring: %m");
+
+                r = userns_registry_remove(registry_dir_fd, existing);
+                if (r < 0)
+                        return log_debug_errno(r, "Failed to remove stale registry entry: %m");
+        }
 
         r = name_is_available(registry_dir_fd, info->name);
         if (r < 0)


### PR DESCRIPTION
systemd-nsresourced keeps a registry of allocated user namespaces keyed by the kernel-assigned namespace inode and tears them down when the BPF kprobe on namespace destruction reports the inode via a ring buffer. The kernel reuses inode numbers; the ring buffer notification is asynchronous, so the following two interleavings can happen between a worker registering a fresh user namespace and the manager processing a delayed death notification for the previous occupant of the same inode:

1. The worker is asked to register a namespace whose inode is already in the registry because the manager has not yet processed the death notification for the previous occupant. The worker returns -EDEADLK, which the varlink layer maps to UserNamespaceExists -> EBADR, breaking the caller.

2. The worker manages to register first; the manager later processes the stale death notification and tears down the brand-new namespace's BPF rules, fdstore entry and registry files.

usernsId (the kernel namespace ID from NS_GET_ID, requires Linux >= 6.13) is already recorded in every registry entry but was never consulted again. It disambiguates "same inode, same namespace" from "same inode, different namespace" and is what both sides of the fix use:

- The worker, when it finds an existing registry entry for the inode it is about to register, loads the entry and, if its usernsId differs from the one of the namespace it has been given, drops the stale entry (cgroups, netifs, registry files) and proceeds. BPF rules and the fdstore entry are replaced by userns_restrict_put_by_fd(replace=true) and the subsequent FDSTORE notification (FDNAME is the inode). If either side has no usernsId recorded, or the IDs match, the original -EDEADLK behaviour is preserved.

- The manager, before releasing state in manager_release_userns_by_inode(), probes the recorded usernsId with namespace_open_by_id(). If the namespace is still alive, the registry entry has been replaced for a different namespace that happens to share the inode, and the release is skipped. This mirrors the existing startup sweep added in 23f2204718.

This shows up as flaky TEST-29-PORTABLE.user.sh failures. Excerpts from the journal of a failing run, ci-mkosi-25989237312-1-arch-rolling-ubuntu-24.04.

The worker rejects a fresh allocation request with UserNamespaceExists:

```
  [  153.888321] systemd-nsresourcework[4712]: varlink-6-6: Received message: {"method":"io.systemd.NamespaceResource.AllocateUserRange","parameters":{"name":"systemd-po38281b","mangleName":true,"size":65536,"userNamespaceFileDescriptor":0}}
  [  154.020536] systemd-nsresourcework[4712]: varlink-6-6: Sending message: {"error":"io.systemd.NamespaceResource.UserNamespaceExists"}
  [  154.024633] systemd-portabled[3828]: json-stream: Received message: {"error":"io.systemd.NamespaceResource.UserNamespaceExists"}
  [  154.027354] systemd-portabled[3828]: Failed to allocate user namespace with 65536 users: io.systemd.NamespaceResource.UserNamespaceExists
  [  154.029095] systemd-portabled[3828]: Failed to allocate user namespace: Invalid request descriptor
  [  154.029215] systemd-portabled[3828]: Sent message type=error sender=n/a destination=:1.39 path=n/a interface=n/a member=n/a cookie=92 reply_cookie=3 signature=s error-name=System.Error.EBADR error-message=Invalid request descriptor
  [  154.029223] systemd-portabled[3828]: Failed to process message type=method_call sender=:1.39 destination=org.freedesktop.portable1 path=/org/freedesktop/portable1 interface=org.freedesktop.portable1.Manager member=GetImageMetadataWithExtensions cookie=3 reply_cookie=0 signature=sasast error-name=n/a error-message=n/a: Invalid request descriptor
```

portablectl propagates the EBADR/Invalid request descriptor to the calling test and continues, leaving the units active, so the subsequent detach fails:

```
  [  154.030112] TEST-29-PORTABLE.sh[4982]: Got message type=error sender=:1.0 destination=:1.39 path=n/a interface=n/a member=n/a  cookie=92 reply_cookie=3 signature=s error-name=System.Error.EBADR error-message=Invalid request descriptor
  [  154.030112] TEST-29-PORTABLE.sh[4982]: Failed to inspect image metadata: Invalid request descriptor
  [  154.034620] TEST-29-PORTABLE.sh[4982]: Got message type=error sender=:1.0 destination=:1.39 path=n/a interface=n/a member=n/a  cookie=94 reply_cookie=5 signature=s error-name=org.freedesktop.systemd1.UnitExists error-message=Unit file 'app1.service' is active, can't detach.
  [  154.037384] TEST-29-PORTABLE.sh[4982]: DetachImageWithExtensions failed: Unit file 'app1.service' is active, can't detach.
```

Co-developed-by: Claude Opus 4.7 <noreply@anthropic.com>

eg: https://github.com/systemd/systemd/actions/runs/25989237312/job/76392251206