### PR TITLE
network: avoid false rename conflict when updating link name

### DIFF
--- a/src/network/networkd-link.c
+++ b/src/network/networkd-link.c
@@ -2641,6 +2641,32 @@ static int link_update_name(Link *link, sd_netlink_message *message) {
 
         hashmap_remove(link->manager->links_by_name, link->ifname);
 
+        Link *existing = hashmap_get(link->manager->links_by_name, ifname);
+        if (existing && existing != link) {
+                log_link_warning(link, "Interface name '%s' is already in use by ifindex %d.", 
+                                ifname, existing->ifindex);
+
+                /* Restore the occupant to the current name in the kernel */
+                char current_name[IF_NAMESIZE];
+                r = format_ifname(existing->ifindex, current_name);
+                if (r >= 0 && !streq(current_name, existing->ifname)) {
+                        log_link_info(existing, "Updating stale name '%s' to current kernel name '%s'.",
+                                        strna(existing->ifname), current_name);
+                        hashmap_remove(link->manager->links_by_name, existing->ifname);
+                        r = free_and_strdup(&existing->ifname, current_name);
+                        if (r < 0)
+                                return log_oom_debug();
+                        r = hashmap_ensure_put(&link->manager->links_by_name, &string_hash_ops, existing->ifname, existing);
+                        if (r < 0)
+                                return log_link_debug_errno(existing, r, "Failed to manage existing link by its real name: %m");
+                } else {
+                        /* If recovery is not possible, based on the trustworthiness of the kernel netlink messages,
+                         * make the occupant enter a failed state and remove it */
+                        link_enter_failed(existing);
+                        hashmap_remove(link->manager->links_by_name, ifname);
+                }
+        }
+
         r = free_and_strdup(&link->ifname, ifname);
         if (r < 0)
                 return log_oom_debug();


### PR DESCRIPTION
This PR fixes the issue where, when there is a naming conflict for network interfaces, the data in the hashmap 'link_by_name' becomes inconsistent.

For more related context, you can refer to the issue.
Fixes #42527.

# Root Cause
A rename race can occur between the speed at which the kernel completes interface renames and the speed at which networkd processes the corresponding netlink messages. When networkd lags behind the kernel, the format_ifname verification introduced by commit https://github.com/systemd/systemd/commit/7294314cfc3dcf566a3ddeea10cddbb1a0a0cd1f may cause an intermediate rename message to be skipped. As a result, the interface name recorded in networkd's hashmap can become stale, eventually leading to an EEXIST conflict during later processing.

# Solution
To address this, add an extra check when a name conflict is detected in the hashmap. If the conflicting Link object is found to still carry an outdated interface name, refresh it to the latest name first. This keeps the hashmap state consistent with the kernel and avoids reporting a stale-name conflict as a real one.

# Verification
After my testing, by repeatedly verifying with the following reproduction script, the problem no longer occurred.
```
#!/bin/bash

swap() {
    local a=$1 b=$2
    ip link set $a down
    ip link set $b down

    ip link set $a name tmp$a  # enp0->tmpenp0
    ip link set $b name $a     # enp1->enp0  
    ip link set tmp$a name $b  # tmpenp0->enp1

    ip link set $a up
    ip link set $b up
    echo "success：$a <-> $b"
}

swap enp0 enp1

echo -e "\nExchange completed！"
```