### PR TITLE
[v256-stable] Backport CVE-2026-29111: validate input cgroup path

### DIFF
--- a/src/core/dbus-manager.c
+++ b/src/core/dbus-manager.c
@@ -619,6 +619,12 @@ static int method_get_unit_by_control_group(sd_bus_message *message, void *userd
         if (r < 0)
                 return r;
 
+        if (!path_is_absolute(cgroup))
+                return sd_bus_error_setf(error, SD_BUS_ERROR_INVALID_ARGS, "Control group path is not absolute: %s", cgroup);
+
+        if (!path_is_normalized(cgroup))
+                return sd_bus_error_setf(error, SD_BUS_ERROR_INVALID_ARGS, "Control group path is not normalized: %s", cgroup);
+
         u = manager_get_unit_by_cgroup(m, cgroup);
         if (!u)
                 return sd_bus_error_setf(error, BUS_ERROR_NO_SUCH_UNIT,


### PR DESCRIPTION
backport of `1d22f706bd04` onto `v256-stable` for CVE-2026-29111.

the upstream fix tightens cgroup-path validation in `src/core/dbus-manager.c` (+6 -0) — rejects malformed cgroup paths from dbus.

upstream: https://github.com/systemd/systemd/commit/1d22f706bd04
CVE: https://nvd.nist.gov/vuln/detail/CVE-2026-29111

cherry-pick applied cleanly with `-x`. haven't run the integration tests locally.