### PR TITLE
resolved: use correct Cloudflare DoT hostname one.one.one.one

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -385,7 +385,7 @@ option('dns-over-tls', type : 'combo', choices : ['auto', 'gnutls', 'openssl', '
        description : 'DNS-over-TLS support')
 option('dns-servers', type : 'string',
        description : 'space-separated list of default DNS servers',
-       value : '1.1.1.1#cloudflare-dns.com 8.8.8.8#dns.google 9.9.9.9#dns.quad9.net 1.0.0.1#cloudflare-dns.com 8.8.4.4#dns.google 149.112.112.112#dns.quad9.net 2606:4700:4700::1111#cloudflare-dns.com 2001:4860:4860::8888#dns.google 2620:fe::fe#dns.quad9.net 2606:4700:4700::1001#cloudflare-dns.com 2001:4860:4860::8844#dns.google 2620:fe::9#dns.quad9.net')
+       value : '1.1.1.1#one.one.one.one 8.8.8.8#dns.google 9.9.9.9#dns.quad9.net 1.0.0.1#one.one.one.one 8.8.4.4#dns.google 149.112.112.112#dns.quad9.net 2606:4700:4700::1111#one.one.one.one 2001:4860:4860::8888#dns.google 2620:fe::fe#dns.quad9.net 2606:4700:4700::1001#one.one.one.one 2001:4860:4860::8844#dns.google 2620:fe::9#dns.quad9.net')
 option('ntp-servers', type : 'string',
        description : 'space-separated list of default NTP servers',
        value : 'time1.google.com time2.google.com time3.google.com time4.google.com')

--- a/src/resolve/resolved.conf.in
+++ b/src/resolve/resolved.conf.in
@@ -18,7 +18,7 @@
 
 [Resolve]
 # Some examples of DNS servers which may be used for DNS= and FallbackDNS=:
-# Cloudflare: 1.1.1.1#cloudflare-dns.com 1.0.0.1#cloudflare-dns.com 2606:4700:4700::1111#cloudflare-dns.com 2606:4700:4700::1001#cloudflare-dns.com
+# Cloudflare: 1.1.1.1#one.one.one.one 1.0.0.1#one.one.one.one 2606:4700:4700::1111#one.one.one.one 2606:4700:4700::1001#one.one.one.one
 # Google:     8.8.8.8#dns.google 8.8.4.4#dns.google 2001:4860:4860::8888#dns.google 2001:4860:4860::8844#dns.google
 # Quad9:      9.9.9.9#dns.quad9.net 149.112.112.112#dns.quad9.net 2620:fe::fe#dns.quad9.net 2620:fe::9#dns.quad9.net
 #


### PR DESCRIPTION
## Summary
- Update Cloudflare DNS-over-TLS hostname from `cloudflare-dns.com` to `one.one.one.one` in both the example configuration and the default build option.

## Context
`cloudflare-dns.com` is the hostname for Cloudflare's **DNS-over-HTTPS** service, not DNS-over-TLS. According to Cloudflare's official documentation and the DNS SVCB/PTR records for `1.1.1.1`, the correct hostname for DNS-over-TLS is `one.one.one.one`.

Since systemd-resolved only supports DNS-over-TLS (not DoH), the entries should use the DoT-specific hostname.

## Changes
| File | Change |
|------|--------|
| `src/resolve/resolved.conf.in` | Replace `cloudflare-dns.com` → `one.one.one.one` in Cloudflare DNS example comment |
| `meson_options.txt` | Replace `cloudflare-dns.com` → `one.one.one.one` in default dns-servers value |

## Test Plan
- [x] Verified no remaining `cloudflare-dns.com` references in the changed files
- [x] Google (`dns.google`) and Quad9 (`dns.quad9.net`) entries are unchanged
- [x] `dig -x 1.1.1.1` returns `one.one.one.one` (PTR record confirms the correct name)

Fixes #42287
