### PR TITLE
updatectl: Add a --no-ask-password argument

### DIFF
--- a/man/updatectl.xml
+++ b/man/updatectl.xml
@@ -119,6 +119,7 @@
         <xi:include href="version-info.xml" xpointer="v257"/></listitem>
       </varlistentry>
 
+      <xi:include href="standard-options.xml" xpointer="no-ask-password" />
       <xi:include href="standard-options.xml" xpointer="help" />
       <xi:include href="standard-options.xml" xpointer="version" />
     </variablelist>

--- a/src/sysupdate/updatectl.c
+++ b/src/sysupdate/updatectl.c
@@ -35,6 +35,7 @@ static bool arg_legend = true;
 static bool arg_reboot = false;
 static bool arg_offline = false;
 static bool arg_now = false;
+static bool arg_ask_password = true;
 static BusTransport arg_transport = BUS_TRANSPORT_LOCAL;
 static const char *arg_host = NULL;
 
@@ -1723,6 +1724,10 @@ static int parse_argv(int argc, char *argv[], char ***ret_args) {
 
                 OPTION_GROUP("Verbs"): {}
 
+                OPTION_COMMON_NO_ASK_PASSWORD:
+                        arg_ask_password = false;
+                        break;
+
                 OPTION_COMMON_HELP:
                         return help();
 
@@ -1755,7 +1760,7 @@ static int run(int argc, char *argv[]) {
         if (arg_transport == BUS_TRANSPORT_LOCAL)
                 polkit_agent_open();
 
-        (void) sd_bus_set_allow_interactive_authorization(bus, true);
+        (void) sd_bus_set_allow_interactive_authorization(bus, arg_ask_password);
 
         return dispatch_verb(args, bus);
 }


### PR DESCRIPTION
While commit 83c1e8ff5f9 added support for interactive polkit authentication in `updatectl`, some users might want to disable that for some use cases; so add the standard `--no-ask-password` argument.

Helps: https://github.com/systemd/systemd/issues/37412