### PR TITLE
nspawn: downgrade log level when unregistering and machine is already gone

### DIFF
--- a/src/shared/machine-register.c
+++ b/src/shared/machine-register.c
@@ -286,11 +286,12 @@ void unregister_machine_with_fallback_and_log(
         }
 
         if (r < 0)
-                log_notice_errno(r, "Failed to unregister machine in %s context, ignoring: %m",
-                                 machine_registration_scope_string(
-                                                 ctx->registered_system && ctx->registered_user ? _RUNTIME_SCOPE_INVALID :
-                                                 ctx->registered_system ? RUNTIME_SCOPE_SYSTEM : RUNTIME_SCOPE_USER,
-                                                 !failed_system, !failed_user));
+                log_full_errno(r == -ENXIO ? LOG_DEBUG : LOG_INFO, /* Might have already been noticed and unregistered by machined itself */
+                               r, "Failed to unregister machine in %s context, ignoring: %m",
+                               machine_registration_scope_string(
+                                                ctx->registered_system && ctx->registered_user ? _RUNTIME_SCOPE_INVALID :
+                                                ctx->registered_system ? RUNTIME_SCOPE_SYSTEM : RUNTIME_SCOPE_USER,
+                                                !failed_system, !failed_user));
 }
 
 int unregister_machine(sd_bus *bus, const char *machine_name, RuntimeScope scope) {


### PR DESCRIPTION
nspawn started logging at notice level when exiting a container:

```
root@sid-arm64:~# exit
logout
Container sid-arm64 exited successfully.
Failed to unregister machine in system context, ignoring: No such device or address
```

Looks like it's racing with machined which already noticed it was gone and remove it. Downgrade to debug on ENXIO.

Follow-up for 1e084aad7d5c2132ed32ff2a75bbe21205c0f5f3