### PR TITLE
Revert "meson: shrink developer-mode build artifacts"

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -501,12 +501,6 @@ possible_cc_flags = [
 
 if get_option('mode') == 'developer'
         possible_cc_flags += '-fno-omit-frame-pointer'
-        # Let -Wl,--gc-sections drop unused functions/data instead of whole
-        # .o files; biggest win on statically-linked NSS/PAM modules.
-        possible_cc_flags += ['-ffunction-sections', '-fdata-sections']
-        # Compress and dedupe DWARF; transparent to GDB / readelf.
-        possible_cc_flags += ['-gz=zstd', '-fdebug-types-section']
-        possible_link_flags += '-Wl,--compress-debug-sections=zstd'
 endif
 
 add_project_arguments(

--- a/mkosi/mkosi.images/build/mkosi.conf.d/debian-ubuntu/mkosi.build.chroot
+++ b/mkosi/mkosi.images/build/mkosi.conf.d/debian-ubuntu/mkosi.build.chroot
@@ -40,12 +40,6 @@ if [[ -d "$SRCDIR/debian/patches" ]]; then
     mount --bind /tmp/patches "$SRCDIR/debian/patches"
 fi
 
-# mode=developer enables -Wl,--compress-debug-sections=zstd in meson.build, which dwz cannot process.
-cp "$SRCDIR/debian/rules" /tmp/rules
-chmod +x /tmp/rules
-printf '\noverride_dh_dwz:\n' >>/tmp/rules
-mount --bind /tmp/rules "$SRCDIR/debian/rules"
-
 # While the build directory can be specified through DH_OPTIONS, the default one is hardcoded everywhere so
 # we have to use that. Because it is architecture dependent, we query it using dpkg-architecture first.
 DEB_HOST_GNU_TYPE="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)"


### PR DESCRIPTION
Breaks debs builds

Fixes https://github.com/systemd/systemd/issues/42201

Reverts systemd/systemd#42118