### PR TITLE
import: don't assert on missing signature file

### DIFF
--- a/src/import/pull-common.c
+++ b/src/import/pull-common.c
@@ -531,7 +531,6 @@ int pull_verify(ImportVerify verify,
                 PullJob *verity_job) {
 
         _cleanup_free_ char *fn = NULL;
-        VerificationStyle style;
         PullJob *verify_job;
         int r;
 
@@ -579,11 +578,6 @@ int pull_verify(ImportVerify verify,
                 return 0;
 
         assert(verify_job);
-
-        r = verification_style_from_url(verify_job->url, &style);
-        if (r < 0)
-                return log_error_errno(r, "Failed to determine verification style from URL '%s': %m", verify_job->url);
-
         assert(signature_job);
         assert(signature_job->state == PULL_JOB_DONE);
 

--- a/src/import/pull-raw.c
+++ b/src/import/pull-raw.c
@@ -543,31 +543,11 @@ static void raw_pull_job_on_finished(PullJob *j) {
                 return;
 
         if (p->signature_job && p->signature_job->error != 0) {
-                VerificationStyle style;
-                PullJob *verify_job;
+                assert(p->checksum_job || p->raw_job);
 
-                /* The signature job failed. Let's see if we actually need it */
-
-                verify_job = p->checksum_job ?: p->raw_job; /* if the checksum job doesn't exist this must be
-                                                             * because the main job is the checksum file
-                                                             * itself */
-
-                assert(verify_job);
-
-                r = verification_style_from_url(verify_job->url, &style);
-                if (r < 0) {
-                        log_error_errno(r, "Failed to determine verification style from checksum URL: %m");
-                        goto finish;
-                }
-
-                if (style == VERIFICATION_PER_DIRECTORY) { /* A failed signature file download only matters
-                                                            * in per-directory verification mode, since only
-                                                            * then the signature is detached, and thus a file
-                                                            * of its own. */
-                        r = log_error_errno(p->signature_job->error,
-                                            "Failed to retrieve signature file, cannot verify. (Try --verify=no?)");
-                        goto finish;
-                }
+                r = log_error_errno(p->signature_job->error,
+                                    "Failed to retrieve signature file, cannot verify. (Try --verify=no?)");
+                goto finish;
         }
 
         PullJob *jj;

--- a/src/import/pull-tar.c
+++ b/src/import/pull-tar.c
@@ -452,24 +452,11 @@ static void tar_pull_job_on_finished(PullJob *j) {
                 return;
 
         if (p->signature_job && p->signature_job->error != 0) {
-                VerificationStyle style;
-
                 assert(p->checksum_job);
 
-                r = verification_style_from_url(p->checksum_job->url, &style);
-                if (r < 0) {
-                        log_error_errno(r, "Failed to determine verification style from checksum URL: %m");
-                        goto finish;
-                }
-
-                if (style == VERIFICATION_PER_DIRECTORY) { /* A failed signature file download only matters
-                                                            * in per-directory verification mode, since only
-                                                            * then the signature is detached, and thus a file
-                                                            * of its own. */
-                        r = log_error_errno(p->signature_job->error,
-                                            "Failed to retrieve signature file, cannot verify. (Try --verify=no?)");
-                        goto finish;
-                }
+                r = log_error_errno(p->signature_job->error,
+                                    "Failed to retrieve signature file, cannot verify. (Try --verify=no?)");
+                goto finish;
         }
 
         pull_job_close_disk_fd(p->tar_job);


### PR DESCRIPTION
Since ac9edf991142c1597c8d86431ee9bd50c21bce41 even the per-file verification style uses detached signatures instead of inline ones. That commit dropped the inline verification fallback, but it didn't update the raw_pull_job_on_finished()/tar_pull_job_on_finished() callbacks, which caused the per-file verification to silently fall through the signature check and eventually hit the now unconditional assert in pull_verify():

```
~# importctl pull-tar -mN https://distfiles.gentoo.org/releases/amd64/autobuilds/20260426T153103Z/stage3-amd64-systemd-20260426T153103Z.tar.xz
...
Acquired 1.2G for https://distfiles.gentoo.org/releases/amd64/autobuilds/20260426T153103Z/stage3-amd64-systemd-20260426T153103Z.tar.xz.
Download of https://distfiles.gentoo.org/releases/amd64/autobuilds/20260426T153103Z/stage3-amd64-systemd-20260426T153103Z.tar.xz complete.
SHA256 checksum of https://distfiles.gentoo.org/releases/amd64/autobuilds/20260426T153103Z/stage3-amd64-systemd-20260426T153103Z.tar.xz is valid.
Assertion 'signature_job->state == PULL_JOB_DONE' failed at src/import/pull-common.c:588, function pull_verify(). Aborting.
```
To fix this, let's drop the now outdated guards from the callbacks, given that both per-file and per-directory verification uses detached signatures. Also, drop some dead code along the way, given we no longer need to even determine the verification style anymore.

With this, the reproducer above now shows a proper error:
```
...
Acquired 1.2G for https://distfiles.gentoo.org/releases/amd64/autobuilds/20260426T153103Z/stage3-amd64-systemd-20260426T153103Z.tar.xz.
Download of https://distfiles.gentoo.org/releases/amd64/autobuilds/20260426T153103Z/stage3-amd64-systemd-20260426T153103Z.tar.xz complete.
Failed to retrieve signature file, cannot verify. (Try --verify=no?)
```
Also, both --verify=checksum/--verify=no keep working as expected.

Follow-up for ac9edf991142c1597c8d86431ee9bd50c21bce41.
Resolves: #41895