### PR TITLE
vmspawn: rearrange --help and man page a bit

### DIFF
--- a/man/systemd-vmspawn.xml
+++ b/man/systemd-vmspawn.xml
@@ -292,6 +292,18 @@
         </varlistentry>
 
         <varlistentry>
+          <term><option>--secure-boot=<replaceable>BOOL</replaceable></option></term>
+
+          <listitem><para>Configure whether to search for firmware which supports Secure Boot. Takes a
+          boolean or <literal>auto</literal>. Setting this to yes is equivalent to
+          <option>--firmware-features=secure-boot</option> and setting this to no is equivalent to
+          <option>--firmware-features=~secure-boot</option>. Setting this to <literal>auto</literal>
+          removes <literal>secure-boot</literal> from both the included and excluded feature lists.</para>
+
+          <xi:include href="version-info.xml" xpointer="v255"/></listitem>
+        </varlistentry>
+
+        <varlistentry>
           <term><option>--firmware=<replaceable>PATH</replaceable></option></term>
 
           <listitem><para>Selects which firmware to use in the VM. Takes one of <literal>auto</literal>,
@@ -325,18 +337,6 @@
           firmware features.</para>
 
           <xi:include href="version-info.xml" xpointer="v261"/></listitem>
-        </varlistentry>
-
-        <varlistentry>
-          <term><option>--secure-boot=<replaceable>BOOL</replaceable></option></term>
-
-          <listitem><para>Configure whether to search for firmware which supports Secure Boot. Takes a
-          boolean or <literal>auto</literal>. Setting this to yes is equivalent to
-          <option>--firmware-features=secure-boot</option> and setting this to no is equivalent to
-          <option>--firmware-features=~secure-boot</option>. Setting this to <literal>auto</literal>
-          removes <literal>secure-boot</literal> from both the included and excluded feature lists.</para>
-
-          <xi:include href="version-info.xml" xpointer="v255"/></listitem>
         </varlistentry>
 
         <varlistentry>

--- a/man/systemd-vmspawn.xml
+++ b/man/systemd-vmspawn.xml
@@ -708,7 +708,7 @@
     </refsect2>
 
     <refsect2>
-      <title>Integration Options</title>
+      <title>Logging Options</title>
 
       <variablelist>
         <varlistentry>
@@ -740,6 +740,13 @@
           <xi:include href="version-info.xml" xpointer="v261"/></listitem>
         </varlistentry>
 
+      </variablelist>
+    </refsect2>
+
+    <refsect2>
+      <title>SSH Options</title>
+
+      <variablelist>
         <varlistentry>
           <term><option>--pass-ssh-key=<replaceable>BOOL</replaceable></option></term>
 

--- a/man/systemd-vmspawn.xml
+++ b/man/systemd-vmspawn.xml
@@ -292,37 +292,6 @@
         </varlistentry>
 
         <varlistentry>
-          <term><option>--linux=<replaceable>PATH</replaceable></option></term>
-
-          <listitem>
-            <para>Set the linux kernel image to use for direct kernel boot.
-            If a directory type image is used and <option>--linux=</option> was omitted, vmspawn will search for boot loader entries
-            according to the
-            <ulink url="https://uapi-group.org/specifications/specs/boot_loader_specification">UAPI.1 Boot Loader Specification</ulink> assuming
-            XBOOTLDR to be located at /boot and ESP to be /efi respectively.
-            If no kernel was installed into the image then the image will fail to boot.</para>
-
-            <xi:include href="version-info.xml" xpointer="v256"/>
-          </listitem>
-        </varlistentry>
-
-        <varlistentry>
-          <term><option>--initrd=<replaceable>PATH</replaceable></option></term>
-
-          <listitem>
-            <para>Set the initrd to use for direct kernel boot.
-            If the <option>--linux=</option> supplied is a
-            <ulink url="https://uapi-group.org/specifications/specs/boot_loader_specification">UAPI.1 Boot Loader Specification</ulink>
-            Type #2 entry, then this argument is not required.
-            If no initrd was installed into the image then the image will fail to boot.</para>
-
-            <para><option>--initrd=</option> can be specified multiple times and vmspawn will merge them together.</para>
-
-            <xi:include href="version-info.xml" xpointer="v256"/>
-          </listitem>
-        </varlistentry>
-
-        <varlistentry>
           <term><option>--firmware=<replaceable>PATH</replaceable></option></term>
 
           <listitem><para>Selects which firmware to use in the VM. Takes one of <literal>auto</literal>,
@@ -393,37 +362,6 @@
 
           <xi:include href="version-info.xml" xpointer="v261"/></listitem>
         </varlistentry>
-
-        <varlistentry>
-          <term><option>--smbios11=<replaceable>STRING</replaceable></option></term>
-          <term><option>-s <replaceable>STRING</replaceable></option></term>
-
-          <listitem><para>Passes the specified string into the VM as an SMBIOS Type #11 vendor string. This
-          is useful to parameterize the invoked VM in various ways. See
-          <citerefentry><refentrytitle>smbios-type-11</refentrytitle><manvolnum>7</manvolnum></citerefentry>
-          for details.</para>
-
-          <xi:include href="version-info.xml" xpointer="v258"/></listitem>
-        </varlistentry>
-
-        <varlistentry>
-          <term><option>--notify-ready=</option></term>
-
-          <listitem><para>Configures support for notifications from the VM's init process to
-          <command>systemd-vmspawn</command>.  If true, <command>systemd-vmspawn</command> will consider the
-          machine as ready only when it has received a <literal>READY=1</literal> message from the init
-          process in the VM. If false, <command>systemd-vmspawn</command> will consider the machine as ready
-          immediately after creation.  In either case, <command>systemd-vmspawn</command> sends its own
-          readiness notification to its manager after the spawned VM is ready. For more details about
-          notifications see
-          <citerefentry><refentrytitle>sd_notify</refentrytitle><manvolnum>3</manvolnum></citerefentry>.</para>
-
-          <para>Defaults to true. (Note that this is unlike the option of the same name to
-          <citerefentry><refentrytitle>systemd-nspawn</refentrytitle><manvolnum>1</manvolnum></citerefentry>
-          that defaults to false.)</para>
-
-          <xi:include href="version-info.xml" xpointer="v258"/></listitem>
-        </varlistentry>
       </variablelist>
     </refsect2>
 
@@ -456,6 +394,74 @@
           <listitem><para>Use user mode networking.</para>
 
           <xi:include href="version-info.xml" xpointer="v255"/></listitem>
+        </varlistentry>
+      </variablelist>
+    </refsect2>
+
+    <refsect2>
+      <title>Execution Options</title>
+
+      <variablelist>
+        <varlistentry>
+          <term><option>--linux=<replaceable>PATH</replaceable></option></term>
+
+          <listitem>
+            <para>Set the linux kernel image to use for direct kernel boot.
+            If a directory type image is used and <option>--linux=</option> was omitted, vmspawn will search for boot loader entries
+            according to the
+            <ulink url="https://uapi-group.org/specifications/specs/boot_loader_specification">UAPI.1 Boot Loader Specification</ulink> assuming
+            XBOOTLDR to be located at /boot and ESP to be /efi respectively.
+            If no kernel was installed into the image then the image will fail to boot.</para>
+
+            <xi:include href="version-info.xml" xpointer="v256"/>
+          </listitem>
+        </varlistentry>
+
+        <varlistentry>
+          <term><option>--initrd=<replaceable>PATH</replaceable></option></term>
+
+          <listitem>
+            <para>Set the initrd to use for direct kernel boot.
+            If the <option>--linux=</option> supplied is a
+            <ulink url="https://uapi-group.org/specifications/specs/boot_loader_specification">UAPI.1 Boot Loader Specification</ulink>
+            Type #2 entry, then this argument is not required.
+            If no initrd was installed into the image then the image will fail to boot.</para>
+
+            <para><option>--initrd=</option> can be specified multiple times and vmspawn will merge them together.</para>
+
+            <xi:include href="version-info.xml" xpointer="v256"/>
+          </listitem>
+        </varlistentry>
+
+        <varlistentry>
+          <term><option>--smbios11=<replaceable>STRING</replaceable></option></term>
+          <term><option>-s <replaceable>STRING</replaceable></option></term>
+
+          <listitem><para>Passes the specified string into the VM as an SMBIOS Type #11 vendor string. This
+          is useful to parameterize the invoked VM in various ways. See
+          <citerefentry><refentrytitle>smbios-type-11</refentrytitle><manvolnum>7</manvolnum></citerefentry>
+          for details.</para>
+
+          <xi:include href="version-info.xml" xpointer="v258"/></listitem>
+        </varlistentry>
+
+        <varlistentry>
+          <term><option>--notify-ready=</option></term>
+
+          <listitem><para>Configures support for notifications from the VM's init process to
+          <command>systemd-vmspawn</command>.  If true, <command>systemd-vmspawn</command> will consider the
+          machine as ready only when it has received a <literal>READY=1</literal> message from the init
+          process in the VM. If false, <command>systemd-vmspawn</command> will consider the machine as ready
+          immediately after creation.  In either case, <command>systemd-vmspawn</command> sends its own
+          readiness notification to its manager after the spawned VM is ready. For more details about
+          notifications see
+          <citerefentry><refentrytitle>sd_notify</refentrytitle><manvolnum>3</manvolnum></citerefentry>.</para>
+
+          <para>Defaults to true. (Note that this is unlike the option of the same name to
+          <citerefentry><refentrytitle>systemd-nspawn</refentrytitle><manvolnum>1</manvolnum></citerefentry>
+          that defaults to false.)</para>
+
+          <xi:include href="version-info.xml" xpointer="v258"/></listitem>
         </varlistentry>
       </variablelist>
     </refsect2>

--- a/man/systemd-vmspawn.xml
+++ b/man/systemd-vmspawn.xml
@@ -323,33 +323,6 @@
         </varlistentry>
 
         <varlistentry>
-          <term><option>-n</option></term>
-          <term><option>--network-tap</option></term>
-
-          <listitem>
-            <para>Create a TAP device to network with the virtual machine.</para>
-
-            <para>Note: root privileges are required to use TAP networking.
-            Additionally,
-            <citerefentry><refentrytitle>systemd-networkd</refentrytitle><manvolnum>8</manvolnum></citerefentry>
-            must be running and correctly set up on the host to provision the host interface. The relevant
-            <literal>.network</literal> file can be found at
-            <filename>/usr/lib/systemd/network/80-vm-vt.network</filename>.
-            </para>
-
-            <xi:include href="version-info.xml" xpointer="v255"/>
-          </listitem>
-        </varlistentry>
-
-        <varlistentry>
-          <term><option>--network-user-mode</option></term>
-
-          <listitem><para>Use user mode networking.</para>
-
-          <xi:include href="version-info.xml" xpointer="v255"/></listitem>
-        </varlistentry>
-
-        <varlistentry>
           <term><option>--firmware=<replaceable>PATH</replaceable></option></term>
 
           <listitem><para>Selects which firmware to use in the VM. Takes one of <literal>auto</literal>,
@@ -450,6 +423,39 @@
           that defaults to false.)</para>
 
           <xi:include href="version-info.xml" xpointer="v258"/></listitem>
+        </varlistentry>
+      </variablelist>
+    </refsect2>
+
+    <refsect2>
+      <title>Networking Options</title>
+
+      <variablelist>
+        <varlistentry>
+          <term><option>-n</option></term>
+          <term><option>--network-tap</option></term>
+
+          <listitem>
+            <para>Create a TAP device to network with the virtual machine.</para>
+
+            <para>Note: root privileges are required to use TAP networking.
+            Additionally,
+            <citerefentry><refentrytitle>systemd-networkd</refentrytitle><manvolnum>8</manvolnum></citerefentry>
+            must be running and correctly set up on the host to provision the host interface. The relevant
+            <literal>.network</literal> file can be found at
+            <filename>/usr/lib/systemd/network/80-vm-vt.network</filename>.
+            </para>
+
+            <xi:include href="version-info.xml" xpointer="v255"/>
+          </listitem>
+        </varlistentry>
+
+        <varlistentry>
+          <term><option>--network-user-mode</option></term>
+
+          <listitem><para>Use user mode networking.</para>
+
+          <xi:include href="version-info.xml" xpointer="v255"/></listitem>
         </varlistentry>
       </variablelist>
     </refsect2>

--- a/man/systemd-vmspawn.xml
+++ b/man/systemd-vmspawn.xml
@@ -105,6 +105,18 @@
         </varlistentry>
 
         <varlistentry>
+          <term><option>-x</option></term>
+          <term><option>--ephemeral</option></term>
+
+          <listitem><para>If specified, the VM is run with a temporary snapshot of its file system that is removed
+          immediately when the VM terminates. Only works with <option>--image=</option> currently.
+
+          Note that <option>--ephemeral</option> will not work with <option>--extra-drive=</option>.</para>
+
+          <xi:include href="version-info.xml" xpointer="v260"/></listitem>
+        </varlistentry>
+
+        <varlistentry>
           <term><option>-i</option></term>
           <term><option>--image=</option></term>
 
@@ -139,15 +151,25 @@
         </varlistentry>
 
         <varlistentry>
-          <term><option>-x</option></term>
-          <term><option>--ephemeral</option></term>
+          <term><option>--discard-disk=<replaceable>BOOL</replaceable></option></term>
 
-          <listitem><para>If specified, the VM is run with a temporary snapshot of its file system that is removed
-          immediately when the VM terminates. Only works with <option>--image=</option> currently.
+          <listitem><para>Controls whether qemu processes discard requests from the VM.
+          This prevents long running VMs from using more disk space than required.
+          This is enabled by default.</para>
 
-          Note that <option>--ephemeral</option> will not work with <option>--extra-drive=</option>.</para>
+          <xi:include href="version-info.xml" xpointer="v256"/></listitem>
+        </varlistentry>
 
-          <xi:include href="version-info.xml" xpointer="v260"/></listitem>
+        <varlistentry>
+          <term><option>--grow-image=<replaceable>BYTES</replaceable></option></term>
+          <term><option>-G <replaceable>BYTES</replaceable></option></term>
+
+          <listitem><para>Grows the image file specified by <option>--image=</option> to the specified size
+          in bytes if it is smaller. Executes no operation if no image file is used or the image file is
+          already as large or larger than requested. The specified size accepts the usual K, M, G suffixes
+          (to the base of 1024). Specified values are rounded up to multiples of 4096.</para>
+
+          <xi:include href="version-info.xml" xpointer="v258"/></listitem>
         </varlistentry>
       </variablelist>
     </refsect2>
@@ -364,16 +386,6 @@
         </varlistentry>
 
         <varlistentry>
-          <term><option>--discard-disk=<replaceable>BOOL</replaceable></option></term>
-
-          <listitem><para>Controls whether qemu processes discard requests from the VM.
-          This prevents long running VMs from using more disk space than required.
-          This is enabled by default.</para>
-
-          <xi:include href="version-info.xml" xpointer="v256"/></listitem>
-        </varlistentry>
-
-        <varlistentry>
           <term><option>--secure-boot=<replaceable>BOOL</replaceable></option></term>
 
           <listitem><para>Configure whether to search for firmware which supports Secure Boot. Takes a
@@ -407,18 +419,6 @@
           <option>--tpm=</option>, must be treated as untrusted by the guest.</para>
 
           <xi:include href="version-info.xml" xpointer="v261"/></listitem>
-        </varlistentry>
-
-        <varlistentry>
-          <term><option>--grow-image=<replaceable>BYTES</replaceable></option></term>
-          <term><option>-G <replaceable>BYTES</replaceable></option></term>
-
-          <listitem><para>Grows the image file specified by <option>--image=</option> to the specified size
-          in bytes if it is smaller. Executes no operation if no image file is used or the image file is
-          already as large or larger than requested. The specified size accepts the usual K, M, G suffixes
-          (to the base of 1024). Specified values are rounded up to multiples of 4096.</para>
-
-          <xi:include href="version-info.xml" xpointer="v258"/></listitem>
         </varlistentry>
 
         <varlistentry>

--- a/src/vmspawn/vmspawn.c
+++ b/src/vmspawn/vmspawn.c
@@ -232,6 +232,7 @@ static int help(void) {
                 NULL,
                 "Image",
                 "Host Configuration",
+                "Networking",
                 "Execution",
                 "System Identity",
                 "Properties",
@@ -255,7 +256,7 @@ static int help(void) {
         (void) table_sync_column_widths(
                         0, tables[0], tables[1], tables[2], tables[3], tables[4],
                         tables[5], tables[6], tables[7], tables[8], tables[9], tables[10],
-                        tables[11]);
+                        tables[11], tables[12]);
 
         help_cmdline("[OPTIONS...] [ARGUMENTS...]");
         help_abstract("Spawn a command or OS in a virtual machine.");
@@ -540,14 +541,6 @@ static int parse_argv(int argc, char *argv[]) {
                         break;
                 }
 
-                OPTION('n', "network-tap", NULL, "Create a TAP device for networking"):
-                        arg_network_stack = NETWORK_STACK_TAP;
-                        break;
-
-                OPTION_LONG("network-user-mode", NULL, "Use user mode networking"):
-                        arg_network_stack = NETWORK_STACK_USER;
-                        break;
-
                 OPTION_LONG("secure-boot", "BOOL|auto", "Enable searching for firmware supporting SecureBoot"): {
                         int b;
 
@@ -665,6 +658,16 @@ static int parse_argv(int argc, char *argv[]) {
                         arg_confidential_computing = cc;
                         break;
                 }
+
+                OPTION_GROUP("Networking"): {}
+
+                OPTION('n', "network-tap", NULL, "Create a TAP device for networking"):
+                        arg_network_stack = NETWORK_STACK_TAP;
+                        break;
+
+                OPTION_LONG("network-user-mode", NULL, "Use user mode networking"):
+                        arg_network_stack = NETWORK_STACK_USER;
+                        break;
 
                 OPTION_GROUP("Execution"): {}
 

--- a/src/vmspawn/vmspawn.c
+++ b/src/vmspawn/vmspawn.c
@@ -523,24 +523,6 @@ static int parse_argv(int argc, char *argv[]) {
                         arg_efi_nvram_state_mode = STATE_PATH;
                         break;
 
-                OPTION_LONG("linux", "PATH", "Specify the linux kernel for direct kernel boot"):
-                        r = parse_path_argument(opts.arg, /* suppress_root= */ false, &arg_linux);
-                        if (r < 0)
-                                return r;
-                        break;
-
-                OPTION_LONG("initrd", "PATH", "Specify the initrd for direct kernel boot"): {
-                        _cleanup_free_ char *initrd_path = NULL;
-                        r = parse_path_argument(opts.arg, /* suppress_root= */ false, &initrd_path);
-                        if (r < 0)
-                                return r;
-
-                        r = strv_consume(&arg_initrds, TAKE_PTR(initrd_path));
-                        if (r < 0)
-                                return log_oom();
-                        break;
-                }
-
                 OPTION_LONG("secure-boot", "BOOL|auto", "Enable searching for firmware supporting SecureBoot"): {
                         int b;
 
@@ -670,6 +652,24 @@ static int parse_argv(int argc, char *argv[]) {
                         break;
 
                 OPTION_GROUP("Execution"): {}
+
+                OPTION_LONG("linux", "PATH", "Specify the linux kernel for direct kernel boot"):
+                        r = parse_path_argument(opts.arg, /* suppress_root= */ false, &arg_linux);
+                        if (r < 0)
+                                return r;
+                        break;
+
+                OPTION_LONG("initrd", "PATH", "Specify the initrd for direct kernel boot"): {
+                        _cleanup_free_ char *initrd_path = NULL;
+                        r = parse_path_argument(opts.arg, /* suppress_root= */ false, &initrd_path);
+                        if (r < 0)
+                                return r;
+
+                        r = strv_consume(&arg_initrds, TAKE_PTR(initrd_path));
+                        if (r < 0)
+                                return log_oom();
+                        break;
+                }
 
                 OPTION('s', "smbios11", "STRING", "Pass an arbitrary SMBIOS Type #11 string to the VM"):
                         if (isempty(opts.arg)) {

--- a/src/vmspawn/vmspawn.c
+++ b/src/vmspawn/vmspawn.c
@@ -237,7 +237,8 @@ static int help(void) {
                 "Properties",
                 "User Namespacing",
                 "Mounts",
-                "Integration",
+                "Logging",
+                "SSH",
                 "Input/Output",
                 "Credentials",
         };
@@ -251,8 +252,10 @@ static int help(void) {
                         return r;
         }
 
-        (void) table_sync_column_widths(0, tables[0], tables[1], tables[2], tables[3], tables[4],
-                                        tables[5], tables[6], tables[7], tables[8], tables[9], tables[10]);
+        (void) table_sync_column_widths(
+                        0, tables[0], tables[1], tables[2], tables[3], tables[4],
+                        tables[5], tables[6], tables[7], tables[8], tables[9], tables[10],
+                        tables[11]);
 
         help_cmdline("[OPTIONS...] [ARGUMENTS...]");
         help_abstract("Spawn a command or OS in a virtual machine.");
@@ -839,7 +842,7 @@ static int parse_argv(int argc, char *argv[]) {
                                 return log_oom();
                         break;
 
-                OPTION_GROUP("Integration"): {}
+                OPTION_GROUP("Logging"): {}
 
                 OPTION_LONG("forward-journal", "FILE|DIR", "Forward the VM's journal to the host"):
                         r = parse_path_argument(opts.arg, /* suppress_root= */ false, &arg_forward_journal);
@@ -870,6 +873,8 @@ static int parse_argv(int argc, char *argv[]) {
                         if (r < 0)
                                 return log_error_errno(r, "Failed to parse --forward-journal-max-files= value: %s", opts.arg);
                         break;
+
+                OPTION_GROUP("SSH"): {}
 
                 OPTION_LONG("pass-ssh-key", "BOOL", "Create an SSH key to access the VM"):
                         r = parse_boolean_argument("--pass-ssh-key=", opts.arg, &arg_pass_ssh_key);

--- a/src/vmspawn/vmspawn.c
+++ b/src/vmspawn/vmspawn.c
@@ -394,6 +394,23 @@ static int parse_argv(int argc, char *argv[]) {
                                                        "Invalid image disk type: %s", opts.arg);
                         break;
 
+                OPTION_LONG("discard-disk", "BOOL", "Control processing of discard requests"):
+                        r = parse_boolean_argument("--discard-disk=", opts.arg, &arg_discard_disk);
+                        if (r < 0)
+                                return r;
+                        break;
+
+                OPTION('G', "grow-image", "BYTES", "Grow image file to specified size in bytes"):
+                        if (isempty(opts.arg)) {
+                                arg_grow_image = 0;
+                                break;
+                        }
+
+                        r = parse_size(opts.arg, 1024, &arg_grow_image);
+                        if (r < 0)
+                                return log_error_errno(r, "Failed to parse --grow-image= parameter: %s", opts.arg);
+                        break;
+
                 OPTION_GROUP("Host Configuration"): {}
 
                 OPTION_LONG("cpus", "CPUS", "Configure number of CPUs in guest"): {}
@@ -645,23 +662,6 @@ static int parse_argv(int argc, char *argv[]) {
                         arg_confidential_computing = cc;
                         break;
                 }
-
-                OPTION_LONG("discard-disk", "BOOL", "Control processing of discard requests"):
-                        r = parse_boolean_argument("--discard-disk=", opts.arg, &arg_discard_disk);
-                        if (r < 0)
-                                return r;
-                        break;
-
-                OPTION('G', "grow-image", "BYTES", "Grow image file to specified size in bytes"):
-                        if (isempty(opts.arg)) {
-                                arg_grow_image = 0;
-                                break;
-                        }
-
-                        r = parse_size(opts.arg, 1024, &arg_grow_image);
-                        if (r < 0)
-                                return log_error_errno(r, "Failed to parse --grow-image= parameter: %s", opts.arg);
-                        break;
 
                 OPTION_GROUP("Execution"): {}
 


### PR DESCRIPTION
This does not change man page or --help contents at all, but it does introduce new sections, and moves some knobs between sections. It also reorders things in the man page so that man page and --help show items in the same order again.

