### PR TITLE
bootctl: Respect --variables from the command line

### DIFF
--- a/src/bootctl/bootctl-install.c
+++ b/src/bootctl/bootctl-install.c
@@ -211,6 +211,8 @@ static int install_context_from_cmdline(
                         return log_oom();
         }
 
+        b.touch_variables = arg_touch_variables;
+
         *ret = TAKE_GENERIC(b, InstallContext, INSTALL_CONTEXT_NULL);
 
         return !!ret->esp_path; /* return positive if we found an ESP */


### PR DESCRIPTION
A previous refactoring failed to copy the flag from the command line argument to the installation context object, so the flag was ignored.

Closes: https://github.com/systemd/systemd/issues/41488
Fixes: 38433a6d06ef ("bootctl: rework bootctl-install.c in preparation of varlinkification")