### PR TITLE
sd-varlink: disable event source in varlink_server_socket_free()

### DIFF
--- a/src/libsystemd/sd-varlink/sd-varlink.c
+++ b/src/libsystemd/sd-varlink/sd-varlink.c
@@ -3297,6 +3297,7 @@ VarlinkServerSocket* varlink_server_socket_free(VarlinkServerSocket *ss) {
         if (!ss)
                 return NULL;
 
+        sd_event_source_disable_unref(ss->event_source);
         free(ss->address);
         return mfree(ss);
 }


### PR DESCRIPTION
The cleanup destructor for VarlinkServerSocket only freed ss->address and the struct, leaking ss->event_source. If sd_varlink_server_listen_address() hits OOM at free_and_strdup() after the io-source was already armed, the source stays registered in the event loop with userdata pointing at the freed socket. Disable it before freeing; the call is a no-op when the source was never armed, so the other freep sites are unaffected.

Follow-up for c14e841f31682a383edce68a9142a01589a95f50

Co-developed-by: Claude Opus 4.8 <noreply@anthropic.com>