### PR TITLE
resolved: process networkd events before RTNL updates

### DIFF
--- a/src/resolve/resolved-manager.c
+++ b/src/resolve/resolved-manager.c
@@ -369,7 +369,7 @@ static int manager_network_monitor_listen(Manager *m) {
         if (r < 0)
                 return r;
 
-        r = sd_event_source_set_priority(m->network_event_source, SD_EVENT_PRIORITY_IMPORTANT+5);
+        r = sd_event_source_set_priority(m->network_event_source, SD_EVENT_PRIORITY_IMPORTANT-5);
         if (r < 0)
                 return r;
 


### PR DESCRIPTION
### Problem

resolved watches networkd state changes and RTNL updates separately. RTNL
events are processed at `SD_EVENT_PRIORITY_IMPORTANT`, while networkd state
changes are currently processed later at `SD_EVENT_PRIORITY_IMPORTANT+5`.

If both are pending, an `RTM_NEWADDR` update can make a link relevant for
LLMNR/mDNS scope allocation before resolved has consumed the corresponding
networkd state update. In that window, scope recalculation can use stale
per-link LLMNR/mDNS settings.

### Change

Process networkd state changes before RTNL updates by setting the network
monitor event source priority to `SD_EVENT_PRIORITY_IMPORTANT-5`.

This keeps the existing scope lifecycle intact: `link_allocate_scopes()` still
owns creating and dropping LLMNR/mDNS scopes, but it is reached after resolved
has had a chance to consume pending networkd link settings.

### Testing

```sh
meson test -C build test-dns-query test-resolved-link -v
```

### AI code generator disclosure

This change was prepared with OpenAI Codex and manually reviewed.

Fixes #42079