### PR TITLE
tree-wide: move static dl handles into their dlopen_*() functions

### DIFF
--- a/src/basic/compress.c
+++ b/src/basic/compress.c
@@ -40,8 +40,6 @@
 #include "unaligned.h"
 
 #if HAVE_XZ
-static void *lzma_dl = NULL;
-
 static DLSYM_PROTOTYPE(lzma_code) = NULL;
 static DLSYM_PROTOTYPE(lzma_easy_encoder) = NULL;
 static DLSYM_PROTOTYPE(lzma_end) = NULL;
@@ -62,8 +60,6 @@ static inline void lzma_end_wrapper(lzma_stream *ls) {
 #endif
 
 #if HAVE_LZ4
-static void *lz4_dl = NULL;
-
 static DLSYM_PROTOTYPE(LZ4F_compressBegin) = NULL;
 static DLSYM_PROTOTYPE(LZ4F_compressBound) = NULL;
 static DLSYM_PROTOTYPE(LZ4F_compressEnd) = NULL;
@@ -86,8 +82,6 @@ static const LZ4F_preferences_t lz4_preferences = {
 #endif
 
 #if HAVE_ZSTD
-static void *zstd_dl = NULL;
-
 static DLSYM_PROTOTYPE(ZSTD_CCtx_setParameter) = NULL;
 static DLSYM_PROTOTYPE(ZSTD_compress) = NULL;
 static DLSYM_PROTOTYPE(ZSTD_compressStream2) = NULL;
@@ -120,8 +114,6 @@ static int zstd_ret_to_errno(size_t ret) {
 #endif
 
 #if HAVE_ZLIB
-static void *zlib_dl = NULL;
-
 static DLSYM_PROTOTYPE(deflateInit2_) = NULL;
 static DLSYM_PROTOTYPE(deflate) = NULL;
 static DLSYM_PROTOTYPE(deflateEnd) = NULL;
@@ -139,8 +131,6 @@ static inline void inflateEnd_wrapper(z_stream *s) {
 #endif
 
 #if HAVE_BZIP2
-static void *bzip2_dl = NULL;
-
 static DLSYM_PROTOTYPE(BZ2_bzCompressInit) = NULL;
 static DLSYM_PROTOTYPE(BZ2_bzCompress) = NULL;
 static DLSYM_PROTOTYPE(BZ2_bzCompressEnd) = NULL;
@@ -286,6 +276,8 @@ Compression compression_detect_from_magic(const uint8_t data[static COMPRESSION_
 
 int dlopen_xz(int log_level) {
 #if HAVE_XZ
+        static void *lzma_dl = NULL;
+
         SD_ELF_NOTE_DLOPEN(
                         "lzma",
                         "Support lzma compression in journal and coredump files",
@@ -309,6 +301,8 @@ int dlopen_xz(int log_level) {
 
 int dlopen_lz4(int log_level) {
 #if HAVE_LZ4
+        static void *lz4_dl = NULL;
+
         SD_ELF_NOTE_DLOPEN(
                         "lz4",
                         "Support lz4 compression in journal and coredump files",
@@ -341,6 +335,8 @@ int dlopen_lz4(int log_level) {
 
 int dlopen_zstd(int log_level) {
 #if HAVE_ZSTD
+        static void *zstd_dl = NULL;
+
         SD_ELF_NOTE_DLOPEN(
                         "zstd",
                         "Support zstd compression in journal and coredump files",
@@ -374,6 +370,8 @@ int dlopen_zstd(int log_level) {
 
 int dlopen_zlib(int log_level) {
 #if HAVE_ZLIB
+        static void *zlib_dl = NULL;
+
         SD_ELF_NOTE_DLOPEN(
                         "zlib",
                         "Support gzip compression and decompression",
@@ -397,6 +395,8 @@ int dlopen_zlib(int log_level) {
 
 int dlopen_bzip2(int log_level) {
 #if HAVE_BZIP2
+        static void *bzip2_dl = NULL;
+
         SD_ELF_NOTE_DLOPEN(
                         "bzip2",
                         "Support bzip2 compression and decompression",

--- a/src/basic/gcrypt-util.c
+++ b/src/basic/gcrypt-util.c
@@ -9,8 +9,6 @@
 
 #if HAVE_GCRYPT
 
-static void *gcrypt_dl = NULL;
-
 static DLSYM_PROTOTYPE(gcry_control) = NULL;
 static DLSYM_PROTOTYPE(gcry_check_version) = NULL;
 DLSYM_PROTOTYPE(gcry_md_close) = NULL;
@@ -47,6 +45,8 @@ DLSYM_PROTOTYPE(gcry_strerror) = NULL;
 
 int dlopen_gcrypt(int log_level) {
 #if HAVE_GCRYPT
+        static void *gcrypt_dl = NULL;
+
         SD_ELF_NOTE_DLOPEN(
                         "gcrypt",
                         "Support for journald forward-sealing",

--- a/src/libsystemd/sd-bus/test-bus-marshal.c
+++ b/src/libsystemd/sd-bus/test-bus-marshal.c
@@ -31,13 +31,14 @@ REENABLE_WARNING
 #include "tests.h"
 
 #if HAVE_GLIB
-static void *glib_dl = NULL;
 static DLSYM_PROTOTYPE(g_dbus_message_new_from_blob) = NULL;
 static DLSYM_PROTOTYPE(g_dbus_message_print)         = NULL;
 static DLSYM_PROTOTYPE(g_free)                       = NULL;
 static DLSYM_PROTOTYPE(g_object_unref)               = NULL;
 
 static int dlopen_glib(void) {
+        static void *glib_dl = NULL;
+
         return dlopen_many_sym_or_warn(
                         &glib_dl, "libgio-2.0.so.0", LOG_DEBUG,
                         DLSYM_ARG(g_dbus_message_new_from_blob),
@@ -48,13 +49,14 @@ static int dlopen_glib(void) {
 #endif
 
 #if HAVE_DBUS
-static void *libdbus_dl = NULL;
 static DLSYM_PROTOTYPE(dbus_error_init)        = NULL;
 static DLSYM_PROTOTYPE(dbus_error_free)        = NULL;
 static DLSYM_PROTOTYPE(dbus_message_demarshal) = NULL;
 static DLSYM_PROTOTYPE(dbus_message_unref)     = NULL;
 
 static int dlopen_libdbus(void) {
+        static void *libdbus_dl = NULL;
+
         return dlopen_many_sym_or_warn(
                         &libdbus_dl, "libdbus-1.so.3", LOG_DEBUG,
                         DLSYM_ARG(dbus_error_init),

--- a/src/locale/xkbcommon-util.c
+++ b/src/locale/xkbcommon-util.c
@@ -8,8 +8,6 @@
 #include "xkbcommon-util.h"
 
 #if HAVE_XKBCOMMON
-static void *xkbcommon_dl = NULL;
-
 DLSYM_PROTOTYPE(xkb_context_new) = NULL;
 DLSYM_PROTOTYPE(xkb_context_unref) = NULL;
 DLSYM_PROTOTYPE(xkb_context_set_log_fn) = NULL;
@@ -17,6 +15,8 @@ DLSYM_PROTOTYPE(xkb_keymap_new_from_names) = NULL;
 DLSYM_PROTOTYPE(xkb_keymap_unref) = NULL;
 
 static int dlopen_xkbcommon(int log_level) {
+        static void *xkbcommon_dl = NULL;
+
         SD_ELF_NOTE_DLOPEN(
                         "xkbcommon",
                         "Support for keyboard locale descriptions",

--- a/src/shared/acl-util.c
+++ b/src/shared/acl-util.c
@@ -17,8 +17,6 @@
 #include "user-util.h"
 
 #if HAVE_ACL
-static void *libacl_dl = NULL;
-
 DLSYM_PROTOTYPE(acl_add_perm);
 DLSYM_PROTOTYPE(acl_calc_mask);
 DLSYM_PROTOTYPE(acl_copy_entry);
@@ -49,6 +47,8 @@ DLSYM_PROTOTYPE(acl_to_any_text);
 
 int dlopen_libacl(int log_level) {
 #if HAVE_ACL
+        static void *libacl_dl = NULL;
+
         SD_ELF_NOTE_DLOPEN(
                         "acl",
                         "Support for file Access Control Lists (ACLs)",

--- a/src/shared/apparmor-util.c
+++ b/src/shared/apparmor-util.c
@@ -11,8 +11,6 @@
 
 #include "fileio.h"
 
-static void *libapparmor_dl = NULL;
-
 DLSYM_PROTOTYPE(aa_change_onexec) = NULL;
 DLSYM_PROTOTYPE(aa_change_profile) = NULL;
 DLSYM_PROTOTYPE(aa_features_new_from_kernel) = NULL;
@@ -48,6 +46,8 @@ bool mac_apparmor_use(void) {
 
 int dlopen_libapparmor(int log_level) {
 #if HAVE_APPARMOR
+        static void *libapparmor_dl = NULL;
+
         SD_ELF_NOTE_DLOPEN(
                         "apparmor",
                         "Support for AppArmor policies",

--- a/src/shared/blkid-util.c
+++ b/src/shared/blkid-util.c
@@ -9,8 +9,6 @@
 #include "string-util.h"
 
 #if HAVE_BLKID
-static void *libblkid_dl = NULL;
-
 DLSYM_PROTOTYPE(blkid_do_fullprobe) = NULL;
 DLSYM_PROTOTYPE(blkid_do_probe) = NULL;
 DLSYM_PROTOTYPE(blkid_do_safeprobe) = NULL;
@@ -99,6 +97,8 @@ int blkid_probe_lookup_value_u64(blkid_probe b, const char *field, uint64_t *ret
 
 int dlopen_libblkid(int log_level) {
 #if HAVE_BLKID
+        static void *libblkid_dl = NULL;
+
         SD_ELF_NOTE_DLOPEN(
                         "blkid",
                         "Support for block device identification",

--- a/src/shared/bpf-util.c
+++ b/src/shared/bpf-util.c
@@ -78,7 +78,14 @@ static int bpf_print_func(enum libbpf_print_level level, const char *fmt, va_lis
 
 int dlopen_bpf(int log_level) {
         static void *bpf_dl = NULL;
-        int r;
+        static int cached = 0;
+        int r = -ENOENT;
+
+        if (bpf_dl)
+                return 1; /* Already loaded */
+
+        if (cached < 0)
+                return cached; /* Already tried, and failed. */
 
         SD_ELF_NOTE_DLOPEN(
                         "bpf",
@@ -135,8 +142,8 @@ int dlopen_bpf(int log_level) {
         }
         REENABLE_WARNING;
         if (r < 0)
-                return log_full_errno(in_initrd() ? LOG_DEBUG : log_level, SYNTHETIC_ERRNO(EOPNOTSUPP),
-                                      "Neither libbpf.so.1 nor libbpf.so.0 are installed, cgroup BPF features disabled.");
+                return cached = log_full_errno(in_initrd() ? LOG_DEBUG : log_level, r,
+                                               "Neither libbpf.so.1 nor libbpf.so.0 are installed, cgroup BPF features disabled.");
 
         /* Version-specific symbols: bpf_create_map exists only in libbpf < 1.0; bpf_map_create and
          * bpf_object__next_map only in 0.7+. bpf_token_create only in 1.5+. Unresolved prototypes keep

--- a/src/shared/crypto-util.c
+++ b/src/shared/crypto-util.c
@@ -37,8 +37,6 @@ struct OpenSSLAskPasswordUI {
 #endif
 };
 
-static void *libcrypto_dl = NULL;
-
 static DLSYM_PROTOTYPE(ASN1_INTEGER_dup) = NULL;
 static DLSYM_PROTOTYPE(ASN1_INTEGER_free) = NULL;
 static DLSYM_PROTOTYPE(ASN1_INTEGER_set) = NULL;
@@ -336,6 +334,8 @@ DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_RENAME(UI_METHOD*, sym_UI_destroy_method, UI_de
 
 int dlopen_libcrypto(int log_level) {
 #if HAVE_OPENSSL
+        static void *libcrypto_dl = NULL;
+
         SD_ELF_NOTE_DLOPEN(
                         "libcrypto",
                         "Support for cryptographic operations",

--- a/src/shared/cryptsetup-util.c
+++ b/src/shared/cryptsetup-util.c
@@ -17,8 +17,6 @@
 #include "strv.h"
 
 #if HAVE_LIBCRYPTSETUP
-static void *cryptsetup_dl = NULL;
-
 DLSYM_PROTOTYPE(crypt_activate_by_passphrase) = NULL;
 DLSYM_PROTOTYPE(crypt_activate_by_signed_key) = NULL;
 DLSYM_PROTOTYPE(crypt_activate_by_token_pin) = NULL;
@@ -275,6 +273,7 @@ int cryptsetup_get_volume_key_id(
 
 int dlopen_cryptsetup(int log_level) {
 #if HAVE_LIBCRYPTSETUP
+        static void *cryptsetup_dl = NULL;
         int r;
 
         /* libcryptsetup added crypt_reencrypt() in 2.2.0, and marked it obsolete in 2.4.0, replacing it with

--- a/src/shared/curl-util.c
+++ b/src/shared/curl-util.c
@@ -18,8 +18,6 @@
 #include "time-util.h"
 #include "version.h"
 
-static void *curl_dl = NULL;
-
 DLSYM_PROTOTYPE(curl_easy_cleanup) = NULL;
 DLSYM_PROTOTYPE(curl_easy_getinfo) = NULL;
 DLSYM_PROTOTYPE(curl_easy_init) = NULL;
@@ -604,6 +602,8 @@ int curl_append_to_header(struct curl_slist **list, char **headers) {
 
 int dlopen_curl(int log_level) {
 #if HAVE_LIBCURL
+        static void *curl_dl = NULL;
+
         SD_ELF_NOTE_DLOPEN(
                         "curl",
                         "Support for downloading and uploading files over HTTP",

--- a/src/shared/elf-util.c
+++ b/src/shared/elf-util.c
@@ -38,9 +38,6 @@
 
 #if HAVE_ELFUTILS
 
-static void *dw_dl = NULL;
-static void *elf_dl = NULL;
-
 /* libdw symbols */
 static DLSYM_PROTOTYPE(dwarf_attr_integrate) = NULL;
 static DLSYM_PROTOTYPE(dwarf_diename) = NULL;
@@ -96,6 +93,7 @@ static DLSYM_PROTOTYPE(gelf_getnote) = NULL;
 
 int dlopen_dw(int log_level) {
 #if HAVE_ELFUTILS
+        static void *dw_dl = NULL;
         int r;
 
         SD_ELF_NOTE_DLOPEN(
@@ -161,6 +159,7 @@ bool dlopen_dw_has_dwfl_set_sysroot(void) {
 
 int dlopen_elf(int log_level) {
 #if HAVE_ELFUTILS
+        static void *elf_dl = NULL;
         int r;
 
         SD_ELF_NOTE_DLOPEN(

--- a/src/shared/fdisk-util.c
+++ b/src/shared/fdisk-util.c
@@ -16,8 +16,6 @@
 #include "parse-util.h"
 #include "string-util.h"
 
-static void *fdisk_dl = NULL;
-
 DLSYM_PROTOTYPE(fdisk_add_partition) = NULL;
 DLSYM_PROTOTYPE(fdisk_apply_table) = NULL;
 DLSYM_PROTOTYPE(fdisk_ask_get_type) = NULL;
@@ -83,6 +81,8 @@ DLSYM_PROTOTYPE(fdisk_write_disklabel) = NULL;
 
 int dlopen_fdisk(int log_level) {
 #if HAVE_LIBFDISK
+        static void *fdisk_dl = NULL;
+
         SD_ELF_NOTE_DLOPEN(
                         "fdisk",
                         "Support for reading and writing partition tables",

--- a/src/shared/gnutls-util.c
+++ b/src/shared/gnutls-util.c
@@ -6,8 +6,6 @@
 #include "log.h"                /* IWYU pragma: keep */
 
 #if HAVE_GNUTLS
-static void *gnutls_dl = NULL;
-
 DLSYM_PROTOTYPE(gnutls_certificate_get_peers) = NULL;
 DLSYM_PROTOTYPE(gnutls_certificate_type_get) = NULL;
 DLSYM_PROTOTYPE(gnutls_certificate_verification_status_print) = NULL;
@@ -23,6 +21,8 @@ DLSYM_PROTOTYPE(gnutls_x509_crt_init) = NULL;
 
 int dlopen_gnutls(int log_level) {
 #if HAVE_GNUTLS
+        static void *gnutls_dl = NULL;
+
         SD_ELF_NOTE_DLOPEN(
                         "gnutls",
                         "Support for TLS via GnuTLS",

--- a/src/shared/libarchive-util.c
+++ b/src/shared/libarchive-util.c
@@ -9,8 +9,6 @@
 #include "user-util.h"                  /* IWYU pragma: keep */
 
 #if HAVE_LIBARCHIVE
-static void *libarchive_dl = NULL;
-
 DLSYM_PROTOTYPE(archive_entry_acl_add_entry) = NULL;
 DLSYM_PROTOTYPE(archive_entry_acl_next) = NULL;
 DLSYM_PROTOTYPE(archive_entry_acl_reset) = NULL;
@@ -79,6 +77,7 @@ DLSYM_PROTOTYPE(archive_write_set_format_pax) = NULL;
 
 int dlopen_libarchive(int log_level) {
 #if HAVE_LIBARCHIVE
+        static void *libarchive_dl = NULL;
         int r;
 
         SD_ELF_NOTE_DLOPEN(

--- a/src/shared/libaudit-util.c
+++ b/src/shared/libaudit-util.c
@@ -14,8 +14,6 @@
 #include "socket-util.h"
 
 #if HAVE_AUDIT
-static void *libaudit_dl = NULL;
-
 static DLSYM_PROTOTYPE(audit_close) = NULL;
 DLSYM_PROTOTYPE(audit_log_acct_message) = NULL;
 DLSYM_PROTOTYPE(audit_log_user_avc_message) = NULL;
@@ -25,6 +23,8 @@ static DLSYM_PROTOTYPE(audit_open) = NULL;
 
 int dlopen_libaudit(int log_level) {
 #if HAVE_AUDIT
+        static void *libaudit_dl = NULL;
+
         SD_ELF_NOTE_DLOPEN(
                         "audit",
                         "Support for Audit logging",

--- a/src/shared/libcrypt-util.c
+++ b/src/shared/libcrypt-util.c
@@ -16,7 +16,6 @@
 
 #if HAVE_LIBCRYPT
 #ifdef __GLIBC__
-static void *libcrypt_dl = NULL;
 static DLSYM_PROTOTYPE(crypt_gensalt_ra) = NULL;
 static DLSYM_PROTOTYPE(crypt_preferred_method) = NULL;
 static DLSYM_PROTOTYPE(crypt_ra) = NULL;
@@ -132,6 +131,7 @@ bool looks_like_hashed_password(const char *s) {
 int dlopen_libcrypt(int log_level) {
 #if HAVE_LIBCRYPT
 #ifdef __GLIBC__
+        static void *libcrypt_dl = NULL;
         static int cached = 0;
         int r = -ENOENT;
 

--- a/src/shared/libcrypt-util.c
+++ b/src/shared/libcrypt-util.c
@@ -15,11 +15,16 @@
 #include "strv.h"
 
 #if HAVE_LIBCRYPT
+#ifdef __GLIBC__
 static void *libcrypt_dl = NULL;
-
 static DLSYM_PROTOTYPE(crypt_gensalt_ra) = NULL;
 static DLSYM_PROTOTYPE(crypt_preferred_method) = NULL;
 static DLSYM_PROTOTYPE(crypt_ra) = NULL;
+#else
+static DLSYM_PROTOTYPE(crypt_gensalt_ra) = missing_crypt_gensalt_ra;
+static DLSYM_PROTOTYPE(crypt_preferred_method) = missing_crypt_preferred_method;
+static DLSYM_PROTOTYPE(crypt_ra) = missing_crypt_ra;
+#endif
 
 int make_salt(char **ret) {
         const char *e;
@@ -128,10 +133,10 @@ int dlopen_libcrypt(int log_level) {
 #if HAVE_LIBCRYPT
 #ifdef __GLIBC__
         static int cached = 0;
-        int r;
+        int r = -ENOENT;
 
         if (libcrypt_dl)
-                return 0; /* Already loaded */
+                return 1; /* Already loaded */
 
         if (cached < 0)
                 return cached; /* Already tried, and failed. */
@@ -145,36 +150,19 @@ int dlopen_libcrypt(int log_level) {
                         SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED,
                         "libcrypt.so.2", "libcrypt.so.1", "libcrypt.so.1.1");
 
-        _cleanup_(dlclosep) void *dl = NULL;
-        const char *dle = NULL;
         FOREACH_STRING(soname, "libcrypt.so.2", "libcrypt.so.1", "libcrypt.so.1.1") {
-                r = dlopen_safe(soname, &dl, &dle);
-                if (r >= 0) {
-                        log_debug("Loaded '%s' via dlopen().", soname);
+                r = dlopen_many_sym_or_warn(
+                                &libcrypt_dl, soname, LOG_DEBUG,
+                                DLSYM_ARG(crypt_gensalt_ra),
+                                DLSYM_ARG(crypt_preferred_method),
+                                DLSYM_ARG(crypt_ra));
+                if (r >= 0)
                         break;
-                }
         }
-        if (r < 0) {
-                log_full_errno(log_level, r, "Failed to load libcrypt: %s", dle ?: STRERROR(r));
-                return (cached = -EOPNOTSUPP); /* turn into recognizable error */
-        }
-
-        r = dlsym_many_or_warn(
-                        dl, log_level,
-                        DLSYM_ARG(crypt_gensalt_ra),
-                        DLSYM_ARG(crypt_preferred_method),
-                        DLSYM_ARG(crypt_ra));
         if (r < 0)
-                return (cached = r);
-
-        libcrypt_dl = TAKE_PTR(dl);
-#else
-        libcrypt_dl = NULL;
-        sym_crypt_gensalt_ra = missing_crypt_gensalt_ra;
-        sym_crypt_preferred_method = missing_crypt_preferred_method;
-        sym_crypt_ra = missing_crypt_ra;
+                return cached = log_full_errno(log_level, r, "Failed to load libcrypt: %m");
 #endif
-        return 0;
+        return 1;
 #else
         return log_full_errno(log_level, SYNTHETIC_ERRNO(EOPNOTSUPP),
                               "libcrypt support is not compiled in.");

--- a/src/shared/libfido2-util.c
+++ b/src/shared/libfido2-util.c
@@ -23,8 +23,6 @@
 #define FIDO_ERR_UV_BLOCKED 0x3c
 #endif
 
-static void *libfido2_dl = NULL;
-
 DLSYM_PROTOTYPE(fido_assert_allow_cred) = NULL;
 DLSYM_PROTOTYPE(fido_assert_free) = NULL;
 DLSYM_PROTOTYPE(fido_assert_hmac_secret_len) = NULL;
@@ -82,6 +80,7 @@ static void fido_log_propagate_handler(const char *s) {
 
 int dlopen_libfido2(int log_level) {
 #if HAVE_LIBFIDO2
+        static void *libfido2_dl = NULL;
         int r;
 
         SD_ELF_NOTE_DLOPEN(

--- a/src/shared/libmount-util.c
+++ b/src/shared/libmount-util.c
@@ -11,8 +11,6 @@
 
 #include "fstab-util.h"
 
-static void *libmount_dl = NULL;
-
 DLSYM_PROTOTYPE(mnt_free_iter) = NULL;
 DLSYM_PROTOTYPE(mnt_free_table) = NULL;
 DLSYM_PROTOTYPE(mnt_fs_get_fs_options) = NULL;
@@ -120,6 +118,8 @@ int libmount_is_leaf(
 
 int dlopen_libmount(int log_level) {
 #if HAVE_LIBMOUNT
+        static void *libmount_dl = NULL;
+
         SD_ELF_NOTE_DLOPEN(
                         "mount",
                         "Support for mount enumeration",

--- a/src/shared/microhttpd-util.c
+++ b/src/shared/microhttpd-util.c
@@ -12,8 +12,6 @@
 #include "strv.h"
 
 #if HAVE_MICROHTTPD
-static void *microhttpd_dl = NULL;
-
 DLSYM_PROTOTYPE(MHD_add_response_header) = NULL;
 DLSYM_PROTOTYPE(MHD_create_response_from_buffer) = NULL;
 DLSYM_PROTOTYPE(MHD_create_response_from_callback) = NULL;
@@ -36,6 +34,8 @@ DLSYM_PROTOTYPE(MHD_stop_daemon) = NULL;
 
 int dlopen_microhttpd(int log_level) {
 #if HAVE_MICROHTTPD
+        static void *microhttpd_dl = NULL;
+
         SD_ELF_NOTE_DLOPEN(
                         "microhttpd",
                         "Support for embedded HTTP server via libmicrohttpd",

--- a/src/shared/module-util.c
+++ b/src/shared/module-util.c
@@ -11,8 +11,6 @@
 
 #if HAVE_KMOD
 
-static void *libkmod_dl = NULL;
-
 DLSYM_PROTOTYPE(kmod_list_next) = NULL;
 DLSYM_PROTOTYPE(kmod_load_resources) = NULL;
 DLSYM_PROTOTYPE(kmod_module_get_initstate) = NULL;
@@ -173,6 +171,8 @@ int module_setup_context(struct kmod_ctx **ret) {
 
 int dlopen_libkmod(int log_level) {
 #if HAVE_KMOD
+        static void *libkmod_dl = NULL;
+
         SD_ELF_NOTE_DLOPEN(
                         "kmod",
                         "Support for loading kernel modules",

--- a/src/shared/pam-util.c
+++ b/src/shared/pam-util.c
@@ -20,8 +20,6 @@
 #include "stdio-util.h"
 #include "string-util.h"
 
-static void *libpam_dl = NULL;
-
 DLSYM_PROTOTYPE(pam_acct_mgmt) = NULL;
 DLSYM_PROTOTYPE(pam_close_session) = NULL;
 DLSYM_PROTOTYPE(pam_end) = NULL;
@@ -383,6 +381,8 @@ int pam_putenv_assign(pam_handle_t *pamh, const char *name, const char *value) {
 
 int dlopen_libpam(int log_level) {
 #if HAVE_PAM
+        static void *libpam_dl = NULL;
+
         SD_ELF_NOTE_DLOPEN(
                         "pam",
                         "Support for LinuxPAM",

--- a/src/shared/password-quality-util-passwdqc.c
+++ b/src/shared/password-quality-util-passwdqc.c
@@ -16,8 +16,6 @@
 #include "memory-util.h"
 #include "strv.h"
 
-static void *passwdqc_dl = NULL;
-
 static DLSYM_PROTOTYPE(passwdqc_params_reset) = NULL;
 static DLSYM_PROTOTYPE(passwdqc_params_load) = NULL;
 static DLSYM_PROTOTYPE(passwdqc_params_parse) = NULL;
@@ -140,6 +138,8 @@ int check_password_quality(
 
 int dlopen_passwdqc(int log_level) {
 #if HAVE_PASSWDQC
+        static void *passwdqc_dl = NULL;
+
         SD_ELF_NOTE_DLOPEN(
                         "passwdqc",
                         "Support for password quality checks",

--- a/src/shared/password-quality-util-pwquality.c
+++ b/src/shared/password-quality-util-pwquality.c
@@ -19,8 +19,6 @@
 #include "string-util.h"
 #include "strv.h"
 
-static void *pwquality_dl = NULL;
-
 static DLSYM_PROTOTYPE(pwquality_check) = NULL;
 static DLSYM_PROTOTYPE(pwquality_default_settings) = NULL;
 static DLSYM_PROTOTYPE(pwquality_free_settings) = NULL;
@@ -156,6 +154,8 @@ int check_password_quality(const char *password, const char *old, const char *us
 
 int dlopen_pwquality(int log_level) {
 #if HAVE_PWQUALITY
+        static void *pwquality_dl = NULL;
+
         SD_ELF_NOTE_DLOPEN(
                         "pwquality",
                         "Support for password quality checks",

--- a/src/shared/pcre2-util.c
+++ b/src/shared/pcre2-util.c
@@ -8,8 +8,6 @@
 #include "pcre2-util.h"
 
 #if HAVE_PCRE2
-static void *pcre2_dl = NULL;
-
 DLSYM_PROTOTYPE(pcre2_match_data_create) = NULL;
 DLSYM_PROTOTYPE(pcre2_match_data_free) = NULL;
 DLSYM_PROTOTYPE(pcre2_code_free) = NULL;
@@ -30,6 +28,8 @@ const struct hash_ops pcre2_code_hash_ops_free = {};
 
 int dlopen_pcre2(int log_level) {
 #if HAVE_PCRE2
+        static void *pcre2_dl = NULL;
+
         SD_ELF_NOTE_DLOPEN(
                         "pcre2",
                         "Support for regular expressions",
@@ -127,7 +127,7 @@ int pattern_matches_and_log(pcre2_code *compiled_pattern, const char *message, s
         assert(message);
         /* pattern_compile_and_log() must be called before this function is called and that function already
          * dlopens pcre2 so we can assert on it being available here. */
-        assert(pcre2_dl);
+        assert(sym_pcre2_match);
 
         md = sym_pcre2_match_data_create(1, NULL);
         if (!md)

--- a/src/shared/pkcs11-util.c
+++ b/src/shared/pkcs11-util.c
@@ -43,8 +43,6 @@ bool pkcs11_uri_valid(const char *uri) {
 
 #if HAVE_P11KIT
 
-static void *p11kit_dl = NULL;
-
 DLSYM_PROTOTYPE(p11_kit_module_get_name) = NULL;
 DLSYM_PROTOTYPE(p11_kit_modules_finalize_and_release) = NULL;
 DLSYM_PROTOTYPE(p11_kit_modules_load_and_initialize) = NULL;
@@ -1807,6 +1805,8 @@ static int list_callback(
 
 int dlopen_p11kit(int log_level) {
 #if HAVE_P11KIT
+        static void *p11kit_dl = NULL;
+
         SD_ELF_NOTE_DLOPEN(
                         "p11-kit",
                         "Support for PKCS11 hardware tokens",

--- a/src/shared/qrcode-util.c
+++ b/src/shared/qrcode-util.c
@@ -22,14 +22,13 @@
 #define UNICODE_UPPER_HALF_BLOCK UTF8("▀")
 
 #if HAVE_QRENCODE
-static void *qrcode_dl = NULL;
-
 static DLSYM_PROTOTYPE(QRcode_encodeString) = NULL;
 static DLSYM_PROTOTYPE(QRcode_free) = NULL;
 #endif
 
 int dlopen_qrencode(int log_level) {
 #if HAVE_QRENCODE
+        static void *qrcode_dl = NULL;
         int r;
 
         SD_ELF_NOTE_DLOPEN(

--- a/src/shared/seccomp-util.c
+++ b/src/shared/seccomp-util.c
@@ -34,8 +34,6 @@
 #include "strv.h"
 
 #if HAVE_SECCOMP
-static void *libseccomp_dl = NULL;
-
 DLSYM_PROTOTYPE(seccomp_api_get) = NULL;
 DLSYM_PROTOTYPE(seccomp_arch_add) = NULL;
 DLSYM_PROTOTYPE(seccomp_arch_exist) = NULL;
@@ -2604,6 +2602,8 @@ int seccomp_suppress_sync(void) {
 
 int dlopen_libseccomp(int log_level) {
 #if HAVE_SECCOMP
+        static void *libseccomp_dl = NULL;
+
         SD_ELF_NOTE_DLOPEN(
                         "seccomp",
                         "Support for Seccomp Sandboxes",

--- a/src/shared/selinux-util.c
+++ b/src/shared/selinux-util.c
@@ -55,8 +55,6 @@ static int mac_selinux_label_post(int dir_fd, const char *path, bool created) {
         return 0;
 }
 
-static void *libselinux_dl = NULL;
-
 DLSYM_PROTOTYPE(avc_open) = NULL;
 DLSYM_PROTOTYPE(context_free) = NULL;
 DLSYM_PROTOTYPE(context_new) = NULL;
@@ -95,6 +93,8 @@ DLSYM_PROTOTYPE(string_to_security_class) = NULL;
 
 int dlopen_libselinux(int log_level) {
 #if HAVE_SELINUX
+        static void *libselinux_dl = NULL;
+
         SD_ELF_NOTE_DLOPEN(
                         "selinux",
                         "Support for SELinux",

--- a/src/shared/ssl-util.c
+++ b/src/shared/ssl-util.c
@@ -7,8 +7,6 @@
 
 #if HAVE_OPENSSL
 
-static void *libssl_dl = NULL;
-
 DLSYM_PROTOTYPE(SSL_ctrl) = NULL;
 DLSYM_PROTOTYPE(SSL_CTX_ctrl) = NULL;
 DLSYM_PROTOTYPE(SSL_CTX_free) = NULL;
@@ -36,6 +34,8 @@ DLSYM_PROTOTYPE(TLS_client_method) = NULL;
 
 int dlopen_libssl(int log_level) {
 #if HAVE_OPENSSL
+        static void *libssl_dl = NULL;
+
         SD_ELF_NOTE_DLOPEN(
                         "libssl",
                         "Support for TLS",

--- a/src/shared/tpm2-util.c
+++ b/src/shared/tpm2-util.c
@@ -53,11 +53,6 @@
 #include "virt.h"
 
 #if HAVE_TPM2
-static void *libtss2_esys_dl = NULL;
-static void *libtss2_rc_dl = NULL;
-static void *libtss2_mu_dl = NULL;
-static void *libtss2_tcti_device_dl = NULL;
-
 static DLSYM_PROTOTYPE(Esys_Create) = NULL;
 static DLSYM_PROTOTYPE(Esys_CreateLoaded) = NULL;
 static DLSYM_PROTOTYPE(Esys_CreatePrimary) = NULL;
@@ -126,6 +121,7 @@ static DLSYM_PROTOTYPE(Tss2_MU_UINT32_Marshal) = NULL;
 static DLSYM_PROTOTYPE(Tss2_RC_Decode) = NULL;
 
 static int dlopen_tpm2_esys(int log_level) {
+        static void *libtss2_esys_dl = NULL;
         int r;
 
         SD_ELF_NOTE_DLOPEN(
@@ -192,6 +188,8 @@ static int dlopen_tpm2_esys(int log_level) {
 }
 
 static int dlopen_tpm2_rc(int log_level) {
+        static void *libtss2_rc_dl = NULL;
+
         SD_ELF_NOTE_DLOPEN(
                         "tpm",
                         "Support for TPM",
@@ -204,6 +202,8 @@ static int dlopen_tpm2_rc(int log_level) {
 }
 
 static int dlopen_tpm2_mu(int log_level) {
+        static void *libtss2_mu_dl = NULL;
+
         SD_ELF_NOTE_DLOPEN(
                         "tpm",
                         "Support for TPM",
@@ -234,6 +234,8 @@ static int dlopen_tpm2_mu(int log_level) {
 }
 
 static int dlopen_tpm2_tcti_device(int log_level) {
+        static void *libtss2_tcti_device_dl = NULL;
+
         /* The "device" TCTI is the most relevant one, let's also load it explicitly on dlopen_tpm2(), even
          * if we don't resolve any symbols here. */
 


### PR DESCRIPTION
Each dlopen_*() wrapper kept its dl handle as a file-scope
'static void *xxx_dl = NULL;' even though only the wrapper itself
ever referenced it. Move each one inside the corresponding function
so its scope matches its actual use, leaving the rest of each
translation unit free of the unused file-scope name.

In pcre2-util.c the assert(pcre2_dl) in pattern_matches_and_log()
becomes assert(sym_pcre2_match), which carries the same invariant
(pattern_compile_and_log() ran dlopen_pcre2()).
