### PR TITLE
test: disable ManagedOOMMemoryPressure on /system.slice in TEST-55-OOMD

### DIFF
--- a/test/units/TEST-55-OOMD.sh
+++ b/test/units/TEST-55-OOMD.sh
@@ -62,6 +62,13 @@ cat >/run/systemd/system/-.slice.d/99-oomd-test.conf <<EOF
 ManagedOOMSwap=auto
 EOF
 
+mkdir -p /run/systemd/system/system.slice.d/
+cat >/run/systemd/system/system.slice.d/99-oomd-test.conf <<EOF
+[Slice]
+ManagedOOMMemoryPressure=auto
+ManagedOOMMemoryPressureLimit=0%
+EOF
+
 mkdir -p /run/systemd/system/user@.service.d/
 cat >/run/systemd/system/user@.service.d/99-oomd-test.conf <<EOF
 [Service]


### PR DESCRIPTION
The systemd-oomd-defaults rpm installed on Fedora/CentOS images via mkosi/mkosi.conf.d/centos-fedora/mkosi.conf ships
/usr/lib/systemd/system/system.slice.d/10-oomd-per-slice-defaults.conf:

    [Slice]
    ManagedOOMMemoryPressure=kill
    ManagedOOMMemoryPressureLimit=80%

https://gitlab.com/redhat/centos-stream/rpms/systemd/-/blob/c10s/10-oomd-per-slice-defaults.conf

In a recent flaky CI run on centos-10, the following sequence was recorded in test/journal/TEST-55-OOMD-1.journal:

    [   77.740597] systemd-oomd[659]: Memory pressure for /system.slice is 85.03% > 80.00% for > 2s with reclaim activity
    [   77.745326] TEST-55-OOMD.sh[1292]: + journalctl --sync
    [   77.749125] systemd-oomd[659]: Considered 19 cgroups for killing, top candidates were:
    [   77.749128] systemd-oomd[659]:         Path: /system.slice/systemd-journald.service
    [   77.749134] systemd-oomd[659]:                 Current Memory Usage: 55.5M
    [   77.749597] systemd-oomd[659]: oomd attempting to kill 407 with KILL
    [   77.749670] systemd-oomd[659]: Marked /system.slice/systemd-journald.service for killing due to memory pressure for /system.slice being 85.03% > 80.00% for > 2s with reclaim activity
    [   77.752252] systemd[1]: systemd-journald.service: systemd-oomd killed 1 process(es) in this unit.
    [   77.752293] systemd[1]: systemd-journald.service: Changed running -> stop-sigterm
    [  329.922401] systemd[1]: systemd-journald.service: Main process exited, code=killed, status=9/KILL

PID 1292 (the test script) never logged anything after the `journalctl --sync` line at [77.745326], and the unit stayed in stop-sigterm until [329.922401].

Override /system.slice to ManagedOOMMemoryPressure=auto in the test setup so the test does not rely on whichever per-slice oomd defaults the distro happens to ship.

Co-developed-by: Claude Opus 4.7 <noreply@anthropic.com>

eg: https://github.com/systemd/systemd/actions/runs/26460300263/job/77905894039?pr=42317