### PR TITLE
test-btrfs: quota test is slow

### DIFF
--- a/src/test/meson.build
+++ b/src/test/meson.build
@@ -66,7 +66,6 @@ simple_tests += files(
         'test-bitmap.c',
         'test-blockdev-util.c',
         'test-bootspec.c',
-        'test-btrfs.c',
         'test-build-path.c',
         'test-bus-unit-util.c',
         'test-bus-util.c',
@@ -259,6 +258,10 @@ executables += [
         test_template + {
                 'sources' : files('test-boot-timestamps.c'),
                 'conditions' : ['ENABLE_EFI'],
+        },
+        test_template + {
+                'sources' : files('test-btrfs.c'),
+                'timeout' : 120,
         },
         test_template + {
                 'sources' : files('test-chase-manual.c'),

--- a/src/test/test-btrfs.c
+++ b/src/test/test-btrfs.c
@@ -141,6 +141,9 @@ TEST(recursive) {
 }
 
 TEST(quota) {
+        if (!slow_tests_enabled())
+                return (void) log_tests_skipped("slow tests are disabled");
+
         _cleanup_(rm_rf_subvolume_and_freep) char *dir = NULL;
         _cleanup_close_ int dir_fd = ASSERT_OK(open_test_subvol(&dir));
         BtrfsQuotaInfo quota;


### PR DESCRIPTION
The quota test takes ~30 seconds on my poor laptop, and randomly fails with timeout. Let's extend the timeout and skip the test case when slow tests are disabled.