### PR TITLE
test: skip test-pressure in Salsa CI

### DIFF
--- a/src/test/test-pressure.c
+++ b/src/test/test-pressure.c
@@ -636,4 +636,11 @@ static int outro(void) {
         return 0;
 }
 
-DEFINE_TEST_MAIN_FULL(LOG_DEBUG, NULL, outro);
+static int intro(void) {
+        if (strstr_ptr(ci_environment(), "autopkgtest"))
+                return log_tests_skipped("test hangs on autopkgtest, skipping");
+
+        return EXIT_SUCCESS;
+}
+
+DEFINE_TEST_MAIN_FULL(LOG_DEBUG, intro, outro);

--- a/src/test/test-pressure.c
+++ b/src/test/test-pressure.c
@@ -600,4 +600,11 @@ static int outro(void) {
         return 0;
 }
 
-DEFINE_TEST_MAIN_FULL(LOG_DEBUG, NULL, outro);
+static int intro(void) {
+        if (strstr_ptr(ci_environment(), "autopkgtest"))
+                return log_tests_skipped("test hangs on autopkgtest, skipping");
+
+        return EXIT_SUCCESS;
+}
+
+DEFINE_TEST_MAIN_FULL(LOG_DEBUG, intro, outro);


### PR DESCRIPTION
This test gets stuck for 2 hours and then times out on Salsa CI in autopkgtest. Just skip it.

Follow-up for b3bb4fefde2e116b663c05c29ada8496b97c3b0b