### PR TITLE
udev: skip loop device setup for device-mapper devices

### DIFF
--- a/src/udev/udev-builtin-blkid.c
+++ b/src/udev/udev-builtin-blkid.c
@@ -458,6 +458,12 @@ static int probe_gpt_boot_disk_needs_loop(UdevEvent *event, int fd) {
                         return log_device_debug_errno(dev, r, "Failed to check if partition scanning is enabled: %m");
                 if (r > 0)
                         return 0;
+
+                r = device_sysname_startswith(dev, "dm-");
+                if (r < 0)
+                        return log_device_debug_errno(dev, r, "Failed to check sysname: %m");
+                if (r > 0)
+                        return 0;
         }
 
         if (sector_size_mismatch)

--- a/src/udev/udev-builtin-blkid.c
+++ b/src/udev/udev-builtin-blkid.c
@@ -458,6 +458,15 @@ static int probe_gpt_boot_disk_needs_loop(UdevEvent *event, int fd) {
                         return log_device_debug_errno(dev, r, "Failed to check if partition scanning is enabled: %m");
                 if (r > 0)
                         return 0;
+
+                /* DM devices disable kernel partition scanning, relying on user space
+                 * tools. This is not a hardware limitation, so a loop device is not
+                 * needed. MD and loop devices are also skipped to be extra safe. */
+                r = device_sysname_startswith(dev, "dm-", "md", "loop");
+                if (r < 0)
+                        return log_device_debug_errno(dev, r, "Failed to check sysname: %m");
+                if (r > 0)
+                        return 0;
         }
 
         if (sector_size_mismatch)


### PR DESCRIPTION
Device mapper devices do not have partscan enabled, so probe_gpt_boot_disk_needs_loop would identify them as needing a loop device when they contain the EFI partition from which the machine booted. This causes blkid probing to not take place.

Fixes: #42472

Co-developed-by: Claude Opus 4.6 <noreply@anthropic.com>