### PR TITLE
meson: Limit test-link-abi to developer mode

### DIFF
--- a/test/meson.build
+++ b/test/meson.build
@@ -130,12 +130,15 @@ if want_tests != 'false'
         foreach _, exe : executables_by_name
                 link_abi_targets += exe
         endforeach
-        test('test-link-abi',
-             files('test-link-abi.py'),
-             args : link_abi_targets,
-             depends : link_abi_targets,
-             suite : 'dist',
-             timeout : 120)
+
+        if conf.get('BUILD_MODE_DEVELOPER') == 1
+                test('test-link-abi',
+                     files('test-link-abi.py'),
+                     args : link_abi_targets,
+                     depends : link_abi_targets,
+                     suite : 'dist',
+                     timeout : 120)
+        endif
 endif
 
 ############################################################


### PR DESCRIPTION
This test can regress without changes on our end when
an older systemd is built against a newer glibc and 
the newer glibc has an ABI break for a symbol we use
but don't dlsym(). To avoid spurious test failures for
downstream packagers, let's only run the test in developer
mode for now.
