### PR TITLE
core: unshare fs_struct from kernel threads when running as PID 1

### DIFF
--- a/src/core/main.c
+++ b/src/core/main.c
@@ -4,6 +4,7 @@
 #include <getopt.h>
 #include <linux/oom.h>
 #include <linux/vt.h>
+#include <sched.h>
 #include <stdlib.h>
 #include <sys/mount.h>
 #include <sys/prctl.h>
@@ -3126,6 +3127,12 @@ int main(int argc, char *argv[]) {
         if (getpid_cached() == 1) {
                 /* When we run as PID 1 force system mode */
                 arg_runtime_scope = RUNTIME_SCOPE_SYSTEM;
+
+                /* The Linux kernel creates PID 1 and all kernel threads with CLONE_FS by default,
+                 * meaning they share fs_struct (umask, root, pwd). Unshare it so our umask(0) below
+                 * (and any later umask changes) don't race with kernel threads. */
+                if (unshare(CLONE_FS) < 0)
+                        log_warning_errno(errno, "Failed to unshare fs_struct, ignoring: %m");
 
                 /* Disable the umask logic */
                 umask(0);


### PR DESCRIPTION
The Linux kernel creates PID 1 and all kernel threads with CLONE_FS by default, meaning they all share the same fs_struct (umask, root, pwd). This means that any umask() call we make in PID 1 will also affect kernel threads, and vice versa.

Unshare it to prevent potential data races.

```
:: ~ » bpftrace ./check_fs.bt                                                                                                 130 ↵
Attaching 1 probe...
pid=1      comm=systemd          fs=0xffffffffa13ca800
pid=2      comm=kthreadd         fs=0xffffffffa13ca800
pid=3      comm=pool_workqueue_  fs=0xffffffffa13ca800
pid=4      comm=kworker/R-rcu_g  fs=0xffffffffa13ca800
pid=5      comm=kworker/R-rcu_p  fs=0xffffffffa13ca800
pid=6      comm=kworker/R-slub_  fs=0xffffffffa13ca800
pid=7      comm=kworker/R-netns  fs=0xffffffffa13ca800
pid=8      comm=kworker/0:0      fs=0xffffffffa13ca800
pid=9      comm=kworker/0:0H     fs=0xffffffffa13ca800
pid=10     comm=kworker/0:1      fs=0xffffffffa13ca800
pid=11     comm=kworker/u16:0    fs=0xffffffffa13ca800
pid=12     comm=kworker/R-mm_pe  fs=0xffffffffa13ca800
pid=13     comm=rcu_tasks_kthre  fs=0xffffffffa13ca800
pid=14     comm=rcu_tasks_rude_  fs=0xffffffffa13ca800
pid=15     comm=rcu_tasks_trace  fs=0xffffffffa13ca800
pid=16     comm=ksoftirqd/0      fs=0xffffffffa13ca800
pid=17     comm=rcu_preempt      fs=0xffffffffa13ca800
pid=18     comm=migration/0      fs=0xffffffffa13ca800
pid=19     comm=idle_inject/0    fs=0xffffffffa13ca800
pid=20     comm=cpuhp/0          fs=0xffffffffa13ca800
pid=21     comm=cpuhp/2          fs=0xffffffffa13ca800
pid=22     comm=idle_inject/2    fs=0xffffffffa13ca800
pid=23     comm=migration/2      fs=0xffffffffa13ca800
......

:: ~ » cat check_fs.bt                                                                                                        130 ↵
#!/usr/bin/env bpftrace
/*
 * Show that pid 1 (systemd) and every kernel thread share the same
 * fs_struct (init_fs).
 *
 * Run: sudo bpftrace check_fs.bt
 */

iter:task {
        $t = ctx->task;

        /* (1) pid 1 */
        if ($t->pid == 1) {
                printf("pid=%-6d comm=%-16s fs=0x%lx\n",
                       $t->pid, $t->comm, (uint64)$t->fs);
        }

        /* (2) all kernel threads (PF_KTHREAD = 0x00200000) */
        if ($t->flags & 0x00200000) {
                printf("pid=%-6d comm=%-16s fs=0x%lx\n",
                       $t->pid, $t->comm, (uint64)$t->fs);
        }
}

```