### PR TITLE
mount: add fanotify-based incremental mount monitoring

### DIFF
--- a/src/core/manager.h
+++ b/src/core/manager.h
@@ -304,6 +304,8 @@ typedef struct Manager {
         /* Data specific to the mount subsystem */
         struct libmnt_monitor *mount_monitor;
         sd_event_source *mount_event_source;
+        bool mount_use_fanotify;
+        struct libmnt_fs *mount_fanotify_fs;
 
         /* Data specific to the swap filesystem */
         FILE *proc_swaps;

--- a/src/core/manager.h
+++ b/src/core/manager.h
@@ -304,6 +304,9 @@ typedef struct Manager {
         /* Data specific to the mount subsystem */
         struct libmnt_monitor *mount_monitor;
         sd_event_source *mount_event_source;
+        bool mount_use_fanotify;
+        struct libmnt_fs *mount_fanotify_fs;
+        Hashmap *mounts_by_uniq_id;
 
         /* Data specific to the swap filesystem */
         FILE *proc_swaps;

--- a/src/core/mount.c
+++ b/src/core/mount.c
@@ -1723,7 +1723,8 @@ static int update_parameters_kernel(
                 Mount *m,
                 const char *what,
                 const char *options,
-                const char *fstype) {
+                const char *fstype,
+                uint64_t uniq_id) {
 
         MountParameters *p;
         int r, q, w;
@@ -1744,6 +1745,8 @@ static int update_parameters_kernel(
         if (w < 0)
                 return w;
 
+        m->uniq_id = uniq_id;
+
         return r > 0 || q > 0 || w > 0;
 }
 
@@ -1754,6 +1757,7 @@ static int mount_setup_new_unit(
                 const char *where,
                 const char *options,
                 const char *fstype,
+                uint64_t uniq_id,
                 MountProcFlags *ret_flags,
                 Unit **ret) {
 
@@ -1780,7 +1784,7 @@ static int mount_setup_new_unit(
         if (r < 0)
                 return r;
 
-        r = update_parameters_kernel(mnt, what, options, fstype);
+        r = update_parameters_kernel(mnt, what, options, fstype, uniq_id);
         if (r < 0)
                 return r;
 
@@ -1804,6 +1808,7 @@ static int mount_setup_existing_unit(
                 const char *where,
                 const char *options,
                 const char *fstype,
+                uint64_t uniq_id,
                 MountProcFlags *ret_flags) {
 
         Mount *m = ASSERT_PTR(MOUNT(u));
@@ -1825,7 +1830,7 @@ static int mount_setup_existing_unit(
          * iteration and thus worthy of taking into account. */
         MountProcFlags flags = m->proc_flags | MOUNT_PROC_IS_MOUNTED;
 
-        r = update_parameters_kernel(m, what, options, fstype);
+        r = update_parameters_kernel(m, what, options, fstype, uniq_id);
         if (r < 0)
                 return r;
         if (r > 0)
@@ -1872,6 +1877,7 @@ static int mount_setup_unit(
                 const char *where,
                 const char *options,
                 const char *fstype,
+                uint64_t uniq_id,
                 bool set_flags) {
 
         _cleanup_free_ char *e = NULL;
@@ -1910,11 +1916,11 @@ static int mount_setup_unit(
 
         u = manager_get_unit(m, e);
         if (u)
-                r = mount_setup_existing_unit(u, what, where, options, fstype, &flags);
+                r = mount_setup_existing_unit(u, what, where, options, fstype, uniq_id, &flags);
         else
                 /* First time we see this mount point meaning that it's not been initiated by a mount unit
                  * but rather by the sysadmin having called mount(8) directly. */
-                r = mount_setup_new_unit(m, e, what, where, options, fstype, &flags, &u);
+                r = mount_setup_new_unit(m, e, what, where, options, fstype, uniq_id, &flags, &u);
         if (r < 0)
                 return log_warning_errno(r, "Failed to set up mount unit for '%s': %m", where);
 
@@ -1932,28 +1938,39 @@ static int mount_load_kernel_mounttable(Manager *m, bool set_flags) {
         _cleanup_(mnt_free_tablep) struct libmnt_table *table = NULL;
         _cleanup_(mnt_free_iterp) struct libmnt_iter *iter = NULL;
         _cleanup_set_free_ Set *devices = NULL;
+        bool use_listmount = false;
         int r;
 
         assert(m);
 
-        r = libmount_parse_with_utab(&table, &iter);
-        if (r < 0)
-                return log_error_errno(r, "Failed to parse /proc/self/mountinfo: %m");
+        r = libmount_fetch_listmount(&table, &iter);
+        if (r >= 0)
+                use_listmount = true;
+        else {
+                if (r != -EOPNOTSUPP)
+                        log_debug_errno(r, "Failed to use listmount, falling back to /proc/self/mountinfo: %m");
+
+                r = libmount_parse_with_utab(&table, &iter);
+                if (r < 0)
+                        return log_error_errno(r, "Failed to parse /proc/self/mountinfo: %m");
+        }
 
         for (;;) {
                 struct libmnt_fs *fs;
                 const char *device, *path, *options, *fstype;
+                uint64_t uniq_id;
 
                 r = sym_mnt_table_next_fs(table, iter, &fs);
                 if (r == 1)
                         break;
                 if (r < 0)
-                        return log_error_errno(r, "Failed to get next entry from /proc/self/mountinfo: %m");
+                        return log_error_errno(r, "Failed to get next entry from mount table: %m");
 
                 device = sym_mnt_fs_get_source(fs);
                 path = sym_mnt_fs_get_target(fs);
                 options = sym_mnt_fs_get_options(fs);
                 fstype = sym_mnt_fs_get_fstype(fs);
+                uniq_id = use_listmount ? sym_mnt_fs_get_uniq_id(fs) : 0;
 
                 if (!device || !path)
                         continue;
@@ -1964,7 +1981,7 @@ static int mount_load_kernel_mounttable(Manager *m, bool set_flags) {
                 if (set_put_strdup_full(&devices, &path_hash_ops_free, device) != 0)
                         device_found_node(m, device, DEVICE_FOUND_MOUNT, DEVICE_FOUND_MOUNT);
 
-                (void) mount_setup_unit(m, device, path, options, fstype, set_flags);
+                (void) mount_setup_unit(m, device, path, options, fstype, uniq_id, set_flags);
         }
 
         return 0;
@@ -2231,7 +2248,7 @@ static int mount_process_kernel_mounttable(Manager *m) {
                                         log_oom(); /* we don't care too much about OOM here... */
 
                         mount->from_kernel = false;
-                        assert_se(update_parameters_kernel(mount, NULL, NULL, NULL) >= 0);
+                        assert_se(update_parameters_kernel(mount, NULL, NULL, NULL, 0) >= 0);
 
                         switch (mount->state) {
 

--- a/src/core/mount.c
+++ b/src/core/mount.c
@@ -1820,6 +1820,25 @@ static int update_parameters_kernel(
         return r > 0 || q > 0 || u > 0 || w > 0;
 }
 
+/* Update only the user options (from utab), rebuild merged options. Returns > 0 if changed. */
+static int update_parameters_useropts(Mount *m, const char *opt_user) {
+        MountParameters *p;
+        int r;
+
+        assert(m);
+
+        p = &m->parameters_kernel;
+
+        if (streq_ptr(p->opt_user, opt_user))
+                return 0;
+
+        r = free_and_strdup(&p->opt_user, opt_user);
+        if (r < 0)
+                return r;
+
+        return mount_parameters_rebuild_options(p);
+}
+
 static int mount_setup_new_unit(
                 Manager *m,
                 const char *name,
@@ -2629,8 +2648,32 @@ static void mount_process_fanotify_events(Manager *m, bool *rescan) {
                                 log_warning_errno(r, "Failed to read fanotify mount events, rescanning: %m");
                                 *rescan = true;
                         }
+                } else if (sym_mnt_table_parse_utab) {
+                        /* Incremental utab processing: parse utab, update user options on
+                         * matching mount units without a full kernel mount table rescan. */
+                        _cleanup_(mnt_free_tablep) struct libmnt_table *utab = NULL;
+                        _cleanup_(mnt_free_iterp) struct libmnt_iter *itr = NULL;
+                        struct libmnt_fs *uf;
+
+                        utab = sym_mnt_new_table();
+                        itr = sym_mnt_new_iter(MNT_ITER_FORWARD);
+                        if (!utab || !itr) {
+                                log_oom();
+                                *rescan = true;
+                        } else if (sym_mnt_table_parse_utab(utab, NULL) < 0)
+                                *rescan = true;
+                        else
+                                while (sym_mnt_table_next_fs(utab, itr, &uf) == 0) {
+                                        uint64_t id = sym_mnt_fs_get_uniq_id(uf);
+                                        Mount *mount = mount_find_by_uniq_id(m, id);
+                                        if (!mount)
+                                                continue;
+                                        if (update_parameters_useropts(mount,
+                                                        sym_mnt_fs_get_user_options(uf)) > 0)
+                                                mount->proc_flags |= MOUNT_PROC_IS_MOUNTED | MOUNT_PROC_JUST_CHANGED;
+                                }
                 } else
-                        /* Non-fanotify change (utab update via inotify) — need full rescan. */
+                        /* No utab API available — fall back to full rescan. */
                         *rescan = true;
 
                 if (*rescan) {

--- a/src/core/mount.c
+++ b/src/core/mount.c
@@ -219,6 +219,8 @@ static void mount_parameters_done(MountParameters *p) {
 
         p->what = mfree(p->what);
         p->options = mfree(p->options);
+        p->opt_kernel = mfree(p->opt_kernel);
+        p->opt_user = mfree(p->opt_user);
         p->fstype = mfree(p->fstype);
 }
 
@@ -1722,35 +1724,100 @@ static int mount_dispatch_timer(sd_event_source *source, usec_t usec, void *user
 }
 
 #if HAVE_LIBMOUNT
+
+/* Merge two comma-separated option strings into one. Either or both may be NULL. */
+static int mount_merge_options(const char *a, const char *b, char **ret) {
+        _cleanup_free_ char *merged = NULL;
+
+        assert(ret);
+
+        if (a && b)
+                merged = strjoin(a, ",", b);
+        else if (a)
+                merged = strdup(a);
+        else if (b)
+                merged = strdup(b);
+        else {
+                *ret = NULL;
+                return 0;
+        }
+
+        if (!merged)
+                return -ENOMEM;
+
+        *ret = TAKE_PTR(merged);
+        return 0;
+}
+
+/* Merge VFS and FS options into a single kernel options string. */
+static int mount_build_kernel_options(struct libmnt_fs *fs, char **ret) {
+        assert(fs);
+        assert(ret);
+
+        return mount_merge_options(
+                        sym_mnt_fs_get_vfs_options(fs),
+                        sym_mnt_fs_get_fs_options(fs),
+                        ret);
+}
+
+/* Rebuild the merged options string from opt_kernel and opt_user. */
+static int mount_parameters_rebuild_options(MountParameters *p) {
+        _cleanup_free_ char *merged = NULL;
+        int r;
+
+        assert(p);
+
+        r = mount_merge_options(p->opt_kernel, p->opt_user, &merged);
+        if (r < 0)
+                return r;
+
+        return free_and_replace(p->options, merged);
+}
+
 static int update_parameters_kernel(
                 Mount *m,
                 const char *what,
-                const char *options,
+                const char *opt_kernel,
+                const char *opt_user,
                 const char *fstype,
                 uint64_t uniq_id) {
 
         MountParameters *p;
-        int r, q, w;
+        bool rebuild;
+        int r, q, u, w;
 
         assert(m);
 
         p = &m->parameters_kernel;
 
+        rebuild = !streq_ptr(p->opt_kernel, opt_kernel) ||
+                  !streq_ptr(p->opt_user, opt_user);
+
         r = free_and_strdup(&p->what, what);
         if (r < 0)
                 return r;
 
-        q = free_and_strdup(&p->options, options);
+        q = free_and_strdup(&p->opt_kernel, opt_kernel);
         if (q < 0)
                 return q;
+
+        u = free_and_strdup(&p->opt_user, opt_user);
+        if (u < 0)
+                return u;
 
         w = free_and_strdup(&p->fstype, fstype);
         if (w < 0)
                 return w;
 
+        if (rebuild) {
+                int x = mount_parameters_rebuild_options(p);
+                if (x < 0)
+                        return x;
+        }
+
         m->uniq_id = uniq_id;
 
-        return r > 0 || q > 0 || w > 0;
+        return r > 0 || q > 0 || u > 0 || w > 0;
 }
 
 static int mount_setup_new_unit(
@@ -1758,7 +1825,8 @@ static int mount_setup_new_unit(
                 const char *name,
                 const char *what,
                 const char *where,
-                const char *options,
+                const char *opt_kernel,
+                const char *opt_user,
                 const char *fstype,
                 uint64_t uniq_id,
                 MountProcFlags *ret_flags,
@@ -1787,7 +1855,7 @@ static int mount_setup_new_unit(
         if (r < 0)
                 return r;
 
-        r = update_parameters_kernel(mnt, what, options, fstype, uniq_id);
+        r = update_parameters_kernel(mnt, what, opt_kernel, opt_user, fstype, uniq_id);
         if (r < 0)
                 return r;
 
@@ -1809,7 +1877,8 @@ static int mount_setup_existing_unit(
                 Unit *u,
                 const char *what,
                 const char *where,
-                const char *options,
+                const char *opt_kernel,
+                const char *opt_user,
                 const char *fstype,
                 uint64_t uniq_id,
                 MountProcFlags *ret_flags) {
@@ -1833,7 +1902,7 @@ static int mount_setup_existing_unit(
          * iteration and thus worthy of taking into account. */
         MountProcFlags flags = m->proc_flags | MOUNT_PROC_IS_MOUNTED;
 
-        r = update_parameters_kernel(m, what, options, fstype, uniq_id);
+        r = update_parameters_kernel(m, what, opt_kernel, opt_user, fstype, uniq_id);
         if (r < 0)
                 return r;
         if (r > 0)
@@ -1878,7 +1947,8 @@ static int mount_setup_unit(
                 Manager *m,
                 const char *what,
                 const char *where,
-                const char *options,
+                const char *opt_kernel,
+                const char *opt_user,
                 const char *fstype,
                 uint64_t uniq_id,
                 bool set_flags) {
@@ -1891,7 +1961,6 @@ static int mount_setup_unit(
         assert(m);
         assert(what);
         assert(where);
-        assert(options);
         assert(fstype);
 
         /* Ignore API and credential mount points. They should never be referenced in dependencies ever.
@@ -1919,11 +1988,11 @@ static int mount_setup_unit(
 
         u = manager_get_unit(m, e);
         if (u)
-                r = mount_setup_existing_unit(u, what, where, options, fstype, uniq_id, &flags);
+                r = mount_setup_existing_unit(u, what, where, opt_kernel, opt_user, fstype, uniq_id, &flags);
         else
                 /* First time we see this mount point meaning that it's not been initiated by a mount unit
                  * but rather by the sysadmin having called mount(8) directly. */
-                r = mount_setup_new_unit(m, e, what, where, options, fstype, uniq_id, &flags, &u);
+                r = mount_setup_new_unit(m, e, what, where, opt_kernel, opt_user, fstype, uniq_id, &flags, &u);
         if (r < 0)
                 return log_warning_errno(r, "Failed to set up mount unit for '%s': %m", where);
 
@@ -1967,7 +2036,7 @@ static int mount_load_kernel_mounttable(Manager *m, bool set_flags) {
 
         for (;;) {
                 struct libmnt_fs *fs;
-                const char *device, *path, *options, *fstype;
+                const char *device, *path, *fstype;
                 uint64_t uniq_id;
 
                 r = sym_mnt_table_next_fs(table, iter, &fs);
@@ -1978,12 +2047,18 @@ static int mount_load_kernel_mounttable(Manager *m, bool set_flags) {
 
                 device = sym_mnt_fs_get_source(fs);
                 path = sym_mnt_fs_get_target(fs);
-                options = sym_mnt_fs_get_options(fs);
                 fstype = sym_mnt_fs_get_fstype(fs);
                 uniq_id = use_listmount ? sym_mnt_fs_get_uniq_id(fs) : 0;
 
                 if (!device || !path)
                         continue;
+
+                _cleanup_free_ char *opt_kernel = NULL;
+                r = mount_build_kernel_options(fs, &opt_kernel);
+                if (r < 0)
+                        return log_oom();
+
+                const char *opt_user = sym_mnt_fs_get_user_options(fs);
 
                 /* Just to achieve device name uniqueness. Note that the suppression of the duplicate
                  * processing is merely an optimization, hence in case of OOM (unlikely) we'll just process
@@ -1991,7 +2066,7 @@ static int mount_load_kernel_mounttable(Manager *m, bool set_flags) {
                 if (set_put_strdup_full(&devices, &path_hash_ops_free, device) != 0)
                         device_found_node(m, device, DEVICE_FOUND_MOUNT, DEVICE_FOUND_MOUNT);
 
-                (void) mount_setup_unit(m, device, path, options, fstype, uniq_id, set_flags);
+                (void) mount_setup_unit(m, device, path, opt_kernel, opt_user, fstype, uniq_id, set_flags);
         }
 
         return 0;
@@ -2357,7 +2432,7 @@ static void mount_process_mount_units(Manager *m) {
                         mount->from_kernel = false;
                         if (mount->uniq_id > 0)
                                 hashmap_remove(m->mounts_by_uniq_id, &mount->uniq_id);
-                        assert_se(update_parameters_kernel(mount, NULL, NULL, NULL, 0) >= 0);
+                        assert_se(update_parameters_kernel(mount, NULL, NULL, NULL, NULL, 0) >= 0);
 
                         switch (mount->state) {
 
@@ -2490,14 +2565,19 @@ static void mount_process_fanotify_attach(Manager *m, struct libmnt_fs *fs) {
 
         const char *device = sym_mnt_fs_get_source(fs);
         const char *path = sym_mnt_fs_get_target(fs);
-        const char *options = sym_mnt_fs_get_options(fs);
         const char *fstype = sym_mnt_fs_get_fstype(fs);
         if (!device || !path || !fstype)
                 return;
         uint64_t uniq_id = sym_mnt_fs_get_uniq_id(fs);
 
+        /* statmount returns kernel-only data — no utab. User options arrive via a subsequent
+         * utab event. */
+        _cleanup_free_ char *opt_kernel = NULL;
+        if (mount_build_kernel_options(fs, &opt_kernel) < 0)
+                return (void) log_oom();
+
         device_found_node(m, device, DEVICE_FOUND_MOUNT, DEVICE_FOUND_MOUNT);
-        (void) mount_setup_unit(m, device, path, options, fstype, uniq_id, /* set_flags= */ true);
+        (void) mount_setup_unit(m, device, path, opt_kernel, /* opt_user= */ NULL, fstype, uniq_id, /* set_flags= */ true);
 }
 
 /* Incremental fanotify detach: mark the unit as detached. Leave from_kernel and kernel parameters

--- a/src/core/mount.c
+++ b/src/core/mount.c
@@ -66,7 +66,7 @@ static int mount_dispatch_io(sd_event_source *source, int fd, uint32_t revents, 
 static void mount_enter_dead(Mount *m, MountResult f, bool flush_result);
 static void mount_enter_mounted(Mount *m, MountResult f);
 static void mount_cycle_clear(Mount *m);
-static int mount_process_proc_self_mountinfo(Manager *m);
+static int mount_process_kernel_mounttable(Manager *m);
 
 static bool MOUNT_STATE_WITH_PROCESS(MountState state) {
         return IN_SET(state,
@@ -93,8 +93,8 @@ static MountParameters* get_mount_parameters_fragment(Mount *m) {
 static MountParameters* get_mount_parameters(Mount *m) {
         assert(m);
 
-        if (m->from_proc_self_mountinfo)
-                return &m->parameters_proc_self_mountinfo;
+        if (m->from_kernel)
+                return &m->parameters_kernel;
 
         return get_mount_parameters_fragment(m);
 }
@@ -227,7 +227,7 @@ static void mount_done(Unit *u) {
 
         m->where = mfree(m->where);
 
-        mount_parameters_done(&m->parameters_proc_self_mountinfo);
+        mount_parameters_done(&m->parameters_kernel);
         mount_parameters_done(&m->parameters_fragment);
 
         m->exec_runtime = exec_runtime_free(m->exec_runtime);
@@ -361,7 +361,7 @@ static int mount_add_device_dependencies(Mount *m) {
         dep = mount_is_bound_to_device(m) > 0 ? UNIT_BINDS_TO : UNIT_REQUIRES;
 
         /* We always use 'what' from /proc/self/mountinfo if mounted */
-        mask = m->from_proc_self_mountinfo ? UNIT_DEPENDENCY_MOUNTINFO : UNIT_DEPENDENCY_MOUNT_FILE;
+        mask = m->from_kernel ? UNIT_DEPENDENCY_MOUNTINFO : UNIT_DEPENDENCY_MOUNT_FILE;
 
         r = unit_add_node_dependency(UNIT(m), p->what, dep, mask);
         if (r < 0)
@@ -510,7 +510,7 @@ static int mount_add_default_dependencies(Mount *m) {
         if (!p)
                 return 0;
 
-        mask = m->from_proc_self_mountinfo ? UNIT_DEPENDENCY_MOUNTINFO : UNIT_DEPENDENCY_MOUNT_FILE;
+        mask = m->from_kernel ? UNIT_DEPENDENCY_MOUNTINFO : UNIT_DEPENDENCY_MOUNT_FILE;
 
         r = mount_add_default_ordering_dependencies(m, p, mask);
         if (r < 0)
@@ -531,7 +531,7 @@ static int mount_verify(Mount *m) {
         assert(m);
         assert(UNIT(m)->load_state == UNIT_LOADED);
 
-        if (!m->from_fragment && !m->from_proc_self_mountinfo && !UNIT(m)->perpetual)
+        if (!m->from_fragment && !m->from_kernel && !UNIT(m)->perpetual)
                 return -ENOENT;
 
         r = unit_name_from_path(m->where, ".mount", &e);
@@ -663,7 +663,7 @@ static int mount_load(Unit *u) {
 
         mount_load_root_mount(u);
 
-        bool from_kernel = m->from_proc_self_mountinfo || u->perpetual;
+        bool from_kernel = m->from_kernel || u->perpetual;
 
         r = unit_load_fragment_and_dropin(u, /* fragment_required= */ !from_kernel);
 
@@ -739,8 +739,8 @@ static int mount_coldplug(Unit *u) {
 static void mount_catchup(Unit *u) {
         Mount *m = ASSERT_PTR(MOUNT(u));
 
-        /* Adjust the deserialized state. See comments in mount_process_proc_self_mountinfo(). */
-        if (m->from_proc_self_mountinfo)
+        /* Adjust the deserialized state. See comments in mount_process_kernel_mounttable(). */
+        if (m->from_kernel)
                 switch (m->state) {
                 case MOUNT_DEAD:
                 case MOUNT_FAILED:
@@ -807,7 +807,7 @@ static void mount_dump(Unit *u, FILE *f, const char *prefix) {
                 prefix, p ? strna(p->what) : "n/a",
                 prefix, p ? strna(p->fstype) : "n/a",
                 prefix, p ? strna(p->options) : "n/a",
-                prefix, yes_no(m->from_proc_self_mountinfo),
+                prefix, yes_no(m->from_kernel),
                 prefix, yes_no(m->from_fragment),
                 prefix, yes_no(mount_is_extrinsic(u)),
                 prefix, m->directory_mode,
@@ -939,7 +939,7 @@ static void mount_enter_dead_or_mounted(Mount *m, MountResult f, bool flush_resu
          * Note that flush_result only applies to mount_enter_dead(), since that's when the result gets
          * turned into unit end state. */
 
-        if (m->from_proc_self_mountinfo)
+        if (m->from_kernel)
                 mount_enter_mounted(m, f);
         else
                 mount_enter_dead(m, f, flush_result);
@@ -1504,7 +1504,7 @@ static const char *mount_sub_state_to_string(Unit *u) {
 static bool mount_may_gc(Unit *u) {
         Mount *m = ASSERT_PTR(MOUNT(u));
 
-        if (m->from_proc_self_mountinfo)
+        if (m->from_kernel)
                 return false;
 
         return true;
@@ -1533,7 +1533,7 @@ static void mount_sigchld_event(Unit *u, pid_t pid, int code, int status) {
          * race, let's explicitly scan /proc/self/mountinfo before we start processing /usr/bin/(u)mount
          * dying. It's ugly, but it makes our ordering systematic again, and makes sure we always see
          * /proc/self/mountinfo changes before our mount/umount exits. */
-        (void) mount_process_proc_self_mountinfo(u->manager);
+        (void) mount_process_kernel_mounttable(u->manager);
 
         pidref_done(&m->control_pid);
 
@@ -1596,7 +1596,7 @@ static void mount_sigchld_event(Unit *u, pid_t pid, int code, int status) {
                 break;
 
         case MOUNT_UNMOUNTING:
-                if (f == MOUNT_SUCCESS && m->from_proc_self_mountinfo) {
+                if (f == MOUNT_SUCCESS && m->from_kernel) {
                         /* Still a mount point? If so, let's try again. Most likely there were multiple mount points
                          * stacked on top of each other. We might exceed the timeout specified by the user overall,
                          * but we will stop as soon as any one umount times out. */
@@ -1609,7 +1609,7 @@ static void mount_sigchld_event(Unit *u, pid_t pid, int code, int status) {
                                 log_unit_warning(u, "Mount still present after %u attempts to unmount, giving up.", m->n_retry_umount);
                                 mount_enter_mounted(m, MOUNT_FAILURE_PROTOCOL);
                         }
-                } else if (f == MOUNT_FAILURE_EXIT_CODE && !m->from_proc_self_mountinfo) {
+                } else if (f == MOUNT_FAILURE_EXIT_CODE && !m->from_kernel) {
                         /* Hmm, umount process spawned by us failed, but the mount disappeared anyway?
                          * Maybe someone else is trying to unmount at the same time. */
                         log_unit_notice(u, "Mount disappeared even though umount process failed, continuing.");
@@ -1719,7 +1719,7 @@ static int mount_dispatch_timer(sd_event_source *source, usec_t usec, void *user
 }
 
 #if HAVE_LIBMOUNT
-static int update_parameters_proc_self_mountinfo(
+static int update_parameters_kernel(
                 Mount *m,
                 const char *what,
                 const char *options,
@@ -1730,7 +1730,7 @@ static int update_parameters_proc_self_mountinfo(
 
         assert(m);
 
-        p = &m->parameters_proc_self_mountinfo;
+        p = &m->parameters_kernel;
 
         r = free_and_strdup(&p->what, what);
         if (r < 0)
@@ -1780,14 +1780,14 @@ static int mount_setup_new_unit(
         if (r < 0)
                 return r;
 
-        r = update_parameters_proc_self_mountinfo(mnt, what, options, fstype);
+        r = update_parameters_kernel(mnt, what, options, fstype);
         if (r < 0)
                 return r;
 
         /* This unit was generated because /proc/self/mountinfo reported it. Remember this, so that by the
          * time we load the unit file for it (and thus add in extra deps right after) we know what source to
          * attributes the deps to. */
-        mnt->from_proc_self_mountinfo = true;
+        mnt->from_kernel = true;
 
         /* We have only allocated the stub now, let's enqueue this unit for loading now, so that everything
          * else is loaded in now. */
@@ -1825,7 +1825,7 @@ static int mount_setup_existing_unit(
          * iteration and thus worthy of taking into account. */
         MountProcFlags flags = m->proc_flags | MOUNT_PROC_IS_MOUNTED;
 
-        r = update_parameters_proc_self_mountinfo(m, what, options, fstype);
+        r = update_parameters_kernel(m, what, options, fstype);
         if (r < 0)
                 return r;
         if (r > 0)
@@ -1838,10 +1838,10 @@ static int mount_setup_existing_unit(
          * from the serialized state), and need to catch up. Since we know that the MOUNT_MOUNTING state is
          * reached when we wait for the mount to appear we hence can assume that if we are in it, we are
          * actually seeing it established for the first time. */
-        if (!m->from_proc_self_mountinfo || m->state == MOUNT_MOUNTING)
+        if (!m->from_kernel || m->state == MOUNT_MOUNTING)
                 flags |= MOUNT_PROC_JUST_MOUNTED;
 
-        m->from_proc_self_mountinfo = true;
+        m->from_kernel = true;
 
         if (UNIT_IS_LOAD_ERROR(u->load_state)) {
                 /* The unit was previously not found or otherwise not loaded. Now that the unit shows up in
@@ -1928,7 +1928,7 @@ static int mount_setup_unit(
         return 0;
 }
 
-static int mount_load_proc_self_mountinfo(Manager *m, bool set_flags) {
+static int mount_load_kernel_mounttable(Manager *m, bool set_flags) {
         _cleanup_(mnt_free_tablep) struct libmnt_table *table = NULL;
         _cleanup_(mnt_free_iterp) struct libmnt_iter *iter = NULL;
         _cleanup_set_free_ Set *devices = NULL;
@@ -2151,7 +2151,7 @@ static void mount_enumerate(Manager *m) {
                 (void) sd_event_source_set_description(m->mount_event_source, "mount-monitor-dispatch");
         }
 
-        r = mount_load_proc_self_mountinfo(m, false);
+        r = mount_load_kernel_mounttable(m, false);
         if (r < 0)
                 goto fail;
 
@@ -2193,7 +2193,7 @@ static int drain_libmount(Manager *m) {
 #endif
 }
 
-static int mount_process_proc_self_mountinfo(Manager *m) {
+static int mount_process_kernel_mounttable(Manager *m) {
         int r;
 
         assert(m);
@@ -2203,7 +2203,7 @@ static int mount_process_proc_self_mountinfo(Manager *m) {
                 return r;
 
 #if HAVE_LIBMOUNT
-        r = mount_load_proc_self_mountinfo(m, true);
+        r = mount_load_kernel_mounttable(m, true);
         if (r < 0) {
                 /* Reset flags, just in case, for later calls */
                 LIST_FOREACH(units_by_type, u, m->units_by_type[UNIT_MOUNT])
@@ -2224,14 +2224,14 @@ static int mount_process_proc_self_mountinfo(Manager *m) {
                         /* A mount point is not around right now. It might be gone, or might never have
                          * existed. */
 
-                        if (mount->from_proc_self_mountinfo &&
-                            mount->parameters_proc_self_mountinfo.what)
+                        if (mount->from_kernel &&
+                            mount->parameters_kernel.what)
                                 /* Remember that this device might just have disappeared */
-                                if (set_put_strdup_full(&gone, &path_hash_ops_free, mount->parameters_proc_self_mountinfo.what) < 0)
+                                if (set_put_strdup_full(&gone, &path_hash_ops_free, mount->parameters_kernel.what) < 0)
                                         log_oom(); /* we don't care too much about OOM here... */
 
-                        mount->from_proc_self_mountinfo = false;
-                        assert_se(update_parameters_proc_self_mountinfo(mount, NULL, NULL, NULL) >= 0);
+                        mount->from_kernel = false;
+                        assert_se(update_parameters_kernel(mount, NULL, NULL, NULL) >= 0);
 
                         switch (mount->state) {
 
@@ -2285,10 +2285,10 @@ static int mount_process_proc_self_mountinfo(Manager *m) {
                 }
 
                 if (mount_is_mounted(mount) &&
-                    mount->from_proc_self_mountinfo &&
-                    mount->parameters_proc_self_mountinfo.what)
+                    mount->from_kernel &&
+                    mount->parameters_kernel.what)
                         /* Track devices currently used */
-                        if (set_put_strdup_full(&around, &path_hash_ops_free, mount->parameters_proc_self_mountinfo.what) < 0)
+                        if (set_put_strdup_full(&around, &path_hash_ops_free, mount->parameters_kernel.what) < 0)
                                 log_oom();
 
                 /* Reset the flags for later calls */
@@ -2316,7 +2316,7 @@ static int mount_dispatch_io(sd_event_source *source, int fd, uint32_t revents, 
 
         assert(revents & EPOLLIN);
 
-        return mount_process_proc_self_mountinfo(m);
+        return mount_process_kernel_mounttable(m);
 }
 #endif
 
@@ -2434,8 +2434,8 @@ char* mount_get_what_escaped(const Mount *m) {
 
         assert(m);
 
-        if (m->from_proc_self_mountinfo && m->parameters_proc_self_mountinfo.what)
-                s = m->parameters_proc_self_mountinfo.what;
+        if (m->from_kernel && m->parameters_kernel.what)
+                s = m->parameters_kernel.what;
         else if (m->from_fragment && m->parameters_fragment.what)
                 s = m->parameters_fragment.what;
         if (!s)
@@ -2449,8 +2449,8 @@ char* mount_get_options_escaped(const Mount *m) {
 
         assert(m);
 
-        if (m->from_proc_self_mountinfo && m->parameters_proc_self_mountinfo.options)
-                s = m->parameters_proc_self_mountinfo.options;
+        if (m->from_kernel && m->parameters_kernel.options)
+                s = m->parameters_kernel.options;
         else if (m->from_fragment && m->parameters_fragment.options)
                 s = m->parameters_fragment.options;
         if (!s)
@@ -2462,8 +2462,8 @@ char* mount_get_options_escaped(const Mount *m) {
 const char* mount_get_fstype(const Mount *m) {
         assert(m);
 
-        if (m->from_proc_self_mountinfo && m->parameters_proc_self_mountinfo.fstype)
-                return m->parameters_proc_self_mountinfo.fstype;
+        if (m->from_kernel && m->parameters_kernel.fstype)
+                return m->parameters_kernel.fstype;
 
         if (m->from_fragment && m->parameters_fragment.fstype)
                 return m->parameters_fragment.fstype;

--- a/src/core/mount.c
+++ b/src/core/mount.c
@@ -93,8 +93,8 @@ static MountParameters* get_mount_parameters_fragment(Mount *m) {
 static MountParameters* get_mount_parameters(Mount *m) {
         assert(m);
 
-        if (m->from_proc_self_mountinfo)
-                return &m->parameters_proc_self_mountinfo;
+        if (m->from_kernel)
+                return &m->parameters_kernel;
 
         return get_mount_parameters_fragment(m);
 }
@@ -227,7 +227,7 @@ static void mount_done(Unit *u) {
 
         m->where = mfree(m->where);
 
-        mount_parameters_done(&m->parameters_proc_self_mountinfo);
+        mount_parameters_done(&m->parameters_kernel);
         mount_parameters_done(&m->parameters_fragment);
 
         m->exec_runtime = exec_runtime_free(m->exec_runtime);
@@ -361,7 +361,7 @@ static int mount_add_device_dependencies(Mount *m) {
         dep = mount_is_bound_to_device(m) > 0 ? UNIT_BINDS_TO : UNIT_REQUIRES;
 
         /* We always use 'what' from /proc/self/mountinfo if mounted */
-        mask = m->from_proc_self_mountinfo ? UNIT_DEPENDENCY_MOUNTINFO : UNIT_DEPENDENCY_MOUNT_FILE;
+        mask = m->from_kernel ? UNIT_DEPENDENCY_MOUNTINFO : UNIT_DEPENDENCY_MOUNT_FILE;
 
         r = unit_add_node_dependency(UNIT(m), p->what, dep, mask);
         if (r < 0)
@@ -510,7 +510,7 @@ static int mount_add_default_dependencies(Mount *m) {
         if (!p)
                 return 0;
 
-        mask = m->from_proc_self_mountinfo ? UNIT_DEPENDENCY_MOUNTINFO : UNIT_DEPENDENCY_MOUNT_FILE;
+        mask = m->from_kernel ? UNIT_DEPENDENCY_MOUNTINFO : UNIT_DEPENDENCY_MOUNT_FILE;
 
         r = mount_add_default_ordering_dependencies(m, p, mask);
         if (r < 0)
@@ -531,7 +531,7 @@ static int mount_verify(Mount *m) {
         assert(m);
         assert(UNIT(m)->load_state == UNIT_LOADED);
 
-        if (!m->from_fragment && !m->from_proc_self_mountinfo && !UNIT(m)->perpetual)
+        if (!m->from_fragment && !m->from_kernel && !UNIT(m)->perpetual)
                 return -ENOENT;
 
         r = unit_name_from_path(m->where, ".mount", &e);
@@ -663,7 +663,7 @@ static int mount_load(Unit *u) {
 
         mount_load_root_mount(u);
 
-        bool from_kernel = m->from_proc_self_mountinfo || u->perpetual;
+        bool from_kernel = m->from_kernel || u->perpetual;
 
         r = unit_load_fragment_and_dropin(u, /* fragment_required= */ !from_kernel);
 
@@ -740,7 +740,7 @@ static void mount_catchup(Unit *u) {
         Mount *m = ASSERT_PTR(MOUNT(u));
 
         /* Adjust the deserialized state. See comments in mount_process_proc_self_mountinfo(). */
-        if (m->from_proc_self_mountinfo)
+        if (m->from_kernel)
                 switch (m->state) {
                 case MOUNT_DEAD:
                 case MOUNT_FAILED:
@@ -807,7 +807,7 @@ static void mount_dump(Unit *u, FILE *f, const char *prefix) {
                 prefix, p ? strna(p->what) : "n/a",
                 prefix, p ? strna(p->fstype) : "n/a",
                 prefix, p ? strna(p->options) : "n/a",
-                prefix, yes_no(m->from_proc_self_mountinfo),
+                prefix, yes_no(m->from_kernel),
                 prefix, yes_no(m->from_fragment),
                 prefix, yes_no(mount_is_extrinsic(u)),
                 prefix, m->directory_mode,
@@ -939,7 +939,7 @@ static void mount_enter_dead_or_mounted(Mount *m, MountResult f, bool flush_resu
          * Note that flush_result only applies to mount_enter_dead(), since that's when the result gets
          * turned into unit end state. */
 
-        if (m->from_proc_self_mountinfo)
+        if (m->from_kernel)
                 mount_enter_mounted(m, f);
         else
                 mount_enter_dead(m, f, flush_result);
@@ -1504,7 +1504,7 @@ static const char *mount_sub_state_to_string(Unit *u) {
 static bool mount_may_gc(Unit *u) {
         Mount *m = ASSERT_PTR(MOUNT(u));
 
-        if (m->from_proc_self_mountinfo)
+        if (m->from_kernel)
                 return false;
 
         return true;
@@ -1596,7 +1596,7 @@ static void mount_sigchld_event(Unit *u, pid_t pid, int code, int status) {
                 break;
 
         case MOUNT_UNMOUNTING:
-                if (f == MOUNT_SUCCESS && m->from_proc_self_mountinfo) {
+                if (f == MOUNT_SUCCESS && m->from_kernel) {
                         /* Still a mount point? If so, let's try again. Most likely there were multiple mount points
                          * stacked on top of each other. We might exceed the timeout specified by the user overall,
                          * but we will stop as soon as any one umount times out. */
@@ -1609,7 +1609,7 @@ static void mount_sigchld_event(Unit *u, pid_t pid, int code, int status) {
                                 log_unit_warning(u, "Mount still present after %u attempts to unmount, giving up.", m->n_retry_umount);
                                 mount_enter_mounted(m, MOUNT_FAILURE_PROTOCOL);
                         }
-                } else if (f == MOUNT_FAILURE_EXIT_CODE && !m->from_proc_self_mountinfo) {
+                } else if (f == MOUNT_FAILURE_EXIT_CODE && !m->from_kernel) {
                         /* Hmm, umount process spawned by us failed, but the mount disappeared anyway?
                          * Maybe someone else is trying to unmount at the same time. */
                         log_unit_notice(u, "Mount disappeared even though umount process failed, continuing.");
@@ -1719,7 +1719,7 @@ static int mount_dispatch_timer(sd_event_source *source, usec_t usec, void *user
 }
 
 #if HAVE_LIBMOUNT
-static int update_parameters_proc_self_mountinfo(
+static int update_parameters_kernel(
                 Mount *m,
                 const char *what,
                 const char *options,
@@ -1730,7 +1730,7 @@ static int update_parameters_proc_self_mountinfo(
 
         assert(m);
 
-        p = &m->parameters_proc_self_mountinfo;
+        p = &m->parameters_kernel;
 
         r = free_and_strdup(&p->what, what);
         if (r < 0)
@@ -1780,14 +1780,14 @@ static int mount_setup_new_unit(
         if (r < 0)
                 return r;
 
-        r = update_parameters_proc_self_mountinfo(mnt, what, options, fstype);
+        r = update_parameters_kernel(mnt, what, options, fstype);
         if (r < 0)
                 return r;
 
         /* This unit was generated because /proc/self/mountinfo reported it. Remember this, so that by the
          * time we load the unit file for it (and thus add in extra deps right after) we know what source to
          * attributes the deps to. */
-        mnt->from_proc_self_mountinfo = true;
+        mnt->from_kernel = true;
 
         /* We have only allocated the stub now, let's enqueue this unit for loading now, so that everything
          * else is loaded in now. */
@@ -1825,7 +1825,7 @@ static int mount_setup_existing_unit(
          * iteration and thus worthy of taking into account. */
         MountProcFlags flags = m->proc_flags | MOUNT_PROC_IS_MOUNTED;
 
-        r = update_parameters_proc_self_mountinfo(m, what, options, fstype);
+        r = update_parameters_kernel(m, what, options, fstype);
         if (r < 0)
                 return r;
         if (r > 0)
@@ -1838,10 +1838,10 @@ static int mount_setup_existing_unit(
          * from the serialized state), and need to catch up. Since we know that the MOUNT_MOUNTING state is
          * reached when we wait for the mount to appear we hence can assume that if we are in it, we are
          * actually seeing it established for the first time. */
-        if (!m->from_proc_self_mountinfo || m->state == MOUNT_MOUNTING)
+        if (!m->from_kernel || m->state == MOUNT_MOUNTING)
                 flags |= MOUNT_PROC_JUST_MOUNTED;
 
-        m->from_proc_self_mountinfo = true;
+        m->from_kernel = true;
 
         if (UNIT_IS_LOAD_ERROR(u->load_state)) {
                 /* The unit was previously not found or otherwise not loaded. Now that the unit shows up in
@@ -2224,14 +2224,14 @@ static int mount_process_proc_self_mountinfo(Manager *m) {
                         /* A mount point is not around right now. It might be gone, or might never have
                          * existed. */
 
-                        if (mount->from_proc_self_mountinfo &&
-                            mount->parameters_proc_self_mountinfo.what)
+                        if (mount->from_kernel &&
+                            mount->parameters_kernel.what)
                                 /* Remember that this device might just have disappeared */
-                                if (set_put_strdup_full(&gone, &path_hash_ops_free, mount->parameters_proc_self_mountinfo.what) < 0)
+                                if (set_put_strdup_full(&gone, &path_hash_ops_free, mount->parameters_kernel.what) < 0)
                                         log_oom(); /* we don't care too much about OOM here... */
 
-                        mount->from_proc_self_mountinfo = false;
-                        assert_se(update_parameters_proc_self_mountinfo(mount, NULL, NULL, NULL) >= 0);
+                        mount->from_kernel = false;
+                        assert_se(update_parameters_kernel(mount, NULL, NULL, NULL) >= 0);
 
                         switch (mount->state) {
 
@@ -2285,10 +2285,10 @@ static int mount_process_proc_self_mountinfo(Manager *m) {
                 }
 
                 if (mount_is_mounted(mount) &&
-                    mount->from_proc_self_mountinfo &&
-                    mount->parameters_proc_self_mountinfo.what)
+                    mount->from_kernel &&
+                    mount->parameters_kernel.what)
                         /* Track devices currently used */
-                        if (set_put_strdup_full(&around, &path_hash_ops_free, mount->parameters_proc_self_mountinfo.what) < 0)
+                        if (set_put_strdup_full(&around, &path_hash_ops_free, mount->parameters_kernel.what) < 0)
                                 log_oom();
 
                 /* Reset the flags for later calls */
@@ -2434,8 +2434,8 @@ char* mount_get_what_escaped(const Mount *m) {
 
         assert(m);
 
-        if (m->from_proc_self_mountinfo && m->parameters_proc_self_mountinfo.what)
-                s = m->parameters_proc_self_mountinfo.what;
+        if (m->from_kernel && m->parameters_kernel.what)
+                s = m->parameters_kernel.what;
         else if (m->from_fragment && m->parameters_fragment.what)
                 s = m->parameters_fragment.what;
         if (!s)
@@ -2449,8 +2449,8 @@ char* mount_get_options_escaped(const Mount *m) {
 
         assert(m);
 
-        if (m->from_proc_self_mountinfo && m->parameters_proc_self_mountinfo.options)
-                s = m->parameters_proc_self_mountinfo.options;
+        if (m->from_kernel && m->parameters_kernel.options)
+                s = m->parameters_kernel.options;
         else if (m->from_fragment && m->parameters_fragment.options)
                 s = m->parameters_fragment.options;
         if (!s)
@@ -2462,8 +2462,8 @@ char* mount_get_options_escaped(const Mount *m) {
 const char* mount_get_fstype(const Mount *m) {
         assert(m);
 
-        if (m->from_proc_self_mountinfo && m->parameters_proc_self_mountinfo.fstype)
-                return m->parameters_proc_self_mountinfo.fstype;
+        if (m->from_kernel && m->parameters_kernel.fstype)
+                return m->parameters_kernel.fstype;
 
         if (m->from_fragment && m->parameters_fragment.fstype)
                 return m->parameters_fragment.fstype;

--- a/src/core/mount.c
+++ b/src/core/mount.c
@@ -66,7 +66,7 @@ static int mount_dispatch_io(sd_event_source *source, int fd, uint32_t revents, 
 static void mount_enter_dead(Mount *m, MountResult f, bool flush_result);
 static void mount_enter_mounted(Mount *m, MountResult f);
 static void mount_cycle_clear(Mount *m);
-static int mount_process_kernel_mounttable(Manager *m);
+static int mount_process_kernel_mounttable(Manager *m, bool skip_drain);
 
 static bool MOUNT_STATE_WITH_PROCESS(MountState state) {
         return IN_SET(state,
@@ -224,6 +224,9 @@ static void mount_parameters_done(MountParameters *p) {
 
 static void mount_done(Unit *u) {
         Mount *m = ASSERT_PTR(MOUNT(u));
+
+        if (m->uniq_id > 0)
+                hashmap_remove(u->manager->mounts_by_uniq_id, &m->uniq_id);
 
         m->where = mfree(m->where);
 
@@ -1533,7 +1536,7 @@ static void mount_sigchld_event(Unit *u, pid_t pid, int code, int status) {
          * race, let's explicitly scan /proc/self/mountinfo before we start processing /usr/bin/(u)mount
          * dying. It's ugly, but it makes our ordering systematic again, and makes sure we always see
          * /proc/self/mountinfo changes before our mount/umount exits. */
-        (void) mount_process_kernel_mounttable(u->manager);
+        (void) mount_process_kernel_mounttable(u->manager, /* skip_drain= */ false);
 
         pidref_done(&m->control_pid);
 
@@ -1924,6 +1927,13 @@ static int mount_setup_unit(
         if (r < 0)
                 return log_warning_errno(r, "Failed to set up mount unit for '%s': %m", where);
 
+        if (uniq_id > 0) {
+                r = hashmap_ensure_allocated(&m->mounts_by_uniq_id, &uint64_hash_ops);
+                if (r < 0)
+                        return log_oom();
+                (void) hashmap_put(m->mounts_by_uniq_id, &MOUNT(u)->uniq_id, MOUNT(u));
+        }
+
         /* If the mount changed properties or state, let's notify our clients */
         if (flags & (MOUNT_PROC_JUST_CHANGED|MOUNT_PROC_JUST_MOUNTED))
                 unit_add_to_dbus_queue(u);
@@ -1997,6 +2007,16 @@ static void mount_shutdown(Manager *m) {
                 sym_mnt_unref_monitor(m->mount_monitor);
                 m->mount_monitor = NULL;
         }
+
+#if HAVE_LIBMOUNT
+        if (m->mount_fanotify_fs) {
+                sym_mnt_unref_fs(m->mount_fanotify_fs);
+                m->mount_fanotify_fs = NULL;
+        }
+        m->mount_use_fanotify = false;
+#endif
+
+        m->mounts_by_uniq_id = hashmap_free(m->mounts_by_uniq_id);
 }
 
 static void mount_handoff_timestamp(
@@ -2085,6 +2105,71 @@ static int mount_on_ratelimit_expire(sd_event_source *s, void *userdata) {
 
         return 0;
 }
+
+static bool mount_monitor_is_fanotify_usable(void) {
+        static int cached = -1;
+
+        if (cached != -1)
+                return cached;
+
+        _cleanup_(mnt_unref_monitorp) struct libmnt_monitor *probe = NULL;
+
+        if (DLOPEN_LIBMOUNT_FANOTIFY(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED) < 0)
+                return (cached = false);
+
+        /* mnt_monitor_enable_fanotify() only allocates data structures; the actual
+         * fanotify_init(FAN_REPORT_MNT) syscall happens inside mnt_monitor_get_fd().
+         * Use a throwaway probe monitor to test kernel support. */
+        probe = sym_mnt_new_monitor();
+        if (!probe)
+                return (cached = false);
+
+        if (sym_mnt_monitor_enable_fanotify(probe, /* enable= */ 1, /* ns= */ -1) < 0)
+                return (cached = false);
+
+        cached = sym_mnt_monitor_get_fd(probe) >= 0;
+        return cached;
+}
+
+static int mount_monitor_init_fanotify(Manager *m) {
+        int r;
+
+        assert(m);
+        assert(m->mount_monitor);
+
+        r = sym_mnt_monitor_enable_fanotify(m->mount_monitor, /* enable= */ 1, /* ns= */ -1);
+        if (r < 0)
+                return r;
+
+        m->mount_fanotify_fs = sym_mnt_new_fs();
+        if (!m->mount_fanotify_fs) {
+                r = log_oom();
+                goto fail;
+        }
+
+        struct libmnt_statmnt *stmnt = sym_mnt_new_statmnt();
+        if (!stmnt) {
+                r = log_oom();
+                goto fail;
+        }
+
+        r = sym_mnt_fs_refer_statmnt(m->mount_fanotify_fs, stmnt);
+        sym_mnt_unref_statmnt(stmnt);
+        if (r < 0) {
+                log_debug_errno(r, "Failed to attach statmnt to fs: %m");
+                goto fail;
+        }
+
+        return 0;
+
+fail:
+        (void) sym_mnt_monitor_enable_fanotify(m->mount_monitor, /* enable= */ 0, /* ns= */ -1);
+        if (m->mount_fanotify_fs) {
+                sym_mnt_unref_fs(m->mount_fanotify_fs);
+                m->mount_fanotify_fs = NULL;
+        }
+        return r;
+}
 #endif
 
 static void mount_enumerate(Manager *m) {
@@ -2099,6 +2184,7 @@ static void mount_enumerate(Manager *m) {
         if (!m->mount_monitor) {
                 usec_t mount_rate_limit_interval = 1 * USEC_PER_SEC;
                 unsigned mount_rate_limit_burst = 5;
+                bool use_fanotify;
                 int fd;
 
                 m->mount_monitor = sym_mnt_new_monitor();
@@ -2107,10 +2193,22 @@ static void mount_enumerate(Manager *m) {
                         goto fail;
                 }
 
-                r = sym_mnt_monitor_enable_kernel(m->mount_monitor, 1);
-                if (r < 0) {
-                        log_error_errno(r, "Failed to enable watching of kernel mount events: %m");
-                        goto fail;
+                use_fanotify = mount_monitor_is_fanotify_usable();
+
+                if (use_fanotify) {
+                        r = mount_monitor_init_fanotify(m);
+                        if (r < 0) {
+                                log_warning_errno(r, "Failed to initialize fanotify mount monitoring, falling back to inotify: %m");
+                                use_fanotify = false;
+                        }
+                }
+
+                if (!use_fanotify) {
+                        r = sym_mnt_monitor_enable_kernel(m->mount_monitor, 1);
+                        if (r < 0) {
+                                log_error_errno(r, "Failed to enable watching of kernel mount events: %m");
+                                goto fail;
+                        }
                 }
 
                 r = sym_mnt_monitor_enable_userspace(m->mount_monitor, 1, NULL);
@@ -2166,6 +2264,9 @@ static void mount_enumerate(Manager *m) {
                 }
 
                 (void) sd_event_source_set_description(m->mount_event_source, "mount-monitor-dispatch");
+
+                m->mount_use_fanotify = use_fanotify;
+                log_debug("Using %s for mount monitoring.", use_fanotify ? "fanotify" : "inotify");
         }
 
         r = mount_load_kernel_mounttable(m, false);
@@ -2211,9 +2312,24 @@ static int drain_libmount(Manager *m) {
 }
 
 #if HAVE_LIBMOUNT
-/* Dispatch the load queue, run state transitions based on proc_flags, and reconcile device
- * nodes (around/gone sets). Called after mount_load_kernel_mounttable() has populated the
- * mount units with current kernel state. */
+/* Post-processing for mount units after kernel state has been updated.
+ *
+ * Dispatches the load queue, performs state transitions based on proc_flags, and reconciles
+ * device nodes (around/gone sets). Used by both paths:
+ *
+ * Full-rescan path: mount_load_kernel_mounttable() sets MOUNT_PROC_IS_MOUNTED on every mount
+ *   found in the kernel table. Units absent from the table are explicitly marked
+ *   MOUNT_PROC_IS_DETACHED by the caller. Units with proc_flags == 0 are non-kernel (e.g.
+ *   fstab-only, never mounted) and skipped.
+ *
+ * Incremental fanotify path: only event-affected units get proc_flags set — attach sets
+ *   IS_MOUNTED (via mount_setup_unit()), detach sets IS_DETACHED, utab changes set
+ *   IS_MOUNTED|JUST_CHANGED. Units with proc_flags == 0 were not part of this event batch
+ *   and are skipped.
+ *
+ * For detached units, from_kernel and parameters_kernel are still intact at this point —
+ * the gone/around cross-check needs parameters_kernel.what to track disappearing devices.
+ * Cleanup (from_kernel, hashmap, parameters) happens here after the cross-check. */
 static void mount_process_mount_units(Manager *m) {
         _cleanup_set_free_ Set *around = NULL, *gone = NULL;
 
@@ -2223,6 +2339,9 @@ static void mount_process_mount_units(Manager *m) {
 
         LIST_FOREACH(units_by_type, u, m->units_by_type[UNIT_MOUNT]) {
                 Mount *mount = MOUNT(u);
+
+                if (mount->proc_flags == 0)
+                        continue;
 
                 if (!mount_is_mounted(mount)) {
 
@@ -2236,6 +2355,8 @@ static void mount_process_mount_units(Manager *m) {
                                         log_oom(); /* we don't care too much about OOM here... */
 
                         mount->from_kernel = false;
+                        if (mount->uniq_id > 0)
+                                hashmap_remove(m->mounts_by_uniq_id, &mount->uniq_id);
                         assert_se(update_parameters_kernel(mount, NULL, NULL, NULL, 0) >= 0);
 
                         switch (mount->state) {
@@ -2312,14 +2433,16 @@ static void mount_process_mount_units(Manager *m) {
 #endif /* HAVE_LIBMOUNT */
 
 /* Load the complete kernel mount table and process all mount units. */
-static int mount_process_kernel_mounttable(Manager *m) {
+static int mount_process_kernel_mounttable(Manager *m, bool skip_drain) {
         int r;
 
         assert(m);
 
-        r = drain_libmount(m);
-        if (r <= 0)
-                return r;
+        if (!skip_drain) {
+                r = drain_libmount(m);
+                if (r <= 0)
+                        return r;
+        }
 
 #if HAVE_LIBMOUNT
         r = mount_load_kernel_mounttable(m, /* set_flags= */ true);
@@ -2331,6 +2454,12 @@ static int mount_process_kernel_mounttable(Manager *m) {
                 return 0;
         }
 
+        /* Units previously from kernel but absent from the table are gone — mark them
+         * explicitly so mount_process_mount_units() picks them up. */
+        LIST_FOREACH(units_by_type, u, m->units_by_type[UNIT_MOUNT])
+                if (MOUNT(u)->proc_flags == 0 && MOUNT(u)->from_kernel)
+                        MOUNT(u)->proc_flags = MOUNT_PROC_IS_DETACHED;
+
         mount_process_mount_units(m);
 
         return 0;
@@ -2340,12 +2469,115 @@ static int mount_process_kernel_mounttable(Manager *m) {
 }
 
 #if HAVE_LIBMOUNT
+static Mount *mount_find_by_uniq_id(Manager *m, uint64_t uniq_id) {
+        assert(m);
+
+        if (uniq_id == 0)
+                return NULL;
+
+        return hashmap_get(m->mounts_by_uniq_id, &uniq_id);
+}
+
+/* Incremental fanotify attach: populate the mount unit via mount_setup_unit() and register the
+ * device. State transitions are deferred to mount_process_mount_units(). */
+static void mount_process_fanotify_attach(Manager *m, struct libmnt_fs *fs) {
+        assert(m);
+        assert(fs);
+
+        int r = sym_mnt_fs_fetch_statmount(fs, /* mask= */ 0);
+        if (r < 0)
+                return (void) log_debug_errno(r, "Failed to fetch statmount: %m");
+
+        const char *device = sym_mnt_fs_get_source(fs);
+        const char *path = sym_mnt_fs_get_target(fs);
+        const char *options = sym_mnt_fs_get_options(fs);
+        const char *fstype = sym_mnt_fs_get_fstype(fs);
+        if (!device || !path || !fstype)
+                return;
+        uint64_t uniq_id = sym_mnt_fs_get_uniq_id(fs);
+
+        device_found_node(m, device, DEVICE_FOUND_MOUNT, DEVICE_FOUND_MOUNT);
+        (void) mount_setup_unit(m, device, path, options, fstype, uniq_id, /* set_flags= */ true);
+}
+
+/* Incremental fanotify detach: mark the unit as detached. Leave from_kernel and kernel parameters
+ * intact so mount_process_mount_units() can use them for the gone/around device cross-check. */
+static void mount_process_fanotify_detach(Manager *m, struct libmnt_fs *fs) {
+        assert(m);
+        assert(fs);
+
+        Mount *mount = mount_find_by_uniq_id(m, sym_mnt_fs_get_uniq_id(fs));
+        if (!mount)
+                return;
+
+        mount->proc_flags &= ~MOUNT_PROC_IS_MOUNTED;
+        mount->proc_flags |= MOUNT_PROC_IS_DETACHED;
+}
+
+static void mount_process_fanotify_events(Manager *m, bool *rescan) {
+        const char *filename;
+        int type;
+
+        assert(m);
+        assert(m->mount_monitor);
+        assert(rescan);
+
+        while (sym_mnt_monitor_next_change(m->mount_monitor, &filename, &type) == 0) {
+                if (type == MNT_MONITOR_TYPE_FANOTIFY) {
+                        struct libmnt_fs *fs = m->mount_fanotify_fs;
+                        int r;
+
+                        assert(fs);
+
+                        while ((r = sym_mnt_monitor_event_next_fs(m->mount_monitor, fs)) == 0) {
+                                if (sym_mnt_fs_is_moved(fs)) {
+                                        if (mount_find_by_uniq_id(m, sym_mnt_fs_get_uniq_id(fs))) {
+                                                mount_process_fanotify_detach(m, fs);
+                                                mount_process_fanotify_attach(m, fs);
+                                        } else
+                                                *rescan = true;
+                                } else if (sym_mnt_fs_is_detached(fs))
+                                        mount_process_fanotify_detach(m, fs);
+                                else
+                                        mount_process_fanotify_attach(m, fs);
+
+                                sym_mnt_reset_fs(fs);
+                        }
+
+                        /* Includes -EOVERFLOW when the fanotify event queue overflows */
+                        if (r < 0) {
+                                log_warning_errno(r, "Failed to read fanotify mount events, rescanning: %m");
+                                *rescan = true;
+                        }
+                } else
+                        /* Non-fanotify change (utab update via inotify) — need full rescan. */
+                        *rescan = true;
+
+                if (*rescan) {
+                        (void) sym_mnt_monitor_event_cleanup(m->mount_monitor);
+                        break;
+                }
+        }
+}
+
 static int mount_dispatch_io(sd_event_source *source, int fd, uint32_t revents, void *userdata) {
         Manager *m = ASSERT_PTR(userdata);
 
         assert(revents & EPOLLIN);
 
-        return mount_process_kernel_mounttable(m);
+        if (m->mount_use_fanotify) {
+                bool rescan = false;
+
+                mount_process_fanotify_events(m, &rescan);
+
+                if (rescan)
+                        return mount_process_kernel_mounttable(m, /* skip_drain= */ true);
+
+                mount_process_mount_units(m);
+                return 0;
+        }
+
+        return mount_process_kernel_mounttable(m, /* skip_drain= */ false);
 }
 #endif
 

--- a/src/core/mount.c
+++ b/src/core/mount.c
@@ -1872,6 +1872,7 @@ static int mount_setup_unit(
                 const char *where,
                 const char *options,
                 const char *fstype,
+                uint64_t uniq_id,
                 bool set_flags) {
 
         _cleanup_free_ char *e = NULL;
@@ -1917,6 +1918,8 @@ static int mount_setup_unit(
                 r = mount_setup_new_unit(m, e, what, where, options, fstype, &flags, &u);
         if (r < 0)
                 return log_warning_errno(r, "Failed to set up mount unit for '%s': %m", where);
+
+        MOUNT(u)->uniq_id = uniq_id;
 
         /* If the mount changed properties or state, let's notify our clients */
         if (flags & (MOUNT_PROC_JUST_CHANGED|MOUNT_PROC_JUST_MOUNTED))
@@ -1964,7 +1967,11 @@ static int mount_load_proc_self_mountinfo(Manager *m, bool set_flags) {
                 if (set_put_strdup_full(&devices, &path_hash_ops_free, device) != 0)
                         device_found_node(m, device, DEVICE_FOUND_MOUNT, DEVICE_FOUND_MOUNT);
 
-                (void) mount_setup_unit(m, device, path, options, fstype, set_flags);
+                uint64_t uniq_id = 0;
+                if (m->mount_use_fanotify && sym_mnt_id_from_path)
+                        (void) sym_mnt_id_from_path(path, &uniq_id, NULL);
+
+                (void) mount_setup_unit(m, device, path, options, fstype, uniq_id, set_flags);
         }
 
         return 0;
@@ -1980,6 +1987,15 @@ static void mount_shutdown(Manager *m) {
                 sym_mnt_unref_monitor(m->mount_monitor);
                 m->mount_monitor = NULL;
         }
+
+#if HAVE_LIBMOUNT
+        if (m->mount_fanotify_fs) {
+                sym_mnt_unref_fs(m->mount_fanotify_fs);
+                m->mount_fanotify_fs = NULL;
+        }
+
+        m->mount_use_fanotify = false;
+#endif
 }
 
 static void mount_handoff_timestamp(
@@ -2068,6 +2084,70 @@ static int mount_on_ratelimit_expire(sd_event_source *s, void *userdata) {
 
         return 0;
 }
+
+static bool mount_monitor_is_fanotify_usable(void) {
+        static int cached = -1;
+
+        if (cached != -1)
+                return cached;
+
+        _cleanup_(mnt_unref_monitorp) struct libmnt_monitor *probe = NULL;
+
+        if (DLOPEN_LIBMOUNT_FANOTIFY(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_SUGGESTED) < 0)
+                goto unsupported;
+
+        /* mnt_monitor_enable_fanotify() only allocates data structures; the actual
+         * fanotify_init(FAN_REPORT_MNT) syscall happens inside mnt_monitor_get_fd().
+         * Use a throwaway probe monitor to test kernel support. */
+        probe = sym_mnt_new_monitor();
+        if (!probe)
+                goto unsupported;
+
+        if (sym_mnt_monitor_enable_fanotify(probe, /* enable= */ 1, /* ns= */ -1) < 0)
+                goto unsupported;
+
+        cached = sym_mnt_monitor_get_fd(probe) >= 0;
+        return cached;
+
+unsupported:
+        cached = false;
+        return false;
+}
+
+static int mount_monitor_init_fanotify(Manager *m) {
+        int r;
+
+        assert(m);
+        assert(m->mount_monitor);
+
+        r = sym_mnt_monitor_enable_fanotify(m->mount_monitor, /* enable= */ 1, /* ns= */ -1);
+        if (r < 0)
+                return r;
+
+        m->mount_fanotify_fs = sym_mnt_new_fs();
+        if (!m->mount_fanotify_fs)
+                return log_oom();
+
+        struct libmnt_statmnt *stmnt = sym_mnt_new_statmnt();
+        if (!stmnt) {
+                r = log_oom();
+                goto fail;
+        }
+
+        r = sym_mnt_fs_refer_statmnt(m->mount_fanotify_fs, stmnt);
+        sym_mnt_unref_statmnt(stmnt);
+        if (r < 0) {
+                log_error_errno(r, "Failed to attach statmnt to fs: %m");
+                goto fail;
+        }
+
+        return 0;
+
+fail:
+        sym_mnt_unref_fs(m->mount_fanotify_fs);
+        m->mount_fanotify_fs = NULL;
+        return r;
+}
 #endif
 
 static void mount_enumerate(Manager *m) {
@@ -2082,6 +2162,7 @@ static void mount_enumerate(Manager *m) {
         if (!m->mount_monitor) {
                 usec_t mount_rate_limit_interval = 1 * USEC_PER_SEC;
                 unsigned mount_rate_limit_burst = 5;
+                bool use_fanotify;
                 int fd;
 
                 m->mount_monitor = sym_mnt_new_monitor();
@@ -2090,10 +2171,22 @@ static void mount_enumerate(Manager *m) {
                         goto fail;
                 }
 
-                r = sym_mnt_monitor_enable_kernel(m->mount_monitor, 1);
-                if (r < 0) {
-                        log_error_errno(r, "Failed to enable watching of kernel mount events: %m");
-                        goto fail;
+                use_fanotify = mount_monitor_is_fanotify_usable();
+
+                if (use_fanotify) {
+                        r = mount_monitor_init_fanotify(m);
+                        if (r < 0) {
+                                log_warning_errno(r, "Failed to initialize fanotify mount monitoring, falling back to inotify: %m");
+                                use_fanotify = false;
+                        }
+                }
+
+                if (!use_fanotify) {
+                        r = sym_mnt_monitor_enable_kernel(m->mount_monitor, 1);
+                        if (r < 0) {
+                                log_error_errno(r, "Failed to enable watching of kernel mount events: %m");
+                                goto fail;
+                        }
                 }
 
                 r = sym_mnt_monitor_enable_userspace(m->mount_monitor, 1, NULL);
@@ -2149,6 +2242,9 @@ static void mount_enumerate(Manager *m) {
                 }
 
                 (void) sd_event_source_set_description(m->mount_event_source, "mount-monitor-dispatch");
+
+                m->mount_use_fanotify = use_fanotify;
+                log_debug("Using %s for mount monitoring.", use_fanotify ? "fanotify" : "inotify");
         }
 
         r = mount_load_proc_self_mountinfo(m, false);
@@ -2311,10 +2407,181 @@ static int mount_process_proc_self_mountinfo(Manager *m) {
 }
 
 #if HAVE_LIBMOUNT
+static Mount *mount_find_by_uniq_id(Manager *m, uint64_t uniq_id) {
+        assert(m);
+
+        if (uniq_id == 0)
+                return NULL;
+
+        LIST_FOREACH(units_by_type, u, m->units_by_type[UNIT_MOUNT]) {
+                Mount *mount = MOUNT(u);
+                if (mount->uniq_id == uniq_id)
+                        return mount;
+        }
+
+        return NULL;
+}
+
+static void mount_process_fanotify_attach(Manager *m, struct libmnt_fs *fs) {
+        assert(m);
+        assert(fs);
+
+        int r = sym_mnt_fs_fetch_statmount(fs, /* mask= */ 0);
+        if (r < 0)
+                return (void) log_debug_errno(r, "Failed to fetch statmount: %m");
+
+        const char *device  = sym_mnt_fs_get_source(fs);
+        const char *path    = sym_mnt_fs_get_target(fs);
+        const char *options = sym_mnt_fs_get_options(fs);
+        const char *fstype  = sym_mnt_fs_get_fstype(fs);
+
+        if (!device || !path)
+                return;
+
+        device_found_node(m, device, DEVICE_FOUND_MOUNT, DEVICE_FOUND_MOUNT);
+        (void) mount_setup_unit(m, device, path, options, fstype, sym_mnt_fs_get_uniq_id(fs), /* set_flags= */ true);
+
+        _cleanup_free_ char *e = NULL;
+        r = unit_name_from_path(path, ".mount", &e);
+        if (r < 0)
+                return (void) log_debug_errno(r, "Failed to generate unit name from path '%s': %m", path);
+
+        Unit *u = manager_get_unit(m, e);
+        if (!u)
+                return;
+
+        Mount *mount = MOUNT(u);
+
+        if (mount->proc_flags & (MOUNT_PROC_JUST_MOUNTED|MOUNT_PROC_JUST_CHANGED)) {
+                switch (mount->state) {
+
+                case MOUNT_DEAD:
+                case MOUNT_FAILED:
+                        (void) unit_acquire_invocation_id(u);
+                        mount_cycle_clear(mount);
+                        mount_enter_mounted(mount, MOUNT_SUCCESS);
+                        break;
+
+                case MOUNT_MOUNTING:
+                        mount_set_state(mount, MOUNT_MOUNTING_DONE);
+                        break;
+
+                default:
+                        mount_set_state(mount, mount->state);
+                }
+
+                unit_add_to_dbus_queue(u);
+        }
+
+        mount->proc_flags = 0;
+}
+
+static void mount_process_fanotify_detach(Manager *m, struct libmnt_fs *fs) {
+        assert(m);
+        assert(fs);
+
+        /* Try ID-based lookup first — no statmount needed, the uniq_id comes
+         * directly from the fanotify event. This avoids a statmount() syscall
+         * that would fail anyway since the mount is already gone. */
+        Mount *mount = mount_find_by_uniq_id(m, sym_mnt_fs_get_uniq_id(fs));
+
+        if (!mount) {
+                /* Fall back to path-based lookup — this may trigger statmount()
+                 * inside libmount, which may fail for already-detached mounts. */
+                const char *path = sym_mnt_fs_get_target(fs);
+                if (!path)
+                        return;
+
+                _cleanup_free_ char *e = NULL;
+                int r = unit_name_from_path(path, ".mount", &e);
+                if (r < 0)
+                        return (void) log_debug_errno(r, "Failed to generate unit name from path '%s': %m", path);
+
+                Unit *u = manager_get_unit(m, e);
+                if (u)
+                        mount = MOUNT(u);
+        }
+
+        if (!mount)
+                return;
+
+        if (mount->parameters_kernel.what)
+                device_found_node(m, mount->parameters_kernel.what, DEVICE_NOT_FOUND, DEVICE_FOUND_MOUNT);
+
+        mount->from_kernel = false;
+        mount->uniq_id = 0;
+        assert_se(update_parameters_kernel(mount, NULL, NULL, NULL) >= 0);
+
+        switch (mount->state) {
+
+        case MOUNT_MOUNTED:
+                mount_cycle_clear(mount);
+                mount_enter_dead(mount, MOUNT_SUCCESS, /* flush_result= */ true);
+                break;
+
+        case MOUNT_MOUNTING_DONE:
+                mount_set_state(mount, MOUNT_MOUNTING);
+                break;
+
+        default:
+                break;
+        }
+}
+
+static int mount_process_fanotify_events(Manager *m) {
+        bool rescan = false;
+        const char *filename;
+        int type;
+
+        assert(m);
+        assert(m->mount_monitor);
+
+        while (sym_mnt_monitor_next_change(m->mount_monitor, &filename, &type) == 0) {
+
+                if (type == MNT_MONITOR_TYPE_FANOTIFY) {
+                        assert(m->mount_fanotify_fs);
+                        struct libmnt_fs *fs = m->mount_fanotify_fs;
+
+                        while (sym_mnt_monitor_event_next_fs(m->mount_monitor, fs) == 0) {
+                                if (sym_mnt_fs_is_moved(fs)) {
+                                        /* Mount moved — the uniq_id is preserved across
+                                         * moves. Find the old unit by ID and detach it,
+                                         * then attach at the new path. If the old unit
+                                         * can't be found by ID (e.g. from initial scan),
+                                         * fall back to full rescan for cleanup. */
+                                        if (mount_find_by_uniq_id(m, sym_mnt_fs_get_uniq_id(fs)))
+                                                mount_process_fanotify_detach(m, fs);
+                                        else
+                                                rescan = true;
+                                        mount_process_fanotify_attach(m, fs);
+                                } else if (sym_mnt_fs_is_detached(fs))
+                                        mount_process_fanotify_detach(m, fs);
+                                else
+                                        mount_process_fanotify_attach(m, fs);
+
+                                sym_mnt_reset_fs(fs);
+                        }
+                } else
+                        rescan = true;
+        }
+
+        (void) sym_mnt_monitor_event_cleanup(m->mount_monitor);
+
+        if (rescan)
+                (void) mount_load_proc_self_mountinfo(m, true);
+
+        manager_dispatch_load_queue(m);
+
+        return 0;
+}
+
 static int mount_dispatch_io(sd_event_source *source, int fd, uint32_t revents, void *userdata) {
         Manager *m = ASSERT_PTR(userdata);
 
         assert(revents & EPOLLIN);
+
+        if (m->mount_use_fanotify)
+                return mount_process_fanotify_events(m);
 
         return mount_process_proc_self_mountinfo(m);
 }

--- a/src/core/mount.c
+++ b/src/core/mount.c
@@ -2210,28 +2210,16 @@ static int drain_libmount(Manager *m) {
 #endif
 }
 
-static int mount_process_kernel_mounttable(Manager *m) {
-        int r;
+#if HAVE_LIBMOUNT
+/* Dispatch the load queue, run state transitions based on proc_flags, and reconcile device
+ * nodes (around/gone sets). Called after mount_load_kernel_mounttable() has populated the
+ * mount units with current kernel state. */
+static void mount_process_mount_units(Manager *m) {
+        _cleanup_set_free_ Set *around = NULL, *gone = NULL;
 
         assert(m);
 
-        r = drain_libmount(m);
-        if (r <= 0)
-                return r;
-
-#if HAVE_LIBMOUNT
-        r = mount_load_kernel_mounttable(m, true);
-        if (r < 0) {
-                /* Reset flags, just in case, for later calls */
-                LIST_FOREACH(units_by_type, u, m->units_by_type[UNIT_MOUNT])
-                        MOUNT(u)->proc_flags = 0;
-
-                return 0;
-        }
-
         manager_dispatch_load_queue(m);
-
-        _cleanup_set_free_ Set *around = NULL, *gone = NULL;
 
         LIST_FOREACH(units_by_type, u, m->units_by_type[UNIT_MOUNT]) {
                 Mount *mount = MOUNT(u);
@@ -2320,6 +2308,30 @@ static int mount_process_kernel_mounttable(Manager *m) {
                 /* Let the device units know that the device is no longer mounted */
                 device_found_node(m, what, DEVICE_NOT_FOUND, DEVICE_FOUND_MOUNT);
         }
+}
+#endif /* HAVE_LIBMOUNT */
+
+/* Load the complete kernel mount table and process all mount units. */
+static int mount_process_kernel_mounttable(Manager *m) {
+        int r;
+
+        assert(m);
+
+        r = drain_libmount(m);
+        if (r <= 0)
+                return r;
+
+#if HAVE_LIBMOUNT
+        r = mount_load_kernel_mounttable(m, /* set_flags= */ true);
+        if (r < 0) {
+                /* Reset flags, just in case, for later calls */
+                LIST_FOREACH(units_by_type, u, m->units_by_type[UNIT_MOUNT])
+                        MOUNT(u)->proc_flags = 0;
+
+                return 0;
+        }
+
+        mount_process_mount_units(m);
 
         return 0;
 #else

--- a/src/core/mount.h
+++ b/src/core/mount.h
@@ -47,10 +47,10 @@ typedef struct Mount {
 
         char *where;
 
-        MountParameters parameters_proc_self_mountinfo;
+        MountParameters parameters_kernel;
         MountParameters parameters_fragment;
 
-        bool from_proc_self_mountinfo:1;
+        bool from_kernel:1;
         bool from_fragment:1;
 
         MountProcFlags proc_flags;

--- a/src/core/mount.h
+++ b/src/core/mount.h
@@ -31,7 +31,9 @@ typedef enum MountResult {
 
 typedef struct MountParameters {
         char *what;
-        char *options;
+        char *options;      /* merged: opt_kernel + opt_user (read by all consumers) */
+        char *opt_kernel;   /* VFS + FS options from statmount/mountinfo */
+        char *opt_user;     /* user options from utab (x-systemd.*, etc.) */
         char *fstype;
 } MountParameters;
 

--- a/src/core/mount.h
+++ b/src/core/mount.h
@@ -40,6 +40,7 @@ typedef enum MountProcFlags {
         MOUNT_PROC_IS_MOUNTED   = 1 << 0,
         MOUNT_PROC_JUST_MOUNTED = 1 << 1,
         MOUNT_PROC_JUST_CHANGED = 1 << 2,
+        MOUNT_PROC_IS_DETACHED  = 1 << 3,
 } MountProcFlags;
 
 typedef struct Mount {

--- a/src/core/mount.h
+++ b/src/core/mount.h
@@ -50,6 +50,8 @@ typedef struct Mount {
         MountParameters parameters_kernel;
         MountParameters parameters_fragment;
 
+        uint64_t uniq_id;
+
         bool from_kernel:1;
         bool from_fragment:1;
 

--- a/src/shared/libmount-util.c
+++ b/src/shared/libmount-util.c
@@ -50,6 +50,18 @@ DLSYM_PROTOTYPE(mnt_table_refer_statmnt) = NULL;
 DLSYM_PROTOTYPE(mnt_table_fetch_listmount) = NULL;
 DLSYM_PROTOTYPE(mnt_fs_get_uniq_id) = NULL;
 
+/* Optional fanotify mount monitor symbols (libmount >= 2.42) */
+DLSYM_PROTOTYPE(mnt_monitor_enable_fanotify) = NULL;
+DLSYM_PROTOTYPE(mnt_monitor_event_cleanup) = NULL;
+DLSYM_PROTOTYPE(mnt_monitor_event_next_fs) = NULL;
+DLSYM_PROTOTYPE(mnt_new_fs) = NULL;
+DLSYM_PROTOTYPE(mnt_unref_fs) = NULL;
+DLSYM_PROTOTYPE(mnt_reset_fs) = NULL;
+DLSYM_PROTOTYPE(mnt_fs_refer_statmnt) = NULL;
+DLSYM_PROTOTYPE(mnt_fs_fetch_statmount) = NULL;
+DLSYM_PROTOTYPE(mnt_fs_is_detached) = NULL;
+DLSYM_PROTOTYPE(mnt_fs_is_moved) = NULL;
+
 int libmount_parse_full(
                 const char *path,
                 FILE *source,
@@ -231,5 +243,37 @@ int dlopen_libmount_listmount(int log_level) {
 #else
         return log_full_errno(log_level, SYNTHETIC_ERRNO(EOPNOTSUPP),
                               "libmount listmount support is not compiled in.");
+#endif
+}
+
+int dlopen_libmount_fanotify(int log_level) {
+#if HAVE_LIBMOUNT
+        static void *libmount_fanotify_dl = NULL;
+        int r;
+
+        r = dlopen_libmount(log_level);
+        if (r < 0)
+                return r;
+
+        return dlopen_many_sym_or_warn(
+                        &libmount_fanotify_dl,
+                        "libmount.so.1",
+                        log_level,
+                        DLSYM_ARG(mnt_monitor_enable_fanotify),
+                        DLSYM_ARG(mnt_monitor_event_cleanup),
+                        DLSYM_ARG(mnt_monitor_event_next_fs),
+                        DLSYM_ARG(mnt_new_fs),
+                        DLSYM_ARG(mnt_unref_fs),
+                        DLSYM_ARG(mnt_reset_fs),
+                        DLSYM_ARG(mnt_new_statmnt),
+                        DLSYM_ARG(mnt_unref_statmnt),
+                        DLSYM_ARG(mnt_fs_refer_statmnt),
+                        DLSYM_ARG(mnt_fs_fetch_statmount),
+                        DLSYM_ARG(mnt_fs_get_uniq_id),
+                        DLSYM_ARG(mnt_fs_is_detached),
+                        DLSYM_ARG(mnt_fs_is_moved));
+#else
+        return log_full_errno(log_level, SYNTHETIC_ERRNO(EOPNOTSUPP),
+                              "libmount fanotify support is not compiled in.");
 #endif
 }

--- a/src/shared/libmount-util.c
+++ b/src/shared/libmount-util.c
@@ -51,6 +51,9 @@ DLSYM_PROTOTYPE(mnt_table_refer_statmnt) = NULL;
 DLSYM_PROTOTYPE(mnt_table_fetch_listmount) = NULL;
 DLSYM_PROTOTYPE(mnt_fs_get_uniq_id) = NULL;
 
+/* Optional utab parsing API (libmount >= 2.43) */
+DLSYM_PROTOTYPE(mnt_table_parse_utab) = NULL;
+
 /* Optional fanotify mount monitor symbols (libmount >= 2.42) */
 DLSYM_PROTOTYPE(mnt_monitor_enable_fanotify) = NULL;
 DLSYM_PROTOTYPE(mnt_monitor_event_cleanup) = NULL;
@@ -257,7 +260,7 @@ int dlopen_libmount_fanotify(int log_level) {
         if (r < 0)
                 return r;
 
-        return dlopen_many_sym_or_warn(
+        r = dlopen_many_sym_or_warn(
                         &libmount_fanotify_dl,
                         "libmount.so.1",
                         log_level,
@@ -274,6 +277,13 @@ int dlopen_libmount_fanotify(int log_level) {
                         DLSYM_ARG(mnt_fs_get_uniq_id),
                         DLSYM_ARG(mnt_fs_is_detached),
                         DLSYM_ARG(mnt_fs_is_moved));
+        if (r <= 0)
+                return r;
+
+        /* Optional: available since libmount 2.43 */
+        DLSYM_OPTIONAL(libmount_fanotify_dl, mnt_table_parse_utab);
+
+        return 1;
 #else
         return log_full_errno(log_level, SYNTHETIC_ERRNO(EOPNOTSUPP),
                               "libmount fanotify support is not compiled in.");

--- a/src/shared/libmount-util.c
+++ b/src/shared/libmount-util.c
@@ -19,6 +19,7 @@ DLSYM_PROTOTYPE(mnt_fs_get_id) = NULL;
 DLSYM_PROTOTYPE(mnt_fs_get_option) = NULL;
 DLSYM_PROTOTYPE(mnt_fs_get_options) = NULL;
 DLSYM_PROTOTYPE(mnt_fs_get_passno) = NULL;
+DLSYM_PROTOTYPE(mnt_fs_get_user_options) = NULL;
 DLSYM_PROTOTYPE(mnt_fs_get_propagation) = NULL;
 DLSYM_PROTOTYPE(mnt_fs_get_source) = NULL;
 DLSYM_PROTOTYPE(mnt_fs_get_target) = NULL;
@@ -193,6 +194,7 @@ int dlopen_libmount(int log_level) {
                         DLSYM_ARG(mnt_fs_get_option),
                         DLSYM_ARG(mnt_fs_get_options),
                         DLSYM_ARG(mnt_fs_get_passno),
+                        DLSYM_ARG(mnt_fs_get_user_options),
                         DLSYM_ARG(mnt_fs_get_propagation),
                         DLSYM_ARG(mnt_fs_get_source),
                         DLSYM_ARG(mnt_fs_get_target),

--- a/src/shared/libmount-util.c
+++ b/src/shared/libmount-util.c
@@ -43,6 +43,13 @@ DLSYM_PROTOTYPE(mnt_table_parse_stream) = NULL;
 DLSYM_PROTOTYPE(mnt_table_parse_swaps) = NULL;
 DLSYM_PROTOTYPE(mnt_unref_monitor) = NULL;
 
+/* Optional listmount/statmount symbols (libmount >= 2.41) */
+DLSYM_PROTOTYPE(mnt_new_statmnt) = NULL;
+DLSYM_PROTOTYPE(mnt_unref_statmnt) = NULL;
+DLSYM_PROTOTYPE(mnt_table_refer_statmnt) = NULL;
+DLSYM_PROTOTYPE(mnt_table_fetch_listmount) = NULL;
+DLSYM_PROTOTYPE(mnt_fs_get_uniq_id) = NULL;
+
 int libmount_parse_full(
                 const char *path,
                 FILE *source,
@@ -80,6 +87,46 @@ int libmount_parse_full(
                 r = sym_mnt_table_parse_mtab(table, NULL);
         if (r < 0)
                 return r;
+
+        *ret_table = TAKE_PTR(table);
+        *ret_iter = TAKE_PTR(iter);
+        return 0;
+}
+
+int libmount_fetch_listmount(
+                struct libmnt_table **ret_table,
+                struct libmnt_iter **ret_iter) {
+
+        _cleanup_(mnt_free_tablep) struct libmnt_table *table = NULL;
+        _cleanup_(mnt_free_iterp) struct libmnt_iter *iter = NULL;
+        int r;
+
+        assert(ret_table);
+        assert(ret_iter);
+
+        r = dlopen_libmount_listmount(LOG_DEBUG);
+        if (r < 0)
+                return r;
+
+        table = sym_mnt_new_table();
+        if (!table)
+                return -ENOMEM;
+
+        struct libmnt_statmnt *stmnt = sym_mnt_new_statmnt();
+        if (stmnt) {
+                r = sym_mnt_table_refer_statmnt(table, stmnt);
+                sym_mnt_unref_statmnt(stmnt);
+                if (r < 0)
+                        log_debug_errno(r, "Failed to set statmnt on table, ignoring: %m");
+        }
+
+        r = sym_mnt_table_fetch_listmount(table);
+        if (r < 0)
+                return r;
+
+        iter = sym_mnt_new_iter(MNT_ITER_FORWARD);
+        if (!iter)
+                return -ENOMEM;
 
         *ret_table = TAKE_PTR(table);
         *ret_iter = TAKE_PTR(iter);
@@ -160,5 +207,29 @@ int dlopen_libmount(int log_level) {
 #else
         return log_full_errno(log_level, SYNTHETIC_ERRNO(EOPNOTSUPP),
                               "libmount support is not compiled in.");
+#endif
+}
+
+int dlopen_libmount_listmount(int log_level) {
+#if HAVE_LIBMOUNT
+        static void *libmount_listmount_dl = NULL;
+        int r;
+
+        r = dlopen_libmount(log_level);
+        if (r < 0)
+                return r;
+
+        return dlopen_many_sym_or_warn(
+                        &libmount_listmount_dl,
+                        "libmount.so.1",
+                        log_level,
+                        DLSYM_ARG(mnt_new_statmnt),
+                        DLSYM_ARG(mnt_unref_statmnt),
+                        DLSYM_ARG(mnt_table_refer_statmnt),
+                        DLSYM_ARG(mnt_table_fetch_listmount),
+                        DLSYM_ARG(mnt_fs_get_uniq_id));
+#else
+        return log_full_errno(log_level, SYNTHETIC_ERRNO(EOPNOTSUPP),
+                              "libmount listmount support is not compiled in.");
 #endif
 }

--- a/src/shared/libmount-util.c
+++ b/src/shared/libmount-util.c
@@ -43,6 +43,23 @@ DLSYM_PROTOTYPE(mnt_table_parse_stream) = NULL;
 DLSYM_PROTOTYPE(mnt_table_parse_swaps) = NULL;
 DLSYM_PROTOTYPE(mnt_unref_monitor) = NULL;
 
+/* Optional fanotify monitor symbols */
+DLSYM_PROTOTYPE(mnt_monitor_enable_fanotify) = NULL;
+DLSYM_PROTOTYPE(mnt_monitor_event_cleanup) = NULL;
+DLSYM_PROTOTYPE(mnt_monitor_event_next_fs) = NULL;
+DLSYM_PROTOTYPE(mnt_new_fs) = NULL;
+DLSYM_PROTOTYPE(mnt_unref_fs) = NULL;
+DLSYM_PROTOTYPE(mnt_reset_fs) = NULL;
+DLSYM_PROTOTYPE(mnt_new_statmnt) = NULL;
+DLSYM_PROTOTYPE(mnt_unref_statmnt) = NULL;
+DLSYM_PROTOTYPE(mnt_fs_refer_statmnt) = NULL;
+DLSYM_PROTOTYPE(mnt_fs_fetch_statmount) = NULL;
+DLSYM_PROTOTYPE(mnt_fs_get_uniq_id) = NULL;
+DLSYM_PROTOTYPE(mnt_id_from_path) = NULL;
+DLSYM_PROTOTYPE(mnt_fs_is_attached) = NULL;
+DLSYM_PROTOTYPE(mnt_fs_is_detached) = NULL;
+DLSYM_PROTOTYPE(mnt_fs_is_moved) = NULL;
+
 int libmount_parse_full(
                 const char *path,
                 FILE *source,
@@ -157,6 +174,40 @@ int dlopen_libmount(int log_level) {
                         DLSYM_ARG(mnt_table_parse_stream),
                         DLSYM_ARG(mnt_table_parse_swaps),
                         DLSYM_ARG(mnt_unref_monitor));
+#else
+        return log_full_errno(log_level, SYNTHETIC_ERRNO(EOPNOTSUPP),
+                              "libmount support is not compiled in.");
+#endif
+}
+
+int dlopen_libmount_fanotify(int log_level) {
+#if HAVE_LIBMOUNT
+        static void *libmount_fanotify_dl = NULL;
+        int r;
+
+        r = dlopen_libmount(log_level);
+        if (r < 0)
+                return r;
+
+        return dlopen_many_sym_or_warn(
+                        &libmount_fanotify_dl,
+                        "libmount.so.1",
+                        log_level,
+                        DLSYM_ARG(mnt_monitor_enable_fanotify),
+                        DLSYM_ARG(mnt_monitor_event_cleanup),
+                        DLSYM_ARG(mnt_monitor_event_next_fs),
+                        DLSYM_ARG(mnt_new_fs),
+                        DLSYM_ARG(mnt_unref_fs),
+                        DLSYM_ARG(mnt_reset_fs),
+                        DLSYM_ARG(mnt_new_statmnt),
+                        DLSYM_ARG(mnt_unref_statmnt),
+                        DLSYM_ARG(mnt_fs_refer_statmnt),
+                        DLSYM_ARG(mnt_fs_fetch_statmount),
+                        DLSYM_ARG(mnt_fs_get_uniq_id),
+                        DLSYM_ARG(mnt_id_from_path),
+                        DLSYM_ARG(mnt_fs_is_attached),
+                        DLSYM_ARG(mnt_fs_is_detached),
+                        DLSYM_ARG(mnt_fs_is_moved));
 #else
         return log_full_errno(log_level, SYNTHETIC_ERRNO(EOPNOTSUPP),
                               "libmount support is not compiled in.");

--- a/src/shared/libmount-util.h
+++ b/src/shared/libmount-util.h
@@ -44,8 +44,26 @@ extern DLSYM_PROTOTYPE(mnt_table_parse_stream);
 extern DLSYM_PROTOTYPE(mnt_table_parse_swaps);
 extern DLSYM_PROTOTYPE(mnt_unref_monitor);
 
+/* Available since libmount 2.41. Always redeclare so DLSYM_PROTOTYPE's typeof() resolves on older
+ * headers; suppress the warning when newer libmount already declares them. */
+struct libmnt_statmnt;
+DISABLE_WARNING_REDUNDANT_DECLS;
+extern struct libmnt_statmnt *mnt_new_statmnt(void);
+extern void mnt_unref_statmnt(struct libmnt_statmnt *sm);
+extern int mnt_table_refer_statmnt(struct libmnt_table *tb, struct libmnt_statmnt *sm);
+extern int mnt_table_fetch_listmount(struct libmnt_table *tb);
+extern uint64_t mnt_fs_get_uniq_id(struct libmnt_fs *fs);
+REENABLE_WARNING;
+
+extern DLSYM_PROTOTYPE(mnt_new_statmnt);
+extern DLSYM_PROTOTYPE(mnt_unref_statmnt);
+extern DLSYM_PROTOTYPE(mnt_table_refer_statmnt);
+extern DLSYM_PROTOTYPE(mnt_table_fetch_listmount);
+extern DLSYM_PROTOTYPE(mnt_fs_get_uniq_id);
+
 DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_RENAME(struct libmnt_table*, sym_mnt_free_table, mnt_free_tablep, NULL);
 DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_RENAME(struct libmnt_iter*, sym_mnt_free_iter, mnt_free_iterp, NULL);
+DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_RENAME(struct libmnt_monitor*, sym_mnt_unref_monitor, mnt_unref_monitorp, NULL);
 
 int libmount_parse_full(
                 const char *path,
@@ -69,6 +87,8 @@ static inline int libmount_parse_with_utab(
         return libmount_parse_full(NULL, NULL, MNT_ITER_FORWARD, ret_table, ret_iter);
 }
 
+int libmount_fetch_listmount(struct libmnt_table **ret_table, struct libmnt_iter **ret_iter);
+
 int libmount_parse_fstab(struct libmnt_table **ret_table, struct libmnt_iter **ret_iter);
 
 int libmount_is_leaf(
@@ -86,6 +106,7 @@ int libmount_is_leaf(
                 LIBMOUNT_NOTE(priority);                                \
                 dlopen_libmount(log_level);                             \
         })
+
 #else
 
 struct libmnt_monitor;
@@ -100,3 +121,4 @@ static inline void* sym_mnt_unref_monitor(struct libmnt_monitor *p) {
 #endif
 
 int dlopen_libmount(int log_level);
+int dlopen_libmount_listmount(int log_level);

--- a/src/shared/libmount-util.h
+++ b/src/shared/libmount-util.h
@@ -55,6 +55,10 @@ extern int mnt_table_refer_statmnt(struct libmnt_table *tb, struct libmnt_statmn
 extern int mnt_table_fetch_listmount(struct libmnt_table *tb);
 extern uint64_t mnt_fs_get_uniq_id(struct libmnt_fs *fs);
 
+/* Available since libmount 2.43 (utab parsing API). */
+extern int mnt_table_parse_utab(struct libmnt_table *tb, const char *filename);
+extern DLSYM_PROTOTYPE(mnt_table_parse_utab);
+
 /* Available since libmount 2.42 (fanotify mount monitoring). */
 extern int mnt_monitor_enable_fanotify(struct libmnt_monitor *mn, int enable, int ns);
 extern int mnt_monitor_event_cleanup(struct libmnt_monitor *mn);

--- a/src/shared/libmount-util.h
+++ b/src/shared/libmount-util.h
@@ -44,8 +44,50 @@ extern DLSYM_PROTOTYPE(mnt_table_parse_stream);
 extern DLSYM_PROTOTYPE(mnt_table_parse_swaps);
 extern DLSYM_PROTOTYPE(mnt_unref_monitor);
 
+/* Available since libmount 2.42. Always redeclare so DLSYM_PROTOTYPE's typeof() resolves on older
+ * headers; suppress the warning when newer libmount already declares them. */
+struct libmnt_statmnt;
+DISABLE_WARNING_REDUNDANT_DECLS;
+extern int mnt_monitor_enable_fanotify(struct libmnt_monitor *mn, int enable, int ns);
+extern int mnt_monitor_event_cleanup(struct libmnt_monitor *mn);
+extern int mnt_monitor_event_next_fs(struct libmnt_monitor *mn, struct libmnt_fs *fs);
+extern struct libmnt_fs *mnt_new_fs(void);
+extern void mnt_unref_fs(struct libmnt_fs *fs);
+extern void mnt_reset_fs(struct libmnt_fs *fs);
+extern struct libmnt_statmnt *mnt_new_statmnt(void);
+extern void mnt_unref_statmnt(struct libmnt_statmnt *sm);
+extern int mnt_fs_refer_statmnt(struct libmnt_fs *fs, struct libmnt_statmnt *sm);
+extern int mnt_fs_fetch_statmount(struct libmnt_fs *fs, uint64_t mask);
+extern uint64_t mnt_fs_get_uniq_id(struct libmnt_fs *fs);
+extern int mnt_id_from_path(const char *path, uint64_t *uniq_id, int *id);
+extern int mnt_fs_is_attached(struct libmnt_fs *fs);
+extern int mnt_fs_is_detached(struct libmnt_fs *fs);
+extern int mnt_fs_is_moved(struct libmnt_fs *fs);
+REENABLE_WARNING;
+
+#ifndef MNT_MONITOR_TYPE_FANOTIFY
+#define MNT_MONITOR_TYPE_FANOTIFY 3
+#endif
+
+extern DLSYM_PROTOTYPE(mnt_monitor_enable_fanotify);
+extern DLSYM_PROTOTYPE(mnt_monitor_event_cleanup);
+extern DLSYM_PROTOTYPE(mnt_monitor_event_next_fs);
+extern DLSYM_PROTOTYPE(mnt_new_fs);
+extern DLSYM_PROTOTYPE(mnt_unref_fs);
+extern DLSYM_PROTOTYPE(mnt_reset_fs);
+extern DLSYM_PROTOTYPE(mnt_new_statmnt);
+extern DLSYM_PROTOTYPE(mnt_unref_statmnt);
+extern DLSYM_PROTOTYPE(mnt_fs_refer_statmnt);
+extern DLSYM_PROTOTYPE(mnt_fs_fetch_statmount);
+extern DLSYM_PROTOTYPE(mnt_fs_get_uniq_id);
+extern DLSYM_PROTOTYPE(mnt_id_from_path);
+extern DLSYM_PROTOTYPE(mnt_fs_is_attached);
+extern DLSYM_PROTOTYPE(mnt_fs_is_detached);
+extern DLSYM_PROTOTYPE(mnt_fs_is_moved);
+
 DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_RENAME(struct libmnt_table*, sym_mnt_free_table, mnt_free_tablep, NULL);
 DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_RENAME(struct libmnt_iter*, sym_mnt_free_iter, mnt_free_iterp, NULL);
+DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_RENAME(struct libmnt_monitor*, sym_mnt_unref_monitor, mnt_unref_monitorp, NULL);
 
 int libmount_parse_full(
                 const char *path,
@@ -86,6 +128,12 @@ int libmount_is_leaf(
                 LIBMOUNT_NOTE(priority);                                \
                 dlopen_libmount(log_level);                             \
         })
+
+#define DLOPEN_LIBMOUNT_FANOTIFY(log_level, priority)                   \
+        ({                                                              \
+                LIBMOUNT_NOTE(priority);                                \
+                dlopen_libmount_fanotify(log_level);                    \
+        })
 #else
 
 struct libmnt_monitor;
@@ -97,6 +145,8 @@ static inline void* sym_mnt_unref_monitor(struct libmnt_monitor *p) {
 }
 
 #define DLOPEN_LIBMOUNT(log_level, priority) dlopen_libmount(log_level)
+#define DLOPEN_LIBMOUNT_FANOTIFY(log_level, priority) dlopen_libmount_fanotify(log_level)
 #endif
 
 int dlopen_libmount(int log_level);
+int dlopen_libmount_fanotify(int log_level);

--- a/src/shared/libmount-util.h
+++ b/src/shared/libmount-util.h
@@ -20,6 +20,7 @@ extern DLSYM_PROTOTYPE(mnt_fs_get_id);
 extern DLSYM_PROTOTYPE(mnt_fs_get_option);
 extern DLSYM_PROTOTYPE(mnt_fs_get_options);
 extern DLSYM_PROTOTYPE(mnt_fs_get_passno);
+extern DLSYM_PROTOTYPE(mnt_fs_get_user_options);
 extern DLSYM_PROTOTYPE(mnt_fs_get_propagation);
 extern DLSYM_PROTOTYPE(mnt_fs_get_source);
 extern DLSYM_PROTOTYPE(mnt_fs_get_target);

--- a/src/shared/libmount-util.h
+++ b/src/shared/libmount-util.h
@@ -53,13 +53,40 @@ extern void mnt_unref_statmnt(struct libmnt_statmnt *sm);
 extern int mnt_table_refer_statmnt(struct libmnt_table *tb, struct libmnt_statmnt *sm);
 extern int mnt_table_fetch_listmount(struct libmnt_table *tb);
 extern uint64_t mnt_fs_get_uniq_id(struct libmnt_fs *fs);
+
+/* Available since libmount 2.42 (fanotify mount monitoring). */
+extern int mnt_monitor_enable_fanotify(struct libmnt_monitor *mn, int enable, int ns);
+extern int mnt_monitor_event_cleanup(struct libmnt_monitor *mn);
+extern int mnt_monitor_event_next_fs(struct libmnt_monitor *mn, struct libmnt_fs *fs);
+extern struct libmnt_fs *mnt_new_fs(void);
+extern void mnt_unref_fs(struct libmnt_fs *fs);
+extern void mnt_reset_fs(struct libmnt_fs *fs);
+extern int mnt_fs_refer_statmnt(struct libmnt_fs *fs, struct libmnt_statmnt *sm);
+extern int mnt_fs_fetch_statmount(struct libmnt_fs *fs, uint64_t mask);
+extern int mnt_fs_is_detached(struct libmnt_fs *fs);
+extern int mnt_fs_is_moved(struct libmnt_fs *fs);
 REENABLE_WARNING;
+
+#ifndef MNT_MONITOR_TYPE_FANOTIFY
+#define MNT_MONITOR_TYPE_FANOTIFY 3
+#endif
 
 extern DLSYM_PROTOTYPE(mnt_new_statmnt);
 extern DLSYM_PROTOTYPE(mnt_unref_statmnt);
 extern DLSYM_PROTOTYPE(mnt_table_refer_statmnt);
 extern DLSYM_PROTOTYPE(mnt_table_fetch_listmount);
 extern DLSYM_PROTOTYPE(mnt_fs_get_uniq_id);
+
+extern DLSYM_PROTOTYPE(mnt_monitor_enable_fanotify);
+extern DLSYM_PROTOTYPE(mnt_monitor_event_cleanup);
+extern DLSYM_PROTOTYPE(mnt_monitor_event_next_fs);
+extern DLSYM_PROTOTYPE(mnt_new_fs);
+extern DLSYM_PROTOTYPE(mnt_unref_fs);
+extern DLSYM_PROTOTYPE(mnt_reset_fs);
+extern DLSYM_PROTOTYPE(mnt_fs_refer_statmnt);
+extern DLSYM_PROTOTYPE(mnt_fs_fetch_statmount);
+extern DLSYM_PROTOTYPE(mnt_fs_is_detached);
+extern DLSYM_PROTOTYPE(mnt_fs_is_moved);
 
 DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_RENAME(struct libmnt_table*, sym_mnt_free_table, mnt_free_tablep, NULL);
 DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_RENAME(struct libmnt_iter*, sym_mnt_free_iter, mnt_free_iterp, NULL);
@@ -107,6 +134,11 @@ int libmount_is_leaf(
                 dlopen_libmount(log_level);                             \
         })
 
+#define DLOPEN_LIBMOUNT_FANOTIFY(log_level, priority)                   \
+        ({                                                              \
+                LIBMOUNT_NOTE(priority);                                \
+                dlopen_libmount_fanotify(log_level);                    \
+        })
 #else
 
 struct libmnt_monitor;
@@ -118,7 +150,9 @@ static inline void* sym_mnt_unref_monitor(struct libmnt_monitor *p) {
 }
 
 #define DLOPEN_LIBMOUNT(log_level, priority) dlopen_libmount(log_level)
+#define DLOPEN_LIBMOUNT_FANOTIFY(log_level, priority) dlopen_libmount_fanotify(log_level)
 #endif
 
 int dlopen_libmount(int log_level);
 int dlopen_libmount_listmount(int log_level);
+int dlopen_libmount_fanotify(int log_level);


### PR DESCRIPTION
This PR adds fanotify-based mount monitoring to systemd as an alternative to the current inotify + /proc/self/mountinfo polling approach. When the kernel (>= 6.15) and libmount (>= 2.42) support `FAN_REPORT_MNT`, systemd uses fanotify to receive per-mount attach/detach/move events incrementally, avoiding the cost of re-reading and re-parsing the entire mountinfo file on every mount change.

## Why

The current inotify path triggers a full `/proc/self/mountinfo` rescan on every mount event. On systems with many mounts (containers, NFS, snap packages), this becomes a significant overhead — the file grows linearly with mount count, and every mount/umount causes PID 1 to re-read and diff the entire file.

## How it works

1. **Initial mount table scan** — On startup (and after switch-root), a full mount table scan is always performed to discover existing mounts. When libmount >= 2.41 and kernel >= 6.8 are available, `listmount`/`statmount` is used as the primary source instead of parsing `/proc/self/mountinfo`, with mountinfo as fallback.
2. **Probe at startup** — `mount_monitor_is_fanotify_usable()` checks for kernel + libmount fanotify support. Falls back to inotify if unavailable.
3. **Incremental events** — `mount_process_fanotify_events()` drains per-mount events from libmount's monitor, dispatching attach/detach/move individually without rescanning the mount table.
4. **Unique mount ID tracking** — Each mount unit tracks a 64-bit kernel-assigned unique ID (`uniq_id`), used for reliable lookup on detach and move events (the ID is never recycled by the kernel). A hashmap (`mounts_by_uniq_id`) provides O(1) lookups.
5. **Kernel/user options separation** — `MountParameters` stores kernel options (`opt_kernel` from VFS + FS options) and user options (`opt_user` from utab, e.g. `x-systemd.*`) separately. The merged `options` string is rebuilt whenever either changes, so all existing consumers are unaffected.
6. **Incremental utab handling** — With libmount >= 2.43 (`mnt_table_parse_utab`), utab inotify events are handled incrementally: parse utab, look up mount units by unique ID, update only user options. When options change, `MOUNT_PROC_IS_MOUNTED|MOUNT_PROC_JUST_CHANGED` is set to regenerate non-exec dependencies and notify dbus — matching the full-rescan path.
7. **Fallback to full rescan** — If the monitor reports a move for a mount not tracked by ID, a queue overflow, or the utab API is unavailable (libmount < 2.43), a full mount table rescan is performed.

## Key design: `proc_flags` and `MOUNT_PROC_IS_DETACHED`

`mount_process_mount_units()` is the shared post-processing function used by both the full-rescan and incremental paths. It skips units with `proc_flags == 0` (not touched this iteration):

- **Full-rescan path**: `mount_load_kernel_mounttable()` sets `MOUNT_PROC_IS_MOUNTED` on every mount found in the kernel table. After loading, gone units (previously from kernel but absent) are explicitly marked `MOUNT_PROC_IS_DETACHED`.
- **Incremental path**: attach sets `IS_MOUNTED` (via `mount_setup_unit()`), detach sets `IS_DETACHED` (leaving `from_kernel` and `parameters_kernel` intact for the gone/around device cross-check), utab changes set `IS_MOUNTED|JUST_CHANGED`.

## Stress test results

Tests with background mounts + mount/umount churn cycles, 100-200ms random delay between operations.

| Test | fanotify syscalls | inotify syscalls | ratio | fanotify CPU | inotify CPU | CPU ratio |
|---|---|---|---|---|---|---|
| 100bg + 100 churn, 2w | 7,268 | 52,538 | **7.2x** | 29 | 132 | **4.6x** |
| 200bg + 200 churn, 2w | 14,502 | 117,119 | **8.1x** | 66 | 302 | **4.6x** |
| 1000bg + 1000 churn, 2w | 103,676 | 630,684 | **6.1x** | 342 | 2,073 | **6.1x** |
| 1000bg + 1000 churn, 10w | 28,316 | 169,288 | **6.0x** | 65 | 455 | **7.0x** |

With 10 parallel workers, fanotify batches events more aggressively (800 vs 3,815 epoll wakeups at 2 workers), resulting in fewer total syscalls while maintaining zero full rescans.

## Planned libmount improvement

When mount+umount happen faster than the consumer processes events, the event batch contains both attach and detach for the same mount ID. Since kernel mount IDs are never recycled, these pairs cancel out — processing the attach is wasted work (statmount fails because the mount is already gone). A future libmount improvement will coalesce these pairs in the monitor's event buffer before delivery, eliminating unnecessary statmount calls.

## Dependencies

- Kernel >= 6.8 for `listmount`/`statmount` (optional, falls back to mountinfo)
- Kernel >= 6.15 for `FAN_REPORT_MNT` (optional, falls back to inotify)
- libmount >= 2.41 for `mnt_table_fetch_listmount()` (optional)
- libmount >= 2.42 for `mnt_monitor_enable_fanotify()` (optional)
- libmount >= 2.43 for `mnt_table_parse_utab()` (optional, falls back to full rescan on utab events)
- Graceful fallback at each level when unavailable