### PR TITLE
[experiment] resolved: convert to fibers

### DIFF
--- a/src/libsystemd/sd-future/fiber.c
+++ b/src/libsystemd/sd-future/fiber.c
@@ -703,6 +703,10 @@ int sd_fiber_new(sd_event *e, const char *name, sd_fiber_func_t func, void *user
         if (ret)
                 *ret = TAKE_PTR(f);
         else {
+                r = sd_future_set_callback(f, /* callback= */ NULL, /* userdata= */ NULL);
+                if (r < 0)
+                        return r;
+
                 /* Fire-and-forget: the fiber is guaranteed to resolve (via completion, cancellation, or
                  * the event loop exit handler), so making the future floating cleans it up. */
                 r = sd_fiber_set_floating(f, true);

--- a/src/libsystemd/sd-future/test-fiber.c
+++ b/src/libsystemd/sd-future/test-fiber.c
@@ -847,6 +847,70 @@ TEST(fiber_floating_callback_drops_ref) {
         ASSERT_EQ(counter, 2);
 }
 
+typedef struct DetachedChildContext {
+        unsigned parent_done;
+        unsigned child_started;
+        unsigned child_done;
+} DetachedChildContext;
+
+static int detached_child_fiber(void *userdata) {
+        DetachedChildContext *ctx = ASSERT_PTR(userdata);
+        int r;
+
+        ctx->child_started++;
+
+        r = sd_fiber_yield();
+        if (r < 0)
+                return r;
+
+        ctx->child_done++;
+        return 0;
+}
+
+static int detached_parent_fiber(void *userdata) {
+        DetachedChildContext *ctx = ASSERT_PTR(userdata);
+        int r;
+
+        r = sd_fiber_new(
+                        sd_fiber_get_event(),
+                        "detached-child",
+                        detached_child_fiber,
+                        userdata,
+                        /* destroy= */ NULL,
+                        /* ret= */ NULL);
+        if (r < 0)
+                return r;
+
+        ctx->parent_done++;
+        return 0;
+}
+
+TEST(fiber_detached_child_does_not_resume_parent) {
+        _cleanup_(sd_event_unrefp) sd_event *e = NULL;
+        ASSERT_OK(sd_event_new(&e));
+        ASSERT_OK(sd_event_set_exit_on_idle(e, true));
+
+        DetachedChildContext ctx = {};
+        sd_future *parent = NULL;
+        ASSERT_OK(sd_fiber_new(
+                        e,
+                        "detached-parent",
+                        detached_parent_fiber,
+                        &ctx,
+                        /* destroy= */ NULL,
+                        &parent));
+
+        ASSERT_OK_POSITIVE(sd_event_run(e, 0));
+        ASSERT_OK(sd_future_result(parent));
+        ASSERT_EQ(ctx.parent_done, 1u);
+
+        parent = sd_future_unref(parent);
+
+        ASSERT_OK(sd_event_loop(e));
+        ASSERT_EQ(ctx.child_started, 1u);
+        ASSERT_EQ(ctx.child_done, 1u);
+}
+
 TEST(fiber_floating_toggle) {
         _cleanup_(sd_event_unrefp) sd_event *e = NULL;
         ASSERT_OK(sd_event_new(&e));

--- a/src/resolve/meson.build
+++ b/src/resolve/meson.build
@@ -28,6 +28,7 @@ systemd_resolved_extract_sources = files(
         'resolved-dnssd-bus.c',
         'resolved-dnssd.c',
         'resolved-etc-hosts.c',
+        'resolved-fiber-util.c',
         'resolved-hook.c',
         'resolved-link-bus.c',
         'resolved-link.c',

--- a/src/resolve/resolved-bus.c
+++ b/src/resolve/resolved-bus.c
@@ -5,6 +5,7 @@
 #include "alloc-util.h"
 #include "bus-common-errors.h"
 #include "bus-get-properties.h"
+#include "bus-internal.h"
 #include "bus-locator.h"
 #include "bus-log-control-api.h"
 #include "bus-message-util.h"
@@ -285,10 +286,9 @@ static int append_address(sd_bus_message *reply, DnsResourceRecord *rr, int ifin
         return 0;
 }
 
-static void bus_method_resolve_hostname_complete(DnsQuery *query) {
+static int bus_method_resolve_hostname_reply(DnsQuery *q) {
         _cleanup_(dns_resource_record_unrefp) DnsResourceRecord *canonical = NULL;
         _cleanup_(sd_bus_message_unrefp) sd_bus_message *reply = NULL;
-        _cleanup_(dns_query_freep) DnsQuery *q = query;
         _cleanup_free_ char *normalized = NULL;
         DnsQuestion *question;
         DnsResourceRecord *rr;
@@ -297,23 +297,8 @@ static void bus_method_resolve_hostname_complete(DnsQuery *query) {
 
         assert(q);
 
-        if (q->state != DNS_TRANSACTION_SUCCESS) {
-                r = reply_query_state(q);
-                goto finish;
-        }
-
-        r = dns_query_process_cname_many(q);
-        if (r == -ELOOP) {
-                r = reply_method_errorf(q, BUS_ERROR_CNAME_LOOP, "CNAME loop detected, or CNAME resolving disabled on '%s'", dns_query_string(q));
-                goto finish;
-        }
-        if (r < 0)
-                goto finish;
-        if (r == DNS_QUERY_CNAME) {
-                /* This was a cname, and the query was restarted. */
-                TAKE_PTR(q);
-                return;
-        }
+        if (!IN_SET(q->state, DNS_TRANSACTION_SUCCESS, DNS_TRANSACTION_NULL))
+                return reply_query_state(q);
 
         r = sd_bus_message_new_method_return(q->bus_request, &reply);
         if (r < 0)
@@ -345,7 +330,7 @@ static void bus_method_resolve_hostname_complete(DnsQuery *query) {
 
         if (added <= 0) {
                 r = reply_method_errorf(q, BUS_ERROR_NO_SUCH_RR, "'%s' does not have any RR of the requested type", dns_query_string(q));
-                goto finish;
+                return r;
         }
 
         r = sd_bus_message_close_container(reply);
@@ -373,8 +358,10 @@ static void bus_method_resolve_hostname_complete(DnsQuery *query) {
 finish:
         if (r < 0) {
                 log_error_errno(r, "Failed to send hostname reply: %m");
-                (void) reply_method_errnof(q, r, NULL);
+                return reply_method_errnof(q, r, NULL);
         }
+
+        return r;
 }
 
 static int parse_as_address(sd_bus_message *m, int ifindex, const char *hostname, int family, uint64_t flags) {
@@ -519,7 +506,6 @@ static int bus_method_resolve_hostname(sd_bus_message *message, void *userdata, 
 
         q->bus_request = sd_bus_message_ref(message);
         q->request_family = family;
-        q->complete = bus_method_resolve_hostname_complete;
 
         r = dns_query_bus_track(q, message);
         if (r < 0)
@@ -529,13 +515,28 @@ static int bus_method_resolve_hostname(sd_bus_message *message, void *userdata, 
         if (r < 0)
                 return r;
 
-        TAKE_PTR(q);
-        return 1;
+        for (;;) {
+                r = dns_query_await(q);
+                if (r < 0)
+                        return r;
+
+                if (q->state != DNS_TRANSACTION_SUCCESS)
+                        break;
+
+                r = dns_query_process_cname_many(q);
+                if (r == -ELOOP)
+                        return reply_method_errorf(q, BUS_ERROR_CNAME_LOOP, "CNAME loop detected, or CNAME resolving disabled on '%s'", dns_query_string(q));
+                if (r < 0)
+                        return r;
+                if (r != DNS_QUERY_CNAME)
+                        break;
+        }
+
+        return bus_method_resolve_hostname_reply(q);
 }
 
-static void bus_method_resolve_address_complete(DnsQuery *query) {
+static int bus_method_resolve_address_reply(DnsQuery *q) {
         _cleanup_(sd_bus_message_unrefp) sd_bus_message *reply = NULL;
-        _cleanup_(dns_query_freep) DnsQuery *q = query;
         DnsQuestion *question;
         DnsResourceRecord *rr;
         unsigned added = 0;
@@ -543,23 +544,8 @@ static void bus_method_resolve_address_complete(DnsQuery *query) {
 
         assert(q);
 
-        if (q->state != DNS_TRANSACTION_SUCCESS) {
-                r = reply_query_state(q);
-                goto finish;
-        }
-
-        r = dns_query_process_cname_many(q);
-        if (r == -ELOOP) {
-                r = reply_method_errorf(q, BUS_ERROR_CNAME_LOOP, "CNAME loop detected, or CNAME resolving disabled on '%s'", dns_query_string(q));
-                goto finish;
-        }
-        if (r < 0)
-                goto finish;
-        if (r == DNS_QUERY_CNAME) {
-                /* This was a cname, and the query was restarted. */
-                TAKE_PTR(q);
-                return;
-        }
+        if (!IN_SET(q->state, DNS_TRANSACTION_SUCCESS, DNS_TRANSACTION_NULL))
+                return reply_query_state(q);
 
         r = sd_bus_message_new_method_return(q->bus_request, &reply);
         if (r < 0)
@@ -595,7 +581,7 @@ static void bus_method_resolve_address_complete(DnsQuery *query) {
                 r = reply_method_errorf(q, BUS_ERROR_NO_SUCH_RR,
                                         "Address %s does not have any RR of requested type",
                                         IN_ADDR_TO_STRING(q->request_family, &q->request_address));
-                goto finish;
+                return r;
         }
 
         r = sd_bus_message_close_container(reply);
@@ -612,8 +598,10 @@ static void bus_method_resolve_address_complete(DnsQuery *query) {
 finish:
         if (r < 0) {
                 log_error_errno(r, "Failed to send address reply: %m");
-                (void) reply_method_errnof(q, r, NULL);
+                return reply_method_errnof(q, r, NULL);
         }
+
+        return r;
 }
 
 static int bus_method_resolve_address(sd_bus_message *message, void *userdata, sd_bus_error *error) {
@@ -660,7 +648,6 @@ static int bus_method_resolve_address(sd_bus_message *message, void *userdata, s
         q->bus_request = sd_bus_message_ref(message);
         q->request_family = family;
         q->request_address = a;
-        q->complete = bus_method_resolve_address_complete;
 
         r = dns_query_bus_track(q, message);
         if (r < 0)
@@ -670,8 +657,24 @@ static int bus_method_resolve_address(sd_bus_message *message, void *userdata, s
         if (r < 0)
                 return r;
 
-        TAKE_PTR(q);
-        return 1;
+        for (;;) {
+                r = dns_query_await(q);
+                if (r < 0)
+                        return r;
+
+                if (q->state != DNS_TRANSACTION_SUCCESS)
+                        break;
+
+                r = dns_query_process_cname_many(q);
+                if (r == -ELOOP)
+                        return reply_method_errorf(q, BUS_ERROR_CNAME_LOOP, "CNAME loop detected, or CNAME resolving disabled on '%s'", dns_query_string(q));
+                if (r < 0)
+                        return r;
+                if (r != DNS_QUERY_CNAME)
+                        break;
+        }
+
+        return bus_method_resolve_address_reply(q);
 }
 
 static int bus_message_append_rr(sd_bus_message *m, DnsResourceRecord *rr, int ifindex) {
@@ -702,9 +705,8 @@ static int bus_message_append_rr(sd_bus_message *m, DnsResourceRecord *rr, int i
         return sd_bus_message_close_container(m);
 }
 
-static void bus_method_resolve_record_complete(DnsQuery *query) {
+static int bus_method_resolve_record_reply(DnsQuery *q) {
         _cleanup_(sd_bus_message_unrefp) sd_bus_message *reply = NULL;
-        _cleanup_(dns_query_freep) DnsQuery *q = query;
         DnsResourceRecord *rr;
         DnsQuestion *question;
         unsigned added = 0;
@@ -713,23 +715,8 @@ static void bus_method_resolve_record_complete(DnsQuery *query) {
 
         assert(q);
 
-        if (q->state != DNS_TRANSACTION_SUCCESS) {
-                r = reply_query_state(q);
-                goto finish;
-        }
-
-        r = dns_query_process_cname_many(q);
-        if (r == -ELOOP) {
-                r = reply_method_errorf(q, BUS_ERROR_CNAME_LOOP, "CNAME loop detected, or CNAME resolving disabled on '%s'", dns_query_string(q));
-                goto finish;
-        }
-        if (r < 0)
-                goto finish;
-        if (r == DNS_QUERY_CNAME) {
-                /* This was a cname, and the query was restarted. */
-                TAKE_PTR(q);
-                return;
-        }
+        if (!IN_SET(q->state, DNS_TRANSACTION_SUCCESS, DNS_TRANSACTION_NULL))
+                return reply_query_state(q);
 
         r = sd_bus_message_new_method_return(q->bus_request, &reply);
         if (r < 0)
@@ -757,7 +744,7 @@ static void bus_method_resolve_record_complete(DnsQuery *query) {
 
         if (added <= 0) {
                 r = reply_method_errorf(q, BUS_ERROR_NO_SUCH_RR, "Name '%s' does not have any RR of the requested type", dns_query_string(q));
-                goto finish;
+                return r;
         }
 
         r = sd_bus_message_close_container(reply);
@@ -774,8 +761,10 @@ static void bus_method_resolve_record_complete(DnsQuery *query) {
 finish:
         if (r < 0) {
                 log_error_errno(r, "Failed to send record reply: %m");
-                (void) reply_method_errnof(q, r, NULL);
+                return reply_method_errnof(q, r, NULL);
         }
+
+        return r;
 }
 
 static int bus_method_resolve_record(sd_bus_message *message, void *userdata, sd_bus_error *error) {
@@ -836,7 +825,6 @@ static int bus_method_resolve_record(sd_bus_message *message, void *userdata, sd
                 return r;
 
         q->bus_request = sd_bus_message_ref(message);
-        q->complete = bus_method_resolve_record_complete;
 
         r = dns_query_bus_track(q, message);
         if (r < 0)
@@ -846,8 +834,24 @@ static int bus_method_resolve_record(sd_bus_message *message, void *userdata, sd
         if (r < 0)
                 return r;
 
-        TAKE_PTR(q);
-        return 1;
+        for (;;) {
+                r = dns_query_await(q);
+                if (r < 0)
+                        return r;
+
+                if (q->state != DNS_TRANSACTION_SUCCESS)
+                        break;
+
+                r = dns_query_process_cname_many(q);
+                if (r == -ELOOP)
+                        return reply_method_errorf(q, BUS_ERROR_CNAME_LOOP, "CNAME loop detected, or CNAME resolving disabled on '%s'", dns_query_string(q));
+                if (r < 0)
+                        return r;
+                if (r != DNS_QUERY_CNAME)
+                        break;
+        }
+
+        return bus_method_resolve_record_reply(q);
 }
 
 static int append_srv(DnsQuery *q, sd_bus_message *reply, DnsResourceRecord *rr) {
@@ -870,14 +874,14 @@ static int append_srv(DnsQuery *q, sd_bus_message *reply, DnsResourceRecord *rr)
                         DnsResourceRecord *zz;
                         DnsQuestion *question;
 
-                        if (aux->state != DNS_TRANSACTION_SUCCESS)
+                        if (!IN_SET(aux->state, DNS_TRANSACTION_SUCCESS, DNS_TRANSACTION_NULL))
                                 continue;
                         if (aux->auxiliary_result != 0)
                                 continue;
 
                         question = dns_query_question_for_protocol(aux, aux->answer_protocol);
 
-                        r = dns_name_equal(dns_question_first_name(question), rr->srv.name);
+                        r = dns_name_equal(aux->auxiliary_name ?: dns_question_first_name(question), rr->srv.name);
                         if (r < 0)
                                 return r;
                         if (r == 0)
@@ -929,14 +933,14 @@ static int append_srv(DnsQuery *q, sd_bus_message *reply, DnsResourceRecord *rr)
                         DnsQuestion *question;
                         int ifindex;
 
-                        if (aux->state != DNS_TRANSACTION_SUCCESS)
+                        if (!IN_SET(aux->state, DNS_TRANSACTION_SUCCESS, DNS_TRANSACTION_NULL))
                                 continue;
                         if (aux->auxiliary_result != 0)
                                 continue;
 
                         question = dns_query_question_for_protocol(aux, aux->answer_protocol);
 
-                        r = dns_name_equal(dns_question_first_name(question), rr->srv.name);
+                        r = dns_name_equal(aux->auxiliary_name ?: dns_question_first_name(question), rr->srv.name);
                         if (r < 0)
                                 return r;
                         if (r == 0)
@@ -1005,11 +1009,10 @@ static int append_txt(sd_bus_message *reply, DnsResourceRecord *rr) {
         return 1;
 }
 
-static void resolve_service_all_complete(DnsQuery *query) {
+static int resolve_service_reply(DnsQuery *q) {
         _cleanup_(dns_resource_record_unrefp) DnsResourceRecord *canonical = NULL;
         _cleanup_(sd_bus_message_unrefp) sd_bus_message *reply = NULL;
         _cleanup_free_ char *name = NULL, *type = NULL, *domain = NULL;
-        _cleanup_(dns_query_freep) DnsQuery *q = query;
         DnsQuestion *question;
         DnsResourceRecord *rr;
         unsigned added = 0;
@@ -1017,10 +1020,8 @@ static void resolve_service_all_complete(DnsQuery *query) {
 
         assert(q);
 
-        if (q->hook_query || q->block_all_complete > 0) {
-                TAKE_PTR(q);
-                return;
-        }
+        if (!IN_SET(q->state, DNS_TRANSACTION_SUCCESS, DNS_TRANSACTION_NULL))
+                return reply_query_state(q);
 
         if ((q->flags & SD_RESOLVED_NO_ADDRESS) == 0) {
                 DnsQuery *bad = NULL;
@@ -1028,19 +1029,13 @@ static void resolve_service_all_complete(DnsQuery *query) {
 
                 LIST_FOREACH(auxiliary_queries, aux, q->auxiliary_queries) {
 
-                        if (aux->hook_query) {
-                                /* If an auxiliary query's hook is still pending, let's wait */
-                                TAKE_PTR(q);
-                                return;
-                        }
-
                         switch (aux->state) {
 
                         case DNS_TRANSACTION_PENDING:
-                                /* If an auxiliary query is still pending, let's wait */
-                                TAKE_PTR(q);
-                                return;
+                        case DNS_TRANSACTION_VALIDATING:
+                                return -EBUSY;
 
+                        case DNS_TRANSACTION_NULL:
                         case DNS_TRANSACTION_SUCCESS:
                                 if (aux->auxiliary_result == 0)
                                         have_success = true;
@@ -1058,12 +1053,12 @@ static void resolve_service_all_complete(DnsQuery *query) {
 
                         assert(bad);
 
-                        if (bad->state == DNS_TRANSACTION_SUCCESS) {
+                        if (IN_SET(bad->state, DNS_TRANSACTION_SUCCESS, DNS_TRANSACTION_NULL)) {
                                 assert(bad->auxiliary_result != 0);
 
                                 if (bad->auxiliary_result == -ELOOP) {
                                         r = reply_method_errorf(q, BUS_ERROR_CNAME_LOOP, "CNAME loop detected, or CNAME resolving disabled on '%s'", dns_query_string(bad));
-                                        goto finish;
+                                        return r;
                                 }
 
                                 assert(bad->auxiliary_result < 0);
@@ -1107,7 +1102,7 @@ static void resolve_service_all_complete(DnsQuery *query) {
 
         if (added <= 0) {
                 r = reply_method_errorf(q, BUS_ERROR_NO_SUCH_RR, "'%s' does not have any RR of the requested type", dns_query_string(q));
-                goto finish;
+                return r;
         }
 
         r = sd_bus_message_close_container(reply);
@@ -1141,7 +1136,7 @@ static void resolve_service_all_complete(DnsQuery *query) {
 
         if (isempty(type)) {
                 r = reply_method_errorf(q, BUS_ERROR_INCONSISTENT_SERVICE_RECORDS, "'%s' does not provide a consistent set of service resource records", dns_query_string(q));
-                goto finish;
+                return r;
         }
 
         r = sd_bus_message_append(
@@ -1158,28 +1153,10 @@ static void resolve_service_all_complete(DnsQuery *query) {
 finish:
         if (r < 0) {
                 log_error_errno(r, "Failed to send service reply: %m");
-                (void) reply_method_errnof(q, r, NULL);
-        }
-}
-
-static void resolve_service_hostname_complete(DnsQuery *q) {
-        int r;
-
-        assert(q);
-        assert(q->auxiliary_for);
-
-        if (q->state != DNS_TRANSACTION_SUCCESS) {
-                resolve_service_all_complete(q->auxiliary_for);
-                return;
+                return reply_method_errnof(q, r, NULL);
         }
 
-        r = dns_query_process_cname_many(q);
-        if (r == DNS_QUERY_CNAME) /* This was a cname, and the query was restarted. */
-                return;
-
-        /* This auxiliary lookup is finished or failed, let's see if all are finished now. */
-        q->auxiliary_result = r < 0 ? r : 0;
-        resolve_service_all_complete(q->auxiliary_for);
+        return r;
 }
 
 static int resolve_service_hostname(DnsQuery *q, DnsResourceRecord *rr, int ifindex) {
@@ -1206,7 +1183,9 @@ static int resolve_service_hostname(DnsQuery *q, DnsResourceRecord *rr, int ifin
                 return r;
 
         aux->request_family = q->request_family;
-        aux->complete = resolve_service_hostname_complete;
+        aux->auxiliary_name = strdup(rr->srv.name);
+        if (!aux->auxiliary_name)
+                return -ENOMEM;
 
         r = dns_query_make_auxiliary(aux, q);
         if (r == -EAGAIN)
@@ -1228,8 +1207,35 @@ static int resolve_service_hostname(DnsQuery *q, DnsResourceRecord *rr, int ifin
         return 1;
 }
 
-static void bus_method_resolve_service_complete(DnsQuery *query) {
-        _cleanup_(dns_query_freep) DnsQuery *q = query;
+static int resolve_service_await_auxiliary(DnsQuery *q) {
+        int r;
+
+        assert(q);
+
+        LIST_FOREACH(auxiliary_queries, aux, q->auxiliary_queries)
+                for (;;) {
+                        r = dns_query_await(aux);
+                        if (r < 0)
+                                return r;
+
+                        if (aux->state != DNS_TRANSACTION_SUCCESS)
+                                break;
+
+                        r = dns_query_process_cname_many(aux);
+                        if (r < 0) {
+                                aux->auxiliary_result = r;
+                                break;
+                        }
+                        if (r != DNS_QUERY_CNAME) {
+                                aux->auxiliary_result = 0;
+                                break;
+                        }
+                }
+
+        return 0;
+}
+
+static int resolve_service_start_auxiliary(DnsQuery *q) {
         bool has_root_domain = false;
         DnsResourceRecord *rr;
         DnsQuestion *question;
@@ -1238,30 +1244,12 @@ static void bus_method_resolve_service_complete(DnsQuery *query) {
 
         assert(q);
 
-        if (q->state != DNS_TRANSACTION_SUCCESS) {
-                r = reply_query_state(q);
-                goto finish;
-        }
-
-        r = dns_query_process_cname_many(q);
-        if (r == -ELOOP) {
-                r = reply_method_errorf(q, BUS_ERROR_CNAME_LOOP, "CNAME loop detected, or CNAME resolving disabled on '%s'", dns_query_string(q));
-                goto finish;
-        }
-        if (r < 0)
-                goto finish;
-        if (r == DNS_QUERY_CNAME) {
-                /* This was a cname, and the query was restarted. */
-                TAKE_PTR(q);
-                return;
-        }
-
         question = dns_query_question_for_protocol(q, q->answer_protocol);
 
         DNS_ANSWER_FOREACH_IFINDEX(rr, ifindex, q->answer) {
                 r = dns_question_matches_rr(question, rr, NULL);
                 if (r < 0)
-                        goto finish;
+                        return r;
                 if (r == 0)
                         continue;
 
@@ -1274,12 +1262,10 @@ static void bus_method_resolve_service_complete(DnsQuery *query) {
                 }
 
                 if ((q->flags & SD_RESOLVED_NO_ADDRESS) == 0) {
-                        q->block_all_complete++;
                         r = resolve_service_hostname(q, rr, ifindex);
-                        q->block_all_complete--;
 
                         if (r < 0)
-                                goto finish;
+                                return r;
                 }
 
                 found++;
@@ -1290,23 +1276,15 @@ static void bus_method_resolve_service_complete(DnsQuery *query) {
                  * explicitly not offered on the domain. Report this as a recognizable error. See RFC 2782,
                  * Section "Usage Rules". */
                 r = reply_method_errorf(q, BUS_ERROR_NO_SUCH_SERVICE, "'%s' does not provide the requested service", dns_query_string(q));
-                goto finish;
+                return r;
         }
 
         if (found <= 0) {
                 r = reply_method_errorf(q, BUS_ERROR_NO_SUCH_RR, "'%s' does not have any RR of the requested type", dns_query_string(q));
-                goto finish;
+                return r;
         }
 
-        /* Maybe we are already finished? check now... */
-        resolve_service_all_complete(TAKE_PTR(q));
-        return;
-
-finish:
-        if (r < 0) {
-                log_error_errno(r, "Failed to send service reply: %m");
-                (void) reply_method_errnof(q, r, NULL);
-        }
+        return 0;
 }
 
 static int bus_method_resolve_service(sd_bus_message *message, void *userdata, sd_bus_error *error) {
@@ -1374,7 +1352,6 @@ static int bus_method_resolve_service(sd_bus_message *message, void *userdata, s
 
         q->bus_request = sd_bus_message_ref(message);
         q->request_family = family;
-        q->complete = bus_method_resolve_service_complete;
 
         r = dns_query_bus_track(q, message);
         if (r < 0)
@@ -1384,8 +1361,35 @@ static int bus_method_resolve_service(sd_bus_message *message, void *userdata, s
         if (r < 0)
                 return r;
 
-        TAKE_PTR(q);
-        return 1;
+        for (;;) {
+                r = dns_query_await(q);
+                if (r < 0)
+                        return r;
+
+                if (q->state != DNS_TRANSACTION_SUCCESS)
+                        break;
+
+                r = dns_query_process_cname_many(q);
+                if (r == -ELOOP)
+                        return reply_method_errorf(q, BUS_ERROR_CNAME_LOOP, "CNAME loop detected, or CNAME resolving disabled on '%s'", dns_query_string(q));
+                if (r < 0)
+                        return r;
+                if (r != DNS_QUERY_CNAME)
+                        break;
+        }
+
+        if (!IN_SET(q->state, DNS_TRANSACTION_SUCCESS, DNS_TRANSACTION_NULL))
+                return reply_query_state(q);
+
+        r = resolve_service_start_auxiliary(q);
+        if (r != 0)
+                return r;
+
+        r = resolve_service_await_auxiliary(q);
+        if (r < 0)
+                return r;
+
+        return resolve_service_reply(q);
 }
 
 int bus_dns_server_append(
@@ -2195,17 +2199,17 @@ static const sd_bus_vtable resolve_vtable[] = {
                                 SD_BUS_ARGS("i", ifindex, "s", name, "i", family, "t", flags),
                                 SD_BUS_RESULT("a(iiay)", addresses, "s", canonical, "t", flags),
                                 bus_method_resolve_hostname,
-                                SD_BUS_VTABLE_UNPRIVILEGED),
+                                SD_BUS_VTABLE_UNPRIVILEGED|SD_BUS_VTABLE_METHOD_FIBER),
         SD_BUS_METHOD_WITH_ARGS("ResolveAddress",
                                 SD_BUS_ARGS("i",  ifindex, "i", family, "ay", address, "t", flags),
                                 SD_BUS_RESULT("a(is)", names, "t", flags),
                                 bus_method_resolve_address,
-                                SD_BUS_VTABLE_UNPRIVILEGED),
+                                SD_BUS_VTABLE_UNPRIVILEGED|SD_BUS_VTABLE_METHOD_FIBER),
         SD_BUS_METHOD_WITH_ARGS("ResolveRecord",
                                 SD_BUS_ARGS("i", ifindex, "s", name, "q", class, "q", type, "t", flags),
                                 SD_BUS_RESULT("a(iqqay)", records, "t", flags),
                                 bus_method_resolve_record,
-                                SD_BUS_VTABLE_UNPRIVILEGED),
+                                SD_BUS_VTABLE_UNPRIVILEGED|SD_BUS_VTABLE_METHOD_FIBER),
         SD_BUS_METHOD_WITH_ARGS("ResolveService",
                                 SD_BUS_ARGS("i", ifindex,
                                             "s", name,
@@ -2220,7 +2224,7 @@ static const sd_bus_vtable resolve_vtable[] = {
                                               "s", canonical_domain,
                                               "t", flags),
                                 bus_method_resolve_service,
-                                SD_BUS_VTABLE_UNPRIVILEGED),
+                                SD_BUS_VTABLE_UNPRIVILEGED|SD_BUS_VTABLE_METHOD_FIBER),
         SD_BUS_METHOD_WITH_ARGS("GetLink",
                                 SD_BUS_ARGS("i", ifindex),
                                 SD_BUS_RESULT("o", path),

--- a/src/resolve/resolved-dns-browse-services.c
+++ b/src/resolve/resolved-dns-browse-services.c
@@ -1,5 +1,7 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
+#include "sd-future.h"
+
 #include "af-list.h"
 #include "alloc-util.h"
 #include "dns-domain.h"
@@ -78,29 +80,45 @@ static usec_t mdns_maintenance_jitter(uint32_t ttl) {
         return random_u64_range(2 * ttl * USEC_PER_SEC / 100);
 }
 
-static void mdns_maintenance_query_complete(DnsQuery *q) {
+static void mdns_query_fiber_destroy(void *userdata) {
+        dns_query_free(userdata);
+}
+
+static int mdns_spawn_query_fiber(DnsQuery *q, const char *name, sd_fiber_func_t func) {
+        assert(q);
+        assert(q->manager);
+
+        return sd_fiber_new(q->manager->event, name, func, q, mdns_query_fiber_destroy, /* ret= */ NULL);
+}
+
+static int mdns_maintenance_query_fiber(void *userdata) {
+        DnsQuery *query = ASSERT_PTR(userdata);
         _cleanup_(dns_service_browser_unrefp) DnsServiceBrowser *sb = NULL;
-        _cleanup_(dns_query_freep) DnsQuery *query = q;
-        DnssdDiscoveredService *service = NULL;
+        _cleanup_(dnssd_discovered_service_unrefp) DnssdDiscoveredService *service = NULL;
         int r;
 
-        assert(query);
         assert(query->manager);
 
+        r = dns_query_await(query);
+        if (r < 0)
+                return r;
+
         if (query->state != DNS_TRANSACTION_SUCCESS)
-                return;
+                return 0;
+
+        sb = dns_service_browser_ref(query->service_browser_request);
+        if (!sb)
+                return 0;
 
         service = dnssd_discovered_service_ref(query->dnsservice_request);
         if (!service)
-                return;
-
-        sb = dns_service_browser_ref(service->service_browser);
-        if (!sb)
-                return;
+                return 0;
 
         r = mdns_browser_revisit_cache(sb, query->answer_family);
         if (r < 0)
-                return (void) log_error_errno(r, "Failed to revisit cache for family %s: %m", af_to_name(query->answer_family));
+                log_error_errno(r, "Failed to revisit cache for family %s: %m", af_to_name(query->answer_family));
+
+        return 0;
 }
 
 static int mdns_maintenance_query(sd_event_source *s, uint64_t usec, void *userdata) {
@@ -125,9 +143,9 @@ static int mdns_maintenance_query(sd_event_source *s, uint64_t usec, void *userd
         if (r < 0)
                 return log_error_errno(r, "Failed to create mDNS query for maintenance: %m");
 
-        q->complete = mdns_maintenance_query_complete;
         q->varlink_request = sd_varlink_ref(service->service_browser->link);
         q->dnsservice_request = dnssd_discovered_service_ref(service);
+        q->service_browser_request = dns_service_browser_ref(service->service_browser);
 
         /* Schedule the next maintenance query based on the TTL */
         usec_t next_time = mdns_maintenance_next_time(service->until, service->rr->ttl, service->rr_ttl_state);
@@ -150,6 +168,10 @@ static int mdns_maintenance_query(sd_event_source *s, uint64_t usec, void *userd
         r = dns_query_go(q);
         if (r < 0)
                 return log_error_errno(r, "Failed to send mDNS maintenance query: %m");
+
+        r = mdns_spawn_query_fiber(q, "mdns-maintenance-query", mdns_maintenance_query_fiber);
+        if (r < 0)
+                return log_error_errno(r, "Failed to spawn mDNS maintenance query fiber: %m");
 
         TAKE_PTR(q);
         return 0;
@@ -593,24 +615,29 @@ int mdns_notify_browsers_unsolicited_updates(Manager *m, DnsAnswer *answer, int 
         return 0;
 }
 
-static void mdns_browse_service_query_complete(DnsQuery *q) {
+static int mdns_browse_service_query_fiber(void *userdata) {
+        DnsQuery *query = ASSERT_PTR(userdata);
         _cleanup_(dns_service_browser_unrefp) DnsServiceBrowser *sb = NULL;
-        _cleanup_(dns_query_freep) DnsQuery *query = q;
         int r;
 
-        assert(query);
         assert(query->manager);
 
+        r = dns_query_await(query);
+        if (r < 0)
+                return r;
+
         if (query->state != DNS_TRANSACTION_SUCCESS)
-                return;
+                return 0;
 
         sb = dns_service_browser_ref(query->service_browser_request);
         if (!sb)
-                return;
+                return 0;
 
         r = mdns_browser_revisit_cache(sb, query->answer_family);
-        if (r < 0)
-                return (void) log_error_errno(r, "Failed to revisit cache for service browser: %m");
+        if (r < 0) {
+                log_error_errno(r, "Failed to revisit cache for service browser: %m");
+                return 0;
+        }
 
         /* When the query is answered from cache, we only get answers for one
          * answer_family i.e. either ipv4 or ipv6. We need to perform another
@@ -618,8 +645,10 @@ static void mdns_browse_service_query_complete(DnsQuery *q) {
         if (query->answer_query_flags == SD_RESOLVED_FROM_CACHE) {
                 r = mdns_browser_revisit_cache(sb, query->answer_family == AF_INET ? AF_INET6 : AF_INET);
                 if (r < 0)
-                        return (void) log_error_errno(r, "Failed to revisit cache for service browser: %m");
+                        log_error_errno(r, "Failed to revisit cache for service browser: %m");
         }
+
+        return 0;
 }
 
 static int mdns_next_query_schedule(sd_event_source *s, uint64_t usec, void *userdata) {
@@ -643,7 +672,6 @@ static int mdns_next_query_schedule(sd_event_source *s, uint64_t usec, void *use
         if (r < 0)
                 return log_error_errno(r, "Failed to create new DNS query: %m");
 
-        q->complete = mdns_browse_service_query_complete;
         q->service_browser_request = dns_service_browser_ref(sb);
         q->varlink_request = sd_varlink_ref(sb->link);
         sd_varlink_set_userdata(sb->link, q);
@@ -670,6 +698,10 @@ static int mdns_next_query_schedule(sd_event_source *s, uint64_t usec, void *use
                         /* force_reset= */ true);
         if (r < 0)
                 return log_error_errno(r, "Failed to reset event time for next query schedule: %m");
+
+        r = mdns_spawn_query_fiber(q, "mdns-browse-service-query", mdns_browse_service_query_fiber);
+        if (r < 0)
+                return log_error_errno(r, "Failed to spawn mDNS browse service query fiber: %m");
 
         TAKE_PTR(q);
 

--- a/src/resolve/resolved-dns-query.c
+++ b/src/resolve/resolved-dns-query.c
@@ -320,6 +320,10 @@ int dns_query_candidate_await(DnsQueryCandidate *c) {
 
         assert(c);
 
+        DnsTransactionState state = dns_query_candidate_state(c);
+        if (!DNS_TRANSACTION_IS_LIVE(state))
+                return state;
+
         r = dns_query_candidate_get_completion_future(c, &f);
         if (r < 0)
                 return r;
@@ -882,7 +886,13 @@ int dns_query_await(DnsQuery *q) {
                 if (r < 0)
                         return r;
 
-                return sd_fiber_await(f);
+                r = sd_fiber_await(f);
+                if (r < 0)
+                        return r;
+                if (DNS_TRANSACTION_IS_LIVE(q->state))
+                        continue;
+
+                return q->state;
         }
 }
 

--- a/src/resolve/resolved-dns-query.c
+++ b/src/resolve/resolved-dns-query.c
@@ -19,6 +19,7 @@
 #include "resolved-dns-synthesize.h"
 #include "resolved-dns-transaction.h"
 #include "resolved-etc-hosts.h"
+#include "resolved-fiber-util.h"
 #include "resolved-hook.h"
 #include "resolved-manager.h"
 #include "resolved-static-records.h"
@@ -79,6 +80,8 @@ static void dns_query_candidate_abandon(DnsQueryCandidate *c) {
         assert(c);
 
         (void) event_source_disable(c->timeout_event_source);
+        if (c->completion_future)
+                (void) sd_future_resolve(c->completion_future, -ECANCELED);
 
         /* Abandon all the DnsTransactions attached to this query */
 
@@ -113,6 +116,9 @@ static DnsQueryCandidate* dns_query_candidate_free(DnsQueryCandidate *c) {
                 return NULL;
 
         c->timeout_event_source = sd_event_source_disable_unref(c->timeout_event_source);
+        if (c->completion_future)
+                (void) sd_future_resolve(c->completion_future, -ECANCELED);
+        c->completion_future = sd_future_unref(c->completion_future);
 
         dns_query_candidate_stop(c);
         dns_query_candidate_unlink(c);
@@ -281,6 +287,46 @@ static DnsTransactionState dns_query_candidate_state(DnsQueryCandidate *c) {
         return state;
 }
 
+static void dns_query_candidate_resolve(DnsQueryCandidate *c, int result) {
+        assert(c);
+
+        if (c->completion_future)
+                (void) sd_future_resolve(c->completion_future, result);
+}
+
+int dns_query_candidate_get_completion_future(DnsQueryCandidate *c, sd_future **ret) {
+        int r;
+
+        assert(c);
+        assert(ret);
+
+        if (!c->completion_future) {
+                r = resolved_future_new(&c->completion_future);
+                if (r < 0)
+                        return r;
+
+                DnsTransactionState state = dns_query_candidate_state(c);
+                if (!DNS_TRANSACTION_IS_LIVE(state))
+                        (void) sd_future_resolve(c->completion_future, state);
+        }
+
+        *ret = sd_future_ref(c->completion_future);
+        return 0;
+}
+
+int dns_query_candidate_await(DnsQueryCandidate *c) {
+        _cleanup_(sd_future_unrefp) sd_future *f = NULL;
+        int r;
+
+        assert(c);
+
+        r = dns_query_candidate_get_completion_future(c, &f);
+        if (r < 0)
+                return r;
+
+        return sd_fiber_await(f);
+}
+
 static int dns_query_candidate_setup_transactions(DnsQueryCandidate *c) {
         DnsQuestion *question;
         DnsResourceKey *key;
@@ -418,11 +464,13 @@ void dns_query_candidate_notify(DnsQueryCandidate *c) {
 
         }
 
+        dns_query_candidate_resolve(c, state);
         dns_query_ready(c->query);
         return;
 
 fail:
         c->error_code = log_warning_errno(r, "Failed to follow search domains: %m");
+        dns_query_candidate_resolve(c, DNS_TRANSACTION_ERRNO);
         dns_query_ready(c->query);
 }
 
@@ -440,6 +488,8 @@ static void dns_query_abandon(DnsQuery *q) {
 
         /* Thankfully transactions have their own timeouts */
         event_source_disable(q->timeout_event_source);
+
+        hook_query_abort(q->hook_query);
 
         LIST_FOREACH(candidates_by_query, c, q->candidates)
                 dns_query_candidate_abandon(c);
@@ -475,6 +525,9 @@ DnsQuery *dns_query_free(DnsQuery *q) {
                 return NULL;
 
         q->timeout_event_source = sd_event_source_disable_unref(q->timeout_event_source);
+        if (q->completion_future)
+                (void) sd_future_resolve(q->completion_future, -ECANCELED);
+        q->completion_future = sd_future_unref(q->completion_future);
 
         while (q->auxiliary_queries)
                 dns_query_free(q->auxiliary_queries);
@@ -493,6 +546,8 @@ DnsQuery *dns_query_free(DnsQuery *q) {
         dns_question_unref(q->collected_questions);
 
         dns_query_reset_answer(q);
+
+        free(q->auxiliary_name);
 
         sd_bus_message_unref(q->bus_request);
         sd_bus_track_unref(q->bus_track);
@@ -779,8 +834,56 @@ void dns_query_complete(DnsQuery *q, DnsTransactionState state) {
         (void) manager_monitor_send(q->manager, q);
 
         dns_query_abandon(q);
-        if (q->complete)
-                q->complete(q);
+        if (q->completion_future)
+                (void) sd_future_resolve(q->completion_future, state);
+}
+
+int dns_query_get_completion_future(DnsQuery *q, sd_future **ret) {
+        int r;
+
+        assert(q);
+        assert(ret);
+
+        if (!q->completion_future) {
+                r = resolved_future_new(&q->completion_future);
+                if (r < 0)
+                        return r;
+
+                if (!DNS_TRANSACTION_IS_LIVE(q->state))
+                        (void) sd_future_resolve(q->completion_future, q->state);
+        }
+
+        *ret = sd_future_ref(q->completion_future);
+        return 0;
+}
+
+static int dns_query_process_hook_result(DnsQuery *q);
+
+int dns_query_await(DnsQuery *q) {
+        int r;
+
+        assert(q);
+
+        for (;;) {
+                _cleanup_(sd_future_unrefp) sd_future *f = NULL;
+
+                if (!DNS_TRANSACTION_IS_LIVE(q->state))
+                        return q->state;
+
+                if (q->hook_query) {
+                        r = dns_query_process_hook_result(q);
+                        if (r < 0)
+                                return r;
+
+                        continue;
+                }
+
+                r = dns_query_get_completion_future(q, &f);
+                if (r < 0)
+                        return r;
+
+                return sd_fiber_await(f);
+        }
 }
 
 static int on_query_timeout(sd_event_source *s, usec_t usec, void *userdata) {
@@ -1023,18 +1126,31 @@ fail:
         return r;
 }
 
-static void on_hook_complete(HookQuery *hq, int rcode, DnsAnswer *answer, void *userdata) {
-        DnsQuery *q = ASSERT_PTR(userdata);
+static int dns_query_process_hook_result(DnsQuery *q) {
+        _cleanup_(hook_query_freep) HookQuery *finished = NULL;
+        _cleanup_(dns_answer_unrefp) DnsAnswer *answer = NULL;
+        HookQuery *hq;
         int r;
+        int rcode;
 
-        assert(hq);
-        assert(q->hook_query == hq);
+        assert(q);
+        assert(q->hook_query);
         assert(q->state == DNS_TRANSACTION_NULL);
 
-        q->hook_query = hook_query_free(q->hook_query);
-        TAKE_PTR(hq);
+        hq = q->hook_query;
 
-        if (rcode < 0) {
+        r = hook_query_await(hq);
+        if (!DNS_TRANSACTION_IS_LIVE(q->state))
+                return q->state;
+        if (r < 0 && r != -ENODATA) {
+                q->hook_query = hook_query_free(q->hook_query);
+                return r;
+        }
+
+        finished = TAKE_PTR(q->hook_query);
+
+        r = hook_query_get_result(finished, &rcode, &answer);
+        if (r == -ENODATA) {
                 log_debug("Hook yielded no results, proceeding.");
                 r = dns_query_go_scopes(q);
                 if (r < 0) {
@@ -1043,17 +1159,21 @@ static void on_hook_complete(HookQuery *hq, int rcode, DnsAnswer *answer, void *
                         dns_query_complete(q, DNS_TRANSACTION_ERRNO);
                 }
 
-                return;
+                return 0;
         }
+        if (r < 0)
+                return r;
 
         dns_query_reset_answer(q);
 
-        q->answer = dns_answer_ref(answer);
+        q->answer = TAKE_PTR(answer);
         q->answer_rcode = rcode;
         q->answer_protocol = dns_synthesize_protocol(q->flags);
         q->answer_family = dns_synthesize_family(q->flags);
         q->answer_query_flags = SD_RESOLVED_FROM_HOOK;
         dns_query_complete(q, rcode == DNS_RCODE_SUCCESS ? DNS_TRANSACTION_SUCCESS : DNS_TRANSACTION_RCODE_FAILURE);
+
+        return 0;
 }
 
 int dns_query_go(DnsQuery *q) {
@@ -1065,6 +1185,9 @@ int dns_query_go(DnsQuery *q) {
         if (q->hook_query ||
             q->state != DNS_TRANSACTION_NULL)
                 return 0;
+
+        if (q->completion_future && sd_future_state(q->completion_future) == SD_FUTURE_RESOLVED)
+                q->completion_future = sd_future_unref(q->completion_future);
 
         r = dns_query_try_static_records(q);
         if (r < 0)
@@ -1086,8 +1209,6 @@ int dns_query_go(DnsQuery *q) {
                         q->manager,
                         q->question_bypass ? q->question_bypass->question : q->question_idna,
                         q->question_bypass ? q->question_bypass->question : q->question_utf8,
-                        on_hook_complete,
-                        q,
                         &q->hook_query);
         if (r < 0)
                 return r;
@@ -1215,6 +1336,7 @@ static void dns_query_accept(DnsQuery *q, DnsQueryCandidate *c) {
         if (r < 0)
                 goto fail;
 
+        dns_query_candidate_resolve(c, state);
         dns_query_complete(q, state);
         return;
 

--- a/src/resolve/resolved-dns-query.h
+++ b/src/resolve/resolved-dns-query.h
@@ -4,6 +4,7 @@
 #include "dns-packet.h"
 #include "in-addr-util.h"
 #include "list.h"
+#include "sd-future.h"
 #include "resolved-dns-browse-services.h"
 #include "resolved-dns-transaction.h"
 #include "resolved-forward.h"
@@ -20,6 +21,7 @@ typedef struct DnsQueryCandidate {
 
         Set *transactions;
         sd_event_source *timeout_event_source;
+        sd_future *completion_future;
 
         LIST_FIELDS(DnsQueryCandidate, candidates_by_query);
         LIST_FIELDS(DnsQueryCandidate, candidates_by_scope);
@@ -59,11 +61,13 @@ typedef struct DnsQuery {
          * auxiliary A+AAAA queries. This pointer always points from the auxiliary queries back to the
          * TXT+SRV query. */
         int auxiliary_result;
+        char *auxiliary_name;
         DnsQuery *auxiliary_for;
         LIST_HEAD(DnsQuery, auxiliary_queries);
 
         LIST_HEAD(DnsQueryCandidate, candidates);
         sd_event_source *timeout_event_source;
+        sd_future *completion_future;
 
         /* Discovered data */
         DnsAnswer *answer;
@@ -113,9 +117,6 @@ typedef struct DnsQuery {
         /* Pending query to any installed hooks */
         HookQuery *hook_query;
 
-        /* Completion callback */
-        void (*complete)(DnsQuery* q);
-
         sd_bus_track *bus_track;
 
         LIST_FIELDS(DnsQuery, queries);
@@ -134,6 +135,8 @@ DECLARE_TRIVIAL_REF_UNREF_FUNC(DnsQueryCandidate, dns_query_candidate);
 DEFINE_TRIVIAL_CLEANUP_FUNC(DnsQueryCandidate*, dns_query_candidate_unref);
 
 void dns_query_candidate_notify(DnsQueryCandidate *c);
+int dns_query_candidate_get_completion_future(DnsQueryCandidate *c, sd_future **ret);
+int dns_query_candidate_await(DnsQueryCandidate *c);
 
 int dns_query_new(Manager *m, DnsQuery **ret, DnsQuestion *question_utf8, DnsQuestion *question_idna, DnsPacket *question_bypass, int ifindex, uint64_t flags);
 DnsQuery *dns_query_free(DnsQuery *q);
@@ -142,6 +145,8 @@ int dns_query_make_auxiliary(DnsQuery *q, DnsQuery *auxiliary_for);
 
 int dns_query_go(DnsQuery *q);
 void dns_query_ready(DnsQuery *q);
+int dns_query_get_completion_future(DnsQuery *q, sd_future **ret);
+int dns_query_await(DnsQuery *q);
 
 int dns_query_process_cname_one(DnsQuery *q);
 int dns_query_process_cname_many(DnsQuery *q);

--- a/src/resolve/resolved-dns-query.h
+++ b/src/resolve/resolved-dns-query.h
@@ -99,7 +99,6 @@ typedef struct DnsQuery {
         sd_varlink *varlink_request;
         int request_family;
         union in_addr_union request_address;
-        unsigned block_all_complete;
         char *request_address_string;
 
         /* DNS stub information */

--- a/src/resolve/resolved-dns-stream.c
+++ b/src/resolve/resolved-dns-stream.c
@@ -641,6 +641,9 @@ int dns_stream_await(DnsStream *s) {
 
         assert(s);
 
+        if (s->completed)
+                return s->completion_result;
+
         r = dns_stream_get_completion_future(s, &f);
         if (r < 0)
                 return r;

--- a/src/resolve/resolved-dns-stream.c
+++ b/src/resolve/resolved-dns-stream.c
@@ -14,6 +14,7 @@
 #include "ordered-set.h"
 #include "resolved-dns-server.h"
 #include "resolved-dns-stream.h"
+#include "resolved-fiber-util.h"
 #include "resolved-manager.h"
 #include "set.h"
 #include "time-util.h"
@@ -87,9 +88,12 @@ static int dns_stream_complete(DnsStream *s, int error) {
 
         dns_stream_detach(s);
 
-        if (s->complete)
-                s->complete(s, error);
-        else /* the default action if no completion function is set is to close the stream */
+        s->completed = true;
+        s->completion_result = error == 0 ? 0 : -error;
+
+        if (s->completion_future)
+                (void) sd_future_resolve(s->completion_future, s->completion_result);
+        else /* the default action without a completion waiter is to close the stream */
                 dns_stream_unref(s);
 
         return 0;
@@ -500,6 +504,9 @@ static DnsStream *dns_stream_free(DnsStream *s) {
         dns_packet_unref(s->write_packet);
         dns_packet_unref(s->read_packet);
         dns_server_unref(s->server);
+        if (s->completion_future)
+                (void) sd_future_resolve(s->completion_future, -ECANCELED);
+        s->completion_future = sd_future_unref(s->completion_future);
 
         ordered_set_free(s->write_queue);
 
@@ -516,7 +523,6 @@ int dns_stream_new(
                 int fd,
                 const union sockaddr_union *tfo_address,
                 int (on_packet)(DnsStream*, DnsPacket*),
-                int (complete)(DnsStream*, int), /* optional */
                 usec_t connect_timeout_usec) {
 
         _cleanup_(dns_stream_unrefp) DnsStream *s = NULL;
@@ -572,7 +578,6 @@ int dns_stream_new(
 
         s->fd = fd;
         s->on_packet = on_packet;
-        s->complete = complete;
 
         if (tfo_address) {
                 s->tfo_address = *tfo_address;
@@ -609,6 +614,38 @@ void dns_stream_detach(DnsStream *s) {
                 return;
 
         dns_server_unref_stream(s->server);
+}
+
+int dns_stream_get_completion_future(DnsStream *s, sd_future **ret) {
+        int r;
+
+        assert(s);
+        assert(ret);
+
+        if (!s->completion_future) {
+                r = resolved_future_new(&s->completion_future);
+                if (r < 0)
+                        return r;
+
+                if (s->completed)
+                        (void) sd_future_resolve(s->completion_future, s->completion_result);
+        }
+
+        *ret = sd_future_ref(s->completion_future);
+        return 0;
+}
+
+int dns_stream_await(DnsStream *s) {
+        _cleanup_(sd_future_unrefp) sd_future *f = NULL;
+        int r;
+
+        assert(s);
+
+        r = dns_stream_get_completion_future(s, &f);
+        if (r < 0)
+                return r;
+
+        return sd_fiber_await(f);
 }
 
 DEFINE_PRIVATE_HASH_OPS_WITH_KEY_DESTRUCTOR(

--- a/src/resolve/resolved-dns-stream.h
+++ b/src/resolve/resolved-dns-stream.h
@@ -3,6 +3,7 @@
 
 #include "dns-packet.h"
 #include "list.h"
+#include "sd-future.h"
 #include "resolved-dnstls.h"
 #include "resolved-forward.h"
 #include "socket-util.h"
@@ -68,6 +69,8 @@ typedef struct DnsStream {
 
         sd_event_source *io_event_source;
         sd_event_source *timeout_event_source;
+        sd_future *completion_future;
+        int completion_result;
 
         be16_t write_size, read_size;
         DnsPacket *write_packet, *read_packet;
@@ -75,7 +78,6 @@ typedef struct DnsStream {
         OrderedSet *write_queue;
 
         int (*on_packet)(DnsStream *s, DnsPacket *p);
-        int (*complete)(DnsStream *s, int error);
 
         LIST_HEAD(DnsTransaction, transactions); /* when used by the transaction logic */
         DnsServer *server;                       /* when used by the transaction logic */
@@ -83,6 +85,7 @@ typedef struct DnsStream {
 
         /* used when DNS-over-TLS is enabled */
         bool encrypted:1;
+        bool completed:1;
 
         DnsStubListenerExtra *stub_listener_extra;
 
@@ -97,7 +100,6 @@ int dns_stream_new(
                 int fd,
                 const union sockaddr_union *tfo_address,
                 int (on_packet)(DnsStream*, DnsPacket*),
-                int (complete)(DnsStream*, int), /* optional */
                 usec_t connect_timeout_usec);
 #if ENABLE_DNS_OVER_TLS
 int dns_stream_connect_tls(DnsStream *s, void *tls_session);
@@ -107,6 +109,8 @@ DECLARE_TRIVIAL_REF_UNREF_FUNC(DnsStream, dns_stream);
 DEFINE_TRIVIAL_CLEANUP_FUNC(DnsStream*, dns_stream_unref);
 
 int dns_stream_write_packet(DnsStream *s, DnsPacket *p);
+int dns_stream_get_completion_future(DnsStream *s, sd_future **ret);
+int dns_stream_await(DnsStream *s);
 ssize_t dns_stream_writev(DnsStream *s, const struct iovec *iov, size_t iovcnt, int flags);
 
 static inline bool DNS_STREAM_QUEUED(DnsStream *s) {

--- a/src/resolve/resolved-dns-stub.c
+++ b/src/resolve/resolved-dns-stub.c
@@ -752,8 +752,25 @@ static int dns_stub_patch_bypass_reply_packet(
         return 0;
 }
 
-static void dns_stub_query_complete(DnsQuery *query) {
-        _cleanup_(dns_query_freep) DnsQuery *q = query;
+typedef struct DnsStubQueryFiberData {
+        DnsQuery *query;
+} DnsStubQueryFiberData;
+
+static DnsStubQueryFiberData* dns_stub_query_fiber_data_free(DnsStubQueryFiberData *d) {
+        if (!d)
+                return NULL;
+
+        dns_query_free(d->query);
+        return mfree(d);
+}
+
+DEFINE_TRIVIAL_CLEANUP_FUNC(DnsStubQueryFiberData*, dns_stub_query_fiber_data_free);
+
+static void dns_stub_query_fiber_data_destroy(void *userdata) {
+        dns_stub_query_fiber_data_free(userdata);
+}
+
+static int dns_stub_query_process(DnsQuery *q) {
         int r;
 
         assert(q);
@@ -776,7 +793,7 @@ static void dns_stub_query_complete(DnsQuery *query) {
                         else
                                 (void) dns_stub_send(q->manager, q->stub_listener_extra, q->request_stream, q->request_packet, reply);
 
-                        return;
+                        return 0;
                 }
         }
 
@@ -788,7 +805,7 @@ static void dns_stub_query_complete(DnsQuery *query) {
                         dns_query_question_for_protocol(q, DNS_PROTOCOL_DNS),
                         dns_stub_reply_with_edns0_do(q));
         if (r < 0)
-                return (void) log_debug_errno(r, "Failed to assign sections: %m");
+                return log_debug_errno(r, "Failed to assign sections: %m");
 
         switch (q->state) {
 
@@ -823,10 +840,9 @@ static void dns_stub_query_complete(DnsQuery *query) {
                                  * now with the redirected question. We'll */
                                 r = dns_query_go(q);
                                 if (r < 0)
-                                        return (void) log_debug_errno(r, "Failed to restart query: %m");
+                                        return log_debug_errno(r, "Failed to restart query: %m");
 
-                                TAKE_PTR(q);
-                                return;
+                                return 1;
                         }
 
                         r = dns_stub_assign_sections(
@@ -834,7 +850,7 @@ static void dns_stub_query_complete(DnsQuery *query) {
                                         dns_query_question_for_protocol(q, DNS_PROTOCOL_DNS),
                                         dns_stub_reply_with_edns0_do(q));
                         if (r < 0)
-                                return (void) log_debug_errno(r, "Failed to assign sections: %m");
+                                return log_debug_errno(r, "Failed to assign sections: %m");
 
                         if (cname_result == DNS_QUERY_MATCH) /* A match? Then we are done, let's return what we got */
                                 break;
@@ -888,27 +904,79 @@ static void dns_stub_query_complete(DnsQuery *query) {
         default:
                 assert_not_reached();
         }
+
+        return 0;
+}
+
+static int dns_stub_query_fiber(void *userdata) {
+        DnsStubQueryFiberData *data = ASSERT_PTR(userdata);
+        _cleanup_(dns_query_freep) DnsQuery *q = TAKE_PTR(data->query);
+        int r;
+
+        for (;;) {
+                r = dns_query_await(q);
+                if (r < 0)
+                        return r;
+
+                if (q->request_packet->ipproto == IPPROTO_TCP && !q->request_stream)
+                        return 0;
+
+                r = dns_stub_query_process(q);
+                if (r <= 0)
+                        return r;
+        }
 }
 
 static int dns_stub_stream_complete(DnsStream *s, int error) {
         assert(s);
 
-        log_debug_errno(error, "DNS TCP connection terminated, destroying queries: %m");
+        log_debug_errno(error, "DNS TCP connection terminated, aborting queries: %m");
 
         for (;;) {
                 DnsQuery *q;
 
-                q = set_first(s->queries);
+                q = set_steal_first(s->queries);
                 if (!q)
                         break;
 
-                dns_query_free(q);
+                assert(q->request_stream == s);
+
+                q->request_stream = dns_stream_unref(q->request_stream);
+
+                if (DNS_TRANSACTION_IS_LIVE(q->state))
+                        dns_query_complete(q, DNS_TRANSACTION_ABORTED);
         }
 
-        /* This drops the implicit ref we keep around since it was allocated, as incoming stub connections
-         * should be kept as long as the client wants to. */
-        dns_stream_unref(s);
         return 0;
+}
+
+static void dns_stub_stream_complete_fiber_destroy(void *userdata) {
+        dns_stream_unref(userdata);
+}
+
+static int dns_stub_stream_complete_fiber(void *userdata) {
+        DnsStream *s = ASSERT_PTR(userdata);
+        int r;
+
+        r = dns_stream_await(s);
+        if (r == -ECANCELED)
+                return 0;
+
+        return dns_stub_stream_complete(s, r < 0 ? -r : 0);
+}
+
+static int dns_stub_watch_stream(DnsStream *s) {
+        _cleanup_(sd_future_unrefp) sd_future *completion = NULL;
+        int r;
+
+        assert(s);
+        assert(s->manager);
+
+        r = dns_stream_get_completion_future(s, &completion);
+        if (r < 0)
+                return r;
+
+        return sd_fiber_new(s->manager->event, "dns-stub-stream-complete", dns_stub_stream_complete_fiber, s, dns_stub_stream_complete_fiber_destroy, NULL);
 }
 
 static void dns_stub_process_query(Manager *m, DnsStubListenerExtra *l, DnsStream *s, DnsPacket *p) {
@@ -1023,7 +1091,6 @@ static void dns_stub_process_query(Manager *m, DnsStubListenerExtra *l, DnsStrea
         q->request_packet = dns_packet_ref(p);
         q->request_stream = dns_stream_ref(s); /* make sure the stream stays around until we can send a reply through it */
         q->stub_listener_extra = l;
-        q->complete = dns_stub_query_complete;
 
         if (s) {
                 /* Remember which queries belong to this stream, so that we can cancel them when the stream
@@ -1049,8 +1116,26 @@ static void dns_stub_process_query(Manager *m, DnsStubListenerExtra *l, DnsStrea
                 return;
         }
 
+        _cleanup_(dns_stub_query_fiber_data_freep) DnsStubQueryFiberData *data = new(DnsStubQueryFiberData, 1);
+        if (!data) {
+                log_oom();
+                dns_stub_send_failure(m, l, s, p, DNS_RCODE_SERVFAIL, false);
+                return;
+        }
+
+        *data = (DnsStubQueryFiberData) {
+                .query = TAKE_PTR(q),
+        };
+
+        r = sd_fiber_new(m->event, "dns-stub-query", dns_stub_query_fiber, data, dns_stub_query_fiber_data_destroy, NULL);
+        if (r < 0) {
+                log_error_errno(r, "Failed to create stub query fiber: %m");
+                dns_stub_send_failure(m, l, s, p, DNS_RCODE_SERVFAIL, false);
+                return;
+        }
+
         log_debug("Processing query...");
-        TAKE_PTR(q);
+        TAKE_PTR(data);
 }
 
 static int on_dns_stub_packet_internal(sd_event_source *s, int fd, uint32_t revents, Manager *m, DnsStubListenerExtra *l) {
@@ -1097,7 +1182,7 @@ static int on_dns_stub_stream_packet(DnsStream *s, DnsPacket *p) {
 }
 
 static int on_dns_stub_stream_internal(sd_event_source *s, int fd, uint32_t revents, Manager *m, DnsStubListenerExtra *l) {
-        DnsStream *stream;
+        _cleanup_(dns_stream_unrefp) DnsStream *stream = NULL;
         int cfd, r;
 
         cfd = accept4(fd, NULL, NULL, SOCK_NONBLOCK|SOCK_CLOEXEC);
@@ -1109,7 +1194,7 @@ static int on_dns_stub_stream_internal(sd_event_source *s, int fd, uint32_t reve
         }
 
         r = dns_stream_new(m, &stream, DNS_STREAM_STUB, DNS_PROTOCOL_DNS, cfd, NULL,
-                           on_dns_stub_stream_packet, dns_stub_stream_complete, DNS_STREAM_STUB_TIMEOUT_USEC);
+                           on_dns_stub_stream_packet, DNS_STREAM_STUB_TIMEOUT_USEC);
         if (r < 0) {
                 safe_close(cfd);
                 return r;
@@ -1117,7 +1202,13 @@ static int on_dns_stub_stream_internal(sd_event_source *s, int fd, uint32_t reve
 
         stream->stub_listener_extra = l;
 
-        /* We let the reference to the stream dangle here, it will be dropped later by the complete callback. */
+        r = dns_stub_watch_stream(stream);
+        if (r < 0)
+                return r;
+
+        /* The stream-completion fiber now owns the implicit ref, keeping incoming stub connections alive
+         * for as long as the client wants to keep them open. */
+        TAKE_PTR(stream);
 
         return 0;
 }

--- a/src/resolve/resolved-dns-transaction.c
+++ b/src/resolve/resolved-dns-transaction.c
@@ -23,6 +23,7 @@
 #include "resolved-dns-stream.h"
 #include "resolved-dns-transaction.h"
 #include "resolved-dnstls.h"
+#include "resolved-fiber-util.h"
 #include "resolved-link.h"
 #include "resolved-llmnr.h"
 #include "resolved-manager.h"
@@ -125,6 +126,9 @@ DnsTransaction* dns_transaction_free(DnsTransaction *t) {
 
         dns_transaction_close_connection(t, true);
         dns_transaction_stop_timeout(t);
+        if (t->completion_future)
+                (void) sd_future_resolve(t->completion_future, -ECANCELED);
+        t->completion_future = sd_future_unref(t->completion_future);
 
         dns_packet_unref(t->sent);
         dns_transaction_reset_answer(t);
@@ -451,6 +455,9 @@ void dns_transaction_complete(DnsTransaction *t, DnsTransactionState state) {
          * transaction isn't freed while we are still looking at it */
         t->block_gc++;
 
+        if (t->completion_future)
+                (void) sd_future_resolve(t->completion_future, state);
+
         SET_FOREACH_MOVE(c, t->notify_query_candidates_done, t->notify_query_candidates)
                 dns_query_candidate_notify(c);
         SWAP_TWO(t->notify_query_candidates, t->notify_query_candidates_done);
@@ -467,6 +474,38 @@ void dns_transaction_complete(DnsTransaction *t, DnsTransactionState state) {
 
         t->block_gc--;
         dns_transaction_gc(t);
+}
+
+int dns_transaction_get_completion_future(DnsTransaction *t, sd_future **ret) {
+        int r;
+
+        assert(t);
+        assert(ret);
+
+        if (!t->completion_future) {
+                r = resolved_future_new(&t->completion_future);
+                if (r < 0)
+                        return r;
+
+                if (!DNS_TRANSACTION_IS_LIVE(t->state))
+                        (void) sd_future_resolve(t->completion_future, t->state);
+        }
+
+        *ret = sd_future_ref(t->completion_future);
+        return 0;
+}
+
+int dns_transaction_await(DnsTransaction *t) {
+        _cleanup_(sd_future_unrefp) sd_future *f = NULL;
+        int r;
+
+        assert(t);
+
+        r = dns_transaction_get_completion_future(t, &f);
+        if (r < 0)
+                return r;
+
+        return sd_fiber_await(f);
 }
 
 static void dns_transaction_complete_errno(DnsTransaction *t, int error) {
@@ -665,6 +704,43 @@ static int on_stream_complete(DnsStream *s, int error) {
         return 0;
 }
 
+static void on_stream_complete_fiber_destroy(void *userdata) {
+        dns_stream_unref(userdata);
+}
+
+static int on_stream_complete_fiber(void *userdata) {
+        DnsStream *s = ASSERT_PTR(userdata);
+        int r;
+
+        r = dns_stream_await(s);
+        if (r == -ECANCELED)
+                return 0;
+
+        return on_stream_complete(s, r < 0 ? -r : 0);
+}
+
+static int dns_transaction_watch_stream(DnsStream *s) {
+        _cleanup_(sd_future_unrefp) sd_future *completion = NULL;
+        DnsStream *ref;
+        int r;
+
+        assert(s);
+        assert(s->manager);
+
+        r = dns_stream_get_completion_future(s, &completion);
+        if (r < 0)
+                return r;
+
+        ref = dns_stream_ref(s);
+        r = sd_fiber_new(s->manager->event, "dns-transaction-stream-complete", on_stream_complete_fiber, ref, on_stream_complete_fiber_destroy, NULL);
+        if (r < 0) {
+                dns_stream_unref(ref);
+                return r;
+        }
+
+        return 0;
+}
+
 static int on_stream_packet(DnsStream *s, DnsPacket *p) {
         DnsTransaction *t;
 
@@ -774,7 +850,7 @@ static int dns_transaction_emit_tcp(DnsTransaction *t) {
                         return fd;
 
                 r = dns_stream_new(t->scope->manager, &s, type, t->scope->protocol, fd, &sa,
-                                   on_stream_packet, on_stream_complete, stream_timeout_usec);
+                                   on_stream_packet, stream_timeout_usec);
                 if (r < 0)
                         return r;
 
@@ -791,16 +867,20 @@ static int dns_transaction_emit_tcp(DnsTransaction *t) {
                 }
 #endif
 
+                /* The interface index is difficult to determine if we are
+                 * connecting to the local host, hence fill this in right away
+                 * instead of determining it from the socket */
+                s->ifindex = dns_scope_ifindex(t->scope);
+
+                r = dns_transaction_watch_stream(s);
+                if (r < 0)
+                        return r;
+
                 if (t->server) {
                         dns_server_unref_stream(t->server);
                         s->server = dns_server_ref(t->server);
                         t->server->stream = dns_stream_ref(s);
                 }
-
-                /* The interface index is difficult to determine if we are
-                 * connecting to the local host, hence fill this in right away
-                 * instead of determining it from the socket */
-                s->ifindex = dns_scope_ifindex(t->scope);
         }
 
         t->stream = TAKE_PTR(s);

--- a/src/resolve/resolved-dns-transaction.c
+++ b/src/resolve/resolved-dns-transaction.c
@@ -501,6 +501,9 @@ int dns_transaction_await(DnsTransaction *t) {
 
         assert(t);
 
+        if (!DNS_TRANSACTION_IS_LIVE(t->state))
+                return t->state;
+
         r = dns_transaction_get_completion_future(t, &f);
         if (r < 0)
                 return r;

--- a/src/resolve/resolved-dns-transaction.h
+++ b/src/resolve/resolved-dns-transaction.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "list.h"
+#include "sd-future.h"
 #include "resolved-def.h"
 #include "resolved-dns-dnssec.h"
 #include "resolved-dns-server.h"
@@ -76,6 +77,7 @@ typedef struct DnsTransaction {
         usec_t start_usec;
         usec_t next_attempt_after;
         sd_event_source *timeout_event_source;
+        sd_future *completion_future;
         unsigned n_attempts;
 
         /* UDP connection logic, if we need it */
@@ -147,6 +149,8 @@ DnsTransaction* dns_transaction_gc(DnsTransaction *t);
 DEFINE_TRIVIAL_CLEANUP_FUNC(DnsTransaction*, dns_transaction_gc);
 
 int dns_transaction_go(DnsTransaction *t);
+int dns_transaction_get_completion_future(DnsTransaction *t, sd_future **ret);
+int dns_transaction_await(DnsTransaction *t);
 
 void dns_transaction_process_reply(DnsTransaction *t, DnsPacket *p, bool encrypted);
 void dns_transaction_complete(DnsTransaction *t, DnsTransactionState state);

--- a/src/resolve/resolved-fiber-util.c
+++ b/src/resolve/resolved-fiber-util.c
@@ -1,7 +1,5 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
-#include <errno.h>
-
 #include "sd-future.h"
 
 #include "alloc-util.h"

--- a/src/resolve/resolved-fiber-util.c
+++ b/src/resolve/resolved-fiber-util.c
@@ -1,0 +1,55 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include <errno.h>
+
+#include "sd-future.h"
+
+#include "alloc-util.h"
+#include "resolved-fiber-util.h"
+
+typedef struct ResolvedFuture {
+        int dummy;
+} ResolvedFuture;
+
+static void* resolved_future_alloc(void) {
+        return new0(ResolvedFuture, 1);
+}
+
+static void resolved_future_free(sd_future *f) {
+        free(sd_future_get_private(f));
+}
+
+static int resolved_future_cancel(sd_future *f) {
+        assert(f);
+
+        return -EOPNOTSUPP;
+}
+
+static const sd_future_ops resolved_future_ops = {
+        .size = sizeof(sd_future_ops),
+        .alloc = resolved_future_alloc,
+        .free = resolved_future_free,
+        .cancel = resolved_future_cancel,
+};
+
+int resolved_future_new(sd_future **ret) {
+        _cleanup_(sd_future_unrefp) sd_future *f = NULL;
+        int r;
+
+        assert(ret);
+
+        r = sd_future_new(&resolved_future_ops, &f);
+        if (r < 0)
+                return r;
+
+        /* Object completion futures are shared by all waiters. sd_future_new() defaults to resuming the
+         * current fiber when called from fiber context, which would make a shared future keep a stale
+         * callback to the first waiter. Awaiters must use sd_future_new_wait() via sd_fiber_await()
+         * instead, so each waiter owns its own callback and cancellation state. */
+        r = sd_future_set_callback(f, NULL, NULL);
+        if (r < 0)
+                return r;
+
+        *ret = TAKE_PTR(f);
+        return 0;
+}

--- a/src/resolve/resolved-fiber-util.h
+++ b/src/resolve/resolved-fiber-util.h
@@ -1,0 +1,6 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#pragma once
+
+#include "sd-future.h"
+
+int resolved_future_new(sd_future **ret);

--- a/src/resolve/resolved-hook.c
+++ b/src/resolve/resolved-hook.c
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
 #include "sd-event.h"
+#include "sd-future.h"
 #include "sd-varlink.h"
 
 #include "dirent-util.h"
@@ -12,6 +13,7 @@
 #include "iovec-util.h"
 #include "json-util.h"
 #include "ratelimit.h"
+#include "resolved-fiber-util.h"
 #include "resolved-hook.h"
 #include "resolved-manager.h"
 #include "set.h"
@@ -458,9 +460,9 @@ struct HookQuery {
         /* Candidates for a reply, i.e, one entry for each hook */
         LIST_HEAD(HookQueryCandidate, candidates);
 
-        /* Completion callback to invoke */
-        void (*complete)(HookQuery *q, int answer_rcode, DnsAnswer *answer, void *userdata);
-        void *userdata;
+        sd_future *completion_future;
+        int completion_result;
+        bool completed;
 };
 
 /* Encapsulates the state of a hook query to one specific hook */
@@ -498,11 +500,81 @@ HookQuery* hook_query_free(HookQuery *hq) {
         dns_question_unref(hq->question_idna);
         dns_answer_unref(hq->answer);
         hook_unref(hq->answer_hook);
+        if (hq->completion_future)
+                (void) sd_future_resolve(hq->completion_future, -ECANCELED);
+        hq->completion_future = sd_future_unref(hq->completion_future);
 
         return mfree(hq);
 }
 
-DEFINE_TRIVIAL_CLEANUP_FUNC(HookQuery*, hook_query_free);
+static int hook_query_complete(HookQuery *hq, int result) {
+        assert(hq);
+
+        if (hq->completed)
+                return 0;
+
+        hq->completed = true;
+        hq->completion_result = result;
+        if (hq->completion_future)
+                (void) sd_future_resolve(hq->completion_future, result);
+
+        return 0;
+}
+
+void hook_query_abort(HookQuery *hq) {
+        if (!hq)
+                return;
+
+        (void) hook_query_complete(hq, -ECANCELED);
+}
+
+int hook_query_get_completion_future(HookQuery *hq, sd_future **ret) {
+        int r;
+
+        assert(hq);
+        assert(ret);
+
+        if (!hq->completion_future) {
+                r = resolved_future_new(&hq->completion_future);
+                if (r < 0)
+                        return r;
+
+                if (hq->completed)
+                        (void) sd_future_resolve(hq->completion_future, hq->completion_result);
+        }
+
+        *ret = sd_future_ref(hq->completion_future);
+        return 0;
+}
+
+int hook_query_await(HookQuery *hq) {
+        _cleanup_(sd_future_unrefp) sd_future *f = NULL;
+        int r;
+
+        assert(hq);
+
+        r = hook_query_get_completion_future(hq, &f);
+        if (r < 0)
+                return r;
+
+        return sd_fiber_await(f);
+}
+
+int hook_query_get_result(HookQuery *hq, int *ret_rcode, DnsAnswer **ret_answer) {
+        assert(hq);
+        assert(ret_rcode);
+        assert(ret_answer);
+
+        if (hq->completion_result < 0)
+                return hq->completion_result;
+
+        if (hq->answer_rcode < 0)
+                return -ENODATA;
+
+        *ret_rcode = hq->answer_rcode;
+        *ret_answer = dns_answer_ref(hq->answer);
+        return 0;
+}
 
 static void hook_query_ready(HookQuery *hq) {
         assert(hq);
@@ -516,12 +588,7 @@ static void hook_query_ready(HookQuery *hq) {
 
         if (!done)
                 return;
-
-        /* The complete() callback quite likely will destroy 'hq', which might be what keeps the answer
-         * object alive. Let's take an explicit ref here hence, so that it definitely remains alive for the
-         * whole callback lifetime */
-        _cleanup_(dns_answer_unrefp) DnsAnswer *answer = dns_answer_ref(hq->answer);
-        hq->complete(hq, hq->answer_rcode, answer, hq->userdata);
+        (void) hook_query_complete(hq, hq->answer_rcode >= 0 ? hq->answer_rcode : -ENODATA);
 }
 
 static int dispatch_rcode(const char *name, sd_json_variant *variant, sd_json_dispatch_flags_t flags, void *userdata) {
@@ -806,8 +873,6 @@ int manager_hook_query(
                 Manager *m,
                 DnsQuestion *question_idna,
                 DnsQuestion *question_utf8,
-                HookCompleteCallback complete_cb,
-                void *userdata,
                 HookQuery **ret) {
 
         int r;
@@ -857,8 +922,7 @@ int manager_hook_query(
                                 .question_idna = dns_question_ref(question_idna),
                                 .question_utf8 = dns_question_ref(question_utf8),
                                 .answer_rcode = -1,
-                                .complete = complete_cb,
-                                .userdata = userdata,
+                                .completion_result = -ENODATA,
                         };
                 }
 

--- a/src/resolve/resolved-hook.c
+++ b/src/resolve/resolved-hook.c
@@ -553,6 +553,9 @@ int hook_query_await(HookQuery *hq) {
 
         assert(hq);
 
+        if (hq->completed)
+                return hq->completion_result;
+
         r = hook_query_get_completion_future(hq, &f);
         if (r < 0)
                 return r;

--- a/src/resolve/resolved-hook.h
+++ b/src/resolve/resolved-hook.h
@@ -1,10 +1,15 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 #pragma once
 
+#include "sd-future.h"
+
 #include "resolved-forward.h"
 
-typedef void (HookCompleteCallback)(HookQuery *q, int rcode, DnsAnswer *answer, void *userdata);
-
-int manager_hook_query(Manager *m, DnsQuestion *question_idna, DnsQuestion *question_utf8, HookCompleteCallback complete_cb, void *userdata, HookQuery **ret);
+int manager_hook_query(Manager *m, DnsQuestion *question_idna, DnsQuestion *question_utf8, HookQuery **ret);
 
 HookQuery* hook_query_free(HookQuery *hq);
+DEFINE_TRIVIAL_CLEANUP_FUNC(HookQuery*, hook_query_free);
+void hook_query_abort(HookQuery *hq);
+int hook_query_get_completion_future(HookQuery *hq, sd_future **ret);
+int hook_query_await(HookQuery *hq);
+int hook_query_get_result(HookQuery *hq, int *ret_rcode, DnsAnswer **ret_answer);

--- a/src/resolve/resolved-llmnr.c
+++ b/src/resolve/resolved-llmnr.c
@@ -329,9 +329,8 @@ static int on_llmnr_stream(sd_event_source *s, int fd, uint32_t revents, void *u
                 return -errno;
         }
 
-        /* We don't configure a "complete" handler here, we rely on the default handler, thus freeing it */
         r = dns_stream_new(m, &stream, DNS_STREAM_LLMNR_RECV, DNS_PROTOCOL_LLMNR, cfd, NULL,
-                           on_llmnr_stream_packet, NULL, DNS_STREAM_DEFAULT_TIMEOUT_USEC);
+                           on_llmnr_stream_packet, DNS_STREAM_DEFAULT_TIMEOUT_USEC);
         if (r < 0) {
                 safe_close(cfd);
                 return r;

--- a/src/resolve/resolved-varlink.c
+++ b/src/resolve/resolved-varlink.c
@@ -202,6 +202,21 @@ static void vl_on_notification_disconnect(sd_varlink_server *s, sd_varlink *link
         }
 }
 
+static int dns_query_varlink_request_connected(DnsQuery *q) {
+        int r;
+
+        assert(q);
+        assert(q->varlink_request);
+
+        r = sd_varlink_is_connected(q->varlink_request);
+        if (r < 0)
+                return r;
+        if (r == 0)
+                return -ECANCELED;
+
+        return 0;
+}
+
 static int find_addr_records(
                 sd_json_variant **array,
                 DnsQuestion *question,
@@ -254,29 +269,17 @@ static int find_addr_records(
         return 0;
 }
 
-static void vl_method_resolve_hostname_complete(DnsQuery *query) {
+static int vl_method_resolve_hostname_reply(DnsQuery *q) {
         _cleanup_(dns_resource_record_unrefp) DnsResourceRecord *canonical = NULL;
         _cleanup_(sd_json_variant_unrefp) sd_json_variant *array = NULL;
-        _cleanup_(dns_query_freep) DnsQuery *q = query;
         _cleanup_free_ char *normalized = NULL;
         DnsQuestion *question;
         int r;
 
         assert(q);
 
-        if (q->state != DNS_TRANSACTION_SUCCESS)
-                return (void) reply_query_state(q);
-
-        r = dns_query_process_cname_many(q);
-        if (r == -ELOOP)
-                return (void) sd_varlink_error(q->varlink_request, "io.systemd.Resolve.CNAMELoop", NULL);
-        if (r < 0)
-                goto finish;
-        if (r == DNS_QUERY_CNAME) {
-                /* This was a cname, and the query was restarted. */
-                TAKE_PTR(q);
-                return;
-        }
+        if (!IN_SET(q->state, DNS_TRANSACTION_SUCCESS, DNS_TRANSACTION_NULL))
+                return reply_query_state(q);
 
         question = dns_query_question_for_protocol(q, q->answer_protocol);
 
@@ -285,7 +288,7 @@ static void vl_method_resolve_hostname_complete(DnsQuery *query) {
                 goto finish;
 
         if (sd_json_variant_is_blank_object(array))
-                return (void) sd_varlink_error(q->varlink_request, "io.systemd.Resolve.NoSuchResourceRecord", NULL);
+                return sd_varlink_error(q->varlink_request, "io.systemd.Resolve.NoSuchResourceRecord", NULL);
 
         assert(canonical);
         r = dns_name_normalize(dns_resource_key_name(canonical->key), 0, &normalized);
@@ -300,8 +303,10 @@ static void vl_method_resolve_hostname_complete(DnsQuery *query) {
 finish:
         if (r < 0) {
                 log_full_errno(ERRNO_IS_DISCONNECT(r) ? LOG_DEBUG : LOG_ERR, r, "Failed to send hostname reply: %m");
-                (void) sd_varlink_error_errno(q->varlink_request, r);
+                return sd_varlink_error_errno(q->varlink_request, r);
         }
+
+        return r;
 }
 
 static int parse_as_address(sd_varlink *link, LookupParameters *p) {
@@ -402,38 +407,49 @@ static int vl_method_resolve_hostname(sd_varlink *link, sd_json_variant *paramet
         q->varlink_request = sd_varlink_ref(link);
         sd_varlink_set_userdata(link, q);
         q->request_family = p.family;
-        q->complete = vl_method_resolve_hostname_complete;
 
         r = dns_query_go(q);
         if (r < 0)
                 return r;
 
-        TAKE_PTR(q);
-        return 1;
+        for (;;) {
+                r = dns_query_await(q);
+                if (r < 0)
+                        return r;
+
+                r = dns_query_varlink_request_connected(q);
+                if (r < 0)
+                        return r;
+
+                if (q->state != DNS_TRANSACTION_SUCCESS)
+                        break;
+
+                r = dns_query_process_cname_many(q);
+                if (r == -ELOOP)
+                        return sd_varlink_error(q->varlink_request, "io.systemd.Resolve.CNAMELoop", NULL);
+                if (r < 0)
+                        return r;
+                if (r != DNS_QUERY_CNAME)
+                        break;
+        }
+
+        r = dns_query_varlink_request_connected(q);
+        if (r < 0)
+                return r;
+
+        return vl_method_resolve_hostname_reply(q);
 }
 
-static void vl_method_resolve_address_complete(DnsQuery *query) {
+static int vl_method_resolve_address_reply(DnsQuery *q) {
         _cleanup_(sd_json_variant_unrefp) sd_json_variant *array = NULL;
-        _cleanup_(dns_query_freep) DnsQuery *q = query;
         DnsQuestion *question;
         DnsResourceRecord *rr;
         int ifindex, r;
 
         assert(q);
 
-        if (q->state != DNS_TRANSACTION_SUCCESS)
-                return (void) reply_query_state(q);
-
-        r = dns_query_process_cname_many(q);
-        if (r == -ELOOP)
-                return (void) sd_varlink_error(q->varlink_request, "io.systemd.Resolve.CNAMELoop", NULL);
-        if (r < 0)
-                goto finish;
-        if (r == DNS_QUERY_CNAME) {
-                /* This was a cname, and the query was restarted. */
-                TAKE_PTR(q);
-                return;
-        }
+        if (!IN_SET(q->state, DNS_TRANSACTION_SUCCESS, DNS_TRANSACTION_NULL))
+                return reply_query_state(q);
 
         question = dns_query_question_for_protocol(q, q->answer_protocol);
 
@@ -459,7 +475,7 @@ static void vl_method_resolve_address_complete(DnsQuery *query) {
         }
 
         if (sd_json_variant_is_blank_object(array))
-                return (void) sd_varlink_error(q->varlink_request, "io.systemd.Resolve.NoSuchResourceRecord", NULL);
+                return sd_varlink_error(q->varlink_request, "io.systemd.Resolve.NoSuchResourceRecord", NULL);
 
         r = sd_varlink_replybo(
                         q->varlink_request,
@@ -468,8 +484,10 @@ static void vl_method_resolve_address_complete(DnsQuery *query) {
 finish:
         if (r < 0) {
                 log_full_errno(ERRNO_IS_DISCONNECT(r) ? LOG_DEBUG : LOG_ERR, r, "Failed to send address reply: %m");
-                (void) sd_varlink_error_errno(q->varlink_request, r);
+                return sd_varlink_error_errno(q->varlink_request, r);
         }
+
+        return r;
 }
 
 static int vl_method_resolve_address(sd_varlink *link, sd_json_variant *parameters, sd_varlink_method_flags_t flags, void *userdata) {
@@ -525,14 +543,37 @@ static int vl_method_resolve_address(sd_varlink *link, sd_json_variant *paramete
 
         q->request_family = p.family;
         q->request_address = a;
-        q->complete = vl_method_resolve_address_complete;
 
         r = dns_query_go(q);
         if (r < 0)
                 return r;
 
-        TAKE_PTR(q);
-        return 1;
+        for (;;) {
+                r = dns_query_await(q);
+                if (r < 0)
+                        return r;
+
+                r = dns_query_varlink_request_connected(q);
+                if (r < 0)
+                        return r;
+
+                if (q->state != DNS_TRANSACTION_SUCCESS)
+                        break;
+
+                r = dns_query_process_cname_many(q);
+                if (r == -ELOOP)
+                        return sd_varlink_error(q->varlink_request, "io.systemd.Resolve.CNAMELoop", NULL);
+                if (r < 0)
+                        return r;
+                if (r != DNS_QUERY_CNAME)
+                        break;
+        }
+
+        r = dns_query_varlink_request_connected(q);
+        if (r < 0)
+                return r;
+
+        return vl_method_resolve_address_reply(q);
 }
 
 static int append_txt(sd_json_variant **txt, DnsResourceRecord *rr) {
@@ -588,14 +629,14 @@ static int append_srv(
                         DnsResourceRecord *zz;
                         DnsQuestion *question;
 
-                        if (aux->state != DNS_TRANSACTION_SUCCESS)
+                        if (!IN_SET(aux->state, DNS_TRANSACTION_SUCCESS, DNS_TRANSACTION_NULL))
                                 continue;
                         if (aux->auxiliary_result != 0)
                                 continue;
 
                         question = dns_query_question_for_protocol(aux, aux->answer_protocol);
 
-                        r = dns_name_equal(dns_question_first_name(question), rr->srv.name);
+                        r = dns_name_equal(aux->auxiliary_name ?: dns_question_first_name(question), rr->srv.name);
                         if (r < 0)
                                 return r;
                         if (r == 0)
@@ -652,14 +693,14 @@ static int append_srv(
                 LIST_FOREACH(auxiliary_queries, aux, q->auxiliary_queries) {
                         DnsQuestion *question;
 
-                        if (aux->state != DNS_TRANSACTION_SUCCESS)
+                        if (!IN_SET(aux->state, DNS_TRANSACTION_SUCCESS, DNS_TRANSACTION_NULL))
                                 continue;
                         if (aux->auxiliary_result != 0)
                                 continue;
 
                         question = dns_query_question_for_protocol(aux, aux->answer_protocol);
 
-                        r = dns_name_equal(dns_question_first_name(question), rr->srv.name);
+                        r = dns_name_equal(aux->auxiliary_name ?: dns_question_first_name(question), rr->srv.name);
                         if (r < 0)
                                 return r;
                         if (r == 0)
@@ -682,18 +723,7 @@ static int append_srv(
         return 1; /* added */
 }
 
-static sd_varlink* take_vl_link_aux_query(DnsQuery *aux) {
-        assert(aux);
-
-        /* Find the main query */
-        while (aux->auxiliary_for)
-                aux = aux->auxiliary_for;
-
-        return TAKE_PTR(aux->varlink_request);
-}
-
-static void resolve_service_all_complete(DnsQuery *query) {
-        _cleanup_(dns_query_freep) DnsQuery *q = query;
+static int resolve_service_reply(DnsQuery *q) {
         _cleanup_(sd_json_variant_unrefp) sd_json_variant *srv = NULL, *txt = NULL;
         _cleanup_free_ char *name = NULL, *type = NULL, *domain = NULL;
         _cleanup_(dns_resource_record_unrefp) DnsResourceRecord *canonical = NULL;
@@ -703,10 +733,8 @@ static void resolve_service_all_complete(DnsQuery *query) {
 
         assert(q);
 
-        if (q->hook_query || q->block_all_complete > 0) {
-                TAKE_PTR(q);
-                return;
-        }
+        if (!IN_SET(q->state, DNS_TRANSACTION_SUCCESS, DNS_TRANSACTION_NULL))
+                return reply_query_state(q);
 
         if ((q->flags & SD_RESOLVED_NO_ADDRESS) == 0) {
                 DnsQuery *bad = NULL;
@@ -714,19 +742,13 @@ static void resolve_service_all_complete(DnsQuery *query) {
 
                 LIST_FOREACH(auxiliary_queries, aux, q->auxiliary_queries) {
 
-                        if (aux->hook_query) {
-                                /* If an auxiliary query's hook is still pending, let's wait */
-                                TAKE_PTR(q);
-                                return;
-                        }
-
                         switch (aux->state) {
 
                         case DNS_TRANSACTION_PENDING:
-                                /* If an auxiliary query is still pending, let's wait */
-                                TAKE_PTR(q);
-                                return;
+                        case DNS_TRANSACTION_VALIDATING:
+                                return -EBUSY;
 
+                        case DNS_TRANSACTION_NULL:
                         case DNS_TRANSACTION_SUCCESS:
                                 if (aux->auxiliary_result == 0)
                                         have_success = true;
@@ -742,19 +764,22 @@ static void resolve_service_all_complete(DnsQuery *query) {
                         /* We can only return one error, hence pick the last error we encountered */
 
                         assert(bad);
-                        if (bad->state == DNS_TRANSACTION_SUCCESS) {
+                        if (IN_SET(bad->state, DNS_TRANSACTION_SUCCESS, DNS_TRANSACTION_NULL)) {
                                 assert(bad->auxiliary_result != 0);
 
                                 if (bad->auxiliary_result == -ELOOP)
-                                        return (void) sd_varlink_error(query->varlink_request, "io.systemd.Resolve.CNAMELoop", NULL);
+                                        return sd_varlink_error(q->varlink_request, "io.systemd.Resolve.CNAMELoop", NULL);
 
                                 assert(bad->auxiliary_result < 0);
                                 r = bad->auxiliary_result;
                                 goto finish;
                         }
 
-                        bad->varlink_request = take_vl_link_aux_query(bad);
-                        return (void) reply_query_state(bad);
+                        assert(!bad->varlink_request);
+                        bad->varlink_request = sd_varlink_ref(q->varlink_request);
+                        r = reply_query_state(bad);
+                        bad->varlink_request = sd_varlink_unref(bad->varlink_request);
+                        return r;
                 }
         }
 
@@ -778,7 +803,7 @@ static void resolve_service_all_complete(DnsQuery *query) {
         }
 
         if (sd_json_variant_is_blank_object(srv))
-                return (void) sd_varlink_error(query->varlink_request, "io.systemd.Resolve.NoSuchResourceRecord", NULL);
+                return sd_varlink_error(q->varlink_request, "io.systemd.Resolve.NoSuchResourceRecord", NULL);
 
         DNS_ANSWER_FOREACH(rr, q->answer) {
                 r = dns_question_matches_rr(question, rr, NULL);
@@ -801,43 +826,25 @@ static void resolve_service_all_complete(DnsQuery *query) {
                 goto finish;
 
         if (isempty(type))
-                return (void) sd_varlink_error(q->varlink_request, "io.systemd.Resolve.InconsistentServiceRecords", NULL);
+                return sd_varlink_error(q->varlink_request, "io.systemd.Resolve.InconsistentServiceRecords", NULL);
 
         r = sd_varlink_replybo(
-                        query->varlink_request,
+                        q->varlink_request,
                         SD_JSON_BUILD_PAIR_VARIANT("services", srv),
                         SD_JSON_BUILD_PAIR_CONDITION(!sd_json_variant_is_blank_object(txt), "txt", SD_JSON_BUILD_VARIANT(txt)),
                         SD_JSON_BUILD_PAIR("canonical", SD_JSON_BUILD_OBJECT(
                                                            SD_JSON_BUILD_PAIR_STRING("name", name),
                                                            SD_JSON_BUILD_PAIR_STRING("type", type),
                                                            SD_JSON_BUILD_PAIR_STRING("domain", domain))),
-                        SD_JSON_BUILD_PAIR_UNSIGNED("flags", dns_query_reply_flags_make(query)));
+                        SD_JSON_BUILD_PAIR_UNSIGNED("flags", dns_query_reply_flags_make(q)));
 
 finish:
         if (r < 0) {
                 log_error_errno(r, "Failed to resolve service: %m");
-                (void) sd_varlink_error_errno(q->varlink_request, r);
-        }
-}
-
-static void resolve_service_hostname_complete(DnsQuery *q) {
-        int r;
-
-        assert(q);
-        assert(q->auxiliary_for);
-
-        if (q->state != DNS_TRANSACTION_SUCCESS) {
-                resolve_service_all_complete(q->auxiliary_for);
-                return;
+                return sd_varlink_error_errno(q->varlink_request, r);
         }
 
-        r = dns_query_process_cname_many(q);
-        if (r == DNS_QUERY_CNAME) /* This was a cname, and the query was restarted. */
-                return;
-
-        /* This auxiliary lookup is finished or failed, let's see if all are finished now. */
-        q->auxiliary_result = r < 0 ? r : 0;
-        resolve_service_all_complete(q->auxiliary_for);
+        return r;
 }
 
 static int resolve_service_hostname(DnsQuery *q, DnsResourceRecord *rr, int ifindex) {
@@ -862,7 +869,9 @@ static int resolve_service_hostname(DnsQuery *q, DnsResourceRecord *rr, int ifin
                 return r;
 
         aux->request_family = q->request_family;
-        aux->complete = resolve_service_hostname_complete;
+        aux->auxiliary_name = strdup(rr->srv.name);
+        if (!aux->auxiliary_name)
+                return -ENOMEM;
 
         r = dns_query_make_auxiliary(aux, q);
         if (r == -EAGAIN)
@@ -884,8 +893,39 @@ static int resolve_service_hostname(DnsQuery *q, DnsResourceRecord *rr, int ifin
         return 1;
 }
 
-static void vl_method_resolve_service_complete(DnsQuery *query) {
-        _cleanup_(dns_query_freep) DnsQuery *q = query;
+static int resolve_service_await_auxiliary(DnsQuery *q) {
+        int r;
+
+        assert(q);
+
+        LIST_FOREACH(auxiliary_queries, aux, q->auxiliary_queries)
+                for (;;) {
+                        r = dns_query_await(aux);
+                        if (r < 0)
+                                return r;
+
+                        r = dns_query_varlink_request_connected(q);
+                        if (r < 0)
+                                return r;
+
+                        if (aux->state != DNS_TRANSACTION_SUCCESS)
+                                break;
+
+                        r = dns_query_process_cname_many(aux);
+                        if (r < 0) {
+                                aux->auxiliary_result = r;
+                                break;
+                        }
+                        if (r != DNS_QUERY_CNAME) {
+                                aux->auxiliary_result = 0;
+                                break;
+                        }
+                }
+
+        return 0;
+}
+
+static int resolve_service_start_auxiliary(DnsQuery *q) {
         bool has_root_domain = false;
         DnsResourceRecord *rr;
         DnsQuestion *question;
@@ -894,26 +934,14 @@ static void vl_method_resolve_service_complete(DnsQuery *query) {
 
         assert(q);
 
-        if (q->state != DNS_TRANSACTION_SUCCESS)
-                return (void) reply_query_state(q);
-
-        r = dns_query_process_cname_many(q);
-        if (r == -ELOOP)
-                return (void) sd_varlink_error(q->varlink_request, "io.systemd.Resolve.CNAMELoop", NULL);
-        if (r < 0)
-                goto fail;
-        if (r == DNS_QUERY_CNAME) {
-                /* This was a cname, and the query was restarted. */
-                TAKE_PTR(q);
-                return;
-        }
-
         question = dns_query_question_for_protocol(q, q->answer_protocol);
 
         DNS_ANSWER_FOREACH_IFINDEX(rr, ifindex, q->answer) {
                 r = dns_question_matches_rr(question, rr, NULL);
-                if (r < 0)
-                        goto fail;
+                if (r < 0) {
+                        log_error_errno(r, "Failed to resolve service: %m");
+                        return sd_varlink_error_errno(q->varlink_request, r);
+                }
                 if (r == 0)
                         continue;
 
@@ -926,12 +954,11 @@ static void vl_method_resolve_service_complete(DnsQuery *query) {
                 }
 
                 if ((q->flags & SD_RESOLVED_NO_ADDRESS) == 0) {
-                        q->block_all_complete++;
                         r = resolve_service_hostname(q, rr, ifindex);
-                        q->block_all_complete--;
-
-                        if (r < 0)
-                                goto fail;
+                        if (r < 0) {
+                                log_error_errno(r, "Failed to resolve service hostname: %m");
+                                return sd_varlink_error_errno(q->varlink_request, r);
+                        }
                 }
 
                 found++;
@@ -941,21 +968,15 @@ static void vl_method_resolve_service_complete(DnsQuery *query) {
                 /* If there's exactly one SRV RR and it uses the root domain as hostname, then the service is
                  * explicitly not offered on the domain. Report this as a recognizable error. See RFC 2782,
                  * Section "Usage Rules". */
-                return (void) sd_varlink_error(q->varlink_request, "io.systemd.Resolve.ServiceNotProvided", NULL);
+                return sd_varlink_error(q->varlink_request, "io.systemd.Resolve.ServiceNotProvided", NULL);
 
         if (found <= 0)
-                return (void) sd_varlink_error(q->varlink_request, "io.systemd.Resolve.NoSuchResourceRecord", NULL);
+                return sd_varlink_error(q->varlink_request, "io.systemd.Resolve.NoSuchResourceRecord", NULL);
 
-        /* Maybe we are already finished? check now... */
-        resolve_service_all_complete(TAKE_PTR(q));
-        return;
-
-fail:
-        log_error_errno(r, "Failed to send address reply: %m");
-        (void) sd_varlink_error_errno(q->varlink_request, r);
+        return 0;
 }
 
-static int vl_method_resolve_service(sd_varlink* link, sd_json_variant* parameters, sd_varlink_method_flags_t flags, void* userdata) {
+static int vl_method_resolve_service(sd_varlink *link, sd_json_variant *parameters, sd_varlink_method_flags_t flags, void *userdata) {
         static const sd_json_dispatch_field dispatch_table[] = {
                 { "name",    SD_JSON_VARIANT_STRING,        sd_json_dispatch_const_string, offsetof(LookupParametersResolveService, name),    0                 },
                 { "type",    SD_JSON_VARIANT_STRING,        sd_json_dispatch_const_string, offsetof(LookupParametersResolveService, type),    0                 },
@@ -1029,40 +1050,65 @@ static int vl_method_resolve_service(sd_varlink* link, sd_json_variant* paramete
                 return r;
 
         q->varlink_request = sd_varlink_ref(link);
-        q->request_family = p.family;
-        q->complete = vl_method_resolve_service_complete;
-
         sd_varlink_set_userdata(link, q);
+        q->request_family = p.family;
 
         r = dns_query_go(q);
         if (r < 0)
                 return r;
 
-        TAKE_PTR(q);
-        return 1;
+        for (;;) {
+                r = dns_query_await(q);
+                if (r < 0)
+                        return r;
+
+                r = dns_query_varlink_request_connected(q);
+                if (r < 0)
+                        return r;
+
+                if (q->state != DNS_TRANSACTION_SUCCESS)
+                        break;
+
+                r = dns_query_process_cname_many(q);
+                if (r == -ELOOP)
+                        return sd_varlink_error(q->varlink_request, "io.systemd.Resolve.CNAMELoop", NULL);
+                if (r < 0)
+                        return r;
+                if (r != DNS_QUERY_CNAME)
+                        break;
+        }
+
+        r = dns_query_varlink_request_connected(q);
+        if (r < 0)
+                return r;
+
+        if (!IN_SET(q->state, DNS_TRANSACTION_SUCCESS, DNS_TRANSACTION_NULL))
+                return reply_query_state(q);
+
+        r = resolve_service_start_auxiliary(q);
+        if (r != 0)
+                return r;
+
+        r = resolve_service_await_auxiliary(q);
+        if (r < 0)
+                return r;
+
+        r = dns_query_varlink_request_connected(q);
+        if (r < 0)
+                return r;
+
+        return resolve_service_reply(q);
 }
 
-static void vl_method_resolve_record_complete(DnsQuery *query) {
+static int vl_method_resolve_record_reply(DnsQuery *q) {
         _cleanup_(sd_json_variant_unrefp) sd_json_variant *array = NULL;
-        _cleanup_(dns_query_freep) DnsQuery *q = query;
         DnsQuestion *question;
         int r;
 
         assert(q);
 
-        if (q->state != DNS_TRANSACTION_SUCCESS)
-                return (void) reply_query_state(q);
-
-        r = dns_query_process_cname_many(q);
-        if (r == -ELOOP)
-                return (void) sd_varlink_error(q->varlink_request, "io.systemd.Resolve.CNAMELoop", NULL);
-        if (r < 0)
-                goto finish;
-        if (r == DNS_QUERY_CNAME) {
-                /* This was a cname, and the query was restarted. */
-                TAKE_PTR(q);
-                return;
-        }
+        if (!IN_SET(q->state, DNS_TRANSACTION_SUCCESS, DNS_TRANSACTION_NULL))
+                return reply_query_state(q);
 
         question = dns_query_question_for_protocol(q, q->answer_protocol);
 
@@ -1098,7 +1144,7 @@ static void vl_method_resolve_record_complete(DnsQuery *query) {
         }
 
         if (added <= 0)
-                return (void) sd_varlink_error(q->varlink_request, "io.systemd.Resolve.NoSuchResourceRecord", NULL);
+                return sd_varlink_error(q->varlink_request, "io.systemd.Resolve.NoSuchResourceRecord", NULL);
 
         r = sd_varlink_replybo(
                         q->varlink_request,
@@ -1107,8 +1153,10 @@ static void vl_method_resolve_record_complete(DnsQuery *query) {
 finish:
         if (r < 0) {
                 log_full_errno(ERRNO_IS_DISCONNECT(r) ? LOG_DEBUG : LOG_ERR, r, "Failed to send record reply: %m");
-                (void) sd_varlink_error_errno(q->varlink_request, r);
+                return sd_varlink_error_errno(q->varlink_request, r);
         }
+
+        return r;
 }
 
 static int vl_method_resolve_record(sd_varlink *link, sd_json_variant *parameters, sd_varlink_method_flags_t flags, void *userdata) {
@@ -1175,14 +1223,37 @@ static int vl_method_resolve_record(sd_varlink *link, sd_json_variant *parameter
 
         q->varlink_request = sd_varlink_ref(link);
         sd_varlink_set_userdata(link, q);
-        q->complete = vl_method_resolve_record_complete;
 
         r = dns_query_go(q);
         if (r < 0)
                 return r;
 
-        TAKE_PTR(q);
-        return 1;
+        for (;;) {
+                r = dns_query_await(q);
+                if (r < 0)
+                        return r;
+
+                r = dns_query_varlink_request_connected(q);
+                if (r < 0)
+                        return r;
+
+                if (q->state != DNS_TRANSACTION_SUCCESS)
+                        break;
+
+                r = dns_query_process_cname_many(q);
+                if (r == -ELOOP)
+                        return sd_varlink_error(q->varlink_request, "io.systemd.Resolve.CNAMELoop", NULL);
+                if (r < 0)
+                        return r;
+                if (r != DNS_QUERY_CNAME)
+                        break;
+        }
+
+        r = dns_query_varlink_request_connected(q);
+        if (r < 0)
+                return r;
+
+        return vl_method_resolve_record_reply(q);
 }
 
 static int verify_polkit(sd_varlink *link, sd_json_variant *parameters, const char *action) {
@@ -1507,10 +1578,6 @@ static int varlink_main_server_init(Manager *m) {
 
         r = sd_varlink_server_bind_method_many(
                         s,
-                        "io.systemd.Resolve.ResolveHostname",      vl_method_resolve_hostname,
-                        "io.systemd.Resolve.ResolveAddress",       vl_method_resolve_address,
-                        "io.systemd.Resolve.ResolveService",       vl_method_resolve_service,
-                        "io.systemd.Resolve.ResolveRecord",        vl_method_resolve_record,
                         "io.systemd.service.Ping",                 varlink_method_ping,
                         "io.systemd.service.SetLogLevel",          varlink_method_set_log_level,
                         "io.systemd.service.GetEnvironment",       varlink_method_get_environment,
@@ -1518,6 +1585,15 @@ static int varlink_main_server_init(Manager *m) {
                         "io.systemd.Resolve.DumpDNSConfiguration", vl_method_dump_dns_configuration);
         if (r < 0)
                 return log_error_errno(r, "Failed to register varlink methods: %m");
+
+        r = varlink_server_bind_fiber_many(
+                        s,
+                        "io.systemd.Resolve.ResolveHostname", vl_method_resolve_hostname,
+                        "io.systemd.Resolve.ResolveAddress", vl_method_resolve_address,
+                        "io.systemd.Resolve.ResolveService", vl_method_resolve_service,
+                        "io.systemd.Resolve.ResolveRecord", vl_method_resolve_record);
+        if (r < 0)
+                return log_error_errno(r, "Failed to register varlink fiber methods: %m");
 
         r = sd_varlink_server_bind_disconnect(s, vl_on_disconnect);
         if (r < 0)

--- a/src/resolve/test-dns-query.c
+++ b/src/resolve/test-dns-query.c
@@ -277,6 +277,7 @@ typedef struct QueryAwaitContext {
 static int query_await_fiber(void *userdata) {
         QueryAwaitContext *ctx = ASSERT_PTR(userdata);
 
+        ctx->result = -ENOTRECOVERABLE;
         ctx->result = dns_query_await(ctx->query);
         return ctx->result;
 }
@@ -302,6 +303,40 @@ TEST(dns_query_completion_future_await) {
         ASSERT_EQ(sd_future_state(fiber), SD_FUTURE_PENDING);
         ASSERT_OK(dns_query_get_completion_future(query, &completion));
         ASSERT_NULL(sd_future_get_userdata(completion));
+
+        dns_query_complete(query, DNS_TRANSACTION_ABORTED);
+
+        ASSERT_OK(sd_event_loop(event));
+        ASSERT_EQ(ctx.result, DNS_TRANSACTION_ABORTED);
+        ASSERT_EQ(sd_future_result(fiber), DNS_TRANSACTION_ABORTED);
+}
+
+TEST(dns_query_completion_future_await_spurious_resume) {
+        _cleanup_(sd_event_unrefp) sd_event *event = NULL;
+        Manager manager = {};
+        _cleanup_(dns_question_unrefp) DnsQuestion *question = NULL;
+        _cleanup_(dns_query_freep) DnsQuery *query = NULL;
+        _cleanup_(sd_future_unrefp) sd_future *fiber = NULL;
+        QueryAwaitContext ctx = {};
+
+        ASSERT_OK(sd_event_new(&event));
+        ASSERT_OK(sd_event_set_exit_on_idle(event, true));
+        manager.event = event;
+
+        ASSERT_OK(dns_question_new_address(&question, AF_INET, "www.example.com", false));
+        ASSERT_OK(dns_query_new(&manager, &query, question, NULL, NULL, 1, 0));
+        query->state = DNS_TRANSACTION_PENDING;
+        ctx.query = query;
+
+        ASSERT_OK(sd_fiber_new(event, "query-await-spurious-resume", query_await_fiber, &ctx, NULL, &fiber));
+        ASSERT_OK_POSITIVE(sd_event_run(event, 0));
+        ASSERT_EQ(sd_future_state(fiber), SD_FUTURE_PENDING);
+        ASSERT_EQ(ctx.result, -ENOTRECOVERABLE);
+
+        ASSERT_OK(sd_fiber_resume(fiber, DNS_TRANSACTION_PENDING));
+        ASSERT_OK_POSITIVE(sd_event_run(event, 0));
+        ASSERT_EQ(sd_future_state(fiber), SD_FUTURE_PENDING);
+        ASSERT_EQ(ctx.result, -ENOTRECOVERABLE);
 
         dns_query_complete(query, DNS_TRANSACTION_ABORTED);
 

--- a/src/resolve/test-dns-query.c
+++ b/src/resolve/test-dns-query.c
@@ -16,6 +16,7 @@
 #include "resolved-link.h"
 #include "resolved-manager.h"
 #include "tests.h"
+#include "time-util.h"
 
 static char* checked_strdup(const char *str) {
         char *copy = strdup(str);
@@ -185,6 +186,169 @@ TEST(dns_query_new_too_many_questions) {
 
         for (size_t i = 0; i < MAX_QUERIES; i++)
                 dns_query_free(queries[i]);
+}
+
+TEST(dns_query_completion_future) {
+        Manager manager = {};
+        _cleanup_(dns_question_unrefp) DnsQuestion *question = NULL;
+        _cleanup_(dns_query_freep) DnsQuery *query = NULL;
+        _cleanup_(sd_future_unrefp) sd_future *future = NULL, *late_future = NULL;
+
+        ASSERT_OK(dns_question_new_address(&question, AF_INET, "www.example.com", false));
+        ASSERT_OK(dns_query_new(&manager, &query, question, NULL, NULL, 1, 0));
+
+        ASSERT_OK(dns_query_get_completion_future(query, &future));
+        ASSERT_EQ(sd_future_state(future), SD_FUTURE_PENDING);
+
+        dns_query_complete(query, DNS_TRANSACTION_ABORTED);
+
+        ASSERT_EQ(sd_future_state(future), SD_FUTURE_RESOLVED);
+        ASSERT_EQ(sd_future_result(future), DNS_TRANSACTION_ABORTED);
+
+        ASSERT_OK(dns_query_get_completion_future(query, &late_future));
+        ASSERT_EQ(sd_future_state(late_future), SD_FUTURE_RESOLVED);
+        ASSERT_EQ(sd_future_result(late_future), DNS_TRANSACTION_ABORTED);
+}
+
+TEST(dns_query_completion_future_free) {
+        Manager manager = {};
+        _cleanup_(dns_question_unrefp) DnsQuestion *question = NULL;
+        _cleanup_(sd_future_unrefp) sd_future *future = NULL;
+        DnsQuery *query = NULL;
+
+        ASSERT_OK(dns_question_new_address(&question, AF_INET, "www.example.com", false));
+        ASSERT_OK(dns_query_new(&manager, &query, question, NULL, NULL, 1, 0));
+
+        ASSERT_OK(dns_query_get_completion_future(query, &future));
+        ASSERT_EQ(sd_future_state(future), SD_FUTURE_PENDING);
+
+        query = dns_query_free(query);
+
+        ASSERT_EQ(sd_future_state(future), SD_FUTURE_RESOLVED);
+        ASSERT_ERROR(sd_future_result(future), ECANCELED);
+}
+
+TEST(dns_query_completion_future_cancel) {
+        Manager manager = {};
+        _cleanup_(dns_question_unrefp) DnsQuestion *question = NULL;
+        _cleanup_(dns_query_freep) DnsQuery *query = NULL;
+        _cleanup_(sd_future_unrefp) sd_future *future = NULL;
+
+        ASSERT_OK(dns_question_new_address(&question, AF_INET, "www.example.com", false));
+        ASSERT_OK(dns_query_new(&manager, &query, question, NULL, NULL, 1, 0));
+
+        ASSERT_OK(dns_query_get_completion_future(query, &future));
+        ASSERT_ERROR(sd_future_cancel(future), EOPNOTSUPP);
+        ASSERT_EQ(sd_future_state(future), SD_FUTURE_PENDING);
+
+        dns_query_complete(query, DNS_TRANSACTION_ABORTED);
+
+        ASSERT_EQ(sd_future_state(future), SD_FUTURE_RESOLVED);
+        ASSERT_EQ(sd_future_result(future), DNS_TRANSACTION_ABORTED);
+}
+
+TEST(dns_query_completion_future_restart) {
+        Manager manager = {};
+        _cleanup_(dns_question_unrefp) DnsQuestion *question = NULL;
+        _cleanup_(dns_query_freep) DnsQuery *query = NULL;
+        _cleanup_(sd_future_unrefp) sd_future *first = NULL, *second = NULL;
+
+        ASSERT_OK(dns_question_new_address(&question, AF_INET, "www.example.com", false));
+        ASSERT_OK(dns_query_new(&manager, &query, question, NULL, NULL, 1, SD_RESOLVED_NO_SYNTHESIZE));
+
+        ASSERT_OK(dns_query_get_completion_future(query, &first));
+        dns_query_complete(query, DNS_TRANSACTION_ABORTED);
+        ASSERT_EQ(sd_future_result(first), DNS_TRANSACTION_ABORTED);
+
+        query->state = DNS_TRANSACTION_NULL;
+        ASSERT_OK_POSITIVE(dns_query_go(query));
+
+        ASSERT_EQ(sd_future_result(first), DNS_TRANSACTION_ABORTED);
+        ASSERT_OK(dns_query_get_completion_future(query, &second));
+        ASSERT_EQ(sd_future_state(second), SD_FUTURE_RESOLVED);
+        ASSERT_EQ(sd_future_result(second), DNS_TRANSACTION_NO_SERVERS);
+}
+
+typedef struct QueryAwaitContext {
+        DnsQuery *query;
+        int result;
+} QueryAwaitContext;
+
+static int query_await_fiber(void *userdata) {
+        QueryAwaitContext *ctx = ASSERT_PTR(userdata);
+
+        ctx->result = dns_query_await(ctx->query);
+        return ctx->result;
+}
+
+TEST(dns_query_completion_future_await) {
+        _cleanup_(sd_event_unrefp) sd_event *event = NULL;
+        Manager manager = {};
+        _cleanup_(dns_question_unrefp) DnsQuestion *question = NULL;
+        _cleanup_(dns_query_freep) DnsQuery *query = NULL;
+        _cleanup_(sd_future_unrefp) sd_future *completion = NULL, *fiber = NULL;
+        QueryAwaitContext ctx = {};
+
+        ASSERT_OK(sd_event_new(&event));
+        ASSERT_OK(sd_event_set_exit_on_idle(event, true));
+        manager.event = event;
+
+        ASSERT_OK(dns_question_new_address(&question, AF_INET, "www.example.com", false));
+        ASSERT_OK(dns_query_new(&manager, &query, question, NULL, NULL, 1, 0));
+        ctx.query = query;
+
+        ASSERT_OK(sd_fiber_new(event, "query-await", query_await_fiber, &ctx, NULL, &fiber));
+        ASSERT_OK_POSITIVE(sd_event_run(event, 0));
+        ASSERT_EQ(sd_future_state(fiber), SD_FUTURE_PENDING);
+        ASSERT_OK(dns_query_get_completion_future(query, &completion));
+        ASSERT_NULL(sd_future_get_userdata(completion));
+
+        dns_query_complete(query, DNS_TRANSACTION_ABORTED);
+
+        ASSERT_OK(sd_event_loop(event));
+        ASSERT_EQ(ctx.result, DNS_TRANSACTION_ABORTED);
+        ASSERT_EQ(sd_future_result(fiber), DNS_TRANSACTION_ABORTED);
+}
+
+static int query_await_timeout_fiber(void *userdata) {
+        QueryAwaitContext *ctx = ASSERT_PTR(userdata);
+
+        ctx->result = -ENOTRECOVERABLE;
+        SD_FIBER_WITH_TIMEOUT(20 * USEC_PER_MSEC)
+                ctx->result = dns_query_await(ctx->query);
+
+        return ctx->result;
+}
+
+TEST(dns_query_completion_future_await_timeout) {
+        _cleanup_(sd_event_unrefp) sd_event *event = NULL;
+        Manager manager = {};
+        _cleanup_(dns_question_unrefp) DnsQuestion *question = NULL;
+        _cleanup_(dns_query_freep) DnsQuery *query = NULL;
+        _cleanup_(sd_future_unrefp) sd_future *completion = NULL, *fiber = NULL;
+        QueryAwaitContext ctx = {};
+
+        ASSERT_OK(sd_event_new(&event));
+        ASSERT_OK(sd_event_set_exit_on_idle(event, true));
+        manager.event = event;
+
+        ASSERT_OK(dns_question_new_address(&question, AF_INET, "www.example.com", false));
+        ASSERT_OK(dns_query_new(&manager, &query, question, NULL, NULL, 1, 0));
+        ctx.query = query;
+
+        ASSERT_OK(sd_fiber_new(event, "query-await-timeout", query_await_timeout_fiber, &ctx, NULL, &fiber));
+        ASSERT_OK(sd_event_loop(event));
+        ASSERT_EQ(ctx.result, -ETIME);
+        ASSERT_ERROR(sd_future_result(fiber), ETIME);
+
+        ASSERT_OK(dns_query_get_completion_future(query, &completion));
+        ASSERT_EQ(sd_future_state(completion), SD_FUTURE_PENDING);
+        ASSERT_NULL(sd_future_get_userdata(completion));
+
+        dns_query_complete(query, DNS_TRANSACTION_ABORTED);
+
+        ASSERT_EQ(sd_future_state(completion), SD_FUTURE_RESOLVED);
+        ASSERT_EQ(sd_future_result(completion), DNS_TRANSACTION_ABORTED);
 }
 
 /* ================================================================

--- a/src/resolve/test-resolved-stream.c
+++ b/src/resolve/test-resolved-stream.c
@@ -201,13 +201,10 @@ static int on_stream_packet(DnsStream *stream, DnsPacket *p) {
         return 0;
 }
 
-static int on_stream_complete_do_nothing(DnsStream *s, int error) {
-        return 0;
-}
-
 static void test_dns_stream(bool tls) {
         Manager manager = {};
-         _cleanup_(dns_stream_unrefp) DnsStream *stream = NULL;
+        _cleanup_(dns_stream_unrefp) DnsStream *stream = NULL;
+        _cleanup_(sd_future_unrefp) sd_future *completion = NULL;
         _cleanup_(sd_event_unrefp) sd_event *event = NULL;
         _cleanup_close_ int clientfd = -EBADF;
         int r;
@@ -254,11 +251,9 @@ static void test_dns_stream(bool tls) {
         /* systemd-resolved uses (and requires) the socket to be in nonblocking mode */
         assert_se(fcntl(clientfd, F_SETFL, O_NONBLOCK) >= 0);
 
-        /* Initialize DNS stream (disabling the default self-destruction
-           behaviour when no complete callback is set) */
         assert_se(dns_stream_new(&manager, &stream, DNS_STREAM_LOOKUP, DNS_PROTOCOL_DNS,
-                                 TAKE_FD(clientfd), NULL, on_stream_packet, on_stream_complete_do_nothing,
-                                 DNS_STREAM_DEFAULT_TIMEOUT_USEC) >= 0);
+                                 TAKE_FD(clientfd), NULL, on_stream_packet, DNS_STREAM_DEFAULT_TIMEOUT_USEC) >= 0);
+        assert_se(dns_stream_get_completion_future(stream, &completion) >= 0);
 #if ENABLE_DNS_OVER_TLS
         if (tls) {
                 DnsServer server = {


### PR DESCRIPTION
Resolved used ad-hoc completion callbacks for queries, hooks, streams, and client replies. That made fiber-based D-Bus and varlink methods hard to abort cleanly when callers disconnected or TCP streams closed.

Add shared resolved future helpers and await helpers for queries, candidates, transactions, streams, and hooks. Move D-Bus and varlink Resolve* handlers to fiber methods, and run stub and mDNS completion from fire-and-forget fibers.

Preserve TCP disconnect, hook abort, and CNAME restart behavior by resolving object futures on terminal states and rechecking query liveness after awaits.

Co-developed-by: OpenAI Codex <noreply@openai.com>