### PR TITLE
test: cover lingering users surviving a soft-reboot in TEST-82

### DIFF
--- a/test/units/TEST-82-SOFTREBOOT.sh
+++ b/test/units/TEST-82-SOFTREBOOT.sh
@@ -190,6 +190,17 @@ elif [ -f /run/TEST-82-SOFTREBOOT.touch ]; then
     test "$(systemctl show -P ActiveState TEST-82-SOFTREBOOT-nosurvive-sigterm.service)" != "active"
     test "$(systemctl show -P ActiveState TEST-82-SOFTREBOOT-nosurvive.service)" != "active"
 
+    # Regression test for #41789: the lingering user enabled on the first boot must
+    # have its user@.service started again after the soft reboot. Before the fix it
+    # was GC'd at logind startup and never restarted. Disable lingering again here,
+    # before the nextroot switch below (the third boot runs on a minimal overlay
+    # rootfs that does not have this user). terminate-user is best-effort: it can
+    # race the asynchronous disable-linger/UserStopDelaySec teardown.
+    linger_uid=$(id -u testuser)
+    timeout 30 bash -c "until systemctl is-active --quiet user@${linger_uid}.service; do sleep 1; done"
+    loginctl disable-linger testuser
+    loginctl terminate-user testuser || true
+
     # This time we test the /run/nextroot/ root switching logic. (We synthesize a new rootfs from the old via overlayfs)
     mkdir -p /run/nextroot /tmp/nextroot-lower /original-root
     mount -t tmpfs tmpfs /tmp/nextroot-lower
@@ -312,6 +323,18 @@ EOF
         # used instead of the bus ID)
         systemd-run --wait false || true
     done
+
+    # Regression test for #41789: a lingering user's user@.service must come back
+    # after a soft reboot, the same way it does after a hardware reboot. It used
+    # to be garbage-collected at logind startup (before user_start() ran), because
+    # /run/systemd/users is preserved across soft-reboot and fed the user into the
+    # GC queue while its units were not active yet. Enable lingering for the
+    # pre-existing testuser here; the second boot asserts the service is active
+    # again. testuser lives in the persistent rootfs, so it survives the
+    # (non-nextroot) soft reboot into the second boot.
+    loginctl enable-linger testuser
+    linger_uid=$(id -u testuser)
+    timeout 30 bash -c "until systemctl is-active --quiet user@${linger_uid}.service; do sleep 1; done"
 
     trigger_uevent
 


### PR DESCRIPTION
## Summary

Adds regression coverage for #41789 ("lingering users not automatically started after a soft reboot"), fixed in [`9f25feb4ed18`](https://github.com/systemd/systemd/commit/9f25feb4ed18) ("logind: keep lingering users at startup-time GC", #42124). That bug had no automated test; this closes the gap.

The fix was a one-liner in `user_may_gc()`. The failure mode is specific to soft-reboot (cold boot is unaffected because `/run/systemd/users` is empty and lingering users aren't enqueued for GC), so the test has to span a real soft-reboot — `TEST-82-SOFTREBOOT` already owns that multi-boot machinery, so the coverage lives there.

## What the test does

- **First boot:** create `softreboot-linger-user`, `loginctl enable-linger`, and wait (`timeout 30 … until systemctl is-active user@UID.service`) for the service to come up on a running system.
- **Second boot (after the first soft-reboot, same persistent rootfs):** assert `user@UID.service` is active again — the regression check. Then tear down (disable-linger → terminate-user → wait for the service to go inactive → `userdel --force --remove`) before the nextroot switch later in that boot (the third boot runs on a minimal overlay rootfs without this user).

The teardown stops the user manager before `userdel` on purpose: `disable-linger` is asynchronous and `UserStopDelaySec` keeps the manager around briefly, so a naive `userdel` would fail with "user currently logged in".

## Validation

Run locally in a qemu/KVM VM (aarch64) via `meson test --setup=integration -v TEST-82-SOFTREBOOT`:

- **With the fix present:** PASS. The second-boot assertion returns in well under a second (the lingering service is back almost immediately; 30 s is just a generous ceiling).
- **With the fix reverted** (rebuilt image, same VM): FAIL — the second-boot assertion times out (exit 124). The failing VM's logind journal confirms the mechanism: on the post-soft-reboot boot, logind enumerates uid 1000 from `/run/systemd/users`, checks its units (all inactive), and garbage-collects it before `user_start()` — `user@1000.service` only ever shows "Collecting", never starts. This confirms the test actually exercises the bug and isn't a tautology.

- `shellcheck -x` and `bash -n` clean.