### PR TITLE
mkosi: update debian commit reference to 3e1930512d1efee7e11b619a5f493b3229594a51

### DIFF
--- a/mkosi/mkosi.pkgenv/mkosi.conf.d/debian-ubuntu.conf
+++ b/mkosi/mkosi.pkgenv/mkosi.conf.d/debian-ubuntu.conf
@@ -9,5 +9,5 @@ Environment=
         GIT_URL=https://salsa.debian.org/systemd-team/systemd.git
         GIT_SUBDIR=debian
         GIT_BRANCH=debian/master
-        GIT_COMMIT=8b9ea8981eee267a2fa493435f2869f7b2479350
+        GIT_COMMIT=3e1930512d1efee7e11b619a5f493b3229594a51
         PKG_SUBDIR=debian


### PR DESCRIPTION
* 3e1930512d Downgrade dependency on dbus to recommends in sd-container
* 61d6ecf0a0 Conflict with sysuser-helper
* fbc4646437 autopkgtest: add dependency on procps