### PR TITLE
Revert "units: order networkd resolve hook After=network-pre.target"

### DIFF
--- a/units/systemd-networkd-resolve-hook.socket
+++ b/units/systemd-networkd-resolve-hook.socket
@@ -12,7 +12,6 @@ Description=Network Management Resolve Hook Socket
 Documentation=man:systemd-networkd.service(8)
 ConditionCapability=CAP_NET_ADMIN
 DefaultDependencies=no
-After=network-pre.target
 Before=sockets.target shutdown.target
 Conflicts=shutdown.target
 


### PR DESCRIPTION
This reverts commit 37adb410a2b62716b666dbf8359edf8a6546ff94. As reported, this causes dependency loops
(https://github.com/systemd/systemd/42353). This socket has WantedBy=sockets.target, which is intended to start very early and without waiting for the implementing services. In fact, this lack of ordering is part of the original design for socket activation: start all sockets early, and if things try to use the sockets before the backing services are available, they will block.

The original issue that was reported (cloud-init hanging trying to query nss) will need to be solved in a different way.

Fixes #42353.