### PR TITLE
Bump minimum required version of musl to 1.2.6

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -73,6 +73,9 @@ CHANGES WITH 261 in spe:
           effectively means live upgrades from versions older than v247 are not
           supported anymore.
 
+        * Required version of musl (when built with -Dlibc=musl) has been raised
+          from 1.2.5 to 1.2.6.
+
         Changes in the system and service manager:
 
         * PID1 now supports the kernel's Live Update Orchestration (LUO) /

--- a/README
+++ b/README
@@ -205,8 +205,7 @@ REQUIREMENTS:
           CONFIG_MEMCG
 
         glibc >= 2.34
-        musl >= 1.2.5 with fde29c04adbab9d5b081bf6717b5458188647f1c
-                (required when building systemd with -Dlibc=musl)
+        musl >= 1.2.6 (required when building systemd with -Dlibc=musl)
         libxcrypt >= 4.4.0 (optional)
         libmount >= 2.30 (from util-linux)
                 (util-linux *must* be built without --enable-libmount-support-mtab)

--- a/src/include/musl/stdio.h
+++ b/src/include/musl/stdio.h
@@ -3,15 +3,6 @@
 
 #include_next <stdio.h>
 
-#ifndef RENAME_NOREPLACE
-#  define RENAME_NOREPLACE (1 << 0)
-#  define RENAME_EXCHANGE  (1 << 1)
-#  define RENAME_WHITEOUT  (1 << 2)
-#endif
-
-int renameat2_shim(int __oldfd, const char *__old, int __newfd, const char *__new, unsigned __flags);
-#define renameat2 renameat2_shim
-
 /* When a stream is opened read-only under glibc, fputs() and friends fail with EBADF. However, they
  * succeed under musl. We rely on the glibc behavior in the code base. The following _check_writable()
  * functions first check if the passed stream is writable, and refuse to write with EBADF if not. */

--- a/src/include/musl/sys/stat.h
+++ b/src/include/musl/sys/stat.h
@@ -3,64 +3,9 @@
 
 #include_next <sys/stat.h>
 
-#include <assert.h>
-#include <stddef.h>
-
 /* musl's sys/stat.h does not include linux/stat.h, and unfortunately they conflict with each other.
  * Hence, some relatively new macros need to be explicitly defined here. */
 
-/* Before 23ab04a8630225371455d5f4538fd078665bb646, statx.stx_mnt_id is not defined. */
-#ifndef STATX_MNT_ID
-static_assert(offsetof(struct statx, __pad1) == offsetof(struct statx, stx_dev_minor) + sizeof(uint32_t), "");
-#define stx_mnt_id __pad1[0]
-#endif
-
-#ifndef STATX_MNT_ID
-#define STATX_MNT_ID            0x00001000U
-#endif
-#ifndef STATX_DIOALIGN
-#define STATX_DIOALIGN          0x00002000U
-#endif
-#ifndef STATX_MNT_ID_UNIQUE
-#define STATX_MNT_ID_UNIQUE     0x00004000U
-#endif
-#ifndef STATX_SUBVOL
-#define STATX_SUBVOL            0x00008000U
-#endif
-#ifndef STATX_WRITE_ATOMIC
-#define STATX_WRITE_ATOMIC      0x00010000U
-#endif
 #ifndef STATX_DIO_READ_ALIGN
 #define STATX_DIO_READ_ALIGN    0x00020000U
-#endif
-
-#ifndef STATX_ATTR_COMPRESSED
-#define STATX_ATTR_COMPRESSED   0x00000004
-#endif
-#ifndef STATX_ATTR_IMMUTABLE
-#define STATX_ATTR_IMMUTABLE    0x00000010
-#endif
-#ifndef STATX_ATTR_APPEND
-#define STATX_ATTR_APPEND       0x00000020
-#endif
-#ifndef STATX_ATTR_NODUMP
-#define STATX_ATTR_NODUMP       0x00000040
-#endif
-#ifndef STATX_ATTR_ENCRYPTED
-#define STATX_ATTR_ENCRYPTED    0x00000800
-#endif
-#ifndef STATX_ATTR_AUTOMOUNT
-#define STATX_ATTR_AUTOMOUNT    0x00001000
-#endif
-#ifndef STATX_ATTR_MOUNT_ROOT
-#define STATX_ATTR_MOUNT_ROOT   0x00002000
-#endif
-#ifndef STATX_ATTR_VERITY
-#define STATX_ATTR_VERITY       0x00100000
-#endif
-#ifndef STATX_ATTR_DAX
-#define STATX_ATTR_DAX          0x00200000
-#endif
-#ifndef STATX_ATTR_WRITE_ATOMIC
-#define STATX_ATTR_WRITE_ATOMIC 0x00400000
 #endif

--- a/src/libc/musl/stdio.c
+++ b/src/libc/musl/stdio.c
@@ -4,15 +4,6 @@
 #include <stdio.h>
 #include <stdio_ext.h>
 
-#include "../libc-shim.h"
-
-DEFINE_SYSCALL_SHIM(renameat2, int,
-                    int, __oldfd,
-                    const char *, __old,
-                    int, __newfd,
-                    const char *, __new,
-                    unsigned, __flags)
-
 #define DEFINE_PUT(func)                                         \
         int func##_check_writable(int c, FILE *stream) {         \
                 if (!__fwritable(stream)) {                      \


### PR DESCRIPTION
musl v1.2.6 has been released on 2026-03-20, and alpine-edge already has it:
https://pkgs.alpinelinux.org/package/edge/main/x86_64/musl