### PR TITLE
boot: enable only IMAFDCZicsrZifencei for RISC-V

### DIFF
--- a/src/boot/meson.build
+++ b/src/boot/meson.build
@@ -270,6 +270,9 @@ efi_arch_c_args = {
         'arm'         : ['-mgeneral-regs-only'],
         # Until -mgeneral-regs-only is supported in LoongArch, use the following option instead:
         'loongarch64' : ['-mno-lsx', '-mno-lasx'],
+        # Assume F/D is usable on RISC-V because they're difficult to disable
+        'riscv32'     : ['-march=rv32imafdc_zicsr_zifencei'],
+        'riscv64'     : ['-march=rv64imafdc_zicsr_zifencei'],
         # Pass -m64/32 explicitly to make building on x32 work.
         'x86_64'      : ['-m64', '-march=x86-64', '-mno-red-zone', '-mgeneral-regs-only'],
         'x86'         : ['-m32', '-march=i686', '-mgeneral-regs-only', '-malign-double'],


### PR DESCRIPTION
The UEFI specification only defines A/C/I/M/Zicsr/Zifencei as mandatory extensions in boot services. However, on systems with everything built with F/D support, its difficult to disable F/D without changing a toolchain. In addition, both EDK2 and U-Boot enable F/D on boot, although they neither enable nor disable V. EDK2 comments even claim the enablement of FPU is "to be compliant with UEFI spec" despite the spec requires dynamic detection before using F/D.

Add corresponding -march flags to prevent systemd-boot from using other extensions on RISC-V, and a comment for the temporary enablement of F/D.

This prevents V usage of systemd-boot, which will fail in a RISC-V KVM virtual machine with EDK2.