### PR TITLE
mkosi: update mkosi ref to 1f811f0524be3096872e79161c8e6ab3e7c2bb1f

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
-      - uses: systemd/mkosi@444d247d1a1328bcfb84a945e84959bd4bd0e02d
+      - uses: systemd/mkosi@1f811f0524be3096872e79161c8e6ab3e7c2bb1f
 
       # Freeing up disk space with rm -rf can take multiple minutes. Since we don't need the extra free space
       # immediately, we remove the files in the background. However, we first move them to a different location

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -40,7 +40,7 @@ jobs:
           GITHUB_ACTIONS_CONFIG_FILE: actionlint.yml
           ENABLE_GITHUB_PULL_REQUEST_SUMMARY_COMMENT: false
 
-      - uses: systemd/mkosi@444d247d1a1328bcfb84a945e84959bd4bd0e02d
+      - uses: systemd/mkosi@1f811f0524be3096872e79161c8e6ab3e7c2bb1f
 
       - name: Check that tabs are not used in Python code
         run: sh -c '! git grep -P "\\t" -- src/core/generate-bpf-delegate-configs.py src/boot/generate-hwids-section.py src/ukify/ukify.py test/integration-tests/integration-test-wrapper.py'

--- a/.github/workflows/mkosi.yml
+++ b/.github/workflows/mkosi.yml
@@ -169,7 +169,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
-      - uses: systemd/mkosi@444d247d1a1328bcfb84a945e84959bd4bd0e02d
+      - uses: systemd/mkosi@1f811f0524be3096872e79161c8e6ab3e7c2bb1f
 
       # Freeing up disk space with rm -rf can take multiple minutes. Since we don't need the extra free space
       # immediately, we remove the files in the background. However, we first move them to a different location

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: systemd/mkosi@444d247d1a1328bcfb84a945e84959bd4bd0e02d
+      - uses: systemd/mkosi@1f811f0524be3096872e79161c8e6ab3e7c2bb1f
 
       - name: Install apk
         # ubuntu-24.04 doesn't package apk, so fetch the official statically-linked binary from

--- a/mkosi/mkosi.conf
+++ b/mkosi/mkosi.conf
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 [Config]
-MinimumVersion=commit:444d247d1a1328bcfb84a945e84959bd4bd0e02d
+MinimumVersion=commit:1f811f0524be3096872e79161c8e6ab3e7c2bb1f
 Dependencies=
         minimal-base
         minimal-0


### PR DESCRIPTION
* 1f811f0524 tools: move grub-pc-bin to arch-specific drop-in
* 063f916427 config: Add logging for default initrd selection
* f64ec15a87 action: Install apk
* 973c09c101 mkosi-initrd: Add libfdisk to PostmarketOS
* 327644ecec mkosi-initrd: Add libfdisk1
* c4af878bcb postmarketos: Fetch keys by default on Ubuntu
* 2155c1b3e7 Fix typo in SELinux relabel instruction
* fe4119d353 fedora: allow Snapshot= for any kojipkgs-style mirror