### PR TITLE
resolved: add missing polkit checks on FlushCaches and ResetServerFeatures D-Bus methods

### DIFF
--- a/src/resolve/org.freedesktop.resolve1.policy
+++ b/src/resolve/org.freedesktop.resolve1.policy
@@ -205,4 +205,26 @@
                 <annotate key="org.freedesktop.policykit.owner">unix-user:systemd-resolve</annotate>
         </action>
 
+        <action id="org.freedesktop.resolve1.flush-caches">
+                <description gettext-domain="systemd">Flush DNS caches</description>
+                <message gettext-domain="systemd">Authentication is required to flush DNS caches.</message>
+                <defaults>
+                        <allow_any>auth_admin</allow_any>
+                        <allow_inactive>auth_admin</allow_inactive>
+                        <allow_active>auth_admin_keep</allow_active>
+                </defaults>
+                <annotate key="org.freedesktop.policykit.owner">unix-user:systemd-resolve</annotate>
+        </action>
+
+        <action id="org.freedesktop.resolve1.reset-server-features">
+                <description gettext-domain="systemd">Reset server features</description>
+                <message gettext-domain="systemd">Authentication is required to reset server features.</message>
+                <defaults>
+                        <allow_any>auth_admin</allow_any>
+                        <allow_inactive>auth_admin</allow_inactive>
+                        <allow_active>auth_admin_keep</allow_active>
+                </defaults>
+                <annotate key="org.freedesktop.policykit.owner">unix-user:systemd-resolve</annotate>
+        </action>
+
 </policyconfig>

--- a/src/resolve/resolved-bus.c
+++ b/src/resolve/resolved-bus.c
@@ -1842,8 +1842,20 @@ static int bus_method_get_link(sd_bus_message *message, void *userdata, sd_bus_e
 
 static int bus_method_flush_caches(sd_bus_message *message, void *userdata, sd_bus_error *error) {
         Manager *m = ASSERT_PTR(userdata);
+        int r;
 
         assert(message);
+
+        r = bus_verify_polkit_async(
+                        message,
+                        "org.freedesktop.resolve1.flush-caches",
+                        /* details= */ NULL,
+                        &m->polkit_registry,
+                        error);
+        if (r < 0)
+                return r;
+        if (r == 0)
+                return 1; /* Polkit will call us back */
 
         bus_client_log(message, "cache flush");
 
@@ -1854,8 +1866,20 @@ static int bus_method_flush_caches(sd_bus_message *message, void *userdata, sd_b
 
 static int bus_method_reset_server_features(sd_bus_message *message, void *userdata, sd_bus_error *error) {
         Manager *m = ASSERT_PTR(userdata);
+        int r;
 
         assert(message);
+
+        r = bus_verify_polkit_async(
+                        message,
+                        "org.freedesktop.resolve1.reset-server-features",
+                        /* details= */ NULL,
+                        &m->polkit_registry,
+                        error);
+        if (r < 0)
+                return r;
+        if (r == 0)
+                return 1; /* Polkit will call us back */
 
         bus_client_log(message, "server feature reset");
 


### PR DESCRIPTION
The `FlushCaches` and `ResetServerFeatures` D-Bus methods perform destructive operations (flushing all DNS caches and resetting server feature negotiation including DNS-over-TLS state) without any authorization check. Any unprivileged local user can call them via `busctl`.

The corresponding Varlink methods already enforce polkit via `verify_polkit()`, and `ResetStatistics` on the D-Bus side was also already updated, but these two handlers were missed.

Add `bus_verify_polkit_async()` calls to both methods, matching the pattern used by `bus_method_reset_statistics()`. Add the corresponding policy actions to the polkit policy file.