### PR TITLE
run0: allow short -p option as alias for --property

### DIFF
--- a/man/run0.xml
+++ b/man/run0.xml
@@ -82,6 +82,7 @@
       </varlistentry>
 
       <varlistentry>
+        <term><option>-p</option></term>
         <term><option>--property=</option></term>
 
         <listitem><para>Sets a property of the service unit that is created. This option takes an assignment

--- a/src/run/run.c
+++ b/src/run/run.c
@@ -804,7 +804,7 @@ static int parse_argv_sudo_mode(int argc, char *argv[]) {
                         arg_unit = opts.arg;
                         break;
 
-                OPTION_LONG("property", "NAME=VALUE", "Set service or scope unit property"):
+                OPTION('p', "property", "NAME=VALUE", "Set service or scope unit property"):
                         if (strv_extend(&arg_property, opts.arg) < 0)
                                 return log_oom();
                         break;


### PR DESCRIPTION
This feels like an omission compared to the option parsing for systemd-run, which uses -p/--property for the same purpose.