### PR TITLE
oomd: reject invalid arguments early

### DIFF
--- a/src/oom/oomd-manager.c
+++ b/src/oom/oomd-manager.c
@@ -88,6 +88,11 @@ static int process_managed_oom_message(Manager *m, uid_t uid, sd_json_variant *p
                 if (r < 0)
                         continue;
 
+                if (!path_is_normalized(empty_to_root(message.path))) {
+                        log_debug("Received non-normalized cgroup path '%s', ignoring.", message.path);
+                        continue;
+                }
+
                 if (uid != 0) {
                         uid_t cg_uid;
 


### PR DESCRIPTION
Validate input parameter immediately during initial parsing

Follow-up for 9de5e32136949a531e71cb31170025c2e1d3430e