### PR TITLE
kbd-model-map: add Arabic mapping

### DIFF
--- a/src/locale/kbd-model-map
+++ b/src/locale/kbd-model-map
@@ -74,3 +74,4 @@ es-dvorak		es	microsoftpro	dvorak		terminate:ctrl_alt_bksp				-
 lv			lv	pc105		apostrophe	terminate:ctrl_alt_bksp				lv-LV,lv
 lv-tilde		lv	pc105		tilde		terminate:ctrl_alt_bksp				-
 ge			ge,us	pc105		-		terminate:ctrl_alt_bksp				ka-GE,ka
+ara			ara,us	pc105		-		terminate:ctrl_alt_bksp,grp:shifts_toggle,grp_led:scroll	ar-SA,ar


### PR DESCRIPTION
kbd has a switched 'ara' console layout, but we don't have a corresponding line in kbd-model-map. When converting 'us,ara' to a legacy layout we wind up with us-acentos, which is definitely wrong. This will fix it.