### PR TITLE
shutdown: do not delay VM shutdown

### DIFF
--- a/src/shutdown/shutdown.c
+++ b/src/shutdown/shutdown.c
@@ -340,7 +340,12 @@ static void sleep_until_minimum_uptime(void) {
                 r = safe_atou64(e, &minimum_uptime_usec);
                 if (r < 0)
                         log_warning_errno(r, "Failed to parse $MINIMUM_UPTIME_USEC, ignoring: %s", e);
-        }
+        } else if (detect_virtualization() != VIRTUALIZATION_NONE)
+                /* Enforce the minimum uptime, but don't bother with it in containers/VMs, since – unlike on
+                 * bare metal – the screen output isn't flushed out immediately when we reboot (as real PC
+                 * firmwares do). But skip only if there wasn't an explicit configuration, to let users
+                 * override this. */
+                return;
 
         if (minimum_uptime_usec <= 0) /* turned off? */
                 return;
@@ -635,11 +640,7 @@ int main(int argc, char *argv[]) {
 
         notify_supervisor();
 
-        /* Enforce the minimum uptime, but don't bother with it in containers, since – unlike on bare metal
-         * and VMs – the screen output isn't flushed out immediately when we reboot (as OVMF or real PC
-         * firmwares do) */
-        if (!in_container)
-                sleep_until_minimum_uptime();
+        sleep_until_minimum_uptime();
 
         if (streq(arg_verb, "exit")) {
                 if (in_container) {

--- a/src/vmspawn/vmspawn.c
+++ b/src/vmspawn/vmspawn.c
@@ -3049,6 +3049,13 @@ static int run_virtual_machine(int kvm_device_fd, int vhost_device_fd) {
                 if (r < 0)
                         return r;
 
+                /* When using --console=gui the QEMU window closes immediately when the VM has stopped, so
+                 * any console output at shutdown is lost, which makes debugging difficult. Ensure the VM
+                 * stays booted for a minimum of 15s. */
+                r = strv_prepend(&arg_kernel_cmdline_extra, "systemd.minimum_uptime_sec=15");
+                if (r < 0)
+                        return log_oom();
+
                 break;
 
         case CONSOLE_HEADLESS:


### PR DESCRIPTION
Since this was introduced I constantly find myself waiting for VMs to shut down at the end of a test. This not only happens with mkosi integration tests, but with other VM-based tests like for example autopkgtest. In this example, this dracut test suite runtime is tripled due to the artificial delay:

```
[    5.813234] systemd-shutdown[1]: Syncing filesystems and block devices.
[    5.814635] systemd-shutdown[1]: Delaying shutdown for 9s, in order to reach minimum uptime of 15s.
[    8.816855] systemd-shutdown[1]: Delaying shutdown for 6s, in order to reach minimum uptime of 15s.
[   11.819747] systemd-shutdown[1]: Delaying shutdown for 3s, in order to reach minimum uptime of 15s.
[   14.822660] systemd-shutdown[1]: Delaying shutdown for 601ms, in order to reach minimum uptime of 15s.
[   15.427777] systemd-shutdown[1]: Powering off.
[   15.429681] sd 0:0:0:0: [sda] Synchronizing SCSI cache
[   15.433620] ACPI: PM: Preparing to enter system sleep state S5
[   15.435148] reboot: Power down
TEST: root filesystem on a ext4 filesystem with systemd and extensions   [OK]
autopkgtest [19:39:12]: test 46-systemd-sysext: -----------------------]
autopkgtest [19:39:13]: test 46-systemd-sysext:  - - - - - - - - - - results - - - - - - - - - -
46-systemd-sysext    PASS
```

Contrary to what the comment claimed, the scrollback of a VM is _not_ cleared, EDK2 just prints many pages, and one can just scroll up (a lot).

Do not delay by default on VMs. Move the check so that in both containers and VMs users can override and force a delay with the env var.

Follow-up for 0874eea302d0ba2d436dcce0b992cdc957190ff4