### PR TITLE
oom: use cgroup.kill if available

### DIFF
--- a/src/basic/cgroup-util.c
+++ b/src/basic/cgroup-util.c
@@ -406,8 +406,9 @@ int cg_kill_recursive(
         return ret;
 }
 
-int cg_kill_kernel_sigkill(const char *path) {
+int cg_kill_kernel_sigkill(const char *path, uint64_t *ret_n_pids_killed) {
         _cleanup_free_ char *killfile = NULL;
+        uint64_t n_pids = UINT64_MAX;
         int r;
 
         /* Kills the cgroup at `path` directly by writing to its cgroup.kill file.  This sends SIGKILL to all
@@ -422,9 +423,21 @@ int cg_kill_kernel_sigkill(const char *path) {
         if (r < 0)
                 return r;
 
+        if (ret_n_pids_killed) {
+                /* This is not and cannot be atomic so there is a chance the counter might not be accurate
+                 * if a process starts/stops between this read and the next write, but this is used for
+                 * informational purposes so that's ok. */
+                r = cg_get_attribute_as_uint64(path, "pids.current", &n_pids);
+                if (r < 0)
+                        log_debug_errno(r, "Failed to read pids.current from cgroup '%s', ignoring: %m", path);
+        }
+
         r = write_string_file(killfile, "1", WRITE_STRING_FILE_DISABLE_BUFFER);
         if (r < 0)
                 return log_debug_errno(r, "Failed to write to cgroup.kill for cgroup '%s': %m", path);
+
+        if (ret_n_pids_killed)
+                *ret_n_pids_killed = n_pids;
 
         return 0;
 }

--- a/src/basic/cgroup-util.h
+++ b/src/basic/cgroup-util.h
@@ -142,7 +142,7 @@ int cg_read_subgroup(DIR *d, char **ret);
 typedef int (*cg_kill_log_func_t)(const PidRef *pid, int sig, void *userdata);
 
 int cg_kill(const char *path, int sig, CGroupFlags flags, Set *killed_pids, cg_kill_log_func_t log_kill, void *userdata);
-int cg_kill_kernel_sigkill(const char *path);
+int cg_kill_kernel_sigkill(const char *path, uint64_t *ret_n_pids_killed);
 int cg_kill_recursive(const char *path, int sig, CGroupFlags flags, Set *killed_pids, cg_kill_log_func_t log_kill, void *userdata);
 
 int cg_split_spec(const char *spec, char **ret_controller, char **ret_path);

--- a/src/cgtop/cgtop.c
+++ b/src/cgtop/cgtop.c
@@ -391,23 +391,11 @@ static int process(
 
                         g->n_tasks_valid = true;
                 } else {
-                        _cleanup_free_ char *p = NULL, *v = NULL;
-
-                        r = cg_get_path(path, "pids.current", &p);
-                        if (r < 0)
+                        r = cg_get_attribute_as_uint64(path, "pids.current", &g->n_tasks);
+                        if (r < 0 && r != -ENODATA)
                                 return r;
-
-                        r = read_one_line_file(p, &v);
-                        if (r < 0 && r != -ENOENT)
-                                return r;
-                        if (r >= 0) {
-                                r = safe_atou64(v, &g->n_tasks);
-                                if (r < 0)
-                                        return r;
-
-                                if (g->n_tasks > 0)
-                                        g->n_tasks_valid = true;
-                        }
+                        if (r >= 0 && g->n_tasks > 0)
+                                g->n_tasks_valid = true;
                 }
 
         } else

--- a/src/core/unit.c
+++ b/src/core/unit.c
@@ -4158,7 +4158,7 @@ int unit_kill(
                         }
 
                         if (signo == SIGKILL) {
-                                r = cg_kill_kernel_sigkill(p);
+                                r = cg_kill_kernel_sigkill(p, /* ret_n_pids_killed= */ NULL);
                                 if (r >= 0) {
                                         killed = true;
                                         log_unit_info(u, "Killed unit cgroup '%s' with SIGKILL on client request.", p);

--- a/src/oom/oomd-util.c
+++ b/src/oom/oomd-util.c
@@ -14,6 +14,7 @@
 #include "parse-util.h"
 #include "path-util.h"
 #include "pidref.h"
+#include "process-util.h"
 #include "procfs-util.h"
 #include "sd-bus.h"
 #include "set.h"
@@ -249,24 +250,46 @@ int oomd_sort_cgroup_contexts(Hashmap *h, oomd_compare_t compare_func, const cha
 }
 
 int oomd_cgroup_kill(Manager *m, OomdCGroupContext *ctx, bool recurse, const char *reason) {
-        _cleanup_set_free_ Set *pids_killed = NULL;
+        _cleanup_free_ char *cg_path_self = NULL;
+        uint64_t n_pids_killed = UINT64_MAX;
         int r;
 
         assert(ctx);
         assert(!m || reason);
 
-        pids_killed = set_new(NULL);
-        if (!pids_killed)
-                return -ENOMEM;
+        /* Just for safety, in case group.kill is used */
+        r = cg_pid_get_path(getpid_cached(), &cg_path_self);
+        if (r < 0)
+                log_debug_errno(r, "Failed to get cgroup path for self, ignoring: %m");
+        else if (streq(cg_path_self, ctx->path)) {
+                log_debug("Skipping own cgroup '%s'", ctx->path);
+                return 0;
+        }
 
         r = increment_oomd_xattr(ctx->path, "user.oomd_ooms", 1);
         if (r < 0)
                 log_debug_errno(r, "Failed to set user.oomd_ooms before kill: %m");
 
-        if (recurse)
-                r = cg_kill_recursive(ctx->path, SIGKILL, CGROUP_IGNORE_SELF, pids_killed, log_kill, NULL);
-        else
-                r = cg_kill(ctx->path, SIGKILL, CGROUP_IGNORE_SELF, pids_killed, log_kill, NULL);
+        if (recurse) {
+                r = cg_kill_kernel_sigkill(ctx->path, &n_pids_killed);
+                if (r == -EOPNOTSUPP) {
+                        _cleanup_set_free_ Set *pids_killed = set_new(/* hash_ops= */ NULL);
+                        if (!pids_killed)
+                                return -ENOMEM;
+
+                        r = cg_kill_recursive(ctx->path, SIGKILL, CGROUP_IGNORE_SELF, pids_killed, log_kill, /* userdata= */ NULL);
+                        if (r >= 0)
+                                n_pids_killed = set_size(pids_killed);
+                }
+        } else {
+                _cleanup_set_free_ Set *pids_killed = set_new(/* hash_ops= */ NULL);
+                if (!pids_killed)
+                        return -ENOMEM;
+
+                r = cg_kill(ctx->path, SIGKILL, CGROUP_IGNORE_SELF, pids_killed, log_kill, /* userdata= */ NULL);
+                if (r >= 0)
+                        n_pids_killed = set_size(pids_killed);
+        }
 
         /* The cgroup could have been cleaned up after we have sent SIGKILL to all of the processes, but before
          * we could do one last iteration of cgroup.procs to check. Or the service unit could have exited and
@@ -277,12 +300,13 @@ int oomd_cgroup_kill(Manager *m, OomdCGroupContext *ctx, bool recurse, const cha
         else if (r < 0)
                 return r;
 
-        if (set_isempty(pids_killed))
+        if (n_pids_killed == 0)
                 log_debug("Nothing killed when attempting to kill %s", ctx->path);
-
-        r = increment_oomd_xattr(ctx->path, "user.oomd_kill", set_size(pids_killed));
-        if (r < 0)
-                log_debug_errno(r, "Failed to set user.oomd_kill on kill: %m");
+        else if (n_pids_killed != UINT64_MAX) {
+                r = increment_oomd_xattr(ctx->path, "user.oomd_kill", n_pids_killed);
+                if (r < 0)
+                        log_debug_errno(r, "Failed to set user.oomd_kill on kill, ignoring: %m");
+        }
 
         /* send dbus signal */
         if (m)
@@ -294,7 +318,7 @@ int oomd_cgroup_kill(Manager *m, OomdCGroupContext *ctx, bool recurse, const cha
                                           ctx->path,
                                           reason);
 
-        return !set_isempty(pids_killed);
+        return n_pids_killed > 0 && n_pids_killed != UINT64_MAX;
 }
 
 static void oomd_kill_state_free(OomdKillState *ks) {


### PR DESCRIPTION
The log message is informational only, same as the count of killed
processes, so we can safely use cgroup.kill when available instead
of manually recursing through the cgroup tree.