### PR TITLE
Downgrade warning about missing libseccomp

### DIFF
--- a/src/shared/seccomp-util.c
+++ b/src/shared/seccomp-util.c
@@ -1339,7 +1339,7 @@ int seccomp_parse_syscall_filter(
                         if (!FLAGS_SET(flags, SECCOMP_PARSE_PERMISSIVE))
                                 return r;
 
-                        log_syntax(unit, FLAGS_SET(flags, SECCOMP_PARSE_LOG) ? LOG_WARNING : LOG_DEBUG, filename, line, r,
+                        log_syntax(unit, FLAGS_SET(flags, SECCOMP_PARSE_LOG) ? LOG_INFO : LOG_DEBUG, filename, line, r,
                                    "System call %s cannot be resolved as libseccomp is not available, ignoring: %m", name);
                         return 0;
                 }


### PR DESCRIPTION
We currently log at warning level:
/usr/lib/systemd/system/systemd-udevd.service:56: System call bpf cannot be
  resolved as libseccomp is not available, ignoring: Operation not supported

In the initrd, or in minimal installations, not installing libseccomp is reasonable, depending on various other choices. We shouldn't make fuss about this.

C.f. https://bugzilla.redhat.com/show_bug.cgi?id=2463540.