### PR TITLE
firstboot: make clear where the full screen console wizards end

### DIFF
--- a/src/firstboot/firstboot.c
+++ b/src/firstboot/firstboot.c
@@ -103,9 +103,10 @@ STATIC_DESTRUCTOR_REGISTER(arg_root_shell, freep);
 STATIC_DESTRUCTOR_REGISTER(arg_kernel_cmdline, freep);
 STATIC_DESTRUCTOR_REGISTER(arg_image_policy, image_policy_freep);
 
+static bool welcome_done = false;
+
 static void print_welcome(int rfd, sd_varlink **mute_console_link) {
         _cleanup_free_ char *pretty_name = NULL, *os_name = NULL, *ansi_color = NULL, *fancy_name = NULL;
-        static bool done = false;
         const char *pn, *ac;
         int r;
 
@@ -122,7 +123,7 @@ static void print_welcome(int rfd, sd_varlink **mute_console_link) {
         if (!arg_welcome)
                 return;
 
-        if (done) {
+        if (welcome_done) {
                 putchar('\n'); /* Add some breathing room between multiple prompts */
                 return;
         }
@@ -158,7 +159,7 @@ static void print_welcome(int rfd, sd_varlink **mute_console_link) {
         }
         printf("Please configure the system!\n\n");
 
-        done = true;
+        welcome_done = true;
 }
 
 static int should_configure(int dir_fd, const char *filename) {
@@ -1562,6 +1563,15 @@ static int reload_vconsole(sd_bus **bus) {
         return 0;
 }
 
+static void end_marker(void) {
+
+        if (!welcome_done)
+                return;
+
+        printf("\n%sExiting first boot settings tool.%s\n\n", ansi_grey(), ansi_normal());
+        fflush(stdout);
+}
+
 static int run(int argc, char *argv[]) {
         _cleanup_(sd_bus_flush_close_unrefp) sd_bus *bus = NULL;
         _cleanup_(loop_device_unrefp) LoopDevice *loop_device = NULL;
@@ -1627,6 +1637,7 @@ static int run(int argc, char *argv[]) {
         }
 
         LOG_SET_PREFIX(arg_image ?: arg_root);
+        DEFER_VOID_CALL(end_marker);
         DEFER_VOID_CALL(chrome_hide);
 
         /* We check these conditions here instead of in parse_argv() so that we can take the root directory

--- a/src/home/homectl.c
+++ b/src/home/homectl.c
@@ -5,6 +5,7 @@
 #include "sd-bus.h"
 #include "sd-varlink.h"
 
+#include "ansi-color.h"
 #include "ask-password-api.h"
 #include "bitfield.h"
 #include "build.h"
@@ -2979,6 +2980,11 @@ static int username_is_ok(const char *name, void *userdata) {
         return false;
 }
 
+static void end_marker(void) {
+        printf("\n%sExiting user account creation tool.%s\n\n", ansi_grey(), ansi_normal());
+        fflush(stdout);
+}
+
 static int create_interactively(void) {
         _cleanup_free_ char *username = NULL;
         int r;
@@ -2999,6 +3005,7 @@ static int create_interactively(void) {
         if (arg_chrome)
                 chrome_show("Create a User Account", /* bottom= */ NULL);
 
+        DEFER_VOID_CALL(end_marker);
         DEFER_VOID_CALL(chrome_hide);
 
         if (emoji_enabled()) {

--- a/src/sysinstall/sysinstall.c
+++ b/src/sysinstall/sysinstall.c
@@ -1249,6 +1249,15 @@ static int settle_definitions(void) {
         return 0;
 }
 
+static void end_marker(void) {
+
+        if (!arg_welcome)
+                return;
+
+        printf("\n%sExiting first boot settings tool.%s\n\n", ansi_grey(), ansi_normal());
+        fflush(stdout);
+}
+
 static int run(int argc, char *argv[]) {
         int r;
 
@@ -1275,6 +1284,7 @@ static int run(int argc, char *argv[]) {
                         chrome_show("Operating System Installer", /* bottom= */ NULL);
         }
 
+        DEFER_VOID_CALL(end_marker);
         DEFER_VOID_CALL(chrome_hide);
 
         _cleanup_(sd_varlink_flush_close_unrefp) sd_varlink *repart_link = NULL;


### PR DESCRIPTION
The three first boot screens are visually separated from the console output before them via the "chome" and welcome strings and sufficient whitespace. But so far they weren't from the output after them. This is sometimes a big confusing. Let's add a bit of a separator between the end and what comes next, too.

Just cosmetics, nothing else.