### PR TITLE
docs/INHIBITOR_LOCKS: Update sentence for the new mode added

### DIFF
--- a/docs/INHIBITOR_LOCKS.md
+++ b/docs/INHIBITOR_LOCKS.md
@@ -31,7 +31,7 @@ Seven distinct inhibitor lock types may be taken, or a combination of them:
 6. Similar, _handle-hibernate-key_ inhibits the low-level handling of the system **hardware** hibernate key.
 7. Similar, _handle-lid-switch_ inhibits the low-level handling of the systemd **hardware** lid switch.
 
-Two different modes of locks are supported:
+Three different modes of locks are supported:
 
 1. _block_ inhibits operations entirely until the lock is released.
 If such a lock is taken the operation will fail (but still may be overridden if the user possesses the necessary privileges).


### PR DESCRIPTION
804874d26ac73e0af07c4c5d7165c95372f03f6d added a new mode but the
sentence wasn't updated and it was still stating that there are Two modes
instead.