### PR TITLE
hwdb: Add Native Instruments Traktor MX2

### DIFF
--- a/hwdb.d/70-av-production.hwdb
+++ b/hwdb.d/70-av-production.hwdb
@@ -235,6 +235,10 @@ usb:v17CCp1210*
 usb:v17CCp1130*
  ID_AV_PRODUCTION_CONTROLLER=1
 
+# Traktor MX2
+usb:v17CCp2420*
+ ID_AV_PRODUCTION_CONTROLLER=1
+
 ####################
 # Pioneer
 ####################


### PR DESCRIPTION
This adds the following device to AV production hwdb:

 - ID 17cc:2420 Native Instruments Traktor MX2

Support for this new HID-based DJ controller was also recently merged to Mixxx.