### PR TITLE
(hwdb) Update MSI Claw Entries

### DIFF
--- a/hwdb.d/60-keyboard.hwdb
+++ b/hwdb.d/60-keyboard.hwdb
@@ -1665,10 +1665,11 @@ evdev:atkbd:dmi:bvn*:bvr*:bd*:svnMicro-Star*:pn*Modern*:*
  KEYBOARD_KEY_97=unknown                                # Lid close
  KEYBOARD_KEY_98=unknown                                # Lid open
 
-# MSI Claw A1M, MSI Claw 7 AI+ A2VM, MSI Claw 8 AI+ A2VM
-evdev:name:AT Translated Set 2 keyboard:dmi:*:svnMicro-StarInternationalCo.,Ltd.:pnClawA1M:*
-evdev:name:AT Translated Set 2 keyboard:dmi:*:svnMicro-StarInternationalCo.,Ltd.:pnClaw7AI+A2VM:*
-evdev:name:AT Translated Set 2 keyboard:dmi:*:svnMicro-StarInternationalCo.,Ltd.:pnClaw8AI+A2VM:*
+# MSI Claw A1M, MSI Claw 7 AI+ A2VM, MSI Claw 8 AI+ A2VM, MSI Claw A8 BZ2EM
+evdev:name:AT Translated Set 2 keyboard:dmi:*:svnMicro-StarInternationalCo.,Ltd.:rnMS-1T41:*
+evdev:name:AT Translated Set 2 keyboard:dmi:*:svnMicro-StarInternationalCo.,Ltd.:rnMS-1T42:*
+evdev:name:AT Translated Set 2 keyboard:dmi:*:svnMicro-StarInternationalCo.,Ltd.:rnMS-1T52:*
+evdev:name:AT Translated Set 2 keyboard:dmi:*:svnMicro-StarInternationalCo.,Ltd.:rnMS-1T8K:*
  KEYBOARD_KEY_b9=f15                                   # Right Face Button
  KEYBOARD_KEY_ba=f16                                   # Left Face Button
 


### PR DESCRIPTION
- Add support for MSI Claw A8 BZ2EM.
- Switch to using rn vice pn as MSI uses a unique pn for variants of the same model. This prevents needing to update this file when a low volume variant is released (I.E. Polar White 8 AI+).

MSI Claw A1M modalias:
`E: MODALIAS=dmi:bvnAmericanMegatrendsInternational,LLC.:bvrE1T41IMS.10D:bd09/30/2024:br1.13:svnMicro-StarInternationalCo.,Ltd.:pnClawA1M:pvrREV1.0:rvnMicro-StarInternationalCo.,Ltd.:rnMS-1T41:rvrREV1.0:cvnMicro-StarInternationalCo.,Ltd.:ct30:cvrN/A:sku1T41.1:pfaClaw:`

MSI Claw 8 AI+ modalias
`E: MODALIAS=dmi:bvnAmericanMegatrendsInternational,LLC.:bvrE1T52IMS.10B:bd01/06/2025:br1.11:svnMicro-StarInternationalCo.,Ltd.:pnClaw8AI+A2VM:pvrREV1.0:rvnMicro-StarInternationalCo.,Ltd.:rnMS-1T52:rvrREV1.0:cvnMicro-StarInternationalCo.,Ltd.:ct30:cvrN/A:sku1T52.1:`

MSI Claw A8 BZ2EM modalias:
`E: MODALIAS=dmi:bvnAmericanMegatrendsInternational,LLC.:bvrE1T8KAMS.106:bd01/05/2026:br1.6:svnMicro-StarInternationalCo.,Ltd.:pnClawA8BZ2EM:pvrREV1.0:rvnMicro-StarInternationalCo.,Ltd.:rnMS-1T8K:rvrREV1.0:cvnMicro-StarInternationalCo.,Ltd.:ct30:cvrN/A:sku1T8K.1:pfaClawA:`

I don't have access to a Claw 7 AI+, but the motherboard entry matches what is found here:
https://browser.geekbench.com/v6/cpu/17439664