### PR TITLE
repart: Flush varlink messages for progress updates

### DIFF
--- a/src/repart/repart.c
+++ b/src/repart/repart.c
@@ -2905,6 +2905,10 @@ static int context_notify(
                                 JSON_BUILD_PAIR_UNSIGNED_NOT_EQUAL("progress", percent, UINT_MAX));
                 if (r < 0)
                         log_debug_errno(r, "Failed to send varlink notify progress notification, ignoring: %m");
+
+                r = sd_varlink_flush(c->link);
+                if (r < 0)
+                        log_debug_errno(r, "Failed to flush varlink notify progress notification, ignoring: %m");
         }
 
         return 0;


### PR DESCRIPTION
Progress updates are not send out immidialty and only once the handler for the run method completes since the event loop is not processed while the run handler is executed. Therefore flush varlink messages immidialty after a progress update is queued.

Closes: github.com/systemd/systemd/issues/40238