### PR TITLE
test: wrap sd-run call with timeout to avoid long hangs in TEST-54-CREDS

### DIFF
--- a/test/units/TEST-54-CREDS.sh
+++ b/test/units/TEST-54-CREDS.sh
@@ -17,7 +17,8 @@ run_with_cred_compare() (
     trap "rm -f '$log_file'" RETURN
 
     set -o pipefail
-    systemd-run -p SetCredential="$cred" --wait --pipe -- systemd-creds "$@" | tee "$log_file"
+    # This has been observed to get stuck under ASAN, so add a timeout as precaution
+    timeout 120 systemd-run -p SetCredential="$cred" --wait --pipe -- systemd-creds "$@" | tee "$log_file"
     diff "$log_file" <(echo -ne "$exp")
 )
 


### PR DESCRIPTION
This has been observed to get stuck in an ASAN run, so wrap it in a timeout call to at least get it to fail fast and hopefully get better logs rather than a testbed timeout.

e.g.: https://github.com/systemd/systemd/actions/runs/26917537543/job/79410602066?pr=42462