### PR TITLE
resolve: suppress noisy DNSSEC logging in allow-downgrade mode

### DIFF
--- a/src/resolve/resolved-dns-transaction.c
+++ b/src/resolve/resolved-dns-transaction.c
@@ -914,6 +914,17 @@ static int dns_transaction_dnssec_ready(DnsTransaction *t) {
                                   dt->answer_ede_rcode >= 0 ? strempty(dt->answer_ede_msg) : "",
                                   dt->answer_ede_rcode >= 0 ? ")" : "");
 
+                        if (t->scope->dnssec_mode == DNSSEC_ALLOW_DOWNGRADE &&
+                            IN_SET(dt->answer_dnssec_result,
+                                   DNSSEC_INCOMPATIBLE_SERVER,
+                                   DNSSEC_NO_SIGNATURE)) {
+                                /* In allow-downgrade mode, treat auxiliary DNSSEC failures caused
+                                 * by missing signatures or incompatible servers as non-fatal.
+                                 * The server simply doesn't support DNSSEC — continue validating
+                                 * without this auxiliary data. */
+                                break;
+                        }
+
                         /* Copy error code over */
                         t->answer_dnssec_result = dt->answer_dnssec_result;
                         t->answer_ede_rcode = dt->answer_ede_rcode;


### PR DESCRIPTION
## Summary
- In `DNSSEC=allow-downgrade` mode, auxiliary DNSSEC transactions (DS/DNSKEY lookups) that fail with "no-signature" due to non-validating DNS forwarders no longer propagate `DNS_TRANSACTION_DNSSEC_FAILED` to the parent transaction
- The failure is treated as non-fatal (matching existing allow-downgrade logic at `dnssec_validate_records` line ~3457), so validation continues without the unavailable auxiliary data

This fixes excessive "DNSSEC validation failed: no-signature" log messages and incorrect Bogus statistics increments when using a non-DNSSEC-capable DNS forwarder (e.g. ISP router), even though queries resolve successfully.

**Root cause**: `dns_transaction_dnssec_ready()` unconditionally propagated auxiliary DNSSEC failures to the parent transaction, bypassing the allow-downgrade fallback that exists in `dnssec_validate_records()`.

**Files changed**: 1 (`resolved-dns-transaction.c`, +11 lines)

Fixes #42522