### PR TITLE
tmpfiles: add %D specifier resolution

### DIFF
--- a/man/standard-specifiers.xml
+++ b/man/standard-specifiers.xml
@@ -27,6 +27,11 @@
     <entry>Operating system build ID</entry>
     <entry>The operating system build identifier of the running system, as read from the <varname>BUILD_ID=</varname> field of <filename>/etc/os-release</filename>. If not set, resolves to an empty string. See <citerefentry><refentrytitle>os-release</refentrytitle><manvolnum>5</manvolnum></citerefentry> for more information.</entry>
   </row>
+  <row id='D'>
+    <entry><literal>%D</literal></entry>
+    <entry>Shared data directory</entry>
+    <entry>This is either <filename>/usr/share/</filename> (for the system manager) or the path <literal>$XDG_DATA_HOME</literal> resolves to (for user managers).</entry>
+  </row>
   <row id='H'>
     <entry><literal>%H</literal></entry>
     <entry>Host name</entry>

--- a/man/systemd.unit.xml
+++ b/man/systemd.unit.xml
@@ -2452,11 +2452,7 @@
             <entry>Credentials directory</entry>
             <entry>This is the value of the <literal>$CREDENTIALS_DIRECTORY</literal> environment variable if available. See section "Credentials" in <citerefentry><refentrytitle>systemd.exec</refentrytitle><manvolnum>5</manvolnum></citerefentry> for more information.</entry>
           </row>
-          <row>
-            <entry><literal>%D</literal></entry>
-            <entry>Shared data directory</entry>
-            <entry>This is either <filename>/usr/share/</filename> (for the system manager) or the path <literal>$XDG_DATA_HOME</literal> resolves to (for user managers).</entry>
-          </row>
+          <xi:include href="standard-specifiers.xml" xpointer="D"/>
           <row>
             <entry><literal>%E</literal></entry>
             <entry>Configuration directory root</entry>

--- a/man/tmpfiles.d.xml
+++ b/man/tmpfiles.d.xml
@@ -778,6 +778,7 @@ d /tmp/foo/bar - - - bmA:1h -</programlisting></para>
               <entry>System or user cache directory</entry>
               <entry>In <option>--user</option> mode, this is the same as <varname>$XDG_CACHE_HOME</varname>, and <filename>/var/cache</filename> otherwise.</entry>
             </row>
+            <xi:include href="standard-specifiers.xml" xpointer="D"/>
             <row>
               <entry><literal>%g</literal></entry>
               <entry>User group</entry>

--- a/src/tmpfiles/tmpfiles.c
+++ b/src/tmpfiles/tmpfiles.c
@@ -205,6 +205,7 @@ typedef enum DirectoryType {
         DIRECTORY_STATE,
         DIRECTORY_CACHE,
         DIRECTORY_LOGS,
+        DIRECTORY_SHARED,
         _DIRECTORY_TYPE_MAX,
 } DirectoryType;
 
@@ -293,6 +294,7 @@ static int specifier_directory(
                 [DIRECTORY_STATE] =   { SD_PATH_SYSTEM_STATE_PRIVATE      },
                 [DIRECTORY_CACHE] =   { SD_PATH_SYSTEM_STATE_CACHE        },
                 [DIRECTORY_LOGS] =    { SD_PATH_SYSTEM_STATE_LOGS         },
+                [DIRECTORY_SHARED] =  { SD_PATH_SYSTEM_SHARED             },
         };
 
         static const struct table_entry paths_user[] = {
@@ -300,6 +302,7 @@ static int specifier_directory(
                 [DIRECTORY_STATE] =   { SD_PATH_USER_STATE_PRIVATE        },
                 [DIRECTORY_CACHE] =   { SD_PATH_USER_STATE_CACHE          },
                 [DIRECTORY_LOGS] =    { SD_PATH_USER_STATE_PRIVATE, "log" },
+                [DIRECTORY_SHARED] =  { SD_PATH_USER_SHARED               },
         };
 
         const struct table_entry *paths;
@@ -3907,6 +3910,7 @@ static int parse_line(
                 { 'h', specifier_user_home,       NULL },
 
                 { 'C', specifier_directory,       UINT_TO_PTR(DIRECTORY_CACHE)   },
+                { 'D', specifier_directory,       UINT_TO_PTR(DIRECTORY_SHARED)  },
                 { 'L', specifier_directory,       UINT_TO_PTR(DIRECTORY_LOGS)    },
                 { 'S', specifier_directory,       UINT_TO_PTR(DIRECTORY_STATE)   },
                 { 't', specifier_directory,       UINT_TO_PTR(DIRECTORY_RUNTIME) },

--- a/test/test-systemd-tmpfiles.py
+++ b/test/test-systemd-tmpfiles.py
@@ -160,6 +160,13 @@ def test_valid_specifiers(*, user):
                  xdg_cache_home if user else '/var/cache',
                  user=user)  # fmt: skip
 
+    xdg_data_home = os.getenv('XDG_DATA_HOME')
+    if xdg_data_home is None and user:
+        xdg_data_home = os.path.join(home, '.local/share')
+    test_content('f {} - - - - %D',
+                 xdg_data_home if user else '/usr/share',
+                 user=user)  # fmt: skip
+
     test_content('f {} - - - - %L',
                  os.path.join(xdg_state_home, 'log') if user else '/var/log',
                  user=user)  # fmt: skip


### PR DESCRIPTION
systemd-tmpfiles now resolves the %D specifier to /usr/share (for the system manager) or $XDG_DATA_HOME (for the user manager).
This allows the following uses:

1. Management of files in $XDG_DATA_HOME.
The `$XDG_DATA_HOME` directory is the intended location for important, mutable file storage.
Thus it is important for systemd-tmpfiles to properly refer to the directory to create, delete, and otherwise modify directories and files in that location.
2. Generating links to /usr/share
Unlike the linked issue, it *is* relevant for the %D specifier to be available in the system service.
This is because `tmpfiles.d` lines such as `L` substitute specifiers in the argument field.
By using `%D`, tmpfile configs can properly create symlinks into the shared data directory. 
3. Completion.
All other single-directory environment variables from the [XDG Base Directory Specification][] can be represented in `tmpfiles.d` configurations, and this feature completes the set.

### To Review
This PR would likely need a NEWS entry; I'm not sure if that's something I should write up or if that's written by the systemd maintainers.

I used Claude Opus 4.7 to look over the commit prior to making the PR, but it did not generate any code or text.

Closes: #42010

[XDG Base Directory Specification]: https://specifications.freedesktop.org/basedir/latest/