### PR TITLE
Fix handling of `UKI/SBAT` and `UKI/Firmware` config entries.

### DIFF
--- a/src/ukify/ukify.py
+++ b/src/ukify/ukify.py
@@ -1762,6 +1762,8 @@ class ConfigItem:
         old = getattr(namespace, dest, [])
         if old is None:
             old = []
+        if not isinstance(value, list):
+            value = [value]
         setattr(namespace, dest, value + old)
 
     @staticmethod

--- a/src/ukify/ukify.py
+++ b/src/ukify/ukify.py
@@ -2018,6 +2018,7 @@ CONFIG_ITEMS = [
         default=[],
         action='append',
         config_key='UKI/SBAT',
+        config_push=ConfigItem.config_list_prepend,
     ),
     ConfigItem(
         '--pcrpkey',


### PR DESCRIPTION
Hi, first time contributor, but the changes seem minor, so hopefull no big problems there.

This fixes 2 issues with `ukify`:

`config_list_prepend` needs a list. The 2 more used entries are specially treated (parsed into a list) and therefore happen to work, but trying to set `UKI/Firmware` throws a type error, as it is passed as just a string.

The `UKI/SBAT` config entry is a list but used the default `config_push` value which sets it if unset (which also failed since its default of `[]` is not `None`) - change this to `config_list_prepend`.

I did consider adding a `config_list_append`, but as far as I'm aware, the order of sbat entries should not change the outcome anyway.