### PR TITLE
hwdb/keyboard: fix match for for X+ Piccolo, again

### DIFF
--- a/hwdb.d/60-keyboard.hwdb
+++ b/hwdb.d/60-keyboard.hwdb
@@ -2224,7 +2224,7 @@ evdev:atkbd:dmi:bvnTIMI*:bvr*:bd*:svnTIMI*:pnMiNoteBookPro*:*
 ###########################################################
 
 # X+ piccolo series 81X (Intel N305, possibly more)
-evdev:atkbd:dmi:bvn*:bvr*:bd*:svnX-Plus.tech:pnX+ Piccolo:*
+evdev:atkbd:dmi:bvn*:bvr*:bd*:svnX-Plus.tech:pnX+Piccolo:pvr*
  KEYBOARD_KEY_9c=enter                                  # KP_enter in the main area is wrong
 
 ###########################################################


### PR DESCRIPTION
I got infos from product_name:

$ cat /sys/class/dmi/id/product_name
X+ Piccolo

Turns out the modalias has a little difference:

$ cat /sys/class/dmi/id/modalias
dmi:bvnAmericanMegatrendsInternational,LLC.:bvr5.27:bd09/10/2025:br5.27:svnX-Plus.tech:pnX+Piccolo:pvrDefaultstring:rvnX-Plus:rnXPLUS-SERIES81x-DEV:rvrDefaultstring:cvnDefaultstring:ct10:cvrDefaultstring:skuSeries81x:pfaPiccoloSeries:

So let's remove the extra space. Crossing fingers... 🤞

Fixes: 033be1a41b5f75a3f2c8f4fe212512062bc4d5f3