### PR TITLE
sd-dhcp-server: drop unused enum

### DIFF
--- a/src/libsystemd-network/dhcp-server-internal.h
+++ b/src/libsystemd-network/dhcp-server-internal.h
@@ -13,17 +13,6 @@
 #include "sparse-endian.h"
 #include "tlv-util.h"
 
-typedef enum DHCPRawOption {
-        DHCP_RAW_OPTION_DATA_UINT8,
-        DHCP_RAW_OPTION_DATA_UINT16,
-        DHCP_RAW_OPTION_DATA_UINT32,
-        DHCP_RAW_OPTION_DATA_STRING,
-        DHCP_RAW_OPTION_DATA_IPV4ADDRESS,
-        DHCP_RAW_OPTION_DATA_IPV6ADDRESS,
-        _DHCP_RAW_OPTION_DATA_MAX,
-        _DHCP_RAW_OPTION_DATA_INVALID,
-} DHCPRawOption;
-
 typedef struct sd_dhcp_server {
         unsigned n_ref;
 


### PR DESCRIPTION
Follow-up for 2e5580a8c12427ddf421b7fee7be3677ff41bd5b.