### PR TITLE
dependabot: Ignore mkosi

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,10 @@ updates:
       actions:
         patterns:
           - "*"
-        exclude-patterns:
-          - "systemd/mkosi"
+    ignore:
+      # We pin systemd/mkosi to a specific commit on purpose so the CI environment stays
+      # reproducible across runs; bump it with tools/fetch-mkosi.py when we need a newer mkosi.
+      - dependency-name: "systemd/mkosi"
     cooldown:
       default-days: 7
     open-pull-requests-limit: 2


### PR DESCRIPTION
It doesn't update MinimumVersion= in mkosi.conf which breaks
tools/fetch-mkosi.py.
