### PR TITLE
Fix coverage CI job

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -105,7 +105,7 @@ jobs:
             --exclude "*.gperf" \
             --output-file build/test/coverage/initial.coverage-info \
             --base-directory src/ \
-            --ignore-errors source \
+            --ignore-errors source,inconsistent \
             --no-external \
             --substitute "s#src/src#src#g"
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,7 +10,6 @@ on:
   pull_request:
     branches:
       - main
-      - v[0-9]+-stable
     paths:
       - .github/workflows/coverage.yml
       - test/integration-tests/integration-test-wrapper.py


### PR DESCRIPTION
It has been failing for a few days:

```
lcov: ERROR: lcov: ERROR: (inconsistent) mismatched end line for test_path_exists_body at /home/runner/work/systemd/systemd/src/test/test-path.c:158: 158 -> 185 while capturing from build/mkosi.builddir/arch~rolling~x86-64/test-path.p/src_test_test-path.c.gcno
	(use "lcov --ignore-errors inconsistent ..." to bypass this error)
```