### PR TITLE
hwdb: gpd micropc2 sensor fix

### DIFF
--- a/hwdb.d/60-sensor.hwdb
+++ b/hwdb.d/60-sensor.hwdb
@@ -527,7 +527,7 @@ sensor:modalias:acpi:BMI0160:*:dmi:*:svnGPD:pnG1619-04:*    # Win Max 2
  ACCEL_MOUNT_MATRIX=0, -1, 0; -1, 0, 0; 0, 0, 1
 
 sensor:modalias:acpi:MXC6655:*:dmi:*:svnGPD:pnG1688-08:*    # MicroPC 2
- ACCEL_MOUNT_MATRIX=0, -1, 0; -1, 0, 0; 0, 0, -1
+ ACCEL_MOUNT_MATRIX=-1, 0, 0; 0, 1, 0; 0, 0, -1
 
 #########################################
 # Hometech


### PR DESCRIPTION
Correction of matrix for GPD MicroPC 2. No idea why I had done it incorrectly the first time, but this is 100% correct.

udevadm info --export-db output: https://pastebin.com/8LCu8Dpi

For context, when I was on arch and updated to systemd version 259 in which the changes were included, it was working fine - my guess is the update didn't reload the hwdb rules. On NixOS I updated a few hours ago to 26.05 where I realised the matrix was infact wrong. 

I'm not sure why it wasn't correct initially to need a rule which seemed to fix it (hence why I bothered to merge request in the first place), but then the rule also broke it when it finally seemingly got applied. I hope that makes sense; although even having typed it out I'm not entirely sure why this happened.

But anyway, I had rolled back to the previous version of NixOS, cat'd the iio device for the matrix and got the working one, and that is reflected in this request.

Thanks!