### PR TITLE
ci: ignore failures to chown journal in mkosi job

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -131,7 +131,7 @@ jobs:
 
       - name: Fix journal ownership
         if: failure() && (github.repository == 'systemd/systemd' || github.repository == 'systemd/systemd-stable')
-        run: sudo chown -R "$(id -u):$(id -g)" build/test/journal build/meson-logs
+        run: sudo chown -R "$(id -u):$(id -g)" build/test/journal build/meson-logs || true
 
       - name: Archive failed test journals
         uses: actions/upload-artifact@v7

--- a/.github/workflows/mkosi.yml
+++ b/.github/workflows/mkosi.yml
@@ -320,7 +320,7 @@ jobs:
 
       - name: Fix journal ownership
         if: failure() && (github.repository == 'systemd/systemd' || github.repository == 'systemd/systemd-stable')
-        run: sudo chown -R "$(id -u):$(id -g)" build/test/journal build/meson-logs
+        run: sudo chown -R "$(id -u):$(id -g)" build/test/journal build/meson-logs || true
 
       - name: Archive failed test journals
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
Otherwise when the build fails, this fails, and the GUI jumps to the chown failure instead of the actual failure

Follow-up for 35bf1c826454bfcaa3c93cae950d36fa216ac3ce