### PR TITLE
libfido2-util: remove superfluous asserts

### DIFF
--- a/src/shared/libfido2-util.c
+++ b/src/shared/libfido2-util.c
@@ -1153,12 +1153,6 @@ static int check_device_is_fido2_with_hmac_secret(
         _cleanup_(fido_dev_free_wrapper) fido_dev_t *d = NULL;
         int r;
 
-        assert(ret_has_rk);
-        assert(ret_has_client_pin);
-        assert(ret_has_up);
-        assert(ret_has_uv);
-        assert(ret_has_always_uv);
-
         d = sym_fido_dev_new();
         if (!d)
                 return log_oom();
@@ -1170,7 +1164,16 @@ static int check_device_is_fido2_with_hmac_secret(
 
         r = verify_features(d, path, LOG_DEBUG, ret_has_rk, ret_has_client_pin, ret_has_up, ret_has_uv, ret_has_always_uv);
         if (r == -ENODEV) { /* Not a FIDO2 device, or not implementing 'hmac-secret' */
-                *ret_has_rk = *ret_has_client_pin = *ret_has_up = *ret_has_uv = *ret_has_always_uv = false;
+                if (ret_has_rk)
+                        *ret_has_rk = false;
+                if (ret_has_client_pin)
+                        *ret_has_client_pin = false;
+                if (ret_has_up)
+                        *ret_has_up = false;
+                if (ret_has_uv)
+                        *ret_has_uv = false;
+                if (ret_has_always_uv)
+                        *ret_has_always_uv = false;
                 return false;
         }
         if (r < 0)


### PR DESCRIPTION
These asserts don't make sense and actually break the FIDO2 support in systemd-cryptsetup.

This function is called with NULL pointers which trigger these asserts on lines 1311-1315 of the same file.