### PR TITLE
sd-dhcp-server-lease: always update all information in bound lease

### DIFF
--- a/src/libsystemd-network/sd-dhcp-server-lease.c
+++ b/src/libsystemd-network/sd-dhcp-server-lease.c
@@ -65,7 +65,6 @@ int dhcp_server_put_lease(sd_dhcp_server *server, sd_dhcp_server_lease *lease, b
 }
 
 int dhcp_server_set_lease(sd_dhcp_server *server, DHCPRequest *req) {
-        _cleanup_(sd_dhcp_server_lease_unrefp) sd_dhcp_server_lease *lease = NULL;
         int r;
 
         assert(server);
@@ -78,9 +77,10 @@ int dhcp_server_set_lease(sd_dhcp_server *server, DHCPRequest *req) {
         if (r < 0)
                 return r;
 
-        /* If a lease for the host already exists, update it. */
-        lease = hashmap_get(server->bound_leases_by_client_id, &req->client_id);
+        _cleanup_(sd_dhcp_server_lease_unrefp) sd_dhcp_server_lease *lease =
+                hashmap_get(server->bound_leases_by_client_id, &req->client_id);
         if (lease) {
+                /* If a lease for the host already exists, update it. */
                 if (lease->address != req->address) {
                         hashmap_remove_value(server->bound_leases_by_address, UINT32_TO_PTR(lease->address), lease);
                         lease->address = req->address;
@@ -90,36 +90,34 @@ int dhcp_server_set_lease(sd_dhcp_server *server, DHCPRequest *req) {
                                 return r;
                 }
 
+                lease->htype = req->message->header.htype;
+                lease->hw_addr = req->hw_addr;
+                lease->gateway = req->message->header.giaddr;
                 lease->expiration = expiration;
+        } else {
+                /* Otherwise, add a new lease. */
+                lease = new(sd_dhcp_server_lease, 1);
+                if (!lease)
+                        return -ENOMEM;
 
-                TAKE_PTR(lease);
-                return 0;
+                *lease = (sd_dhcp_server_lease) {
+                        .n_ref = 1,
+                        .client_id = req->client_id,
+                        .htype = req->message->header.htype,
+                        .hw_addr = req->hw_addr,
+                        .address = req->address,
+                        .gateway = req->message->header.giaddr,
+                        .expiration = expiration,
+                };
+
+                r = dhcp_server_put_lease(server, lease, /* is_static= */ false);
+                if (r < 0)
+                        return r;
         }
 
-        /* Otherwise, add a new lease. */
-
-        lease = new(sd_dhcp_server_lease, 1);
-        if (!lease)
-                return -ENOMEM;
-
-        *lease = (sd_dhcp_server_lease) {
-                .n_ref = 1,
-                .address = req->address,
-                .client_id = req->client_id,
-                .htype = req->message->header.htype,
-                .gateway = req->message->header.giaddr,
-                .expiration = expiration,
-        };
-
-        lease->hw_addr = req->hw_addr;
-
-        char *hostname;
-        if (dhcp_message_get_option_hostname(req->message, &hostname) >= 0)
-                free_and_replace(lease->hostname, hostname);
-
-        r = dhcp_server_put_lease(server, lease, /* is_static= */ false);
-        if (r < 0)
-                return r;
+        char *hostname = NULL;
+        (void) dhcp_message_get_option_hostname(req->message, &hostname);
+        free_and_replace(lease->hostname, hostname);
 
         TAKE_PTR(lease);
         return 0;


### PR DESCRIPTION
We manage bound leases by their client ID. Hence, potentially, other fields may be changed. Let's always update all information.