### PR TITLE
hwdb: add Infinix Y3 Max YL-613 keyboard Power Boost key and Touchpad Toggle key

### DIFF
--- a/hwdb.d/60-keyboard.hwdb
+++ b/hwdb.d/60-keyboard.hwdb
@@ -960,6 +960,15 @@ evdev:name:Huawei WMI hotkeys:dmi:bvn*:bvr*:bd*:svnHUAWEI*:pnEUL-WX9:*
  KEYBOARD_KEY_282=unknown                               # Brightness Up, also emitted by acpi-video, ignore
 
 ###########################################################
+# Infinix
+###########################################################
+
+# Infinix Y3 Max YL-613
+evdev:atkbd:dmi:*:svnInfinix:*pnY3Max:*
+ KEYBOARD_KEY_64=prog1                                   # Power Boost key (top-right corner)
+ KEYBOARD_KEY_76=f21                                     # Fn+F8 Touchpad toggle, sends Ctrl+Meta+f21
+
+###########################################################
 # IBM
 ###########################################################
 


### PR DESCRIPTION
Map the Power Boost key (top-right corner, scancode 0x64) on the Infinix Y3 Max YL-613 to KEY_PROG1.

The button previously sent KEY_F13 (code 183) with no obvious function. Mapping to KEY_PROG1 allows desktop environments or user scripts to bind actions (e.g. CPU performance mode toggle).

Map the Touchpad Toggle key (Fn+F8, scancode 0x76) to KEY_F21.

Verified working via evtest:

Event: type 4 (EV_MSC), code 4 (MSC_SCAN), value 64
Event: type 1 (EV_KEY), code 148 (KEY_PROG1), value 1

Event: type 4 (EV_MSC), code 4 (MSC_SCAN), value 76
Event: type 1 (EV_KEY), code 206 (KEY_F21), value 1

DMI: svnInfinix:*pnY3Max:*
AT keyboard scancodes: 0x64, 0x76 (set 2)