### PR TITLE
test: install python package needed by networkd-tests.py

### DIFF
--- a/mkosi/mkosi.conf.d/arch/mkosi.conf
+++ b/mkosi/mkosi.conf.d/arch/mkosi.conf
@@ -42,6 +42,7 @@ Packages=
         pkgconf
         polkit
         procps-ng
+        python-packaging
         python-pexpect
         python-psutil
         qrencode

--- a/mkosi/mkosi.conf.d/centos-fedora/mkosi.conf
+++ b/mkosi/mkosi.conf.d/centos-fedora/mkosi.conf
@@ -56,6 +56,7 @@ Packages=
         policycoreutils
         polkit
         procps-ng
+        python3-packaging
         python3-pexpect
         # needed to upgrade and downgrade systemd-ukify in tests
         python3-zstd

--- a/mkosi/mkosi.conf.d/debian-ubuntu/mkosi.conf
+++ b/mkosi/mkosi.conf.d/debian-ubuntu/mkosi.conf
@@ -63,6 +63,7 @@ Packages=
         polkitd
         pkgconf
         procps
+        python3-packaging
         python3-pexpect
         python3-psutil
         # kernel-bootcfg --add-uri= is just too useful

--- a/mkosi/mkosi.conf.d/opensuse/mkosi.conf
+++ b/mkosi/mkosi.conf.d/opensuse/mkosi.conf
@@ -73,6 +73,7 @@ Packages=
         policycoreutils
         pkgconf
         procps4
+        python3-packaging
         python3-pefile
         python3-pexpect
         python3-psutil


### PR DESCRIPTION
systemd-networkd-tests.py[515]: Failed to import either platform or packaging module, assuming the comparison failed