### PR TITLE
TEST-08-INITRD: Set up exitrd on boot rather than including in image

### DIFF
--- a/mkosi/mkosi.conf
+++ b/mkosi/mkosi.conf
@@ -55,7 +55,6 @@ ExtraTrees=
         %O/minimal-1.root-%a-verity.raw:/usr/share/minimal_1.verity
         %O/minimal-1.root-%a-verity-sig.raw:/usr/share/minimal_1.verity.sig
         %O/minimal-base:/usr/share/TEST-13-NSPAWN-container-template
-        %O/initrd:/exitrd
 
 KernelInitrdModules=default
 

--- a/mkosi/mkosi.initrd.conf/mkosi.extra/usr/lib/systemd/system/initrd-run-initramfs.service
+++ b/mkosi/mkosi.initrd.conf/mkosi.extra/usr/lib/systemd/system/initrd-run-initramfs.service
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Unit]
+Description=Copy initrd contents to /run/initramfs to serve as exitrd
+DefaultDependencies=no
+AssertPathExists=/etc/initrd-release
+After=initrd.target
+Before=initrd-cleanup.service initrd-switch-root.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=mkdir -p /run/initramfs
+ExecStart=cp -a --one-file-system /. /run/initramfs/

--- a/test/integration-tests/TEST-08-INITRD/meson.build
+++ b/test/integration-tests/TEST-08-INITRD/meson.build
@@ -5,6 +5,7 @@ integration_tests += [
                 'name' : fs.name(meson.current_source_dir()),
                 'cmdline' : integration_test_template['cmdline'] + [
                         'rd.systemd.wants=initrd-run-mount.service',
+                        'rd.systemd.wants=initrd-run-initramfs.service',
                 ],
                 'exit-code' : 124,
                 'vm' : true,

--- a/test/units/TEST-08-INITRD.sh
+++ b/test/units/TEST-08-INITRD.sh
@@ -22,8 +22,8 @@ test -d /run/initrd-mount-target
 mountpoint /run/initrd-mount-target
 [[ -e /run/initrd-mount-target/hello-world ]]
 
-# Copy the prepared exitrd to its intended location.
-mkdir -p /run/initramfs
-unzstd --stdout /exitrd | cpio --extract --make-directories --directory /run/initramfs/
+# The initrd-run-initramfs.service in the initrd should have populated /run/initramfs
+# from the initrd's own contents before switch-root.
+test -x /run/initramfs/shutdown
 
 touch /testok


### PR DESCRIPTION
Just copy the initramfs from the VM rather than doing it during
the image build.
