### PR TITLE
Allow systemd-imds-import to be ordered early and update enablement

### DIFF
--- a/src/imds/imds-generator.c
+++ b/src/imds/imds-generator.c
@@ -6,6 +6,7 @@
 #include "fileio.h"
 #include "generator.h"
 #include "imds-util.h"
+#include "initrd-util.h"
 #include "log.h"
 #include "parse-util.h"
 #include "proc-cmdline.h"
@@ -13,8 +14,8 @@
 #include "string-util.h"
 #include "virt.h"
 
-static int arg_enabled = -1;           /* Whether we shall offer local IMDS APIs */
-static bool arg_import = true;         /* Whether we shall import IMDS credentials, SSH keys, … into the local system */
+static int arg_enabled = -1;  /* Whether we shall offer local IMDS APIs */
+static int arg_import = -1;   /* Whether we shall import IMDS credentials, SSH keys, … into the local system */
 static ImdsNetworkMode arg_network_mode = IMDS_NETWORK_DEFAULT;
 
 static int parse_proc_cmdline_item(const char *key, const char *value, void *data) {
@@ -179,8 +180,10 @@ static int run(const char *dest, const char *dest_early, const char *dest_late) 
         if (r < 0)
                 return log_error_errno(r, "Failed to hook DMI id device before systemd-imdsd@.service: %m");
 
-        if (arg_import) {
-                /* Enable that we import IMDS data */
+        if (arg_import < 0)
+                arg_import = in_initrd();
+        if (arg_import > 0) {
+                /* Enable the import of IMDS data */
                 r = generator_add_symlink(dest_early, SPECIAL_SYSINIT_TARGET, "wants", SYSTEM_DATA_UNIT_DIR "/systemd-imds-import.service");
                 if (r < 0)
                         return log_error_errno(r, "Failed to hook in systemd-imds-import.service: %m");

--- a/units/systemd-imds-import.service.in
+++ b/units/systemd-imds-import.service.in
@@ -19,8 +19,6 @@ Before=sysinit.target systemd-firstboot.service
 Conflicts=shutdown.target
 Before=shutdown.target
 
-ConditionPathExists=/etc/initrd-release
-
 [Service]
 Type=oneshot
 RemainAfterExit=yes

--- a/units/systemd-imds-import.service.in
+++ b/units/systemd-imds-import.service.in
@@ -11,12 +11,14 @@
 Description=Import System Credentials from IMDS
 Documentation=man:systemd-imds(1)
 Documentation=man:systemd.system-credentials(7)
+
 DefaultDependencies=no
-Wants=systemd-imdsd.socket network-online.target
-After=systemd-imdsd.socket network-online.target
+Wants=systemd-imdsd.socket
+After=systemd-imdsd.socket
 Before=sysinit.target systemd-firstboot.service
 Conflicts=shutdown.target
 Before=shutdown.target
+
 ConditionPathExists=/etc/initrd-release
 
 [Service]


### PR DESCRIPTION
It seems that the enablement of this unit was somewhat confused…