### PR TITLE
meson: fix building without logind

### DIFF
--- a/src/test/meson.build
+++ b/src/test/meson.build
@@ -498,6 +498,7 @@ executables += [
         test_template + {
                 'sources' : files('test-varlink-idl-login.c'),
                 'objects' : ['systemd-logind'],
+                'conditions' : ['ENABLE_LOGIND'],
         },
         test_template + {
                 'sources' : files('test-watchdog.c'),


### PR DESCRIPTION
Otherwise you cannot build systemd (e.g. just the libs) without logind.