### PR TITLE
sd-dlopen: fix build on 'alpha'

### DIFF
--- a/src/systemd/sd-dlopen.h
+++ b/src/systemd/sd-dlopen.h
@@ -68,7 +68,7 @@ extern "C" {
 #define _SD_ELF_NOTE_DLOPEN(json)                                                                                               \
         __asm__ (                                                                                                               \
                 ".ifndef \"sd_dlopen:" json "\"\n"                                                                              \
-                ".set \"sd_dlopen:" json "\", 1\n"                                                                              \
+                ".equ \"sd_dlopen:" json "\", 1\n" /* guard tag, avoid using 'set' as it breaks builds on alpha */              \
                 ".pushsection .note.dlopen, \"" _SD_ELF_NOTE_DLOPEN_SECTION_FLAGS "\", %note, \"sd_dlopen:" json "\", comdat\n" \
                 ".balign 4\n"         /* notes require 4-byte alignment for the header and fields */                            \
                 ".long 884f - 883f\n" /* n_namesz: byte length of the vendor name (label 883->884) */                           \


### PR DESCRIPTION
On alpha '.set' is overridden to mean something else, so the build fails:

```
/tmp/ccckEb4p.s:11442: Warning: Tried to .set unrecognized mode `sd_dlopen:[{"feature":"lzma","description":"Support lzma compression in journal and coredump files","priority":"suggested","soname":["liblzma.so.5"]}]'
/tmp/ccckEb4p.s:11442: Error: junk at end of line, first unrecognized character is `,'
```

Switch to '.equ' which seems to do the job just as well, and builds on alpha too.

Follow-up for 56a7febca7cd68a10cb85c6d8123db63217f4079