### PR TITLE
socket-proxy: support proxying to vsock destination

### DIFF
--- a/man/systemd-socket-proxyd.xml
+++ b/man/systemd-socket-proxyd.xml
@@ -30,13 +30,18 @@
       <arg choice="plain"><replaceable>UNIX-DOMAIN-SOCKET-PATH</replaceable>
       </arg>
     </cmdsynopsis>
+    <cmdsynopsis>
+      <command>systemd-socket-proxyd</command>
+      <arg choice="opt" rep="repeat"><replaceable>OPTIONS</replaceable></arg>
+      <arg choice="plain">vsock:<replaceable>CID</replaceable>:<replaceable>PORT</replaceable></arg>
+    </cmdsynopsis>
   </refsynopsisdiv>
   <refsect1>
     <title>Description</title>
     <para>
     <command>systemd-socket-proxyd</command> is a generic
     socket-activated network socket forwarder proxy daemon for IPv4,
-    IPv6 and UNIX stream sockets. It may be used to bi-directionally
+    IPv6, UNIX stream and vsock sockets. It may be used to bi-directionally
     forward traffic from a local listening socket to a local or remote
     destination socket.</para>
 

--- a/src/socket-proxy/socket-proxyd.c
+++ b/src/socket-proxy/socket-proxyd.c
@@ -340,6 +340,18 @@ fail:
         return 0; /* ignore errors, continue serving */
 }
 
+static inline size_t strcount_char(const char *s, char c) {
+        size_t n = 0;
+
+        assert(s);
+
+        for (const char *p = s; *p; p++)
+                if (*p == c)
+                        n++;
+
+        return n;
+}
+
 static int resolve_remote(Connection *c) {
 
         static const struct addrinfo hints = {
@@ -360,6 +372,14 @@ static int resolve_remote(Connection *c) {
                 sa_len = r;
 
                 return connection_start(c, &sa.sa, sa_len);
+        }
+
+        if (startswith(arg_remote_host, "vsock:") && strcount_char(arg_remote_host, ':') == 2) {
+                SocketAddress address;
+                r = socket_address_parse_vsock(&address, arg_remote_host);
+                if (r < 0)
+                        return log_error_errno(r, "Can't parse '%s' as a VSOCK address, refusing: %m", arg_remote_host);
+                return connection_start(c, &address.sockaddr.sa, address.size);
         }
 
         service = strrchr(arg_remote_host, ':');


### PR DESCRIPTION
supports

	systemd-socket-proxyd [OPTIONS...] vsock:CID:PORT

to connect to a virtual machine listening on a vsock socket

Fixes: #41043
