### PR TITLE
ci: make the review orchestrator emit one complete StructuredOutput call

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -429,10 +429,21 @@ jobs:
 
           ## Review result
 
-          Produce your review result as structured output. The fields are:
+          Produce your review result with a single `StructuredOutput` call that
+          contains all of these fields together:
           - `summary`: The markdown summary for the tracking comment.
           - `comments`: Array of review comments (same schema as the reviewer output above).
           - `resolve`: REST API IDs of review comment threads to resolve.
+
+          `comments` and `resolve` are required — include them in the same call even
+          when they are empty (`[]`). Never emit a call with `summary` alone; a call
+          missing `comments` is rejected and wastes a full retry. Build `comments`
+          first, then write `summary` from it, then emit everything in one call.
+
+          Keep `summary` concise: each checkbox is a short title, `path:line`, and a
+          one-line explanation — the detailed reasoning belongs in the matching
+          `comments` entry, not the summary. Do not restate full findings prose in
+          the summary.
           PROMPT
 
           claude \


### PR DESCRIPTION
The orchestrator repeatedly emitted StructuredOutput with only a long
`summary` and no `comments`, which the schema rejects as missing a required
property; one run burned 12 retries (and a large share of its output tokens)
re-typing rejected summaries before it shrank the summary enough to include
`comments`. Instruct it to build `comments` first, always include `comments`
and `resolve` (even when empty) in a single call, and keep the summary concise
so the detailed prose lives in the comments rather than being duplicated.

Co-developed-by: Claude Opus 4.8 <noreply@anthropic.com>
