### PR TITLE
units: drop Before=sockets.target from networkd resolve hook

### DIFF
--- a/units/systemd-networkd-resolve-hook.socket
+++ b/units/systemd-networkd-resolve-hook.socket
@@ -13,7 +13,7 @@ Documentation=man:systemd-networkd.service(8)
 ConditionCapability=CAP_NET_ADMIN
 DefaultDependencies=no
 After=network-pre.target
-Before=sockets.target shutdown.target
+Before=shutdown.target
 Conflicts=shutdown.target
 
 [Socket]


### PR DESCRIPTION
Otherwise, it introduces cyclic dependencies:
```
systemd[1]: sockets.target: Found ordering cycle:
    systemd-networkd-resolve-hook.socket/start after network-pre.target/start after
    iptables.service/start after basic.target/start after sockets.target/start -
    after systemd-networkd-resolve-hook.socket
systemd[1]: sockets.target: Job systemd-networkd-resolve-hook.socket/start deleted
    to break ordering cycle starting with sockets.target/start
```

Follow-up for 37adb410a2b62716b666dbf8359edf8a6546ff94.
Fixes #42353.

--------

Replaces #42361.