### PR TITLE
test: bump test-execute subtest timeout in CI

### DIFF
--- a/src/test/test-execute.c
+++ b/src/test/test-execute.c
@@ -78,9 +78,9 @@ static void wait_for_service_finish(Manager *m, Unit *unit) {
 
         ASSERT_NOT_NULL(m);
 
-        /* Bump the timeout when running in plain QEMU, as some more involved tests might start hitting the
-         * default 2m timeout (like exec-dynamicuser-statedir.service) */
-        if (detect_virtualization() == VIRTUALIZATION_QEMU)
+        /* Bump the timeout when running in plain QEMU or in CI, as some more involved tests might start
+         * hitting the default 2m timeout (like exec-dynamicuser-statedir.service). */
+        if (detect_virtualization() == VIRTUALIZATION_QEMU || ci_environment())
                 timeout *= 2;
 
         printf("%s\n", unit->id);


### PR DESCRIPTION
The test is flaky and times out lately in ppc64el CI runners:

exec-dynamicuser-statedir.service: Control group is empty. exec-dynamicuser-statedir.service: User lookup succeeded: uid=65325 gid=65325 Test timeout when testing exec-dynamicuser-statedir.service

Bump the timeout also when in a CI, as they are often over subscribed

e.g.: https://github.com/systemd/systemd/actions/runs/26983344385/job/79627487171?pr=42484