### PR TITLE
include: move several missing definitions to musl

### DIFF
--- a/src/include/musl/signal.h
+++ b/src/include/musl/signal.h
@@ -1,0 +1,28 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#pragma once
+
+#include_next <signal.h>        /* IWYU pragma: export */
+
+#ifndef ILL_BADIADDR
+#define ILL_BADIADDR 9
+#endif
+
+#ifndef FPE_FLTUNK
+#define FPE_FLTUNK 14
+#endif
+
+#ifndef FPE_CONDTRAP
+#define FPE_CONDTRAP 15
+#endif
+
+#ifndef SEGV_ACCADI
+#define SEGV_ACCADI 5
+#endif
+
+#ifndef SEGV_ADIDERR
+#define SEGV_ADIDERR 6
+#endif
+
+#ifndef SEGV_ADIPERR
+#define SEGV_ADIPERR 7
+#endif

--- a/src/include/override/signal.h
+++ b/src/include/override/signal.h
@@ -3,30 +3,6 @@
 
 #include_next <signal.h>        /* IWYU pragma: export */
 
-#ifndef ILL_BADIADDR
-#define ILL_BADIADDR 9
-#endif
-
-#ifndef FPE_FLTUNK
-#define FPE_FLTUNK 14
-#endif
-
-#ifndef FPE_CONDTRAP
-#define FPE_CONDTRAP 15
-#endif
-
-#ifndef SEGV_ACCADI
-#define SEGV_ACCADI 5
-#endif
-
-#ifndef SEGV_ADIDERR
-#define SEGV_ADIDERR 6
-#endif
-
-#ifndef SEGV_ADIPERR
-#define SEGV_ADIPERR 7
-#endif
-
 /* Defined since glibc-2.39. */
 #ifndef SEGV_CPERR
 #define SEGV_CPERR 10


### PR DESCRIPTION
Those moved ones have been defined in glibc <= 2.34, and only necessary when built with musl.

Follow-up for c8c1bcf1941047d1fe43d9827ad4826b4620297a.