### PR TITLE
udev: ignore errors in adding property with spurious value

### DIFF
--- a/src/udev/udev-builtin-hwdb.c
+++ b/src/udev/udev-builtin-hwdb.c
@@ -40,9 +40,10 @@ int udev_builtin_hwdb_lookup(
                         continue;
 
                 r = udev_builtin_add_property(event, key, value);
-                if (r < 0)
+                if (r == -ENOMEM)
                         return r;
-                n++;
+                if (r >= 0)
+                        n++;
         }
         return n;
 }

--- a/src/udev/udev-builtin-tpm2_id.c
+++ b/src/udev/udev-builtin-tpm2_id.c
@@ -35,14 +35,18 @@ static int builtin_tpm2_id(UdevEvent *event, int argc, char *argv[]) {
 
         if (!isempty(info.manufacturer)) {
                 r = udev_builtin_add_property(event, "ID_TPM2_MANUFACTURER", info.manufacturer);
+                if (r == -ENOMEM)
+                        return log_oom();
                 if (r < 0)
-                        return log_device_error_errno(dev, r, "Failed to set field: %m");
+                        log_device_warning_errno(dev, r, "Failed to set ID_TPM2_MANUFACTURER property, ignoring: %m");
         }
 
         if (!isempty(info.vendor_string)) {
                 r = udev_builtin_add_property(event, "ID_TPM2_VENDOR_STRING", info.vendor_string);
+                if (r == -ENOMEM)
+                        return log_oom();
                 if (r < 0)
-                        return log_device_error_errno(dev, r, "Failed to set field: %m");
+                        log_device_warning_errno(dev, r, "Failed to set ID_TPM2_VENDOR_STRING property, ignoring: %m");
         }
 
         _cleanup_free_ char *m = NULL;
@@ -51,8 +55,10 @@ static int builtin_tpm2_id(UdevEvent *event, int argc, char *argv[]) {
                 return log_device_error_errno(dev, r, "Failed to get modalias string for TPM2 device: %m");
 
         r = udev_builtin_add_property(event, "ID_TPM2_MODALIAS", m);
+        if (r == -ENOMEM)
+                return log_oom();
         if (r < 0)
-                return log_device_error_errno(dev, r, "Failed to set field: %m");
+                log_device_warning_errno(dev, r, "Failed to set ID_TPM2_MODALIAS property, ignoring: %m");
 
         return 0;
 }

--- a/src/udev/udev-rules.c
+++ b/src/udev/udev-rules.c
@@ -2448,11 +2448,12 @@ static int udev_rule_apply_token_to_event(
                                 continue;
 
                         r = device_add_property(dev, key, value);
+                        if (r == -ENOMEM)
+                                return log_oom();
                         if (r < 0)
-                                return log_event_error_errno(event, token, r,
-                                                             "Failed to add property %s=%s: %m",
-                                                             key, value);
-                        log_event_trace(event, token, "Imported property \"%s=%s\".", key, value);
+                                log_event_warning_errno(event, token, r, "Failed to import property \"%s=%s\", ignoring: %m", key, value);
+                        else
+                                log_event_trace(event, token, "Imported property \"%s=%s\".", key, value);
                 }
 
                 assert_not_reached();
@@ -2514,11 +2515,12 @@ static int udev_rule_apply_token_to_event(
                                 continue;
 
                         r = device_add_property(dev, key, value);
+                        if (r == -ENOMEM)
+                                return log_oom();
                         if (r < 0)
-                                return log_event_error_errno(event, token, r,
-                                                             "Failed to add property %s=%s: %m",
-                                                             key, value);
-                        log_event_trace(event, token, "Imported property \"%s=%s\".", key, value);
+                                log_event_warning_errno(event, token, r, "Failed to import property \"%s=%s\", ignoring: %m", key, value);
+                        else
+                                log_event_trace(event, token, "Imported property \"%s=%s\".", key, value);
                 }
 
                 return log_event_result(event, token, token->op == OP_MATCH);
@@ -2568,10 +2570,12 @@ static int udev_rule_apply_token_to_event(
                                                      token->value);
 
                 r = device_add_property(dev, token->value, val);
+                if (r == -ENOMEM)
+                        return log_oom();
                 if (r < 0)
-                        return log_event_error_errno(event, token, r, "Failed to add property \"%s=%s\": %m",
-                                                     token->value, val);
-                log_event_trace(event, token, "Imported property \"%s=%s\".", token->value, val);
+                        log_event_warning_errno(event, token, r, "Failed to import property \"%s=%s\", ignoring: %m", token->value, val);
+                else
+                        log_event_trace(event, token, "Imported property \"%s=%s\".", token->value, val);
 
                 return log_event_result(event, token, token->op == OP_MATCH);
         }
@@ -2588,10 +2592,12 @@ static int udev_rule_apply_token_to_event(
 
                 const char *val = value ?: "1";
                 r = device_add_property(dev, token->value, val);
+                if (r == -ENOMEM)
+                        return log_oom();
                 if (r < 0)
-                        return log_event_error_errno(event, token, r, "Failed to add property \"%s=%s\": %m",
-                                                     token->value, val);
-                log_event_trace(event, token, "Imported property \"%s=%s\".", token->value, val);
+                        log_event_warning_errno(event, token, r, "Failed to import property \"%s=%s\", ignoring: %m", token->value, val);
+                else
+                        log_event_trace(event, token, "Imported property \"%s=%s\".", token->value, val);
 
                 return log_event_result(event, token, token->op == OP_MATCH);
         }
@@ -2614,10 +2620,14 @@ static int udev_rule_apply_token_to_event(
                                 continue;
 
                         r = device_add_property(dev, key, val);
+                        if (r == -ENOMEM)
+                                return log_oom();
                         if (r < 0)
-                                return log_event_error_errno(event, token, r, "Failed to add property \"%s=%s\": %m", key, val);
-                        log_event_trace(event, token, "Imported property \"%s=%s\".", key, val);
-                        have = true;
+                                log_event_warning_errno(event, token, r, "Failed to import property \"%s=%s\", ignoring: %m", key, val);
+                        else {
+                                log_event_trace(event, token, "Imported property \"%s=%s\".", key, val);
+                                have = true;
+                        }
                 }
 
                 return log_event_result(event, token, token->op == (have ? OP_MATCH : OP_NOMATCH));
@@ -2882,9 +2892,12 @@ static int udev_rule_apply_token_to_event(
                         udev_replace_chars_and_log(event, token, p, /* allow= */ NULL, "property value");
 
                 r = device_add_property(dev, name, value_new);
+                if (r == -ENOMEM)
+                        return log_oom();
                 if (r < 0)
-                        return log_event_error_errno(event, token, r, "Failed to set property \"%s=%s\": %m", name, value_new);
-                log_event_trace(event, token, "Set property \"%s=%s\".", name, value_new);
+                        log_event_warning_errno(event, token, r, "Failed to set property \"%s=%s\", ignoring: %m", name, value_new);
+                else
+                        log_event_trace(event, token, "Set property \"%s=%s\".", name, value_new);
                 return true;
         }
         case TK_A_TAG: {


### PR DESCRIPTION
Since a62cd5a153ffe18c27aff02685ed75c5bc4509a2, when an invalid property is being added, device_add_property() refuses it with -EINVAL. Before the commit, the function could fail with only -ENOMEM, and if it fails, processing udev rules was aborted.

Let's not hard fail when udev rules or udev builtins try to add an invalid property, and let's just log and ignore the failure.

Follow-up for a62cd5a153ffe18c27aff02685ed75c5bc4509a2.

Fixes #41339
Fixes #41296.