### PR TITLE
pam_systemd: fix empty default-capability-ambient-set= not clearing caps

### DIFF
--- a/src/login/pam_systemd.c
+++ b/src/login/pam_systemd.c
@@ -64,6 +64,13 @@ static int parse_caps(
 
         assert(pamh);
         assert(value);
+        assert(caps);
+
+        if (isempty(value)) {
+                *caps = 0;
+                return 0;
+        }
+
 
         if (value[0] == '~') {
                 subtract = true;


### PR DESCRIPTION
parse_caps() returns without modifying *caps when given an empty string, leaving it at CAP_MASK_UNSET which is indistinguishable from "argument not provided". This means setting default-capability-ambient-set= with an empty value does not clear the default CAP_WAKE_ALARM capability.

Add an early check for an empty string in parse_caps() to set *caps to 0 (empty set), allowing users to explicitly clear ambient capabilities via PAM configuration.

Fixes #42302