### PR TITLE
fiber: fix poll and epoll event bits discrepancy

### DIFF
--- a/src/basic/io-util.c
+++ b/src/basic/io-util.c
@@ -13,13 +13,28 @@
 #include "io-util.h"
 #include "time-util.h"
 
-/* EPOLL_POLL_COMMON_MASK in io-util.h treats POLL* and EPOLL* as interchangeable; verify it. */
-assert_cc((uint32_t) POLLIN    == EPOLLIN);
-assert_cc((uint32_t) POLLOUT   == EPOLLOUT);
-assert_cc((uint32_t) POLLERR   == EPOLLERR);
-assert_cc((uint32_t) POLLHUP   == EPOLLHUP);
-assert_cc((uint32_t) POLLPRI   == EPOLLPRI);
-assert_cc((uint32_t) POLLRDHUP == EPOLLRDHUP);
+uint32_t poll_events_to_epoll(uint32_t events) {
+        /* Translate every bit explicitly rather than relying on POLL* and EPOLL* sharing numeric
+         * values: today they happen to match for the POSIX bits on most Linux architectures, but
+         * POLLRDHUP already differs from EPOLLRDHUP on sparc, and there's no guarantee future
+         * architectures won't diverge further. Also pass through EPOLL bits. */
+        uint32_t r = events & (EPOLLET | EPOLLONESHOT | EPOLLWAKEUP | EPOLLEXCLUSIVE);
+
+        if (events & (POLLIN | EPOLLIN))
+                r |= EPOLLIN;
+        if (events & (POLLOUT | EPOLLOUT))
+                r |= EPOLLOUT;
+        if (events & (POLLPRI | EPOLLPRI))
+                r |= EPOLLPRI;
+        if (events & (POLLERR | EPOLLERR))
+                r |= EPOLLERR;
+        if (events & (POLLHUP | EPOLLHUP))
+                r |= EPOLLHUP;
+        if (events & (POLLRDHUP | EPOLLRDHUP))
+                r |= EPOLLRDHUP;
+
+        return r;
+}
 
 int flush_fd(int fd) {
         int count = 0;

--- a/src/basic/io-util.h
+++ b/src/basic/io-util.h
@@ -3,11 +3,7 @@
 
 #include "basic-forward.h"
 
-/* The intersection of poll() and epoll_wait() event masks. Linux defines POLL* and EPOLL* with the
- * same numeric values for these — see the assert_cc()s in io-util.c — so this mask can be used
- * interchangeably as a `revents` (poll) or `events` (epoll) bitset. */
-#define EPOLL_POLL_COMMON_MASK \
-        (EPOLLIN | EPOLLOUT | EPOLLERR | EPOLLHUP | EPOLLPRI | EPOLLRDHUP)
+uint32_t poll_events_to_epoll(uint32_t events);
 
 int flush_fd(int fd);
 

--- a/src/libsystemd/sd-future/fiber-io.c
+++ b/src/libsystemd/sd-future/fiber-io.c
@@ -402,15 +402,15 @@ int sd_fiber_ppoll(struct pollfd *fds, size_t n_fds, const struct timespec *time
         if (!futures)
                 return -ENOMEM;
 
-        /* Set up I/O event sources for all valid fds. POLL* and EPOLL* share their bit values (see
-         * EPOLL_POLL_COMMON_MASK in io-util.h), so we can pass the user-supplied event mask through
-         * to either backend without translation. */
+        /* Set up I/O event sources for all valid fds. POLL* and EPOLL* don't share their bit values
+         * universally (notably POLLRDHUP differs from EPOLLRDHUP on sparc), so translate via
+         * poll_events_to_epoll() rather than passing the user-supplied mask through unchanged. */
         size_t n_io_futures = 0;
         for (size_t i = 0; i < n_fds; i++) {
                 if (fds[i].fd < 0)
                         continue;
 
-                uint32_t events = fds[i].events & EPOLL_POLL_COMMON_MASK;
+                uint32_t events = poll_events_to_epoll(fds[i].events);
                 if (events == 0)
                         continue;
 


### PR DESCRIPTION
The assertion that all poll and epoll event bits match is false, and on some architecture they differ. For example, on sparc64 POLLRDHUP and EPOLLRDHUP are different.

Add a helper to translate from poll to epoll and use it in the fiber ppoll function.

Follow-up for cf4c65afa86021a750de38bbed192eeb1c9fd425