### PR TITLE
Fix an invalid section in example for NFTSet

### DIFF
--- a/man/systemd.resource-control.xml
+++ b/man/systemd.resource-control.xml
@@ -1127,7 +1127,7 @@ BindNetworkInterface=vrf-mgmt
           <command>systemctl daemon-reload</command> can be used to refill the sets.</para>
 
           <para>Example:
-          <programlisting>[Unit]
+          <programlisting>[Service]
 NFTSet=cgroup:inet:filter:my_service user:inet:filter:serviceuser
 </programlisting>
           Corresponding NFT rules:


### PR DESCRIPTION
`NFTSet` is supposed to be in `Service` instead of `Unit` section. The current example leads to `Unknown key 'NFTSet' in section [Unit], ignoring` in systemd logs.