### PR TITLE
test-execute: drop workaround for fixed issue

### DIFF
--- a/src/test/test-execute.c
+++ b/src/test/test-execute.c
@@ -1027,11 +1027,6 @@ static void test_exec_dynamicuser(Manager *m) {
                 return;
         }
 
-        if (strstr_ptr(ci_environment(), "github-actions")) {
-                log_notice("%s: skipping test on GH Actions because of systemd/systemd#10337", __func__);
-                return;
-        }
-
         int status = can_unshare ? 0 : EXIT_NAMESPACE;
 
         test(m, "exec-dynamicuser-fixeduser.service", status, CLD_EXITED);


### PR DESCRIPTION
The issue should be already fixed by f01f70a9a3f3609c0c8bdbaa4b0b4abbb2b43993.