### PR TITLE
sysusers: log new group name on write failure

### DIFF
--- a/src/sysusers/sysusers.c
+++ b/src/sysusers/sysusers.c
@@ -821,7 +821,7 @@ static int write_temporary_group(
                 r = putgrent_with_members(c, &n, group);
                 if (r < 0)
                         return log_error_errno(r, "Failed to add new group \"%s\" to temporary group file: %m",
-                                               gr->gr_name);
+                                               n.gr_name);
 
                 group_changed = true;
         }


### PR DESCRIPTION
This fixes a possible NULL pointer dereference in `write_temporary_group()`.

When adding new groups from `c->todo_gids`, the code constructs a local
`struct group n` and passes it to `putgrent_with_members()`. If that call
fails, the error path currently logs `gr->gr_name`.

`gr` belongs to the earlier loop over the existing group file and may be
`NULL` after EOF. It is also the wrong object for this diagnostic, because
the failing operation is writing the newly constructed group `n`.

Log `n.gr_name` instead.

Found by Linux Verification Center (linuxtesting.org) with Svace.

Testing:
- Not run yet.