### PR TITLE
hostname-util: don't allow machine tags to begin/end with '-' or '.'

### DIFF
--- a/src/basic/hostname-util.c
+++ b/src/basic/hostname-util.c
@@ -259,6 +259,12 @@ bool machine_tag_is_valid(const char *s) {
         if (n <= 0 || n >= 256)
                 return false;
 
+        /* Don't allow "-" and "." as first or last char. (This is load-bearing, we want that "+"/"-" can be
+         * used as prefix for adding/removing tags from the list). */
+        if (strchr("-.", s[0]) ||
+            strchr("-.", s[n-1]))
+                return false;
+
         return in_charset(s, ALPHANUMERICAL "-.");
 }
 

--- a/src/test/test-hostname-util.c
+++ b/src/test/test-hostname-util.c
@@ -132,6 +132,10 @@ TEST(machine_tag_is_valid) {
         assert_se(!machine_tag_is_valid("fööbar"));    /* non-ASCII */
         assert_se(!machine_tag_is_valid("foo/bar"));
         assert_se(!machine_tag_is_valid("foo_bar"));
+        assert_se(!machine_tag_is_valid("-foo"));
+        assert_se(!machine_tag_is_valid("foo-"));
+        assert_se(!machine_tag_is_valid(".foo"));
+        assert_se(!machine_tag_is_valid("foo."));
 
         /* Length boundary: 255 characters is fine, 256 is too long */
         _cleanup_free_ char *max = strrep("a", 255), *over = strrep("a", 256);


### PR DESCRIPTION
This is in a way prep for #42390, which adds "machinectl tags +foo" and "machinectl tags -- -foo" as a mechanism for adding/removing tags from the current list of tags. But to avoid ambiguity let's hence make sure valid machine tags cannot themselves start with "-".

#42390 is material for v262, but let's get this one into v261, since it restricts the tag language