### PR TITLE
test: do not fail test-ukify if we lack read permissions on /boot/

### DIFF
--- a/src/ukify/test/test_ukify.py
+++ b/src/ukify/test/test_ukify.py
@@ -464,6 +464,10 @@ def kernel_initrd():
     # enough.
     linux = items[-1]
 
+    # On some setups we might not have read permissions
+    if not os.access(linux, os.R_OK):
+        return None
+
     # We don't look _into_ the initrd. Any file is OK.
     return ['--linux', linux, '--initrd', ukify.__file__]
 


### PR DESCRIPTION
```
kernel_initrd = ['--linux', '/boot/vmlinuz.old', '--initrd', '/home/runner/work/systemd/systemd/src/ukify/test/../ukify.py'] tmp_path = PosixPath('/tmp/pytest-of-runner/pytest-0/test_inspect0') capsys = <_pytest.capture.CaptureFixture object at 0x7f2b28d67230>, osrel = True

    def test_inspect(kernel_initrd, tmp_path, capsys, osrel=True):
        if kernel_initrd is None:
            pytest.skip('linux+initrd not found')
        if not shutil.which('sbsign'):
            pytest.skip('sbsign not found')

        ourdir = pathlib.Path(__file__).parent
        cert = unbase64(ourdir / 'example.signing.crt.base64')
        key = unbase64(ourdir / 'example.signing.key.base64')

        output = f'{tmp_path}/signed2.efi'
        uname_arg = '1.2.3'
        osrel_arg = 'Linux' if osrel else ''
        cmdline_arg = 'ARG1 ARG2 ARG3'

        args = [
            'build',
            *kernel_initrd,
            f'--cmdline={cmdline_arg}',
            f'--os-release={osrel_arg}',
            f'--uname={uname_arg}',
            f'--output={output}',
        ] + arg_tools
        if slow_tests:
            args += [
                f'--secureboot-certificate={cert.name}',
                f'--secureboot-private-key={key.name}',
            ]

        opts = ukify.parse_args(args)

>       ukify.check_inputs(opts)

../src/ukify/test/test_ukify.py:743:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ ../src/ukify/ukify.py:684: in check_inputs
    value.open().close()
    ^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = PosixPath('/boot/vmlinuz.old'), mode = 'r', buffering = -1 encoding = 'locale', errors = None, newline = None

    def open(self, mode='r', buffering=-1, encoding=None,
             errors=None, newline=None):
        """
        Open the file pointed to by this path and return a file object, as
        the built-in open() function does.
        """
        if "b" not in mode:
            encoding = io.text_encoding(encoding)
>       return io.open(self, mode, buffering, encoding, errors, newline)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       PermissionError: [Errno 13] Permission denied: '/boot/vmlinuz.old'

/usr/lib/python3.14/pathlib/__init__.py:771: PermissionError ____________________________ test_inspect_no_osrel _____________________________

kernel_initrd = ['--linux', '/boot/vmlinuz.old', '--initrd', '/home/runner/work/systemd/systemd/src/ukify/test/../ukify.py'] tmp_path = PosixPath('/tmp/pytest-of-runner/pytest-0/test_inspect_no_osrel0') capsys = <_pytest.capture.CaptureFixture object at 0x7f2b2915d910>

    def test_inspect_no_osrel(kernel_initrd, tmp_path, capsys):
>       test_inspect(kernel_initrd, tmp_path, capsys, osrel=False)

../src/ukify/test/test_ukify.py:771:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ ../src/ukify/test/test_ukify.py:743: in test_inspect
    ukify.check_inputs(opts)
../src/ukify/ukify.py:684: in check_inputs
    value.open().close()
    ^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = PosixPath('/boot/vmlinuz.old'), mode = 'r', buffering = -1 encoding = 'locale', errors = None, newline = None

    def open(self, mode='r', buffering=-1, encoding=None,
             errors=None, newline=None):
        """
        Open the file pointed to by this path and return a file object, as
        the built-in open() function does.
        """
        if "b" not in mode:
            encoding = io.text_encoding(encoding)
>       return io.open(self, mode, buffering, encoding, errors, newline)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       PermissionError: [Errno 13] Permission denied: '/boot/vmlinuz.old'

/usr/lib/python3.14/pathlib/__init__.py:771: PermissionError =========================== short test summary info ============================ FAILED ../src/ukify/test/test_ukify.py::test_uname_scraping - PermissionError: [Errno 13] Permission denied: '/boot/vmlinuz.old' FAILED ../src/ukify/test/test_ukify.py::test_inspect - PermissionError: [Errno 13] Permission denied: '/boot/vmlinuz.old' FAILED ../src/ukify/test/test_ukify.py::test_inspect_no_osrel - PermissionError: [Errno 13] Permission denied: '/boot/vmlinuz.old'
```

Follow-up for 987f4bce938e790622a4b4b89d37daa7adfdc141