### PR TITLE
repart: add live subscription support to ListCandidateDevices() varlink call

### DIFF
--- a/src/repart/meson.build
+++ b/src/repart/meson.build
@@ -9,8 +9,9 @@ executables += [
                 'name' : 'systemd-repart',
                 'public' : true,
                 'extract' : files(
-                        'repart.c',
                         'iso9660.c',
+                        'repart.c',
+                        'repart-list-candidate-devices.c',
                 ),
                 'dependencies' : [
                         libblkid_cflags,

--- a/src/repart/repart-list-candidate-devices.c
+++ b/src/repart/repart-list-candidate-devices.c
@@ -1,0 +1,71 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include "sd-json.h"
+#include "sd-varlink.h"
+
+#include "blockdev-list.h"
+#include "json-util.h"
+#include "repart-list-candidate-devices.h"
+
+int vl_method_list_candidate_devices(
+                sd_varlink *link,
+                sd_json_variant *parameters,
+                sd_varlink_method_flags_t flags,
+                void *userdata) {
+
+        struct {
+                bool ignore_root;
+                bool ignore_empty;
+        } p = {};
+
+        static const sd_json_dispatch_field dispatch_table[] = {
+                { "ignoreRoot",  SD_JSON_VARIANT_BOOLEAN, sd_json_dispatch_stdbool, voffsetof(p, ignore_root),  0 },
+                { "ignoreEmpty", SD_JSON_VARIANT_BOOLEAN, sd_json_dispatch_stdbool, voffsetof(p, ignore_empty), 0 },
+                {}
+        };
+
+        int r;
+
+        assert(link);
+        assert(FLAGS_SET(flags, SD_VARLINK_METHOD_MORE));
+
+        r = sd_varlink_dispatch(link, parameters, dispatch_table, &p);
+        if (r != 0)
+                return r;
+
+        BlockDevice *l = NULL;
+        size_t n = 0;
+        CLEANUP_ARRAY(l, n, block_device_array_free);
+
+        r = blockdev_list(
+                        BLOCKDEV_LIST_SHOW_SYMLINKS|
+                        BLOCKDEV_LIST_REQUIRE_PARTITION_SCANNING|
+                        BLOCKDEV_LIST_IGNORE_ZRAM|
+                        BLOCKDEV_LIST_METADATA|
+                        BLOCKDEV_LIST_IGNORE_READ_ONLY|
+                        (p.ignore_empty ? BLOCKDEV_LIST_IGNORE_EMPTY : 0)|
+                        (p.ignore_root ? BLOCKDEV_LIST_IGNORE_ROOT : 0),
+                        &l,
+                        &n);
+        if (r < 0)
+                return r;
+
+        r = sd_varlink_set_sentinel(link, "io.systemd.Repart.NoCandidateDevices");
+        if (r < 0)
+                return r;
+
+        FOREACH_ARRAY(d, l, n) {
+                r = sd_varlink_replybo(link,
+                                SD_JSON_BUILD_PAIR_STRING("node", d->node),
+                                JSON_BUILD_PAIR_STRV_NON_EMPTY("symlinks", d->symlinks),
+                                JSON_BUILD_PAIR_UNSIGNED_NOT_EQUAL("diskseq", d->diskseq, UINT64_MAX),
+                                JSON_BUILD_PAIR_UNSIGNED_NOT_EQUAL("sizeBytes", d->size, UINT64_MAX),
+                                JSON_BUILD_PAIR_STRING_NON_EMPTY("model", d->model),
+                                JSON_BUILD_PAIR_STRING_NON_EMPTY("vendor", d->vendor),
+                                JSON_BUILD_PAIR_STRING_NON_EMPTY("subsystem", d->subsystem));
+                if (r < 0)
+                        return r;
+        }
+
+        return 0;
+}

--- a/src/repart/repart-list-candidate-devices.c
+++ b/src/repart/repart-list-candidate-devices.c
@@ -1,11 +1,133 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
+#include "sd-device.h"
 #include "sd-json.h"
 #include "sd-varlink.h"
 
 #include "blockdev-list.h"
+#include "device-util.h"
 #include "json-util.h"
 #include "repart-list-candidate-devices.h"
+
+typedef struct ListCandidateDevicesContext {
+        sd_varlink *link;                  /* Owned ref; freed in list_candidate_devices_context_free(). */
+        sd_device_monitor *monitor;
+        BlockDevListFlags flags;
+        dev_t root_devno, whole_root_devno;
+} ListCandidateDevicesContext;
+
+static ListCandidateDevicesContext* list_candidate_devices_context_free(ListCandidateDevicesContext *c) {
+        if (!c)
+                return NULL;
+
+        sd_device_monitor_unref(c->monitor);
+        sd_varlink_unref(c->link);
+        return mfree(c);
+}
+
+DEFINE_TRIVIAL_CLEANUP_FUNC(ListCandidateDevicesContext*, list_candidate_devices_context_free);
+
+static void vl_on_disconnect(sd_varlink_server *server, sd_varlink *link, void *userdata) {
+        assert(server);
+        assert(link);
+
+        list_candidate_devices_context_free(sd_varlink_set_userdata(link, NULL));
+}
+
+static int list_candidate_devices_send_remove(sd_varlink *link, sd_device *dev) {
+        int r;
+
+        assert(link);
+        assert(dev);
+
+        const char *node;
+        r = sd_device_get_devname(dev, &node);
+        if (r < 0) {
+                log_device_debug_errno(dev, r, "Failed to acquire device node of removed block device, ignoring: %m");
+                return 0;
+        }
+
+        return sd_varlink_notifybo(link,
+                        SD_JSON_BUILD_PAIR("action", JSON_BUILD_CONST_STRING("remove")),
+                        SD_JSON_BUILD_PAIR_STRING("node", node));
+}
+
+static int list_candidate_devices_send_add(sd_varlink *link, const BlockDevice *d, bool with_action) {
+        int r;
+
+        assert(link);
+        assert(d);
+
+        /* In subscribe mode we tag every reply with action=add so the discriminator is meaningful;
+         * in plain enumeration mode we omit it (older clients don't know the field). */
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *v = NULL;
+        r = sd_json_buildo(
+                        &v,
+                        SD_JSON_BUILD_PAIR_CONDITION(with_action, "action", JSON_BUILD_CONST_STRING("add")),
+                        SD_JSON_BUILD_PAIR_STRING("node", d->node),
+                        JSON_BUILD_PAIR_STRV_NON_EMPTY("symlinks", d->symlinks),
+                        JSON_BUILD_PAIR_UNSIGNED_NOT_EQUAL("diskseq", d->diskseq, UINT64_MAX),
+                        JSON_BUILD_PAIR_UNSIGNED_NOT_EQUAL("sizeBytes", d->size, UINT64_MAX),
+                        JSON_BUILD_PAIR_STRING_NON_EMPTY("model", d->model),
+                        JSON_BUILD_PAIR_STRING_NON_EMPTY("vendor", d->vendor),
+                        JSON_BUILD_PAIR_STRING_NON_EMPTY("subsystem", d->subsystem));
+        if (r < 0)
+                return r;
+
+        /* Subscribe mode sets no sentinel, so a final reply would terminate the streaming call after
+         * the first device; use intermediate notify messages to keep it open. Plain enumeration relies
+         * on the sentinel mechanism, which buffers and chains replies. */
+        return with_action ? sd_varlink_notify(link, v) : sd_varlink_reply(link, v);
+}
+
+static int list_candidate_devices_on_uevent(sd_device_monitor *monitor, sd_device *dev, void *userdata) {
+        ListCandidateDevicesContext *c = ASSERT_PTR(userdata);
+        int r;
+
+        assert(dev);
+
+        sd_device_action_t action;
+        r = sd_device_get_action(dev, &action);
+        if (r < 0) {
+                log_device_debug_errno(dev, r, "Failed to acquire uevent action of block device, ignoring: %m");
+                return 0;
+        }
+
+        if (action == SD_DEVICE_REMOVE)
+                (void) list_candidate_devices_send_remove(c->link, dev);
+        else {
+                /* All non-REMOVE actions are treated as "device exists afterwards". Re-run the full
+                 * filter set; the tri-state distinguishes "ignore entirely" (static-filtered) from
+                 * "client should treat this as a removal" (dynamic-filtered, e.g. size became 0 or
+                 * read-only became 1). */
+                _cleanup_(block_device_done) BlockDevice d = BLOCK_DEVICE_NULL;
+                r = blockdev_list_one(dev, c->flags, c->root_devno, c->whole_root_devno, &d);
+                if (r < 0)
+                        return r;
+
+                switch (r) {
+                case BLOCKDEV_LIST_MATCH_NO:
+                case BLOCKDEV_LIST_MATCH_SKIPPED:
+                        break;
+
+                case BLOCKDEV_LIST_MATCH_FILTERED:
+                        (void) list_candidate_devices_send_remove(c->link, dev);
+                        break;
+
+                case BLOCKDEV_LIST_MATCH_YES:
+                        (void) list_candidate_devices_send_add(c->link, &d, /* with_action= */ true);
+                        break;
+
+                default:
+                        assert_not_reached();
+                }
+        }
+
+        /* Push out any notifications we just queued so the client doesn't have to wait for the next
+         * event-loop tick to receive them. */
+        (void) sd_varlink_flush(c->link);
+        return 0;
+}
 
 int vl_method_list_candidate_devices(
                 sd_varlink *link,
@@ -16,11 +138,13 @@ int vl_method_list_candidate_devices(
         struct {
                 bool ignore_root;
                 bool ignore_empty;
+                bool subscribe;
         } p = {};
 
         static const sd_json_dispatch_field dispatch_table[] = {
                 { "ignoreRoot",  SD_JSON_VARIANT_BOOLEAN, sd_json_dispatch_stdbool, voffsetof(p, ignore_root),  0 },
                 { "ignoreEmpty", SD_JSON_VARIANT_BOOLEAN, sd_json_dispatch_stdbool, voffsetof(p, ignore_empty), 0 },
+                { "subscribe",   SD_JSON_VARIANT_BOOLEAN, sd_json_dispatch_stdbool, voffsetof(p, subscribe),    0 },
                 {}
         };
 
@@ -33,39 +157,89 @@ int vl_method_list_candidate_devices(
         if (r != 0)
                 return r;
 
+        const BlockDevListFlags listflags =
+                BLOCKDEV_LIST_SHOW_SYMLINKS|
+                BLOCKDEV_LIST_REQUIRE_PARTITION_SCANNING|
+                BLOCKDEV_LIST_IGNORE_ZRAM|
+                BLOCKDEV_LIST_METADATA|
+                BLOCKDEV_LIST_IGNORE_READ_ONLY|
+                (p.ignore_empty ? BLOCKDEV_LIST_IGNORE_EMPTY : 0)|
+                (p.ignore_root ? BLOCKDEV_LIST_IGNORE_ROOT : 0);
+
+        _cleanup_(list_candidate_devices_context_freep) ListCandidateDevicesContext *c = NULL;
+
+        if (p.subscribe) {
+                /* Start the monitor *before* the initial enumeration so we don't lose events that fire
+                 * during the enumeration window. Duplicate add events for the same device are
+                 * legitimate and documented; clients upsert by identifier. */
+
+                c = new(ListCandidateDevicesContext, 1);
+                if (!c)
+                        return -ENOMEM;
+
+                *c = (ListCandidateDevicesContext) {
+                        .flags = listflags,
+                };
+
+                (void) blockdev_list_get_root_devnos(listflags, &c->root_devno, &c->whole_root_devno);
+
+                r = sd_device_monitor_new(&c->monitor);
+                if (r < 0)
+                        return log_error_errno(r, "Failed to allocate block device monitor: %m");
+
+                (void) sd_device_monitor_set_description(c->monitor, "repart-candidate-devices");
+
+                r = sd_device_monitor_filter_add_match_subsystem_devtype(c->monitor, "block", /* devtype= */ NULL);
+                if (r < 0)
+                        return log_error_errno(r, "Failed to configure block device monitor filter: %m");
+
+                r = sd_device_monitor_attach_event(c->monitor, sd_varlink_get_event(link));
+                if (r < 0)
+                        return log_error_errno(r, "Failed to attach block device monitor to event loop: %m");
+
+                r = sd_device_monitor_start(c->monitor, list_candidate_devices_on_uevent, c);
+                if (r < 0)
+                        return log_error_errno(r, "Failed to start block device monitor: %m");
+        } else {
+                /* Non-subscribing: the sentinel fires if no replies were sent. */
+                r = sd_varlink_set_sentinel(link, "io.systemd.Repart.NoCandidateDevices");
+                if (r < 0)
+                        return r;
+        }
+
         BlockDevice *l = NULL;
         size_t n = 0;
         CLEANUP_ARRAY(l, n, block_device_array_free);
 
-        r = blockdev_list(
-                        BLOCKDEV_LIST_SHOW_SYMLINKS|
-                        BLOCKDEV_LIST_REQUIRE_PARTITION_SCANNING|
-                        BLOCKDEV_LIST_IGNORE_ZRAM|
-                        BLOCKDEV_LIST_METADATA|
-                        BLOCKDEV_LIST_IGNORE_READ_ONLY|
-                        (p.ignore_empty ? BLOCKDEV_LIST_IGNORE_EMPTY : 0)|
-                        (p.ignore_root ? BLOCKDEV_LIST_IGNORE_ROOT : 0),
-                        &l,
-                        &n);
-        if (r < 0)
-                return r;
-
-        r = sd_varlink_set_sentinel(link, "io.systemd.Repart.NoCandidateDevices");
+        r = blockdev_list(listflags, &l, &n);
         if (r < 0)
                 return r;
 
         FOREACH_ARRAY(d, l, n) {
-                r = sd_varlink_replybo(link,
-                                SD_JSON_BUILD_PAIR_STRING("node", d->node),
-                                JSON_BUILD_PAIR_STRV_NON_EMPTY("symlinks", d->symlinks),
-                                JSON_BUILD_PAIR_UNSIGNED_NOT_EQUAL("diskseq", d->diskseq, UINT64_MAX),
-                                JSON_BUILD_PAIR_UNSIGNED_NOT_EQUAL("sizeBytes", d->size, UINT64_MAX),
-                                JSON_BUILD_PAIR_STRING_NON_EMPTY("model", d->model),
-                                JSON_BUILD_PAIR_STRING_NON_EMPTY("vendor", d->vendor),
-                                JSON_BUILD_PAIR_STRING_NON_EMPTY("subsystem", d->subsystem));
+                r = list_candidate_devices_send_add(link, d, /* with_action= */ p.subscribe);
                 if (r < 0)
                         return r;
         }
+
+        if (!p.subscribe)
+                return 0;
+
+        /* Subscribing: a single "ready" sentinel marks the boundary between initial enumeration and
+         * live events. The call stays open after we return; live events flow through
+         * list_candidate_devices_on_uevent(). */
+        r = sd_varlink_notifybo(link, SD_JSON_BUILD_PAIR("action", JSON_BUILD_CONST_STRING("ready")));
+        if (r < 0)
+                return r;
+
+        /* Install the on-disconnect handler lazily, only once we actually have a subscription to clean
+         * up. The call is idempotent for the same callback. */
+        r = sd_varlink_server_bind_disconnect(sd_varlink_get_server(link), vl_on_disconnect);
+        if (r < 0)
+                return r;
+
+        /* Hand ownership of the context to the link; vl_on_disconnect() frees it. */
+        c->link = sd_varlink_ref(link);
+        sd_varlink_set_userdata(link, TAKE_PTR(c));
 
         return 0;
 }

--- a/src/repart/repart-list-candidate-devices.h
+++ b/src/repart/repart-list-candidate-devices.h
@@ -1,0 +1,10 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#pragma once
+
+#include "sd-forward.h"
+
+int vl_method_list_candidate_devices(
+                sd_varlink *link,
+                sd_json_variant *parameters,
+                sd_varlink_method_flags_t flags,
+                void *userdata);

--- a/src/repart/repart.c
+++ b/src/repart/repart.c
@@ -70,6 +70,7 @@
 #include "process-util.h"
 #include "random-util.h"
 #include "ratelimit.h"
+#include "repart-list-candidate-devices.h"
 #include "reread-partition-table.h"
 #include "resize-fs.h"
 #include "rm-rf.h"
@@ -11250,69 +11251,6 @@ static int context_ponder(Context *context) {
 
         /* Now calculate where each new partition gets placed */
         context_place_partitions(context);
-
-        return 0;
-}
-
-static int vl_method_list_candidate_devices(
-                sd_varlink *link,
-                sd_json_variant *parameters,
-                sd_varlink_method_flags_t flags,
-                void *userdata) {
-
-        struct {
-                bool ignore_root;
-                bool ignore_empty;
-        } p = {};
-
-        static const sd_json_dispatch_field dispatch_table[] = {
-                { "ignoreRoot",  SD_JSON_VARIANT_BOOLEAN, sd_json_dispatch_stdbool, voffsetof(p, ignore_root),  0 },
-                { "ignoreEmpty", SD_JSON_VARIANT_BOOLEAN, sd_json_dispatch_stdbool, voffsetof(p, ignore_empty), 0 },
-                {}
-        };
-
-        int r;
-
-        assert(link);
-        assert(FLAGS_SET(flags, SD_VARLINK_METHOD_MORE));
-
-        r = sd_varlink_dispatch(link, parameters, dispatch_table, &p);
-        if (r != 0)
-                return r;
-
-        BlockDevice *l = NULL;
-        size_t n = 0;
-        CLEANUP_ARRAY(l, n, block_device_array_free);
-
-        r = blockdev_list(
-                        BLOCKDEV_LIST_SHOW_SYMLINKS|
-                        BLOCKDEV_LIST_REQUIRE_PARTITION_SCANNING|
-                        BLOCKDEV_LIST_IGNORE_ZRAM|
-                        BLOCKDEV_LIST_METADATA|
-                        BLOCKDEV_LIST_IGNORE_READ_ONLY|
-                        (p.ignore_empty ? BLOCKDEV_LIST_IGNORE_EMPTY : 0)|
-                        (p.ignore_root ? BLOCKDEV_LIST_IGNORE_ROOT : 0),
-                        &l,
-                        &n);
-        if (r < 0)
-                return r;
-
-        r = sd_varlink_set_sentinel(link, "io.systemd.Repart.NoCandidateDevices");
-        if (r < 0)
-                return r;
-
-        FOREACH_ARRAY(d, l, n) {
-                r = sd_varlink_replybo(link,
-                                SD_JSON_BUILD_PAIR_STRING("node", d->node),
-                                JSON_BUILD_PAIR_STRV_NON_EMPTY("symlinks", d->symlinks),
-                                JSON_BUILD_PAIR_UNSIGNED_NOT_EQUAL("diskseq", d->diskseq, UINT64_MAX),
-                                JSON_BUILD_PAIR_UNSIGNED_NOT_EQUAL("sizeBytes", d->size, UINT64_MAX),
-                                JSON_BUILD_PAIR_STRING_NON_EMPTY("model", d->model),
-                                JSON_BUILD_PAIR_STRING_NON_EMPTY("vendor", d->vendor),
-                                JSON_BUILD_PAIR_STRING_NON_EMPTY("subsystem", d->subsystem));
-                if (r < 0)
-                        return r;
-        }
 
         return 0;
 }

--- a/src/shared/blockdev-list.c
+++ b/src/shared/blockdev-list.c
@@ -87,20 +87,17 @@ static int blockdev_get_subsystem(sd_device *d, char **ret_subsystem) {
         return ret < 0 ? ret : -ENOENT;
 }
 
-int blockdev_list(BlockDevListFlags flags, BlockDevice **ret_devices, size_t *ret_n_devices) {
-        _cleanup_(sd_device_enumerator_unrefp) sd_device_enumerator *e = NULL;
+int blockdev_list_get_root_devnos(BlockDevListFlags flags, dev_t *ret_root, dev_t *ret_whole_root) {
         int r;
 
-        assert(!!ret_devices == !!ret_n_devices);
-
-        /* If ret_devices/ret_n_devices are passed, returns a list of matching block devices, otherwise
-         * prints the list to stdout */
-
-        BlockDevice *l = NULL;
-        size_t n = 0;
-        CLEANUP_ARRAY(l, n, block_device_array_free);
+        /* Looks up the devno of the block device the OS is booted from, plus the whole-disk devno (e.g.
+         * /dev/sda for /dev/sda3). Returns both as 0 if root can't be determined – which is fine, callers
+         * pass these to blockdev_list_one() and devnum_set_and_equal() handles zero gracefully.
+         *
+         * Split out of blockdev_list() so subscribers can look them up once up-front instead of per uevent. */
 
         dev_t root_devno = 0, whole_root_devno = 0;
+
         if (FLAGS_SET(flags, BLOCKDEV_LIST_IGNORE_ROOT)) {
                 r = blockdev_get_root(LOG_DEBUG, &root_devno);
                 if (r < 0)
@@ -110,98 +107,137 @@ int blockdev_list(BlockDevListFlags flags, BlockDevice **ret_devices, size_t *re
                         if (r < 0)
                                 log_debug_errno(r, "Failed to get whole block device of root device, ignoring: %m");
                 }
-
-                /* It's fine if root_devno/whole_root_devno are zero here as devnum_set_and_equal() will
-                 * happily take that into account – it is in fact its primary raison d'etre. */
         }
 
-        if (sd_device_enumerator_new(&e) < 0)
-                return log_oom();
+        if (ret_root)
+                *ret_root = root_devno;
+        if (ret_whole_root)
+                *ret_whole_root = whole_root_devno;
 
-        r = sd_device_enumerator_add_match_subsystem(e, "block", /* match= */ true);
-        if (r < 0)
-                return log_error_errno(r, "Failed to add subsystem match: %m");
+        return 0;
+}
+
+int blockdev_list_one(
+                sd_device *dev,
+                BlockDevListFlags flags,
+                dev_t root_devno,
+                dev_t whole_root_devno,
+                BlockDevice *ret) {
+
+        int r;
+
+        assert(dev);
+
+        /* Per-device counterpart to blockdev_list(). Applies the same filters and metadata collection,
+         * and reports via a multi-valued return:
+         *
+         *   MATCH_NO       – cleanly fails a static filter (never interesting)
+         *   MATCH_YES      – fully matches
+         *   MATCH_FILTERED – passes static filters but fails a dynamic one (IGNORE_EMPTY / IGNORE_READ_ONLY)
+         *   MATCH_SKIPPED  – an unexpected error tripped during filter evaluation; the caller should
+         *                   treat this like _FILTERED, but the distinct code makes the soft failure
+         *                   visible rather than silently swallowed here.
+         *
+         * On each of the four success codes *ret is initialized: BLOCK_DEVICE_NULL for MATCH_NO and
+         * MATCH_SKIPPED, fully populated for MATCH_YES / MATCH_FILTERED (with d.size / d.read_only
+         * reflecting the current state so callers can tell which dynamic filter tripped). On negative
+         * return *ret is untouched.
+         *
+         * blockdev_list() itself collapses everything except _YES back into "skip". */
+
+        const char *node;
+        r = sd_device_get_devname(dev, &node);
+        if (r < 0) {
+                log_device_warning_errno(dev, r, "Failed to get device node of discovered block device, ignoring: %m");
+                goto skipped;
+        }
+
+        if (FLAGS_SET(flags, BLOCKDEV_LIST_IGNORE_ROOT) && root_devno != 0) {
+                dev_t devno;
+
+                r = sd_device_get_devnum(dev, &devno);
+                if (r < 0) {
+                        log_device_warning_errno(dev, r, "Failed to get major/minor of discovered block device, ignoring: %m");
+                        goto skipped;
+                }
+
+                if (devnum_set_and_equal(devno, root_devno) ||
+                    devnum_set_and_equal(devno, whole_root_devno))
+                        goto no_match;
+        }
+
+        if (FLAGS_SET(flags, BLOCKDEV_LIST_IGNORE_ZRAM)) {
+                r = device_sysname_startswith(dev, "zram");
+                if (r < 0) {
+                        log_device_warning_errno(dev, r, "Failed to check device name of discovered block device '%s', ignoring: %m", node);
+                        goto skipped;
+                }
+                if (r > 0)
+                        goto no_match;
+        }
+
+        if (FLAGS_SET(flags, BLOCKDEV_LIST_REQUIRE_PARTITION_SCANNING)) {
+                r = blockdev_partscan_enabled(dev);
+                if (r < 0) {
+                        log_device_warning_errno(dev, r, "Unable to determine whether '%s' supports partition scanning, skipping device: %m", node);
+                        goto skipped;
+                }
+                if (r == 0) {
+                        log_device_debug(dev, "Device '%s' does not support partition scanning, skipping.", node);
+                        goto no_match;
+                }
+        }
 
         if (FLAGS_SET(flags, BLOCKDEV_LIST_REQUIRE_LUKS)) {
-                r = sd_device_enumerator_add_match_property(e, "ID_FS_TYPE", "crypto_LUKS");
-                if (r < 0)
-                        return log_error_errno(r, "Failed to add match for LUKS block devices: %m");
+                const char *fstype;
+                r = sd_device_get_property_value(dev, "ID_FS_TYPE", &fstype);
+                if (r == -ENOENT)
+                        goto no_match; /* No detected filesystem → not a LUKS superblock. */
+                if (r < 0) {
+                        log_device_warning_errno(dev, r, "Failed to acquire ID_FS_TYPE of device '%s', ignoring: %m", node);
+                        goto skipped;
+                }
+                if (!streq(fstype, "crypto_LUKS"))
+                        goto no_match;
         }
 
-        FOREACH_DEVICE(e, dev) {
-                const char *node;
+        bool dynamic_filtered = false;
 
-                r = sd_device_get_devname(dev, &node);
-                if (r < 0) {
-                        log_device_warning_errno(dev, r, "Failed to get device node of discovered block device, ignoring: %m");
-                        continue;
+        uint64_t size = UINT64_MAX;
+        if (FLAGS_SET(flags, BLOCKDEV_LIST_IGNORE_EMPTY) || ret) {
+                r = device_get_sysattr_u64(dev, "size", &size);
+                if (r < 0)
+                        log_device_debug_errno(dev, r, "Failed to acquire size of device '%s', ignoring: %m", node);
+                else
+                        /* the 'size' sysattr is always in multiples of 512, even on 4K sector block devices! */
+                        assert_se(MUL_ASSIGN_SAFE(&size, 512)); /* Overflow check for coverity */
+
+                if (size == 0 && FLAGS_SET(flags, BLOCKDEV_LIST_IGNORE_EMPTY)) {
+                        log_device_debug(dev, "Device '%s' has a zero size, assuming drive without a medium.", node);
+                        dynamic_filtered = true;
                 }
+        }
 
-                if (FLAGS_SET(flags, BLOCKDEV_LIST_IGNORE_ROOT) && root_devno != 0) {
-                        dev_t devno;
+        int ro = -1;
+        if (FLAGS_SET(flags, BLOCKDEV_LIST_IGNORE_READ_ONLY) || FLAGS_SET(flags, BLOCKDEV_LIST_METADATA)) {
+                r = device_get_sysattr_bool(dev, "ro");
+                if (r < 0)
+                        log_device_debug_errno(dev, r, "Failed to acquire read-only flag of device '%s', ignoring: %m", node);
+                else
+                        ro = r;
 
-                        r = sd_device_get_devnum(dev, &devno);
-                        if (r < 0) {
-                                log_device_warning_errno(dev, r, "Failed to get major/minor of discovered block device, ignoring: %m");
-                                continue;
-                        }
-
-                        if (devnum_set_and_equal(devno, root_devno) ||
-                            devnum_set_and_equal(devno, whole_root_devno))
-                                continue;
+                if (ro > 0 && FLAGS_SET(flags, BLOCKDEV_LIST_IGNORE_READ_ONLY)) {
+                        log_device_debug(dev, "Device '%s' is read-only.", node);
+                        dynamic_filtered = true;
                 }
+        }
 
-                if (FLAGS_SET(flags, BLOCKDEV_LIST_IGNORE_ZRAM)) {
-                        r = device_sysname_startswith(dev, "zram");
-                        if (r < 0) {
-                                log_device_warning_errno(dev, r, "Failed to check device name of discovered block device '%s', ignoring: %m", node);
-                                continue;
-                        }
-                        if (r > 0)
-                                continue;
-                }
+        if (!ret)
+                return dynamic_filtered ? BLOCKDEV_LIST_MATCH_FILTERED : BLOCKDEV_LIST_MATCH_YES;
 
-                if (FLAGS_SET(flags, BLOCKDEV_LIST_REQUIRE_PARTITION_SCANNING)) {
-                        r = blockdev_partscan_enabled(dev);
-                        if (r < 0) {
-                                log_device_warning_errno(dev, r, "Unable to determine whether '%s' supports partition scanning, skipping device: %m", node);
-                                continue;
-                        }
-                        if (r == 0) {
-                                log_device_debug(dev, "Device '%s' does not support partition scanning, skipping.", node);
-                                continue;
-                        }
-                }
-
-                uint64_t size = UINT64_MAX;
-                if (FLAGS_SET(flags, BLOCKDEV_LIST_IGNORE_EMPTY) || ret_devices) {
-                        r = device_get_sysattr_u64(dev, "size", &size);
-                        if (r < 0)
-                                log_device_debug_errno(dev, r, "Failed to acquire size of device '%s', ignoring: %m", node);
-                        else
-                                /* the 'size' sysattr is always in multiples of 512, even on 4K sector block devices! */
-                                assert_se(MUL_ASSIGN_SAFE(&size, 512)); /* Overflow check for coverity */
-
-                        if (size == 0 && FLAGS_SET(flags, BLOCKDEV_LIST_IGNORE_EMPTY)) {
-                                log_device_debug(dev, "Device '%s' has a zero size, assuming drive without a medium, skipping.", node);
-                                continue;
-                        }
-                }
-
-                int ro = -1;
-                if (FLAGS_SET(flags, BLOCKDEV_LIST_IGNORE_READ_ONLY) || FLAGS_SET(flags, BLOCKDEV_LIST_METADATA)) {
-                        r = device_get_sysattr_bool(dev, "ro");
-                        if (r < 0)
-                                log_device_debug_errno(dev, r, "Failed to acquire read-only flag of device '%s', ignoring: %m", node);
-                        else
-                                ro = r;
-
-                        if (ro > 0 && FLAGS_SET(flags, BLOCKDEV_LIST_IGNORE_READ_ONLY)) {
-                                log_device_debug(dev, "Device '%s' is read-only, skipping.", node);
-                                continue;
-                        }
-                }
-
+        /* Wrap the metadata population in a nested scope so the cleanup-attributed locals don't
+         * intersect the goto-target label below (jumping into a protected scope is a clang error). */
+        {
                 _cleanup_strv_free_ char **list = NULL;
                 if (FLAGS_SET(flags, BLOCKDEV_LIST_SHOW_SYMLINKS)) {
                         FOREACH_DEVICE_DEVLINK(dev, sl)
@@ -218,36 +254,95 @@ int blockdev_list(BlockDevListFlags flags, BlockDevice **ret_devices, size_t *re
                         (void) blockdev_get_subsystem(dev, &subsystem);
                 }
 
-                if (ret_devices) {
-                        uint64_t diskseq = UINT64_MAX;
-                        r = sd_device_get_diskseq(dev, &diskseq);
-                        if (r < 0)
-                                log_device_debug_errno(dev, r, "Failed to acquire diskseq of device '%s', ignoring: %m", node);
+                uint64_t diskseq = UINT64_MAX;
+                r = sd_device_get_diskseq(dev, &diskseq);
+                if (r < 0)
+                        log_device_debug_errno(dev, r, "Failed to acquire diskseq of device '%s', ignoring: %m", node);
 
+                _cleanup_free_ char *m = strdup(node);
+                if (!m)
+                        return log_oom();
+
+                *ret = (BlockDevice) {
+                        .node = TAKE_PTR(m),
+                        .symlinks = TAKE_PTR(list),
+                        .diskseq = diskseq,
+                        .size = size,
+                        .model = TAKE_PTR(model),
+                        .vendor = TAKE_PTR(vendor),
+                        .subsystem = TAKE_PTR(subsystem),
+                        .read_only = ro,
+                };
+
+                return dynamic_filtered ? BLOCKDEV_LIST_MATCH_FILTERED : BLOCKDEV_LIST_MATCH_YES;
+        }
+
+no_match:
+        if (ret)
+                *ret = BLOCK_DEVICE_NULL;
+        return BLOCKDEV_LIST_MATCH_NO;
+
+skipped:
+        if (ret)
+                *ret = BLOCK_DEVICE_NULL;
+        return BLOCKDEV_LIST_MATCH_SKIPPED;
+}
+
+int blockdev_list(BlockDevListFlags flags, BlockDevice **ret_devices, size_t *ret_n_devices) {
+        _cleanup_(sd_device_enumerator_unrefp) sd_device_enumerator *e = NULL;
+        int r;
+
+        assert(!!ret_devices == !!ret_n_devices);
+
+        /* If ret_devices/ret_n_devices are passed, returns a list of matching block devices, otherwise
+         * prints the list to stdout */
+
+        BlockDevice *l = NULL;
+        size_t n = 0;
+        CLEANUP_ARRAY(l, n, block_device_array_free);
+
+        dev_t root_devno = 0, whole_root_devno = 0;
+        (void) blockdev_list_get_root_devnos(flags, &root_devno, &whole_root_devno);
+
+        if (sd_device_enumerator_new(&e) < 0)
+                return log_oom();
+
+        r = sd_device_enumerator_add_match_subsystem(e, "block", /* match= */ true);
+        if (r < 0)
+                return log_error_errno(r, "Failed to add subsystem match: %m");
+
+        if (FLAGS_SET(flags, BLOCKDEV_LIST_REQUIRE_LUKS)) {
+                /* blockdev_list_one() enforces this filter authoritatively; the enumerator match is just
+                 * an optimization so we don't iterate non-LUKS devices here. */
+                r = sd_device_enumerator_add_match_property(e, "ID_FS_TYPE", "crypto_LUKS");
+                if (r < 0)
+                        return log_error_errno(r, "Failed to add match for LUKS block devices: %m");
+        }
+
+        FOREACH_DEVICE(e, dev) {
+                _cleanup_(block_device_done) BlockDevice d = BLOCK_DEVICE_NULL;
+
+                r = blockdev_list_one(dev, flags, root_devno, whole_root_devno, ret_devices ? &d : NULL);
+                if (r < 0)
+                        return r;
+                if (r != BLOCKDEV_LIST_MATCH_YES)
+                        continue; /* MATCH_NO or MATCH_FILTERED – bulk enumeration treats both as "skip" */
+
+                if (ret_devices) {
                         if (!GREEDY_REALLOC(l, n+1))
                                 return log_oom();
 
-                        _cleanup_free_ char *m = strdup(node);
-                        if (!m)
-                                return log_oom();
-
-                        l[n++] = (BlockDevice) {
-                                .node = TAKE_PTR(m),
-                                .symlinks = TAKE_PTR(list),
-                                .diskseq = diskseq,
-                                .size = size,
-                                .model = TAKE_PTR(model),
-                                .vendor = TAKE_PTR(vendor),
-                                .subsystem = TAKE_PTR(subsystem),
-                                .read_only = ro,
-                        };
-
+                        l[n++] = TAKE_STRUCT(d);
                 } else {
+                        const char *node;
+                        if (sd_device_get_devname(dev, &node) < 0)
+                                continue;
+
                         printf("%s\n", node);
 
                         if (FLAGS_SET(flags, BLOCKDEV_LIST_SHOW_SYMLINKS))
-                                STRV_FOREACH(i, list)
-                                        printf("%s%s%s%s\n", on_tty() ? "    " : "", ansi_grey(), *i, ansi_normal());
+                                FOREACH_DEVICE_DEVLINK(dev, sl)
+                                        printf("%s%s%s%s\n", on_tty() ? "    " : "", ansi_grey(), sl, ansi_normal());
                 }
         }
 

--- a/src/shared/blockdev-list.h
+++ b/src/shared/blockdev-list.h
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 #pragma once
 
+#include "basic-forward.h"
 #include "shared-forward.h"
 
 typedef enum BlockDevListFlags {
@@ -13,6 +14,12 @@ typedef enum BlockDevListFlags {
         BLOCKDEV_LIST_METADATA                   = 1 << 6, /* Fill in model, vendor, subsystem, read_only */
         BLOCKDEV_LIST_IGNORE_READ_ONLY           = 1 << 7, /* Ignore read-only block devices */
 } BlockDevListFlags;
+
+/* The "dynamic" filters – ones the kernel can flip at runtime via sysattrs on a live device.
+ * Useful for callers that want to distinguish "device is hard-filtered (never interesting)" from
+ * "device just transitioned in or out of the candidate set". */
+#define BLOCKDEV_LIST_DYNAMIC_FILTERS_MASK \
+        (BLOCKDEV_LIST_IGNORE_EMPTY | BLOCKDEV_LIST_IGNORE_READ_ONLY)
 
 typedef struct BlockDevice {
         char *node;
@@ -31,7 +38,29 @@ typedef struct BlockDevice {
                 .read_only = -1,          \
         }
 
+/* Return values of blockdev_list_one(). Not its own type – returned as int. */
+enum {
+        BLOCKDEV_LIST_MATCH_NO,       /* Hard-filtered out by a static filter (subsystem, ZRAM,
+                                       * IGNORE_ROOT, REQUIRE_PARTITION_SCANNING, REQUIRE_LUKS, …). */
+        BLOCKDEV_LIST_MATCH_YES,      /* Passes all filters. */
+        BLOCKDEV_LIST_MATCH_FILTERED, /* Passes the static filters; fails at least one dynamic filter
+                                       * (IGNORE_EMPTY, IGNORE_READ_ONLY). */
+        BLOCKDEV_LIST_MATCH_SKIPPED,  /* Filter evaluation hit an unexpected error (failed sysattr
+                                       * read, missing devname, …). Callers should typically treat
+                                       * this like _FILTERED (device not currently a candidate),
+                                       * but distinguishing it makes the soft failure visible
+                                       * rather than silently swallowed inside blockdev_list_one(). */
+};
+
 void block_device_done(BlockDevice *d);
 void block_device_array_free(BlockDevice *d, size_t n_devices);
+
+int blockdev_list_get_root_devnos(BlockDevListFlags flags, dev_t *ret_root, dev_t *ret_whole_root);
+int blockdev_list_one(
+                sd_device *dev,
+                BlockDevListFlags flags,
+                dev_t root_devno,
+                dev_t whole_root_devno,
+                BlockDevice *ret);
 
 int blockdev_list(BlockDevListFlags flags, BlockDevice **ret_devices, size_t *ret_n_devices);

--- a/src/shared/varlink-io.systemd.Repart.c
+++ b/src/shared/varlink-io.systemd.Repart.c
@@ -29,6 +29,15 @@ static SD_VARLINK_DEFINE_ENUM_TYPE(
                 SD_VARLINK_FIELD_COMMENT("Always create a new partition table, potentially overwriting an existing table"),
                 SD_VARLINK_DEFINE_ENUM_VALUE(force));
 
+static SD_VARLINK_DEFINE_ENUM_TYPE(
+                BlockDeviceAction,
+                SD_VARLINK_FIELD_COMMENT("The device is currently present and a candidate. Emitted both during the initial enumeration and for live uevents (any action other than 'remove' is propagated as 'add', including the synthesized transitions when a device becomes empty or read-only and a relevant ignore* input is in effect)."),
+                SD_VARLINK_DEFINE_ENUM_VALUE(add),
+                SD_VARLINK_FIELD_COMMENT("The device is no longer a candidate, either because the kernel reported a remove event, or because a dynamic filter (ignoreEmpty/ignoreReadOnly) flipped it out of the candidate set. Clients should drop the device identified by 'node'. It is permitted (and harmless) to receive a 'remove' for a device the client never saw an 'add' for; clients should ignore these silently."),
+                SD_VARLINK_DEFINE_ENUM_VALUE(remove),
+                SD_VARLINK_FIELD_COMMENT("Sentinel sent exactly once in subscribe mode, after the initial enumeration is complete. Everything that follows reflects live uevents. Carries no other fields."),
+                SD_VARLINK_DEFINE_ENUM_VALUE(ready));
+
 static SD_VARLINK_DEFINE_METHOD_FULL(
                 Run,
                 SD_VARLINK_SUPPORTS_MORE,
@@ -64,8 +73,12 @@ static SD_VARLINK_DEFINE_METHOD_FULL(
                 SD_VARLINK_DEFINE_INPUT(ignoreRoot, SD_VARLINK_BOOL, SD_VARLINK_NULLABLE),
                 SD_VARLINK_FIELD_COMMENT("Control whether to include block devices with zero size in the list, i.e. typically block devices without any inserted medium. Defaults to false, i.e. empty block devices are included."),
                 SD_VARLINK_DEFINE_INPUT(ignoreEmpty, SD_VARLINK_BOOL, SD_VARLINK_NULLABLE),
-                SD_VARLINK_FIELD_COMMENT("The device node path of the block device."),
-                SD_VARLINK_DEFINE_OUTPUT(node, SD_VARLINK_STRING, 0),
+                SD_VARLINK_FIELD_COMMENT("If true, keep the call open after the initial enumeration and stream live add/remove notifications as block-subsystem uevents arrive. The end of the initial enumeration is marked by exactly one notification with action='ready' and no other fields. Defaults to false."),
+                SD_VARLINK_DEFINE_INPUT(subscribe, SD_VARLINK_BOOL, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("Discriminator field. Only set in subscribe mode. 'add' carries the full device record, 'remove' carries only node, 'ready' carries no other fields and is sent once after the initial enumeration."),
+                SD_VARLINK_DEFINE_OUTPUT_BY_TYPE(action, BlockDeviceAction, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("The device node path of the block device. Identifies the device on 'remove' too."),
+                SD_VARLINK_DEFINE_OUTPUT(node, SD_VARLINK_STRING, SD_VARLINK_NULLABLE),
                 SD_VARLINK_FIELD_COMMENT("List of symlinks pointing to the device node, if any."),
                 SD_VARLINK_DEFINE_OUTPUT(symlinks, SD_VARLINK_STRING, SD_VARLINK_ARRAY|SD_VARLINK_NULLABLE),
                 SD_VARLINK_FIELD_COMMENT("The Linux kernel disk sequence number identifying the medium."),
@@ -106,6 +119,8 @@ SD_VARLINK_DEFINE_INTERFACE(
                 &vl_type_EmptyMode,
                 SD_VARLINK_SYMBOL_COMMENT("Progress phase identifiers. Note that we might add more phases here, and thus identifiers. Frontends can choose to display the phase to the user in some human readable form, or not do that, but if they do it and they receive a notification for a so far unknown phase, they should just ignore it."),
                 &vl_type_ProgressPhase,
+                SD_VARLINK_SYMBOL_COMMENT("Discriminator on streamed ListCandidateDevices replies in subscribe mode."),
+                &vl_type_BlockDeviceAction,
 
                 SD_VARLINK_SYMBOL_COMMENT("Invoke the actual repartitioning operation, either in dry-run mode or for real. If invoked with 'more' enabled will report progress, otherwise will just report completion."),
                 &vl_method_Run,

--- a/test/units/TEST-58-REPART.sh
+++ b/test/units/TEST-58-REPART.sh
@@ -1843,6 +1843,174 @@ testcase_varlink_list_devices() {
     varlinkctl call /run/systemd/io.systemd.Repart --graceful=io.systemd.Repart.NoCandidateDevices --collect io.systemd.Repart.ListCandidateDevices '{"ignoreEmpty":true,"ignoreRoot":true}'
 }
 
+testcase_varlink_subscribe_devices() {
+    local imgs subscribe_log pre_existing_log loop loop2 mark non_sub_output
+    local sub_unit="test-repart-subscribe.service"
+    local pre_unit="test-repart-subscribe-pre.service"
+
+    # The uevent monitor in the spawned systemd-repart only sees events from the host's kernel
+    # uevent namespace, which an nspawn container with --private-network filters away. Loopback
+    # creation also fails inside many container setups.
+    if systemd-detect-virt --container >/dev/null 2>&1; then
+        echo "Skipping subscribe tests inside container."
+        return
+    fi
+
+    REPART="$(which systemd-repart)"
+    imgs="$(mktemp --directory "/var/tmp/test-repart.subscribe.XXXXXXXXXX")"
+    subscribe_log="$(mktemp "/var/tmp/test-repart.subscribe-log.XXXXXXXXXX")"
+    pre_existing_log="$(mktemp "/var/tmp/test-repart.pre-log.XXXXXXXXXX")"
+    loop=""
+    loop2=""
+
+    # Single-quoted trap body so $loop / $loop2 are expanded at trap-fire time, not now.
+    # shellcheck disable=SC2016
+    trap '
+        systemctl stop "$sub_unit" "$pre_unit" 2>/dev/null || true
+        [[ -n "${loop:-}"  ]] && systemd-dissect --detach "$loop"  2>/dev/null || true
+        [[ -n "${loop2:-}" ]] && systemd-dissect --detach "$loop2" 2>/dev/null || true
+        rm -rf "$imgs" "$subscribe_log" "$subscribe_log.err" "$pre_existing_log" "$pre_existing_log.err"
+    ' RETURN
+
+    # systemd-dissect --attach requires a dissectable image; a plain ext4 single-filesystem image
+    # is the simplest thing it accepts.
+    truncate -s 50M "$imgs/loop.img"
+    truncate -s 50M "$imgs/loop2.img"
+    mkfs.ext4 -F -q -L test-repart-1 "$imgs/loop.img"
+    mkfs.ext4 -F -q -L test-repart-2 "$imgs/loop2.img"
+
+    # Make sure no stale unit is sitting around from a previous failed run, then arrange cleanup.
+    systemctl reset-failed "$sub_unit" "$pre_unit" 2>/dev/null || true
+    systemctl stop "$sub_unit" "$pre_unit" 2>/dev/null || true
+
+    # Start a varlinkctl subscriber as a transient Type=notify service. systemd-run blocks until the
+    # service notifies READY=1 -- which varlinkctl does on receipt of the first reply (see
+    # src/varlinkctl/varlinkctl.c reply_callback). For us that's either the first "add" of the
+    # initial enumeration or the "ready" sentinel; either way we are guaranteed the server-side
+    # monitor is up before we trigger any uevents.
+    start_subscriber() {
+        local unit="$1" log="$2" params="$3"
+
+        systemd-run \
+            --quiet \
+            --unit="$unit" \
+            --collect \
+            --service-type=notify \
+            --property=StandardOutput="truncate:$log" \
+            --property=StandardError="truncate:$log.err" \
+            -- \
+            varlinkctl --more --timeout=infinity --json=short call \
+            "$REPART" io.systemd.Repart.ListCandidateDevices "$params"
+    }
+
+    # Poll for a regex match in $1 of the named log file ($3, default $subscribe_log), starting from
+    # byte offset $2. Prints the new byte offset (post-match) on stdout so the caller can advance.
+    expect_event() {
+        local pat="$1" mark_="$2" file="${3:-$subscribe_log}"
+        local deadline_=$((SECONDS + UDEVADM_WAIT_TIMEOUT))
+        local cur
+
+        while (( SECONDS < deadline_ )); do
+            cur=$(stat -c%s "$file" 2>/dev/null || echo 0)
+            if (( cur > mark_ )) && \
+               tail -c +"$((mark_ + 1))" "$file" | grep -a -E "$pat" >/dev/null; then
+                printf '%s\n' "$cur"
+                return 0
+            fi
+            sleep 0.1
+        done
+
+        echo "FAIL: pattern '$pat' did not appear within ${UDEVADM_WAIT_TIMEOUT}s. Output past offset $mark_:" >&2
+        tail -c +"$((mark_ + 1))" "$file" >&2 || true
+        return 1
+    }
+
+    # === Test 1: subscribing produces a "ready" sentinel even on an empty initial set ===
+    start_subscriber "$sub_unit" "$subscribe_log" \
+        '{"ignoreRoot":true,"ignoreEmpty":true,"subscribe":true}'
+    mark=$(expect_event '"action":"ready"' 0) || return 1
+
+    # === Test 2: a freshly-added loopback produces an "add" event ===
+    loop="$(systemd-dissect --attach --loop-ref=test-repart-1 "$imgs/loop.img")"
+    udevadm wait --timeout="$UDEVADM_WAIT_TIMEOUT" --settle "$loop"
+    mark=$(expect_event "\"action\":\"add\".*\"node\":\"$loop\"" "$mark") || return 1
+
+    # === Test 3: detaching the loopback produces a "remove" event ===
+    systemd-dissect --detach "$loop"
+    udevadm wait --timeout="$UDEVADM_WAIT_TIMEOUT" --removed --settle "$loop"
+    mark=$(expect_event "\"action\":\"remove\".*\"node\":\"$loop\"" "$mark") || return 1
+    loop=""
+
+    # === Test 4: five add/remove cycles in a row stay in sync ===
+    for _ in 1 2 3 4 5; do
+        loop="$(systemd-dissect --attach --loop-ref=test-repart-1 "$imgs/loop.img")"
+        udevadm wait --timeout="$UDEVADM_WAIT_TIMEOUT" --settle "$loop"
+        mark=$(expect_event "\"action\":\"add\".*\"node\":\"$loop\"" "$mark") || return 1
+
+        systemd-dissect --detach "$loop"
+        udevadm wait --timeout="$UDEVADM_WAIT_TIMEOUT" --removed --settle "$loop"
+        mark=$(expect_event "\"action\":\"remove\".*\"node\":\"$loop\"" "$mark") || return 1
+        loop=""
+    done
+
+    # === Test 5: two coexisting loop devices each produce their own events ===
+    # Set them up (and tear them down) one at a time and wait for each device in turn, so events
+    # appear in a strict order and we can advance our mark monotonically.
+    loop="$(systemd-dissect --attach --loop-ref=test-repart-1 "$imgs/loop.img")"
+    udevadm wait --timeout="$UDEVADM_WAIT_TIMEOUT" --settle "$loop"
+    mark=$(expect_event "\"action\":\"add\".*\"node\":\"$loop\"" "$mark") || return 1
+
+    loop2="$(systemd-dissect --attach --loop-ref=test-repart-2 "$imgs/loop2.img")"
+    udevadm wait --timeout="$UDEVADM_WAIT_TIMEOUT" --settle "$loop2"
+    mark=$(expect_event "\"action\":\"add\".*\"node\":\"$loop2\"" "$mark") || return 1
+
+    systemd-dissect --detach "$loop2"
+    udevadm wait --timeout="$UDEVADM_WAIT_TIMEOUT" --removed --settle "$loop2"
+    mark=$(expect_event "\"action\":\"remove\".*\"node\":\"$loop2\"" "$mark") || return 1
+    loop2=""
+
+    systemd-dissect --detach "$loop"
+    udevadm wait --timeout="$UDEVADM_WAIT_TIMEOUT" --removed --settle "$loop"
+    mark=$(expect_event "\"action\":\"remove\".*\"node\":\"$loop\"" "$mark") || return 1
+    loop=""
+
+    # Tear down the first subscriber before starting the next one.
+    systemctl stop "$sub_unit"
+
+    # === Test 6: a device that exists *before* subscribe starts shows up in the initial enumeration,
+    # and "ready" arrives only after it ===
+    loop="$(systemd-dissect --attach --loop-ref=test-repart-1 "$imgs/loop.img")"
+    udevadm wait --timeout="$UDEVADM_WAIT_TIMEOUT" --settle "$loop"
+
+    start_subscriber "$pre_unit" "$pre_existing_log" \
+        '{"ignoreRoot":true,"subscribe":true}'
+
+    # systemd-run returned (Type=notify => first reply already received), but "ready" may not be
+    # written yet -- poll for it.
+    expect_event '"action":"ready"' 0 "$pre_existing_log" >/dev/null || return 1
+
+    # Everything up to (but excluding) "ready" is the initial enumeration; it must contain $loop.
+    if ! sed -n '/"action":"ready"/q;p' "$pre_existing_log" | \
+            grep -a -E "\"action\":\"add\".*\"node\":\"$loop\"" >/dev/null; then
+        echo "FAIL: pre-existing loop device $loop not in initial enumeration:" >&2
+        cat "$pre_existing_log" >&2
+        return 1
+    fi
+
+    systemctl stop "$pre_unit"
+
+    # === Test 7: without subscribe the reply has no "action" field (back-compat for older clients) ===
+    non_sub_output="$(varlinkctl --collect --json=short call \
+        "$REPART" --graceful=io.systemd.Repart.NoCandidateDevices \
+        io.systemd.Repart.ListCandidateDevices '{"ignoreRoot":true}')"
+    assert_not_in '"action"' "$non_sub_output"
+    # Sanity-check: our $loop *is* in that output (so the assertion above wasn't vacuous).
+    assert_in "\"node\":\"$loop\"" "$non_sub_output"
+
+    systemd-dissect --detach "$loop"
+    loop=""
+}
+
 testcase_get_size() {
     local defs
 


### PR DESCRIPTION
let's ensure one can watch suitables devices come and go via ListCandidateDevices().