### PR TITLE
test: fix short timeout in TEST-74-AUX-UTILS.busctl

### DIFF
--- a/test/units/TEST-74-AUX-UTILS.busctl.sh
+++ b/test/units/TEST-74-AUX-UTILS.busctl.sh
@@ -82,7 +82,7 @@ systemd-run --quiet --service-type=notify --unit=test-busctl-wait-limited --pty 
 systemd-run --quiet --service-type=notify --unit=test-busctl-wait-unlimited --pty \
             -p Environment=SYSTEMD_LOG_LEVEL=debug \
             -p ExecStartPost="sh -c '$(signal_emit_command 2)'" \
-            busctl --timeout=3 --limit-messages=infinity wait /test org.freedesktop.fake1 TestSignal |
+            busctl --timeout=30 --limit-messages=infinity wait /test org.freedesktop.fake1 TestSignal |
             grep -Fc 's "success"' | xargs test 2 -eq
 
 busctl get-property org.freedesktop.systemd1 /org/freedesktop/systemd1 org.freedesktop.systemd1.Manager \


### PR DESCRIPTION
This was likely a typo as the other timeouts are '30' instead of '3'. This test occasionally fails with sanitizers which make everything slow. Bump it to 30s like other timeouts in the same test.

Follow-up for 985a6fa44b58c307030e43950ff2affa3f32546a

e.g.: https://github.com/systemd/systemd/actions/runs/26874403046/job/79257684357?pr=42439