### PR TITLE
nspawn: mark --bind-user-shell=/BindUserShell= as trusted

### DIFF
--- a/src/nspawn/nspawn.c
+++ b/src/nspawn/nspawn.c
@@ -4986,8 +4986,13 @@ static int merge_settings(Settings *settings, const char *path) {
 
         if (!FLAGS_SET(arg_settings_mask, SETTING_BIND_USER_SHELL) &&
             settings->bind_user_shell_set) {
-                free_and_replace(arg_bind_user_shell, settings->bind_user_shell);
-                arg_bind_user_shell_copy = settings->bind_user_shell_copy;
+
+                if (!arg_settings_trusted)
+                        log_warning("Ignoring bind user shell setting, file %s is not trusted.", path);
+                else {
+                        free_and_replace(arg_bind_user_shell, settings->bind_user_shell);
+                        arg_bind_user_shell_copy = settings->bind_user_shell_copy;
+                }
         }
 
         if ((arg_settings_mask & SETTING_NOTIFY_READY) == 0 &&


### PR DESCRIPTION
Similarly to --bind-user=/BindUser=.

Follow-up for a9e860f22eee540a0a6819034e110572c9c8b9fd.

Reported-by: omkhar <omkhar@users.noreply.github.com>