### PR TITLE
sysupdate: Add separate polkit actions for cancellation

### DIFF
--- a/man/org.freedesktop.sysupdate1.xml
+++ b/man/org.freedesktop.sysupdate1.xml
@@ -412,26 +412,35 @@ node /org/freedesktop/sysupdate1/target/host {
 
       <para><function>List()</function>, <function>Describe()</function>, and <function>CheckNew()</function>
       use the polkit action <interfacename>org.freedesktop.sysupdate1.check</interfacename>.
-      By default, this action is permitted without administrator authentication.</para>
+      By default, this action is permitted without administrator authentication. Cancellation of these
+      methods uses the polkit action <interfacename>org.freedesktop.sysupdate1.cancel-check</interfacename>.
+      By default, this cancellation action is permitted without administrator authentication.</para>
 
       <para><function>Acquire()</function> and <function>Install()</function>
       use the polkit action
       <interfacename>org.freedesktop.sysupdate1.update</interfacename> when no version is specified.
       By default, this action is permitted without administrator authentication. When a version is
       specified, <interfacename>org.freedesktop.sysupdate1.update-to-version</interfacename> is
-      used instead. By default, this alternate action requires administrator authentication.</para>
+      used instead. By default, this alternate action requires administrator authentication. Cancellation of
+      these methods uses the polkit actions
+      <interfacename>org.freedesktop.sysupdate1.cancel-update</interfacename> and
+      <interfacename>org.freedesktop.sysupdate1.cancel-update-to-version</interfacename>.
+      By default, these cancellation actions are permitted without administrator authentication.</para>
 
       <para><function>Vacuum()</function> uses the polkit action
       <interfacename>org.freedesktop.sysupdate1.vacuum</interfacename>. By default, this action requires
-      administrator authentication.</para>
+      administrator authentication. Cancellation of this method uses the polkit action
+      <interfacename>org.freedesktop.sysupdate1.cancel-vacuum</interfacename>.
+      By default, this cancellation action is permitted without administrator authentication.</para>
 
       <para><function>SetFeatureEnabled()</function> uses the polkit action
       <interfacename>org.freedesktop.sysupdate1.manage-features</interfacename>. By default, this action
-      requires administrator authentication.</para>
+      requires administrator authentication. Cancellation is not supported for this method.</para>
 
       <para><function>GetAppStream()</function>, <function>GetVersion()</function>,
       <function>ListFeatures()</function>, and <function>DescribeFeature()</function>
-      are unauthenticated and may be called by anybody.</para>
+      are unauthenticated and may be called by anybody. Cancellation is not supported for these methods, or
+      is always allowed without administrator authentication.</para>
 
       <para>All methods called on this interface expose additional variables to the polkit rules.
       <literal>class</literal> contains the class of the Target being acted upon, and <literal>name</literal>

--- a/src/sysupdate/org.freedesktop.sysupdate1.policy
+++ b/src/sysupdate/org.freedesktop.sysupdate1.policy
@@ -95,8 +95,8 @@
         </action>
 
         <action id="org.freedesktop.sysupdate1.vacuum">
-                <description gettext-domain="systemd">Cleanup old system updates</description>
-                <message gettext-domain="systemd">Authentication is required to cleanup old system updates.</message>
+                <description gettext-domain="systemd">Clean up old system updates</description>
+                <message gettext-domain="systemd">Authentication is required to clean up old system updates.</message>
                 <defaults>
                         <allow_any>auth_admin</allow_any>
                         <allow_inactive>auth_admin</allow_inactive>

--- a/src/sysupdate/org.freedesktop.sysupdate1.policy
+++ b/src/sysupdate/org.freedesktop.sysupdate1.policy
@@ -29,11 +29,24 @@
             a user at the console, and rpm-ostree (generally) needs an "administrative user" at the computer.
             Without this default, distributions hoping to use sysupdate as an update mechanism will have to
             set the policy to it anyhow.
+
+            Cancellation actions are always allowed by default, as the user can typically pull the plug on
+            the computer to prevent an action completing anyway.
         -->
 
         <action id="org.freedesktop.sysupdate1.check">
                 <description gettext-domain="systemd">Check for system updates</description>
                 <message gettext-domain="systemd">Authentication is required to check for system updates.</message>
+                <defaults>
+                        <allow_any>auth_admin</allow_any>
+                        <allow_inactive>auth_admin</allow_inactive>
+                        <allow_active>yes</allow_active>
+                </defaults>
+        </action>
+
+        <action id="org.freedesktop.sysupdate1.cancel-check">
+                <description gettext-domain="systemd">Cancel checking for system updates</description>
+                <message gettext-domain="systemd">Authentication is required to cancel checking for system updates.</message>
                 <defaults>
                         <allow_any>auth_admin</allow_any>
                         <allow_inactive>auth_admin</allow_inactive>
@@ -51,6 +64,16 @@
                 </defaults>
         </action>
 
+        <action id="org.freedesktop.sysupdate1.cancel-update">
+                <description gettext-domain="systemd">Cancel installing system updates</description>
+                <message gettext-domain="systemd">Authentication is required to cancel installing system updates.</message>
+                <defaults>
+                        <allow_any>auth_admin</allow_any>
+                        <allow_inactive>auth_admin</allow_inactive>
+                        <allow_active>yes</allow_active>
+                </defaults>
+        </action>
+
         <action id="org.freedesktop.sysupdate1.update-to-version">
                 <description gettext-domain="systemd">Install specific system version</description>
                 <message gettext-domain="systemd">Authentication is required to update the system to a specific (possibly old) version.</message>
@@ -61,6 +84,16 @@
                 </defaults>
         </action>
 
+        <action id="org.freedesktop.sysupdate1.cancel-update-to-version">
+                <description gettext-domain="systemd">Cancel installing specific system version</description>
+                <message gettext-domain="systemd">Authentication is required to cancel updating the system to a specific (possibly old) version.</message>
+                <defaults>
+                        <allow_any>auth_admin</allow_any>
+                        <allow_inactive>auth_admin</allow_inactive>
+                        <allow_active>yes</allow_active>
+                </defaults>
+        </action>
+
         <action id="org.freedesktop.sysupdate1.vacuum">
                 <description gettext-domain="systemd">Cleanup old system updates</description>
                 <message gettext-domain="systemd">Authentication is required to cleanup old system updates.</message>
@@ -68,6 +101,16 @@
                         <allow_any>auth_admin</allow_any>
                         <allow_inactive>auth_admin</allow_inactive>
                         <allow_active>auth_admin_keep</allow_active>
+                </defaults>
+        </action>
+
+        <action id="org.freedesktop.sysupdate1.cancel-vacuum">
+                <description gettext-domain="systemd">Cancel cleaning up old system updates</description>
+                <message gettext-domain="systemd">Authentication is required to cancel cleanup of old system updates.</message>
+                <defaults>
+                        <allow_any>auth_admin</allow_any>
+                        <allow_inactive>auth_admin</allow_inactive>
+                        <allow_active>yes</allow_active>
                 </defaults>
         </action>
 

--- a/src/sysupdate/sysupdated.c
+++ b/src/sysupdate/sysupdated.c
@@ -595,19 +595,19 @@ static int job_method_cancel(sd_bus_message *msg, void *userdata, sd_bus_error *
         case JOB_LIST:
         case JOB_DESCRIBE:
         case JOB_CHECK_NEW:
-                action = "org.freedesktop.sysupdate1.check";
+                action = "org.freedesktop.sysupdate1.cancel-check";
                 break;
 
         case JOB_ACQUIRE:
         case JOB_INSTALL:
                 if (j->version)
-                        action = "org.freedesktop.sysupdate1.update-to-version";
+                        action = "org.freedesktop.sysupdate1.cancel-update-to-version";
                 else
-                        action = "org.freedesktop.sysupdate1.update";
+                        action = "org.freedesktop.sysupdate1.cancel-update";
                 break;
 
         case JOB_VACUUM:
-                action = "org.freedesktop.sysupdate1.vacuum";
+                action = "org.freedesktop.sysupdate1.cancel-vacuum";
                 break;
 
         case JOB_DESCRIBE_FEATURE:


### PR DESCRIPTION
This allows us to have a separate, more permissive, policy for
cancelling ongoing sysupdate jobs. The new default policy for
cancellation actions is to allow them for the active user, without admin
authentication, because typically the user can just pull the plug on the
computer to cancel a job anyway.

Signed-off-by: Philip Withnall <pwithnall@gnome.org>
Fixes: https://github.com/systemd/systemd/issues/38568