### PR TITLE
gpt-auto-generator: mount ESP/XBOOTLDR independently of LoaderDevicePartUUID

### DIFF
--- a/src/gpt-auto-generator/gpt-auto-generator.c
+++ b/src/gpt-auto-generator/gpt-auto-generator.c
@@ -1075,7 +1075,6 @@ static int add_early_esp_mount(void) {
 }
 
 static int process_loader_partitions(DissectedPartition *esp, DissectedPartition *xbootldr) {
-        sd_id128_t loader_uuid;
         int r;
 
         assert(esp);
@@ -1093,35 +1092,6 @@ static int process_loader_partitions(DissectedPartition *esp, DissectedPartition
         if (r < 0)
                 log_debug_errno(r, "Failed to check fstab existing paths, ignoring: %m");
 
-        if (!is_efi_boot()) {
-                log_debug("Not an EFI boot, skipping loader partition UUID check.");
-                goto mount;
-        }
-
-        /* Let's check if LoaderDevicePartUUID points to either ESP or XBOOTLDR. We prefer it pointing
-         * to the ESP, but we accept XBOOTLDR too. If it points to neither of them, don't mount any
-         * loader partitions, since they are not the ones used for booting. */
-
-        r = efi_loader_get_device_part_uuid(&loader_uuid);
-        if (r == -ENOENT) {
-                log_debug_errno(r, "EFI loader partition unknown, skipping ESP and XBOOTLDR mounts.");
-                return 0;
-        }
-        if (r < 0)
-                return log_debug_errno(r, "Failed to read loader partition UUID, ignoring: %m");
-
-        if (esp->found && sd_id128_equal(esp->uuid, loader_uuid))
-                goto mount;
-
-        if (xbootldr->found && sd_id128_equal(xbootldr->uuid, loader_uuid)) {
-                log_debug("LoaderDevicePartUUID points to XBOOTLDR partition.");
-                goto mount;
-        }
-
-        log_debug("LoaderDevicePartUUID points to neither ESP nor XBOOTLDR, ignoring.");
-        return 0;
-
-mount:
         r = 0;
 
         if (xbootldr->found)

--- a/src/gpt-auto-generator/gpt-auto-generator.c
+++ b/src/gpt-auto-generator/gpt-auto-generator.c
@@ -2,8 +2,6 @@
 
 #include <sys/file.h>
 
-#include "sd-id128.h"
-
 #include "alloc-util.h"
 #include "blockdev-util.h"
 #include "device-util.h"


### PR DESCRIPTION
process_loader_partitions() was gating ESP and XBOOTLDR mounting on the value of the LoaderDevicePartUUID EFI variable. This is incorrect: LoaderDevicePartUUID is only meaningful for root partition discovery in the initrd. The post-initrd discovery of non-root partitions is documented as being independent of boot loader support.

This caused the ESP to not be mounted when booting via an EFI boot stub that does not set LoaderDevicePartUUID, even though the partition was correctly identified on the same disk as the root partition.

All other non-root partition types (home, srv, var, swap, etc.) are mounted purely on the basis of partition type and disk locality, with no reference to EFI variables. There is no justification for the ESP and XBOOTLDR to be treated differently, as the ambiguity of multiple partitions of the same type on the same disk is not unique to the ESP. Partition discovery is already constrained to the root disk by enumerate_partitions().

Remove the LoaderDevicePartUUID check from process_loader_partitions() entirely, so that ESP and XBOOTLDR mounting behaves consistently with all other non-root partition types.

See #42142 

Co-authored by Claude