### PR TITLE
dissect-image: reject empty partitions array

### DIFF
--- a/src/shared/dissect-image.c
+++ b/src/shared/dissect-image.c
@@ -5298,6 +5298,9 @@ int mountfsd_mount_image_fd(
                 };
         }
 
+        if (!di)
+                return log_debug_errno(SYNTHETIC_ERRNO(EBADMSG), "Partition list is empty.");
+
         di->single_file_system = p.single_file_system;
         di->image_size = p.image_size;
         di->sector_size = p.sector_size;

--- a/src/shared/dissect-image.c
+++ b/src/shared/dissect-image.c
@@ -5298,6 +5298,9 @@ int mountfsd_mount_image_fd(
                 };
         }
 
+        if (!di)
+                return log_error_errno(SYNTHETIC_ERRNO(EBADMSG), "Partition list is empty");
+
         di->single_file_system = p.single_file_system;
         di->image_size = p.image_size;
         di->sector_size = p.sector_size;


### PR DESCRIPTION
This fixes a possible NULL pointer dereference in `mountfsd_mount_image_fd()`.

`di` is allocated while iterating over `p.partitions`. If the array is empty,
the loop is skipped and `di` remains `NULL`, but the code still assigns image
metadata through it afterwards.

Return `EBADMSG` before accessing `di` in this case.

Found by Linux Verification Center (linuxtesting.org) with Svace.

Testing:
- Not run yet.