### PR TITLE
libsystemd: force linking against libm

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1764,6 +1764,11 @@ libsystemd = shared_library(
         include_directories : libsystemd_includes,
         implicit_include_directories : false,
         link_args : ['-shared',
+                     # Force linking against libm, even though it's not required anymore because due to
+                     # Hyrum's Law binaries linking against libsystemd depend on it linking against libm to
+                     # pull in libm for other libraries that use symbols from libm but don't link against
+                     # it. IOW, shenanigans.
+                     '-Wl,--push-state,--no-as-needed,-lm,--pop-state',
                      # Make sure our library is never deleted from memory, so that our open logging fds don't leak on dlopen/dlclose cycles.
                      '-z', 'nodelete',
                      '-Wl,--version-script=' + libsystemd_sym_path],


### PR DESCRIPTION
Since the change that removed 'exp10' in favour of a local implementation certain programs that use ifuncs crash on startup, eg:

```
$ rsyslogd
rsyslogd: Relink `/usr/lib/x86_64-linux-gnu/libfastjson.so.4' with `/usr/lib/x86_64-linux-gnu/libm.so.6' for IFUNC symbol `modf'
Segmentation fault         (core dumped) rsyslogd

 #0  0x00007f63703553e7 in modf_ifunc_selector () at ../sysdeps/x86_64/fpu/multiarch/ifunc-sse4_1-avx.h:30
 #1  __modf_ifunc () at ../sysdeps/x86_64/fpu/multiarch/s_modf.c:33
 #2  0x00007f637043f140 in elf_machine_rela (map=0x7f63704261d0, scope=<optimized out>, reloc=0x7f63702f7ef8,
     sym=0x7f63702f6668, version=<optimized out>, reloc_addr_arg=<optimized out>, skip_ifunc=<optimized out>)
     at ../sysdeps/x86_64/dl-machine.h:309
 #3  elf_dynamic_do_Rela (map=0x7f63704261d0, scope=<optimized out>, reladdr=<optimized out>,
     relsize=<optimized out>, nrelative=<optimized out>, lazy=<optimized out>, skip_ifunc=<optimized out>)
     at ./elf/do-rel.h:138
 #4  _dl_relocate_object_no_relro (l=l@entry=0x7f63704261d0, scope=<optimized out>, reloc_mode=<optimized out>,
     consider_profiling=<optimized out>) at ./elf/dl-reloc.c:296
 #5  0x00007f63704409be in _dl_relocate_object (l=0x7f63704261d0, scope=<optimized out>, reloc_mode=<optimized out>,
     consider_profiling=<optimized out>) at ./elf/dl-reloc.c:346
 #6  0x00007f637044fe0b in dl_main (phdr=<optimized out>, phnum=<optimized out>, user_entry=<optimized out>,
     auxv=<optimized out>) at ./elf/rtld.c:2289
 #7  0x00007f637044c7ff in _dl_sysdep_start (start_argptr=start_argptr@entry=0x7fff531ca1b0,
     dl_main=dl_main@entry=0x7f637044dfa0 <dl_main>) at ../sysdeps/unix/sysv/linux/dl-sysdep.c:140
 #8  0x00007f637044dde1 in _dl_start_final (arg=0x7fff531ca1b0) at ./elf/rtld.c:497
 #9  _dl_start (arg=0x7fff531ca1b0) at ./elf/rtld.c:582
 #10 0x00007f637044cd48 in _start () from /lib64/ld-linux-x86-64.so.2
```

Force linking against libm to avoid breaking clients linking against libsystemd

This does not affect our binaries, since they do not link against libsystemd.so (the objects are included in the private shared lib), so we get the benefits without impacting external users.

Follow-up for d52c8f2068b57e191bafd01d9d60bddbf4a20419