### PR TITLE
resolve: use correct hostname for Cloudflare DNS-over-TLS

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -385,7 +385,7 @@ option('dns-over-tls', type : 'combo', choices : ['auto', 'gnutls', 'openssl', '
        description : 'DNS-over-TLS support')
 option('dns-servers', type : 'string',
        description : 'space-separated list of default DNS servers',
-       value : '1.1.1.1#cloudflare-dns.com 8.8.8.8#dns.google 9.9.9.9#dns.quad9.net 1.0.0.1#cloudflare-dns.com 8.8.4.4#dns.google 149.112.112.112#dns.quad9.net 2606:4700:4700::1111#cloudflare-dns.com 2001:4860:4860::8888#dns.google 2620:fe::fe#dns.quad9.net 2606:4700:4700::1001#cloudflare-dns.com 2001:4860:4860::8844#dns.google 2620:fe::9#dns.quad9.net')
+       value : '1.1.1.1#one.one.one.one 8.8.8.8#dns.google 9.9.9.9#dns.quad9.net 1.0.0.1#one.one.one.one 8.8.4.4#dns.google 149.112.112.112#dns.quad9.net 2606:4700:4700::1111#one.one.one.one 2001:4860:4860::8888#dns.google 2620:fe::fe#dns.quad9.net 2606:4700:4700::1001#one.one.one.one 2001:4860:4860::8844#dns.google 2620:fe::9#dns.quad9.net')
 option('ntp-servers', type : 'string',
        description : 'space-separated list of default NTP servers',
        value : 'time1.google.com time2.google.com time3.google.com time4.google.com')

--- a/src/resolve/resolved.conf.in
+++ b/src/resolve/resolved.conf.in
@@ -18,7 +18,7 @@
 
 [Resolve]
 # Some examples of DNS servers which may be used for DNS= and FallbackDNS=:
-# Cloudflare: 1.1.1.1#cloudflare-dns.com 1.0.0.1#cloudflare-dns.com 2606:4700:4700::1111#cloudflare-dns.com 2606:4700:4700::1001#cloudflare-dns.com
+# Cloudflare: 1.1.1.1#one.one.one.one 1.0.0.1#one.one.one.one 2606:4700:4700::1111#one.one.one.one 2606:4700:4700::1001#one.one.one.one
 # Google:     8.8.8.8#dns.google 8.8.4.4#dns.google 2001:4860:4860::8888#dns.google 2001:4860:4860::8844#dns.google
 # Quad9:      9.9.9.9#dns.quad9.net 149.112.112.112#dns.quad9.net 2620:fe::fe#dns.quad9.net 2620:fe::9#dns.quad9.net
 #


### PR DESCRIPTION
## Summary

- Fix the Cloudflare DNS-over-TLS hostname from `cloudflare-dns.com` to `one.one.one.one` to match Cloudflare's official documentation.

## Context

Cloudflare uses different hostnames for DoT vs DoH:
- **DNS-over-TLS (DoT):** `one.one.one.one` (see [Cloudflare DoT docs](https://developers.cloudflare.com/1.1.1.1/encryption/dns-over-tls/))
- **DNS-over-HTTPS (DoH):** `cloudflare-dns.com`

systemd was using `cloudflare-dns.com` for both, which is incorrect for the DoT use case. While `cloudflare-dns.com` likely works in practice (the certificate likely covers both names), following the vendor's documented hostname is the correct approach.

## Changes

| File | Change |
|------|--------|
| `src/resolve/resolved.conf.in` | Update Cloudflare example hostnames to `one.one.one.one` |
| `meson_options.txt` | Update default `dns-servers` Cloudflare hostnames to `one.one.one.one` |

## Test Plan

- [ ] Verified `cloudflare-dns.com` no longer appears in any source files
- [ ] Verified the new hostname `one.one.one.one` matches Cloudflare's DoT documentation

Co-developed-by: Claude Opus 4.6 <noreply@anthropic.com>

Fixes #42287
