### PR TITLE
systemctl: also attempt kexec image extraction on EINVAL

### DIFF
--- a/src/systemctl/systemctl-start-special.c
+++ b/src/systemctl/systemctl-start-special.c
@@ -113,9 +113,14 @@ static int load_kexec_kernel(void) {
 
         int saved_errno = errno;
 
-        if (saved_errno == ENOEXEC) {
+        if (IN_SET(saved_errno, ENOEXEC, EINVAL)) {
                 /* The kernel didn't recognize the image format. Try decompressing or extracting the
-                 * kernel (e.g. compressed Image, ZBOOT PE, or UKI) and loading again. */
+                 * kernel (e.g. compressed Image, ZBOOT PE, or UKI) and loading again.
+                 *
+                 * Most architectures' kexec_file_load() returns ENOEXEC when no image loader matches
+                 * (the default behavior of kexec_image_probe_default()), but arm64's image_probe()
+                 * returns EINVAL for an unrecognized magic. Accept both, otherwise `systemctl kexec`
+                 * of a UKI never reaches the extraction path on arm64. */
                 log_debug_errno(saved_errno, "Kernel rejected image, trying decompression/extraction: %m");
 
                 _cleanup_close_ int extracted_kernel_fd = -EBADF, extracted_initrd_fd = -EBADF;


### PR DESCRIPTION
## Summary

On arm64, `systemctl kexec` of a UKI is broken: it fails with `kexec_file_load() failed ... Invalid argument` and then `/usr/sbin/kexec is not available`.

`load_kexec_kernel()` (`src/systemctl/systemctl-start-special.c`) calls `kexec_file_load()` with the boot entry's kernel. When the kernel rejects the image, it has a fallback that extracts the bare kernel from a compressed Image / ZBOOT PE / **UKI** (`kexec_maybe_decompress_kernel()` → `extract_uki()`) and retries. But that fallback is gated on `if (saved_errno == ENOEXEC)`.

The problem is the errno is architecture-dependent:

- x86's `bzImage64_probe()` and the generic `kexec_image_probe_default()` return **`-ENOEXEC`** for an unrecognized image.
- arm64's `image_probe()` (`arch/arm64/kernel/kexec_image.c`) returns **`-EINVAL`** on an `ARM64_IMAGE_MAGIC` mismatch. arm64 registers a single kexec file loader, and `kexec_image_probe_default()` returns that loader's errno, so userspace sees `EINVAL`.

So on arm64 the extraction path is never reached, and `systemctl kexec` falls back to the `/usr/sbin/kexec` binary — which is no longer a dependency since `e107c7ead0` ("systemctl: replace kexec-tools dependency with direct kexec_file_load() syscall", #41390). The net effect: `systemctl kexec` of a UKI cannot work on arm64.

## Fix

Accept `EINVAL` in addition to `ENOEXEC` before attempting extraction (one line + comment).

This is **safe**: `kexec_maybe_decompress_kernel()` re-gates on the actual file magic (`MZ` / compression headers) and is a no-op returning 0 for anything it doesn't recognize. So an `EINVAL` that is *not* a format mismatch (e.g. a bare Image rejected for an unrelated reason) doesn't match any magic, returns 0, and falls straight through to the existing fallback exactly as before — no risk of mis-loading.

## Why fix it in systemd (not only the kernel)

arm64 returning `EINVAL` for an unrecognized image magic is long-standing behavior. systemd must keep working with already-shipped kernels, so the userspace accommodation is the right layer. (Aligning arm64's `image_probe()` to return `-ENOEXEC` like the generic/x86 path would be a reasonable separate kernel cleanup, but can't be a prerequisite.)

## Validation

Reproduced and validated in a real qemu/KVM **aarch64** VM running a custom Linux 6.19 kernel built with KHO + LUO, via the `TEST-91-LIVEUPDATE` integration test:

- **Without this patch:** `TEST-91-LIVEUPDATE` fails at the kexec step — journal shows `kexec_file_load() failed, falling back to /usr/sbin/kexec binary: Invalid argument` → `/usr/sbin/kexec is not available`.
- **With this patch:** `TEST-91-LIVEUPDATE` passes end-to-end, including the real kexec transition and LUO FD-store hand-over across the kernel switch.
- Controlled negative test: same image, single-variable revert of just this change → fail; restore → pass. (The failure mechanism is also deductively certain from the source paths above; the negative test confirms the patch is necessary and sufficient.)

Note: in the test the `LoaderEntrySelected` EFI variables were absent, so systemd resolved the entry by scanning `/boot/EFI/Linux/`. That only affects *which* UKI is selected; the subsequent `kexec_file_load(<UKI>) → EINVAL` is the same on any arm64 system, so this isn't an artifact of the test setup.

## Related

- #28538 (UKI + systemctl kexec)
- Regression surfaced by #41390 (kexec-tools removal)