### PR TITLE
meson: newer qemu requires '-machine' for '-device help'

### DIFF
--- a/test/integration-tests/TEST-64-UDEV-STORAGE/meson.build
+++ b/test/integration-tests/TEST-64-UDEV-STORAGE/meson.build
@@ -7,11 +7,8 @@ udev_storage_test_template = {
 }
 
 qemu = find_program('qemu-system-@0@'.format(host_machine.cpu_family()), 'qemu-kvm', dirs : ['/usr/libexec'], native : true, required : false)
-if qemu.found() and host_machine.cpu_family() == 'aarch64'
-        # qemu-system-aarch64 errors out if no machine is specified
+if qemu.found()
         devices = run_command(qemu, '-device', 'help', '-machine', 'virt', check : true).stdout().strip()
-elif qemu.found()
-        devices = run_command(qemu, '-device', 'help', check : true).stdout().strip()
 else
         devices = ''
 endif


### PR DESCRIPTION
Fixes the following error in Fedora rawhide:
```
test/integration-tests/TEST-64-UDEV-STORAGE/meson.build:14:18:
ERROR: Command `/usr/sbin/qemu-system-x86_64 -device help` failed with status 127.
```
Old qemu provides list of devices even with '-machine virt'. Let's unconditionally append '-machine virt'.