### PR TITLE
test: only run test-link-abi on x86-64

### DIFF
--- a/test/test-link-abi.py
+++ b/test/test-link-abi.py
@@ -10,6 +10,7 @@
 """
 
 import argparse
+import platform
 import re
 import subprocess
 import sys
@@ -139,6 +140,12 @@ def needed_violations(path: str) -> list[str]:
 
 
 def main() -> int:
+    # When a new architecture is added the symbols will be versioned after the version of glibc at the time
+    # the architecture was added, so the versions checked here are only valid for x86-64
+    if platform.machine() != 'x86_64':
+        print(f'Skipping: ABI checks only run on x86_64 (current: {platform.machine()}).')
+        return 77
+
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument(
         '--baseline',


### PR DESCRIPTION
When a new architecture is added the symbols will be versioned after the version of glibc at the time the architecture was added, so the versions checked here are only valid for x86-64, and fails elsewhere.

On loong64:

./fuzz-compress:
  imports symbols newer than GLIBC_2.34:
    __cxa_finalize@GLIBC_2.36 (GLIBC_2.36)
    __libc_start_main@GLIBC_2.36 (GLIBC_2.36)
    __printf_chk@GLIBC_2.36 (GLIBC_2.36)
    __stack_chk_fail@GLIBC_2.36 (GLIBC_2.36)
    __stack_chk_guard@GLIBC_2.36 (GLIBC_2.36)
    abort@GLIBC_2.36 (GLIBC_2.36)
    fflush@GLIBC_2.36 (GLIBC_2.36)
    free@GLIBC_2.36 (GLIBC_2.36)
    getenv@GLIBC_2.36 (GLIBC_2.36)
    malloc@GLIBC_2.36 (GLIBC_2.36)
    puts@GLIBC_2.36 (GLIBC_2.36)
    stdout@GLIBC_2.36 (GLIBC_2.36)

FAIL: 619 of 619 ELF objects failed the ABI checks.