### PR TITLE
profile.d: add instructions how to deactivate 80-systemd-osc-context.sh

### DIFF
--- a/profile.d/70-systemd-shell-extra.sh
+++ b/profile.d/70-systemd-shell-extra.sh
@@ -12,6 +12,15 @@
 # credentials shell.prompt.prefix, shell.prompt.suffix and shell.welcome, and
 # are propagated into these environment variables by pam_systemd(8).
 
+# This file is "activated" through systemd-tmpfiles which links it into
+# /etc/profile.d/. To disable this, remove the
+# /etc/profile.d/70-systemd-shell-extra.sh symlink and mask the
+# 20-systemd-shell-extra.conf snippet (as root):
+#
+#   test -h /etc/profile.d/70-systemd-shell-extra.sh && \
+#     rm -v /etc/profile.d/70-systemd-shell-extra.sh && \
+#     ln -s /dev/null /etc/tmpfiles.d/20-systemd-shell-extra.conf
+
 if [ -n "${SHELL_PROMPT_PREFIX-}" ]; then
     if [ -n "${BASH_VERSION-}" ] && [ "$PS1" = "\\s-\\v\\\$ " ]; then
         PS1="[\u@\h \W]\\$ "

--- a/profile.d/80-systemd-osc-context.sh
+++ b/profile.d/80-systemd-osc-context.sh
@@ -14,6 +14,15 @@
 # specification for the shell prompt. For details see:
 # https://uapi-group.org/specifications/specs/osc_context/
 
+# This file is "activated" through systemd-tmpfiles which links it into
+# /etc/profile.d/. To disable this, remove the
+# /etc/profile.d/80-systemd-osc-context.sh symlink and mask the
+# 20-systemd-osc-context.conf snippet (as root):
+#
+#   test -h /etc/profile.d/80-systemd-osc-context.sh && \
+#     rm -v /etc/profile.d/80-systemd-osc-context.sh && \
+#     ln -s /dev/null /etc/tmpfiles.d/20-systemd-osc-context.conf
+
 # Not bash?
 [ -n "${BASH_VERSION:-}" ] || return 0
 


### PR DESCRIPTION
This was requested in https://github.com/systemd/systemd/issues/42333. Indeed, this integration is using three levels of systemd magick, so doing this correctly is not obvious. Let's include specific instructions to help people for whom this integration is causing problems.