### PR TITLE
vsock-util: allow VMADDR_CID_ANY as local CID if enabled in hwdb

### DIFF
--- a/hwdb.d/70-vsock.hwdb
+++ b/hwdb.d/70-vsock.hwdb
@@ -1,0 +1,10 @@
+# This file is part of systemd.
+#
+# Database for AF_VSOCK driver implementations.
+#
+# Permitted keys:
+#   Specify if the driver uses VMADDR_CID_ANY as the local CID.
+#   VSOCK_ACCEPT_VMADDR_CID_ANY=1|0
+
+dmi:bvnMicrosoftCorporation:*:pvrHyper-V*
+ VSOCK_ACCEPT_VMADDR_CID_ANY=1

--- a/hwdb.d/meson.build
+++ b/hwdb.d/meson.build
@@ -41,6 +41,7 @@ hwdb_files_test = files(
         '70-software-radio.hwdb',
         '70-sound-card.hwdb',
         '70-touchpad.hwdb',
+        '70-vsock.hwdb',
         '80-ieee1394-unit-function.hwdb',
         '82-net-auto-link-local.hwdb')
 

--- a/hwdb.d/parse_hwdb.py
+++ b/hwdb.d/parse_hwdb.py
@@ -260,6 +260,7 @@ def property_grammar():
         ('IMDS_KEY_USERDATA', name_literal),
         ('IMDS_KEY_USERDATA_BASE', name_literal),
         ('IMDS_KEY_USERDATA_BASE64', name_literal),
+        ('VSOCK_ACCEPT_VMADDR_CID_ANY', zero_one),
     )
     fixed_props = [Literal(name)('NAME') - Suppress('=') - val('VALUE') for name, val in props]
     kbd_props = [

--- a/src/basic/socket-util.c
+++ b/src/basic/socket-util.c
@@ -1798,30 +1798,6 @@ int socket_address_parse_vsock(SocketAddress *ret_address, const char *s) {
         return 0;
 }
 
-int vsock_get_local_cid(unsigned *ret) {
-        _cleanup_close_ int vsock_fd = -EBADF;
-
-        vsock_fd = open("/dev/vsock", O_RDONLY|O_CLOEXEC);
-        if (vsock_fd < 0)
-                return log_debug_errno(errno, "Failed to open %s: %m", "/dev/vsock");
-
-        unsigned tmp;
-        if (ioctl(vsock_fd, IOCTL_VM_SOCKETS_GET_LOCAL_CID, &tmp) < 0)
-                return log_debug_errno(errno, "Failed to query local AF_VSOCK CID: %m");
-        log_debug("Local AF_VSOCK CID: %u", tmp);
-
-        /* If ret == NULL, we're just want to check if AF_VSOCK is available, so accept
-         * any address. Otherwise, filter out special addresses that are cannot be used
-         * to identify _this_ machine from the outside. */
-        if (ret && IN_SET(tmp, VMADDR_CID_LOCAL, VMADDR_CID_HOST, VMADDR_CID_ANY))
-                return log_debug_errno(SYNTHETIC_ERRNO(EADDRNOTAVAIL),
-                                       "IOCTL_VM_SOCKETS_GET_LOCAL_CID returned special value (%u), ignoring.", tmp);
-
-        if (ret)
-                *ret = tmp;
-        return 0;
-}
-
 int netlink_socket_get_multicast_groups(int fd, size_t *ret_len, uint32_t **ret_groups) {
         _cleanup_free_ uint32_t *groups = NULL;
         socklen_t len = 0, old_len;

--- a/src/basic/socket-util.h
+++ b/src/basic/socket-util.h
@@ -261,8 +261,6 @@ int socket_address_equal_unix(const char *a, const char *b);
  * authoritative. */
 #define SOMAXCONN_DELUXE INT_MAX
 
-int vsock_get_local_cid(unsigned *ret);
-
 int netlink_socket_get_multicast_groups(int fd, size_t *ret_len, uint32_t **ret_groups);
 
 int socket_get_cookie(int fd, uint64_t *ret);

--- a/src/hostname/hostnamed.c
+++ b/src/hostname/hostnamed.c
@@ -38,7 +38,6 @@
 #include "parse-util.h"
 #include "path-util.h"
 #include "service-util.h"
-#include "socket-util.h"
 #include "stat-util.h"
 #include "string-util.h"
 #include "strv.h"
@@ -47,6 +46,7 @@
 #include "varlink-io.systemd.service.h"
 #include "varlink-util.h"
 #include "virt.h"
+#include "vsock-util.h"
 
 #define VALID_DEPLOYMENT_CHARS (ALPHANUMERICAL "-.:")
 

--- a/src/machine/machined.c
+++ b/src/machine/machined.c
@@ -32,9 +32,9 @@
 #include "service-util.h"
 #include "set.h"
 #include "signal-util.h"
-#include "socket-util.h"
 #include "special.h"
 #include "string-util.h"
+#include "vsock-util.h"
 
 static Manager* manager_unref(Manager *m);
 DEFINE_TRIVIAL_CLEANUP_FUNC(Manager*, manager_unref);

--- a/src/shared/meson.build
+++ b/src/shared/meson.build
@@ -261,6 +261,7 @@ shared_sources = files(
         'vlan-util.c',
         'volatile-util.c',
         'vpick.c',
+        'vsock-util.c',
         'wall.c',
         'watchdog.c',
         'web-util.c',

--- a/src/shared/vsock-util.c
+++ b/src/shared/vsock-util.c
@@ -1,0 +1,92 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include <fcntl.h>
+#include <sys/ioctl.h>
+
+#include "sd-hwdb.h"
+
+#include "fd-util.h"
+#include "fileio.h"
+#include "log.h"
+#include "parse-util.h"
+#include "string-util.h"
+#include "vsock-util.h"
+
+static int smbios_get_modalias(char **ret) {
+        int r;
+
+        assert(ret);
+
+        _cleanup_free_ char *modalias = NULL;
+        r = read_virtual_file("/sys/devices/virtual/dmi/id/modalias", SIZE_MAX, &modalias, /* ret_size= */ NULL);
+        if (r < 0)
+                return r;
+
+        truncate_nl(modalias);
+
+        *ret = TAKE_PTR(modalias);
+        return 0;
+}
+
+static int smbios_get_accepts_any(void) {
+        static int accepts_any = -1;
+        int r;
+
+        if (accepts_any >= 0)
+                return accepts_any;
+
+        _cleanup_free_ char *modalias = NULL;
+        r = smbios_get_modalias(&modalias);
+        if (r == -ENOENT)
+                return (accepts_any = false);
+        if (r < 0)
+                return log_debug_errno(r, "Failed to read DMI modalias: %m");
+
+        _cleanup_(sd_hwdb_unrefp) sd_hwdb *hwdb = NULL;
+        r = sd_hwdb_new(&hwdb);
+        if (r < 0)
+                return log_debug_errno(r, "Failed to open hwdb: %m");
+
+        const char *value;
+        r = sd_hwdb_get(hwdb, modalias, "VSOCK_ACCEPT_VMADDR_CID_ANY", &value);
+        if (r < 0) {
+                if (r != -ENOENT)
+                        log_debug_errno(r, "Failed to get VSOCK_ACCEPT_VMADDR_CID_ANY, ignoring: %m");
+                return (accepts_any = false);
+        }
+        log_debug("VSOCK_ACCEPT_VMADDR_CID_ANY: %s", value);
+
+        r = parse_boolean(value);
+        if (r < 0) {
+                log_debug_errno(r, "Failed to parse VSOCK_ACCEPT_VMADDR_CID_ANY, ignoring: %m");
+                return (accepts_any = false);
+        }
+
+        return (accepts_any = r);
+}
+
+int vsock_get_local_cid(unsigned *ret) {
+        _cleanup_close_ int vsock_fd = -EBADF;
+
+        vsock_fd = open("/dev/vsock", O_RDONLY|O_CLOEXEC);
+        if (vsock_fd < 0)
+                return log_debug_errno(errno, "Failed to open %s: %m", "/dev/vsock");
+
+        unsigned tmp;
+        if (ioctl(vsock_fd, IOCTL_VM_SOCKETS_GET_LOCAL_CID, &tmp) < 0)
+                return log_debug_errno(errno, "Failed to query local AF_VSOCK CID: %m");
+        log_debug("Local AF_VSOCK CID: %u", tmp);
+
+        /* If ret == NULL, we just want to check if AF_VSOCK is available, so accept any
+         * address. Otherwise, filter out special addresses that cannot be used to identify
+         * _this_ machine from the outside. */
+        if (ret &&
+            (IN_SET(tmp, VMADDR_CID_LOCAL, VMADDR_CID_HOST) ||
+             (tmp == VMADDR_CID_ANY && smbios_get_accepts_any() <= 0)))
+                return log_debug_errno(SYNTHETIC_ERRNO(EADDRNOTAVAIL),
+                                       "IOCTL_VM_SOCKETS_GET_LOCAL_CID returned special value (%u), ignoring.", tmp);
+
+        if (ret)
+                *ret = tmp;
+        return 0;
+}

--- a/src/shared/vsock-util.h
+++ b/src/shared/vsock-util.h
@@ -1,0 +1,6 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#pragma once
+
+#include <linux/vm_sockets.h> /* IWYU pragma: export */
+
+int vsock_get_local_cid(unsigned *ret);

--- a/src/ssh-generator/ssh-util.c
+++ b/src/ssh-generator/ssh-util.c
@@ -5,8 +5,8 @@
 
 #include "errno-util.h"
 #include "log.h"
-#include "socket-util.h"
 #include "ssh-util.h"
+#include "vsock-util.h"
 
 int vsock_open_or_warn(int *ret) {
         int fd = RET_NERRNO(socket(AF_VSOCK, SOCK_STREAM|SOCK_CLOEXEC, 0));


### PR DESCRIPTION
On Hyper-V guests, `VMADDR_CID_ANY` is valid as per implementation in kernel driver: https://github.com/torvalds/linux/blob/v7.0/net/vmw_vsock/hyperv_transport.c#L112-L151.

Fixes #42496 by the suggested approach in https://github.com/systemd/systemd/pull/42515#pullrequestreview-4451251702.

Follow-up for 83359c4da02a82d2972cf957d9855ea957359287.

Tested on my Hyper-V environment, which works fine:

```
Jun 13 20:22:28 lychee systemd-ssh-generator[464]: Virtualization Hyper-V UEFI Release v4.1 found in DMI (/sys/class/dmi/id/product_version)
Jun 13 20:22:28 lychee systemd-ssh-generator[464]: UML virtualization not found in /proc/cpuinfo.
Jun 13 20:22:28 lychee systemd-ssh-generator[464]: Virtualization XEN not found, /proc/xen does not exist
Jun 13 20:22:28 lychee systemd-ssh-generator[464]: Virtualization found, CPUID=Microsoft Hv
Jun 13 20:22:28 lychee systemd-ssh-generator[464]: Found VM virtualization microsoft
Jun 13 20:22:28 lychee systemd-ssh-generator[464]: Local AF_VSOCK CID: 4294967295
Jun 13 20:22:28 lychee systemd-ssh-generator[464]: Trying to open "/etc/systemd/hwdb/hwdb.bin"...
Jun 13 20:22:28 lychee systemd-ssh-generator[464]: Trying to open "/etc/udev/hwdb.bin"...
Jun 13 20:22:28 lychee systemd-ssh-generator[464]: Trying to open "/usr/lib/systemd/hwdb/hwdb.bin"...
Jun 13 20:22:28 lychee systemd-ssh-generator[464]: Trying to open "/usr/lib/udev/hwdb.bin"...
Jun 13 20:22:28 lychee systemd-ssh-generator[464]: === trie on-disk ===
Jun 13 20:22:28 lychee systemd-ssh-generator[464]: tool version:          261
Jun 13 20:22:28 lychee systemd-ssh-generator[464]: file size:        13843225 bytes
Jun 13 20:22:28 lychee systemd-ssh-generator[464]: header size             80 bytes
Jun 13 20:22:28 lychee systemd-ssh-generator[464]: strings            2871129 bytes
Jun 13 20:22:28 lychee systemd-ssh-generator[464]: nodes             10972016 bytes
Jun 13 20:22:28 lychee systemd-ssh-generator[464]: VSOCK_ACCEPT_VMADDR_CID_ANY: 1
Jun 13 20:22:28 lychee systemd-ssh-generator[464]: Binding SSH to AF_VSOCK vsock::22.
Jun 13 20:22:28 lychee systemd-ssh-generator[464]: → connect via 'ssh vsock/4294967295' from host
Jun 13 20:22:28 lychee systemd-ssh-generator[464]: Binding SSH to AF_UNIX socket /run/ssh-unix-local/socket.
Jun 13 20:22:28 lychee systemd-ssh-generator[464]: → connect via 'ssh .host' locally
Jun 13 20:22:28 lychee systemd-ssh-generator[464]: Not running in container, not listening on /run/host/unix-export/ssh
```