### PR TITLE
hwdb: fix match for MSI Claw entries

### DIFF
--- a/hwdb.d/60-keyboard.hwdb
+++ b/hwdb.d/60-keyboard.hwdb
@@ -1666,10 +1666,10 @@ evdev:atkbd:dmi:bvn*:bvr*:bd*:svnMicro-Star*:pn*Modern*:*
  KEYBOARD_KEY_98=unknown                                # Lid open
 
 # MSI Claw A1M, MSI Claw 7 AI+ A2VM, MSI Claw 8 AI+ A2VM, MSI Claw A8 BZ2EM
-evdev:name:AT Translated Set 2 keyboard:dmi:*:svnMicro-StarInternationalCo.,Ltd.:rnMS-1T41:*
-evdev:name:AT Translated Set 2 keyboard:dmi:*:svnMicro-StarInternationalCo.,Ltd.:rnMS-1T42:*
-evdev:name:AT Translated Set 2 keyboard:dmi:*:svnMicro-StarInternationalCo.,Ltd.:rnMS-1T52:*
-evdev:name:AT Translated Set 2 keyboard:dmi:*:svnMicro-StarInternationalCo.,Ltd.:rnMS-1T8K:*
+evdev:name:AT Translated Set 2 keyboard:dmi:*:rvnMicro-StarInternationalCo.,Ltd.:rnMS-1T41:*
+evdev:name:AT Translated Set 2 keyboard:dmi:*:rvnMicro-StarInternationalCo.,Ltd.:rnMS-1T42:*
+evdev:name:AT Translated Set 2 keyboard:dmi:*:rvnMicro-StarInternationalCo.,Ltd.:rnMS-1T52:*
+evdev:name:AT Translated Set 2 keyboard:dmi:*:rvnMicro-StarInternationalCo.,Ltd.:rnMS-1T8K:*
  KEYBOARD_KEY_b9=f15                                   # Right Face Button
  KEYBOARD_KEY_ba=f16                                   # Left Face Button
 


### PR DESCRIPTION
This no longer matched with any MSI Claw device after c65efd4145c4 ("(hwdb) Update MSI Claw Entries") because of the modalias structure:

dmi:bvnAmericanMegatrendsInternational,LLC.:bvrE1T52IMS.112:bd12/04/2025:br1.18:svnMicro-StarInternationalCo.,Ltd.:pnClaw8AI+A2VM:pvrREV1.0:rvnMicro-StarInternationalCo.,Ltd.:rnMS-1T52:rvrREV1.0:cvnMicro-StarInternationalCo.,Ltd.:ct30:cvrN/A:sku1T52.1:

Fix this by matching against board vendor field rather than system vendor.