### PR TITLE
Add varlink interface for sysinstall

### DIFF
--- a/src/repart/repart.c
+++ b/src/repart/repart.c
@@ -2905,6 +2905,10 @@ static int context_notify(
                                 JSON_BUILD_PAIR_UNSIGNED_NOT_EQUAL("progress", percent, UINT_MAX));
                 if (r < 0)
                         log_debug_errno(r, "Failed to send varlink notify progress notification, ignoring: %m");
+
+                r = sd_varlink_flush(c->link);
+                if (r < 0)
+                        log_debug_errno(r, "Failed to flush varlink notify progress notification, ignoring: %m");
         }
 
         return 0;

--- a/src/shared/meson.build
+++ b/src/shared/meson.build
@@ -253,6 +253,7 @@ shared_sources = files(
         'varlink-io.systemd.oom.c',
         'varlink-io.systemd.oom.Prekill.c',
         'varlink-io.systemd.service.c',
+        'varlink-io.systemd.Sysinstall.c',
         'varlink-io.systemd.sysext.c',
         'varlink-serialize.c',
         'vconsole-util.c',

--- a/src/shared/meson.build
+++ b/src/shared/meson.build
@@ -251,6 +251,7 @@ shared_sources = files(
         'varlink-io.systemd.Resolve.Monitor.c',
         'varlink-io.systemd.Shutdown.c',
         'varlink-io.systemd.StorageProvider.c',
+        'varlink-io.systemd.SysInstall.c',
         'varlink-io.systemd.SysUpdate.c',
         'varlink-io.systemd.SysUpdate.Notify.c',
         'varlink-io.systemd.Udev.c',

--- a/src/shared/meson.build
+++ b/src/shared/meson.build
@@ -253,6 +253,7 @@ shared_sources = files(
         'varlink-io.systemd.oom.c',
         'varlink-io.systemd.oom.Prekill.c',
         'varlink-io.systemd.service.c',
+        'varlink-io.systemd.SysInstall.c',
         'varlink-io.systemd.sysext.c',
         'varlink-serialize.c',
         'vconsole-util.c',

--- a/src/shared/varlink-io.systemd.Repart.c
+++ b/src/shared/varlink-io.systemd.Repart.c
@@ -29,7 +29,7 @@ static SD_VARLINK_DEFINE_ENUM_TYPE(
                 SD_VARLINK_FIELD_COMMENT("Always create a new partition table, potentially overwriting an existing table"),
                 SD_VARLINK_DEFINE_ENUM_VALUE(force));
 
-static SD_VARLINK_DEFINE_ENUM_TYPE(
+SD_VARLINK_DEFINE_ENUM_TYPE(
                 BlockDeviceAction,
                 SD_VARLINK_FIELD_COMMENT("The device is currently present and a candidate. Emitted both during the initial enumeration and for live uevents (any action other than 'remove' is propagated as 'add', including the synthesized transitions when a device becomes empty or read-only and a relevant ignore* input is in effect)."),
                 SD_VARLINK_DEFINE_ENUM_VALUE(add),
@@ -93,9 +93,9 @@ static SD_VARLINK_DEFINE_METHOD_FULL(
                 SD_VARLINK_DEFINE_OUTPUT(subsystem, SD_VARLINK_STRING, SD_VARLINK_NULLABLE));
 
 
-static SD_VARLINK_DEFINE_ERROR(NoCandidateDevices);
-static SD_VARLINK_DEFINE_ERROR(ConflictingDiskLabelPresent);
-static SD_VARLINK_DEFINE_ERROR(
+SD_VARLINK_DEFINE_ERROR(NoCandidateDevices);
+SD_VARLINK_DEFINE_ERROR(ConflictingDiskLabelPresent);
+SD_VARLINK_DEFINE_ERROR(
                 InsufficientFreeSpace,
                 SD_VARLINK_FIELD_COMMENT("Minimal size of the disk required for the installation."),
                 SD_VARLINK_DEFINE_FIELD(minimalSizeBytes, SD_VARLINK_INT, SD_VARLINK_NULLABLE),
@@ -103,7 +103,7 @@ static SD_VARLINK_DEFINE_ERROR(
                 SD_VARLINK_DEFINE_FIELD(needFreeBytes, SD_VARLINK_INT, SD_VARLINK_NULLABLE),
                 SD_VARLINK_FIELD_COMMENT("Size of the selected block device."),
                 SD_VARLINK_DEFINE_FIELD(currentSizeBytes, SD_VARLINK_INT, SD_VARLINK_NULLABLE));
-static SD_VARLINK_DEFINE_ERROR(
+SD_VARLINK_DEFINE_ERROR(
                 DiskTooSmall,
                 SD_VARLINK_FIELD_COMMENT("Minimal size of the disk required for the installation."),
                 SD_VARLINK_DEFINE_FIELD(minimalSizeBytes, SD_VARLINK_INT, SD_VARLINK_NULLABLE),

--- a/src/shared/varlink-io.systemd.Repart.h
+++ b/src/shared/varlink-io.systemd.Repart.h
@@ -4,3 +4,9 @@
 #include "sd-varlink-idl.h"
 
 extern const sd_varlink_interface vl_interface_io_systemd_Repart;
+extern const sd_varlink_symbol vl_type_BlockDeviceAction;
+
+extern const sd_varlink_symbol vl_error_NoCandidateDevices;
+extern const sd_varlink_symbol vl_error_ConflictingDiskLabelPresent;
+extern const sd_varlink_symbol vl_error_InsufficientFreeSpace;
+extern const sd_varlink_symbol vl_error_DiskTooSmall;

--- a/src/shared/varlink-io.systemd.SysInstall.c
+++ b/src/shared/varlink-io.systemd.SysInstall.c
@@ -1,0 +1,129 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include "sd-varlink-idl.h"
+
+#include "varlink-io.systemd.SysInstall.h"
+
+static SD_VARLINK_DEFINE_ENUM_TYPE(
+                ProgressPhase,
+
+                SD_VARLINK_DEFINE_ENUM_VALUE(load_credentials),
+                SD_VARLINK_DEFINE_ENUM_VALUE(encrypt_credentials),
+                SD_VARLINK_DEFINE_ENUM_VALUE(install_partitions),
+                SD_VARLINK_DEFINE_ENUM_VALUE(mount_partitions),
+                SD_VARLINK_DEFINE_ENUM_VALUE(install_kernel),
+                SD_VARLINK_DEFINE_ENUM_VALUE(install_bootloader),
+                SD_VARLINK_DEFINE_ENUM_VALUE(unmount_partitions));
+
+static SD_VARLINK_DEFINE_ENUM_TYPE(
+                DeviceFit,
+
+                SD_VARLINK_DEFINE_ENUM_VALUE(enough_free_space),
+                SD_VARLINK_DEFINE_ENUM_VALUE(insufficent_free_space),
+                SD_VARLINK_DEFINE_ENUM_VALUE(disk_too_small),
+                SD_VARLINK_DEFINE_ENUM_VALUE(conflicting_disk_label_present));
+
+static SD_VARLINK_DEFINE_METHOD_FULL(
+                Run,
+                SD_VARLINK_SUPPORTS_MORE,
+                SD_VARLINK_FIELD_COMMENT("Full path to the block device node to operate on. If omitted, dryRun must be true, in which case the minimal disk size is determined."),
+                SD_VARLINK_DEFINE_INPUT(node, SD_VARLINK_STRING, 0),
+                SD_VARLINK_FIELD_COMMENT("Path to directory containing definition files."),
+                SD_VARLINK_DEFINE_INPUT(definitions, SD_VARLINK_STRING, SD_VARLINK_ARRAY|SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("If true, fully erase the target block device."),
+                SD_VARLINK_DEFINE_INPUT(erase, SD_VARLINK_BOOL, 0),
+                SD_VARLINK_FIELD_COMMENT("If true, this modifies EFI variables."),
+                SD_VARLINK_DEFINE_INPUT(variables, SD_VARLINK_BOOL, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("The path to a kernel image, if missing the current kernel is used."),
+                SD_VARLINK_DEFINE_INPUT(kernelImage, SD_VARLINK_STRING, SD_VARLINK_NULLABLE),
+
+
+                SD_VARLINK_FIELD_COMMENT("If true, copy current locale to target system"),
+                SD_VARLINK_DEFINE_INPUT(copyLocale, SD_VARLINK_BOOL, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("If true, copy current keymap to target system"),
+                SD_VARLINK_DEFINE_INPUT(copyKeymap, SD_VARLINK_BOOL, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("If true, copy current timezone to target system"),
+                SD_VARLINK_DEFINE_INPUT(copyTimezone, SD_VARLINK_BOOL, SD_VARLINK_NULLABLE),
+
+                SD_VARLINK_FIELD_COMMENT("A list of credentials with literal value in format 'ID:VALUE' to be installed on the new system."),
+                SD_VARLINK_DEFINE_INPUT(setCredentials, SD_VARLINK_STRING, SD_VARLINK_ARRAY|SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("A list of credentials to be loaded in format 'ID:PATH' to be installed on the new system."),
+                SD_VARLINK_DEFINE_INPUT(loadCredentials, SD_VARLINK_STRING, SD_VARLINK_ARRAY|SD_VARLINK_NULLABLE),
+
+                SD_VARLINK_FIELD_COMMENT("If used with the 'more' flag, a phase identifier is sent in progress updates."),
+                SD_VARLINK_DEFINE_OUTPUT_BY_TYPE(phase, ProgressPhase, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("If used with the 'more' flag, an object identifier string is sent in progress updates."),
+                SD_VARLINK_DEFINE_OUTPUT(object, SD_VARLINK_STRING, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("If used with the 'more' flag, a progress percentage (specific to the work done for the specified phase+object is sent in progress updates)."),
+                SD_VARLINK_DEFINE_OUTPUT(progress, SD_VARLINK_INT, SD_VARLINK_NULLABLE));
+
+static SD_VARLINK_DEFINE_METHOD_FULL(
+                ListCandidateDevices,
+                SD_VARLINK_REQUIRES_MORE,
+                SD_VARLINK_FIELD_COMMENT("Path to directory containing definition files."),
+                SD_VARLINK_DEFINE_INPUT(definitions, SD_VARLINK_STRING, SD_VARLINK_ARRAY|SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("The device node path of the block device."),
+                SD_VARLINK_DEFINE_OUTPUT(node, SD_VARLINK_STRING, 0),
+                SD_VARLINK_FIELD_COMMENT("List of symlinks pointing to the device node, if any."),
+                SD_VARLINK_DEFINE_OUTPUT(symlinks, SD_VARLINK_STRING, SD_VARLINK_ARRAY|SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("The Linux kernel disk sequence number identifying the medium."),
+                SD_VARLINK_DEFINE_OUTPUT(diskseq, SD_VARLINK_INT, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("The size of the block device in bytes."),
+                SD_VARLINK_DEFINE_OUTPUT(sizeBytes, SD_VARLINK_INT, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("The device vendor string if known."),
+                SD_VARLINK_DEFINE_OUTPUT(vendor, SD_VARLINK_STRING, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("The device model string if known."),
+                SD_VARLINK_DEFINE_OUTPUT(model, SD_VARLINK_STRING, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("The subsystem the block device belongs to if known."),
+                SD_VARLINK_DEFINE_OUTPUT(subsystem, SD_VARLINK_STRING, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("The fit indicating whether the OS would have enough available space on the device."),
+                SD_VARLINK_DEFINE_OUTPUT_BY_TYPE(fit, DeviceFit, 0),
+                SD_VARLINK_FIELD_COMMENT("Minimal size of the disk required for the installation."),
+                SD_VARLINK_DEFINE_FIELD(minimalSizeBytes, SD_VARLINK_INT, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("Additional free space needed for the installation."),
+                SD_VARLINK_DEFINE_FIELD(needFreeBytes, SD_VARLINK_INT, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("Current allocated size of this block device."),
+                SD_VARLINK_DEFINE_FIELD(currentSizeBytes, SD_VARLINK_INT, SD_VARLINK_NULLABLE));
+
+
+static SD_VARLINK_DEFINE_ERROR(NoCandidateDevices);
+static SD_VARLINK_DEFINE_ERROR(ConflictingDiskLabelPresent);
+static SD_VARLINK_DEFINE_ERROR(
+                InsufficientFreeSpace,
+                SD_VARLINK_FIELD_COMMENT("Minimal size of the disk required for the installation."),
+                SD_VARLINK_DEFINE_FIELD(minimalSizeBytes, SD_VARLINK_INT, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("Additional free space needed on the selected disk."),
+                SD_VARLINK_DEFINE_FIELD(needFreeBytes, SD_VARLINK_INT, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("Size of the selected block device."),
+                SD_VARLINK_DEFINE_FIELD(currentSizeBytes, SD_VARLINK_INT, SD_VARLINK_NULLABLE));
+static SD_VARLINK_DEFINE_ERROR(
+                DiskTooSmall,
+                SD_VARLINK_FIELD_COMMENT("Minimal size of the disk required for the installation."),
+                SD_VARLINK_DEFINE_FIELD(minimalSizeBytes, SD_VARLINK_INT, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("Actual size of the selected block device."),
+                SD_VARLINK_DEFINE_FIELD(currentSizeBytes, SD_VARLINK_INT, SD_VARLINK_NULLABLE));
+
+SD_VARLINK_DEFINE_INTERFACE(
+                io_systemd_SysInstall,
+                "io.systemd.SysInstall",
+                SD_VARLINK_INTERFACE_COMMENT("API for installing the OS to another block device."),
+
+                SD_VARLINK_SYMBOL_COMMENT("Progress phase identifiers. Note that we might add more phases here, and thus identifiers. Frontends can choose to display the phase to the user in some human readable form, or not do that, but if they do it and they receive a notification for a so far unknown phase, they should just ignore it."),
+                &vl_type_ProgressPhase,
+
+                SD_VARLINK_SYMBOL_COMMENT(""),
+                &vl_type_DeviceFit,
+
+                SD_VARLINK_SYMBOL_COMMENT("Invoke the actual installation of the OS. If invoked with 'more' enabled will report progress, otherwise will just report completion."),
+                &vl_method_Run,
+                SD_VARLINK_SYMBOL_COMMENT("An incompatible disk label present, and not told to erase it."),
+                &vl_error_ConflictingDiskLabelPresent,
+                SD_VARLINK_SYMBOL_COMMENT("The target disk has insufficient free space to fit all requested partitions. (But the disk would fit, if emptied.)"),
+                &vl_error_InsufficientFreeSpace,
+                SD_VARLINK_SYMBOL_COMMENT("The target disk is too small to fit the installation. (Regardless if emptied or not.)"),
+                &vl_error_DiskTooSmall,
+
+                SD_VARLINK_SYMBOL_COMMENT("Return a list of candidate block devices, i.e. that support partition scanning and other requirements for successful operation."),
+                &vl_method_ListCandidateDevices,
+                SD_VARLINK_SYMBOL_COMMENT("Not a single candidate block device could be found."),
+                &vl_error_NoCandidateDevices);

--- a/src/shared/varlink-io.systemd.SysInstall.c
+++ b/src/shared/varlink-io.systemd.SysInstall.c
@@ -1,0 +1,125 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include "sd-varlink-idl.h"
+
+#include "varlink-io.systemd.SysInstall.h"
+#include "varlink-io.systemd.Repart.h"
+
+static SD_VARLINK_DEFINE_ENUM_TYPE(
+                ProgressPhase,
+
+                SD_VARLINK_DEFINE_ENUM_VALUE(encrypt_credentials),
+                SD_VARLINK_DEFINE_ENUM_VALUE(install_partitions),
+                SD_VARLINK_DEFINE_ENUM_VALUE(mount_partitions),
+                SD_VARLINK_DEFINE_ENUM_VALUE(install_kernel),
+                SD_VARLINK_DEFINE_ENUM_VALUE(install_bootloader),
+                SD_VARLINK_DEFINE_ENUM_VALUE(unmount_partitions));
+
+static SD_VARLINK_DEFINE_ENUM_TYPE(
+                DeviceFit,
+
+                SD_VARLINK_DEFINE_ENUM_VALUE(enough_free_space),
+                SD_VARLINK_DEFINE_ENUM_VALUE(insufficent_free_space),
+                SD_VARLINK_DEFINE_ENUM_VALUE(disk_too_small),
+                SD_VARLINK_DEFINE_ENUM_VALUE(conflicting_disk_label_present));
+
+static SD_VARLINK_DEFINE_STRUCT_TYPE(
+                Credential,
+                SD_VARLINK_FIELD_COMMENT("The id of the credential."),
+                SD_VARLINK_DEFINE_FIELD(id, SD_VARLINK_STRING, 0),
+                SD_VARLINK_FIELD_COMMENT("The value of the credential in base64 encoding."),
+                SD_VARLINK_DEFINE_FIELD(value, SD_VARLINK_STRING, 0));
+
+static SD_VARLINK_DEFINE_METHOD_FULL(
+                Run,
+                SD_VARLINK_SUPPORTS_MORE,
+                SD_VARLINK_FIELD_COMMENT("Full path to the block device node to operate on."),
+                SD_VARLINK_DEFINE_INPUT(node, SD_VARLINK_STRING, 0),
+                SD_VARLINK_FIELD_COMMENT("Path to directory containing definition files."),
+                SD_VARLINK_DEFINE_INPUT(definitions, SD_VARLINK_STRING, SD_VARLINK_ARRAY|SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("If true, fully erase the target block device."),
+                SD_VARLINK_DEFINE_INPUT(erase, SD_VARLINK_BOOL, 0),
+                SD_VARLINK_FIELD_COMMENT("If true, EFI variables are modified to register the installed boot loader in the firmware's boot options database."),
+                SD_VARLINK_DEFINE_INPUT(variables, SD_VARLINK_BOOL, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("The path to a kernel image, if missing the current kernel is dedected and used."),
+                SD_VARLINK_DEFINE_INPUT(kernelImagePath, SD_VARLINK_STRING, SD_VARLINK_NULLABLE),
+
+                SD_VARLINK_FIELD_COMMENT("If true, the current locale is copied to target system"),
+                SD_VARLINK_DEFINE_INPUT(copyLocale, SD_VARLINK_BOOL, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("If true, the current keymap is copied to target system"),
+                SD_VARLINK_DEFINE_INPUT(copyKeymap, SD_VARLINK_BOOL, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("If true, the current timezone is copied to target system"),
+                SD_VARLINK_DEFINE_INPUT(copyTimezone, SD_VARLINK_BOOL, SD_VARLINK_NULLABLE),
+
+                SD_VARLINK_FIELD_COMMENT("A list of credentials to be installed to target system."),
+                SD_VARLINK_DEFINE_INPUT_BY_TYPE(credentials, Credential, SD_VARLINK_ARRAY|SD_VARLINK_NULLABLE),
+
+                SD_VARLINK_FIELD_COMMENT("If used with the 'more' flag, a phase identifier is sent in progress updates."),
+                SD_VARLINK_DEFINE_OUTPUT_BY_TYPE(phase, ProgressPhase, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("If used with the 'more' flag, an object identifier string is sent in progress updates."),
+                SD_VARLINK_DEFINE_OUTPUT(object, SD_VARLINK_STRING, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("If used with the 'more' flag, a progress percentage (specific to the work done for the specified phase+object is sent in progress updates)."),
+                SD_VARLINK_DEFINE_OUTPUT(progress, SD_VARLINK_INT, SD_VARLINK_NULLABLE));
+
+static SD_VARLINK_DEFINE_METHOD_FULL(
+                ListCandidateDevices,
+                SD_VARLINK_REQUIRES_MORE,
+                SD_VARLINK_FIELD_COMMENT("Path to directory containing definition files, used to evaluate the fit of the target OS for each block device."),
+                SD_VARLINK_DEFINE_INPUT(definitions, SD_VARLINK_STRING, SD_VARLINK_ARRAY|SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("If true, keep the call open after the initial enumeration and stream live add/remove notifications as block-subsystem uevents arrive. The end of the initial enumeration is marked by exactly one notification with action='ready' and no other fields. Defaults to false."),
+                SD_VARLINK_DEFINE_INPUT(subscribe, SD_VARLINK_BOOL, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("Discriminator field. Only set in subscribe mode. 'add' carries the full device record, 'remove' carries only node, 'ready' carries no other fields and is sent once after the initial enumeration."),
+                SD_VARLINK_DEFINE_OUTPUT_BY_TYPE(action, BlockDeviceAction, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("The device node path of the block device."),
+                SD_VARLINK_DEFINE_OUTPUT(node, SD_VARLINK_STRING, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("List of symlinks pointing to the device node, if any."),
+                SD_VARLINK_DEFINE_OUTPUT(symlinks, SD_VARLINK_STRING, SD_VARLINK_ARRAY|SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("The Linux kernel disk sequence number identifying the medium."),
+                SD_VARLINK_DEFINE_OUTPUT(diskseq, SD_VARLINK_INT, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("The size of the block device in bytes."),
+                SD_VARLINK_DEFINE_OUTPUT(sizeBytes, SD_VARLINK_INT, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("The device vendor string if known."),
+                SD_VARLINK_DEFINE_OUTPUT(vendor, SD_VARLINK_STRING, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("The device model string if known."),
+                SD_VARLINK_DEFINE_OUTPUT(model, SD_VARLINK_STRING, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("The subsystem the block device belongs to if known."),
+                SD_VARLINK_DEFINE_OUTPUT(subsystem, SD_VARLINK_STRING, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("The fit indicating whether the OS would have enough available space on the device."),
+                SD_VARLINK_DEFINE_OUTPUT_BY_TYPE(fit, DeviceFit, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("Minimal size of the disk required for the installation."),
+                SD_VARLINK_DEFINE_OUTPUT(minimalSizeBytes, SD_VARLINK_INT, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("Additional free space needed for the installation."),
+                SD_VARLINK_DEFINE_OUTPUT(needFreeBytes, SD_VARLINK_INT, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("Current allocated size of this block device."),
+                SD_VARLINK_DEFINE_OUTPUT(currentSizeBytes, SD_VARLINK_INT, SD_VARLINK_NULLABLE));
+
+SD_VARLINK_DEFINE_INTERFACE(
+                io_systemd_SysInstall,
+                "io.systemd.SysInstall",
+                SD_VARLINK_INTERFACE_COMMENT("API for installing the OS to another block device."),
+
+                SD_VARLINK_SYMBOL_COMMENT("Progress phase identifiers. Note that we might add more phases here, and thus identifiers. Frontends can choose to display the phase to the user in some human readable form, or not do that, but if they do it and they receive a notification for a so far unknown phase, they should just ignore it."),
+                &vl_type_ProgressPhase,
+
+                SD_VARLINK_SYMBOL_COMMENT("Description about the fit of an OS on a block device."),
+                &vl_type_DeviceFit,
+
+                SD_VARLINK_SYMBOL_COMMENT("Discriminator on streamed ListCandidateDevices replies in subscribe mode."),
+                &vl_type_BlockDeviceAction,
+
+                SD_VARLINK_SYMBOL_COMMENT("A credential to install to target OS."),
+                &vl_type_Credential,
+
+                SD_VARLINK_SYMBOL_COMMENT("Invoke the actual installation of the OS. If invoked with 'more' enabled will report progress, otherwise will just report completion."),
+                &vl_method_Run,
+                SD_VARLINK_SYMBOL_COMMENT("An incompatible disk label present, and not told to erase it."),
+                &vl_error_ConflictingDiskLabelPresent,
+                SD_VARLINK_SYMBOL_COMMENT("The target disk has insufficient free space to fit all requested partitions. (But the disk would fit, if emptied.)"),
+                &vl_error_InsufficientFreeSpace,
+                SD_VARLINK_SYMBOL_COMMENT("The target disk is too small to fit the installation. (Regardless if emptied or not.)"),
+                &vl_error_DiskTooSmall,
+
+                SD_VARLINK_SYMBOL_COMMENT("Return a list of candidate block devices, i.e. that support partition scanning and other requirements for successful operation."),
+                &vl_method_ListCandidateDevices,
+                SD_VARLINK_SYMBOL_COMMENT("Not a single candidate block device could be found."),
+                &vl_error_NoCandidateDevices);

--- a/src/shared/varlink-io.systemd.SysInstall.h
+++ b/src/shared/varlink-io.systemd.SysInstall.h
@@ -1,0 +1,6 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#pragma once
+
+#include "sd-varlink-idl.h"
+
+extern const sd_varlink_interface vl_interface_io_systemd_SysInstall;

--- a/src/shared/varlink-io.systemd.Sysinstall.c
+++ b/src/shared/varlink-io.systemd.Sysinstall.c
@@ -1,0 +1,126 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include "sd-varlink-idl.h"
+
+#include "varlink-io.systemd.Sysinstall.h"
+
+static SD_VARLINK_DEFINE_ENUM_TYPE(
+                ProgressPhase,
+
+                SD_VARLINK_DEFINE_ENUM_VALUE(validate_block_device),
+                SD_VARLINK_DEFINE_ENUM_VALUE(load_credentials),
+                SD_VARLINK_DEFINE_ENUM_VALUE(encrypt_credentials),
+
+                SD_VARLINK_DEFINE_ENUM_VALUE(loading_definitions),
+                SD_VARLINK_DEFINE_ENUM_VALUE(loading_table),
+                SD_VARLINK_DEFINE_ENUM_VALUE(opening_copy_block_sources),
+                SD_VARLINK_DEFINE_ENUM_VALUE(acquiring_partition_labels),
+                SD_VARLINK_DEFINE_ENUM_VALUE(minimizing),
+                SD_VARLINK_DEFINE_ENUM_VALUE(placing),
+                SD_VARLINK_DEFINE_ENUM_VALUE(wiping_disk),
+                SD_VARLINK_DEFINE_ENUM_VALUE(wiping_partition),
+                SD_VARLINK_DEFINE_ENUM_VALUE(copying_partition),
+                SD_VARLINK_DEFINE_ENUM_VALUE(formatting_partition),
+                SD_VARLINK_DEFINE_ENUM_VALUE(adjusting_partition),
+                SD_VARLINK_DEFINE_ENUM_VALUE(writing_table),
+                SD_VARLINK_DEFINE_ENUM_VALUE(rereading_table),
+
+                SD_VARLINK_DEFINE_ENUM_VALUE(mount_partitions),
+                SD_VARLINK_DEFINE_ENUM_VALUE(install_kernel),
+                SD_VARLINK_DEFINE_ENUM_VALUE(install_bootloader),
+                SD_VARLINK_DEFINE_ENUM_VALUE(unmount_partitions));
+
+static SD_VARLINK_DEFINE_METHOD_FULL(
+                Run,
+                SD_VARLINK_SUPPORTS_MORE,
+                SD_VARLINK_FIELD_COMMENT("Full path to the block device node to operate on. If omitted, dryRun must be true, in which case the minimal disk size is determined."),
+                SD_VARLINK_DEFINE_INPUT(node, SD_VARLINK_STRING, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("If true this will ponder if the installation would fit on the block device and report a summary. It does not actually write anything to disk. Must be set to false to actually install the OS to the block device."),
+                SD_VARLINK_DEFINE_INPUT(dryRun, SD_VARLINK_BOOL, 0),
+                SD_VARLINK_FIELD_COMMENT("Path to directory containing definition files."),
+                SD_VARLINK_DEFINE_INPUT(definitions, SD_VARLINK_STRING, SD_VARLINK_ARRAY),
+                SD_VARLINK_FIELD_COMMENT("If true, fully erase the target block device."),
+                SD_VARLINK_DEFINE_INPUT(erase, SD_VARLINK_BOOL, 0),
+                SD_VARLINK_FIELD_COMMENT("If true, this modifies EFI variables."),
+                SD_VARLINK_DEFINE_INPUT(variables, SD_VARLINK_BOOL, SD_VARLINK_NULLABLE),
+
+
+                SD_VARLINK_FIELD_COMMENT("If true, copy current locale to target system"),
+                SD_VARLINK_DEFINE_INPUT(copyLocale, SD_VARLINK_BOOL, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("If true, copy current keymap to target system"),
+                SD_VARLINK_DEFINE_INPUT(copyKeymap, SD_VARLINK_BOOL, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("If true, copy current timezone to target system"),
+                SD_VARLINK_DEFINE_INPUT(copyTimezone, SD_VARLINK_BOOL, SD_VARLINK_NULLABLE),
+
+                SD_VARLINK_FIELD_COMMENT("In dry mode returns the minimal disk size required."),
+                SD_VARLINK_DEFINE_OUTPUT(minimalSizeBytes, SD_VARLINK_INT, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("In dry mode returns the current allocated size of the selected block device."),
+                SD_VARLINK_DEFINE_OUTPUT(currentSizeBytes, SD_VARLINK_INT, SD_VARLINK_NULLABLE),
+
+                SD_VARLINK_FIELD_COMMENT("If used with the 'more' flag, a phase identifier is sent in progress updates."),
+                SD_VARLINK_DEFINE_OUTPUT_BY_TYPE(phase, ProgressPhase, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("If used with the 'more' flag, an object identifier string is sent in progress updates."),
+                SD_VARLINK_DEFINE_OUTPUT(object, SD_VARLINK_STRING, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("If used with the 'more' flag, a progress percentrage (specific to the work done for the specified phase+object is sent in progress updates."),
+                SD_VARLINK_DEFINE_OUTPUT(progress, SD_VARLINK_INT, SD_VARLINK_NULLABLE));
+
+static SD_VARLINK_DEFINE_METHOD(
+                ListCandidateDevices,
+                SD_VARLINK_FIELD_COMMENT("Control whether to include the root disk of the currently booted OS in the list. Defaults to false, i.e. the root disk is included."),
+                SD_VARLINK_DEFINE_INPUT(ignoreRoot, SD_VARLINK_BOOL, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("Control whether to include block devices with zero size in the list, i.e. typically block devices without any inserted medium. Defaults to false, i.e. empty block devices are included."),
+                SD_VARLINK_DEFINE_INPUT(ignoreEmpty, SD_VARLINK_BOOL, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("The device node path of the block device."),
+                SD_VARLINK_DEFINE_OUTPUT(node, SD_VARLINK_STRING, 0),
+                SD_VARLINK_FIELD_COMMENT("List of symlinks pointing to the device node, if any."),
+                SD_VARLINK_DEFINE_OUTPUT(symlinks, SD_VARLINK_STRING, SD_VARLINK_ARRAY|SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("The Linux kernel disk sequence number identifying the medium."),
+                SD_VARLINK_DEFINE_OUTPUT(diskseq, SD_VARLINK_INT, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("The size of the block device in bytes."),
+                SD_VARLINK_DEFINE_OUTPUT(sizeBytes, SD_VARLINK_INT, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("The device vendor string if known"),
+                SD_VARLINK_DEFINE_OUTPUT(vendor, SD_VARLINK_STRING, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("The device model string if known"),
+                SD_VARLINK_DEFINE_OUTPUT(model, SD_VARLINK_STRING, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("The subsystem the block device belongs to if known"),
+                SD_VARLINK_DEFINE_OUTPUT(subsystem, SD_VARLINK_STRING, SD_VARLINK_NULLABLE));
+
+
+static SD_VARLINK_DEFINE_ERROR(NoCandidateDevices);
+static SD_VARLINK_DEFINE_ERROR(ConflictingDiskLabelPresent);
+static SD_VARLINK_DEFINE_ERROR(
+                InsufficientFreeSpace,
+                SD_VARLINK_FIELD_COMMENT("Minimal size of the disk required for the installation."),
+                SD_VARLINK_DEFINE_FIELD(minimalSizeBytes, SD_VARLINK_INT, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("Additional free space needed on the selected disk."),
+                SD_VARLINK_DEFINE_FIELD(needFreeBytes, SD_VARLINK_INT, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("Size of the selected block device."),
+                SD_VARLINK_DEFINE_FIELD(currentSizeBytes, SD_VARLINK_INT, SD_VARLINK_NULLABLE));
+static SD_VARLINK_DEFINE_ERROR(
+                DiskTooSmall,
+                SD_VARLINK_FIELD_COMMENT("Minimal size of the disk required for the installation."),
+                SD_VARLINK_DEFINE_FIELD(minimalSizeBytes, SD_VARLINK_INT, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("Actual size of the selected block device."),
+                SD_VARLINK_DEFINE_FIELD(currentSizeBytes, SD_VARLINK_INT, SD_VARLINK_NULLABLE));
+
+SD_VARLINK_DEFINE_INTERFACE(
+                io_systemd_Sysinstall,
+                "io.systemd.Sysintall",
+                SD_VARLINK_INTERFACE_COMMENT("API for installing the OS to another block device."),
+
+                SD_VARLINK_SYMBOL_COMMENT("Progress phase identifiers. Note that we might add more phases here, and thus identifiers. Frontends can choose to display the phase to the user in some human readable form, or not do that, but if they do it and they receive a notification for a so far unknown phase, they should just ignore it."),
+                &vl_type_ProgressPhase,
+
+                SD_VARLINK_SYMBOL_COMMENT("Invoke the actual installation of the OS. If invoked with 'more' enabled will report progress, otherwise will just report completion."),
+                &vl_method_Run,
+                SD_VARLINK_SYMBOL_COMMENT("An incompatible disk label present, and not told to erase it."),
+                &vl_error_ConflictingDiskLabelPresent,
+                SD_VARLINK_SYMBOL_COMMENT("The target disk has insufficient free space to fit all requested partitions. (But the disk would fit, if emptied.)"),
+                &vl_error_InsufficientFreeSpace,
+                SD_VARLINK_SYMBOL_COMMENT("The target disk is too small to fit the installation. (Regardless if emptied or not.)"),
+                &vl_error_DiskTooSmall,
+
+                SD_VARLINK_SYMBOL_COMMENT("Return a list of candidate block devices, i.e. that support partition scanning and other requirements for successful operation."),
+                &vl_method_ListCandidateDevices,
+                SD_VARLINK_SYMBOL_COMMENT("Not a single candidate block device could be found."),
+                &vl_error_NoCandidateDevices);

--- a/src/shared/varlink-io.systemd.Sysinstall.h
+++ b/src/shared/varlink-io.systemd.Sysinstall.h
@@ -1,0 +1,6 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#pragma once
+
+#include "sd-varlink-idl.h"
+
+extern const sd_varlink_interface vl_interface_io_systemd_Sysinstall;

--- a/src/sysinstall/io.systemd.sysinstall.policy
+++ b/src/sysinstall/io.systemd.sysinstall.policy
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?> <!--*-nxml-*-->
+<!DOCTYPE policyconfig PUBLIC "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
+        "https://www.freedesktop.org/standards/PolicyKit/1/policyconfig.dtd">
+
+<!--
+  SPDX-License-Identifier: LGPL-2.1-or-later
+
+  This file is part of systemd.
+
+  systemd is free software; you can redistribute it and/or modify it
+  under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation; either version 2.1 of the License, or
+  (at your option) any later version.
+-->
+
+<policyconfig>
+
+        <vendor>The systemd Project</vendor>
+        <vendor_url>https://systemd.io</vendor_url>
+
+        <action id="io.systemd.sysinstall.Run">
+                <description gettext-domain="systemd">Install OS to disk</description>
+                <message gettext-domain="systemd">Authentication is required to install an OS to disk.</message>
+                <defaults>
+                        <allow_any>auth_admin</allow_any>
+                        <allow_inactive>auth_admin</allow_inactive>
+                        <allow_active>auth_admin_keep</allow_active>
+                </defaults>
+        </action>
+
+        <action id="io.systemd.sysinstall.ListCandidateDevices">
+                <description gettext-domain="systemd">List candidate devices</description>
+                <message gettext-domain="systemd">Authentication is required to list device candidates.</message>
+                <defaults>
+                        <allow_any>auth_admin</allow_any>
+                        <allow_inactive>auth_admin</allow_inactive>
+                        <allow_active>auth_admin_keep</allow_active>
+                </defaults>
+        </action>
+</policyconfig>

--- a/src/sysinstall/io.systemd.sysinstall.policy
+++ b/src/sysinstall/io.systemd.sysinstall.policy
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?> <!--*-nxml-*-->
+<!DOCTYPE policyconfig PUBLIC "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
+        "https://www.freedesktop.org/standards/PolicyKit/1/policyconfig.dtd">
+
+<!--
+  SPDX-License-Identifier: LGPL-2.1-or-later
+
+  This file is part of systemd.
+
+  systemd is free software; you can redistribute it and/or modify it
+  under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation; either version 2.1 of the License, or
+  (at your option) any later version.
+-->
+
+<policyconfig>
+
+        <vendor>The systemd Project</vendor>
+        <vendor_url>https://systemd.io</vendor_url>
+
+        <!--
+            SECURITY: the default policy allows no user to query candidate devices nor install an OS.
+            Permissions should be given via a polkit rule.
+        -->
+
+        <action id="io.systemd.sysinstall.Run">
+                <description gettext-domain="systemd">Install OS to disk</description>
+                <message gettext-domain="systemd">Authentication is required to install a OS to disk.</message>
+                <defaults>
+                        <allow_any>no</allow_any>
+                        <allow_inactive>no</allow_inactive>
+                        <allow_active>no</allow_active>
+                </defaults>
+        </action>
+
+        <action id="io.systemd.sysinstall.ListCandidateDevices">
+                <description gettext-domain="systemd">List candidate devices</description>
+                <message gettext-domain="systemd">Authentication is required to list device candidates.</message>
+                <defaults>
+                        <allow_any>no</allow_any>
+                        <allow_inactive>no</allow_inactive>
+                        <allow_active>no</allow_active>
+                </defaults>
+        </action>
+
+</policyconfig>

--- a/src/sysinstall/meson.build
+++ b/src/sysinstall/meson.build
@@ -8,3 +8,8 @@ executables += [
                 'sources' : files('sysinstall.c'),
         },
 ]
+
+if conf.get('ENABLE_SYSINSTALL') == 1
+        install_data('io.systemd.sysinstall.policy',
+                     install_dir : polkitpolicydir)
+endif

--- a/src/sysinstall/sysinstall.c
+++ b/src/sysinstall/sysinstall.c
@@ -930,12 +930,16 @@ static int invoke_bootctl_link(
                 sd_varlink **link,
                 const char *root_dir,
                 int root_fd,
+                const char *kernel_filename,
+                int kernel_fd,
                 char **encrypted_credentials) {
         int r;
 
         assert(link);
         assert(root_dir);
         assert(root_fd >= 0);
+        assert(kernel_filename);
+        assert(kernel_fd >= 0);
 
         r = connect_to_bootctl(link);
         if (r < 0)
@@ -958,25 +962,6 @@ static int invoke_bootctl_link(
         int root_fd_idx = sd_varlink_push_dup_fd(*link, root_fd);
         if (root_fd_idx < 0)
                 return log_error_errno(root_fd_idx, "Failed to submit root fd onto Varlink connection: %m");
-
-        _cleanup_free_ char *kernel_filename = NULL;
-        _cleanup_close_ int kernel_fd = -EBADF;
-        if (arg_kernel_image) {
-                r = path_extract_filename(arg_kernel_image, &kernel_filename);
-                if (r < 0)
-                        return log_error_errno(r, "Failed to extract filename from kernel path '%s': %m", arg_kernel_image);
-                if (r == O_DIRECTORY)
-                        return log_error_errno(SYNTHETIC_ERRNO(EISDIR), "Kernel path '%s' refers to directory, must be regular file, refusing.", arg_kernel_image);
-
-                kernel_fd = xopenat_full(XAT_FDROOT, arg_kernel_image, O_RDONLY|O_CLOEXEC, XO_REGULAR, MODE_INVALID);
-                if (kernel_fd < 0)
-                        return log_error_errno(kernel_fd, "Failed to open kernel image '%s': %m", arg_kernel_image);
-
-        } else {
-                r = find_current_kernel(&kernel_filename, &kernel_fd);
-                if (r < 0)
-                        return r;
-        }
 
         int kernel_fd_idx = sd_varlink_push_dup_fd(*link, kernel_fd);
         if (kernel_fd_idx < 0)
@@ -1259,6 +1244,8 @@ static void end_marker(void) {
 }
 
 static int run(int argc, char *argv[]) {
+        _cleanup_free_ char *kernel_filename = NULL;
+        _cleanup_close_ int kernel_fd = -EBADF;
         int r;
 
         setlocale(LC_ALL, "");
@@ -1341,6 +1328,22 @@ static int run(int argc, char *argv[]) {
         if (r < 0)
                 return r;
 
+        if (arg_kernel_image) {
+                r = path_extract_filename(arg_kernel_image, &kernel_filename);
+                if (r < 0)
+                        return log_error_errno(r, "Failed to extract filename from kernel path '%s': %m", arg_kernel_image);
+                if (r == O_DIRECTORY)
+                        return log_error_errno(SYNTHETIC_ERRNO(EISDIR), "Kernel path '%s' refers to directory, must be regular file, refusing.", arg_kernel_image);
+
+                kernel_fd = xopenat_full(XAT_FDROOT, arg_kernel_image, O_RDONLY|O_CLOEXEC, XO_REGULAR, MODE_INVALID);
+                if (kernel_fd < 0)
+                        return log_error_errno(kernel_fd, "Failed to open kernel image '%s': %m", arg_kernel_image);
+        } else {
+                r = find_current_kernel(&kernel_filename, &kernel_fd);
+                if (r < 0)
+                        return r;
+        }
+
         /* Verify we have everything we need */
         assert(arg_node);
         assert(arg_erase >= 0);
@@ -1408,7 +1411,7 @@ static int run(int argc, char *argv[]) {
                    emoji_enabled() ? glyph(GLYPH_COMPUTER_DISK) : "", emoji_enabled() ? " " : "");
 
         _cleanup_(sd_varlink_flush_close_unrefp) sd_varlink *bootctl_link = NULL;
-        r = invoke_bootctl_link(&bootctl_link, root_dir, root_fd, encrypted_credentials);
+        r = invoke_bootctl_link(&bootctl_link, root_dir, root_fd, kernel_filename, kernel_fd, encrypted_credentials);
         if (r < 0)
                 return r;
 

--- a/src/sysinstall/sysinstall.c
+++ b/src/sysinstall/sysinstall.c
@@ -11,6 +11,7 @@
 #include "blockdev-list.h"
 #include "build.h"
 #include "build-path.h"
+#include "bus-polkit.h"
 #include "chase.h"
 #include "conf-files.h"
 #include "constants.h"
@@ -24,6 +25,7 @@
 #include "format-util.h"
 #include "fs-util.h"
 #include "glyph-util.h"
+#include "hashmap.h"
 #include "help-util.h"
 #include "image-policy.h"
 #include "json-util.h"
@@ -39,9 +41,11 @@
 #include "parse-util.h"
 #include "path-util.h"
 #include "prompt-util.h"
+#include "string-table.h"
 #include "strv.h"
 #include "terminal-util.h"
 #include "varlink-util.h"
+#include "varlink-io.systemd.SysInstall.h"
 
 static char *arg_node = NULL;
 static bool arg_welcome = true;
@@ -58,11 +62,86 @@ static bool arg_copy_keymap = true;
 static bool arg_copy_timezone = true;
 static bool arg_chrome = true;
 static bool arg_mute_console = false;
+static bool arg_varlink = false;
 
 STATIC_DESTRUCTOR_REGISTER(arg_node, freep);
 STATIC_DESTRUCTOR_REGISTER(arg_definitions, strv_freep);
 STATIC_DESTRUCTOR_REGISTER(arg_kernel_image, freep);
 STATIC_DESTRUCTOR_REGISTER(arg_credentials, machine_credential_context_done);
+
+typedef enum ProgressPhase {
+        PROGRESS_LOAD_CREDENTIALS,
+        PROGRESS_ENCRYPT_CREDENTIALS,
+        PROGRESS_INSTALL_PARTITIONS,
+        PROGRESS_MOUNT_PARTITIONS,
+        PROGRESS_INSTALL_KERNEL,
+        PROGRESS_INSTALL_BOOTLOADER,
+        PROGRESS_UNMOUNT_PARTITIONS,
+        _PROGRESS_PHASE_MAX,
+        _PROGRESS_PHASE_INVALID = -EINVAL,
+} ProgressPhase;
+
+static const char *progress_phase_table[_PROGRESS_PHASE_MAX] = {
+        [PROGRESS_LOAD_CREDENTIALS]           = "load-credentials",
+        [PROGRESS_ENCRYPT_CREDENTIALS]        = "encrypt-credentials",
+        [PROGRESS_INSTALL_PARTITIONS]         = "install-partitions",
+        [PROGRESS_MOUNT_PARTITIONS]           = "mount-partitions",
+        [PROGRESS_INSTALL_KERNEL]             = "install-kernel",
+        [PROGRESS_INSTALL_BOOTLOADER]         = "install-bootloader",
+        [PROGRESS_UNMOUNT_PARTITIONS]         = "unmount-partitions",
+};
+
+DEFINE_PRIVATE_STRING_TABLE_LOOKUP_TO_STRING(progress_phase, ProgressPhase);
+
+typedef enum DeviceFit {
+        ENOUGH_FREE_SPACE,
+        INSUFFICIENT_FREE_SPACE,
+        DISK_TOO_SMALL,
+        CONFLICTING_DISK_LABEL_PRESENT,
+        _DEVICE_FIT_MAX,
+        _DEVICE_FIT_INVALID = -EINVAL,
+} DeviceFit;
+
+static const char *device_fit_table[_DEVICE_FIT_MAX] = {
+        [ENOUGH_FREE_SPACE]                   = "enough-free-space",
+        [INSUFFICIENT_FREE_SPACE]              = "insufficient-free-space",
+        [DISK_TOO_SMALL]                      = "disk-too-small",
+        [CONFLICTING_DISK_LABEL_PRESENT]      = "conflicting-disk-label-present",
+};
+
+DEFINE_PRIVATE_STRING_TABLE_LOOKUP_TO_STRING(device_fit, DeviceFit);
+
+typedef struct SysinstallContext {
+        bool copy_locale;
+        bool copy_keymap;
+        bool copy_timezone;
+        MachineCredentialContext credentials;
+        char **definitions;
+        bool erase;
+        char *node;
+        char *kernel_image;
+        bool variables;
+
+        sd_varlink *repart_link;
+
+        sd_varlink *link; /* If 'more' is used on the Varlink call, we'll send progress info over this link */
+} SysinstallContext;
+
+static void sysinstall_context_done(SysinstallContext *c) {
+        assert(c);
+
+        strv_free(c->definitions);
+
+        free(c->node);
+
+        free(c->kernel_image);
+
+        machine_credential_context_done(&c->credentials);
+
+        c->repart_link = sd_varlink_flush_close_unref(c->repart_link);
+
+        c->link = sd_varlink_unref(c->link);
+}
 
 static int help(void) {
         int r;
@@ -208,6 +287,13 @@ static int parse_argv(int argc, char *argv[]) {
                 arg_node = strdup(args[0]);
                 if (!arg_node)
                         return log_oom();
+        }
+
+        r = sd_varlink_invocation(SD_VARLINK_ALLOW_ACCEPT);
+        if (r < 0)
+                return log_error_errno(r, "Failed to check if invoked in Varlink mode: %m");
+        if (r > 0) {
+                arg_varlink = true;
         }
 
         return 1;
@@ -403,6 +489,235 @@ static int prompt_block_device(sd_varlink **repart_link, char **ret_node) {
         return 0;
 }
 
+static int sysinstall_context_notify(
+                SysinstallContext *context,
+                ProgressPhase phase,
+                const char *object,
+                unsigned percent) {
+
+        int r;
+        const char *description;
+
+        assert(context);
+        assert(phase >= 0);
+        assert(phase < _PROGRESS_PHASE_MAX);
+
+        switch (phase) {
+
+        case PROGRESS_ENCRYPT_CREDENTIALS:
+                description = "Encrypting credentials...";
+                break;
+
+        case PROGRESS_INSTALL_PARTITIONS:
+                description = "Installing partitions...";
+                break;
+
+        case PROGRESS_MOUNT_PARTITIONS:
+                description = "Mounting partitions...";
+                break;
+
+        case PROGRESS_INSTALL_KERNEL:
+                description = "Installing kernel...";
+                break;
+
+        case PROGRESS_INSTALL_BOOTLOADER:
+                description = "Installing boot loader...";
+                break;
+
+        case PROGRESS_UNMOUNT_PARTITIONS:
+                description = "Unmounting partitions...";
+                break;
+        default:
+                description = NULL;
+                break;
+        }
+
+        if (description)
+                log_notice("%s%s%s",
+                        emoji_enabled() ? glyph(GLYPH_SPARKLES) : "", emoji_enabled() ? " " : "", description);
+
+        if (context->link) {
+                r = sd_varlink_notifybo(
+                                context->link,
+                                JSON_BUILD_PAIR_ENUM("phase", progress_phase_to_string(phase)),
+                                JSON_BUILD_PAIR_STRING_NON_EMPTY("object", object),
+                                JSON_BUILD_PAIR_UNSIGNED_NOT_EQUAL("progress", percent, UINT_MAX));
+                if (r < 0)
+                        log_debug_errno(r, "Failed to send varlink notify progress notification, ignoring: %m");
+
+                r = sd_varlink_flush(context->link);
+                if (r < 0)
+                        log_debug_errno(r, "Failed to flush varlink notify progress notification, ignoring: %m");
+        }
+
+        return 0;
+}
+
+typedef struct RepartResult {
+        int ret;
+        SysinstallContext *context;
+} RepartResult;
+
+static int handle_repart_reply(
+                sd_varlink *link,
+                sd_json_variant *reply,
+                const char *error_id,
+                sd_varlink_reply_flags_t flags,
+                void *userdata) {
+
+        RepartResult *result = userdata;
+        int r;
+
+        assert(result);
+
+        struct {
+                uint64_t min_size;
+                uint64_t current_size;
+                uint64_t need_free;
+
+                const char *phase;
+                const char *object;
+                unsigned progress;
+        } p = {
+                .min_size = UINT64_MAX,
+                .current_size = UINT64_MAX,
+                .need_free = UINT64_MAX,
+                .progress = UINT_MAX,
+        };
+
+        static const sd_json_dispatch_field dispatch_table[] = {
+                { "minimalSizeBytes", _SD_JSON_VARIANT_TYPE_INVALID, sd_json_dispatch_uint64, voffsetof(p, min_size),     0 },
+                { "currentSizeBytes", _SD_JSON_VARIANT_TYPE_INVALID, sd_json_dispatch_uint64, voffsetof(p, current_size), 0 },
+                { "needFreeBytes",    _SD_JSON_VARIANT_TYPE_INVALID, sd_json_dispatch_uint64, voffsetof(p, need_free),    0 },
+                { "phase",            _SD_JSON_VARIANT_TYPE_INVALID, sd_json_dispatch_const_string, voffsetof(p, phase),        0 },
+                { "object",           _SD_JSON_VARIANT_TYPE_INVALID, sd_json_dispatch_const_string, voffsetof(p, object),       0 },
+                { "progress",         _SD_JSON_VARIANT_TYPE_INVALID, sd_json_dispatch_uint,   voffsetof(p, progress),     0 },
+                {}
+        };
+
+        r = sd_json_dispatch(reply, dispatch_table, SD_JSON_ALLOW_EXTENSIONS, &p);
+        if (r < 0)
+                return result->ret = r;
+
+        if (error_id) {
+                const char *sysinstall_error_id = NULL;
+
+                if (streq(error_id, "io.systemd.Repart.InsufficientFreeSpace")) {
+                        sysinstall_error_id = "io.systemd.SysInstall.InsufficientFreeSpace";
+                        result->ret = log_error_errno(SYNTHETIC_ERRNO(ENOSPC), "Not enough free space on disk, cannot install.");
+                }
+
+                if (streq(error_id, "io.systemd.Repart.DiskTooSmall")) {
+                        sysinstall_error_id = "io.systemd.SysInstall.DiskTooSmall";
+
+                        result->ret = log_error_errno(SYNTHETIC_ERRNO(E2BIG), "Disk too small for installation, cannot install.");
+                }
+
+                if (streq(error_id, "io.systemd.Repart.ConflictingDiskLabelPresent")) {
+                        sysinstall_error_id = "io.systemd.SysInstall.ConflictingDiskLabelPresent";
+
+                        result->ret = log_error_errno(
+                                        SYNTHETIC_ERRNO(EHWPOISON),
+                                        "A conflicting disk label is already present on the target disk, cannot install unless disk is erased.");
+                }
+
+                if (sysinstall_error_id && result->context->link) {
+                        r = sd_varlink_errorbo(
+                                        result->context->link,
+                                        sysinstall_error_id,
+                                        JSON_BUILD_PAIR_UNSIGNED_NOT_EQUAL("currentSizeBytes", p.current_size, UINT64_MAX),
+                                        JSON_BUILD_PAIR_UNSIGNED_NOT_EQUAL("needFreeBytes", p.need_free, UINT64_MAX),
+                                        JSON_BUILD_PAIR_UNSIGNED_NOT_EQUAL("minimalSizeBytes", p.min_size, UINT64_MAX));
+
+                        if (r < 0)
+                                return result->ret = r;
+
+                        return result->ret;
+                }
+
+                r = sd_varlink_error_to_errno(error_id, reply); /* If this is a system errno style error, output it with %m */
+                if (r != -EBADR)
+                        return result->ret = log_error_errno(r, "Failed to issue io.systemd.Repart.Run() varlink call: %m");
+
+                return result->ret = log_error_errno(r, "Failed to issue io.systemd.Repart.Run() varlink call: %s", error_id);
+        }
+
+        if ((p.progress != UINT_MAX || p.object) && result->context->link) {
+                (void) sysinstall_context_notify(result->context, PROGRESS_INSTALL_PARTITIONS, p.object, p.progress);
+        }
+
+        return result->ret = 0;
+}
+
+static int sysinstall_context_invoke_repart_run(SysinstallContext *context) {
+
+        int r;
+
+        assert(context);
+
+        r = connect_to_repart(&context->repart_link);
+        if (r < 0) {
+                return r;
+        }
+
+        /* Seeding the partitions might be very slow, disable timeout */
+        r = sd_varlink_set_relative_timeout(context->repart_link, UINT64_MAX);
+        if (r < 0)
+                return log_error_errno(r, "Failed to disable IPC timeout: %m");
+
+        RepartResult result = {
+                .ret = 0,
+                .context = context,
+        };
+
+        sd_varlink_set_userdata(context->repart_link, &result);
+
+        r = sd_varlink_bind_reply(context->repart_link, handle_repart_reply);
+        if (r < 0) {
+                return log_error_errno(r, "Failed to bind repart reply callback: %m");
+        }
+
+        r = sd_varlink_observebo(
+                        context->repart_link,
+                        "io.systemd.Repart.Run",
+                        SD_JSON_BUILD_PAIR_STRING("node", context->node),
+                        SD_JSON_BUILD_PAIR_STRING("empty", context->erase ? "force" : "allow"),
+                        SD_JSON_BUILD_PAIR_BOOLEAN("dryRun", false),
+                        SD_JSON_BUILD_PAIR_CONDITION(!!context->definitions, "definitions", SD_JSON_BUILD_STRV(context->definitions)),
+                        SD_JSON_BUILD_PAIR_BOOLEAN("deferPartitionsEmpty", true),
+                        SD_JSON_BUILD_PAIR_BOOLEAN("deferPartitionsFactoryReset", true));
+        if (r < 0) {
+                return log_error_errno(r, "Failed to issue io.systemd.Repart.Run() varlink call: %m");
+        }
+
+        for (;;) {
+                r = sd_varlink_is_idle(context->repart_link);
+                if (r < 0)
+                        return log_error_errno(r, "Failed to check if varlink connection is idle: %m");
+                if (r > 0)
+                        break;
+
+                r = sd_varlink_process(context->repart_link);
+                if (r < 0)
+                        return log_error_errno(r, "Failed to process varlink connection: %m");
+                if (r != 0)
+                        continue;
+
+                r = sd_varlink_wait(context->repart_link, USEC_INFINITY);
+                if (r < 0)
+                        return log_error_errno(r, "Failed to wait for varlink connection events: %m");
+        }
+
+        sd_varlink_set_userdata(context->repart_link, NULL);
+
+        r = sd_varlink_bind_reply(context->repart_link, NULL);
+        if (r < 0) {
+                return log_error_errno(r, "Failed to unbind repart reply callback: %m");
+        }
+
+        return result.ret;
+}
+
 static int read_space_metrics(
                 sd_json_variant *v,
                 uint64_t *min_size,
@@ -447,6 +762,7 @@ static int invoke_repart(
                 const char *node,
                 bool erase,
                 bool dry_run,
+                char **definitions,
                 uint64_t *min_size,        /* initialized both on success and error */
                 uint64_t *current_size,    /* ditto */
                 uint64_t *need_free) {     /* ditto */
@@ -481,7 +797,7 @@ static int invoke_repart(
                         SD_JSON_BUILD_PAIR_STRING("node", node),
                         SD_JSON_BUILD_PAIR_STRING("empty", erase ? "force" : "allow"),
                         SD_JSON_BUILD_PAIR_BOOLEAN("dryRun", dry_run),
-                        SD_JSON_BUILD_PAIR_CONDITION(!!arg_definitions, "definitions", SD_JSON_BUILD_STRV(arg_definitions)),
+                        SD_JSON_BUILD_PAIR_CONDITION(!!definitions, "definitions", SD_JSON_BUILD_STRV(definitions)),
                         SD_JSON_BUILD_PAIR_BOOLEAN("deferPartitionsEmpty", true),
                         SD_JSON_BUILD_PAIR_BOOLEAN("deferPartitionsFactoryReset", true));
         if (r < 0) {
@@ -656,6 +972,7 @@ static int validate_run(sd_varlink **repart_link, const char *node) {
                                 node,
                                 try_erase,
                                 /* dry_run= */ true,
+                                arg_definitions,
                                 &min_size,
                                 &current_size,
                                 &need_free);
@@ -894,6 +1211,7 @@ static int connect_to_bootctl(sd_varlink **link) {
 
 static int invoke_bootctl_install(
                 sd_varlink **link,
+                bool variables,
                 const char *root_dir,
                 int root_fd) {
         int r;
@@ -919,7 +1237,7 @@ static int invoke_bootctl_install(
                         SD_JSON_BUILD_PAIR_STRING("operation", "new"),
                         SD_JSON_BUILD_PAIR_INTEGER("rootFileDescriptor", fd_idx),
                         SD_JSON_BUILD_PAIR_STRING("rootDirectory", root_dir),
-                        SD_JSON_BUILD_PAIR_BOOLEAN("touchVariables", arg_touch_variables));
+                        SD_JSON_BUILD_PAIR_BOOLEAN("touchVariables", variables));
         if (r < 0)
                 return r;
 
@@ -928,6 +1246,7 @@ static int invoke_bootctl_install(
 
 static int invoke_bootctl_link(
                 sd_varlink **link,
+                const char *kernel_image,
                 const char *root_dir,
                 int root_fd,
                 char **encrypted_credentials) {
@@ -961,16 +1280,16 @@ static int invoke_bootctl_link(
 
         _cleanup_free_ char *kernel_filename = NULL;
         _cleanup_close_ int kernel_fd = -EBADF;
-        if (arg_kernel_image) {
-                r = path_extract_filename(arg_kernel_image, &kernel_filename);
+        if (kernel_image) {
+                r = path_extract_filename(kernel_image, &kernel_filename);
                 if (r < 0)
-                        return log_error_errno(r, "Failed to extract filename from kernel path '%s': %m", arg_kernel_image);
+                        return log_error_errno(r, "Failed to extract filename from kernel path '%s': %m", kernel_image);
                 if (r == O_DIRECTORY)
-                        return log_error_errno(SYNTHETIC_ERRNO(EISDIR), "Kernel path '%s' refers to directory, must be regular file, refusing.", arg_kernel_image);
+                        return log_error_errno(SYNTHETIC_ERRNO(EISDIR), "Kernel path '%s' refers to directory, must be regular file, refusing.", kernel_image);
 
-                kernel_fd = xopenat_full(XAT_FDROOT, arg_kernel_image, O_RDONLY|O_CLOEXEC, XO_REGULAR, MODE_INVALID);
+                kernel_fd = xopenat_full(XAT_FDROOT, kernel_image, O_RDONLY|O_CLOEXEC, XO_REGULAR, MODE_INVALID);
                 if (kernel_fd < 0)
-                        return log_error_errno(kernel_fd, "Failed to open kernel image '%s': %m", arg_kernel_image);
+                        return log_error_errno(kernel_fd, "Failed to open kernel image '%s': %m", kernel_image);
 
         } else {
                 r = find_current_kernel(&kernel_filename, &kernel_fd);
@@ -1032,14 +1351,11 @@ static int maybe_reboot(void) {
         return 0;
 }
 
-static int read_credential_locale(void) {
+static int read_credential_locale(MachineCredentialContext *credentials) {
         int r;
 
-        if (!arg_copy_locale)
-                return 0;
-
-        if (machine_credential_find(&arg_credentials, "firstboot.locale") ||
-            machine_credential_find(&arg_credentials, "firstboot.locale-messages"))
+        if (machine_credential_find(credentials, "firstboot.locale") ||
+            machine_credential_find(credentials, "firstboot.locale-messages"))
                 return 0;
 
         /* For the main locale we check the two env vars, and if neither is there, we use LC_NUMERIC, since
@@ -1047,14 +1363,14 @@ static int read_credential_locale(void) {
          * separate setting after all */
         const char *l = getenv("LC_ALL") ?: getenv("LANG") ?: setlocale(LC_NUMERIC, NULL);
         if (l) {
-                r = machine_credential_add(&arg_credentials, "firstboot.locale", l, /* size= */ SIZE_MAX);
+                r = machine_credential_add(credentials, "firstboot.locale", l, /* size= */ SIZE_MAX);
                 if (r < 0)
                         return log_oom();
         }
 
         const char *m = setlocale(LC_MESSAGES, NULL);
         if (m && !streq_ptr(m, l)) {
-                r = machine_credential_add(&arg_credentials, "firstboot.locale-messages", m, /* size= */ SIZE_MAX);
+                r = machine_credential_add(credentials, "firstboot.locale-messages", m, /* size= */ SIZE_MAX);
                 if (r < 0)
                         return log_oom();
         }
@@ -1062,13 +1378,10 @@ static int read_credential_locale(void) {
         return 0;
 }
 
-static int read_credential_keymap(void) {
+static int read_credential_keymap(MachineCredentialContext *credentials) {
         int r;
 
-        if (!arg_copy_keymap)
-                return 0;
-
-        if (machine_credential_find(&arg_credentials, "firstboot.keymap"))
+        if (machine_credential_find(credentials, "firstboot.keymap"))
                 return 0;
 
         _cleanup_free_ char *keymap = NULL;
@@ -1080,7 +1393,7 @@ static int read_credential_keymap(void) {
                 return log_error_errno(r, "Failed to parse '%s': %m", etc_vconsole_conf());
 
         if (!isempty(keymap)) {
-                r = machine_credential_add(&arg_credentials, "firstboot.keymap", keymap, /* size= */ SIZE_MAX);
+                r = machine_credential_add(credentials, "firstboot.keymap", keymap, /* size= */ SIZE_MAX);
                 if (r < 0)
                         return log_oom();
         }
@@ -1088,13 +1401,10 @@ static int read_credential_keymap(void) {
         return 0;
 }
 
-static int read_credential_timezone(void) {
+static int read_credential_timezone(MachineCredentialContext *credentials) {
         int r;
 
-        if (!arg_copy_timezone)
-                return 0;
-
-        if (machine_credential_find(&arg_credentials, "firstboot.timezone"))
+        if (machine_credential_find(credentials, "firstboot.timezone"))
                 return 0;
 
         _cleanup_free_ char *tz = NULL;
@@ -1102,7 +1412,7 @@ static int read_credential_timezone(void) {
         if (r < 0)
                 log_warning_errno(r, "Failed to read timezone, skipping timezone propagation: %m");
         else {
-                r = machine_credential_add(&arg_credentials, "firstboot.timezone", tz, /* size= */ SIZE_MAX);
+                r = machine_credential_add(credentials, "firstboot.timezone", tz, /* size= */ SIZE_MAX);
                 if (r < 0)
                         return log_oom();
         }
@@ -1110,20 +1420,26 @@ static int read_credential_timezone(void) {
         return 0;
 }
 
-static int read_credentials(void) {
+static int read_credentials(MachineCredentialContext *credentials, bool copy_locale, bool copy_keymap, bool copy_timezone) {
         int r;
 
-        r = read_credential_locale();
-        if (r < 0)
-                return r;
+        if (copy_locale) {
+                r = read_credential_locale(credentials);
+                if (r < 0)
+                        return r;
+        }
 
-        r = read_credential_keymap();
-        if (r < 0)
-                return r;
+        if (copy_keymap) {
+                r = read_credential_keymap(credentials);
+                if (r < 0)
+                        return r;
+        }
 
-        r = read_credential_timezone();
-        if (r < 0)
-                return r;
+        if (copy_timezone) {
+                r = read_credential_timezone(credentials);
+                if (r < 0)
+                        return r;
+        }
 
         return 0;
 }
@@ -1194,13 +1510,13 @@ static int encrypt_one_credential(sd_varlink **link, const MachineCredential *in
         return 0;
 }
 
-static int encrypt_credentials(sd_varlink **link, char ***encrypted) {
+static int encrypt_credentials(sd_varlink **link, MachineCredentialContext credentials, char ***encrypted) {
         int r;
 
         assert(link);
         assert(encrypted);
 
-        FOREACH_ARRAY(cred, arg_credentials.credentials, arg_credentials.n_credentials) {
+        FOREACH_ARRAY(cred, credentials.credentials, credentials.n_credentials) {
                 r = encrypt_one_credential(link, cred, encrypted);
                 if (r < 0)
                         return r;
@@ -1221,10 +1537,11 @@ static const ImagePolicy image_policy = {
         .default_flags = PARTITION_POLICY_IGNORE,
 };
 
-static int settle_definitions(void) {
+static int settle_definitions(char ***definitions) {
+
         int r;
 
-        if (arg_definitions)
+        if (*definitions)
                 return 0;
 
         /* If /usr/lib/repart.sysinstall.d/ is populated, use it, otherwise use the regular definition
@@ -1241,10 +1558,461 @@ static int settle_definitions(void) {
                 return log_error_errno(r, "Failed to enumerate *.conf files: %m");
 
         if (!strv_isempty(files)) {
-                arg_definitions = strv_copy(CONF_PATHS_STRV("repart.sysinstall.d"));
-                if (!arg_definitions)
+                *definitions = strv_copy(CONF_PATHS_STRV("repart.sysinstall.d"));
+                if (!*definitions)
                         return log_oom();
         }
+
+        return 0;
+}
+
+static int sysinstall_context_run(SysinstallContext *context) {
+
+        int r;
+
+        assert(context);
+
+        (void) sysinstall_context_notify(context, PROGRESS_ENCRYPT_CREDENTIALS, NULL, UINT_MAX);
+
+        _cleanup_(sd_varlink_flush_close_unrefp) sd_varlink *creds_link = NULL;
+        _cleanup_strv_free_ char **encrypted_credentials = NULL;
+        r = encrypt_credentials(&creds_link, context->credentials, &encrypted_credentials);
+        if (r < 0)
+                return r;
+
+        (void) sysinstall_context_notify(context, PROGRESS_INSTALL_PARTITIONS, NULL, UINT_MAX);
+
+        /* Do the main part of the installation */
+
+        r = sysinstall_context_invoke_repart_run(context);
+        if (r < 0)
+                return r;
+
+        (void) sysinstall_context_notify(context, PROGRESS_MOUNT_PARTITIONS, NULL, UINT_MAX);
+
+        _cleanup_(loop_device_unrefp) LoopDevice *loop_device = NULL;
+        _cleanup_(umount_and_freep) char *root_dir = NULL;
+        _cleanup_close_ int root_fd = -EBADF;
+        r = mount_image_privately_interactively(
+                        context->node,
+                        &image_policy,
+                        DISSECT_IMAGE_REQUIRE_ROOT |
+                        DISSECT_IMAGE_RELAX_VAR_CHECK |
+                        DISSECT_IMAGE_ALLOW_USERSPACE_VERITY |
+                        DISSECT_IMAGE_DISCARD_ANY |
+                        DISSECT_IMAGE_GPT_ONLY |
+                        DISSECT_IMAGE_FSCK |
+                        DISSECT_IMAGE_USR_NO_ROOT |
+                        DISSECT_IMAGE_ADD_PARTITION_DEVICES |
+                        DISSECT_IMAGE_PIN_PARTITION_DEVICES,
+                        &root_dir,
+                        &root_fd,
+                        &loop_device);
+        if (r < 0)
+                return log_error_errno(r, "Failed to mount new image: %m");
+
+        (void) sysinstall_context_notify(context, PROGRESS_INSTALL_KERNEL, NULL, UINT_MAX);
+
+        _cleanup_(sd_varlink_flush_close_unrefp) sd_varlink *bootctl_link = NULL;
+        r = invoke_bootctl_link(&bootctl_link, context->kernel_image, root_dir, root_fd, encrypted_credentials);
+        if (r < 0)
+                return r;
+
+        (void) sysinstall_context_notify(context, PROGRESS_INSTALL_BOOTLOADER, NULL, UINT_MAX);
+
+        r = invoke_bootctl_install(&bootctl_link, context->variables, root_dir, root_fd);
+        if (r < 0)
+                return r;
+
+        (void) sysinstall_context_notify(context, PROGRESS_UNMOUNT_PARTITIONS, NULL, UINT_MAX);
+
+        root_fd = safe_close(root_fd);
+        r = umount_recursive(root_dir, /* flags= */ 0);
+        if (r < 0)
+                log_warning_errno(r, "Failed to unmount target disk, proceeding anyway: %m");
+        loop_device = loop_device_unref(loop_device);
+        sync();
+
+        return 0;
+}
+
+typedef struct ListCandidateDevicesContext {
+        char **definitions;
+
+        sd_varlink *repart_link; /* A second repart connection to perform a dry run on each node */
+
+        sd_varlink *link;
+} ListCandidateDevicesContext;
+
+static ListCandidateDevicesContext* list_candidate_devices_context_new(void) {
+        ListCandidateDevicesContext *context = new(ListCandidateDevicesContext, 1);
+
+        if (!context)
+                return NULL;
+
+        *context = (ListCandidateDevicesContext) {};
+
+        return context;
+}
+
+static ListCandidateDevicesContext* list_candidate_devices_context_free(ListCandidateDevicesContext *context) {
+        if (!context)
+                return NULL;
+
+        strv_free(context->definitions);
+
+        context->repart_link = sd_varlink_unref(context->repart_link);
+        context->link = sd_varlink_unref(context->link);
+
+        return mfree(context);
+}
+
+DEFINE_TRIVIAL_CLEANUP_FUNC(ListCandidateDevicesContext*, list_candidate_devices_context_free);
+
+static void vl_on_disconnect(sd_varlink_server *server, sd_varlink *link, void *userdata) {
+        assert(server);
+        assert(link);
+
+        sd_varlink *repart_link = sd_varlink_set_userdata(link, NULL);
+        if (repart_link) {
+                list_candidate_devices_context_free(sd_varlink_set_userdata(repart_link, NULL));
+                sd_varlink_flush_close_unref(repart_link);
+        }
+}
+
+typedef struct DevicesResponse {
+        const char *node;
+        char **symlinks;
+        uint64_t diskseq;
+        uint64_t size;
+        const char *model;
+        const char *vendor;
+        const char *subsystem;
+} DevicesResponse;
+
+static void devices_response_done(DevicesResponse *p) {
+        assert(p);
+
+        p->symlinks = strv_free(p->symlinks);
+}
+
+static int fetch_candidate_devices_reply(
+                sd_varlink *repart_link,
+                sd_json_variant *reply,
+                const char *error_id,
+                sd_varlink_reply_flags_t flags,
+                void *userdata) {
+
+        int r;
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *v = NULL;
+        ListCandidateDevicesContext *context = ASSERT_PTR(userdata);
+
+        if (error_id) {
+                if (streq(error_id, "io.systemd.Repart.NoCandidateDevices"))
+                        return sd_varlink_error(context->link, "io.systemd.SysInstall.NoCandidateDevices", NULL);
+
+                return sd_varlink_error(context->link, error_id, NULL);
+        }
+
+        static const sd_json_dispatch_field dispatch_table[] = {
+                { "node",      SD_JSON_VARIANT_STRING,        sd_json_dispatch_const_string, offsetof(DevicesResponse, node),      0 },
+                { "symlinks",  SD_JSON_VARIANT_ARRAY,         sd_json_dispatch_strv,         offsetof(DevicesResponse, symlinks),  0 },
+                { "diskseq",   _SD_JSON_VARIANT_TYPE_INVALID, sd_json_dispatch_uint64,       offsetof(DevicesResponse, diskseq),   0 },
+                { "sizeBytes", _SD_JSON_VARIANT_TYPE_INVALID, sd_json_dispatch_uint64,       offsetof(DevicesResponse, size),      0 },
+                { "model",     SD_JSON_VARIANT_STRING,        sd_json_dispatch_const_string, offsetof(DevicesResponse, model),     0 },
+                { "vendor",    SD_JSON_VARIANT_STRING,        sd_json_dispatch_const_string, offsetof(DevicesResponse, vendor),    0 },
+                { "subsystem", SD_JSON_VARIANT_STRING,        sd_json_dispatch_const_string, offsetof(DevicesResponse, subsystem), 0 },
+                {}
+        };
+
+        _cleanup_(devices_response_done) DevicesResponse p = {
+                .diskseq = UINT64_MAX,
+                .size = UINT64_MAX,
+        };
+        r = sd_json_dispatch(reply, dispatch_table, SD_JSON_ALLOW_EXTENSIONS, &p);
+        if (r < 0)
+                return r;
+
+        uint64_t min_size = UINT64_MAX, current_size = UINT64_MAX, need_free = UINT64_MAX;
+        r = invoke_repart(
+                        &context->repart_link,
+                        p.node,
+                        /* erase= */ false,
+                        /* dry_run= */ true,
+                        context->definitions,
+                        &min_size,
+                        &current_size,
+                        &need_free);
+
+        DeviceFit fit;
+        if (r < 0) {
+                if (r == -ENOSPC)
+                        fit = INSUFFICIENT_FREE_SPACE;
+                else if (r == -E2BIG)
+                        fit = DISK_TOO_SMALL;
+                else if (r == -EHWPOISON)
+                        fit = CONFLICTING_DISK_LABEL_PRESENT;
+
+                else
+                        return r;
+        } else {
+                fit = ENOUGH_FREE_SPACE;
+        }
+
+        r = sd_json_buildo(&v,
+                        SD_JSON_BUILD_PAIR_STRING("node", p.node),
+                        JSON_BUILD_PAIR_STRV_NON_EMPTY("symlinks", p.symlinks),
+                        JSON_BUILD_PAIR_UNSIGNED_NOT_EQUAL("diskseq", p.diskseq, UINT64_MAX),
+                        JSON_BUILD_PAIR_UNSIGNED_NOT_EQUAL("sizeBytes", p.size, UINT64_MAX),
+                        JSON_BUILD_PAIR_STRING_NON_EMPTY("model", p.model),
+                        JSON_BUILD_PAIR_STRING_NON_EMPTY("vendor", p.vendor),
+                        JSON_BUILD_PAIR_STRING_NON_EMPTY("subsystem", p.subsystem),
+                        JSON_BUILD_PAIR_ENUM("fit", device_fit_to_string(fit)),
+                        JSON_BUILD_PAIR_UNSIGNED_NOT_EQUAL("currentSizeBytes", current_size, UINT64_MAX),
+                        JSON_BUILD_PAIR_UNSIGNED_NOT_EQUAL("needFreeBytes", need_free, UINT64_MAX),
+                        JSON_BUILD_PAIR_UNSIGNED_NOT_EQUAL("minimalSizeBytes", min_size, UINT64_MAX));
+        if (r < 0)
+                return r;
+
+        if (FLAGS_SET(flags, SD_VARLINK_REPLY_CONTINUES))
+                return sd_varlink_notify(context->link, v);
+        else
+                return sd_varlink_reply(context->link, v);
+}
+
+typedef struct ListCandidateDevicesParameters {
+        char **definitions;
+} ListCandidateDevicesParameters;
+
+static void list_candidate_devices_parameters_done(ListCandidateDevicesParameters *p) {
+        assert(p);
+
+        p->definitions = strv_free(p->definitions);
+}
+
+static int vl_method_list_candidate_devices(
+                sd_varlink *link,
+                sd_json_variant *parameters,
+                sd_varlink_method_flags_t flags,
+                void *userdata) {
+        int r;
+
+        assert(link);
+
+        sd_varlink_server *varlink_server = sd_varlink_get_server(link);
+        sd_event *event = sd_varlink_server_get_event(varlink_server);
+        Hashmap **polkit_registry = ASSERT_PTR(sd_varlink_server_get_userdata(varlink_server));
+
+        assert(FLAGS_SET(flags, SD_VARLINK_METHOD_MORE));
+
+        r = varlink_verify_polkit_async(
+                        link,
+                        /* bus= */ NULL,
+                        "io.systemd.sysinstall.ListCandidateDevices",
+                        /* details= */ NULL,
+                        polkit_registry);
+        if (r <= 0)
+                return r;
+
+        static const sd_json_dispatch_field dispatch_table[] = {
+                { "definitions", SD_JSON_VARIANT_ARRAY, json_dispatch_strv_path, offsetof(ListCandidateDevicesParameters, definitions), SD_JSON_STRICT },
+                {}
+        };
+
+        _cleanup_(list_candidate_devices_parameters_done) ListCandidateDevicesParameters p = {};
+        r = sd_varlink_dispatch(link, parameters, dispatch_table, &p);
+        if (r != 0)
+                return r;
+
+        _cleanup_(list_candidate_devices_context_freep) ListCandidateDevicesContext* context = list_candidate_devices_context_new();
+        if (!context)
+                return log_oom();
+
+        if (p.definitions) {
+                context->definitions = TAKE_PTR(p.definitions);
+        } else {
+                r = settle_definitions(&context->definitions);
+                if (r < 0)
+                        return r;
+        }
+        context->link = sd_varlink_ref(link);
+
+        _cleanup_(sd_varlink_flush_close_unrefp) sd_varlink *repart_link = NULL;
+
+        r = connect_to_repart(&repart_link);
+        if (r < 0)
+                return r;
+
+        r = sd_varlink_attach_event(repart_link, event, SD_EVENT_PRIORITY_NORMAL);
+        if (r < 0)
+                return log_error_errno(
+                                r,
+                                "Failed to attach io.systemd.Repart.ListCandidateDevices() varlink connection to event loop: %m");
+
+        r = sd_varlink_bind_reply(repart_link, fetch_candidate_devices_reply);
+        if (r < 0)
+                return r;
+
+        r = sd_varlink_observebo(
+                        repart_link,
+                        "io.systemd.Repart.ListCandidateDevices",
+                        SD_JSON_BUILD_PAIR_BOOLEAN("ignoreRoot", true));
+
+        if (r < 0)
+                return log_error_errno(
+                                r,
+                                "Failed to issue io.systemd.Repart.ListCandidateDevices() varlink call: %m");
+
+        r = sd_varlink_server_bind_disconnect(varlink_server, vl_on_disconnect);
+        if (r < 0)
+                return r;
+
+        /* The repart link and context is freed in vl_on_disconnect() */
+        sd_varlink_set_userdata(repart_link, TAKE_PTR(context));
+        sd_varlink_set_userdata(link, TAKE_PTR(repart_link));
+
+        return 0;
+}
+
+typedef struct RunParameters {
+        char *node;
+        char **definitions;
+        bool erase;
+        bool variables;
+        char *kernel_image;
+        bool copy_locale;
+        bool copy_keymap;
+        bool copy_timezone;
+        char **set_credentials;
+        char **load_credentials;
+} RunParameters;
+
+static void run_parameters_done(RunParameters *p) {
+        assert(p);
+
+        p->node = mfree(p->node);
+        p->definitions = strv_free(p->definitions);
+        p->kernel_image = mfree(p->kernel_image);
+        p->set_credentials = strv_free(p->set_credentials);
+        p->load_credentials = strv_free(p->load_credentials);
+}
+
+static int vl_method_run(
+                sd_varlink *link,
+                sd_json_variant *parameters,
+                sd_varlink_method_flags_t flags,
+                void *userdata) {
+
+        static const sd_json_dispatch_field dispatch_table[] = {
+                { "node",            SD_JSON_VARIANT_STRING,  sd_json_dispatch_string,  offsetof(RunParameters, node),             SD_JSON_MANDATORY                 },
+                { "definitions",     SD_JSON_VARIANT_ARRAY,   json_dispatch_strv_path,  offsetof(RunParameters, definitions),      SD_JSON_NULLABLE | SD_JSON_STRICT },
+                { "erase",           SD_JSON_VARIANT_BOOLEAN, sd_json_dispatch_stdbool, offsetof(RunParameters, erase),            SD_JSON_MANDATORY                 },
+                { "variables",       SD_JSON_VARIANT_BOOLEAN, sd_json_dispatch_stdbool, offsetof(RunParameters, variables),        SD_JSON_NULLABLE                  },
+                { "kernelImage",     SD_JSON_VARIANT_STRING,  json_dispatch_path,       offsetof(RunParameters, kernel_image),     SD_JSON_NULLABLE | SD_JSON_STRICT },
+                { "copyLocale",      SD_JSON_VARIANT_BOOLEAN, sd_json_dispatch_stdbool, offsetof(RunParameters, copy_locale),      SD_JSON_NULLABLE                  },
+                { "copyKeymap",      SD_JSON_VARIANT_BOOLEAN, sd_json_dispatch_stdbool, offsetof(RunParameters, copy_keymap),      SD_JSON_NULLABLE                  },
+                { "copyTimezone",    SD_JSON_VARIANT_BOOLEAN, sd_json_dispatch_stdbool, offsetof(RunParameters, copy_timezone),    SD_JSON_NULLABLE                  },
+                { "setCredentials",  SD_JSON_VARIANT_ARRAY,   sd_json_dispatch_strv,    offsetof(RunParameters, set_credentials),  SD_JSON_NULLABLE | SD_JSON_STRICT },
+                { "loadCredentials", SD_JSON_VARIANT_ARRAY,   sd_json_dispatch_strv,    offsetof(RunParameters, load_credentials), SD_JSON_NULLABLE | SD_JSON_STRICT },
+                {}
+        };
+
+        int r;
+
+        assert(link);
+
+        sd_varlink_server *varlink_server = sd_varlink_get_server(link);
+        Hashmap **polkit_registry = ASSERT_PTR(sd_varlink_server_get_userdata(varlink_server));
+
+        r = varlink_verify_polkit_async(
+                        link,
+                        /* bus= */ NULL,
+                        "io.systemd.sysinstall.Run",
+                        /* details= */ NULL,
+                        polkit_registry);
+        if (r <= 0)
+                return r;
+
+        _cleanup_(run_parameters_done) RunParameters p = {};
+        r = sd_varlink_dispatch(link, parameters, dispatch_table, &p);
+        if (r != 0)
+                return r;
+
+        _cleanup_(sysinstall_context_done) SysinstallContext context = (SysinstallContext) {
+                .copy_locale = p.copy_locale,
+                .copy_keymap = p.copy_keymap,
+                .copy_timezone = p.copy_timezone,
+                .erase = p.erase,
+                .variables = p.variables,
+                .node = TAKE_PTR(p.node),
+                .kernel_image = TAKE_PTR(p.kernel_image),
+                .credentials = {},
+        };
+
+        if (p.definitions) {
+                context.definitions = TAKE_PTR(p.definitions);
+        } else {
+                r = settle_definitions(&context.definitions);
+                if (r < 0)
+                        return r;
+        }
+
+        if (FLAGS_SET(flags, SD_VARLINK_METHOD_MORE))
+                context.link = sd_varlink_ref(link);
+
+        (void) sysinstall_context_notify(&context, PROGRESS_LOAD_CREDENTIALS, NULL, UINT_MAX);
+
+        STRV_FOREACH(credential, p.set_credentials) {
+                r = machine_credential_set(&context.credentials, *credential);
+                if (r < 0)
+                        return r;
+        }
+
+        STRV_FOREACH(credential, p.load_credentials) {
+                r = machine_credential_load(&context.credentials, *credential);
+                if (r < 0)
+                        return r;
+        }
+
+        r = read_credentials(&context.credentials, p.copy_locale, p.copy_keymap, p.copy_timezone);
+        if (r < 0)
+                return r;
+
+        r = sysinstall_context_run(&context);
+        if (r < 0)
+                return r;
+
+        return sd_varlink_reply(link, NULL);
+}
+
+static int vl_server(void) {
+        _cleanup_(sd_varlink_server_unrefp) sd_varlink_server *varlink_server = NULL;
+        _cleanup_hashmap_free_ Hashmap *polkit_registry = NULL;
+        int r;
+
+        /* Invocation as Varlink service */
+
+        r = varlink_server_new(
+                        &varlink_server,
+                        0,
+                        /* userdata= */ &polkit_registry);
+        if (r < 0)
+                return log_error_errno(r, "Failed to allocate Varlink server: %m");
+
+        r = sd_varlink_server_add_interface(varlink_server, &vl_interface_io_systemd_SysInstall);
+        if (r < 0)
+                return log_error_errno(r, "Failed to add Varlink interface: %m");
+
+        r = sd_varlink_server_bind_method_many(
+                        varlink_server,
+                        "io.systemd.SysInstall.ListCandidateDevices", vl_method_list_candidate_devices,
+                        "io.systemd.SysInstall.Run",                  vl_method_run);
+        if (r < 0)
+                return log_error_errno(r, "Failed to bind Varlink methods: %m");
+
+        r = sd_varlink_server_loop_auto(varlink_server);
+        if (r < 0)
+                return log_error_errno(r, "Failed to run Varlink event loop: %m");
 
         return 0;
 }
@@ -1269,7 +2037,10 @@ static int run(int argc, char *argv[]) {
 
         log_setup();
 
-        r = settle_definitions();
+        if (arg_varlink)
+                return vl_server();
+
+        r = settle_definitions(&arg_definitions);
         if (r < 0)
                 return r;
 
@@ -1304,6 +2075,7 @@ static int run(int argc, char *argv[]) {
                                 /* node= */ NULL,
                                 /* erase= */ true,
                                 /* dry_run= */ true,
+                                arg_definitions,
                                 &min_size,
                                 /* current_size= */ NULL,
                                 /* need_free= */ NULL);
@@ -1337,7 +2109,7 @@ static int run(int argc, char *argv[]) {
         if (r < 0)
                 return r;
 
-        r = read_credentials();
+        r = read_credentials(&arg_credentials, arg_copy_locale, arg_copy_keymap, arg_copy_timezone);
         if (r < 0)
                 return r;
 
@@ -1356,78 +2128,22 @@ static int run(int argc, char *argv[]) {
 
         putchar('\n');
 
-        log_notice("%s%sEncrypting credentials...",
-                   emoji_enabled() ? glyph(GLYPH_LOCK_AND_KEY) : "", emoji_enabled() ? " " : "");
+        _cleanup_(sysinstall_context_done) SysinstallContext context = (SysinstallContext) {
+                .copy_locale = arg_copy_locale,
+                .copy_keymap = arg_copy_keymap,
+                .copy_timezone = arg_copy_timezone,
+                .erase = arg_erase,
+                .variables = arg_touch_variables,
+                .node = TAKE_PTR(arg_node),
+                .kernel_image = TAKE_PTR(arg_kernel_image),
+                .definitions = TAKE_PTR(arg_definitions),
+                .credentials = arg_credentials,
+                .repart_link = TAKE_PTR(repart_link),
+        };
 
-        _cleanup_(sd_varlink_flush_close_unrefp) sd_varlink *creds_link = NULL;
-        _cleanup_strv_free_ char **encrypted_credentials = NULL;
-        r = encrypt_credentials(&creds_link, &encrypted_credentials);
+        r = sysinstall_context_run(&context);
         if (r < 0)
                 return r;
-
-        log_notice("%s%sInstalling partitions...",
-                   emoji_enabled() ? glyph(GLYPH_COMPUTER_DISK) : "", emoji_enabled() ? " " : "");
-
-        /* Do the main part of the installation */
-        r = invoke_repart(
-                        &repart_link,
-                        arg_node,
-                        arg_erase,
-                        /* dry_run= */ false,
-                        /* min_size= */ NULL,
-                        /* current_size= */ NULL,
-                        /* need_free= */ NULL);
-        if (r < 0)
-                return r;
-
-        log_notice("%s%sMounting partitions...",
-                   emoji_enabled() ? glyph(GLYPH_COMPUTER_DISK) : "", emoji_enabled() ? " " : "");
-
-        _cleanup_(loop_device_unrefp) LoopDevice *loop_device = NULL;
-        _cleanup_(umount_and_freep) char *root_dir = NULL;
-        _cleanup_close_ int root_fd = -EBADF;
-        r = mount_image_privately_interactively(
-                        arg_node,
-                        &image_policy,
-                        DISSECT_IMAGE_REQUIRE_ROOT |
-                        DISSECT_IMAGE_RELAX_VAR_CHECK |
-                        DISSECT_IMAGE_ALLOW_USERSPACE_VERITY |
-                        DISSECT_IMAGE_DISCARD_ANY |
-                        DISSECT_IMAGE_GPT_ONLY |
-                        DISSECT_IMAGE_FSCK |
-                        DISSECT_IMAGE_USR_NO_ROOT |
-                        DISSECT_IMAGE_ADD_PARTITION_DEVICES |
-                        DISSECT_IMAGE_PIN_PARTITION_DEVICES,
-                        &root_dir,
-                        &root_fd,
-                        &loop_device);
-        if (r < 0)
-                return log_error_errno(r, "Failed to mount new image: %m");
-
-        log_notice("%s%sInstalling kernel...",
-                   emoji_enabled() ? glyph(GLYPH_COMPUTER_DISK) : "", emoji_enabled() ? " " : "");
-
-        _cleanup_(sd_varlink_flush_close_unrefp) sd_varlink *bootctl_link = NULL;
-        r = invoke_bootctl_link(&bootctl_link, root_dir, root_fd, encrypted_credentials);
-        if (r < 0)
-                return r;
-
-        log_notice("%s%sInstalling boot loader...",
-                   emoji_enabled() ? glyph(GLYPH_COMPUTER_DISK) : "", emoji_enabled() ? " " : "");
-
-        r = invoke_bootctl_install(&bootctl_link, root_dir, root_fd);
-        if (r < 0)
-                return r;
-
-        log_notice("%s%sUnmounting partitions...",
-                   emoji_enabled() ? glyph(GLYPH_COMPUTER_DISK) : "", emoji_enabled() ? " " : "");
-
-        root_fd = safe_close(root_fd);
-        r = umount_recursive(root_dir, /* flags= */ 0);
-        if (r < 0)
-                log_warning_errno(r, "Failed to unmount target disk, proceeding anyway: %m");
-        loop_device = loop_device_unref(loop_device);
-        sync();
 
         log_notice("%s%sInstallation succeeded.",
                    emoji_enabled() ? glyph(GLYPH_SPARKLES) : "", emoji_enabled() ? " " : "");

--- a/src/sysinstall/sysinstall.c
+++ b/src/sysinstall/sysinstall.c
@@ -11,6 +11,7 @@
 #include "blockdev-list.h"
 #include "build.h"
 #include "build-path.h"
+#include "bus-polkit.h"
 #include "chase.h"
 #include "conf-files.h"
 #include "constants.h"
@@ -24,6 +25,7 @@
 #include "format-util.h"
 #include "fs-util.h"
 #include "glyph-util.h"
+#include "hashmap.h"
 #include "help-util.h"
 #include "image-policy.h"
 #include "json-util.h"
@@ -39,8 +41,10 @@
 #include "parse-util.h"
 #include "path-util.h"
 #include "prompt-util.h"
+#include "string-table.h"
 #include "strv.h"
 #include "terminal-util.h"
+#include "varlink-io.systemd.SysInstall.h"
 #include "varlink-util.h"
 
 static char *arg_node = NULL;
@@ -58,11 +62,97 @@ static bool arg_copy_keymap = true;
 static bool arg_copy_timezone = true;
 static bool arg_chrome = true;
 static bool arg_mute_console = false;
+static bool arg_varlink = false;
 
 STATIC_DESTRUCTOR_REGISTER(arg_node, freep);
 STATIC_DESTRUCTOR_REGISTER(arg_definitions, strv_freep);
 STATIC_DESTRUCTOR_REGISTER(arg_kernel_image, freep);
 STATIC_DESTRUCTOR_REGISTER(arg_credentials, machine_credential_context_done);
+
+typedef enum ProgressPhase {
+        PROGRESS_ENCRYPT_CREDENTIALS,
+        PROGRESS_INSTALL_PARTITIONS,
+        PROGRESS_MOUNT_PARTITIONS,
+        PROGRESS_INSTALL_KERNEL,
+        PROGRESS_INSTALL_BOOTLOADER,
+        PROGRESS_UNMOUNT_PARTITIONS,
+        _PROGRESS_PHASE_MAX,
+        _PROGRESS_PHASE_INVALID = -EINVAL,
+} ProgressPhase;
+
+static const char *progress_phase_table[_PROGRESS_PHASE_MAX] = {
+        [PROGRESS_ENCRYPT_CREDENTIALS] = "encrypt-credentials",
+        [PROGRESS_INSTALL_PARTITIONS]  = "install-partitions",
+        [PROGRESS_MOUNT_PARTITIONS]    = "mount-partitions",
+        [PROGRESS_INSTALL_KERNEL]      = "install-kernel",
+        [PROGRESS_INSTALL_BOOTLOADER]  = "install-bootloader",
+        [PROGRESS_UNMOUNT_PARTITIONS]  = "unmount-partitions",
+};
+
+DEFINE_PRIVATE_STRING_TABLE_LOOKUP_TO_STRING(progress_phase, ProgressPhase);
+
+static const char *progress_phase_log_table[_PROGRESS_PHASE_MAX] = {
+        [PROGRESS_ENCRYPT_CREDENTIALS] = "Encrypting credentials...",
+        [PROGRESS_INSTALL_PARTITIONS]  = "Installing partitions...",
+        [PROGRESS_MOUNT_PARTITIONS]    = "Mounting partitions...",
+        [PROGRESS_INSTALL_KERNEL]      = "Installing kernel...",
+        [PROGRESS_INSTALL_BOOTLOADER]  = "Installing boot loader...",
+        [PROGRESS_UNMOUNT_PARTITIONS]  = "Unmounting partitions...",
+};
+
+DEFINE_PRIVATE_STRING_TABLE_LOOKUP_TO_STRING(progress_phase_log, ProgressPhase);
+
+typedef enum DeviceFit {
+        DEVICE_FIT_ENOUGH_FREE_SPACE,
+        DEVICE_FIT_INSUFFICIENT_FREE_SPACE,
+        DEVICE_FIT_DISK_TOO_SMALL,
+        DEVICE_FIT_CONFLICTING_DISK_LABEL_PRESENT,
+        _DEVICE_FIT_MAX,
+        _DEVICE_FIT_INVALID = -EINVAL,
+} DeviceFit;
+
+static const char *device_fit_table[_DEVICE_FIT_MAX] = {
+        [DEVICE_FIT_ENOUGH_FREE_SPACE]              = "enough-free-space",
+        [DEVICE_FIT_INSUFFICIENT_FREE_SPACE]        = "insufficient-free-space",
+        [DEVICE_FIT_DISK_TOO_SMALL]                 = "disk-too-small",
+        [DEVICE_FIT_CONFLICTING_DISK_LABEL_PRESENT] = "conflicting-disk-label-present",
+};
+
+DEFINE_PRIVATE_STRING_TABLE_LOOKUP_TO_STRING(device_fit, DeviceFit);
+
+typedef struct SysInstallContext {
+        bool copy_locale;
+        bool copy_keymap;
+        bool copy_timezone;
+        MachineCredentialContext credentials;
+        char **definitions;
+        bool erase;
+        char *node;
+        char *kernel_filename;
+        int kernel_fd;
+        bool touch_variables;
+
+        sd_varlink *repart_link;
+
+        sd_varlink *link; /* If 'more' is used on the Varlink call, we'll send progress info over this link */
+} SysInstallContext;
+
+static void sysinstall_context_done(SysInstallContext *c) {
+        assert(c);
+
+        strv_free(c->definitions);
+
+        free(c->node);
+
+        free(c->kernel_filename);
+        safe_close(c->kernel_fd);
+
+        machine_credential_context_done(&c->credentials);
+
+        sd_varlink_flush_close_unref(c->repart_link);
+
+        sd_varlink_unref(c->link);
+}
 
 static int help(void) {
         int r;
@@ -209,6 +299,12 @@ static int parse_argv(int argc, char *argv[]) {
                 if (!arg_node)
                         return log_oom();
         }
+
+        r = sd_varlink_invocation(SD_VARLINK_ALLOW_ACCEPT);
+        if (r < 0)
+                return log_error_errno(r, "Failed to check if invoked in Varlink mode: %m");
+        if (r > 0)
+                arg_varlink = true;
 
         return 1;
 }
@@ -403,6 +499,195 @@ static int prompt_block_device(sd_varlink **repart_link, char **ret_node) {
         return 0;
 }
 
+static int sysinstall_context_notify(
+                SysInstallContext *context,
+                ProgressPhase phase,
+                const char *object,
+                unsigned percent) {
+
+        int r;
+
+        assert(context);
+        assert(phase >= 0);
+        assert(phase < _PROGRESS_PHASE_MAX);
+
+        log_notice("%s%s%s",
+                   emoji_enabled() ? phase == PROGRESS_ENCRYPT_CREDENTIALS ?  glyph(GLYPH_LOCK_AND_KEY) : glyph(GLYPH_COMPUTER_DISK) : "",
+                   emoji_enabled() ? " " : "",
+                   progress_phase_log_to_string(phase));
+
+        if (context->link) {
+                r = sd_varlink_notifybo(
+                                context->link,
+                                JSON_BUILD_PAIR_ENUM("phase", progress_phase_to_string(phase)),
+                                JSON_BUILD_PAIR_STRING_NON_EMPTY("object", object),
+                                JSON_BUILD_PAIR_UNSIGNED_NOT_EQUAL("progress", percent, UINT_MAX));
+                if (r < 0)
+                        log_debug_errno(r, "Failed to send varlink notify progress notification, ignoring: %m");
+
+                r = sd_varlink_flush(context->link);
+                if (r < 0)
+                        log_debug_errno(r, "Failed to flush varlink notify progress notification, ignoring: %m");
+        }
+
+        return 0;
+}
+
+typedef struct RepartResult {
+        int ret;
+        SysInstallContext *context;
+} RepartResult;
+
+static int handle_repart_reply(
+                sd_varlink *link,
+                sd_json_variant *reply,
+                const char *error_id,
+                sd_varlink_reply_flags_t flags,
+                void *userdata) {
+
+        RepartResult *result = userdata;
+        int r;
+
+        assert(result);
+
+        struct {
+                uint64_t min_size;
+                uint64_t current_size;
+                uint64_t need_free;
+
+                const char *phase;
+                const char *object;
+                unsigned progress;
+        } p = {
+                .min_size = UINT64_MAX,
+                .current_size = UINT64_MAX,
+                .need_free = UINT64_MAX,
+                .progress = UINT_MAX,
+        };
+
+        static const sd_json_dispatch_field dispatch_table[] = {
+                { "minimalSizeBytes", _SD_JSON_VARIANT_TYPE_INVALID, sd_json_dispatch_uint64,       voffsetof(p, min_size),     0 },
+                { "currentSizeBytes", _SD_JSON_VARIANT_TYPE_INVALID, sd_json_dispatch_uint64,       voffsetof(p, current_size), 0 },
+                { "needFreeBytes",    _SD_JSON_VARIANT_TYPE_INVALID, sd_json_dispatch_uint64,       voffsetof(p, need_free),    0 },
+                { "phase",            _SD_JSON_VARIANT_TYPE_INVALID, sd_json_dispatch_const_string, voffsetof(p, phase),        0 },
+                { "object",           _SD_JSON_VARIANT_TYPE_INVALID, sd_json_dispatch_const_string, voffsetof(p, object),       0 },
+                { "progress",         _SD_JSON_VARIANT_TYPE_INVALID, sd_json_dispatch_uint,         voffsetof(p, progress),     0 },
+                {}
+        };
+
+        r = sd_json_dispatch(reply, dispatch_table, SD_JSON_ALLOW_EXTENSIONS, &p);
+        if (r < 0)
+                return result->ret = r;
+
+        if (error_id) {
+                const char *sysinstall_error_id = NULL;
+
+                if (streq(error_id, "io.systemd.Repart.InsufficientFreeSpace")) {
+                        sysinstall_error_id = "io.systemd.SysInstall.InsufficientFreeSpace";
+                        result->ret = log_error_errno(SYNTHETIC_ERRNO(ENOSPC), "Not enough free space on disk, cannot install.");
+                } else if (streq(error_id, "io.systemd.Repart.DiskTooSmall")) {
+                        sysinstall_error_id = "io.systemd.SysInstall.DiskTooSmall";
+
+                        result->ret = log_error_errno(SYNTHETIC_ERRNO(E2BIG), "Disk too small for installation, cannot install.");
+                } else if (streq(error_id, "io.systemd.Repart.ConflictingDiskLabelPresent")) {
+                        sysinstall_error_id = "io.systemd.SysInstall.ConflictingDiskLabelPresent";
+
+                        result->ret = log_error_errno(
+                                        SYNTHETIC_ERRNO(EHWPOISON),
+                                        "A conflicting disk label is already present on the target disk, cannot install unless disk is erased.");
+                }
+
+                if (sysinstall_error_id && result->context->link) {
+                        r = sd_varlink_errorbo(
+                                        result->context->link,
+                                        sysinstall_error_id,
+                                        JSON_BUILD_PAIR_UNSIGNED_NOT_EQUAL("currentSizeBytes", p.current_size, UINT64_MAX),
+                                        JSON_BUILD_PAIR_UNSIGNED_NOT_EQUAL("needFreeBytes", p.need_free, UINT64_MAX),
+                                        JSON_BUILD_PAIR_UNSIGNED_NOT_EQUAL("minimalSizeBytes", p.min_size, UINT64_MAX));
+
+                        if (r < 0)
+                                return result->ret = r;
+
+                        return result->ret;
+                }
+
+                r = sd_varlink_error_to_errno(error_id, reply); /* If this is a system errno style error, output it with %m */
+                if (r != -EBADR)
+                        return result->ret = log_error_errno(r, "Failed to issue io.systemd.Repart.Run() varlink call: %m");
+
+                return result->ret = log_error_errno(r, "Failed to issue io.systemd.Repart.Run() varlink call: %s", error_id);
+        }
+
+        if ((p.progress != UINT_MAX || p.object) && result->context->link)
+                (void) sysinstall_context_notify(result->context, PROGRESS_INSTALL_PARTITIONS, p.object, p.progress);
+
+        return result->ret = 0;
+}
+
+static int sysinstall_context_invoke_repart_run(SysInstallContext *context) {
+
+        int r;
+
+        assert(context);
+
+        r = connect_to_repart(&context->repart_link);
+        if (r < 0)
+                return r;
+
+        /* Seeding the partitions might be very slow, disable timeout */
+        r = sd_varlink_set_relative_timeout(context->repart_link, UINT64_MAX);
+        if (r < 0)
+                return log_error_errno(r, "Failed to disable IPC timeout: %m");
+
+        RepartResult result = {
+                .context = context,
+        };
+
+        sd_varlink_set_userdata(context->repart_link, &result);
+
+        r = sd_varlink_bind_reply(context->repart_link, handle_repart_reply);
+        if (r < 0)
+                return log_error_errno(r, "Failed to bind repart reply callback: %m");
+
+        r = sd_varlink_observebo(
+                        context->repart_link,
+                        "io.systemd.Repart.Run",
+                        SD_JSON_BUILD_PAIR_STRING("node", context->node),
+                        SD_JSON_BUILD_PAIR_STRING("empty", context->erase ? "force" : "allow"),
+                        SD_JSON_BUILD_PAIR_BOOLEAN("dryRun", false),
+                        SD_JSON_BUILD_PAIR_CONDITION(!!context->definitions, "definitions", SD_JSON_BUILD_STRV(context->definitions)),
+                        SD_JSON_BUILD_PAIR_BOOLEAN("deferPartitionsEmpty", true),
+                        SD_JSON_BUILD_PAIR_BOOLEAN("deferPartitionsFactoryReset", true));
+        if (r < 0)
+                return log_error_errno(r, "Failed to issue io.systemd.Repart.Run() varlink call: %m");
+
+        for (;;) {
+                r = sd_varlink_is_idle(context->repart_link);
+                if (r < 0)
+                        return log_error_errno(r, "Failed to check if varlink connection is idle: %m");
+                if (r > 0)
+                        break;
+
+                r = sd_varlink_process(context->repart_link);
+                if (r < 0)
+                        return log_error_errno(r, "Failed to process varlink connection: %m");
+                if (r != 0)
+                        continue;
+
+                r = sd_varlink_wait(context->repart_link, USEC_INFINITY);
+                if (r < 0)
+                        return log_error_errno(r, "Failed to wait for varlink connection events: %m");
+        }
+
+        sd_varlink_set_userdata(context->repart_link, NULL);
+
+        r = sd_varlink_bind_reply(context->repart_link, NULL);
+        if (r < 0)
+                return log_error_errno(r, "Failed to unbind repart reply callback: %m");
+
+        return result.ret;
+}
+
 static int read_space_metrics(
                 sd_json_variant *v,
                 uint64_t *min_size,
@@ -447,6 +732,7 @@ static int invoke_repart(
                 const char *node,
                 bool erase,
                 bool dry_run,
+                char **definitions,
                 uint64_t *min_size,        /* initialized both on success and error */
                 uint64_t *current_size,    /* ditto */
                 uint64_t *need_free) {     /* ditto */
@@ -481,7 +767,7 @@ static int invoke_repart(
                         SD_JSON_BUILD_PAIR_STRING("node", node),
                         SD_JSON_BUILD_PAIR_STRING("empty", erase ? "force" : "allow"),
                         SD_JSON_BUILD_PAIR_BOOLEAN("dryRun", dry_run),
-                        SD_JSON_BUILD_PAIR_CONDITION(!!arg_definitions, "definitions", SD_JSON_BUILD_STRV(arg_definitions)),
+                        SD_JSON_BUILD_PAIR_CONDITION(!!definitions, "definitions", SD_JSON_BUILD_STRV(definitions)),
                         SD_JSON_BUILD_PAIR_BOOLEAN("deferPartitionsEmpty", true),
                         SD_JSON_BUILD_PAIR_BOOLEAN("deferPartitionsFactoryReset", true));
         if (r < 0) {
@@ -656,6 +942,7 @@ static int validate_run(sd_varlink **repart_link, const char *node) {
                                 node,
                                 try_erase,
                                 /* dry_run= */ true,
+                                arg_definitions,
                                 &min_size,
                                 &current_size,
                                 &need_free);
@@ -705,11 +992,8 @@ static int validate_run(sd_varlink **repart_link, const char *node) {
         }
 }
 
-static int show_summary(void) {
+static int sysinstall_context_show_summary(SysInstallContext *context) {
         int r;
-
-        if (!arg_summary)
-                return 0;
 
         printf("\n"
                "%sSummary:%s\n", ansi_underline(), ansi_normal());
@@ -721,12 +1005,12 @@ static int show_summary(void) {
         r = table_add_many(
                         table,
                         TABLE_FIELD, "Selected Disk",
-                        TABLE_STRING, arg_node,
+                        TABLE_STRING, context->node,
                         TABLE_FIELD, "Erase Disk",
-                        TABLE_BOOLEAN, arg_erase,
-                        TABLE_SET_COLOR, arg_erase ? ansi_highlight_red() : NULL,
+                        TABLE_BOOLEAN, context->erase,
+                        TABLE_SET_COLOR, context->erase ? ansi_highlight_red() : NULL,
                         TABLE_FIELD, "Register in Firmware",
-                        TABLE_BOOLEAN, arg_touch_variables);
+                        TABLE_BOOLEAN, context->touch_variables);
         if (r < 0)
                 return table_log_add_error(r);
 
@@ -739,7 +1023,7 @@ static int show_summary(void) {
         };
 
         STRV_FOREACH_PAIR(id, text, map) {
-                MachineCredential *c = machine_credential_find(&arg_credentials, *id);
+                MachineCredential *c = machine_credential_find(&context->credentials, *id);
                 if (!c)
                         continue;
 
@@ -756,7 +1040,7 @@ static int show_summary(void) {
         }
 
         unsigned n_extra_credentials = 0;
-        FOREACH_ARRAY(cred, arg_credentials.credentials, arg_credentials.n_credentials) {
+        FOREACH_ARRAY(cred, context->credentials.credentials, context->credentials.n_credentials) {
                 bool covered = false;
 
                 STRV_FOREACH_PAIR(id, text, map)
@@ -894,6 +1178,7 @@ static int connect_to_bootctl(sd_varlink **link) {
 
 static int invoke_bootctl_install(
                 sd_varlink **link,
+                bool variables,
                 const char *root_dir,
                 int root_fd) {
         int r;
@@ -919,7 +1204,7 @@ static int invoke_bootctl_install(
                         SD_JSON_BUILD_PAIR_STRING("operation", "new"),
                         SD_JSON_BUILD_PAIR_INTEGER("rootFileDescriptor", fd_idx),
                         SD_JSON_BUILD_PAIR_STRING("rootDirectory", root_dir),
-                        SD_JSON_BUILD_PAIR_BOOLEAN("touchVariables", arg_touch_variables));
+                        SD_JSON_BUILD_PAIR_BOOLEAN("touchVariables", variables));
         if (r < 0)
                 return r;
 
@@ -1017,14 +1302,11 @@ static int maybe_reboot(void) {
         return 0;
 }
 
-static int read_credential_locale(void) {
+static int read_credential_locale(MachineCredentialContext *credentials) {
         int r;
 
-        if (!arg_copy_locale)
-                return 0;
-
-        if (machine_credential_find(&arg_credentials, "firstboot.locale") ||
-            machine_credential_find(&arg_credentials, "firstboot.locale-messages"))
+        if (machine_credential_find(credentials, "firstboot.locale") ||
+            machine_credential_find(credentials, "firstboot.locale-messages"))
                 return 0;
 
         /* For the main locale we check the two env vars, and if neither is there, we use LC_NUMERIC, since
@@ -1032,14 +1314,14 @@ static int read_credential_locale(void) {
          * separate setting after all */
         const char *l = getenv("LC_ALL") ?: getenv("LANG") ?: setlocale(LC_NUMERIC, NULL);
         if (l) {
-                r = machine_credential_add(&arg_credentials, "firstboot.locale", l, /* size= */ SIZE_MAX);
+                r = machine_credential_add(credentials, "firstboot.locale", l, /* size= */ SIZE_MAX);
                 if (r < 0)
                         return log_oom();
         }
 
         const char *m = setlocale(LC_MESSAGES, NULL);
         if (m && !streq_ptr(m, l)) {
-                r = machine_credential_add(&arg_credentials, "firstboot.locale-messages", m, /* size= */ SIZE_MAX);
+                r = machine_credential_add(credentials, "firstboot.locale-messages", m, /* size= */ SIZE_MAX);
                 if (r < 0)
                         return log_oom();
         }
@@ -1047,13 +1329,10 @@ static int read_credential_locale(void) {
         return 0;
 }
 
-static int read_credential_keymap(void) {
+static int read_credential_keymap(MachineCredentialContext *credentials) {
         int r;
 
-        if (!arg_copy_keymap)
-                return 0;
-
-        if (machine_credential_find(&arg_credentials, "firstboot.keymap"))
+        if (machine_credential_find(credentials, "firstboot.keymap"))
                 return 0;
 
         _cleanup_free_ char *keymap = NULL;
@@ -1065,7 +1344,7 @@ static int read_credential_keymap(void) {
                 return log_error_errno(r, "Failed to parse '%s': %m", etc_vconsole_conf());
 
         if (!isempty(keymap)) {
-                r = machine_credential_add(&arg_credentials, "firstboot.keymap", keymap, /* size= */ SIZE_MAX);
+                r = machine_credential_add(credentials, "firstboot.keymap", keymap, /* size= */ SIZE_MAX);
                 if (r < 0)
                         return log_oom();
         }
@@ -1073,13 +1352,10 @@ static int read_credential_keymap(void) {
         return 0;
 }
 
-static int read_credential_timezone(void) {
+static int read_credential_timezone(MachineCredentialContext *credentials) {
         int r;
 
-        if (!arg_copy_timezone)
-                return 0;
-
-        if (machine_credential_find(&arg_credentials, "firstboot.timezone"))
+        if (machine_credential_find(credentials, "firstboot.timezone"))
                 return 0;
 
         _cleanup_free_ char *tz = NULL;
@@ -1087,7 +1363,7 @@ static int read_credential_timezone(void) {
         if (r < 0)
                 log_warning_errno(r, "Failed to read timezone, skipping timezone propagation: %m");
         else {
-                r = machine_credential_add(&arg_credentials, "firstboot.timezone", tz, /* size= */ SIZE_MAX);
+                r = machine_credential_add(credentials, "firstboot.timezone", tz, /* size= */ SIZE_MAX);
                 if (r < 0)
                         return log_oom();
         }
@@ -1095,20 +1371,26 @@ static int read_credential_timezone(void) {
         return 0;
 }
 
-static int read_credentials(void) {
+static int sysinstall_context_read_credentials(SysInstallContext *context) {
         int r;
 
-        r = read_credential_locale();
-        if (r < 0)
-                return r;
+        if (context->copy_locale) {
+                r = read_credential_locale(&context->credentials);
+                if (r < 0)
+                        return r;
+        }
 
-        r = read_credential_keymap();
-        if (r < 0)
-                return r;
+        if (context->copy_keymap) {
+                r = read_credential_keymap(&context->credentials);
+                if (r < 0)
+                        return r;
+        }
 
-        r = read_credential_timezone();
-        if (r < 0)
-                return r;
+        if (context->copy_timezone) {
+                r = read_credential_timezone(&context->credentials);
+                if (r < 0)
+                        return r;
+        }
 
         return 0;
 }
@@ -1179,13 +1461,13 @@ static int encrypt_one_credential(sd_varlink **link, const MachineCredential *in
         return 0;
 }
 
-static int encrypt_credentials(sd_varlink **link, char ***encrypted) {
+static int encrypt_credentials(sd_varlink **link, MachineCredentialContext *credentials, char ***encrypted) {
         int r;
 
         assert(link);
         assert(encrypted);
 
-        FOREACH_ARRAY(cred, arg_credentials.credentials, arg_credentials.n_credentials) {
+        FOREACH_ARRAY(cred, credentials->credentials, credentials->n_credentials) {
                 r = encrypt_one_credential(link, cred, encrypted);
                 if (r < 0)
                         return r;
@@ -1206,11 +1488,22 @@ static const ImagePolicy image_policy = {
         .default_flags = PARTITION_POLICY_IGNORE,
 };
 
-static int settle_definitions(void) {
+static int settle_definitions(char **definitions, char ***ret_definitions) {
+
+        _cleanup_strv_free_ char **d = NULL;
         int r;
 
-        if (arg_definitions)
+        assert(ret_definitions);
+
+        if (definitions) {
+                d = strv_copy(definitions);
+                if (!d)
+                        return log_oom();
+
+                *ret_definitions = TAKE_PTR(d);
+
                 return 0;
+        }
 
         /* If /usr/lib/repart.sysinstall.d/ is populated, use it, otherwise use the regular definition
          * files */
@@ -1226,10 +1519,548 @@ static int settle_definitions(void) {
                 return log_error_errno(r, "Failed to enumerate *.conf files: %m");
 
         if (!strv_isempty(files)) {
-                arg_definitions = strv_copy(CONF_PATHS_STRV("repart.sysinstall.d"));
-                if (!arg_definitions)
+                d = strv_copy(CONF_PATHS_STRV("repart.sysinstall.d"));
+                if (!d)
                         return log_oom();
+
+                *ret_definitions = TAKE_PTR(d);
         }
+
+        return 0;
+}
+
+static int sysinstall_context_settle_definitions(SysInstallContext *context,
+                                                 char **definitions) {
+
+        return settle_definitions(definitions, &context->definitions);
+}
+
+static int sysinstall_context_settle_kernel_image(SysInstallContext *context,
+                                                  const char *kernel_image) {
+
+        _cleanup_free_ char *kernel_filename = NULL;
+        _cleanup_close_ int kernel_fd = -EBADF;
+        int r;
+
+        assert(context->kernel_fd < 0);
+        assert(!context->kernel_filename);
+
+        if (kernel_image) {
+                r = path_extract_filename(kernel_image, &kernel_filename);
+                if (r < 0)
+                        return log_error_errno(r, "Failed to extract filename from kernel path '%s': %m", kernel_image);
+                if (r == O_DIRECTORY)
+                        return log_error_errno(SYNTHETIC_ERRNO(EISDIR), "Kernel path '%s' refers to directory, must be regular file, refusing.", kernel_image);
+
+                kernel_fd = xopenat_full(XAT_FDROOT, kernel_image, O_RDONLY|O_CLOEXEC, XO_REGULAR, MODE_INVALID);
+                if (kernel_fd < 0)
+                        return log_error_errno(kernel_fd, "Failed to open kernel image '%s': %m", kernel_image);
+
+        } else {
+                r = find_current_kernel(&kernel_filename, &kernel_fd);
+                if (r < 0)
+                        return r;
+        }
+
+        context->kernel_filename = TAKE_PTR(kernel_filename);
+        context->kernel_fd = TAKE_FD(kernel_fd);
+
+        return 0;
+}
+
+static int sysinstall_context_run(SysInstallContext *context) {
+
+        int r;
+
+        assert(context);
+
+        (void) sysinstall_context_notify(context, PROGRESS_ENCRYPT_CREDENTIALS, NULL, UINT_MAX);
+
+        _cleanup_(sd_varlink_flush_close_unrefp) sd_varlink *creds_link = NULL;
+        _cleanup_strv_free_ char **encrypted_credentials = NULL;
+        r = encrypt_credentials(&creds_link, &context->credentials, &encrypted_credentials);
+        if (r < 0)
+                return r;
+
+        (void) sysinstall_context_notify(context, PROGRESS_INSTALL_PARTITIONS, NULL, UINT_MAX);
+
+        /* Do the main part of the installation */
+
+        r = sysinstall_context_invoke_repart_run(context);
+        if (r < 0)
+                return r;
+
+        (void) sysinstall_context_notify(context, PROGRESS_MOUNT_PARTITIONS, NULL, UINT_MAX);
+
+        _cleanup_(loop_device_unrefp) LoopDevice *loop_device = NULL;
+        _cleanup_(umount_and_freep) char *root_dir = NULL;
+        _cleanup_close_ int root_fd = -EBADF;
+        r = mount_image_privately_interactively(
+                        context->node,
+                        &image_policy,
+                        DISSECT_IMAGE_REQUIRE_ROOT |
+                        DISSECT_IMAGE_RELAX_VAR_CHECK |
+                        DISSECT_IMAGE_ALLOW_USERSPACE_VERITY |
+                        DISSECT_IMAGE_DISCARD_ANY |
+                        DISSECT_IMAGE_GPT_ONLY |
+                        DISSECT_IMAGE_FSCK |
+                        DISSECT_IMAGE_USR_NO_ROOT |
+                        DISSECT_IMAGE_ADD_PARTITION_DEVICES |
+                        DISSECT_IMAGE_PIN_PARTITION_DEVICES,
+                        &root_dir,
+                        &root_fd,
+                        &loop_device);
+        if (r < 0)
+                return log_error_errno(r, "Failed to mount new image: %m");
+
+        (void) sysinstall_context_notify(context, PROGRESS_INSTALL_KERNEL, NULL, UINT_MAX);
+
+        _cleanup_(sd_varlink_flush_close_unrefp) sd_varlink *bootctl_link = NULL;
+        r = invoke_bootctl_link(&bootctl_link, root_dir, root_fd, context->kernel_filename, context->kernel_fd, encrypted_credentials);
+        if (r < 0)
+                return r;
+
+        (void) sysinstall_context_notify(context, PROGRESS_INSTALL_BOOTLOADER, NULL, UINT_MAX);
+
+        r = invoke_bootctl_install(&bootctl_link, context->touch_variables, root_dir, root_fd);
+        if (r < 0)
+                return r;
+
+        (void) sysinstall_context_notify(context, PROGRESS_UNMOUNT_PARTITIONS, NULL, UINT_MAX);
+
+        root_fd = safe_close(root_fd);
+        r = umount_recursive(root_dir, /* flags= */ 0);
+        if (r < 0)
+                log_warning_errno(r, "Failed to unmount target disk, proceeding anyway: %m");
+        loop_device = loop_device_unref(loop_device);
+        sync();
+
+        return 0;
+}
+
+typedef struct ListCandidateDevicesContext {
+        char **definitions;
+        bool subscribe;
+
+        sd_varlink *repart_link; /* A repart connection to get candidate devices */
+        sd_varlink *dry_run_repart_link; /* A second repart connection to perform a dry run on each node */
+
+        sd_varlink *link;
+} ListCandidateDevicesContext;
+
+static ListCandidateDevicesContext* list_candidate_devices_context_new(void) {
+        ListCandidateDevicesContext *context = new(ListCandidateDevicesContext, 1);
+
+        if (!context)
+                return NULL;
+
+        *context = (ListCandidateDevicesContext) {};
+
+        return context;
+}
+
+static ListCandidateDevicesContext* list_candidate_devices_context_free(ListCandidateDevicesContext *context) {
+        if (!context)
+                return NULL;
+
+        strv_free(context->definitions);
+
+        context->repart_link = sd_varlink_flush_close_unref(context->repart_link);
+        context->dry_run_repart_link = sd_varlink_flush_close_unref(context->dry_run_repart_link);
+        context->link = sd_varlink_unref(context->link);
+
+        return mfree(context);
+}
+
+DEFINE_TRIVIAL_CLEANUP_FUNC(ListCandidateDevicesContext*, list_candidate_devices_context_free);
+
+static int list_candidate_devices_context_settle_definitions(ListCandidateDevicesContext *context,
+                                                             char **definitions) {
+
+        return settle_definitions(definitions, &context->definitions);
+}
+
+static void vl_on_disconnect(sd_varlink_server *server, sd_varlink *link, void *userdata) {
+        assert(server);
+        assert(link);
+
+        list_candidate_devices_context_free(sd_varlink_set_userdata(link, NULL));
+}
+
+typedef struct DevicesResponse {
+        const char *node;
+        char **symlinks;
+        uint64_t diskseq;
+        uint64_t size;
+        const char *model;
+        const char *vendor;
+        const char *subsystem;
+        const char *action;
+} DevicesResponse;
+
+static void devices_response_done(DevicesResponse *p) {
+        assert(p);
+
+        p->symlinks = strv_free(p->symlinks);
+}
+
+static int fetch_candidate_devices_reply(
+                sd_varlink *repart_link,
+                sd_json_variant *reply,
+                const char *error_id,
+                sd_varlink_reply_flags_t flags,
+                void *userdata) {
+
+        int r;
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *v = NULL;
+        ListCandidateDevicesContext *context = ASSERT_PTR(userdata);
+
+        if (error_id) {
+                if (streq(error_id, "io.systemd.Repart.NoCandidateDevices"))
+                        return sd_varlink_error(context->link, "io.systemd.SysInstall.NoCandidateDevices", NULL);
+
+                return sd_varlink_error(context->link, error_id, NULL);
+        }
+
+        static const sd_json_dispatch_field dispatch_table[] = {
+                { "node",      SD_JSON_VARIANT_STRING,        sd_json_dispatch_const_string, offsetof(DevicesResponse, node),      0 },
+                { "symlinks",  SD_JSON_VARIANT_ARRAY,         sd_json_dispatch_strv,         offsetof(DevicesResponse, symlinks),  0 },
+                { "diskseq",   _SD_JSON_VARIANT_TYPE_INVALID, sd_json_dispatch_uint64,       offsetof(DevicesResponse, diskseq),   0 },
+                { "sizeBytes", _SD_JSON_VARIANT_TYPE_INVALID, sd_json_dispatch_uint64,       offsetof(DevicesResponse, size),      0 },
+                { "model",     SD_JSON_VARIANT_STRING,        sd_json_dispatch_const_string, offsetof(DevicesResponse, model),     0 },
+                { "vendor",    SD_JSON_VARIANT_STRING,        sd_json_dispatch_const_string, offsetof(DevicesResponse, vendor),    0 },
+                { "subsystem", SD_JSON_VARIANT_STRING,        sd_json_dispatch_const_string, offsetof(DevicesResponse, subsystem), 0 },
+                { "action",    SD_JSON_VARIANT_STRING,        sd_json_dispatch_const_string, offsetof(DevicesResponse, action),    0 },
+                {}
+        };
+
+        _cleanup_(devices_response_done) DevicesResponse p = {
+                .diskseq = UINT64_MAX,
+                .size = UINT64_MAX,
+        };
+        r = sd_json_dispatch(reply, dispatch_table, SD_JSON_ALLOW_EXTENSIONS, &p);
+        if (r < 0)
+                return r;
+
+        if (context->subscribe) {
+                /* The action needs to be ready, remove or add else we don't support the action */
+                if (streq(p.action, "ready"))
+                        return sd_varlink_notifybo(context->link, SD_JSON_BUILD_PAIR("action", JSON_BUILD_CONST_STRING("ready")));
+
+                if (streq(p.action, "remove"))
+                        return sd_varlink_notifybo(context->link,
+                                        SD_JSON_BUILD_PAIR("action", JSON_BUILD_CONST_STRING("remove")),
+                                        SD_JSON_BUILD_PAIR_STRING("node", p.node));
+
+                if (!streq(p.action, "add")) {
+                        log_debug("Skip unsupported action '%s' while fetching candidate devices.", p.action);
+                        return 0;
+                }
+        }
+
+        uint64_t min_size = UINT64_MAX, current_size = UINT64_MAX, need_free = UINT64_MAX;
+        r = invoke_repart(
+                        &context->dry_run_repart_link,
+                        p.node,
+                        /* erase= */ false,
+                        /* dry_run= */ true,
+                        context->definitions,
+                        &min_size,
+                        &current_size,
+                        &need_free);
+
+        DeviceFit fit;
+        if (r < 0) {
+                if (r == -ENOSPC)
+                        fit = DEVICE_FIT_INSUFFICIENT_FREE_SPACE;
+                else if (r == -E2BIG)
+                        fit = DEVICE_FIT_DISK_TOO_SMALL;
+                else if (r == -EHWPOISON)
+                        fit = DEVICE_FIT_CONFLICTING_DISK_LABEL_PRESENT;
+                else
+                        return r;
+        } else
+                fit = DEVICE_FIT_ENOUGH_FREE_SPACE;
+
+        r = sd_json_buildo(&v,
+                        SD_JSON_BUILD_PAIR_STRING("node", p.node),
+                        JSON_BUILD_PAIR_STRV_NON_EMPTY("symlinks", p.symlinks),
+                        JSON_BUILD_PAIR_UNSIGNED_NOT_EQUAL("diskseq", p.diskseq, UINT64_MAX),
+                        JSON_BUILD_PAIR_UNSIGNED_NOT_EQUAL("sizeBytes", p.size, UINT64_MAX),
+                        JSON_BUILD_PAIR_STRING_NON_EMPTY("model", p.model),
+                        JSON_BUILD_PAIR_STRING_NON_EMPTY("vendor", p.vendor),
+                        JSON_BUILD_PAIR_STRING_NON_EMPTY("subsystem", p.subsystem),
+                        JSON_BUILD_PAIR_ENUM("fit", device_fit_to_string(fit)),
+                        JSON_BUILD_PAIR_UNSIGNED_NOT_EQUAL("currentSizeBytes", current_size, UINT64_MAX),
+                        JSON_BUILD_PAIR_UNSIGNED_NOT_EQUAL("needFreeBytes", need_free, UINT64_MAX),
+                        JSON_BUILD_PAIR_UNSIGNED_NOT_EQUAL("minimalSizeBytes", min_size, UINT64_MAX),
+                        SD_JSON_BUILD_PAIR_CONDITION(context->subscribe, "action", JSON_BUILD_CONST_STRING("add")));
+        if (r < 0)
+                return r;
+
+        if (FLAGS_SET(flags, SD_VARLINK_REPLY_CONTINUES))
+                return sd_varlink_notify(context->link, v);
+
+        return sd_varlink_reply(context->link, v);
+}
+
+typedef struct ListCandidateDevicesParameters {
+        char **definitions;
+        bool subscribe;
+} ListCandidateDevicesParameters;
+
+static void list_candidate_devices_parameters_done(ListCandidateDevicesParameters *p) {
+        assert(p);
+
+        p->definitions = strv_free(p->definitions);
+}
+
+static int vl_method_list_candidate_devices(
+                sd_varlink *link,
+                sd_json_variant *parameters,
+                sd_varlink_method_flags_t flags,
+                void *userdata) {
+        int r;
+
+        assert(link);
+
+        sd_varlink_server *varlink_server = sd_varlink_get_server(link);
+        sd_event *event = sd_varlink_server_get_event(varlink_server);
+        Hashmap **polkit_registry = ASSERT_PTR(sd_varlink_server_get_userdata(varlink_server));
+
+        assert(FLAGS_SET(flags, SD_VARLINK_METHOD_MORE));
+
+        r = varlink_verify_polkit_async(
+                        link,
+                        /* bus= */ NULL,
+                        "io.systemd.sysinstall.ListCandidateDevices",
+                        /* details= */ NULL,
+                        polkit_registry);
+        if (r <= 0)
+                return r;
+
+        static const sd_json_dispatch_field dispatch_table[] = {
+                { "definitions", SD_JSON_VARIANT_ARRAY,   json_dispatch_strv_path,  offsetof(ListCandidateDevicesParameters, definitions), SD_JSON_STRICT },
+                { "subscribe",   SD_JSON_VARIANT_BOOLEAN, sd_json_dispatch_stdbool, offsetof(ListCandidateDevicesParameters, subscribe),   0              },
+                {}
+        };
+
+        _cleanup_(list_candidate_devices_parameters_done) ListCandidateDevicesParameters p = {};
+        r = sd_varlink_dispatch(link, parameters, dispatch_table, &p);
+        if (r != 0)
+                return r;
+
+        _cleanup_(list_candidate_devices_context_freep) ListCandidateDevicesContext* context = list_candidate_devices_context_new();
+        if (!context)
+                return log_oom();
+
+        context->subscribe = p.subscribe;
+        r = list_candidate_devices_context_settle_definitions(context, p.definitions);
+        if (r < 0)
+                return r;
+
+        context->link = sd_varlink_ref(link);
+
+        r = connect_to_repart(&context->repart_link);
+        if (r < 0)
+                return r;
+
+        r = sd_varlink_attach_event(context->repart_link, event, SD_EVENT_PRIORITY_NORMAL);
+        if (r < 0)
+                return log_error_errno(
+                                r,
+                                "Failed to attach io.systemd.Repart.ListCandidateDevices() varlink connection to event loop: %m");
+
+        r = sd_varlink_bind_reply(context->repart_link, fetch_candidate_devices_reply);
+        if (r < 0)
+                return r;
+
+        r = sd_varlink_observebo(
+                        context->repart_link,
+                        "io.systemd.Repart.ListCandidateDevices",
+                        SD_JSON_BUILD_PAIR_BOOLEAN("subscribe", context->subscribe),
+                        SD_JSON_BUILD_PAIR_BOOLEAN("ignoreRoot", true));
+
+        if (r < 0)
+                return log_error_errno(
+                                r,
+                                "Failed to issue io.systemd.Repart.ListCandidateDevices() varlink call: %m");
+
+        r = sd_varlink_server_bind_disconnect(varlink_server, vl_on_disconnect);
+        if (r < 0)
+                return r;
+
+        /* The context is freed in vl_on_disconnect() */
+        sd_varlink_set_userdata(context->repart_link, context);
+        sd_varlink_set_userdata(link, TAKE_PTR(context));
+
+        return 0;
+}
+
+typedef struct RunParameters {
+        char *node;
+        char **definitions;
+        bool erase;
+        bool variables;
+        char *kernel_image;
+        bool copy_locale;
+        bool copy_keymap;
+        bool copy_timezone;
+        sd_json_variant *credentials;
+} RunParameters;
+
+static void run_parameters_done(RunParameters *p) {
+        assert(p);
+
+        p->node = mfree(p->node);
+        p->definitions = strv_free(p->definitions);
+        p->kernel_image = mfree(p->kernel_image);
+        p->credentials = sd_json_variant_unref(p->credentials);
+}
+
+typedef struct CredentialParameters {
+        const char *id;
+        struct iovec value;
+} CredentialParameters;
+
+static void credential_parameters_done(CredentialParameters *p) {
+        assert(p);
+
+        iovec_done_erase(&p->value);
+}
+
+static int credentials_from_json_array(MachineCredentialContext *credentials, sd_json_variant *v) {
+
+        int r;
+        sd_json_variant *credential;
+
+        assert(credentials);
+
+        static const sd_json_dispatch_field dispatch_table[] = {
+                { "id",    SD_JSON_VARIANT_STRING, sd_json_dispatch_const_string, offsetof(CredentialParameters, id),    SD_JSON_MANDATORY },
+                { "value", SD_JSON_VARIANT_STRING, json_dispatch_unbase64_iovec,  offsetof(CredentialParameters, value), SD_JSON_MANDATORY },
+                {}
+        };
+
+        JSON_VARIANT_ARRAY_FOREACH(credential, v) {
+                _cleanup_(credential_parameters_done) CredentialParameters p = {};
+
+                r = sd_json_dispatch(credential, dispatch_table, /* flags= */ 0, &p);
+                if (r < 0)
+                        return r;
+
+                r = machine_credential_add(credentials, p.id, p.value.iov_base, p.value.iov_len);
+                if (r < 0)
+                        return r;
+        }
+
+        return 0;
+}
+
+static int vl_method_run(
+                sd_varlink *link,
+                sd_json_variant *parameters,
+                sd_varlink_method_flags_t flags,
+                void *userdata) {
+
+        static const sd_json_dispatch_field dispatch_table[] = {
+                { "node",            SD_JSON_VARIANT_STRING,  json_dispatch_path,       offsetof(RunParameters, node),          SD_JSON_MANDATORY | SD_JSON_STRICT },
+                { "definitions",     SD_JSON_VARIANT_ARRAY,   json_dispatch_strv_path,  offsetof(RunParameters, definitions),   SD_JSON_NULLABLE | SD_JSON_STRICT  },
+                { "erase",           SD_JSON_VARIANT_BOOLEAN, sd_json_dispatch_stdbool, offsetof(RunParameters, erase),         SD_JSON_MANDATORY                  },
+                { "variables",       SD_JSON_VARIANT_BOOLEAN, sd_json_dispatch_stdbool, offsetof(RunParameters, variables),     SD_JSON_NULLABLE                   },
+                { "kernelImagePath", SD_JSON_VARIANT_STRING,  json_dispatch_path,       offsetof(RunParameters, kernel_image),  SD_JSON_NULLABLE | SD_JSON_STRICT  },
+                { "copyLocale",      SD_JSON_VARIANT_BOOLEAN, sd_json_dispatch_stdbool, offsetof(RunParameters, copy_locale),   SD_JSON_NULLABLE                   },
+                { "copyKeymap",      SD_JSON_VARIANT_BOOLEAN, sd_json_dispatch_stdbool, offsetof(RunParameters, copy_keymap),   SD_JSON_NULLABLE                   },
+                { "copyTimezone",    SD_JSON_VARIANT_BOOLEAN, sd_json_dispatch_stdbool, offsetof(RunParameters, copy_timezone), SD_JSON_NULLABLE                   },
+                { "credentials",     SD_JSON_VARIANT_ARRAY,   sd_json_dispatch_variant, offsetof(RunParameters, credentials),   SD_JSON_NULLABLE                   },
+                {}
+        };
+
+        int r;
+
+        assert(link);
+
+        sd_varlink_server *varlink_server = sd_varlink_get_server(link);
+        Hashmap **polkit_registry = ASSERT_PTR(sd_varlink_server_get_userdata(varlink_server));
+
+        r = varlink_verify_polkit_async(
+                        link,
+                        /* bus= */ NULL,
+                        "io.systemd.sysinstall.Run",
+                        /* details= */ NULL,
+                        polkit_registry);
+        if (r <= 0)
+                return r;
+
+        _cleanup_(run_parameters_done) RunParameters p = {};
+        r = sd_varlink_dispatch(link, parameters, dispatch_table, &p);
+        if (r != 0)
+                return r;
+
+        _cleanup_(sysinstall_context_done) SysInstallContext context = (SysInstallContext) {
+                .copy_locale = p.copy_locale,
+                .copy_keymap = p.copy_keymap,
+                .copy_timezone = p.copy_timezone,
+                .erase = p.erase,
+                .touch_variables = p.variables,
+                .node = TAKE_PTR(p.node),
+                .kernel_fd = -EBADF,
+        };
+
+        r = sysinstall_context_settle_definitions(&context, p.definitions);
+        if (r < 0)
+                return r;
+
+        if (FLAGS_SET(flags, SD_VARLINK_METHOD_MORE))
+                context.link = sd_varlink_ref(link);
+
+        r = credentials_from_json_array(&context.credentials, p.credentials);
+        if (r < 0)
+                return r;
+
+        r = sysinstall_context_read_credentials(&context);
+        if (r < 0)
+                return r;
+
+        r = sysinstall_context_settle_kernel_image(&context, p.kernel_image);
+        if (r < 0)
+                return r;
+
+        r = sysinstall_context_run(&context);
+        if (r < 0)
+                return r;
+
+        return sd_varlink_reply(link, NULL);
+}
+
+static int vl_server(void) {
+        _cleanup_(sd_varlink_server_unrefp) sd_varlink_server *varlink_server = NULL;
+        _cleanup_hashmap_free_ Hashmap *polkit_registry = NULL;
+        int r;
+
+        /* Invocation as Varlink service */
+
+        r = varlink_server_new(
+                        &varlink_server,
+                        0,
+                        /* userdata= */ &polkit_registry);
+        if (r < 0)
+                return log_error_errno(r, "Failed to allocate Varlink server: %m");
+
+        r = sd_varlink_server_add_interface(varlink_server, &vl_interface_io_systemd_SysInstall);
+        if (r < 0)
+                return log_error_errno(r, "Failed to add Varlink interface: %m");
+
+        r = sd_varlink_server_bind_method_many(
+                        varlink_server,
+                        "io.systemd.SysInstall.ListCandidateDevices", vl_method_list_candidate_devices,
+                        "io.systemd.SysInstall.Run",                  vl_method_run);
+        if (r < 0)
+                return log_error_errno(r, "Failed to bind Varlink methods: %m");
+
+        r = sd_varlink_server_loop_auto(varlink_server);
+        if (r < 0)
+                return log_error_errno(r, "Failed to run Varlink event loop: %m");
 
         return 0;
 }
@@ -1244,8 +2075,6 @@ static void end_marker(void) {
 }
 
 static int run(int argc, char *argv[]) {
-        _cleanup_free_ char *kernel_filename = NULL;
-        _cleanup_close_ int kernel_fd = -EBADF;
         int r;
 
         setlocale(LC_ALL, "");
@@ -1256,7 +2085,18 @@ static int run(int argc, char *argv[]) {
 
         log_setup();
 
-        r = settle_definitions();
+        if (arg_varlink)
+                return vl_server();
+
+        _cleanup_(sysinstall_context_done) SysInstallContext context = (SysInstallContext) {
+                .copy_locale = arg_copy_locale,
+                .copy_keymap = arg_copy_keymap,
+                .copy_timezone = arg_copy_timezone,
+                .credentials = TAKE_STRUCT(arg_credentials),
+                .kernel_fd = -EBADF,
+        };
+
+        r = sysinstall_context_settle_definitions(&context, arg_definitions);
         if (r < 0)
                 return r;
 
@@ -1291,6 +2131,7 @@ static int run(int argc, char *argv[]) {
                                 /* node= */ NULL,
                                 /* erase= */ true,
                                 /* dry_run= */ true,
+                                arg_definitions,
                                 &min_size,
                                 /* current_size= */ NULL,
                                 /* need_free= */ NULL);
@@ -1324,34 +2165,28 @@ static int run(int argc, char *argv[]) {
         if (r < 0)
                 return r;
 
-        r = read_credentials();
+        r = sysinstall_context_read_credentials(&context);
         if (r < 0)
                 return r;
 
-        if (arg_kernel_image) {
-                r = path_extract_filename(arg_kernel_image, &kernel_filename);
-                if (r < 0)
-                        return log_error_errno(r, "Failed to extract filename from kernel path '%s': %m", arg_kernel_image);
-                if (r == O_DIRECTORY)
-                        return log_error_errno(SYNTHETIC_ERRNO(EISDIR), "Kernel path '%s' refers to directory, must be regular file, refusing.", arg_kernel_image);
-
-                kernel_fd = xopenat_full(XAT_FDROOT, arg_kernel_image, O_RDONLY|O_CLOEXEC, XO_REGULAR, MODE_INVALID);
-                if (kernel_fd < 0)
-                        return log_error_errno(kernel_fd, "Failed to open kernel image '%s': %m", arg_kernel_image);
-        } else {
-                r = find_current_kernel(&kernel_filename, &kernel_fd);
-                if (r < 0)
-                        return r;
-        }
+        r = sysinstall_context_settle_kernel_image(&context, arg_kernel_image);
+        if (r < 0)
+                return r;
 
         /* Verify we have everything we need */
         assert(arg_node);
         assert(arg_erase >= 0);
         assert(arg_touch_variables >= 0);
 
-        r = show_summary();
-        if (r < 0)
-                return r;
+        context.node = TAKE_PTR(arg_node);
+        context.touch_variables = arg_touch_variables;
+        context.erase = arg_erase;
+
+        if (arg_summary) {
+                r = sysinstall_context_show_summary(&context);
+                if (r < 0)
+                        return r;
+        }
 
         r = prompt_confirm();
         if (r < 0)
@@ -1359,78 +2194,9 @@ static int run(int argc, char *argv[]) {
 
         putchar('\n');
 
-        log_notice("%s%sEncrypting credentials...",
-                   emoji_enabled() ? glyph(GLYPH_LOCK_AND_KEY) : "", emoji_enabled() ? " " : "");
-
-        _cleanup_(sd_varlink_flush_close_unrefp) sd_varlink *creds_link = NULL;
-        _cleanup_strv_free_ char **encrypted_credentials = NULL;
-        r = encrypt_credentials(&creds_link, &encrypted_credentials);
+        r = sysinstall_context_run(&context);
         if (r < 0)
                 return r;
-
-        log_notice("%s%sInstalling partitions...",
-                   emoji_enabled() ? glyph(GLYPH_COMPUTER_DISK) : "", emoji_enabled() ? " " : "");
-
-        /* Do the main part of the installation */
-        r = invoke_repart(
-                        &repart_link,
-                        arg_node,
-                        arg_erase,
-                        /* dry_run= */ false,
-                        /* min_size= */ NULL,
-                        /* current_size= */ NULL,
-                        /* need_free= */ NULL);
-        if (r < 0)
-                return r;
-
-        log_notice("%s%sMounting partitions...",
-                   emoji_enabled() ? glyph(GLYPH_COMPUTER_DISK) : "", emoji_enabled() ? " " : "");
-
-        _cleanup_(loop_device_unrefp) LoopDevice *loop_device = NULL;
-        _cleanup_(umount_and_freep) char *root_dir = NULL;
-        _cleanup_close_ int root_fd = -EBADF;
-        r = mount_image_privately_interactively(
-                        arg_node,
-                        &image_policy,
-                        DISSECT_IMAGE_REQUIRE_ROOT |
-                        DISSECT_IMAGE_RELAX_VAR_CHECK |
-                        DISSECT_IMAGE_ALLOW_USERSPACE_VERITY |
-                        DISSECT_IMAGE_DISCARD_ANY |
-                        DISSECT_IMAGE_GPT_ONLY |
-                        DISSECT_IMAGE_FSCK |
-                        DISSECT_IMAGE_USR_NO_ROOT |
-                        DISSECT_IMAGE_ADD_PARTITION_DEVICES |
-                        DISSECT_IMAGE_PIN_PARTITION_DEVICES,
-                        &root_dir,
-                        &root_fd,
-                        &loop_device);
-        if (r < 0)
-                return log_error_errno(r, "Failed to mount new image: %m");
-
-        log_notice("%s%sInstalling kernel...",
-                   emoji_enabled() ? glyph(GLYPH_COMPUTER_DISK) : "", emoji_enabled() ? " " : "");
-
-        _cleanup_(sd_varlink_flush_close_unrefp) sd_varlink *bootctl_link = NULL;
-        r = invoke_bootctl_link(&bootctl_link, root_dir, root_fd, kernel_filename, kernel_fd, encrypted_credentials);
-        if (r < 0)
-                return r;
-
-        log_notice("%s%sInstalling boot loader...",
-                   emoji_enabled() ? glyph(GLYPH_COMPUTER_DISK) : "", emoji_enabled() ? " " : "");
-
-        r = invoke_bootctl_install(&bootctl_link, root_dir, root_fd);
-        if (r < 0)
-                return r;
-
-        log_notice("%s%sUnmounting partitions...",
-                   emoji_enabled() ? glyph(GLYPH_COMPUTER_DISK) : "", emoji_enabled() ? " " : "");
-
-        root_fd = safe_close(root_fd);
-        r = umount_recursive(root_dir, /* flags= */ 0);
-        if (r < 0)
-                log_warning_errno(r, "Failed to unmount target disk, proceeding anyway: %m");
-        loop_device = loop_device_unref(loop_device);
-        sync();
 
         log_notice("%s%sInstallation succeeded.",
                    emoji_enabled() ? glyph(GLYPH_SPARKLES) : "", emoji_enabled() ? " " : "");

--- a/src/sysinstall/sysinstall.c
+++ b/src/sysinstall/sysinstall.c
@@ -1,5 +1,6 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
+#include <linux/loop.h>
 #include <locale.h>
 #include <sys/stat.h>
 #include <unistd.h>
@@ -35,7 +36,9 @@
 #include "loop-util.h"
 #include "machine-credential.h"
 #include "main-func.h"
+#include "mkdir.h"
 #include "mount-util.h"
+#include "namespace-util.h"
 #include "options.h"
 #include "os-util.h"
 #include "parse-argument.h"
@@ -822,6 +825,8 @@ static int invoke_repart(
         return 0;
 }
 
+
+
 static int prompt_erase(
                 bool can_add,
                 int *ret_erase) {
@@ -1511,7 +1516,7 @@ static const ImagePolicy image_policy = {
         .n_policies = 4,
         .policies = {
                 /* We mount / and /usr/ so that we can get access to /etc/machine-id and /etc/kernel/ */
-                { PARTITION_ROOT,     PARTITION_POLICY_VERITY|PARTITION_POLICY_SIGNED|PARTITION_POLICY_UNPROTECTED|PARTITION_POLICY_ABSENT },
+                { PARTITION_ROOT,     PARTITION_POLICY_VERITY|PARTITION_POLICY_SIGNED|PARTITION_POLICY_ENCRYPTED|PARTITION_POLICY_ABSENT },
                 { PARTITION_USR,      PARTITION_POLICY_VERITY|PARTITION_POLICY_SIGNED|PARTITION_POLICY_UNPROTECTED|PARTITION_POLICY_ABSENT },
                 { PARTITION_ESP,      PARTITION_POLICY_UNPROTECTED|PARTITION_POLICY_ABSENT },
                 { PARTITION_XBOOTLDR, PARTITION_POLICY_UNPROTECTED|PARTITION_POLICY_ABSENT },
@@ -1630,6 +1635,118 @@ static int vl_method_list_candidate_devices(
                         return log_error_errno(r, "Failed to wait for varlink connection events: %m");
         }
 
+        return 0;
+}
+
+
+static int mount_image_privately(
+                const char *image,
+                const ImagePolicy *policy,
+                DissectImageFlags flags,
+                char **ret_directory,
+                int *ret_dir_fd,
+                LoopDevice **ret_loop_device) {
+
+        _cleanup_(verity_settings_done) VeritySettings verity = VERITY_SETTINGS_DEFAULT;
+        _cleanup_(loop_device_unrefp) LoopDevice *d = NULL;
+        _cleanup_(dissected_image_unrefp) DissectedImage *dissected_image = NULL;
+        _cleanup_free_ char *dir = NULL;
+        int r;
+
+        /* Mounts an OS image at a temporary place, inside a newly created mount namespace of our own. This
+         * is used by tools such as systemd-tmpfiles or systemd-firstboot to operate on some disk image
+         * easily. */
+
+        assert(image);
+        assert(ret_loop_device);
+
+        /* We intend to mount this right-away, hence add the partitions if needed and pin them. */
+        flags |= DISSECT_IMAGE_ADD_PARTITION_DEVICES |
+                DISSECT_IMAGE_PIN_PARTITION_DEVICES;
+
+        r = verity_settings_load(&verity, image, NULL, NULL);
+        if (r < 0)
+                return log_error_errno(r, "Failed to load root hash data: %m");
+
+        r = loop_device_make_by_path(
+                        image,
+                        FLAGS_SET(flags, DISSECT_IMAGE_DEVICE_READ_ONLY) ? O_RDONLY : -1,
+                        /* sector_size= */ UINT32_MAX,
+                        FLAGS_SET(flags, DISSECT_IMAGE_NO_PARTITION_TABLE) ? 0 : LO_FLAGS_PARTSCAN,
+                        LOCK_SH,
+                        &d);
+        if (r < 0)
+                return log_error_errno(r, "Failed to set up loopback device for %s: %m", image);
+
+        r = dissect_loop_device_and_warn(
+                        d,
+                        &verity,
+                        /* mount_options= */ NULL,
+                        policy,
+                        /* image_filter= */ NULL,
+                        flags,
+                        &dissected_image);
+        if (r < 0)
+                return r;
+
+        r = dissected_image_load_verity_sig_partition(dissected_image, d->fd, &verity);
+        if (r < 0)
+                return r;
+
+        r = dissected_image_guess_verity_roothash(dissected_image, &verity);
+        if (r < 0)
+                return r;
+
+        r = dissected_image_decrypt(dissected_image, /* root= */ NULL, /* passphrase= */ "", &verity, policy, flags);
+        if (r < 0)
+                return r;
+
+        r = detach_mount_namespace();
+        if (r < 0)
+                return log_error_errno(r, "Failed to detach mount namespace: %m");
+
+        r = mkdir_p("/run/systemd/mount-rootfs", 0555);
+        if (r < 0)
+                return log_error_errno(r, "Failed to create mount point: %m");
+
+        r = dissected_image_mount_and_warn(
+                        dissected_image,
+                        "/run/systemd/mount-rootfs",
+                        /* uid_shift= */ UID_INVALID,
+                        /* uid_range= */ UID_INVALID,
+                        /* userns_fd= */ -EBADF,
+                        flags);
+        if (r < 0)
+                return r;
+
+        r = loop_device_flock(d, LOCK_UN);
+        if (r < 0)
+                return r;
+
+        r = dissected_image_relinquish(dissected_image);
+        if (r < 0)
+                return log_error_errno(r, "Failed to relinquish DM and loopback block devices: %m");
+
+        if (ret_directory) {
+                dir = strdup("/run/systemd/mount-rootfs");
+                if (!dir)
+                        return log_oom();
+        }
+
+        if (ret_dir_fd) {
+                _cleanup_close_ int dir_fd = -EBADF;
+
+                dir_fd = open("/run/systemd/mount-rootfs", O_CLOEXEC|O_DIRECTORY);
+                if (dir_fd < 0)
+                        return log_error_errno(errno, "Failed to open mount point directory: %m");
+
+                *ret_dir_fd = TAKE_FD(dir_fd);
+        }
+
+        if (ret_directory)
+                *ret_directory = TAKE_PTR(dir);
+
+        *ret_loop_device = TAKE_PTR(d);
         return 0;
 }
 
@@ -1845,7 +1962,7 @@ static int vl_method_run(
         _cleanup_(loop_device_unrefp) LoopDevice *loop_device = NULL;
         _cleanup_(umount_and_freep) char *root_dir = NULL;
         _cleanup_close_ int root_fd = -EBADF;
-        r = mount_image_privately_interactively(
+        r = mount_image_privately(
                         context->node,
                         &image_policy,
                         DISSECT_IMAGE_REQUIRE_ROOT | DISSECT_IMAGE_RELAX_VAR_CHECK |

--- a/src/sysinstall/sysinstall.c
+++ b/src/sysinstall/sysinstall.c
@@ -4,6 +4,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#include "sd-daemon.h"
 #include "sd-varlink.h"
 
 #include "alloc-util.h"
@@ -13,6 +14,7 @@
 #include "build-path.h"
 #include "chase.h"
 #include "conf-files.h"
+#include "bus-polkit.h"
 #include "constants.h"
 #include "efi-loader.h"
 #include "efivars.h"
@@ -25,6 +27,7 @@
 #include "fs-util.h"
 #include "glyph-util.h"
 #include "help-util.h"
+#include "hashmap.h"
 #include "image-policy.h"
 #include "json-util.h"
 #include "locale-setup.h"
@@ -39,9 +42,11 @@
 #include "parse-util.h"
 #include "path-util.h"
 #include "prompt-util.h"
+#include "string-table.h"
 #include "strv.h"
 #include "terminal-util.h"
 #include "varlink-util.h"
+#include "varlink-io.systemd.Sysinstall.h"
 
 static char *arg_node = NULL;
 static bool arg_welcome = true;
@@ -58,11 +63,119 @@ static bool arg_copy_keymap = true;
 static bool arg_copy_timezone = true;
 static bool arg_chrome = true;
 static bool arg_mute_console = false;
+static bool arg_varlink = false;
 
 STATIC_DESTRUCTOR_REGISTER(arg_node, freep);
 STATIC_DESTRUCTOR_REGISTER(arg_definitions, strv_freep);
 STATIC_DESTRUCTOR_REGISTER(arg_kernel_image, freep);
 STATIC_DESTRUCTOR_REGISTER(arg_credentials, machine_credential_context_done);
+
+typedef enum ProgressPhase {
+        PROGRESS_VALIDATE_BLOCK_DEVICE,
+        PROGRESS_LOAD_CREDENTIALS,
+        PROGRESS_ENCRYPT_CREDENTIALS,
+
+        /* The same progress phases as repart */
+        PROGRESS_LOADING_DEFINITIONS,
+        PROGRESS_LOADING_TABLE,
+        PROGRESS_OPENING_COPY_BLOCK_SOURCES,
+        PROGRESS_ACQUIRING_PARTITION_LABELS,
+        PROGRESS_MINIMIZING,
+        PROGRESS_PLACING,
+        PROGRESS_WIPING_DISK,
+        PROGRESS_WIPING_PARTITION,
+        PROGRESS_COPYING_PARTITION,
+        PROGRESS_FORMATTING_PARTITION,
+        PROGRESS_ADJUSTING_PARTITION,
+        PROGRESS_WRITING_TABLE,
+        PROGRESS_REREADING_TABLE,
+
+        PROGRESS_MOUNT_PARTITIONS,
+        PROGRESS_INSTALL_KERNEL,
+        PROGRESS_INSTALL_BOOTLOADER,
+        PROGRESS_UNMOUNT_PARTITIONS,
+        _PROGRESS_PHASE_MAX,
+        _PROGRESS_PHASE_INVALID = -EINVAL,
+} ProgressPhase;
+
+static const char *progress_phase_table[_PROGRESS_PHASE_MAX] = {
+        [PROGRESS_VALIDATE_BLOCK_DEVICE]      = "validate-block-device",
+        [PROGRESS_LOAD_CREDENTIALS]           = "load-credentials",
+        [PROGRESS_ENCRYPT_CREDENTIALS]        = "encrypt-credentials",
+
+        [PROGRESS_LOADING_DEFINITIONS]        = "loading-definitions",
+        [PROGRESS_LOADING_TABLE]              = "loading-table",
+        [PROGRESS_OPENING_COPY_BLOCK_SOURCES] = "opening-copy-block-sources",
+        [PROGRESS_ACQUIRING_PARTITION_LABELS] = "acquiring-partition-labels",
+        [PROGRESS_MINIMIZING]                 = "minimizing",
+        [PROGRESS_PLACING]                    = "placing",
+        [PROGRESS_WIPING_DISK]                = "wiping-disk",
+        [PROGRESS_WIPING_PARTITION]           = "wiping-partition",
+        [PROGRESS_COPYING_PARTITION]          = "copying-partition",
+        [PROGRESS_FORMATTING_PARTITION]       = "formatting-partition",
+        [PROGRESS_ADJUSTING_PARTITION]        = "adjusting-partition",
+        [PROGRESS_WRITING_TABLE]              = "writing-table",
+        [PROGRESS_REREADING_TABLE]            = "rereading-table",
+
+        [PROGRESS_MOUNT_PARTITIONS]           = "mount-partitions",
+        [PROGRESS_INSTALL_KERNEL]             = "install-kernel",
+        [PROGRESS_INSTALL_BOOTLOADER]         = "install-bootloader",
+        [PROGRESS_UNMOUNT_PARTITIONS]         = "unmount-partitions",
+};
+
+DEFINE_PRIVATE_STRING_TABLE_LOOKUP_TO_STRING(progress_phase, ProgressPhase);
+DEFINE_PRIVATE_STRING_TABLE_LOOKUP_FROM_STRING(progress_phase, ProgressPhase);
+
+typedef struct Context {
+        bool copy_locale;
+        bool copy_keymap;
+        bool copy_timezone;
+        char **definitions;
+        bool dry_run;
+        bool erase;
+        char *node;
+        char *kernel_image;
+        bool variables;
+
+        uint64_t min_size, current_size, need_free;
+        char *repart_error;
+
+        sd_varlink *link; /* If 'more' is used on the Varlink call, we'll send progress info over this link */
+} Context;
+
+static Context* context_new(void) {
+
+        Context *context = new(Context, 1);
+        if (!context)
+                return NULL;
+
+        *context = (Context) {
+                .min_size = UINT64_MAX,
+                .current_size = UINT64_MAX,
+                .need_free = UINT64_MAX,
+        };
+
+        return context;
+}
+
+static Context* context_free(Context *context) {
+        if (!context)
+                return NULL;
+
+        strv_free(context->definitions);
+
+        free(context->node);
+
+        free(context->kernel_image);
+
+        free(context->repart_error);
+
+        context->link = sd_varlink_unref(context->link);
+
+        return mfree(context);
+}
+
+DEFINE_TRIVIAL_CLEANUP_FUNC(Context*, context_free);
 
 static int help(void) {
         int r;
@@ -208,6 +321,13 @@ static int parse_argv(int argc, char *argv[]) {
                 arg_node = strdup(args[0]);
                 if (!arg_node)
                         return log_oom();
+        }
+
+        r = sd_varlink_invocation(SD_VARLINK_ALLOW_ACCEPT);
+        if (r < 0)
+                return log_error_errno(r, "Failed to check if invoked in Varlink mode: %m");
+        if (r > 0) {
+                arg_varlink = true;
         }
 
         return 1;
@@ -403,6 +523,178 @@ static int prompt_block_device(sd_varlink **repart_link, char **ret_node) {
         return 0;
 }
 
+static int context_notify_progress(
+                Context *context,
+                ProgressPhase phase,
+                const char *object,
+                unsigned percent) {
+
+        int r;
+
+        assert(context);
+        assert(phase >= 0);
+        assert(phase < _PROGRESS_PHASE_MAX);
+
+        /* Send progress information, via sd_notify() and via varlink (if client asked for it by setting "more" flag) */
+
+        _cleanup_free_ char *n = NULL;
+        if (asprintf(&n,
+                     "STATUS=Phase %1$s\n"
+                     "X_SYSTEMD_PHASE=%1$s",
+                     progress_phase_to_string(phase)) < 0)
+                return log_oom_debug();
+
+        if (percent != UINT_MAX)
+                if (strextendf(&n, "\nX_SYSTEMD_PHASE_PROGRESS=%u", percent) < 0)
+                        return log_oom_debug();
+
+        r = sd_notify(/* unset_environment= */ false, n);
+        if (r < 0)
+                log_debug_errno(r, "Failed to send sd_notify() progress notification, ignoring: %m");
+
+        if (context->link) {
+                r = sd_varlink_notifybo(
+                                context->link,
+                                JSON_BUILD_PAIR_ENUM("phase", progress_phase_to_string(phase)),
+                                JSON_BUILD_PAIR_STRING_NON_EMPTY("object", object),
+                                JSON_BUILD_PAIR_UNSIGNED_NOT_EQUAL("progress", percent, UINT_MAX));
+                if (r < 0)
+                        log_debug_errno(r, "Failed to send varlink notify progress notification, ignoring: %m");
+
+                r = sd_varlink_flush(context->link);
+                if (r < 0)
+                        log_debug_errno(r, "Failed to flush varlink notify progress notification, ignoring: %m");
+        }
+
+        return 0;
+}
+
+static int handle_repart_reply(
+                sd_varlink *link,
+                sd_json_variant *reply,
+                const char *error_id,
+                sd_varlink_reply_flags_t flags,
+                void *userdata) {
+
+        Context *context = userdata;
+        int r;
+
+        assert(context);
+
+        struct {
+                uint64_t min_size;
+                uint64_t current_size;
+                uint64_t need_free;
+
+                char *phase;
+                char *object;
+                unsigned progress;
+        } p = {
+                .min_size = UINT64_MAX,
+                .current_size = UINT64_MAX,
+                .need_free = UINT64_MAX,
+                .progress = UINT_MAX,
+        };
+
+        static const sd_json_dispatch_field dispatch_table[] = {
+                { "minimalSizeBytes", _SD_JSON_VARIANT_TYPE_INVALID, sd_json_dispatch_uint64, voffsetof(p, min_size),     0 },
+                { "currentSizeBytes", _SD_JSON_VARIANT_TYPE_INVALID, sd_json_dispatch_uint64, voffsetof(p, current_size), 0 },
+                { "needFreeBytes",    _SD_JSON_VARIANT_TYPE_INVALID, sd_json_dispatch_uint64, voffsetof(p, need_free),    0 },
+                { "phase",            _SD_JSON_VARIANT_TYPE_INVALID, sd_json_dispatch_string, voffsetof(p, phase),        0 },
+                { "object",           _SD_JSON_VARIANT_TYPE_INVALID, sd_json_dispatch_string, voffsetof(p, object),       0 },
+                { "progress",         _SD_JSON_VARIANT_TYPE_INVALID, sd_json_dispatch_uint,   voffsetof(p, progress),     0 },
+                {}
+        };
+
+        r = sd_json_dispatch(reply, dispatch_table, SD_JSON_ALLOW_EXTENSIONS, &p);
+        if (r < 0)
+                return r;
+
+        context->min_size = p.min_size;
+        context->current_size = p.current_size;
+        context->need_free = p.need_free;
+
+        if (error_id) {
+                context->repart_error = strdup(error_id);
+
+                if (!(streq(error_id, "io.systemd.Repart.InsufficientFreeSpace") ||
+                      streq(error_id, "io.systemd.Repart.DiskTooSmall") ||
+                      streq(error_id, "io.systemd.Repart.ConflictingDiskLabelPresent"))) {
+
+                        r = sd_varlink_error_to_errno(error_id, reply); /* If this is a system errno style error, output it with %m */
+                        if (r != -EBADR)
+                                log_error_errno(r, "Failed to issue io.systemd.Repart.Run() varlink call: %m");
+
+                        log_error_errno(r, "Failed to issue io.systemd.Repart.Run() varlink call: %s", error_id);
+                }
+        }
+
+        if (p.phase) {
+                (void) context_notify_progress(context, progress_phase_from_string(json_dashify(p.phase)), p.object, p.progress);
+        }
+
+        return 0;
+}
+
+static int context_invoke_repart(
+                Context *context,
+                sd_varlink **link) {
+
+        int r;
+
+        assert(link);
+
+        r = connect_to_repart(link);
+        if (r < 0) {
+                return r;
+        }
+
+        /* Seeding the partitions might be very slow, disable timeout */
+        r = sd_varlink_set_relative_timeout(*link, UINT64_MAX);
+        if (r < 0)
+                return log_error_errno(r, "Failed to disable IPC timeout: %m");
+
+        sd_varlink_set_userdata(*link, context);
+
+        r = sd_varlink_bind_reply(*link, handle_repart_reply);
+        if (r < 0) {
+                return log_error_errno(r, "Failed to bind repart reply callback: %m");
+        }
+
+        r = sd_varlink_observebo(
+                        *link,
+                        "io.systemd.Repart.Run",
+                        SD_JSON_BUILD_PAIR_STRING("node", context->node),
+                        SD_JSON_BUILD_PAIR_STRING("empty", context->erase ? "force" : "allow"),
+                        SD_JSON_BUILD_PAIR_BOOLEAN("dryRun", false),
+                        SD_JSON_BUILD_PAIR_CONDITION(!!context->definitions, "definitions", SD_JSON_BUILD_STRV(context->definitions)),
+                        SD_JSON_BUILD_PAIR_BOOLEAN("deferPartitionsEmpty", true),
+                        SD_JSON_BUILD_PAIR_BOOLEAN("deferPartitionsFactoryReset", true));
+        if (r < 0) {
+                return log_error_errno(r, "Failed to issue io.systemd.Repart.Run() varlink call: %m");
+        }
+
+        for (;;) {
+                r = sd_varlink_is_idle(*link);
+                if (r < 0)
+                        return log_error_errno(r, "Failed to check if varlink connection is idle: %m");
+                if (r > 0)
+                        break;
+
+                r = sd_varlink_process(*link);
+                if (r < 0)
+                        return log_error_errno(r, "Failed to process varlink connection: %m");
+                if (r != 0)
+                        continue;
+
+                r = sd_varlink_wait(*link, USEC_INFINITY);
+                if (r < 0)
+                        return log_error_errno(r, "Failed to wait for varlink connection events: %m");
+        }
+
+        return 0;
+}
+
 static int read_space_metrics(
                 sd_json_variant *v,
                 uint64_t *min_size,
@@ -447,6 +739,8 @@ static int invoke_repart(
                 const char *node,
                 bool erase,
                 bool dry_run,
+                char **definitions,
+                char **ret_error,
                 uint64_t *min_size,        /* initialized both on success and error */
                 uint64_t *current_size,    /* ditto */
                 uint64_t *need_free) {     /* ditto */
@@ -481,7 +775,7 @@ static int invoke_repart(
                         SD_JSON_BUILD_PAIR_STRING("node", node),
                         SD_JSON_BUILD_PAIR_STRING("empty", erase ? "force" : "allow"),
                         SD_JSON_BUILD_PAIR_BOOLEAN("dryRun", dry_run),
-                        SD_JSON_BUILD_PAIR_CONDITION(!!arg_definitions, "definitions", SD_JSON_BUILD_STRV(arg_definitions)),
+                        SD_JSON_BUILD_PAIR_CONDITION(!!definitions, "definitions", SD_JSON_BUILD_STRV(definitions)),
                         SD_JSON_BUILD_PAIR_BOOLEAN("deferPartitionsEmpty", true),
                         SD_JSON_BUILD_PAIR_BOOLEAN("deferPartitionsFactoryReset", true));
         if (r < 0) {
@@ -489,6 +783,9 @@ static int invoke_repart(
                 return log_error_errno(r, "Failed to issue io.systemd.Repart.Run() varlink call: %m");
         }
         if (error_id) {
+                if (ret_error)
+                        *ret_error = strdup(error_id);
+
                 if (streq(error_id, "io.systemd.Repart.InsufficientFreeSpace")) {
                         (void) read_space_metrics(reply, min_size, current_size, need_free);
                         return log_full_errno(
@@ -656,6 +953,8 @@ static int validate_run(sd_varlink **repart_link, const char *node) {
                                 node,
                                 try_erase,
                                 /* dry_run= */ true,
+                                arg_definitions,
+                                /* ret_error= */ NULL,
                                 &min_size,
                                 &current_size,
                                 &need_free);
@@ -894,6 +1193,7 @@ static int connect_to_bootctl(sd_varlink **link) {
 
 static int invoke_bootctl_install(
                 sd_varlink **link,
+                bool variables,
                 const char *root_dir,
                 int root_fd) {
         int r;
@@ -919,7 +1219,7 @@ static int invoke_bootctl_install(
                         SD_JSON_BUILD_PAIR_STRING("operation", "new"),
                         SD_JSON_BUILD_PAIR_INTEGER("rootFileDescriptor", fd_idx),
                         SD_JSON_BUILD_PAIR_STRING("rootDirectory", root_dir),
-                        SD_JSON_BUILD_PAIR_BOOLEAN("touchVariables", arg_touch_variables));
+                        SD_JSON_BUILD_PAIR_BOOLEAN("touchVariables", variables));
         if (r < 0)
                 return r;
 
@@ -928,6 +1228,7 @@ static int invoke_bootctl_install(
 
 static int invoke_bootctl_link(
                 sd_varlink **link,
+                const char *kernel_image,
                 const char *root_dir,
                 int root_fd,
                 char **encrypted_credentials) {
@@ -961,16 +1262,16 @@ static int invoke_bootctl_link(
 
         _cleanup_free_ char *kernel_filename = NULL;
         _cleanup_close_ int kernel_fd = -EBADF;
-        if (arg_kernel_image) {
-                r = path_extract_filename(arg_kernel_image, &kernel_filename);
+        if (kernel_image) {
+                r = path_extract_filename(kernel_image, &kernel_filename);
                 if (r < 0)
-                        return log_error_errno(r, "Failed to extract filename from kernel path '%s': %m", arg_kernel_image);
+                        return log_error_errno(r, "Failed to extract filename from kernel path '%s': %m", kernel_image);
                 if (r == O_DIRECTORY)
-                        return log_error_errno(SYNTHETIC_ERRNO(EISDIR), "Kernel path '%s' refers to directory, must be regular file, refusing.", arg_kernel_image);
+                        return log_error_errno(SYNTHETIC_ERRNO(EISDIR), "Kernel path '%s' refers to directory, must be regular file, refusing.", kernel_image);
 
-                kernel_fd = xopenat_full(XAT_FDROOT, arg_kernel_image, O_RDONLY|O_CLOEXEC, XO_REGULAR, MODE_INVALID);
+                kernel_fd = xopenat_full(XAT_FDROOT, kernel_image, O_RDONLY|O_CLOEXEC, XO_REGULAR, MODE_INVALID);
                 if (kernel_fd < 0)
-                        return log_error_errno(kernel_fd, "Failed to open kernel image '%s': %m", arg_kernel_image);
+                        return log_error_errno(kernel_fd, "Failed to open kernel image '%s': %m", kernel_image);
 
         } else {
                 r = find_current_kernel(&kernel_filename, &kernel_fd);
@@ -1032,14 +1333,11 @@ static int maybe_reboot(void) {
         return 0;
 }
 
-static int read_credential_locale(void) {
+static int read_credential_locale(MachineCredentialContext credentials) {
         int r;
 
-        if (!arg_copy_locale)
-                return 0;
-
-        if (machine_credential_find(&arg_credentials, "firstboot.locale") ||
-            machine_credential_find(&arg_credentials, "firstboot.locale-messages"))
+        if (machine_credential_find(&credentials, "firstboot.locale") ||
+            machine_credential_find(&credentials, "firstboot.locale-messages"))
                 return 0;
 
         /* For the main locale we check the two env vars, and if neither is there, we use LC_NUMERIC, since
@@ -1047,14 +1345,14 @@ static int read_credential_locale(void) {
          * separate setting after all */
         const char *l = getenv("LC_ALL") ?: getenv("LANG") ?: setlocale(LC_NUMERIC, NULL);
         if (l) {
-                r = machine_credential_add(&arg_credentials, "firstboot.locale", l, /* size= */ SIZE_MAX);
+                r = machine_credential_add(&credentials, "firstboot.locale", l, /* size= */ SIZE_MAX);
                 if (r < 0)
                         return log_oom();
         }
 
         const char *m = setlocale(LC_MESSAGES, NULL);
         if (m && !streq_ptr(m, l)) {
-                r = machine_credential_add(&arg_credentials, "firstboot.locale-messages", m, /* size= */ SIZE_MAX);
+                r = machine_credential_add(&credentials, "firstboot.locale-messages", m, /* size= */ SIZE_MAX);
                 if (r < 0)
                         return log_oom();
         }
@@ -1062,13 +1360,10 @@ static int read_credential_locale(void) {
         return 0;
 }
 
-static int read_credential_keymap(void) {
+static int read_credential_keymap(MachineCredentialContext credentials) {
         int r;
 
-        if (!arg_copy_keymap)
-                return 0;
-
-        if (machine_credential_find(&arg_credentials, "firstboot.keymap"))
+        if (machine_credential_find(&credentials, "firstboot.keymap"))
                 return 0;
 
         _cleanup_free_ char *keymap = NULL;
@@ -1080,7 +1375,7 @@ static int read_credential_keymap(void) {
                 return log_error_errno(r, "Failed to parse '%s': %m", etc_vconsole_conf());
 
         if (!isempty(keymap)) {
-                r = machine_credential_add(&arg_credentials, "firstboot.keymap", keymap, /* size= */ SIZE_MAX);
+                r = machine_credential_add(&credentials, "firstboot.keymap", keymap, /* size= */ SIZE_MAX);
                 if (r < 0)
                         return log_oom();
         }
@@ -1088,13 +1383,10 @@ static int read_credential_keymap(void) {
         return 0;
 }
 
-static int read_credential_timezone(void) {
+static int read_credential_timezone(MachineCredentialContext credentials) {
         int r;
 
-        if (!arg_copy_timezone)
-                return 0;
-
-        if (machine_credential_find(&arg_credentials, "firstboot.timezone"))
+        if (machine_credential_find(&credentials, "firstboot.timezone"))
                 return 0;
 
         _cleanup_free_ char *tz = NULL;
@@ -1102,7 +1394,7 @@ static int read_credential_timezone(void) {
         if (r < 0)
                 log_warning_errno(r, "Failed to read timezone, skipping timezone propagation: %m");
         else {
-                r = machine_credential_add(&arg_credentials, "firstboot.timezone", tz, /* size= */ SIZE_MAX);
+                r = machine_credential_add(&credentials, "firstboot.timezone", tz, /* size= */ SIZE_MAX);
                 if (r < 0)
                         return log_oom();
         }
@@ -1110,20 +1402,26 @@ static int read_credential_timezone(void) {
         return 0;
 }
 
-static int read_credentials(void) {
+static int read_credentials(MachineCredentialContext credentials, bool copy_locale, bool copy_keymap, bool copy_timezone) {
         int r;
 
-        r = read_credential_locale();
-        if (r < 0)
-                return r;
+        if (copy_locale) {
+                r = read_credential_locale(credentials);
+                if (r < 0)
+                        return r;
+        }
 
-        r = read_credential_keymap();
-        if (r < 0)
-                return r;
+        if (copy_keymap) {
+                r = read_credential_keymap(credentials);
+                if (r < 0)
+                        return r;
+        }
 
-        r = read_credential_timezone();
-        if (r < 0)
-                return r;
+        if (copy_timezone) {
+                r = read_credential_timezone(credentials);
+                if (r < 0)
+                        return r;
+        }
 
         return 0;
 }
@@ -1194,13 +1492,13 @@ static int encrypt_one_credential(sd_varlink **link, const MachineCredential *in
         return 0;
 }
 
-static int encrypt_credentials(sd_varlink **link, char ***encrypted) {
+static int encrypt_credentials(sd_varlink **link, MachineCredentialContext credentials, char ***encrypted) {
         int r;
 
         assert(link);
         assert(encrypted);
 
-        FOREACH_ARRAY(cred, arg_credentials.credentials, arg_credentials.n_credentials) {
+        FOREACH_ARRAY(cred, credentials.credentials, credentials.n_credentials) {
                 r = encrypt_one_credential(link, cred, encrypted);
                 if (r < 0)
                         return r;
@@ -1221,11 +1519,13 @@ static const ImagePolicy image_policy = {
         .default_flags = PARTITION_POLICY_IGNORE,
 };
 
-static int settle_definitions(void) {
+static int settle_definitions(char **definitions) {
+
         int r;
 
-        if (arg_definitions)
+        if (definitions) {
                 return 0;
+        }
 
         /* If /usr/lib/repart.sysinstall.d/ is populated, use it, otherwise use the regular definition
          * files */
@@ -1241,10 +1541,377 @@ static int settle_definitions(void) {
                 return log_error_errno(r, "Failed to enumerate *.conf files: %m");
 
         if (!strv_isempty(files)) {
-                arg_definitions = strv_copy(CONF_PATHS_STRV("repart.sysinstall.d"));
-                if (!arg_definitions)
+                definitions = strv_copy(CONF_PATHS_STRV("repart.sysinstall.d"));
+                if (definitions)
                         return log_oom();
         }
+
+        return 0;
+}
+
+static int fetch_candidate_devices_reply(
+                sd_varlink *repart_link,
+                sd_json_variant *reply,
+                const char *error_id,
+                sd_varlink_reply_flags_t flags,
+                void *userdata) {
+        sd_varlink *link = ASSERT_PTR(userdata);
+
+        if (error_id) {
+                if (streq(error_id, "io.systemd.Repart.NoCandidateDevices"))
+                        return sd_varlink_set_sentinel(link, "io.systemd.Sysinstall.NoCandidateDevices");
+
+                return sd_varlink_set_sentinel(link, error_id);
+        }
+
+        if (FLAGS_SET(flags, SD_VARLINK_REPLY_CONTINUES))
+                return sd_varlink_notify(link, reply);
+        else
+                return sd_varlink_reply(link, reply);
+}
+
+static int vl_method_list_candidate_devices(
+                sd_varlink *link,
+                sd_json_variant *parameters,
+                sd_varlink_method_flags_t flags,
+                void *userdata) {
+        int r;
+        _cleanup_(sd_varlink_flush_close_unrefp) sd_varlink *repart_link = NULL;
+
+        Hashmap **polkit_registry = ASSERT_PTR(userdata);
+
+        assert(FLAGS_SET(flags, SD_VARLINK_METHOD_MORE));
+
+        r = varlink_verify_polkit_async(
+                        link,
+                        /* bus= */ NULL,
+                        "io.systemd.sysinstall.ListCandidateDevices",
+                        /* details= */ NULL,
+                        polkit_registry);
+        if (r <= 0)
+                return r;
+
+        r = connect_to_repart(&repart_link);
+        if (r < 0)
+                return r;
+
+        sd_varlink_set_userdata(repart_link, link);
+
+        r = sd_varlink_bind_reply(repart_link, fetch_candidate_devices_reply);
+        if (r < 0)
+                return r;
+
+        r = sd_varlink_observebo(
+                        repart_link,
+                        "io.systemd.Repart.ListCandidateDevices",
+                        SD_JSON_BUILD_PAIR_BOOLEAN("ignoreRoot", true));
+
+        if (r < 0) {
+                return log_error_errno(
+                                r,
+                                "Failed to issue io.systemd.Repart.ListCandidateDevices() varlink call: %m");
+        }
+
+        for (;;) {
+                r = sd_varlink_is_idle(repart_link);
+                if (r < 0)
+                        return log_error_errno(r, "Failed to check if varlink connection is idle: %m");
+                if (r > 0)
+                        break;
+
+                r = sd_varlink_process(repart_link);
+                if (r < 0)
+                        return log_error_errno(r, "Failed to process varlink connection: %m");
+                if (r != 0)
+                        continue;
+
+                r = sd_varlink_wait(repart_link, USEC_INFINITY);
+                if (r < 0)
+                        return log_error_errno(r, "Failed to wait for varlink connection events: %m");
+        }
+
+        return 0;
+}
+
+typedef struct RunParameters {
+        char *node;
+        bool dry_run;
+        char **definitions;
+        bool erase;
+        bool variables;
+        char *kernel_image;
+        bool copy_locale;
+        bool copy_keymap;
+        bool copy_timezone;
+} RunParameters;
+
+static void run_parameters_done(RunParameters *p) {
+        assert(p);
+
+        p->node = mfree(p->node);
+        p->definitions = strv_free(p->definitions);
+}
+
+static int vl_method_run(
+                sd_varlink *link, sd_json_variant *parameters, sd_varlink_method_flags_t flags, void *userdata) {
+
+        // TODO: Also allow to use set credential, load credential
+        static const sd_json_dispatch_field dispatch_table[] = {
+                { "node",
+                 SD_JSON_VARIANT_STRING, sd_json_dispatch_string,
+                 offsetof(RunParameters, node),
+                 SD_JSON_NULLABLE },
+                { "dryRun",
+                 SD_JSON_VARIANT_BOOLEAN, sd_json_dispatch_stdbool,
+                 offsetof(RunParameters, dry_run),
+                 SD_JSON_MANDATORY },
+                { "definitions",
+                 SD_JSON_VARIANT_ARRAY, json_dispatch_strv_path,
+                 offsetof(RunParameters, definitions),
+                 SD_JSON_NULLABLE | SD_JSON_STRICT },
+                { "erase",
+                 SD_JSON_VARIANT_BOOLEAN, sd_json_dispatch_stdbool,
+                 offsetof(RunParameters, erase),
+                 SD_JSON_MANDATORY },
+                { "variables",
+                 SD_JSON_VARIANT_BOOLEAN, sd_json_dispatch_stdbool,
+                 offsetof(RunParameters, variables),
+                 SD_JSON_MANDATORY },
+                { "kernelImage",
+                 SD_JSON_VARIANT_STRING, json_dispatch_path,
+                 offsetof(RunParameters, kernel_image),
+                 SD_JSON_NULLABLE | SD_JSON_STRICT },
+                { "copyLocale",
+                 SD_JSON_VARIANT_BOOLEAN, sd_json_dispatch_stdbool,
+                 offsetof(RunParameters, copy_locale),
+                 SD_JSON_NULLABLE },
+                { "copyKeymap",
+                 SD_JSON_VARIANT_BOOLEAN, sd_json_dispatch_stdbool,
+                 offsetof(RunParameters, copy_keymap),
+                 SD_JSON_NULLABLE },
+                { "copyTimezone",
+                 SD_JSON_VARIANT_BOOLEAN, sd_json_dispatch_stdbool,
+                 offsetof(RunParameters, copy_timezone),
+                 SD_JSON_NULLABLE },
+                {}
+        };
+
+        int r;
+
+        assert(link);
+
+        Hashmap **polkit_registry = ASSERT_PTR(userdata);
+
+        r = varlink_verify_polkit_async(
+                        link,
+                        /* bus= */ NULL,
+                        "io.systemd.sysinstall.Run",
+                        /* details= */ NULL,
+                        polkit_registry);
+        if (r <= 0)
+                return r;
+
+        _cleanup_(run_parameters_done) RunParameters p = {};
+        r = sd_varlink_dispatch(link, parameters, dispatch_table, &p);
+        if (r != 0)
+                return r;
+
+        /* If no device node is specified, this is a dry run. Refuse if the caller claims otherwise. */
+        if (!p.node && !p.dry_run)
+                return sd_varlink_error_invalid_parameter_name(link, "dryRun");
+
+        _cleanup_(context_freep) Context* context = NULL;
+        context = context_new();
+        if (!context)
+                return log_oom();
+
+        context->dry_run = p.dry_run;
+        context->erase = p.erase;
+        context->variables = p.variables;
+        context->copy_locale = p.copy_locale;
+        context->copy_keymap = p.copy_keymap;
+        context->copy_timezone = p.copy_timezone;
+
+        if (p.definitions) {
+                context->definitions = TAKE_PTR(p.definitions);
+        } else {
+                r = settle_definitions(context->definitions);
+                if (r < 0)
+                        return r;
+        }
+
+        if (p.node) {
+                context->node = TAKE_PTR(p.node);
+        }
+
+        if (p.kernel_image) {
+                context->kernel_image = TAKE_PTR(p.kernel_image);
+        }
+
+        if (FLAGS_SET(flags, SD_VARLINK_METHOD_MORE))
+                context->link = sd_varlink_ref(link);
+
+        _cleanup_(sd_varlink_flush_close_unrefp) sd_varlink *repart_link = NULL;
+
+        (void) context_notify_progress(context, PROGRESS_LOAD_CREDENTIALS, /* object= */ NULL, UINT_MAX);
+
+        MachineCredentialContext credentials = {};
+        r = read_credentials(arg_credentials, context->copy_locale, context->copy_keymap, context->copy_timezone);
+        if (r < 0)
+                return r;
+
+        if (context->dry_run) {
+                r = invoke_repart(
+                                &repart_link,
+                                context->node,
+                                context->erase,
+                                /* dry_run= */ true,
+                                context->definitions,
+                                &context->repart_error,
+                                &context->min_size,
+                                &context->current_size,
+                                &context->need_free);
+                if (r < 0) {
+                        if (context->repart_error) {
+                                const char *sysinstall_error = NULL;
+
+                                if (streq(context->repart_error, "io.systemd.Repart.InsufficientFreeSpace"))
+                                        sysinstall_error = "io.systemd.Sysinstall.InsufficientFreeSpace";
+                                if (streq(context->repart_error, "io.systemd.Repart.DiskTooSmall"))
+                                        sysinstall_error = "io.systemd.Sysinstall.DiskTooSmall";
+                                if (streq(context->repart_error, "io.systemd.Repart.ConflictingDiskLabelPresent"))
+                                        sysinstall_error = "io.systemd.Sysinstall.ConflictingDiskLabelPresent";
+
+                                if (sysinstall_error) {
+                                        // TODO: maybe add credentials used, and maybe kernel
+                                        return sd_varlink_errorbo(
+                                                        link,
+                                                        sysinstall_error,
+                                                        JSON_BUILD_PAIR_UNSIGNED_NOT_EQUAL("currentSizeBytes", context->current_size, UINT64_MAX),
+                                                        JSON_BUILD_PAIR_UNSIGNED_NOT_EQUAL("needFreeBytes", context->need_free, UINT64_MAX),
+                                                        JSON_BUILD_PAIR_UNSIGNED_NOT_EQUAL("minimalSizeBytes", context->min_size, UINT64_MAX));
+                                }
+                        }
+
+                        return r;
+                } else {
+                        // TODO: maybe add credentials used, and maybe kernel
+                        return sd_varlink_replybo(
+                                        link,
+                                        JSON_BUILD_PAIR_UNSIGNED_NOT_EQUAL("currentSizeBytes", context->current_size, UINT64_MAX),
+                                        JSON_BUILD_PAIR_UNSIGNED_NOT_EQUAL("needFreeBytes", context->need_free, UINT64_MAX),
+                                        JSON_BUILD_PAIR_UNSIGNED_NOT_EQUAL("minimalSizeBytes", context->min_size, UINT64_MAX));
+                }
+        }
+
+        (void) context_notify_progress(context, PROGRESS_ENCRYPT_CREDENTIALS, /* object= */ NULL, UINT_MAX);
+
+        _cleanup_(sd_varlink_flush_close_unrefp) sd_varlink *creds_link = NULL;
+        _cleanup_strv_free_ char **encrypted_credentials = NULL;
+        r = encrypt_credentials(&creds_link, credentials, &encrypted_credentials);
+        if (r < 0)
+                return r;
+
+        /* Do the main part of the installation */
+        r = context_invoke_repart(context, &repart_link);
+        if (r < 0) {
+                return r;
+        }
+
+        if (context->repart_error) {
+                const char *sysinstall_error = NULL;
+
+                if (streq(context->repart_error, "io.systemd.Repart.InsufficientFreeSpace"))
+                        sysinstall_error = "io.systemd.Sysinstall.InsufficientFreeSpace";
+                if (streq(context->repart_error, "io.systemd.Repart.DiskTooSmall"))
+                        sysinstall_error = "io.systemd.Sysinstall.DiskTooSmall";
+                if (streq(context->repart_error, "io.systemd.Repart.ConflictingDiskLabelPresent"))
+                        sysinstall_error = "io.systemd.Sysinstall.ConflictingDiskLabelPresent";
+
+                if (sysinstall_error) {
+                        return sd_varlink_errorbo(
+                                        context->link,
+                                        sysinstall_error,
+                                        JSON_BUILD_PAIR_UNSIGNED_NOT_EQUAL("currentSizeBytes", context->current_size, UINT64_MAX),
+                                        JSON_BUILD_PAIR_UNSIGNED_NOT_EQUAL("needFreeBytes", context->need_free, UINT64_MAX),
+                                        JSON_BUILD_PAIR_UNSIGNED_NOT_EQUAL("minimalSizeBytes", context->min_size, UINT64_MAX));
+                } else {
+                        return r;
+                }
+        }
+
+        (void) context_notify_progress(context, PROGRESS_MOUNT_PARTITIONS, /* object= */ NULL, UINT_MAX);
+
+        _cleanup_(loop_device_unrefp) LoopDevice *loop_device = NULL;
+        _cleanup_(umount_and_freep) char *root_dir = NULL;
+        _cleanup_close_ int root_fd = -EBADF;
+        r = mount_image_privately_interactively(
+                        context->node,
+                        &image_policy,
+                        DISSECT_IMAGE_REQUIRE_ROOT | DISSECT_IMAGE_RELAX_VAR_CHECK |
+                        DISSECT_IMAGE_ALLOW_USERSPACE_VERITY | DISSECT_IMAGE_DISCARD_ANY |
+                        DISSECT_IMAGE_GPT_ONLY | DISSECT_IMAGE_FSCK |
+                        DISSECT_IMAGE_USR_NO_ROOT | DISSECT_IMAGE_ADD_PARTITION_DEVICES |
+                        DISSECT_IMAGE_PIN_PARTITION_DEVICES,
+                        &root_dir,
+                        &root_fd,
+                        &loop_device);
+        if (r < 0)
+                return log_error_errno(r, "Failed to mount new image: %m");
+
+        (void) context_notify_progress(context, PROGRESS_INSTALL_KERNEL, /* object= */ NULL, UINT_MAX);
+
+        _cleanup_(sd_varlink_flush_close_unrefp) sd_varlink *bootctl_link = NULL;
+        r = invoke_bootctl_link(&bootctl_link, context->kernel_image, root_dir, root_fd, encrypted_credentials);
+        if (r < 0)
+                return r;
+
+        (void) context_notify_progress(context, PROGRESS_INSTALL_BOOTLOADER, /* object= */ NULL, UINT_MAX);
+
+        r = invoke_bootctl_install(&bootctl_link, context->variables, root_dir, root_fd);
+        if (r < 0)
+                return r;
+
+        (void) context_notify_progress(context, PROGRESS_UNMOUNT_PARTITIONS, /* object= */ NULL, UINT_MAX);
+
+        root_fd = safe_close(root_fd);
+        r = umount_recursive(root_dir, /* flags= */ 0);
+        if (r < 0)
+                log_warning_errno(r, "Failed to unmount target disk, proceeding anyway: %m");
+        loop_device = loop_device_unref(loop_device);
+        sync();
+
+        return sd_varlink_reply(link, NULL);
+}
+
+static int vl_server(void) {
+        _cleanup_(sd_varlink_server_unrefp) sd_varlink_server *varlink_server = NULL;
+        _cleanup_hashmap_free_ Hashmap *polkit_registry = NULL;
+        int r;
+
+        /* Invocation as Varlink service */
+
+        r = varlink_server_new(
+                        &varlink_server,
+                        SD_VARLINK_SERVER_INHERIT_USERDATA,
+                        /* userdata= */ &polkit_registry);
+        if (r < 0)
+                return log_error_errno(r, "Failed to allocate Varlink server: %m");
+
+        r = sd_varlink_server_add_interface(varlink_server, &vl_interface_io_systemd_Sysinstall);
+        if (r < 0)
+                return log_error_errno(r, "Failed to add Varlink interface: %m");
+
+        r = sd_varlink_server_bind_method_many(
+                        varlink_server,
+                        "io.systemd.Sysinstall.ListCandidateDevices", vl_method_list_candidate_devices,
+                        "io.systemd.Sysinstall.Run",                  vl_method_run);
+        if (r < 0)
+                return log_error_errno(r, "Failed to bind Varlink methods: %m");
+
+        r = sd_varlink_server_loop_auto(varlink_server);
+        if (r < 0)
+                return log_error_errno(r, "Failed to run Varlink event loop: %m");
 
         return 0;
 }
@@ -1269,7 +1936,10 @@ static int run(int argc, char *argv[]) {
 
         log_setup();
 
-        r = settle_definitions();
+        if (arg_varlink)
+                return vl_server();
+
+        r = settle_definitions(arg_definitions);
         if (r < 0)
                 return r;
 
@@ -1304,6 +1974,8 @@ static int run(int argc, char *argv[]) {
                                 /* node= */ NULL,
                                 /* erase= */ true,
                                 /* dry_run= */ true,
+                                arg_definitions,
+                                /* ret_error= */ NULL,
                                 &min_size,
                                 /* current_size= */ NULL,
                                 /* need_free= */ NULL);
@@ -1337,7 +2009,7 @@ static int run(int argc, char *argv[]) {
         if (r < 0)
                 return r;
 
-        r = read_credentials();
+        r = read_credentials(arg_credentials, arg_copy_locale, arg_copy_keymap, arg_copy_timezone);
         if (r < 0)
                 return r;
 
@@ -1361,7 +2033,7 @@ static int run(int argc, char *argv[]) {
 
         _cleanup_(sd_varlink_flush_close_unrefp) sd_varlink *creds_link = NULL;
         _cleanup_strv_free_ char **encrypted_credentials = NULL;
-        r = encrypt_credentials(&creds_link, &encrypted_credentials);
+        r = encrypt_credentials(&creds_link, arg_credentials, &encrypted_credentials);
         if (r < 0)
                 return r;
 
@@ -1374,6 +2046,8 @@ static int run(int argc, char *argv[]) {
                         arg_node,
                         arg_erase,
                         /* dry_run= */ false,
+                        arg_definitions,
+                        /* ret_error= */ NULL,
                         /* min_size= */ NULL,
                         /* current_size= */ NULL,
                         /* need_free= */ NULL);
@@ -1408,14 +2082,14 @@ static int run(int argc, char *argv[]) {
                    emoji_enabled() ? glyph(GLYPH_COMPUTER_DISK) : "", emoji_enabled() ? " " : "");
 
         _cleanup_(sd_varlink_flush_close_unrefp) sd_varlink *bootctl_link = NULL;
-        r = invoke_bootctl_link(&bootctl_link, root_dir, root_fd, encrypted_credentials);
+        r = invoke_bootctl_link(&bootctl_link, arg_kernel_image, root_dir, root_fd, encrypted_credentials);
         if (r < 0)
                 return r;
 
         log_notice("%s%sInstalling boot loader...",
                    emoji_enabled() ? glyph(GLYPH_COMPUTER_DISK) : "", emoji_enabled() ? " " : "");
 
-        r = invoke_bootctl_install(&bootctl_link, root_dir, root_fd);
+        r = invoke_bootctl_install(&bootctl_link, arg_touch_variables, root_dir, root_fd);
         if (r < 0)
                 return r;
 

--- a/test/units/TEST-87-AUX-UTILS-VM.sysinstall.sh
+++ b/test/units/TEST-87-AUX-UTILS-VM.sysinstall.sh
@@ -34,12 +34,15 @@ if systemd-detect-virt -cq; then
     exit 0
 fi
 
+# shellcheck source=test/units/test-control.sh
+. "$(dirname "$0")"/test-control.sh
+
 # shellcheck source=test/units/util.sh
 . "$(dirname "$0")"/util.sh
 
-WORKDIR="$(mktemp --directory /tmp/test-sysinstall.XXXXXXXXXX)"
-LOOPDEV=""
-MOUNTED=0
+
+CRED_VALUE="systemd-sysinstall test credential payload"
+CRED_VALUE_BASE64=$(echo -n "$CRED_VALUE" | base64 -w0)
 
 cleanup() {
     set +e
@@ -53,42 +56,42 @@ cleanup() {
     fi
     rm -rf "$WORKDIR"
 }
-trap cleanup EXIT
 
-# 1) Build a small fake "OS source" tree. systemd-sysinstall picks this up via
-#    the repart.sysinstall.d definitions: CopyFiles= seeds the new root
-#    partition with these files.
-SOURCE_ROOT="$WORKDIR/sourceroot"
-mkdir -p "$SOURCE_ROOT/usr/lib" "$SOURCE_ROOT/etc"
+create_fake_os_source_tree() {
+    # 1) Build a small fake "OS source" tree. systemd-sysinstall picks this up via
+    #    the repart.sysinstall.d definitions: CopyFiles= seeds the new root
+    #    partition with these files.
+    SOURCE_ROOT="$WORKDIR/sourceroot"
+    mkdir -p "$SOURCE_ROOT/usr/lib" "$SOURCE_ROOT/etc"
 
-cat >"$SOURCE_ROOT/usr/lib/os-release" <<'EOF'
+    cat >"$SOURCE_ROOT/usr/lib/os-release" <<'EOF'
 ID=testos
 NAME="Test OS"
 PRETTY_NAME="Test OS for systemd-sysinstall"
 VERSION_ID=1
 EOF
-ln -s ../usr/lib/os-release "$SOURCE_ROOT/etc/os-release"
+    ln -s ../usr/lib/os-release "$SOURCE_ROOT/etc/os-release"
 
-# 2) Build a minimal UKI. bootctl link only requires a valid PE with .osrel and
-#    the systemd-stub SBAT marker, so the .linux/.initrd contents do not need
-#    to be a real kernel.
-echo "fake-kernel" >"$WORKDIR/vmlinuz"
-echo "fake-initrd" >"$WORKDIR/initrd"
+    # 2) Build a minimal UKI. bootctl link only requires a valid PE with .osrel and
+    #    the systemd-stub SBAT marker, so the .linux/.initrd contents do not need
+    #    to be a real kernel.
+    echo "fake-kernel" >"$WORKDIR/vmlinuz"
+    echo "fake-initrd" >"$WORKDIR/initrd"
 
-ukify build \
-    --linux "$WORKDIR/vmlinuz" \
-    --initrd "$WORKDIR/initrd" \
-    --os-release "@$SOURCE_ROOT/usr/lib/os-release" \
-    --uname "1.2.3-testkernel" \
-    --cmdline "quiet" \
-    --output "$WORKDIR/testuki.efi"
+    ukify build \
+        --linux "$WORKDIR/vmlinuz" \
+        --initrd "$WORKDIR/initrd" \
+        --os-release "@$SOURCE_ROOT/usr/lib/os-release" \
+        --uname "1.2.3-testkernel" \
+        --cmdline "quiet" \
+        --output "$WORKDIR/testuki.efi"
 
-# 3) Build a sysinstall partition definition: a single ESP plus a root
-#    partition seeded from the fake source tree.
-DEFS="$WORKDIR/sysinstall.d"
-mkdir -p "$DEFS"
+    # 3) Build a sysinstall partition definition: a single ESP plus a root
+    #    partition seeded from the fake source tree.
+    DEFS="$WORKDIR/sysinstall.d"
+    mkdir -p "$DEFS"
 
-cat >"$DEFS/10-esp.conf" <<EOF
+    cat >"$DEFS/10-esp.conf" <<EOF
 [Partition]
 Type=esp
 Format=vfat
@@ -96,7 +99,7 @@ SizeMinBytes=64M
 SizeMaxBytes=64M
 EOF
 
-cat >"$DEFS/20-root.conf" <<EOF
+    cat >"$DEFS/20-root.conf" <<EOF
 [Partition]
 Type=root
 Format=ext4
@@ -104,80 +107,119 @@ SizeMinBytes=128M
 CopyFiles=$SOURCE_ROOT:/
 EOF
 
-# 4) Allocate a sparse target file. systemd-sysinstall accepts a regular file
-#    path here — systemd-repart and the in-process dissect logic transparently
-#    handle the loop attach during install. We can't pre-attach the empty file
-#    via systemd-dissect --attach since that requires a valid DDI.
-truncate -s 512M "$WORKDIR/target.img"
+    # 4) Allocate a sparse target file. systemd-sysinstall accepts a regular file
+    #    path here — systemd-repart and the in-process dissect logic transparently
+    #    handle the loop attach during install. We can't pre-attach the empty file
+    #    via systemd-dissect --attach since that requires a valid DDI.
+    truncate -s 512M "$WORKDIR/target.img"
+}
 
-# 5) Run the installer non-interactively against the target image. Also stash a
-#    literal credential ('marker') so we can verify it ends up next to the UKI
-#    and is referenced from the boot loader entry.
-CRED_VALUE="systemd-sysinstall test credential payload"
-systemd-sysinstall \
-    --welcome=no \
-    --chrome=no \
-    --confirm=no \
-    --summary=no \
-    --erase=yes \
-    --variables=no \
-    --reboot=no \
-    --mute-console=no \
-    --copy-locale=no \
-    --copy-keymap=no \
-    --copy-timezone=no \
-    --set-credential="marker:$CRED_VALUE" \
-    --kernel="$WORKDIR/testuki.efi" \
-    --definitions="$DEFS" \
-    "$WORKDIR/target.img"
+validate_image() {
+    # 1) Attach the freshly installed image as a loopback device for inspection.
+    LOOPDEV="$(systemd-dissect --attach "$WORKDIR/target.img")"
 
-# 6) Attach the freshly installed image as a loopback device for inspection.
-LOOPDEV="$(systemd-dissect --attach "$WORKDIR/target.img")"
+    # Verify the resulting on-disk layout. The disk must now carry a GPT with at
+    # least an ESP partition.
+    sfdisk_dump="$(sfdisk --dump "$LOOPDEV")"
+    assert_in "C12A7328-F81F-11D2-BA4B-00A0C93EC93B" "$sfdisk_dump"
 
-# Verify the resulting on-disk layout. The disk must now carry a GPT with at
-# least an ESP partition.
-sfdisk_dump="$(sfdisk --dump "$LOOPDEV")"
-assert_in "C12A7328-F81F-11D2-BA4B-00A0C93EC93B" "$sfdisk_dump"
+    # 2) Mount the image read-only and verify the installed artifacts: an entry
+    #    file referencing the UKI on the ESP, the UKI itself, and the systemd-boot
+    #    binary.
+    MNT="$WORKDIR/mnt"
+    mkdir -p "$MNT"
 
-# 7) Mount the image read-only and verify the installed artifacts: an entry
-#    file referencing the UKI on the ESP, the UKI itself, and the systemd-boot
-#    binary.
-MNT="$WORKDIR/mnt"
-mkdir -p "$MNT"
+    systemd-dissect --mount --read-only "$LOOPDEV" "$MNT"
+    MOUNTED=1
 
-systemd-dissect --mount --read-only "$LOOPDEV" "$MNT"
-MOUNTED=1
+    ESP="$MNT/efi"
+    test -d "$ESP/loader/entries"
 
-ESP="$MNT/efi"
-test -d "$ESP/loader/entries"
+    # Exactly one entry should have been linked, and it should reference the UKI
+    # we passed via --kernel=.
+    ENTRY=$(find "$ESP/loader/entries" -maxdepth 1 -name '*.conf' -type f | head -n1)
+    test -n "$ENTRY"
+    grep -E "^uki /[^/]+/testuki\.efi$" "$ENTRY" >/dev/null
 
-# Exactly one entry should have been linked, and it should reference the UKI
-# we passed via --kernel=.
-ENTRY=$(find "$ESP/loader/entries" -maxdepth 1 -name '*.conf' -type f | head -n1)
-test -n "$ENTRY"
-grep -E "^uki /[^/]+/testuki\.efi$" "$ENTRY" >/dev/null
+    # The UKI file referenced in the entry must exist on the ESP.
+    UKI_PATH=$(awk '/^uki / { print $2 }' "$ENTRY")
+    test -n "$UKI_PATH"
+    test -f "$ESP$UKI_PATH"
 
-# The UKI file referenced in the entry must exist on the ESP.
-UKI_PATH=$(awk '/^uki / { print $2 }' "$ENTRY")
-test -n "$UKI_PATH"
-test -f "$ESP$UKI_PATH"
+    # bootctl install should have placed sd-boot on the ESP.
+    find "$ESP/EFI/systemd" -type f -iname 'systemd-boot*.efi' | grep . >/dev/null
 
-# bootctl install should have placed sd-boot on the ESP.
-find "$ESP/EFI/systemd" -type f -iname 'systemd-boot*.efi' | grep . >/dev/null
+    # The credential we passed via --set-credential= must have been encrypted and
+    # placed next to the UKI, and must be referenced as 'extra' from the entry.
+    UKI_DIR="$(dirname "$ESP$UKI_PATH")"
+    TOKEN_DIR="$(basename "$UKI_DIR")"
+    test -s "$UKI_DIR/marker.cred"
+    grep -E "^extra /$TOKEN_DIR/marker\.cred$" "$ENTRY" >/dev/null
 
-# The credential we passed via --set-credential= must have been encrypted and
-# placed next to the UKI, and must be referenced as 'extra' from the entry.
-UKI_DIR="$(dirname "$ESP$UKI_PATH")"
-TOKEN_DIR="$(basename "$UKI_DIR")"
-test -s "$UKI_DIR/marker.cred"
-grep -E "^extra /$TOKEN_DIR/marker\.cred$" "$ENTRY" >/dev/null
+    # Locale/keymap/timezone propagation is off, so those .cred files must NOT
+    # exist on the ESP.
+    test ! -e "$UKI_DIR/firstboot.locale.cred"
+    test ! -e "$UKI_DIR/firstboot.keymap.cred"
+    test ! -e "$UKI_DIR/firstboot.timezone.cred"
 
-# Locale/keymap/timezone propagation is off, so those .cred files must NOT
-# exist on the ESP.
-test ! -e "$UKI_DIR/firstboot.locale.cred"
-test ! -e "$UKI_DIR/firstboot.keymap.cred"
-test ! -e "$UKI_DIR/firstboot.timezone.cred"
+    # 3) The seeded files from the fake source tree must end up in the new root.
+    test -f "$MNT/usr/lib/os-release"
+    grep '^ID=testos$' "$MNT/usr/lib/os-release" >/dev/null
+}
 
-# 8) The seeded files from the fake source tree must end up in the new root.
-test -f "$MNT/usr/lib/os-release"
-grep '^ID=testos$' "$MNT/usr/lib/os-release" >/dev/null
+testcase_sysinstall_basic() {
+    WORKDIR="$(mktemp --directory /tmp/test-sysinstall.XXXXXXXXXX)"
+    LOOPDEV=""
+    MOUNTED=0
+
+    echo "WORKDIR=$WORKDIR"
+
+    trap cleanup RETURN
+
+    create_fake_os_source_tree
+
+    # Run the installer non-interactively against the target image. Also stash a
+    # literal credential ('marker') so we can verify it ends up next to the UKI
+    # and is referenced from the boot loader entry.
+    systemd-sysinstall \
+        --welcome=no \
+        --chrome=no \
+        --confirm=no \
+        --summary=no \
+        --erase=yes \
+        --variables=no \
+        --reboot=no \
+        --mute-console=no \
+        --copy-locale=no \
+        --copy-keymap=no \
+        --copy-timezone=no \
+        --set-credential="marker:$CRED_VALUE" \
+        --kernel="$WORKDIR/testuki.efi" \
+        --definitions="$DEFS" \
+        "$WORKDIR/target.img"
+
+    validate_image
+
+    cleanup
+}
+
+testcase_sysinstall_varlink_basic() {
+    WORKDIR="$(mktemp --directory /tmp/test-sysinstall.XXXXXXXXXX)"
+    LOOPDEV=""
+    MOUNTED=0
+
+    echo "WORKDIR=$WORKDIR"
+
+    trap cleanup RETURN
+
+    create_fake_os_source_tree
+
+    # Run the installer via varlink against the target image. Also stash a
+    # literal credential ('marker') so we can verify it ends up next to the UKI
+    # and is referenced from the boot loader entry.
+    varlinkctl call /run/systemd/io.systemd.SysInstall io.systemd.SysInstall.Run "{\"erase\": true, \"variables\": false, \"credentials\" : [{ \"id\" : \"marker\", \"value\" : \"$CRED_VALUE_BASE64\" }], \"kernelImagePath\" : \"$WORKDIR/testuki.efi\", \"node\": \"$WORKDIR/target.img\", \"definitions\" : [\"$DEFS\"] }" --more
+
+    validate_image
+}
+
+run_testcases

--- a/units/meson.build
+++ b/units/meson.build
@@ -789,6 +789,15 @@ units = [
           'symlinks' : ['system-install.target.wants/'],
         },
         {
+          'file' : 'systemd-sysinstall.socket',
+          'conditions' : ['ENABLE_SYSINSTALL'],
+          'symlinks' : ['sockets.target.wants/'],
+        },
+        {
+          'file' : 'systemd-sysinstall@.service',
+          'conditions' : ['ENABLE_SYSINSTALL'],
+        },
+        {
           'file' : 'systemd-sysupdate-reboot.service',
           'conditions' : ['ENABLE_SYSUPDATE'],
         },

--- a/units/meson.build
+++ b/units/meson.build
@@ -841,6 +841,15 @@ units = [
           'symlinks' : ['system-install.target.wants/'],
         },
         {
+          'file' : 'systemd-sysinstall.socket',
+          'conditions' : ['ENABLE_SYSINSTALL'],
+          'symlinks' : ['sockets.target.wants/'],
+        },
+        {
+          'file' : 'systemd-sysinstall@.service',
+          'conditions' : ['ENABLE_SYSINSTALL'],
+        },
+        {
           'file' : 'systemd-sysupdate-reboot.service',
           'conditions' : ['ENABLE_SYSUPDATE'],
         },

--- a/units/meson.build
+++ b/units/meson.build
@@ -789,6 +789,15 @@ units = [
           'symlinks' : ['system-install.target.wants/'],
         },
         {
+          'file' : 'systemd-sysinstall.socket',
+          'conditions' : ['ENABLE_SYSINSTALL'],
+          'symlinks' : ['sockets.target.wants/'],
+        },
+        {
+          'file' : 'systemd-sysinstall@.service',
+          'conditions' : ['ENABLE_SYSUPDATE'],
+        },
+        {
           'file' : 'systemd-sysupdate-reboot.service',
           'conditions' : ['ENABLE_SYSUPDATE'],
         },

--- a/units/systemd-sysinstall.socket
+++ b/units/systemd-sysinstall.socket
@@ -10,15 +10,18 @@
 [Unit]
 Description=System Install Tool
 Documentation=man:systemd-sysinstall(8)
-Wants=systemd-logind.service
-After=systemd-logind.service
+DefaultDependencies=no
+Before=sockets.target
+Conflicts=shutdown.target
+Before=shutdown.target
 
-[Service]
-Type=oneshot
-RemainAfterExit=yes
-ExecStart=systemd-sysinstall --variables=yes --reboot=yes --mute-console=yes
-StandardOutput=tty
-StandardInput=tty
-StandardError=tty
-TTYReset=yes
-FailureAction=halt
+[Socket]
+ListenStream=/run/systemd/io.systemd.SysInstall
+Symlinks=/run/varlink/registry/io.systemd.SysInstall
+FileDescriptorName=varlink
+SocketMode=0666
+Accept=yes
+MaxConnectionsPerSource=16
+XAttrEntryPoint=user.varlink=entrypoint
+XAttrListen=user.varlink=listen
+XAttrAccept=user.varlink=server

--- a/units/systemd-sysinstall.socket
+++ b/units/systemd-sysinstall.socket
@@ -10,15 +10,15 @@
 [Unit]
 Description=System Install Tool
 Documentation=man:systemd-sysinstall(8)
-Wants=systemd-logind.service
-After=systemd-logind.service
+DefaultDependencies=no
+Before=sockets.target
+Conflicts=shutdown.target
+Before=shutdown.target
 
-[Service]
-Type=oneshot
-RemainAfterExit=yes
-ExecStart=systemd-sysinstall --variables=yes --reboot=yes --mute-console=yes
-StandardOutput=tty
-StandardInput=tty
-StandardError=tty
-TTYReset=yes
-FailureAction=halt
+[Socket]
+ListenStream=/run/systemd/io.systemd.Sysinstall
+Symlinks=/run/varlink/registry/io.systemd.Sysinstall
+FileDescriptorName=varlink
+SocketMode=0666
+Accept=yes
+MaxConnectionsPerSource=16

--- a/units/systemd-sysinstall.socket
+++ b/units/systemd-sysinstall.socket
@@ -9,16 +9,15 @@
 
 [Unit]
 Description=System Install Tool
-Documentation=man:systemd-sysinstall(8)
-Wants=systemd-logind.service
-After=systemd-logind.service
+Documentation=man:systemd-sysinstall(1)
+DefaultDependencies=no
+Before=sockets.target
+Conflicts=shutdown.target
+Before=shutdown.target
 
-[Service]
-Type=oneshot
-RemainAfterExit=yes
-ExecStart=systemd-sysinstall --variables=yes --reboot=yes --mute-console=yes
-StandardOutput=tty
-StandardInput=tty
-StandardError=tty
-TTYReset=yes
-FailureAction=halt
+[Socket]
+ListenStream=/run/systemd/io.systemd.Sysinstall
+FileDescriptorName=varlink
+SocketMode=0666
+Accept=yes
+MaxConnectionsPerSource=16

--- a/units/systemd-sysinstall@.service
+++ b/units/systemd-sysinstall@.service
@@ -10,15 +10,11 @@
 [Unit]
 Description=System Install Tool
 Documentation=man:systemd-sysinstall(8)
-Wants=systemd-logind.service
-After=systemd-logind.service
+DefaultDependencies=no
+Wants=modprobe@loop.service modprobe@dm_mod.service
+After=modprobe@loop.service modprobe@dm_mod.service systemd-tpm2-setup-early.service
+Conflicts=shutdown.target
+Before=shutdown.target
 
 [Service]
-Type=oneshot
-RemainAfterExit=yes
-ExecStart=systemd-sysinstall --variables=yes --reboot=yes --mute-console=yes
-StandardOutput=tty
-StandardInput=tty
-StandardError=tty
-TTYReset=yes
-FailureAction=halt
+ExecStart=systemd-sysinstall

--- a/units/systemd-sysinstall@.service
+++ b/units/systemd-sysinstall@.service
@@ -9,16 +9,12 @@
 
 [Unit]
 Description=System Install Tool
-Documentation=man:systemd-sysinstall(8)
-Wants=systemd-logind.service
-After=systemd-logind.service
+Documentation=man:systemd-sysinstall(1)
+DefaultDependencies=no
+Wants=modprobe@loop.service modprobe@dm_mod.service
+After=modprobe@loop.service modprobe@dm_mod.service systemd-tpm2-setup-early.service
+Conflicts=shutdown.target
+Before=shutdown.target
 
 [Service]
-Type=oneshot
-RemainAfterExit=yes
-ExecStart=systemd-sysinstall --variables=yes --reboot=yes --mute-console=yes
-StandardOutput=tty
-StandardInput=tty
-StandardError=tty
-TTYReset=yes
-FailureAction=halt
+ExecStart=systemd-sysinstall


### PR DESCRIPTION
Allow graphical installers to use system sysinstall. This will be used by gnome-setup to install GNOME OS and ideally installers of other distributions talk to the same varlink interface.