### PR TITLE
generator: order cryptsetup/verity/integrity after systemd-udevd

### DIFF
--- a/src/integritysetup/integritysetup-generator.c
+++ b/src/integritysetup/integritysetup-generator.c
@@ -80,7 +80,11 @@ static int create_disk(
                 "SourcePath=%s\n"
                 "DefaultDependencies=no\n"
                 "IgnoreOnIsolate=true\n"
-                "After=integritysetup-pre.target systemd-udevd-kernel.socket\n"
+                /* The systemd-udevd.service ordering is mostly about shutdown, not startup: on stop the dm
+                 * device is detached via an ioctl carrying a udev cookie that blocks in dm_udev_wait() until
+                 * udev releases it (95-dm-notify.rules). Stopping before udevd keeps it around to service the
+                 * cookie; otherwise during soft-reboot/shutdown udevd may exit first and the detach hangs. */
+                "After=integritysetup-pre.target systemd-udevd-kernel.socket systemd-udevd.service\n"
                 "Before=blockdev@dev-mapper-%%i.target\n"
                 "Wants=blockdev@dev-mapper-%%i.target\n"
                 "Conflicts=umount.target\n"

--- a/src/integritysetup/integritysetup-generator.c
+++ b/src/integritysetup/integritysetup-generator.c
@@ -80,7 +80,7 @@ static int create_disk(
                 "SourcePath=%s\n"
                 "DefaultDependencies=no\n"
                 "IgnoreOnIsolate=true\n"
-                "After=integritysetup-pre.target systemd-udevd-kernel.socket\n"
+                "After=integritysetup-pre.target systemd-udevd-kernel.socket systemd-udevd.service\n"
                 "Before=blockdev@dev-mapper-%%i.target\n"
                 "Wants=blockdev@dev-mapper-%%i.target\n"
                 "Conflicts=umount.target\n"

--- a/src/shared/generator.c
+++ b/src/shared/generator.c
@@ -921,7 +921,12 @@ int generator_write_cryptsetup_unit_section(FILE *f, const char *source) {
         fprintf(f,
                 "\n"
                 "DefaultDependencies=no\n"
-                "After=cryptsetup-pre.target systemd-udevd-kernel.socket systemd-tpm2-setup-early.service\n"
+                /* The ordering against systemd-udevd.service is mostly about shutdown, not startup: on stop
+                 * the device is detached via a device-mapper ioctl that carries a udev cookie, and we block in
+                 * dm_udev_wait() until udev releases it (see 95-dm-notify.rules). Ordering After= it means we
+                 * are stopped first, while udevd is still around to service that cookie; otherwise during
+                 * soft-reboot/shutdown udevd may exit first and the detach hangs until the job timeout. */
+                "After=cryptsetup-pre.target systemd-udevd-kernel.socket systemd-udevd.service systemd-tpm2-setup-early.service\n"
                 "Before=blockdev@dev-mapper-%%i.target\n"
                 "Wants=blockdev@dev-mapper-%%i.target\n"
                 "IgnoreOnIsolate=true\n");
@@ -993,7 +998,11 @@ int generator_write_veritysetup_unit_section(FILE *f, const char *source) {
         fprintf(f,
                 "DefaultDependencies=no\n"
                 "IgnoreOnIsolate=true\n"
-                "After=veritysetup-pre.target systemd-udevd-kernel.socket\n"
+                /* The systemd-udevd.service ordering is mostly about shutdown, not startup: on stop the dm
+                 * device is detached via an ioctl carrying a udev cookie that blocks in dm_udev_wait() until
+                 * udev releases it (95-dm-notify.rules). Stopping before udevd keeps it around to service the
+                 * cookie; otherwise during soft-reboot/shutdown udevd may exit first and the detach hangs. */
+                "After=veritysetup-pre.target systemd-udevd-kernel.socket systemd-udevd.service\n"
                 "Before=blockdev@dev-mapper-%%i.target\n"
                 "Wants=blockdev@dev-mapper-%%i.target\n");
 

--- a/src/shared/generator.c
+++ b/src/shared/generator.c
@@ -914,7 +914,7 @@ int generator_write_cryptsetup_unit_section(FILE *f, const char *source) {
         fprintf(f,
                 "\n"
                 "DefaultDependencies=no\n"
-                "After=cryptsetup-pre.target systemd-udevd-kernel.socket systemd-tpm2-setup-early.service\n"
+                "After=cryptsetup-pre.target systemd-udevd-kernel.socket systemd-udevd.service systemd-tpm2-setup-early.service\n"
                 "Before=blockdev@dev-mapper-%%i.target\n"
                 "Wants=blockdev@dev-mapper-%%i.target\n"
                 "IgnoreOnIsolate=true\n");
@@ -986,7 +986,7 @@ int generator_write_veritysetup_unit_section(FILE *f, const char *source) {
         fprintf(f,
                 "DefaultDependencies=no\n"
                 "IgnoreOnIsolate=true\n"
-                "After=veritysetup-pre.target systemd-udevd-kernel.socket\n"
+                "After=veritysetup-pre.target systemd-udevd-kernel.socket systemd-udevd.service\n"
                 "Before=blockdev@dev-mapper-%%i.target\n"
                 "Wants=blockdev@dev-mapper-%%i.target\n");
 


### PR DESCRIPTION
Fixes #40298.

On soft-reboot, `systemd-cryptsetup@.service`'s `ExecStop` calls libcryptsetup's `crypt_deactivate()`, which issues `DM_REMOVE` with a udev cookie and blocks in `dm_udev_wait()` until `95-dm-notify.rules` runs `dmsetup udevcomplete $env{DM_COOKIE}`. Since 0d1819e791 udevd has `Conflicts=soft-reboot.target` but no ordering against the cryptsetup stop, so udevd can stop first and the cookie is never acknowledged. The soft-reboot then sits at "Stopping Cryptography Setup..." until `JobTimeoutSec=30min` on `soft-reboot.target` fires. See @Silvigarabis's [debug-shell capture](https://github.com/systemd/systemd/issues/40298#issuecomment-4631355928).

Add `After=systemd-udevd.service` to the generated cryptsetup, veritysetup and integritysetup units. Per `job_compare()` at `src/core/job.c:1716-1748`, when two units are both stopping the `After=` unit stops first, so cryptsetup gets its cookie acknowledged by the still-live udevd. The existing `After=systemd-udevd-kernel.socket` does not help; that socket has `IgnoreOnIsolate=yes` and is not stopped during soft-reboot.

`After=umount.target` on udevd does not solve this: at soft-reboot udevd's stop job runs against umount.target's start job, and `JOB_STOP` unconditionally precedes `JOB_START` (`src/core/job.c:1742-1747`) regardless of `After=`/`Before=`.

cc @bluca @yuwata
