### PR TITLE
hwdb: add Griffin PowerMate

### DIFF
--- a/hwdb.d/70-av-production.hwdb
+++ b/hwdb.d/70-av-production.hwdb
@@ -122,6 +122,13 @@ usb:v0FD9p0084*
 usb:v0FD9p0086*
  ID_AV_PRODUCTION_CONTROLLER=1
 
+################
+# Griffin
+################
+# PowerMate
+usb:v077Dp0410*
+ ID_AV_PRODUCTION_CONTROLLER=1
+
 #############################
 # Hercules (Guillemot Corp)
 #############################


### PR DESCRIPTION
Discontinued, but still popular among some users (for example [ham radio](https://en.wikipedia.org/wiki/Amateur_radio) operators).

More details:
https://en.wikipedia.org/wiki/Griffin_PowerMate
https://the-sz.com/products/usbid/index.php?v=0x077D&p=0x0410