### PR TITLE
cryptsetup: Do not count stale cached passphrase attempt against tries=

### DIFF
--- a/src/cryptsetup/cryptsetup.c
+++ b/src/cryptsetup/cryptsetup.c
@@ -30,6 +30,7 @@
 #include "fs-util.h"
 #include "hexdecoct.h"
 #include "json-util.h"
+#include "keyring-util.h"
 #include "libfido2-util.h"
 #include "libmount-util.h"
 #include "log.h"
@@ -2733,6 +2734,7 @@ static int verb_attach(int argc, char *argv[], uintptr_t _data, void *userdata) 
                 _cleanup_(iovec_done_erase) struct iovec discovered_key_data = {};
                 const struct iovec *key_data = NULL;
                 TokenType token_type = determine_token_type();
+                bool passphrase_from_cache = false;
 
                 log_debug("Beginning attempt %u to unlock.", tries);
 
@@ -2750,6 +2752,10 @@ static int verb_attach(int argc, char *argv[], uintptr_t _data, void *userdata) 
                                 return r;
                         if (r > 0)
                                 key_data = &discovered_key_data;
+                        else
+                                /* Nothing discovered; disable so the failure path below doesn't fire
+                                 * and silently retry the same password the user just typed. */
+                                try_discover_key = false;
                 }
 
                 if (token_type < 0 && !key_file && !key_data && !passwords) {
@@ -2769,6 +2775,10 @@ static int verb_attach(int argc, char *argv[], uintptr_t _data, void *userdata) 
                                                 return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "No passphrase or recovery key registered.");
                                 }
 
+                                /* Only treat this as a cached attempt if there is actually a key in
+                                 * the keyring; otherwise get_password() will prompt interactively. */
+                                passphrase_from_cache = use_cached_passphrase &&
+                                        request_key("user", "cryptsetup", /* callout_info= */ NULL, /* destringid= */ 0) >= 0;
                                 r = get_password(
                                                 volume,
                                                 source,
@@ -2826,6 +2836,9 @@ static int verb_attach(int argc, char *argv[], uintptr_t _data, void *userdata) 
 
                 if (passwords) {
                         passwords = strv_free_erase(passwords);
+                        /* Don't count the cached keyring attempt against tries= — the user never saw a prompt */
+                        if (passphrase_from_cache)
+                                tries--; /* net zero with for-loop tries++; this iteration is not counted */
                         continue;
                 }
 

--- a/src/cryptsetup/cryptsetup.c
+++ b/src/cryptsetup/cryptsetup.c
@@ -31,6 +31,7 @@
 #include "fs-util.h"
 #include "hexdecoct.h"
 #include "json-util.h"
+#include "keyring-util.h"
 #include "libfido2-util.h"
 #include "libmount-util.h"
 #include "log.h"
@@ -2745,6 +2746,7 @@ static int verb_attach(int argc, char *argv[], uintptr_t _data, void *userdata) 
                 _cleanup_(iovec_done_erase) struct iovec discovered_key_data = {};
                 const struct iovec *key_data = NULL;
                 TokenType token_type = determine_token_type();
+                bool passphrase_from_cache = false;
 
                 log_debug("Beginning attempt %u to unlock.", tries);
 
@@ -2763,6 +2765,8 @@ static int verb_attach(int argc, char *argv[], uintptr_t _data, void *userdata) 
                         if (r > 0)
                                 key_data = &discovered_key_data;
                         else
+                                /* Nothing discovered; disable so the failure path below doesn't fire
+                                 * and silently retry the same password the user just typed. */
                                 try_discover_key = false;
                 }
 
@@ -2783,6 +2787,10 @@ static int verb_attach(int argc, char *argv[], uintptr_t _data, void *userdata) 
                                                 return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "No passphrase or recovery key registered.");
                                 }
 
+                                /* Only treat this as a cached attempt if there is actually a key in
+                                 * the keyring; otherwise get_password() will prompt interactively. */
+                                passphrase_from_cache = use_cached_passphrase && !arg_verify &&
+                                        request_key("user", "cryptsetup", /* callout_info= */ NULL, /* destringid= */ 0) >= 0;
                                 r = get_password(
                                                 volume,
                                                 source,
@@ -2840,6 +2848,9 @@ static int verb_attach(int argc, char *argv[], uintptr_t _data, void *userdata) 
 
                 if (passwords) {
                         passwords = strv_free_erase(passwords);
+                        /* Don't count the cached keyring attempt against tries= — the user never saw a prompt */
+                        if (passphrase_from_cache)
+                                tries--; /* net zero with for-loop tries++; this iteration is not counted */
                         continue;
                 }
 


### PR DESCRIPTION
When a wrong passphrase is cached in the kernel keyring, the first unlock attempt uses it silently without showing a prompt. That silent attempt should not consume one of the user's tries= slots.

When no key file is configured, systemd-cryptsetup also tries to auto-discover a key file before falling back to the user password. This discovery step fires first in the failure chain, leaving the stale cached passphrase held over for a second silent retry. With tries=3 the user ends up seeing only one interactive prompt instead of three.

Fix this by discarding the cached passphrase immediately when key discovery is invalidated, and decrementing tries to cancel the silent attempt.

Fixes [42103](https://github.com/systemd/systemd/issues/42103)