### PR TITLE
basic/math-util: drop libm where possible

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -425,6 +425,11 @@ possible_common_cc_flags = [
         '-fstack-protector',
         '-fstack-protector-strong',
         '-fstrict-flex-arrays=3',
+        # We don't read errno from any libm call, and the math-errno fallback
+        # forces a DT_NEEDED on libm via the cold error path even when the hot
+        # path is a single hardware instruction (sqrtsd, etc.). Drop it so the
+        # builtins lower to pure hardware instructions.
+        '-fno-math-errno',
         '--param=ssp-buffer-size=4',
 ]
 

--- a/src/basic/meson.build
+++ b/src/basic/meson.build
@@ -215,7 +215,6 @@ libbasic_static = static_library(
         dependencies : [libbzip2_cflags,
                         libgcrypt_cflags,
                         liblz4_cflags,
-                        libm,
                         libxz_cflags,
                         libz_cflags,
                         libzstd_cflags,

--- a/src/libsystemd/meson.build
+++ b/src/libsystemd/meson.build
@@ -220,7 +220,6 @@ libsystemd_tests += [
                         libgio_cflags,
                         libglib_cflags,
                         libgobject_cflags,
-                        libm,
                 ],
         },
         {

--- a/src/pcrlock/meson.build
+++ b/src/pcrlock/meson.build
@@ -12,7 +12,6 @@ executables += [
                         'pcrlock-firmware.c',
                 ),
                 'dependencies' : [
-                        libm,
                         libopenssl_cflags,
                         tpm2,
                 ],

--- a/src/resolve/meson.build
+++ b/src/resolve/meson.build
@@ -71,7 +71,6 @@ resolve_common_template = {
         'dependencies' : [
                 libidn2_cflags,
                 libopenssl_cflags,
-                libm,
         ],
 }
 

--- a/src/shared/pretty-print.c
+++ b/src/shared/pretty-print.c
@@ -1,6 +1,5 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
-#include <math.h>
 #include <stdio.h>
 #include <sys/utsname.h>
 #include <unistd.h>
@@ -567,7 +566,10 @@ void draw_progress_bar_unbuffered(const char *prefix, double percentage) {
                  * https://conemu.github.io/en/AnsiEscapeCodes.html#ConEmu_specific_OSC
                  * https://github.com/microsoft/terminal/pull/8055
                  */
-                fprintf(stderr, ANSI_OSC "9;4;1;%u" ANSI_ST, (unsigned) ceil(percentage));
+                unsigned percentage_ceil = (unsigned) percentage;
+                if ((double) percentage_ceil < percentage)
+                        percentage_ceil++;
+                fprintf(stderr, ANSI_OSC "9;4;1;%u" ANSI_ST, percentage_ceil);
 
                 size_t cols = columns();
                 size_t prefix_width = utf8_console_width(prefix) + 1 /* space */;

--- a/src/test/meson.build
+++ b/src/test/meson.build
@@ -407,7 +407,6 @@ executables += [
         },
         test_template + {
                 'sources' : files('test-parse-util.c'),
-                'dependencies' : libm,
         },
         test_template + {
                 'sources' : files('test-shift-uid.c'),
@@ -432,7 +431,6 @@ executables += [
         },
         test_template + {
                 'sources' : files('test-random-util.c'),
-                'dependencies' : libm,
                 'timeout' : 120,
         },
         test_template + {

--- a/src/test/test-random-util.c
+++ b/src/test/test-random-util.c
@@ -1,7 +1,5 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
-#include <math.h>
-
 #include "hexdecoct.h"
 #include "log.h"
 #include "memory-util.h"
@@ -15,7 +13,7 @@ TEST(random_bytes) {
         for (size_t i = 1; i < sizeof buf; i++) {
                 random_bytes(buf, i);
                 if (i + 1 < sizeof buf)
-                        assert_se(buf[i] == 0);
+                        ASSERT_EQ(buf[i], 0);
 
                 hexdump(stdout, buf, i);
         }
@@ -25,9 +23,9 @@ TEST(crypto_random_bytes) {
         uint8_t buf[16] = {};
 
         for (size_t i = 1; i < sizeof buf; i++) {
-                assert_se(crypto_random_bytes(buf, i) == 0);
+                ASSERT_OK(crypto_random_bytes(buf, i));
                 if (i + 1 < sizeof buf)
-                        assert_se(buf[i] == 0);
+                        ASSERT_EQ(buf[i], 0);
 
                 hexdump(stdout, buf, i);
         }
@@ -53,21 +51,25 @@ static void test_random_u64_range_one(unsigned mod) {
         /* Print histogram: vertical axis — value, horizontal axis — count.
          *
          * The expected value is always TOTAL/mod, because the distribution should be flat. The expected
-         * variance is TOTAL×p×(1-p), where p==1/mod, and standard deviation the root of the variance.
-         * Assert that the deviation from the expected value is less than 6 standard deviations.
+         * variance is TOTAL×p×(1-p), where p==1/mod. Assert that the deviation from the expected value
+         * is less than 6 standard deviations by comparing squared values (diff² < 36·variance), which
+         * avoids a sqrt() call and the libm dependency that comes with it at -O0.
          */
         unsigned scale = 2 * max / (columns() < 20 ? 80 : columns() - 20);
         double exp = (double) TOTAL / mod;
+        double variance = exp * (mod > 1 ? mod - 1 : 1) / mod;
 
         for (size_t i = 0; i < mod; i++) {
-                double dev = (count[i] - exp) / sqrt(exp * (mod > 1 ? mod - 1 : 1) / mod);
-                log_debug("%02zu: %5u (%+.3f)%*s",
-                          i, count[i], dev,
+                double diff = count[i] - exp;
+                double dev_sq = diff * diff / variance;
+
+                log_debug("%02zu: %5u (z²=%.3f)%*s",
+                          i, count[i], dev_sq,
                           (int) (count[i] / scale), "x");
 
-                assert_se(ABS(dev) < 6); /* 6 sigma is excessive, but this check should be enough to
-                                           * identify catastrophic failure while minimizing false
-                                           * positives. */
+                ASSERT_TRUE(dev_sq < 36); /* 36 = 6²; 6 sigma is excessive, but this check should be
+                                           * enough to identify catastrophic failure while minimizing
+                                           * false positives. */
         }
 }
 


### PR DESCRIPTION
- test-random-util is reworked to not use sqrt()
- pretty-print.c inlines ceil() so libm doesn't have
  to be linked into libshared
- We add fno-math-errno to allow inlining of more math
  functions by not requiring standard math functions to 
  set errno on invalid input.