### PR TITLE
install: add support for 'mask' directive in preset files

### DIFF
--- a/man/systemd.preset.xml
+++ b/man/systemd.preset.xml
@@ -74,9 +74,9 @@
 
     <para>The preset files contain a list of directives, one per line. Empty lines and lines whose first
     non-whitespace character is <literal>#</literal> or <literal>;</literal> are ignored.  Each directive
-    consists of one of the words <literal>enable</literal>, <literal>disable</literal>, or
-    <literal>ignore</literal>, followed by whitespace and a unit name. The unit name may contain shell-style
-    wildcards.</para>
+    consists of one of the words <literal>enable</literal>, <literal>disable</literal>,
+    <literal>ignore</literal>, or <literal>mask</literal>, followed by whitespace and a unit name. The unit
+    name may contain shell-style wildcards.</para>
 
     <para>For the enable directive for template units, one or more instance names may be specified as a
     space-separated list after the unit name. In this case, those instances will be enabled instead of the
@@ -86,9 +86,11 @@
     <citerefentry><refentrytitle>systemd.unit</refentrytitle><manvolnum>5</manvolnum></citerefentry>
     for a description of unit aliasing.</para>
 
-    <para>Three different directives are understood: <literal>enable</literal> may be used to enable units by
-    default, <literal>disable</literal> to disable units by default, and <literal>ignore</literal> to ignore
-    units and leave existing configuration intact.</para>
+    <para>Four different directives are understood: <literal>enable</literal> may be used to enable units by
+    default, <literal>disable</literal> to disable units by default, <literal>ignore</literal> to ignore
+    units and leave existing configuration intact, and <literal>mask</literal> to mask units and prevent
+    them from being started even when pulled in as a dependency. <literal>mask</literal> will not override
+    existing configuration in the configuration directory.</para>
 
     <para>If multiple lines apply to a unit name, the first matching
     one takes precedence over all others.</para>

--- a/src/shared/install.c
+++ b/src/shared/install.c
@@ -55,6 +55,7 @@ static const char *const preset_action_past_tense_table[_PRESET_ACTION_MAX] = {
         [PRESET_ENABLE]  = "enabled",
         [PRESET_DISABLE] = "disabled",
         [PRESET_IGNORE]  = "ignored",
+        [PRESET_MASK]    = "masked",
 };
 
 DEFINE_STRING_TABLE_LOOKUP_TO_STRING(preset_action_past_tense, PresetAction);
@@ -3439,6 +3440,18 @@ static int read_presets(RuntimeScope scope, const char *root_dir, UnitFilePreset
                                         .pattern = pattern,
                                         .action = PRESET_IGNORE,
                                 };
+
+                        } else if ((parameter = first_word(line, "mask"))) {
+                                char *pattern;
+
+                                pattern = strdup(parameter);
+                                if (!pattern)
+                                        return -ENOMEM;
+
+                                rule = (UnitFilePresetRule) {
+                                        .pattern = pattern,
+                                        .action = PRESET_MASK,
+                                };
                         }
 
                         if (rule.action != 0) {
@@ -3551,6 +3564,10 @@ static int query_presets(const char *name, const UnitFilePresets *presets, char 
                 log_debug("Preset files say ignore %s.", name);
                 return PRESET_IGNORE;
 
+        case PRESET_MASK:
+                log_debug("Preset files say mask %s.", name);
+                return PRESET_MASK;
+
         default:
                 assert_not_reached();
         }
@@ -3575,6 +3592,7 @@ static int execute_preset(
                 UnitFileFlags file_flags,
                 InstallContext *plus,
                 InstallContext *minus,
+                char **masked,
                 const LookupPaths *lp,
                 const char *config_path,
                 char * const *files,
@@ -3616,6 +3634,18 @@ static int execute_preset(
                 }
         }
 
+        if (mode == UNIT_FILE_PRESET_FULL) {
+                STRV_FOREACH(name, masked) {
+                        _cleanup_free_ char *path = path_make_absolute(*name, config_path);
+                        if (!path)
+                                return -ENOMEM;
+
+                        int q = create_symlink(lp, "/dev/null", path, false, changes, n_changes);
+                        if (r >= 0 && q < 0)
+                                r = q;
+                }
+        }
+
         return r;
 }
 
@@ -3624,6 +3654,7 @@ static int preset_prepare_one(
                 InstallContext *plus,
                 InstallContext *minus,
                 LookupPaths *lp,
+                char ***masked,
                 const char *name,
                 const UnitFilePresets *presets,
                 InstallChange **changes,
@@ -3670,6 +3701,12 @@ static int preset_prepare_one(
                 r = install_info_discover(minus, lp, name, SEARCH_FOLLOW_CONFIG_SYMLINKS,
                                           &info, changes, n_changes);
 
+        else if (r == PRESET_MASK) {
+                r = strv_extend(masked, name);
+                if (r < 0)
+                        return r;
+        }
+
         return r;
 }
 
@@ -3685,6 +3722,7 @@ int unit_file_preset(
         _cleanup_(install_context_done) InstallContext plus = {}, minus = {};
         _cleanup_(lookup_paths_done) LookupPaths lp = {};
         _cleanup_(unit_file_presets_done) UnitFilePresets presets = {};
+        _cleanup_strv_free_ char **masked = NULL;
         const char *config_path;
         int r;
 
@@ -3705,12 +3743,12 @@ int unit_file_preset(
                 return r;
 
         STRV_FOREACH(name, names) {
-                r = preset_prepare_one(scope, &plus, &minus, &lp, *name, &presets, changes, n_changes);
+                r = preset_prepare_one(scope, &plus, &minus, &lp, &masked, *name, &presets, changes, n_changes);
                 if (r < 0 && !ERRNO_IS_NEG_UNIT_ISSUE(r))
                         return r;
         }
 
-        return execute_preset(file_flags, &plus, &minus, &lp, config_path, names, mode, changes, n_changes);
+        return execute_preset(file_flags, &plus, &minus, masked, &lp, config_path, names, mode, changes, n_changes);
 }
 
 int unit_file_preset_all(
@@ -3724,6 +3762,7 @@ int unit_file_preset_all(
         _cleanup_(install_context_done) InstallContext plus = {}, minus = {};
         _cleanup_(lookup_paths_done) LookupPaths lp = {};
         _cleanup_(unit_file_presets_done) UnitFilePresets presets = {};
+        _cleanup_strv_free_ char **masked = NULL;
         const char *config_path = NULL;
         int r;
 
@@ -3763,13 +3802,13 @@ int unit_file_preset_all(
                         if (!IN_SET(de->d_type, DT_LNK, DT_REG))
                                 continue;
 
-                        r = preset_prepare_one(scope, &plus, &minus, &lp, de->d_name, &presets, changes, n_changes);
+                        r = preset_prepare_one(scope, &plus, &minus, &lp, &masked, de->d_name, &presets, changes, n_changes);
                         if (r < 0 && !ERRNO_IS_NEG_UNIT_ISSUE(r))
                                 return r;
                 }
         }
 
-        return execute_preset(file_flags, &plus, &minus, &lp, config_path, NULL, mode, changes, n_changes);
+        return execute_preset(file_flags, &plus, &minus, masked, &lp, config_path, NULL, mode, changes, n_changes);
 }
 
 static UnitFileList* unit_file_list_free(UnitFileList *f) {

--- a/src/shared/install.h
+++ b/src/shared/install.h
@@ -232,6 +232,7 @@ typedef enum PresetAction {
         PRESET_ENABLE,
         PRESET_DISABLE,
         PRESET_IGNORE,
+        PRESET_MASK,
         _PRESET_ACTION_MAX,
         _PRESET_ACTION_INVALID = -EINVAL,
         _PRESET_ACTION_ERRNO_MAX = -ERRNO_MAX, /* Ensure this type covers the whole negative errno range */

--- a/src/test/test-install-root.c
+++ b/src/test/test-install-root.c
@@ -730,6 +730,97 @@ TEST(preset_and_list) {
         assert_se(unit_file_get_state(RUNTIME_SCOPE_SYSTEM, root, "preset-ignore.service", &state) >= 0 && state == UNIT_FILE_ENABLED);
 }
 
+TEST(preset_mask) {
+        InstallChange *changes = NULL;
+        size_t n_changes = 0;
+        const char *p;
+        UnitFileState state;
+
+        CLEANUP_ARRAY(changes, n_changes, install_changes_free);
+
+        assert_se(unit_file_get_state(RUNTIME_SCOPE_SYSTEM, root, "preset-mask.service", &state) == -ENOENT);
+        assert_se(unit_file_get_state(RUNTIME_SCOPE_SYSTEM, root, "preset-mask-static.service", &state) == -ENOENT);
+
+        /* installable unit masked via preset */
+        p = strjoina(root, "/usr/lib/systemd/system/preset-mask.service");
+        assert_se(write_string_file(p,
+                                    "[Install]\n"
+                                    "WantedBy=multi-user.target\n", WRITE_STRING_FILE_CREATE) >= 0);
+
+        /* static unit (no [Install] section) masked via preset */
+        p = strjoina(root, "/usr/lib/systemd/system/preset-mask-static.service");
+        assert_se(write_string_file(p, "# static unit, no [Install] section\n", WRITE_STRING_FILE_CREATE) >= 0);
+
+        p = strjoina(root, "/usr/lib/systemd/system-preset/test-mask.preset");
+        assert_se(write_string_file(p,
+                                    "mask preset-mask.service\n"
+                                    "mask preset-mask-static.service\n", WRITE_STRING_FILE_CREATE) >= 0);
+
+        assert_se(unit_file_get_state(RUNTIME_SCOPE_SYSTEM, root, "preset-mask.service", &state) >= 0 && state == UNIT_FILE_DISABLED);
+        assert_se(unit_file_get_state(RUNTIME_SCOPE_SYSTEM, root, "preset-mask-static.service", &state) >= 0 && state == UNIT_FILE_STATIC);
+
+        /* preset should mask both units */
+        assert_se(unit_file_preset(RUNTIME_SCOPE_SYSTEM, 0, root, STRV_MAKE("preset-mask.service"), UNIT_FILE_PRESET_FULL, &changes, &n_changes) >= 0);
+        assert_se(n_changes == 1);
+        assert_se(changes[0].type == INSTALL_CHANGE_SYMLINK);
+        ASSERT_STREQ(changes[0].source, "/dev/null");
+        p = strjoina(root, SYSTEM_CONFIG_UNIT_DIR"/preset-mask.service");
+        ASSERT_STREQ(changes[0].path, p);
+        install_changes_free(changes, n_changes);
+        changes = NULL; n_changes = 0;
+
+        assert_se(unit_file_get_state(RUNTIME_SCOPE_SYSTEM, root, "preset-mask.service", &state) >= 0 && state == UNIT_FILE_MASKED);
+
+        /* static unit: preset mask must succeed even without [Install] section */
+        assert_se(unit_file_preset(RUNTIME_SCOPE_SYSTEM, 0, root, STRV_MAKE("preset-mask-static.service"), UNIT_FILE_PRESET_FULL, &changes, &n_changes) >= 0);
+        assert_se(n_changes == 1);
+        assert_se(changes[0].type == INSTALL_CHANGE_SYMLINK);
+        ASSERT_STREQ(changes[0].source, "/dev/null");
+        p = strjoina(root, SYSTEM_CONFIG_UNIT_DIR"/preset-mask-static.service");
+        ASSERT_STREQ(changes[0].path, p);
+        install_changes_free(changes, n_changes);
+        changes = NULL; n_changes = 0;
+
+        assert_se(unit_file_get_state(RUNTIME_SCOPE_SYSTEM, root, "preset-mask-static.service", &state) >= 0 && state == UNIT_FILE_MASKED);
+
+        /* unmask should reverse the preset for both */
+        assert_se(unit_file_unmask(RUNTIME_SCOPE_SYSTEM, 0, root, STRV_MAKE("preset-mask.service"), &changes, &n_changes) >= 0);
+        assert_se(n_changes == 1);
+        assert_se(changes[0].type == INSTALL_CHANGE_UNLINK);
+        p = strjoina(root, SYSTEM_CONFIG_UNIT_DIR"/preset-mask.service");
+        ASSERT_STREQ(changes[0].path, p);
+        install_changes_free(changes, n_changes);
+        changes = NULL; n_changes = 0;
+
+        assert_se(unit_file_get_state(RUNTIME_SCOPE_SYSTEM, root, "preset-mask.service", &state) >= 0 && state == UNIT_FILE_DISABLED);
+
+        /* preset with enable-only mode should not mask */
+        assert_se(unit_file_preset(RUNTIME_SCOPE_SYSTEM, 0, root, STRV_MAKE("preset-mask.service"), UNIT_FILE_PRESET_ENABLE_ONLY, &changes, &n_changes) >= 0);
+        assert_se(unit_file_get_state(RUNTIME_SCOPE_SYSTEM, root, "preset-mask.service", &state) >= 0 && state == UNIT_FILE_DISABLED);
+        install_changes_free(changes, n_changes);
+        changes = NULL; n_changes = 0;
+
+        /* preset with disable-only mode should not mask */
+        assert_se(unit_file_preset(RUNTIME_SCOPE_SYSTEM, 0, root, STRV_MAKE("preset-mask.service"), UNIT_FILE_PRESET_DISABLE_ONLY, &changes, &n_changes) >= 0);
+        assert_se(unit_file_get_state(RUNTIME_SCOPE_SYSTEM, root, "preset-mask.service", &state) >= 0 && state == UNIT_FILE_DISABLED);
+        install_changes_free(changes, n_changes);
+        changes = NULL; n_changes = 0;
+
+        assert_se(unit_file_unmask(RUNTIME_SCOPE_SYSTEM, 0, root, STRV_MAKE("preset-mask-static.service"), &changes, &n_changes) >= 0);
+        assert_se(n_changes == 1);
+        assert_se(changes[0].type == INSTALL_CHANGE_UNLINK);
+        p = strjoina(root, SYSTEM_CONFIG_UNIT_DIR"/preset-mask-static.service");
+        ASSERT_STREQ(changes[0].path, p);
+        install_changes_free(changes, n_changes);
+        changes = NULL; n_changes = 0;
+
+        assert_se(unit_file_get_state(RUNTIME_SCOPE_SYSTEM, root, "preset-mask-static.service", &state) >= 0 && state == UNIT_FILE_STATIC);
+
+        /* clean up to avoid interfering with other tests */
+        p = strjoina(root, "/usr/lib/systemd/system-preset/test-mask.preset");
+        (void) unlink(p);
+}
+
 TEST(revert) {
         const char *p;
         UnitFileState state;


### PR DESCRIPTION
Preset files currently have no way to mask a unit. Masking is useful for preventing a unit without an [Install] section from being started entirely, e.g., when pulled in via a .wants/ symlink.

This adds a a 'mask' directive to the preset file parser. When a unit matches a 'mask' rule, a /dev/null symlink is written to the persistent config path directly.