### PR TITLE
hwdb: add Infinix Y3 Max YL-613 touchpad properties

### DIFF
--- a/hwdb.d/60-evdev.hwdb
+++ b/hwdb.d/60-evdev.hwdb
@@ -552,6 +552,17 @@ evdev:input:b0003v256Cp006B*
  EVDEV_ABS_36=::42
 
 #########################################
+# Infinix
+#########################################
+
+# Infinix Y3 Max YL-613
+evdev:name:SYNA3602:00 093A:35ED Touchpad:dmi:*svnInfinix:*pnY3Max**
+ EVDEV_ABS_00=::12
+ EVDEV_ABS_01=::12
+ EVDEV_ABS_35=::12
+ EVDEV_ABS_36=::12
+
+#########################################
 # Lenovo
 #########################################
 


### PR DESCRIPTION
Add touchpad calibration properties for the Infinix Y3 Max YL-613.

The touchpad (SYNA3602:00 093A:35ED) was not previously listed in hwdb, causing incorrect resolution defaults.

```
P: /devices/pci0000:00/0000:00:15.0/i2c_designware.1/i2c-11/i2c-SYNA3602:00/0018:093A:35ED.0001/input/input11/event8
M: event8
R: 8
U: input
D: c 13:72
N: input/event8
S: input/by-path/pci-0000:00:15.0-platform-i2c_designware.1-event-mouse
E: DEVPATH=/devices/pci0000:00/0000:00:15.0/i2c_designware.1/i2c-11/i2c-SYNA3602:00/0018:093A:35ED.0001/input/input11/event8
E: DEVNAME=/dev/input/event8
E: MAJOR=13
E: MINOR=72
E: SUBSYSTEM=input
E: USEC_INITIALIZED=5223126
E: ID_INPUT=1
E: ID_INPUT_TOUCHPAD=1
E: ID_INPUT_TOUCHPAD_INTEGRATION=internal
E: ID_BUS=i2c
E: ID_INPUT_WIDTH_MM=155
E: ID_INPUT_HEIGHT_MM=95
E: LIBINPUT_DEVICE_GROUP=18/93a/35ed:i2c-SYNA3602:00
```

DMI: `svnInfinix:*pnY3Max**`