### PR TITLE
ssh-proxy: Default to root user

### DIFF
--- a/src/ssh-generator/20-systemd-ssh-proxy.conf.in
+++ b/src/ssh-generator/20-systemd-ssh-proxy.conf.in
@@ -10,6 +10,7 @@ Host .host machine/.host
 # Make sure machine/* can be used to connect to local machines registered in machined.
 #
 Host unix/* unix%* vsock/* vsock%* vsock-mux/* vsock-mux%* machine/* machine%*
+        User root
         ProxyCommand {{LIBEXECDIR}}/systemd-ssh-proxy %h %p
         ProxyUseFdpass yes
         CheckHostIP no


### PR DESCRIPTION
When ssh-ing into a VM, you generally do not want to log
in as your user from the host. Let's default to the root
user unless a user is explicitly specified.
