### PR TITLE
tests: don't leak TESTFUNCS count into run_test_table() exit code

### DIFF
--- a/src/shared/tests.c
+++ b/src/shared/tests.c
@@ -386,9 +386,9 @@ int run_test_table(const TestFunc *start, const TestFunc *end) {
 
         const char *e = getenv("TESTFUNCS");
         if (e) {
-                r = strv_split_full(&tests, e, ":", EXTRACT_DONT_COALESCE_SEPARATORS);
-                if (r < 0)
-                        return log_error_errno(r, "Failed to parse $TESTFUNCS: %m");
+                int n = strv_split_full(&tests, e, ":", EXTRACT_DONT_COALESCE_SEPARATORS);
+                if (n < 0)
+                        return log_error_errno(n, "Failed to parse $TESTFUNCS: %m");
         }
 
         for (const TestFunc *t = start; t + 1 <= end; t++) {


### PR DESCRIPTION
`strv_split_full()` returns the number of parsed entries, which was assigned to `r`, the variable that also holds the run's exit status. With `TESTFUNCS` set, a passing run of only void tests then exited with the entry count (e.g. 1) instead of `EXIT_SUCCESS`. Use a separate variable for the split result.

Before:
```console
$ env TESTFUNCS=test_copy_tree meson test -C build -v test-copy
1/1 test - systemd:test-copy FAIL            0.01s   exit status 1

$ env TESTFUNCS=test_copy_tree:test_copy_file_fd meson test -C build -v test-copy
1/1 test - systemd:test-copy FAIL            0.01s   exit status 2
```

Now:
```console
$ env TESTFUNCS=test_copy_tree:test_copy_file_fd meson test -C build -v test-copy
1/1 test - systemd:test-copy OK              0.01s
```
