### PR TITLE
resolved: don't rename the mDNS hostname when our own records are reflected back

### DIFF
--- a/src/resolve/resolved-dns-zone.c
+++ b/src/resolve/resolved-dns-zone.c
@@ -521,7 +521,14 @@ static bool dns_zone_item_probe_reply_is_conflict(DnsZoneItem *i) {
          * Per RFC 6762 section 8.2 a record only conflicts with one we are probing for if it carries the
          * same name but *different* rdata; a record with rdata identical to ours is explicitly not a
          * conflict. The steady-state path (dns_zone_check_conflicts()) already honors this via
-         * dns_zone_get(); the probe path should too. */
+         * dns_zone_get(); the probe path should too.
+         *
+         * We treat a record as ours if we publish it on *any* local interface, not just the one this probe
+         * runs on. resolved keeps a separate mDNS zone per interface; if the host is multi-homed and an
+         * mDNS reflector is bridging mDNS between its links, our own announcement on one link can come back
+         * on another carrying that other link's address, and would otherwise look foreign to the receiving
+         * scope's zone. This mirrors how mDNSResponder's conflict check (FindRRSet) ignores the InterfaceID.
+         * See manager_mdns_record_is_ours(). */
 
         DNS_ANSWER_FOREACH(rr, i->probe_transaction->answer) {
                 /* Only consider records carrying the name we are probing for. */
@@ -532,8 +539,8 @@ static bool dns_zone_item_probe_reply_is_conflict(DnsZoneItem *i) {
                 if (dns_resource_key_is_dnssd_ptr(rr->key))
                         continue;
 
-                /* If we own this exact record ourselves, it's ours, not a conflict. */
-                if (dns_zone_get(&i->scope->zone, rr))
+                /* If we publish this record on any of our interfaces, it's ours (possibly reflected). */
+                if (manager_mdns_record_is_ours(i->scope->manager, rr))
                         continue;
 
                 /* A record on our name that we do not own: a genuine, foreign conflict. */

--- a/src/resolve/resolved-dns-zone.c
+++ b/src/resolve/resolved-dns-zone.c
@@ -509,6 +509,40 @@ void dns_zone_item_conflict(DnsZoneItem *i) {
                 manager_next_hostname(i->scope->manager);
 }
 
+static bool dns_zone_item_probe_reply_is_conflict(DnsZoneItem *i) {
+        DnsResourceRecord *rr;
+
+        assert(i);
+        assert(i->probe_transaction);
+
+        /* Checks whether the reply that completed our probe transaction actually represents a conflict,
+         * i.e. carries a record on our name that we do not own ourselves.
+         *
+         * Per RFC 6762 section 8.2 a record only conflicts with one we are probing for if it carries the
+         * same name but *different* rdata; a record with rdata identical to ours is explicitly not a
+         * conflict. The steady-state path (dns_zone_check_conflicts()) already honors this via
+         * dns_zone_get(); the probe path should too. */
+
+        DNS_ANSWER_FOREACH(rr, i->probe_transaction->answer) {
+                /* Only consider records carrying the name we are probing for. */
+                if (dns_name_equal(dns_resource_key_name(rr->key), dns_resource_key_name(i->rr->key)) <= 0)
+                        continue;
+
+                /* DNS-SD service enumeration PTRs are shared, never unique, hence never conflict. */
+                if (dns_resource_key_is_dnssd_ptr(rr->key))
+                        continue;
+
+                /* If we own this exact record ourselves, it's ours, not a conflict. */
+                if (dns_zone_get(&i->scope->zone, rr))
+                        continue;
+
+                /* A record on our name that we do not own: a genuine, foreign conflict. */
+                return true;
+        }
+
+        return false;
+}
+
 void dns_zone_item_notify(DnsZoneItem *i) {
         assert(i);
         assert(i->probe_transaction);
@@ -531,8 +565,17 @@ void dns_zone_item_notify(DnsZoneItem *i) {
                  * and defend it. */
 
                 if (!IN_SET(i->state, DNS_ZONE_ITEM_ESTABLISHED, DNS_ZONE_ITEM_VERIFYING)) {
-                        log_debug("Got a successful probe for not yet established RR, we lost.");
-                        we_lost = true;
+                        /* For mDNS, a probe reply that consists solely of records we already own is not a
+                         * conflict (RFC 6762 section 8.2) — most commonly it is our own announcement
+                         * reflected back to us by an mDNS reflector. Only give up the name if the reply
+                         * carries a foreign record on our name. */
+                        if (i->probe_transaction->scope->protocol == DNS_PROTOCOL_MDNS &&
+                            !dns_zone_item_probe_reply_is_conflict(i))
+                                log_debug("Got a successful probe reply for not yet established RR, but it only contains records we own; not a conflict.");
+                        else {
+                                log_debug("Got a successful probe for not yet established RR, we lost.");
+                                we_lost = true;
+                        }
                 } else if (i->probe_transaction->scope->protocol == DNS_PROTOCOL_LLMNR) {
                         assert(i->probe_transaction->received);
                         we_lost = memcmp(&i->probe_transaction->received->sender, &i->probe_transaction->received->destination, FAMILY_ADDRESS_SIZE(i->probe_transaction->received->family)) < 0;

--- a/src/resolve/resolved-manager.c
+++ b/src/resolve/resolved-manager.c
@@ -1555,6 +1555,37 @@ bool manager_packet_from_local_address(Manager *m, DnsPacket *p) {
         return !!manager_find_link_address(m, p->family, &p->sender);
 }
 
+bool manager_mdns_record_is_ours(Manager *m, DnsResourceRecord *rr) {
+        assert(m);
+        assert(rr);
+
+        /* Checks whether the given record is one we publish ourselves on *any* local interface.
+         *
+         * resolved keeps a separate mDNS zone per interface (per DnsScope, keyed by the arrival ifindex).
+         * On a multi-homed host with an mDNS reflector bridging mDNS between its links, a record we publish
+         * on one link can come back on another carrying that other link's address, and so look foreign to
+         * the receiving scope's zone. To recognize such records as ours regardless of the interface they
+         * arrive on, we consult all scopes' zones here. This mirrors how mDNSResponder's conflict check
+         * (FindRRSet) ignores the InterfaceID. */
+
+        /* Address records: short-circuit via the set of addresses actually configured on our links. This
+         * also covers the window before the corresponding address RR has been entered into a zone. */
+        if (rr->key->type == DNS_TYPE_A &&
+            manager_find_link_address(m, AF_INET, &(union in_addr_union) { .in = rr->a.in_addr }))
+                return true;
+        if (rr->key->type == DNS_TYPE_AAAA &&
+            manager_find_link_address(m, AF_INET6, &(union in_addr_union) { .in6 = rr->aaaa.in6_addr }))
+                return true;
+
+        /* Any record type: is an identical record (same name, type, class, and rdata) published in any
+         * scope's zone? */
+        LIST_FOREACH(scopes, s, m->dns_scopes)
+                if (dns_zone_get(&s->zone, rr))
+                        return true;
+
+        return false;
+}
+
 bool manager_packet_from_our_transaction(Manager *m, DnsPacket *p) {
         DnsTransaction *t;
 

--- a/src/resolve/resolved-manager.h
+++ b/src/resolve/resolved-manager.h
@@ -195,6 +195,7 @@ int manager_next_hostname(Manager *m);
 
 bool manager_packet_from_local_address(Manager *m, DnsPacket *p);
 bool manager_packet_from_our_transaction(Manager *m, DnsPacket *p);
+bool manager_mdns_record_is_ours(Manager *m, DnsResourceRecord *rr);
 
 DnsScope* manager_find_scope_from_protocol(Manager *m, int ifindex, DnsProtocol protocol, int family);
 


### PR DESCRIPTION
## Summary

A multi-homed systemd-resolved host behind an mDNS reflector/repeater (a feature of many prosumer/enterprise routers and APs — e.g. UniFi, pfSense/OPNsense via Avahi, MikroTik — that bridges mDNS between VLANs/segments) can end up renaming its own published hostname against itself, repeatedly: `foo.local` → `foo2.local` → `foo3.local`. In the wild this has run hostnames up to five-digit suffixes.

Addresses #35780.

## Root cause

Two things combine:

1. **The probe path didn't follow RFC 6762's definition of a conflict.** When resolved probes a unique mDNS record (RFC 6762 §8.1), `dns_zone_item_notify()` treated *any* successful probe reply for a not-yet-established record as "we lost", without inspecting the reply's rdata. But §8.2/§9 define a conflict as a record with the same name/rrtype/rrclass and **different** rdata; identical rdata is explicitly *not* a conflict. resolved's steady-state path (`dns_zone_check_conflicts()`) already honors this via `dns_zone_get()`; the probe path did not.

2. **resolved's mDNS zones are per-interface.** Each scope (keyed by arrival ifindex) has its own zone. On a multi-homed host with a reflector bridging mDNS between its links, the host's own announcement on link A comes back on link B carrying link B's address — same name, **different** rdata than link A's zone entry — so even an rdata-aware *per-scope* check sees it as foreign and the host renames against itself. The reflector also re-sources the packet from its own address, so the existing local-host filter in `on_mdns_packet()` can't recognize it as ours either.

## Changes

1. **`resolved: don't treat an identical-rdata reply as an mDNS probe conflict`**
   Align the probe path with the RFC and the steady-state path: for mDNS, only give up the name if the completing reply carries a *foreign* record on our name (one we don't own in this scope's zone, and not a shared DNS-SD enumeration PTR). LLMNR behavior is unchanged.

2. **`resolved: recognize our own mDNS records across all interfaces during probing`**
   Add `manager_mdns_record_is_ours()`, which treats a record as ours if we publish it on *any* interface — A/AAAA via `manager_find_link_address()` (addresses configured on all links), any type via all scopes' zones — and use it from the probe-reply check instead of the single-scope lookup. This is the resolved equivalent of mDNSResponder's `FindRRSet`, which ignores the InterfaceID, and is what handles the multi-homed + reflector case above.

## Reproduction

A multi-homed host with an mDNS reflector bridging its links/VLANs (as in #35780): the host renames its hostname every time its own announcement is reflected back from another link carrying that link's address.

## Out of scope / follow-ups

- The simultaneous-probe **tiebreak** path (`mdns_do_tiebreak()` → `dns_zone_item_conflict()`) reaches the conflict decision independently of the probe-reply path fixed here. It already ties (no loss) on byte-identical records, but a multi-homed *query*-reflection could still misfire; applying the same self-recognition there is a sensible follow-up.
- resolved does not implement RFC 6762 §9's conflict **rate-limiting** (≥5 s backoff after rapid conflicts), which is why the runaway rename loop can climb so fast. Adding it would be good defense-in-depth, independent of this fix.

## Related

- #42072 — same "renames against itself" symptom but a **distinct** root cause (the `526f1594d` local-loopback regression, addressed by revert `658e5ac0`). This PR fixes the reflector variant, which the source-address guard cannot catch.

---

Developed with the help of Claude (Claude Opus 4.8).

The investigation mainly started since we observed that mDNSResponder behaved different from systemd-resolved in environment where the host was multi-homed and Unifi mDNS Proxy was active. Digging into the details revealed the differences in conflict detection.