### PR TITLE
fd-util: add wildcard_fd_is_valid() helper and use it tree-wide

### DIFF
--- a/src/basic/btrfs-util.c
+++ b/src/basic/btrfs-util.c
@@ -48,7 +48,7 @@ int btrfs_subvol_make(int dir_fd, const char *path) {
         _cleanup_close_ int fd = -EBADF;
         int r;
 
-        assert(dir_fd >= 0 || IN_SET(dir_fd, AT_FDCWD, XAT_FDROOT));
+        assert(wildcard_fd_is_valid(dir_fd));
         assert(!isempty(path));
 
         r = extract_subvolume_name(path, &subvolume);

--- a/src/basic/chase.c
+++ b/src/basic/chase.c
@@ -62,7 +62,7 @@ static int chase_openat2(int root_fd, int dir_fd, const char *path, ChaseFlags c
         int r;
 
         assert(path);
-        assert(dir_fd >= 0 || IN_SET(dir_fd, AT_FDCWD, XAT_FDROOT));
+        assert(wildcard_fd_is_valid(dir_fd));
 
         if (!can_openat2)
                 return -EOPNOTSUPP;
@@ -241,8 +241,8 @@ int chaseat(int root_fd, int dir_fd, const char *path, ChaseFlags flags, char **
         assert(!FLAGS_SET(flags, CHASE_PREFIX_ROOT));
         assert(!FLAGS_SET(flags, CHASE_STEP|CHASE_EXTRACT_FILENAME));
         assert(!FLAGS_SET(flags, CHASE_NO_AUTOFS|CHASE_TRIGGER_AUTOFS));
-        assert(dir_fd >= 0 || IN_SET(dir_fd, AT_FDCWD, XAT_FDROOT));
-        assert(root_fd >= 0 || IN_SET(root_fd, AT_FDCWD, XAT_FDROOT));
+        assert(wildcard_fd_is_valid(dir_fd));
+        assert(wildcard_fd_is_valid(root_fd));
         /* AT_FDCWD for dir_fd is only allowed when there is no chroot boundary: otherwise the current
          * working directory might live outside root_fd's subtree. */
         assert(dir_fd != AT_FDCWD || IN_SET(root_fd, AT_FDCWD, XAT_FDROOT));

--- a/src/basic/conf-files.c
+++ b/src/basic/conf-files.c
@@ -155,7 +155,7 @@ static int conf_file_chase_and_verify(
         struct stat st = {};
         int r;
 
-        assert(rfd >= 0 || IN_SET(rfd, AT_FDCWD, XAT_FDROOT));
+        assert(wildcard_fd_is_valid(rfd));
         assert(original_path);
         assert(path);
         assert(name);
@@ -274,7 +274,7 @@ int conf_file_new_at(
         int r;
 
         assert(path);
-        assert(rfd >= 0 || IN_SET(rfd, AT_FDCWD, XAT_FDROOT));
+        assert(wildcard_fd_is_valid(rfd));
         assert(ret);
 
         int log_level = conf_files_log_level(flags);
@@ -390,7 +390,7 @@ static int files_add(
         assert(dir);
         assert(original_dirpath);
         assert(resolved_dirpath);
-        assert(rfd >= 0 || IN_SET(rfd, AT_FDCWD, XAT_FDROOT));
+        assert(wildcard_fd_is_valid(rfd));
         assert(files);
         assert(masked);
 
@@ -622,7 +622,7 @@ static int conf_files_list_impl(
         const ConfFile *inserted = NULL;
         int r;
 
-        assert(rfd >= 0 || IN_SET(rfd, AT_FDCWD, XAT_FDROOT));
+        assert(wildcard_fd_is_valid(rfd));
         assert(ret);
 
         root = empty_to_root(root);
@@ -736,7 +736,7 @@ int conf_files_list_strv_at(
         _cleanup_free_ char *root = NULL;
         int r;
 
-        assert(rfd >= 0 || IN_SET(rfd, AT_FDCWD, XAT_FDROOT));
+        assert(wildcard_fd_is_valid(rfd));
         assert(ret);
 
         if (DEBUG_LOGGING)
@@ -761,7 +761,7 @@ int conf_files_list_strv_at_full(
         _cleanup_free_ char *root = NULL;
         int r;
 
-        assert(rfd >= 0 || IN_SET(rfd, AT_FDCWD, XAT_FDROOT));
+        assert(wildcard_fd_is_valid(rfd));
         assert(ret_files);
         assert(ret_n_files);
 

--- a/src/basic/fd-util.c
+++ b/src/basic/fd-util.c
@@ -581,7 +581,7 @@ bool fdname_is_valid(const char *s) {
 int fd_get_path(int fd, char **ret) {
         int r;
 
-        assert(fd >= 0 || IN_SET(fd, AT_FDCWD, XAT_FDROOT));
+        assert(wildcard_fd_is_valid(fd));
 
         if (fd == AT_FDCWD)
                 return safe_getcwd(ret);
@@ -781,7 +781,7 @@ finish:
 }
 
 int fd_reopen(int fd, int flags) {
-        assert(fd >= 0 || IN_SET(fd, AT_FDCWD, XAT_FDROOT));
+        assert(wildcard_fd_is_valid(fd));
         assert(!FLAGS_SET(flags, O_CREAT));
 
         /* Reopens the specified fd with new flags. This is useful for convert an O_PATH fd into a regular one, or to
@@ -1052,7 +1052,7 @@ static bool is_literal_root(const char *p) {
 }
 
 int path_is_root_at(int dir_fd, const char *path) {
-        assert(dir_fd >= 0 || IN_SET(dir_fd, AT_FDCWD, XAT_FDROOT));
+        assert(wildcard_fd_is_valid(dir_fd));
 
         if (dir_fd == XAT_FDROOT && isempty(path))
                 return true;
@@ -1086,8 +1086,8 @@ int fds_inode_and_mount_same(int fd1, int fd2) {
         struct statx sx1, sx2;
         int r;
 
-        assert(fd1 >= 0 || IN_SET(fd1, AT_FDCWD, XAT_FDROOT));
-        assert(fd2 >= 0 || IN_SET(fd2, AT_FDCWD, XAT_FDROOT));
+        assert(wildcard_fd_is_valid(fd1));
+        assert(wildcard_fd_is_valid(fd2));
 
         r = xstatx(fd1, /* path = */ NULL, AT_EMPTY_PATH,
                    STATX_TYPE|STATX_INO|STATX_MNT_ID,

--- a/src/basic/fd-util.h
+++ b/src/basic/fd-util.h
@@ -64,6 +64,12 @@
 assert_cc(XAT_FDROOT != AT_FDCWD);
 assert_cc(XAT_FDROOT < -ERRNO_MAX);
 
+/* Checks whether the specified fd is acceptable as a *at() directory fd that supports the two "wildcard"
+ * values: it's either a regular, valid fd (i.e. >= 0), or one of the special AT_FDCWD/XAT_FDROOT values. */
+static inline bool wildcard_fd_is_valid(int fd) {
+        return fd >= 0 || IN_SET(fd, AT_FDCWD, XAT_FDROOT);
+}
+
 int close_nointr(int fd);
 int safe_close(int fd);
 void safe_close_pair(int p[static 2]);

--- a/src/basic/fileio.c
+++ b/src/basic/fileio.c
@@ -420,7 +420,7 @@ int read_one_line_file_at(int dir_fd, const char *filename, char **ret) {
         _cleanup_fclose_ FILE *f = NULL;
         int r;
 
-        assert(dir_fd >= 0 || IN_SET(dir_fd, AT_FDCWD, XAT_FDROOT));
+        assert(wildcard_fd_is_valid(dir_fd));
         assert(filename);
         assert(ret);
 
@@ -435,7 +435,7 @@ int read_boolean_file_at(int dir_fd, const char *filename) {
         _cleanup_free_ char *s = NULL;
         int r;
 
-        assert(dir_fd >= 0 || IN_SET(dir_fd, AT_FDCWD, XAT_FDROOT));
+        assert(wildcard_fd_is_valid(dir_fd));
         assert(filename);
 
         r = read_one_line_file_at(dir_fd, filename, &s);
@@ -1024,7 +1024,7 @@ static int xfopenat_regular(int dir_fd, const char *path, const char *mode, int 
 
         /* A combination of fopen() with openat() */
 
-        assert(dir_fd >= 0 || IN_SET(dir_fd, AT_FDCWD, XAT_FDROOT));
+        assert(wildcard_fd_is_valid(dir_fd));
         assert(mode);
         assert(ret);
 
@@ -1071,7 +1071,7 @@ static int xfopenat_unix_socket(int dir_fd, const char *path, const char *bind_n
         FILE *f;
         int r;
 
-        assert(dir_fd >= 0 || IN_SET(dir_fd, AT_FDCWD, XAT_FDROOT));
+        assert(wildcard_fd_is_valid(dir_fd));
         assert(ret);
 
         sk = socket(AF_UNIX, SOCK_STREAM|SOCK_CLOEXEC, 0);
@@ -1119,7 +1119,7 @@ int xfopenat_full(
         FILE *f = NULL;  /* avoid false maybe-uninitialized warning */
         int r;
 
-        assert(dir_fd >= 0 || IN_SET(dir_fd, AT_FDCWD, XAT_FDROOT));
+        assert(wildcard_fd_is_valid(dir_fd));
         assert(mode);
         assert(ret);
 
@@ -1689,7 +1689,7 @@ int write_data_file_atomic_at(
 
         int r;
 
-        assert(dir_fd >= 0 || IN_SET(dir_fd, AT_FDCWD, XAT_FDROOT));
+        assert(wildcard_fd_is_valid(dir_fd));
 
         /* This is a cousin of write_string_file_atomic(), but operates with arbitrary struct iovec binary
          * data (rather than strings), works without FILE* streams, and does direct syscalls instead. */

--- a/src/basic/fs-util.c
+++ b/src/basic/fs-util.c
@@ -1176,7 +1176,7 @@ int xopenat_full(int dir_fd, const char *path, int open_flags, XOpenFlags xopen_
         bool made_dir = false, made_file = false;
         int r;
 
-        assert(dir_fd >= 0 || IN_SET(dir_fd, AT_FDCWD, XAT_FDROOT));
+        assert(wildcard_fd_is_valid(dir_fd));
 
         /* An inode can only be one of a directory, a regular file or a socket at the same time. */
         assert(FLAGS_SET(open_flags, O_DIRECTORY) + FLAGS_SET(xopen_flags, XO_REGULAR) + FLAGS_SET(xopen_flags, XO_SOCKET) <= 1);

--- a/src/basic/mountpoint-util.c
+++ b/src/basic/mountpoint-util.c
@@ -242,7 +242,7 @@ struct file_handle* file_handle_dup(const struct file_handle *fh) {
 int is_mount_point_at(int dir_fd, const char *path, int flags) {
         int r;
 
-        assert(dir_fd >= 0 || IN_SET(dir_fd, AT_FDCWD, XAT_FDROOT));
+        assert(wildcard_fd_is_valid(dir_fd));
         assert((flags & ~AT_SYMLINK_FOLLOW) == 0);
 
         if (path_equal(path, "/"))
@@ -306,7 +306,7 @@ static int path_get_mnt_id_at_internal(int dir_fd, const char *path, bool unique
         struct statx sx;
         int r;
 
-        assert(dir_fd >= 0 || IN_SET(dir_fd, AT_FDCWD, XAT_FDROOT));
+        assert(wildcard_fd_is_valid(dir_fd));
         assert(ret);
 
         r = xstatx(dir_fd, path,

--- a/src/basic/os-util.c
+++ b/src/basic/os-util.c
@@ -170,7 +170,7 @@ int open_os_release_at(int rfd, char **ret_path, int *ret_fd) {
         const char *e;
         int r;
 
-        assert(rfd >= 0 || IN_SET(rfd, AT_FDCWD, XAT_FDROOT));
+        assert(wildcard_fd_is_valid(rfd));
 
         e = secure_getenv("SYSTEMD_OS_RELEASE");
         if (e)
@@ -227,7 +227,7 @@ int open_extension_release_at(
         const char *p;
         int r;
 
-        assert(rfd >= 0 || IN_SET(rfd, AT_FDCWD, XAT_FDROOT));
+        assert(wildcard_fd_is_valid(rfd));
         assert(!extension || (image_class >= 0 && image_class < _IMAGE_CLASS_MAX));
 
         if (!extension)
@@ -372,7 +372,7 @@ static int parse_extension_release_atv(
         _cleanup_free_ char *p = NULL;
         int r;
 
-        assert(rfd >= 0 || IN_SET(rfd, AT_FDCWD, XAT_FDROOT));
+        assert(wildcard_fd_is_valid(rfd));
 
         r = open_extension_release_at(rfd, image_class, extension, relax_extension_release_check, &p, &fd);
         if (r < 0)
@@ -391,7 +391,7 @@ int parse_extension_release_at_sentinel(
         va_list ap;
         int r;
 
-        assert(rfd >= 0 || IN_SET(rfd, AT_FDCWD, XAT_FDROOT));
+        assert(wildcard_fd_is_valid(rfd));
 
         va_start(ap, extension);
         r = parse_extension_release_atv(rfd, image_class, extension, relax_extension_release_check, ap);

--- a/src/basic/socket-util.c
+++ b/src/basic/socket-util.c
@@ -1621,7 +1621,7 @@ int connect_unix_path(int fd, int dir_fd, const char *path) {
         _cleanup_close_ int inode_fd = -EBADF;
 
         assert(fd >= 0);
-        assert(IN_SET(dir_fd, AT_FDCWD, XAT_FDROOT) || dir_fd >= 0);
+        assert(wildcard_fd_is_valid(dir_fd));
 
         /* Connects to the specified AF_UNIX socket in the file system. Works around the 108 byte size limit
          * in sockaddr_un, by going via O_PATH if needed. This hence works for any kind of path. */

--- a/src/basic/stat-util.c
+++ b/src/basic/stat-util.c
@@ -32,7 +32,7 @@ static int verify_stat_at(
         struct stat st;
         int r;
 
-        assert(fd >= 0 || IN_SET(fd, AT_FDCWD, XAT_FDROOT));
+        assert(wildcard_fd_is_valid(fd));
         assert(!isempty(path) || !follow);
         assert(verify_func);
 
@@ -418,7 +418,7 @@ int xstatx_full(int fd,
          *    STATX_MNT_ID if not.
          */
 
-        assert(fd >= 0 || IN_SET(fd, AT_FDCWD, XAT_FDROOT));
+        assert(wildcard_fd_is_valid(fd));
         assert((mandatory_mask & optional_mask) == 0);
         assert(!FLAGS_SET(xstatx_flags, XSTATX_MNT_ID_BEST) || !((mandatory_mask|optional_mask) & (STATX_MNT_ID|STATX_MNT_ID_UNIQUE)));
         assert(ret);
@@ -480,7 +480,7 @@ static int xfstatfs(int fd, struct statfs *ret) {
 int xstatfsat(int dir_fd, const char *path, struct statfs *ret) {
         _cleanup_close_ int fd = -EBADF;
 
-        assert(dir_fd >= 0 || IN_SET(dir_fd, AT_FDCWD, XAT_FDROOT));
+        assert(wildcard_fd_is_valid(dir_fd));
         assert(ret);
 
         if (!isempty(path)) {

--- a/src/kernel-install/kernel-install.c
+++ b/src/kernel-install/kernel-install.c
@@ -153,7 +153,7 @@ static int context_copy(const Context *source, Context *ret) {
 
         assert(source);
         assert(ret);
-        assert(source->rfd >= 0 || source->rfd == AT_FDCWD || source->rfd == XAT_FDROOT);
+        assert(wildcard_fd_is_valid(source->rfd));
 
         _cleanup_(context_done) Context copy = (Context) {
                 .rfd = source->rfd,

--- a/src/libsystemd/sd-id128/id128-util.c
+++ b/src/libsystemd/sd-id128/id128-util.c
@@ -142,7 +142,7 @@ int id128_read_fd(int fd, Id128Flag f, sd_id128_t *ret) {
 int id128_read_at(int dir_fd, const char *path, Id128Flag f, sd_id128_t *ret) {
         _cleanup_close_ int fd = -EBADF;
 
-        assert(dir_fd >= 0 || IN_SET(dir_fd, AT_FDCWD, XAT_FDROOT));
+        assert(wildcard_fd_is_valid(dir_fd));
         assert(path);
 
         fd = xopenat(dir_fd, path, O_RDONLY|O_CLOEXEC|O_NOCTTY);

--- a/src/libsystemd/sd-id128/sd-id128.c
+++ b/src/libsystemd/sd-id128/sd-id128.c
@@ -138,7 +138,7 @@ _public_ int sd_id128_get_machine(sd_id128_t *ret) {
 int id128_get_machine_at(int rfd, sd_id128_t *ret) {
         int r;
 
-        assert(rfd >= 0 || IN_SET(rfd, AT_FDCWD, XAT_FDROOT));
+        assert(wildcard_fd_is_valid(rfd));
 
         r = dir_fd_is_root_or_cwd(rfd);
         if (r < 0)

--- a/src/shared/boot-entry.c
+++ b/src/shared/boot-entry.c
@@ -21,7 +21,7 @@ static int entry_token_load_one(int rfd, const char *dir, BootEntryTokenType *ty
         _cleanup_fclose_ FILE *f = NULL;
         int r;
 
-        assert(rfd >= 0 || IN_SET(rfd, AT_FDCWD, XAT_FDROOT));
+        assert(wildcard_fd_is_valid(rfd));
         assert(dir);
         assert(type);
         assert(*type == BOOT_ENTRY_TOKEN_AUTO);
@@ -57,7 +57,7 @@ static int entry_token_load_one(int rfd, const char *dir, BootEntryTokenType *ty
 static int entry_token_load(int rfd, const char *conf_root, BootEntryTokenType *type, char **token) {
         int r;
 
-        assert(rfd >= 0 || IN_SET(rfd, AT_FDCWD, XAT_FDROOT));
+        assert(wildcard_fd_is_valid(rfd));
         assert(type);
         assert(*type == BOOT_ENTRY_TOKEN_AUTO);
         assert(token);
@@ -97,7 +97,7 @@ static int entry_token_from_os_release(int rfd, BootEntryTokenType *type, char *
         _cleanup_free_ char *id = NULL, *image_id = NULL;
         int r;
 
-        assert(rfd >= 0 || IN_SET(rfd, AT_FDCWD, XAT_FDROOT));
+        assert(wildcard_fd_is_valid(rfd));
         assert(type);
         assert(IN_SET(*type, BOOT_ENTRY_TOKEN_AUTO, BOOT_ENTRY_TOKEN_OS_IMAGE_ID, BOOT_ENTRY_TOKEN_OS_ID));
         assert(token);
@@ -150,7 +150,7 @@ int boot_entry_token_ensure_at(
 
         int r;
 
-        assert(rfd >= 0 || IN_SET(rfd, AT_FDCWD, XAT_FDROOT));
+        assert(wildcard_fd_is_valid(rfd));
         assert(type);
         assert(token);
 

--- a/src/shared/btrfs-util.c
+++ b/src/shared/btrfs-util.c
@@ -109,7 +109,7 @@ int btrfs_get_block_device_at_full(int dir_fd, const char *path, uint64_t *ret_d
          * ret - the returned block device
          */
 
-        assert(dir_fd >= 0 || IN_SET(dir_fd, AT_FDCWD, XAT_FDROOT));
+        assert(wildcard_fd_is_valid(dir_fd));
 
         fd = xopenat(dir_fd, path, O_RDONLY|O_CLOEXEC|O_NONBLOCK|O_NOCTTY);
         if (fd < 0)

--- a/src/shared/conf-parser.c
+++ b/src/shared/conf-parser.c
@@ -603,7 +603,7 @@ static int normalize_root_fd(const char *root, int *root_fd, int *ret_opened_fd)
         /* Normalizes a root dir specification: if root_fd is already valid, keep it. Otherwise, we open the
          * specified dir */
 
-        if (*root_fd >= 0 || IN_SET(*root_fd, AT_FDCWD, XAT_FDROOT)) {
+        if (wildcard_fd_is_valid(*root_fd)) {
                 *ret_opened_fd = -EBADF;
                 return 0;
         }

--- a/src/shared/find-esp.c
+++ b/src/shared/find-esp.c
@@ -323,7 +323,7 @@ static int verify_esp(
                 unprivileged_mode = FLAGS_SET(flags, VERIFY_ESP_UNPRIVILEGED_MODE);
         int r;
 
-        assert(rfd >= 0 || IN_SET(rfd, AT_FDCWD, XAT_FDROOT));
+        assert(wildcard_fd_is_valid(rfd));
         assert(path);
 
         /* This logs about all errors, except:
@@ -420,7 +420,7 @@ int find_esp_and_warn_at_full(
         VerifyESPFlags flags;
         int r;
 
-        assert(rfd >= 0 || IN_SET(rfd, AT_FDCWD, XAT_FDROOT));
+        assert(wildcard_fd_is_valid(rfd));
 
         /* This logs about all errors except:
          *
@@ -733,7 +733,7 @@ static int verify_xbootldr(
                 unprivileged_mode = FLAGS_SET(flags, VERIFY_ESP_UNPRIVILEGED_MODE);
         int r;
 
-        assert(rfd >= 0 || IN_SET(rfd, AT_FDCWD, XAT_FDROOT));
+        assert(wildcard_fd_is_valid(rfd));
         assert(path);
 
         _cleanup_free_ char *p = NULL;
@@ -796,7 +796,7 @@ int find_xbootldr_and_warn_at_full(
 
         /* Similar to find_esp_and_warn(), but finds the XBOOTLDR partition. Returns the same errors. */
 
-        assert(rfd >= 0 || IN_SET(rfd, AT_FDCWD, XAT_FDROOT));
+        assert(wildcard_fd_is_valid(rfd));
 
         flags = verify_esp_flags_init(unprivileged_mode, "SYSTEMD_RELAX_XBOOTLDR_CHECKS");
 

--- a/src/shared/kernel-config.c
+++ b/src/shared/kernel-config.c
@@ -28,7 +28,7 @@ int load_kernel_install_conf_at(
         };
         int r;
 
-        assert(root_fd >= 0 || IN_SET(root_fd, AT_FDCWD, XAT_FDROOT));
+        assert(wildcard_fd_is_valid(root_fd));
 
         if (conf_root) {
                 _cleanup_free_ char *conf = path_join(conf_root, "install.conf");

--- a/src/shared/kernel-image.c
+++ b/src/shared/kernel-image.c
@@ -130,7 +130,7 @@ int inspect_kernel_full(
         _cleanup_close_ int fd = -EBADF;
         int r;
 
-        assert(dir_fd >= 0 || IN_SET(dir_fd, AT_FDCWD, XAT_FDROOT));
+        assert(wildcard_fd_is_valid(dir_fd));
 
         fd = xopenat(dir_fd, filename, O_RDONLY|O_CLOEXEC);
         if (fd < 0)

--- a/src/shared/vpick.c
+++ b/src/shared/vpick.c
@@ -190,7 +190,7 @@ static int pin_choice(
         _cleanup_free_ char *resolved_path = NULL;
         int r;
 
-        assert(toplevel_fd >= 0 || IN_SET(toplevel_fd, AT_FDCWD, XAT_FDROOT));
+        assert(wildcard_fd_is_valid(toplevel_fd));
         assert(inode_path);
         assert(filter);
         assert(ret);
@@ -322,7 +322,7 @@ static int make_choice(
         _cleanup_close_ int inode_fd = TAKE_FD(_inode_fd);
         int r;
 
-        assert(toplevel_fd >= 0 || IN_SET(toplevel_fd, AT_FDCWD, XAT_FDROOT));
+        assert(wildcard_fd_is_valid(toplevel_fd));
         assert(inode_path);
         assert(filter);
         assert(ret);
@@ -513,7 +513,7 @@ static int path_pick_one(
         uint32_t filter_type_mask;
         int r;
 
-        assert(toplevel_fd >= 0 || IN_SET(toplevel_fd, AT_FDCWD, XAT_FDROOT));
+        assert(wildcard_fd_is_valid(toplevel_fd));
         assert(path);
         assert(filter);
         assert(ret);
@@ -662,7 +662,7 @@ int path_pick(const char *toplevel_path,
         _cleanup_(pick_result_done) PickResult best = PICK_RESULT_NULL;
         int r;
 
-        assert(toplevel_fd >= 0 || IN_SET(toplevel_fd, AT_FDCWD, XAT_FDROOT));
+        assert(wildcard_fd_is_valid(toplevel_fd));
         assert(path);
         assert(filters || n_filters == 0);
         assert(ret);


### PR DESCRIPTION
Many *at()-style helpers accept a directory fd that may be either a regular, valid fd (>= 0) or one of the special AT_FDCWD/XAT_FDROOT wildcard values, and open-code that check in their assertions. Add a wildcard_fd_is_valid() helper for it and use it tree-wide.