### PR TITLE
gitignore: also ignore mkosi.local.conf in subdirectories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ __pycache__/
 /install-tree
 /mkosi/mkosi.crt
 /mkosi/mkosi.key
-/mkosi/mkosi.local.conf
+/mkosi/**/mkosi.local.conf
 /mkosi/mkosi.tools
 /mkosi/mkosi.tools.manifest
 /mkosi.tools/


### PR DESCRIPTION
Like done in c7113f6b3cd9932ac2ddba507138bc9d7df49d4d, sometimes we want to create mkosi.local.conf in a sub-mkosi directory, e.g. mkosi.tools.conf.d/mkosi.local.conf, and of course we should not take these files into git repository.