### PR TITLE
test: avoid picking volatile user-session units in varlinkctl-unit test

### DIFF
--- a/test/units/TEST-74-AUX-UTILS.varlinkctl-unit.sh
+++ b/test/units/TEST-74-AUX-UTILS.varlinkctl-unit.sh
@@ -33,8 +33,8 @@ test -n "$automount_id"
 automount_params=$(jq -cn --arg name "$automount_id" '{name: $name}')
 varlinkctl call /run/systemd/io.systemd.Manager io.systemd.Unit.List "$automount_params" | jq -e '.context.Automount'
 varlinkctl call /run/systemd/io.systemd.Manager io.systemd.Unit.List "$automount_params" | jq -e '.runtime.Automount'
-# test for MountContext/Runtime
-mount_id=$(varlinkctl call --collect /run/systemd/io.systemd.Manager io.systemd.Unit.List '{}' | jq -r '.[] | select(.context.Type == "mount" and .runtime.LoadState == "loaded") .context.ID // empty' | tail -n 1)
+# test for MountContext/Runtime (skip volatile run-user-*.mount to avoid GC race)
+mount_id=$(varlinkctl call --collect /run/systemd/io.systemd.Manager io.systemd.Unit.List '{}' | jq -r '.[] | select(.context.Type == "mount" and .runtime.LoadState == "loaded" and (.context.ID | startswith("run-user-") | not)) .context.ID // empty' | tail -n 1)
 test -n "$mount_id"
 mount_params=$(jq -cn --arg name "$mount_id" '{name: $name}')
 varlinkctl call /run/systemd/io.systemd.Manager io.systemd.Unit.List "$mount_params" | jq -e '.context.Mount'
@@ -45,14 +45,14 @@ test -n "$path_id"
 path_params=$(jq -cn --arg name "$path_id" '{name: $name}')
 varlinkctl call /run/systemd/io.systemd.Manager io.systemd.Unit.List "$path_params" | jq -e '.context.Path'
 varlinkctl call /run/systemd/io.systemd.Manager io.systemd.Unit.List "$path_params" | jq -e '.runtime.Path'
-# test for ServiceContext/Runtime
-service_id=$(varlinkctl call --collect /run/systemd/io.systemd.Manager io.systemd.Unit.List '{}' | jq -r '.[] | select(.context.Type == "service" and .runtime.LoadState == "loaded") .context.ID // empty' | tail -n 1)
+# test for ServiceContext/Runtime (skip volatile user@*/user-runtime-dir@* to avoid GC race)
+service_id=$(varlinkctl call --collect /run/systemd/io.systemd.Manager io.systemd.Unit.List '{}' | jq -r '.[] | select(.context.Type == "service" and .runtime.LoadState == "loaded" and (.context.ID | test("^(user|user-runtime-dir)@") | not)) .context.ID // empty' | tail -n 1)
 test -n "$service_id"
 service_params=$(jq -cn --arg name "$service_id" '{name: $name}')
 varlinkctl call /run/systemd/io.systemd.Manager io.systemd.Unit.List "$service_params" | jq -e '.context.Service'
 varlinkctl call /run/systemd/io.systemd.Manager io.systemd.Unit.List "$service_params" | jq -e '.runtime.Service'
-# test for ScopeContext/Runtime
-scope_id=$(varlinkctl call --collect /run/systemd/io.systemd.Manager io.systemd.Unit.List '{}' | jq -r '.[] | select(.context.Type == "scope" and .runtime.LoadState == "loaded") .context.ID // empty' | tail -n 1)
+# test for ScopeContext/Runtime (skip volatile session-*.scope to avoid GC race)
+scope_id=$(varlinkctl call --collect /run/systemd/io.systemd.Manager io.systemd.Unit.List '{}' | jq -r '.[] | select(.context.Type == "scope" and .runtime.LoadState == "loaded" and (.context.ID | startswith("session-") | not)) .context.ID // empty' | tail -n 1)
 test -n "$scope_id"
 scope_params=$(jq -cn --arg name "$scope_id" '{name: $name}')
 varlinkctl call /run/systemd/io.systemd.Manager io.systemd.Unit.List "$scope_params" | jq -e '.context.Scope'


### PR DESCRIPTION
Each <type>_id is picked from a Unit.List '{}' call and immediately queried via a second Unit.List '{"name":"<id>"}' call. When the picked unit is tied to a user session (run-user-N.mount, user@N.service, user-runtime-dir@N.service, session-cN.scope) it may be torn down between the two calls if the user manager happens to exit at that moment, causing a spurious NoSuchUnit failure.

Filter those out of the candidate lists for mount/service/scope. Excerpt from a failed CI run showing the race:

```
  [ 2631.395826] systemd[1]: user-runtime-dir@4711.service: Trying to enqueue job user-runtime-dir@4711.service/stop/fail
  [ 2632.101414] systemd[1]: user-runtime-dir@4711.service: Got final SIGCHLD for state stop.
  [ 2632.182537] TEST-74-AUX-UTILS.sh[3051]: + mount_id=run-user-4711.mount
  [ 2632.186760] TEST-74-AUX-UTILS.sh[3099]: + varlinkctl call /run/systemd/io.systemd.Manager io.systemd.Unit.List '{"name":"run-user-4711.mount"}'
  [ 2632.189752] systemd[1]: varlink-api-3-3: Sending message: {"error":"io.systemd.Unit.NoSuchUnit"}
  [ 2632.190752] TEST-74-AUX-UTILS.sh[3099]: Method call io.systemd.Unit.List() failed: io.systemd.Unit.NoSuchUnit
  [ 2632.191594] TEST-74-AUX-UTILS.sh[101]: Subtest /usr/lib/systemd/tests/testdata/units/TEST-74-AUX-UTILS.varlinkctl-unit.sh failed
```

Co-developed-by: Claude Opus 4.7 <noreply@anthropic.com>

eg: https://github.com/systemd/systemd/actions/runs/26399425027/job/77707788642?pr=42291