### PR TITLE
journalctl: don't assert on MESSAGE field without "MESSAGE=" prefix

### DIFF
--- a/src/journal/journalctl-show.c
+++ b/src/journal/journalctl-show.c
@@ -258,7 +258,18 @@ static int show(Context *c) {
                                 return log_error_errno(r, "Failed to get MESSAGE field: %m");
                         }
 
-                        assert_se(message = startswith(message, "MESSAGE="));
+                        message = startswith(message, "MESSAGE=");
+                        if (!message) {
+                                /* The data object doesn't carry the expected field prefix, e.g. because
+                                 * the journal file is corrupted. Skip over it instead of aborting. */
+                                log_notice("MESSAGE field does not start with \"MESSAGE=\", skipping.");
+
+                                if (!arg_reverse)
+                                        c->until_safe = false;
+
+                                c->need_seek = true;
+                                continue;
+                        }
 
                         r = pattern_matches_and_log(arg_compiled_pattern, message,
                                                     len - strlen("MESSAGE="), highlight);


### PR DESCRIPTION
sd_journal_get_data() can return a MESSAGE data object whose payload does not start with "MESSAGE=", e.g. when the journal file is corrupted. Instead of aborting the whole process, log and skip over such an entry like we do for other bad/missing fields.

```
[   87.287390] post.sh[1619]: + journalctl -q -o short-monotonic --grep 'didn'\''t pass validation'
[   87.287844] post.sh[1620]: + grep -v test-varlink-idl
[   87.325676] post.sh[1619]: Assertion 'message = startswith(message, "MESSAGE=")' failed at src/journal/journalctl-show.c:261, function show(). Aborting.
```

```
 #0  0x00007fb47b49a29c n/a (libc.so.6 + 0x9a29c)
 #1  0x00007fb47b43e7d0 raise (libc.so.6 + 0x3e7d0)
 #2  0x00007fb47b425681 abort (libc.so.6 + 0x25681)
 #3  0x00007fb47b8a1ace log_assert_failed (libsystemd-shared-261~rc2.so + 0xa1ace)
 #4  0x000055f8e1ef9ddb show (journalctl + 0xcddb)
 #5  0x000055f8e1efa6ee action_show (journalctl + 0xd6ee)
 #6  0x000055f8e1ef3c20 run (journalctl + 0x6c20)
 #7  0x00007fb47b427741 n/a (libc.so.6 + 0x27741)
 #8  0x00007fb47b427879 __libc_start_main (libc.so.6 + 0x27879)
 #9  0x000055f8e1ef4915 _start (journalctl + 0x7915)
```

Co-developed-by: Claude Opus 4.8 <noreply@anthropic.com>

e.g.: https://github.com/systemd/systemd/actions/runs/26704533173/job/78703184259?pr=42400