### PR TITLE
docs: specifically mention that braces in if blocks do not need to be symmetric

### DIFF
--- a/docs/CODING_STYLE.md
+++ b/docs/CODING_STYLE.md
@@ -94,6 +94,28 @@ SPDX-License-Identifier: LGPL-2.1-or-later
   }
   ```
 
+- Braces in `if` blocks are not required to be symmetric. Write this:
+
+  ```c
+  if (foobar)
+          waldo();
+  else {
+          foo();
+          bar();
+  }
+  ```
+
+  instead of this:
+
+  ```c
+  if (foobar) {
+          waldo();
+  } else {
+          foo();
+          bar();
+  }
+  ```
+
 - Do not write `foo ()`, write `foo()`.
 
 - `else` blocks should generally start on the same line as the closing `}`:


### PR DESCRIPTION
The claude bot keeps getting this wrong again and again:

  Claude: nit: systemd coding style requires braces on both branches of
               an if/else when one branch uses them. Here the if branch
               is a single statement without braces but the else branch
               uses braces

Specifically mention this is not the case in the coding style doc to hopefully make it stop hallucinating this rule