### PR TITLE
units: Run systemd-pcrnvdone in initrd

### DIFF
--- a/docs/TPM2_PCR_MEASUREMENTS.md
+++ b/docs/TPM2_PCR_MEASUREMENTS.md
@@ -265,7 +265,7 @@ on-the-fly by `systemd-stub`).
 
 ### PCR 9, NvPCR Initializations
 
-The `systemd-tpm2-setup.service` service initializes any NvPCRs defined via
+The `systemd-tpm2-setup-early.service` service initializes any NvPCRs defined via
 `*.nvpcr` files. For each initialized NvPCR it will measure an event into PCR
 9.
 
@@ -341,8 +341,8 @@ single-line JSON. Example string:
 
 ### PCR 9, NvPCR initialization separator
 
-After completion of `systemd-tpm2-setup.service` (which initializes all NvPCRs
-and measures their initial state) at arly boot the `systemd-pcrnvdone.service`
+After completion of `systemd-tpm2-setup-early.service` (which initializes all NvPCRs
+and measures their initial state) at early boot the `systemd-pcrnvdone.service`
 service will measure a separator event into PCR 9, isolating the early-boot
 NvPCR initializations from any later additions.
 

--- a/units/systemd-pcrnvdone.service.in
+++ b/units/systemd-pcrnvdone.service.in
@@ -11,11 +11,12 @@
 Description=TPM PCR NvPCR Initialization Separator
 Documentation=man:systemd-pcrnvdone.service(8)
 DefaultDependencies=no
-Conflicts=shutdown.target
-After=systemd-tpm2-setup-early.service systemd-tpm2-setup.service
-Before=sysinit.target cryptsetup-pre.target cryptsetup.target shutdown.target
+Conflicts=shutdown.target initrd-switch-root.target
+After=tpm2.target
+After=systemd-tpm2-setup-early.service
+Before=sysinit.target cryptsetup-pre.target cryptsetup.target shutdown.target initrd-switch-root.target
 ConditionSecurity=measured-os
-ConditionPathExists=!/etc/initrd-release
+ConditionPathExists=/etc/initrd-release
 FailureAction=reboot-force
 
 [Service]


### PR DESCRIPTION
The measurement that systemd-pcrnvdone corresponds to `src/pcrlock/pcrlock.d/770-nvpcr-separator.pcrlock`, and 770 is supposed to happen in the initrd (which ends at 800).