### PR TITLE
repart: canonicalize node path io.systemd.Repart.Run()

### DIFF
--- a/src/repart/repart.c
+++ b/src/repart/repart.c
@@ -11389,7 +11389,13 @@ static int vl_method_run(
                 return r;
 
         if (p.node) {
-                context->node = TAKE_PTR(p.node);
+                /* Canonicalize the node path so that partition device paths refer to kernel-created nodes
+                 * rather than udev-created symlinks (e.g. /dev/vda1 instead of .../foo-part1) that may not
+                 * yet exist right after BLKPG_ADD_PARTITION. */
+                r = acquire_root_devno(p.node, NULL, O_CLOEXEC|context_open_mode(context),
+                                       &context->node, &context->backing_fd);
+                if (r < 0)
+                        return r;
 
                 r = context_load_partition_table(context);
                 if (r == -EHWPOISON)


### PR DESCRIPTION
During a fresh install via sysinstall (in a systemd-vmspawn machine) I ran into the issue that
```
💽 Installing partitions...
Applying changes to /dev/disk/by-id/virtio-install-target.raw.
...
Block level copying and synchronization of partition 3 complete in 332.743ms (489M/s).
Failed to open new partition '/dev/disk/by-id/virtio-install-target.raw-part1': No such file or directory
Informing kernel about changed partitions...
Failed to issue io.systemd.Repart.Run() varlink call: No such file or directory
```

It seems that the CLI path is doing a canonicalization of the path but the varlink part is not. This commit tweaks the code to follow what the CLI is doing (without we race udev that will only create the symlinks after BLKPG_ADD_PARTITION). With the patch I get:
```
Adding new partition 3 to partition table.
Writing new partition table.
Informing kernel about changed partitions...
Partition table written.
💽 Mounting partitions...
💽 Installing kernel...
```