### PR TITLE
mkosi: update mkosi ref to 77fce77807a9a92bc37edc8f1c967102e6236d94

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
-      - uses: systemd/mkosi@9a28ad20bbea61894ea7b971d318a71f4374cf3b
+      - uses: systemd/mkosi@77fce77807a9a92bc37edc8f1c967102e6236d94
 
       # Freeing up disk space with rm -rf can take multiple minutes. Since we don't need the extra free space
       # immediately, we remove the files in the background. However, we first move them to a different location
@@ -128,6 +128,10 @@ jobs:
             --timeout-multiplier 2 \
             --max-lines 300 \
             --quiet
+
+      - name: Fix journal ownership
+        if: failure() && (github.repository == 'systemd/systemd' || github.repository == 'systemd/systemd-stable')
+        run: sudo chown -R "$(id -u):$(id -g)" build/test/journal build/meson-logs
 
       - name: Archive failed test journals
         uses: actions/upload-artifact@v7

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -40,7 +40,7 @@ jobs:
           GITHUB_ACTIONS_CONFIG_FILE: actionlint.yml
           ENABLE_GITHUB_PULL_REQUEST_SUMMARY_COMMENT: false
 
-      - uses: systemd/mkosi@9a28ad20bbea61894ea7b971d318a71f4374cf3b
+      - uses: systemd/mkosi@77fce77807a9a92bc37edc8f1c967102e6236d94
 
       - name: Check that tabs are not used in Python code
         run: sh -c '! git grep -P "\\t" -- src/core/generate-bpf-delegate-configs.py src/boot/generate-hwids-section.py src/ukify/ukify.py test/integration-tests/integration-test-wrapper.py'

--- a/.github/workflows/mkosi.yml
+++ b/.github/workflows/mkosi.yml
@@ -169,7 +169,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
-      - uses: systemd/mkosi@9a28ad20bbea61894ea7b971d318a71f4374cf3b
+      - uses: systemd/mkosi@77fce77807a9a92bc37edc8f1c967102e6236d94
 
       # Freeing up disk space with rm -rf can take multiple minutes. Since we don't need the extra free space
       # immediately, we remove the files in the background. However, we first move them to a different location
@@ -317,6 +317,10 @@ jobs:
             --no-stdsplit \
             --num-processes "$(($(nproc) - 1))" \
             "${MAX_LINES[@]}"
+
+      - name: Fix journal ownership
+        if: failure() && (github.repository == 'systemd/systemd' || github.repository == 'systemd/systemd-stable')
+        run: sudo chown -R "$(id -u):$(id -g)" build/test/journal build/meson-logs
 
       - name: Archive failed test journals
         uses: actions/upload-artifact@v7

--- a/mkosi/mkosi.conf
+++ b/mkosi/mkosi.conf
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 [Config]
-MinimumVersion=commit:66d51024b7149f40be4702e84275c936373ace97
+MinimumVersion=commit:77fce77807a9a92bc37edc8f1c967102e6236d94
 Dependencies=
         minimal-base
         minimal-0


### PR DESCRIPTION
* 77fce77807 apk: Implement repository_key_fetch for the postmarketOS distribution
* 7068ed49ab postmarketos: Add ruff to tools tree
* dea4b6bfc8 Add newline when writing machine id into /etc/machine-id
* 944b775d40 tools: add libtss2-tcti-device0 to opensuse tools tree
* d856d65d3b mkosi-initrd: Also add cryptsetup-libs explicitly to the initrd
* 1cc967c5b3 mkosi-initrd: Trim orphaned GPU/audio modules, add ACPI platform attrs
* a3e95a7c29 mkosi-tools: Add fish to misc profile
* 76b02d1f84 mkosi-tools: Add jujutsu to misc profile
* 0afe4cd254 mkosi-tools: Move gh to misc profile
* 9077634bad mkosi-tools: Add cryptsetup-libs to centos/fedora/opensuse
* 82846347af box: Drop background tinting
* 3e50b97101 mkosi-tools: Add libfido2
* 78c2784827 vmspawn: Use --ephemeral rather than copy_ephemeral()
* dc801b00a3 Added second call to update kerneltype after kernel is defined
* 0c5cc04a8b vmspawn: Forward journal-remote settings to vmspawn
* 2518468c65 nspawn: Use --forward-journal instead of running journal-remote ourselves
* d2b798d00c apk: skip removal of packages that aren't installed
