### PR TITLE
resolve: only write one ELF note for libcrypto

### DIFF
--- a/src/resolve/resolved-dns-dnssec.c
+++ b/src/resolve/resolved-dns-dnssec.c
@@ -12,6 +12,7 @@
 #include "memory-util.h"
 #include "memstream-util.h"
 #include "resolved-dns-dnssec.h"
+#include "resolved-util.h"
 #include "sort-util.h"
 #include "string-table.h"
 #include "string-util.h"
@@ -709,7 +710,7 @@ int dnssec_verify_rrset(
         assert(dnskey);
         assert(result);
 
-        r = DLOPEN_LIBCRYPTO(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+        r = DLOPEN_LIBCRYPTO(LOG_DEBUG, DLOPEN_LIBCRYPTO_PRIORITY);
         if (r < 0)
                 return r;
 
@@ -1066,7 +1067,7 @@ int dnssec_verify_dnskey_by_ds(DnsResourceRecord *dnskey, DnsResourceRecord *ds,
         assert(dnskey);
         assert(ds);
 
-        r = DLOPEN_LIBCRYPTO(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+        r = DLOPEN_LIBCRYPTO(LOG_DEBUG, DLOPEN_LIBCRYPTO_PRIORITY);
         if (r < 0)
                 return r;
 
@@ -1206,7 +1207,7 @@ int dnssec_nsec3_hash(DnsResourceRecord *nsec3, const char *name, void *ret) {
         assert(name);
         assert(ret);
 
-        r = DLOPEN_LIBCRYPTO(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+        r = DLOPEN_LIBCRYPTO(LOG_DEBUG, DLOPEN_LIBCRYPTO_PRIORITY);
         if (r < 0)
                 return r;
 

--- a/src/resolve/resolved-util.h
+++ b/src/resolve/resolved-util.h
@@ -1,4 +1,12 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 #pragma once
 
+#include "sd-dlopen.h"
+
+#if ENABLE_DNS_OVER_TLS
+#  define DLOPEN_LIBCRYPTO_PRIORITY SD_ELF_NOTE_DLOPEN_PRIORITY_REQUIRED
+#else
+#  define DLOPEN_LIBCRYPTO_PRIORITY SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED
+#endif
+
 int resolve_system_hostname(char **full_hostname, char **first_label);


### PR DESCRIPTION
Otherwise systemd-resolved has 2 contradictory notes for libcrypto:

```
$ systemd-analyze dlopen-metadata /usr/lib/systemd/systemd-resolved
FEATURE   DESCRIPTION                                SONAME         PRIORITY
libcrypto Support for cryptographic operations       libcrypto.so.3 recommended
idn       Support for internationalized domain names libidn2.so.0   recommended
libcrypto Support for cryptographic operations       libcrypto.so.3 required
libssl    Support for TLS                            libssl.so.3    required
```