### PR TITLE
systemd-tmpfiles: remove age-based cleanup of X11 socket directories

### DIFF
--- a/tmpfiles.d/x11.conf
+++ b/tmpfiles.d/x11.conf
@@ -14,5 +14,6 @@ D /tmp/.ICE-unix 1777 root root 1h
 D /tmp/.XIM-unix 1777 root root 1h
 D /tmp/.font-unix 1777 root root 1h
 
-# Unlink the X11 lock files
+# Unlink the X11 lock files at boot, but exclude them from time-based cleanup later
 r! /tmp/.X[0-9]*-lock
+x /tmp/.X[0-9]*-lock

--- a/tmpfiles.d/x11.conf
+++ b/tmpfiles.d/x11.conf
@@ -9,10 +9,10 @@
 
 # Make sure these are created by default so that nobody else can
 # or empty them at startup
-D! /tmp/.X11-unix 1777 root root 10d
-D! /tmp/.ICE-unix 1777 root root 10d
-D! /tmp/.XIM-unix 1777 root root 10d
-D! /tmp/.font-unix 1777 root root 10d
+D /tmp/.X11-unix 1777 root root 1h
+D /tmp/.ICE-unix 1777 root root 1h
+D /tmp/.XIM-unix 1777 root root 1h
+D /tmp/.font-unix 1777 root root 1h
 
 # Unlink the X11 lock files
 r! /tmp/.X[0-9]*-lock


### PR DESCRIPTION
Unexpected cleanup of live X11 socket files was reported in #35182, suggesting an underlying issue with the `!` boot safety switch for tmpfiles.

Regardless of that bug, time-based cleanup of X11 sockets is likely to be unwanted behaviour as systems often stay up for extended periods of time, and cleanup of these directories based on age alone is liable to cause issues at runtime for user sessions.