### PR TITLE
test: add missing bpf dependency

### DIFF
--- a/src/test/meson.build
+++ b/src/test/meson.build
@@ -510,6 +510,7 @@ executables += [
         core_test_template + {
                 'sources' : files('test-bpf-restrict-fsaccess.c'),
                 'dependencies' : common_test_dependencies,
+                'bpf_programs' : ['restrict-fsaccess'],
                 'type' : 'manual',
         },
         core_test_template + {


### PR DESCRIPTION
Fixes the following build error:
```
ninja: job failed: cc (snip) -o test-bpf-restrict-fsaccess.p/src_test_test-bpf-restrict-fsaccess.c.o -c ../src/test/test-bpf-restrict-fsaccess.c
In file included from ../src/test/test-bpf-restrict-fsaccess.c:96:
src/bpf/restrict-fsaccess-skel.h:19:10: fatal error: restrict-fsaccess.bpf.skel.h: No such file or directory
   19 | #include "restrict-fsaccess.bpf.skel.h"    /* IWYU pragma: export */
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
ninja: subcommand failed
```

Follow-up for e6fc73350f9485064302e687b964f70b28b2e4f6.