### PR TITLE
repart: Rescan after writing partition table on factory reset

### DIFF
--- a/src/repart/repart.c
+++ b/src/repart/repart.c
@@ -8707,6 +8707,9 @@ static int context_factory_reset(Context *context) {
         if (r < 0)
                 return log_error_errno(r, "Failed to write disk label: %m");
 
+        /* We do not want to stop if partscan has errors */
+        (void) context_partscan(context);
+
         log_info("Successfully deleted %zu partitions.", n);
         return 1;
 }


### PR DESCRIPTION
If a partition gets removed due to factory reset, we will recreate it as blkpg later. So it needs to get removed. So rescan is needed to be done after we write the partition table for factory reset.

Fixes #42453