### PR TITLE
po: skip automated fuzzy translations when generating new po files

### DIFF
--- a/po/meson.build
+++ b/po/meson.build
@@ -3,6 +3,12 @@
 want_translations = get_option('translations')
 
 if want_translations
+        # The msgmerge invocation hidden behind i18n.gettext()'s update-po target inserts auto-guessed
+        # "fuzzy" translations for new strings, which are almost always wrong, use a wrapper to skip it.
+        meson.override_find_program(
+                'msgmerge',
+                find_program('../tools/msgmerge-no-fuzzy.py'))
+
         i18n = import('i18n')
         i18n.gettext(meson.project_name(),
                      preset : 'glib',

--- a/tools/msgmerge-no-fuzzy.py
+++ b/tools/msgmerge-no-fuzzy.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-or-later
+"""
+Fuzzy translations are always bogus, but the meson integration doesn't allow overriding. With this wrapper
+we can skip them.
+"""
+
+import os
+import shutil
+import sys
+
+msgmerge = shutil.which('msgmerge')
+if msgmerge is None:
+    sys.exit('msgmerge-no-fuzzy: msgmerge not found in PATH')
+
+os.execv(msgmerge, [msgmerge, '--no-fuzzy-matching', *sys.argv[1:]])


### PR DESCRIPTION
The fuzzy translations are always wrong, but meson's integration does not allow skipping them. Add a tiny wrapper for 'msgmerge' to workaround the issue and skip them when running ninja systemd-update-po