### PR TITLE
ci: add build coverage for riscv64

### DIFF
--- a/.github/workflows/build-test.sh
+++ b/.github/workflows/build-test.sh
@@ -96,6 +96,9 @@ if [[ -n "$CROSS_ARCH" ]]; then
         armhf)
             triplet=arm-linux-gnueabihf
             ;;
+        riscv64)
+            triplet=riscv64-linux-gnu
+            ;;
         *)
             fatal "Unsupported cross architecture: $CROSS_ARCH"
             ;;

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -42,6 +42,9 @@ jobs:
           - env: { COMPILER: "gcc",   COMPILER_VERSION: "13", LINKER: "bfd", CROSS_ARCH: "armhf"  }
             runner: [ ubuntu-24.04-arm ]
             python-version: ''
+          - env: { COMPILER: "gcc",   COMPILER_VERSION: "13", LINKER: "bfd", CROSS_ARCH: "riscv64"  }
+            runner: [ ubuntu-24.04-arm ]
+            python-version: ''
           - env: { COMPILER: "clang", COMPILER_VERSION: "18", LINKER: "lld"  }
             runner: [ ubuntu-24.04-s390x ]
             python-version: ''

--- a/.github/workflows/riscv64-gcc.cross
+++ b/.github/workflows/riscv64-gcc.cross
@@ -1,0 +1,21 @@
+[binaries]
+c = 'riscv64-linux-gnu-gcc'
+cpp = 'riscv64-linux-gnu-g++'
+ar = 'riscv64-linux-gnu-gcc-ar'
+nm = 'riscv64-linux-gnu-gcc-nm'
+strip = 'riscv64-linux-gnu-strip'
+pkgconfig = 'pkg-config'
+
+[properties]
+needs_exe_wrapper = true
+pkg_config_libdir = '/usr/lib/riscv64-linux-gnu/pkgconfig:/usr/share/pkgconfig'
+c_args = ['-O2', '-pipe', '-g', '-feliminate-unused-debug-types']
+c_link_args = ['-fuse-ld=bfd', '-Wl,-O1', '-Wl,--hash-style=gnu', '-Wl,--as-needed', '-Wl,-z,relro,-z,now,-z,noexecstack']
+cpp_args = []
+cpp_link_args = ['-fuse-ld=bfd', '-Wl,-O1', '-Wl,--hash-style=gnu', '-Wl,--as-needed', '-Wl,-z,relro,-z,now,-z,noexecstack']
+
+[host_machine]
+system = 'linux'
+cpu_family = 'riscv64'
+cpu = 'riscv64'
+endian = 'little'

--- a/src/core/dynamic-user.c
+++ b/src/core/dynamic-user.c
@@ -357,8 +357,8 @@ static int dynamic_user_realize(
 
         r = dynamic_user_pop(d, &num, &uid_lock_fd);
         if (r < 0) {
-                int new_uid_lock_fd;
-                uid_t new_uid;
+                int new_uid_lock_fd = -EBADF; /* avoid false maybe-uninitialized warning */
+                uid_t new_uid = UID_INVALID; /* avoid false maybe-uninitialized warning */
 
                 if (r != -EAGAIN)
                         return r;
@@ -465,7 +465,7 @@ static int dynamic_user_realize(
 
 int dynamic_user_current(DynamicUser *d, uid_t *ret) {
         _cleanup_close_ int lock_fd = -EBADF;
-        uid_t uid;
+        uid_t uid = UID_INVALID; /* avoid false maybe-uninitialized warning */
         int r;
 
         assert(d);


### PR DESCRIPTION
This is already a primary architecture in Ubuntu, and more distributions
are adding support for it. It's too slow for emulation, but we can at
least verify that compilation works.

Use the arm worker, for two reasons:

- it is already set up with ports.ubuntu.com so we don't have to muck
  with apt sources manually
- it is used a lot less than the x86 worker