### PR TITLE
nsresourced: reclaim ranges from dead namespaces during allocation

### DIFF
--- a/src/nsresourced/nsresourced-manager.c
+++ b/src/nsresourced/nsresourced-manager.c
@@ -647,37 +647,19 @@ int manager_startup(Manager *m) {
         SET_FOREACH(p, registry_inodes) {
                 uint64_t inode = PTR_TO_UINT32(p);
 
-                _cleanup_(userns_info_freep) UserNamespaceInfo *userns_info = NULL;
-                r = userns_registry_load_by_userns_inode(m->registry_fd, inode, &userns_info);
+                r = userns_registry_reap_if_dead(manager_bpf(m), m->registry_fd, inode);
                 if (r < 0) {
-                        log_debug_errno(r, "Failed to load registry entry for user namespace %" PRIu64 ", ignoring: %m", inode);
+                        log_debug_errno(r, "Failed to probe liveness of user namespace %" PRIu64 ", ignoring: %m", inode);
                         continue;
                 }
-
-                if (userns_info->userns_id == 0)
-                        continue; /* Entry predates ns_id tracking, can't probe authoritatively */
-
-                _cleanup_close_ int probe_fd = namespace_open_by_id(userns_info->userns_id);
-                if (probe_fd >= 0)
-                        continue; /* User namespace is still alive */
-                /* EPERM/EACCES means we're not in the initial user/pid namespace or missing
-                 * CAP_SYS_ADMIN; ENOTSUP/ENOSYS means the kernel is too old for
-                 * open_by_handle_at() on nsfs. Either way the sweep can't proceed for any
-                 * entry, so bail out rather than logging once per entry. */
-                if (ERRNO_IS_NEG_PRIVILEGE(probe_fd) || ERRNO_IS_NEG_NOT_SUPPORTED(probe_fd)) {
-                        log_debug_errno(probe_fd, "Cannot detect stale registry entries, skipping: %m");
+                if (r == USERNS_REAP_UNSUPPORTED) {
+                        /* Can't look namespaces up by id at all here (old kernel, or not in the
+                         * initial user namespace) — no entry is probeable, so stop rather than
+                         * continuing to probe (and log) once per entry. */
+                        log_debug("Cannot detect stale registry entries, skipping the rest.");
                         break;
                 }
-                /* Anything else except ESTALE is unexpected — log it but skip just this one. */
-                if (probe_fd != -ESTALE) {
-                        log_debug_errno(probe_fd, "Failed to probe liveness of user namespace %" PRIu64 " (id %" PRIu64 "), ignoring: %m",
-                                        inode, userns_info->userns_id);
-                        continue;
-                }
-
-                log_debug("Registry entry for user namespace %" PRIu64 " (id %" PRIu64 ") refers to a dead namespace, removing.",
-                          inode, userns_info->userns_id);
-                manager_release_userns_by_info(m, userns_info);
+                /* USERNS_REAP_RELEASED, _ALIVE, or _INDETERMINATE — nothing more to do for this entry. */
         }
 
         r = manager_make_listen_socket(m);

--- a/src/nsresourced/nsresourcework.c
+++ b/src/nsresourced/nsresourcework.c
@@ -374,7 +374,119 @@ static int vl_method_get_memberships(sd_varlink *link, sd_json_variant *paramete
         return sd_varlink_error(link, "io.systemd.UserDatabase.NoRecordFound", NULL);
 }
 
-static int uid_is_available(int registry_dir_fd, uid_t candidate, int parent_userns_fd) {
+static int registry_range_is_available(
+                struct userns_restrict_bpf *bpf,
+                int registry_dir_fd,
+                uid_t candidate,
+                bool gid) {
+
+        _cleanup_(userns_info_freep) UserNamespaceInfo *owner = NULL;
+        int r;
+
+        assert(registry_dir_fd >= 0);
+
+        /* Checks whether the (UID or GID) range starting at candidate is free to allocate as a fresh
+         * transient range. If an existing registry entry claims it but its owning namespace has since
+         * died — without a BPF death event reaping it yet — we reclaim it on the spot and treat the range
+         * as available. Unlike delegations, transient registrations have no ancestor chain, so a single
+         * reap suffices. */
+
+        r = gid ? userns_registry_gid_exists(registry_dir_fd, (gid_t) candidate)
+                : userns_registry_uid_exists(registry_dir_fd, candidate);
+        if (r < 0)
+                return r;
+        if (r == 0)
+                return true; /* No registry entry for this range → available. */
+
+        r = gid ? userns_registry_load_by_start_gid(registry_dir_fd, (gid_t) candidate, &owner)
+                : userns_registry_load_by_start_uid(registry_dir_fd, candidate, &owner);
+        if (r == -ENOENT)
+                return true; /* Raced away between the existence check and the load → available. */
+        if (r < 0)
+                return r;
+
+        r = userns_registry_reap_if_dead(bpf, registry_dir_fd, owner->userns_inode);
+        if (r < 0)
+                return r;
+        if (r == USERNS_REAP_RELEASED)
+                return true; /* Owner was dead and reaped → range is now free. */
+
+        /* Owner is alive or its liveness couldn't be determined → we can't reclaim it, so the range
+         * is taken. */
+        log_debug("%s" UID_FMT " unavailable: already registered in userns registry.",
+                  gid ? "GID " : "UID ", candidate);
+        return false;
+}
+
+static int delegation_range_is_available(
+                struct userns_restrict_bpf *bpf,
+                int registry_dir_fd,
+                uid_t candidate,
+                uint64_t parent_userns_inode,
+                bool gid) {
+
+        int r;
+
+        assert(registry_dir_fd >= 0);
+
+        /* Checks whether the (UID or GID) range starting at candidate is free to allocate as far as
+         * the delegation registry is concerned. A delegated range is available only if it's owned by
+         * the requesting parent user namespace (which may then sub-allocate within it). If it's owned
+         * by another namespace that has since died — without a BPF death event reaping it yet — we reclaim
+         * it on the spot, which restores the range to its ancestor (possibly the parent), and
+         * re-evaluate. This walks a chain of dead ancestors until it reaches a live owner, the
+         * requesting parent, or a fully freed range. */
+
+        r = gid ? userns_registry_delegation_gid_exists(registry_dir_fd, (gid_t) candidate)
+                : userns_registry_delegation_uid_exists(registry_dir_fd, candidate);
+        if (r < 0)
+                return r;
+        if (r == 0)
+                return true; /* No delegation for this range → available. */
+
+        for (;;) {
+                _cleanup_(delegated_userns_info_done) DelegatedUserNamespaceInfo delegation = DELEGATED_USER_NAMESPACE_INFO_NULL;
+
+                r = gid ? userns_registry_load_delegation_by_gid(registry_dir_fd, (gid_t) candidate, &delegation)
+                        : userns_registry_load_delegation_by_uid(registry_dir_fd, candidate, &delegation);
+                if (r == -ENOENT)
+                        return true; /* Delegation removed while reaping (no ancestor left) → fully free. */
+                if (r < 0)
+                        return r;
+
+                if (delegation.userns_inode == parent_userns_inode) {
+                        /* The parent userns owns this delegation, so the range is available for nested
+                         * allocation. */
+                        log_debug("%s" UID_FMT " is delegated by parent userns inode %" PRIu64 ", available for nested allocation.",
+                                  gid ? "GID " : "UID ", candidate, parent_userns_inode);
+                        return true;
+                }
+
+                /* Owned by some other namespace. If that namespace is dead, reclaim it (restoring the
+                 * range to its ancestor) and loop to re-evaluate; otherwise the range is genuinely
+                 * taken. */
+                r = userns_registry_reap_if_dead(bpf, registry_dir_fd, delegation.userns_inode);
+                if (r < 0)
+                        return r;
+                if (r == USERNS_REAP_RELEASED)
+                        continue; /* Reaped a dead owner; re-evaluate the now-restored delegation. */
+
+                /* Owner is alive, or its liveness couldn't be determined (no recorded id, or a dead
+                 * ancestor that an earlier reap popped into ownership but left no registry entry to
+                 * drive a further restore). We can't reclaim the range here — and mustn't loop, since
+                 * re-reaping would not make progress — so treat it as taken. */
+                log_debug("%s" UID_FMT " unavailable: delegated to userns inode %" PRIu64 " that can't be reclaimed (parent is %" PRIu64 ").",
+                          gid ? "GID " : "UID ", candidate, delegation.userns_inode, parent_userns_inode);
+                return false;
+        }
+}
+
+static int uid_is_available(
+                struct userns_restrict_bpf *bpf,
+                int registry_dir_fd,
+                uid_t candidate,
+                int parent_userns_fd) {
+
         int r;
 
         assert(registry_dir_fd >= 0);
@@ -387,63 +499,35 @@ static int uid_is_available(int registry_dir_fd, uid_t candidate, int parent_use
                 return log_debug_errno(errno, "Failed to fstat parent user namespace: %m");
         parent_userns_inode = parent_st.st_ino;
 
-        r = userns_registry_uid_exists(registry_dir_fd, candidate);
+        /* Check whether an existing transient registration claims this range; a dead owner is reclaimed
+         * inline so its range doesn't stay blocked. The UID and GID are checked separately as either
+         * can exist independently. */
+        r = registry_range_is_available(bpf, registry_dir_fd, candidate, /* gid= */ false);
         if (r < 0)
                 return r;
-        if (r > 0) {
-                log_debug("UID " UID_FMT " unavailable: already registered in userns registry.", candidate);
+        if (r == 0)
                 return false;
-        }
 
-        r = userns_registry_gid_exists(registry_dir_fd, (gid_t) candidate);
+        r = registry_range_is_available(bpf, registry_dir_fd, candidate, /* gid= */ true);
         if (r < 0)
                 return r;
-        if (r > 0) {
-                log_debug("UID " UID_FMT " unavailable: GID already registered in userns registry.", candidate);
+        if (r == 0)
                 return false;
-        }
 
-        /* Also check delegation files. If parent_userns_inode is set and matches the delegation's userns
-         * inode, the UID is available because the parent owns that delegation. */
-        r = userns_registry_delegation_uid_exists(registry_dir_fd, candidate);
+        /* Also check delegation files. A delegated range is only available for nested allocation when
+         * the requesting parent owns it; dead owners are reclaimed inline so their ranges don't stay
+         * blocked. We check the UID and GID delegations separately as either can exist independently. */
+        r = delegation_range_is_available(bpf, registry_dir_fd, candidate, parent_userns_inode, /* gid= */ false);
         if (r < 0)
                 return r;
-        if (r > 0) {
-                _cleanup_(delegated_userns_info_done) DelegatedUserNamespaceInfo delegation = DELEGATED_USER_NAMESPACE_INFO_NULL;
-                r = userns_registry_load_delegation_by_uid(registry_dir_fd, candidate, &delegation);
-                if (r < 0)
-                        return r;
+        if (r == 0)
+                return false;
 
-                if (delegation.userns_inode != parent_userns_inode) {
-                        log_debug("UID " UID_FMT " unavailable: delegated to userns inode %" PRIu64 " (parent is %" PRIu64 ").",
-                                  candidate, delegation.userns_inode, parent_userns_inode);
-                        return false;
-                }
-
-                /* The parent userns owns this delegation, so the UID is available for nested allocation */
-                log_debug("UID " UID_FMT " is delegated by parent userns inode %" PRIu64 ", available for nested allocation.",
-                          candidate, parent_userns_inode);
-        }
-
-        r = userns_registry_delegation_gid_exists(registry_dir_fd, (gid_t) candidate);
+        r = delegation_range_is_available(bpf, registry_dir_fd, candidate, parent_userns_inode, /* gid= */ true);
         if (r < 0)
                 return r;
-        if (r > 0) {
-                _cleanup_(delegated_userns_info_done) DelegatedUserNamespaceInfo delegation = DELEGATED_USER_NAMESPACE_INFO_NULL;
-                r = userns_registry_load_delegation_by_gid(registry_dir_fd, candidate, &delegation);
-                if (r < 0)
-                        return r;
-
-                if (delegation.userns_inode != parent_userns_inode) {
-                        log_debug("UID " UID_FMT " unavailable: GID delegated to userns inode %" PRIu64 " (parent is %" PRIu64 ").",
-                                  candidate, delegation.userns_inode, parent_userns_inode);
-                        return false;
-                }
-
-                /* The parent userns owns this delegation, so the UID is available for nested allocation */
-                log_debug("UID " UID_FMT " is delegated by parent userns inode %" PRIu64 ", available for nested allocation.",
-                          candidate, parent_userns_inode);
-        }
+        if (r == 0)
+                return false;
 
         r = is_our_namespace(parent_userns_fd, NAMESPACE_USER);
         if (r < 0)
@@ -551,6 +635,7 @@ static int inode_slot_is_available(
 }
 
 static int allocate_one(
+                struct userns_restrict_bpf *bpf,
                 int registry_dir_fd,
                 const char *name,
                 uint32_t size,
@@ -623,7 +708,7 @@ static int allocate_one(
 
                 /* We only check the base UID for each range. Pass the parent userns inode so that
                  * allocating from a delegated range owned by the parent is allowed. */
-                r = uid_is_available(registry_dir_fd, candidate, parent_userns_fd);
+                r = uid_is_available(bpf, registry_dir_fd, candidate, parent_userns_fd);
                 if (r < 0)
                         return log_debug_errno(r, "Can't determine if UID range " UID_FMT " is available: %m", candidate);
                 if (r > 0)
@@ -710,6 +795,7 @@ static int allocate_now(
          * allocate a transient range. */
         if (!uid_is_valid(info->start_uid) && !gid_is_valid(info->start_gid)) {
                 r = allocate_one(
+                                bpf,
                                 registry_dir_fd,
                                 info->name, info->size,
                                 parent_userns_fd,
@@ -728,6 +814,7 @@ static int allocate_now(
 
                 FOREACH_ARRAY(delegate, info->delegates, info->n_delegates) {
                         r = allocate_one(
+                                        bpf,
                                         registry_dir_fd,
                                         /* name= */ NULL,
                                         delegate->size,

--- a/src/nsresourced/userns-registry.c
+++ b/src/nsresourced/userns-registry.c
@@ -17,6 +17,7 @@
 #include "format-util.h"
 #include "fs-util.h"
 #include "json-util.h"
+#include "namespace-util.h"
 #include "path-util.h"
 #include "recurse-dir.h"
 #include "rm-rf.h"
@@ -536,6 +537,48 @@ void userns_registry_release_by_userns_inode(struct userns_restrict_bpf *bpf, in
         /* No registry entry — still clean up the inode-keyed kernel resources (BPF map allowlist and
          * fdstore fd), which can outlive a missing registry record. */
         release_userns_inode_resources(bpf, inode);
+}
+
+int userns_registry_reap_if_dead(struct userns_restrict_bpf *bpf, int dir_fd, uint64_t inode) {
+        _cleanup_(userns_info_freep) UserNamespaceInfo *info = NULL;
+        int r;
+
+        assert(dir_fd >= 0);
+        assert(inode != 0);
+
+        /* This is the shared engine behind both the runtime allocation hot path and the startup
+         * registry sweep: it reclaims ranges blocked by a dead namespace that no BPF death event
+         * cleaned up, without waiting for the manager to restart. */
+
+        r = userns_registry_load_by_userns_inode(dir_fd, inode, &info);
+        if (r == -ENOENT)
+                /* No entry is registered for this inode any more (already gone) — e.g. a dead ancestor
+                 * still referenced by a delegation chain. Nothing to reap. */
+                return USERNS_REAP_INDETERMINATE;
+        if (r < 0)
+                return r;
+
+        if (info->userns_id == 0)
+                return USERNS_REAP_INDETERMINATE; /* Entry predates ns id tracking, can't probe authoritatively. */
+
+        _cleanup_close_ int probe_fd = namespace_open_by_id(info->userns_id);
+        if (probe_fd >= 0)
+                return USERNS_REAP_ALIVE; /* Still alive (or the inode was recycled for a live namespace). */
+        if (ERRNO_IS_NEG_PRIVILEGE(probe_fd) || ERRNO_IS_NEG_NOT_SUPPORTED(probe_fd) || probe_fd == -EINVAL)
+                /* EPERM/EACCES (not in the initial user namespace, missing CAP_SYS_ADMIN), or
+                 * ENOTSUP/ENOSYS/EINVAL (kernel new enough for NS_GET_ID but too old for
+                 * open_by_handle_at() lookup by id on nsfs) — we can't confirm death for this or any
+                 * other entry. The userns_id == 0 case is already handled above, so -EINVAL here means
+                 * the lookup is unsupported rather than a bad id. */
+                return USERNS_REAP_UNSUPPORTED;
+        if (probe_fd != -ESTALE)
+                return probe_fd; /* Unexpected probe error. */
+
+        log_debug("User namespace %" PRIu64 " (id %" PRIu64 ") refers to a dead namespace, reclaiming its resources.",
+                  inode, info->userns_id);
+
+        userns_registry_release_by_info(bpf, dir_fd, info);
+        return USERNS_REAP_RELEASED;
 }
 
 int userns_info_verify_fd(int userns_fd, const UserNamespaceInfo *info) {

--- a/src/nsresourced/userns-registry.h
+++ b/src/nsresourced/userns-registry.h
@@ -76,6 +76,26 @@ int userns_info_verify_fd(int userns_fd, const UserNamespaceInfo *info);
 void userns_registry_release_by_info(struct userns_restrict_bpf *bpf, int dir_fd, UserNamespaceInfo *info);
 void userns_registry_release_by_userns_inode(struct userns_restrict_bpf *bpf, int dir_fd, uint64_t inode);
 
+typedef enum UserNamespaceReapStatus {
+        USERNS_REAP_RELEASED,      /* Confirmed dead via its kernel id — registry entry released. */
+        USERNS_REAP_ALIVE,         /* Still alive — left untouched. */
+        USERNS_REAP_INDETERMINATE, /* Liveness couldn't be determined for this entry — it predates id
+                                      tracking, or no entry is registered for the inode any more (e.g. a
+                                      dead ancestor still referenced by a delegation chain). */
+        USERNS_REAP_UNSUPPORTED,   /* Namespaces can't be looked up by id in this environment at all (old
+                                      kernel, or not in the initial user namespace). Applies to every
+                                      entry, so callers sweeping many of them can stop probing. */
+        _USERNS_REAP_MAX,
+        _USERNS_REAP_INVALID = -EINVAL,
+} UserNamespaceReapStatus;
+
+/* Probes the registered user namespace with the given inode for liveness via its recorded kernel
+ * namespace id and, if it is authoritatively dead, releases its registry entry (restoring any ranges
+ * it received via delegation to their ancestors). Returns a non-negative UserNamespaceReapStatus
+ * describing what happened, or a negative errno on genuine failure. The caller must hold the registry
+ * lock (or otherwise be free of concurrent writers). */
+int userns_registry_reap_if_dead(struct userns_restrict_bpf *bpf, int dir_fd, uint64_t inode);
+
 int userns_registry_store(int dir_fd, UserNamespaceInfo *info);
 int userns_registry_remove(int dir_fd, UserNamespaceInfo *info);
 


### PR DESCRIPTION
The only runtime trigger for registry cleanup is the BPF kprobe that fires
on user namespace destruction; when it is missed (ring buffer overflow,
kprobe missing, fdstore entry dropped), the dead namespace's registry entry
survives and keeps its UID/GID ranges blocked until the manager restarts and
its startup sweep runs. The allocation hot path checked whether a candidate
range was already taken but never whether the namespace holding it was still
alive, so a single dead namespace could permanently starve an allocation.
This is most visible when a parent delegates its entire container UID window
to a child that then dies: every subsequent allocation from the parent fails
with NoDynamicRange even though the ranges are reclaimable.

Add userns_registry_reap_if_dead(), which probes a registered namespace's
liveness via the kernel namespace identifier recorded at allocation time and,
if it is authoritatively dead, releases its registry entry — restoring any
ranges it received via delegation to their ancestors. Call it from the
allocation availability check for both transient registrations and delegated
ranges, walking a chain of dead ancestors in the delegation case. This
mirrors the existing inode-slot stale cleanup and makes allocation
self-healing without waiting for a restart.

The startup sweep grew the same load-probe-release logic, so route it through
the new helper too; its errno return distinguishes alive, no-recorded-id, and
unprobeable-environment cases so the sweep keeps its early-out when lookup by
id isn't possible at all.

Add a regression test covering the reap-and-restore mechanism.

Co-developed-by: Claude Opus 4.8 <noreply@anthropic.com>
