### PR TITLE
dhcp-client: reject overloaded messages that no longer fit after rebuild

### DIFF
--- a/src/libsystemd-network/dhcp-message.c
+++ b/src/libsystemd-network/dhcp-message.c
@@ -1428,6 +1428,10 @@ int dhcp_message_parse(
                 memzero(message->header.sname, sizeof(message->header.sname));
         }
 
+        /* Merging the overloaded fields grows the message, so reject anything we could no longer rebuild. */
+        if (dhcp_message_payload_size(message) > UDP_PAYLOAD_MAX_SIZE)
+                return -EBADMSG;
+
         *ret = TAKE_PTR(message);
         return 0;
 }

--- a/src/libsystemd-network/test-dhcp-message.c
+++ b/src/libsystemd-network/test-dhcp-message.c
@@ -553,6 +553,74 @@ TEST(dhcp_message) {
         ASSERT_OK(dump_dhcp_message(m, /* args= */ NULL, DUMP_DHCP_MESSAGE_LEGEND | DUMP_DHCP_MESSAGE_FULL));
 }
 
+static void build_overloaded_message(uint8_t *buf, size_t size) {
+        assert(buf);
+        assert(size >= sizeof(DHCPMessageHeader) + 3);
+
+        DHCPMessageHeader *header = (DHCPMessageHeader*) buf;
+        header->op = BOOTREPLY;
+        header->htype = ARPHRD_ETHER;
+        header->hlen = ETH_ALEN;
+        header->magic = htobe32(DHCP_MAGIC_COOKIE);
+
+        /* One maximal option per overloaded field, for the largest expansion on rebuild. */
+        header->sname[0] = 0xAA; /* arbitrary unknown option code */
+        header->sname[1] = sizeof(header->sname) - 2;
+        header->file[0] = 0xAA;
+        header->file[1] = sizeof(header->file) - 2;
+
+        /* Declare the overload, then pad out with filler options. */
+        uint8_t *p = buf + sizeof(DHCPMessageHeader), *end = buf + size;
+        *p++ = SD_DHCP_OPTION_OVERLOAD;
+        *p++ = 1;
+        *p++ = DHCP_OVERLOAD_FILE | DHCP_OVERLOAD_SNAME;
+
+        while (end - p >= 2) {
+                size_t data = MIN((size_t) (end - p) - 2, (size_t) UINT8_MAX);
+                *p++ = 0xAA;
+                *p++ = data;
+                p += data;
+        }
+}
+
+TEST(overload_oversized) {
+        /* Merging overloaded fields grows the message, so an input near the UDP limit may not fit once
+         * rebuilt and must be rejected on parse. */
+
+        _cleanup_free_ uint8_t *buf = new0(uint8_t, UDP_PAYLOAD_MAX_SIZE);
+        ASSERT_NOT_NULL(buf);
+
+        /* Largest valid UDP input: accepted on length, but rejected once the overload is expanded. */
+        build_overloaded_message(buf, UDP_PAYLOAD_MAX_SIZE);
+
+        _cleanup_(sd_dhcp_message_unrefp) sd_dhcp_message *m = NULL;
+        ASSERT_ERROR(dhcp_message_parse(
+                                  &IOVEC_MAKE(buf, UDP_PAYLOAD_MAX_SIZE),
+                                  BOOTREPLY,
+                                  /* xid= */ NULL,
+                                  ARPHRD_ETHER,
+                                  /* hw_addr= */ NULL,
+                                  &m),
+                     EBADMSG);
+
+        /* A small overloaded message stays valid and must round-trip. */
+        _cleanup_free_ uint8_t *small = new0(uint8_t, sizeof(DHCPMessageHeader) + 512);
+        ASSERT_NOT_NULL(small);
+        build_overloaded_message(small, sizeof(DHCPMessageHeader) + 512);
+
+        _cleanup_(sd_dhcp_message_unrefp) sd_dhcp_message *m2 = NULL;
+        ASSERT_OK(dhcp_message_parse(
+                                  &IOVEC_MAKE(small, sizeof(DHCPMessageHeader) + 512),
+                                  BOOTREPLY,
+                                  /* xid= */ NULL,
+                                  ARPHRD_ETHER,
+                                  /* hw_addr= */ NULL,
+                                  &m2));
+
+        _cleanup_(iovw_done_free) struct iovec_wrapper iovw = {};
+        ASSERT_OK(dhcp_message_build(m2, &iovw));
+}
+
 static void test_domains_one(size_t len, const uint8_t *data, char * const *expected) {
         _cleanup_strv_free_ char **strv = NULL;
         _cleanup_(sd_dhcp_message_unrefp) sd_dhcp_message *m = NULL;


### PR DESCRIPTION
6fa5ebc506 rejected parse inputs larger than UDP_PAYLOAD_MAX_SIZE up front, but that check runs in dhcp_message_verify_header() before the options are parsed. RFC 2131 allows options to be "overloaded" into the fixed-size 'sname' (64 bytes) and 'file' (128 bytes) header fields: dhcp_message_parse() merges those into the main option list and zeroes the two fields, but dhcp_message_build() still emits them (now zeroed), so the rebuilt message is up to 192 bytes larger than the input. An input that fits a UDP payload can thus no longer fit once rebuilt, and dhcp_message_build() later fails with -E2BIG on a message we already accepted, which the fuzzer surfaced as an assertion failure:

```
    ==249==ERROR: MemorySanitizer: ABRT on unknown address 0x0539000000f9 (pc 0x79c92488cb2c bp 0x7ffdc3884210 sp 0x7ffdc38841d0 T249)
        #0 0x79c92488cb2c in __pthread_kill_implementation nptl/pthread_kill.c:44:76
        #1 0x79c92488cb2c in __pthread_kill_internal nptl/pthread_kill.c:78:10
        #2 0x79c92488cb2c in pthread_kill nptl/pthread_kill.c:89:10
        #3 0x79c92483327d in raise sysdeps/posix/raise.c:26:13
        #4 0x79c9248168fe in abort stdlib/abort.c:79:7
        #5 0x79c924d4b954 in log_test_failed_internal systemd/src/shared/tests.c:482:9
        #6 0x5ad4d2a032a2 in LLVMFuzzerTestOneInput systemd/src/libsystemd-network/fuzz-dhcp-client.c:0
        #7 0x5ad4d2a62bfd in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:619:13
        #8 0x5ad4d2a4da92 in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:329:6
        #9 0x5ad4d2a53960 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:865:9
        #10 0x5ad4d2a7e452 in main /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerMain.cpp:20:10
        #11 0x79c9248181c9 in __libc_start_call_main sysdeps/nptl/libc_start_call_main.h:58:16
        #12 0x79c92481828a in __libc_start_main csu/libc-start.c:360:3
        #13 0x5ad4d2974054 in _start
```

Re-check the payload size after merging the overloaded fields, and reject the message if it would no longer fit, mirroring the size check in dhcp_message_build() so that anything we accept can also be rebuilt.

The expansion is bounded by those 192 overloaded bytes, so a reproducer has to be close to the maximum UDP payload; add a unit test that constructs one in memory instead of shipping a ~65 KB fuzzer corpus entry.

Follow-up for 6fa5ebc506fc75fa2398e10ad2506dedf70d44d6

Fixes https://github.com/systemd/systemd/issues/42516

Co-developed-by: Claude Opus 4.8 <noreply@anthropic.com>