### PR TITLE
bus-map-properties: reject wrong variant type

### DIFF
--- a/src/analyze/analyze-security.c
+++ b/src/analyze/analyze-security.c
@@ -2338,7 +2338,7 @@ static int acquire_security_info(sd_bus *bus, const char *name, SecurityInfo *in
                 { "RootImage",               "s",       NULL,                                    offsetof(SecurityInfo, root_image)                },
                 { "SupplementaryGroups",     "as",      NULL,                                    offsetof(SecurityInfo, supplementary_groups)      },
                 { "SystemCallArchitectures", "as",      property_read_syscall_archs,             0                                                 },
-                { "SystemCallFilter",        "(as)",    property_read_system_call_filter,        0                                                 },
+                { "SystemCallFilter",        "(bas)",   property_read_system_call_filter,        0                                                 },
                 { "Type",                    "s",       NULL,                                    offsetof(SecurityInfo, type)                      },
                 { "UMask",                   "u",       property_read_umask,                     0                                                 },
                 { "User",                    "s",       NULL,                                    offsetof(SecurityInfo, user)                      },

--- a/src/analyze/analyze-time-data.c
+++ b/src/analyze/analyze-time-data.c
@@ -56,7 +56,7 @@ int acquire_boot_times(sd_bus *bus, bool require_finished, BootTimes **ret) {
                 { "InitRDGeneratorsFinishTimestampMonotonic", "t", NULL, offsetof(BootTimes, initrd_generators_finish_time) },
                 { "InitRDUnitsLoadStartTimestampMonotonic",   "t", NULL, offsetof(BootTimes, initrd_unitsload_start_time)   },
                 { "InitRDUnitsLoadFinishTimestampMonotonic",  "t", NULL, offsetof(BootTimes, initrd_unitsload_finish_time)  },
-                { "SoftRebootsCount",                         "t", NULL, offsetof(BootTimes, soft_reboots_count)            },
+                { "SoftRebootsCount",                         "u", NULL, offsetof(BootTimes, soft_reboots_count)            },
                 {},
         };
         _cleanup_(sd_bus_error_free) sd_bus_error error = SD_BUS_ERROR_NULL;
@@ -212,7 +212,7 @@ int pretty_boot_time(sd_bus *bus, char **ret) {
                 return log_oom();
         if (timestamp_is_set(t->initrd_time) && !strextend(&text, FORMAT_TIMESPAN(t->userspace_time - t->initrd_time, USEC_PER_MSEC), " (initrd) + "))
                 return log_oom();
-        if (t->soft_reboots_count > 0 && strextendf(&text, "%s (soft reboot #%" PRIu64 ") + ", FORMAT_TIMESPAN(t->userspace_time, USEC_PER_MSEC), t->soft_reboots_count) < 0)
+        if (t->soft_reboots_count > 0 && strextendf(&text, "%s (soft reboot #%" PRIu32 ") + ", FORMAT_TIMESPAN(t->userspace_time, USEC_PER_MSEC), t->soft_reboots_count) < 0)
                 return log_oom();
 
         if (!strextend(&text, FORMAT_TIMESPAN(t->finish_time - t->userspace_time, USEC_PER_MSEC), " (userspace) "))

--- a/src/analyze/analyze-time-data.h
+++ b/src/analyze/analyze-time-data.h
@@ -26,7 +26,7 @@ typedef struct BootTimes {
         usec_t initrd_unitsload_start_time;
         usec_t initrd_unitsload_finish_time;
         /* Not strictly a timestamp, but we are going to show it next to the other timestamps */
-        uint64_t soft_reboots_count;
+        uint32_t soft_reboots_count;
 
         /*
          * If we're analyzing the user instance, all timestamps will be offset by its own start-up timestamp,

--- a/src/network/networkd-wwan-bus.c
+++ b/src/network/networkd-wwan-bus.c
@@ -882,12 +882,12 @@ static int modem_properties_changed_signal(
                 sd_bus_error *ret_error) {
 
         static const struct bus_properties_map map[] = {
-                { "Bearers",       "a{sv}", modem_map_bearers, 0,                                 },
+                { "Bearers",          "ao", modem_map_bearers, 0,                                 },
                 { "State",             "i", NULL,              offsetof(Modem, state)             },
                 { "StateFailedReason", "u", NULL,              offsetof(Modem, state_fail_reason) },
                 { "Manufacturer",      "s", NULL,              offsetof(Modem, manufacturer)      },
                 { "Model",             "s", NULL,              offsetof(Modem, model)             },
-                { "Ports",         "a{su}", modem_map_ports,   0,                                 },
+                { "Ports",         "a(su)", modem_map_ports,   0,                                 },
                 {}
         };
         Modem *modem = ASSERT_PTR(userdata);
@@ -969,7 +969,7 @@ static int modem_add(Manager *m, const char *path, sd_bus_message *message, sd_b
                 { "StateFailedReason", "u",     NULL,              offsetof(Modem, state_fail_reason) },
                 { "Manufacturer",      "s",     NULL,              offsetof(Modem, manufacturer)      },
                 { "Model",             "s",     NULL,              offsetof(Modem, model)             },
-                { "Ports",             "a{su}", modem_map_ports,   0,                                 },
+                { "Ports",             "a(su)", modem_map_ports,   0,                                 },
                 {}
         };
         Modem *modem;

--- a/src/shared/bus-map-properties.c
+++ b/src/shared/bus-map-properties.c
@@ -173,21 +173,29 @@ int bus_message_map_all_properties(
                         if (r < 0)
                                 return bus_log_parse_error_debug(r);
 
-                        r = sd_bus_message_enter_container(m, SD_BUS_TYPE_VARIANT, contents);
-                        if (r < 0)
-                                return bus_log_parse_error_debug(r);
+                        if (prop->signature && !streq(contents, prop->signature)) {
+                                log_debug("Unexpected type for property '%s': expected '%s', got '%s', ignoring.",
+                                          member, prop->signature, contents);
+                                r = sd_bus_message_skip(m, "v");
+                                if (r < 0)
+                                        return bus_log_parse_error_debug(r);
+                        } else {
+                                r = sd_bus_message_enter_container(m, SD_BUS_TYPE_VARIANT, contents);
+                                if (r < 0)
+                                        return bus_log_parse_error_debug(r);
 
-                        v = (uint8_t *)userdata + prop->offset;
-                        if (map[i].set)
-                                r = prop->set(sd_bus_message_get_bus(m), member, m, reterr_error, v);
-                        else
-                                r = map_basic(m, flags, v);
-                        if (r < 0)
-                                return bus_log_parse_error_debug(r);
+                                v = (uint8_t*) userdata + prop->offset;
+                                if (prop->set)
+                                        r = prop->set(sd_bus_message_get_bus(m), member, m, reterr_error, v);
+                                else
+                                        r = map_basic(m, flags, v);
+                                if (r < 0)
+                                        return bus_log_parse_error_debug(r);
 
-                        r = sd_bus_message_exit_container(m);
-                        if (r < 0)
-                                return bus_log_parse_error_debug(r);
+                                r = sd_bus_message_exit_container(m);
+                                if (r < 0)
+                                        return bus_log_parse_error_debug(r);
+                        }
                 } else {
                         r = sd_bus_message_skip(m, "v");
                         if (r < 0)

--- a/src/systemctl/systemctl-show.c
+++ b/src/systemctl/systemctl-show.c
@@ -2204,7 +2204,7 @@ static int show_one(
                 { "ActiveExitTimestamp",            "t",               NULL,           offsetof(UnitStatusInfo, active_exit_timestamp)             },
                 { "InactiveEnterTimestamp",         "t",               NULL,           offsetof(UnitStatusInfo, inactive_enter_timestamp)          },
                 { "RuntimeMaxUSec",                 "t",               NULL,           offsetof(UnitStatusInfo, runtime_max_sec)                   },
-                { "InvocationID",                   "s",               bus_map_id128,  offsetof(UnitStatusInfo, invocation_id)                     },
+                { "InvocationID",                   "ay",              bus_map_id128,  offsetof(UnitStatusInfo, invocation_id)                     },
                 { "NeedDaemonReload",               "b",               NULL,           offsetof(UnitStatusInfo, need_daemon_reload)                },
                 { "Transient",                      "b",               NULL,           offsetof(UnitStatusInfo, transient)                         },
                 { "ExecMainPID",                    "u",               NULL,           offsetof(UnitStatusInfo, main_pid)                          },

--- a/src/test/test-bus-util.c
+++ b/src/test/test-bus-util.c
@@ -2,6 +2,8 @@
 
 #include "sd-bus.h"
 
+#include "bus-internal.h"
+#include "bus-map-properties.h"
 #include "bus-util.h"
 #include "log.h"
 #include "tests.h"
@@ -42,6 +44,178 @@ TEST(destroy_callback) {
         ASSERT_EQ(n_called, 0);
         sd_bus_slot_unref(slot);
         ASSERT_EQ(n_called, 1);
+}
+
+/* Guard field detects an over-wide write spilling past the declared slot. */
+struct numeric_target {
+        uint32_t value;
+        uint32_t guard;
+};
+
+struct strv_target {
+        char **list;
+        char **guard;
+};
+
+#define GUARD_PATTERN UINT32_C(0x5A5A5A5A)
+
+/* Unconnected bus, only good for constructing messages locally. */
+static void map_properties_fake_bus(sd_bus **ret) {
+        sd_bus *bus = NULL;
+
+        ASSERT_OK(sd_bus_new(&bus));
+        bus->state = BUS_RUNNING; /* Fake state to allow message creation */
+        *ret = bus;
+}
+
+static void map_properties_seal_for_read(sd_bus_message *m) {
+        ASSERT_OK(sd_bus_message_seal(m, 1, 0));
+        ASSERT_OK(sd_bus_message_rewind(m, true));
+}
+
+/* Over-wide scalar wire type must not write past the declared slot. */
+TEST(map_all_properties_numeric_type_confusion) {
+        _cleanup_(sd_bus_unrefp) sd_bus *bus = NULL;
+        _cleanup_(sd_bus_message_unrefp) sd_bus_message *m = NULL;
+
+        struct numeric_target data = { .value = 0, .guard = GUARD_PATTERN };
+
+        static const struct bus_properties_map map[] = {
+                { "Value", "u", NULL, offsetof(struct numeric_target, value) },
+                {},
+        };
+
+        map_properties_fake_bus(&bus);
+
+        ASSERT_OK(sd_bus_message_new_method_call(bus, &m, "foo.bar", "/", "foo.bar", "Get"));
+        ASSERT_OK(sd_bus_message_append(m, "a{sv}", 1, "Value", "t", (uint64_t) 0xAABBCCDD11223344ULL));
+        map_properties_seal_for_read(m);
+
+        ASSERT_OK(bus_message_map_all_properties(m, map, /* flags= */ 0, /* reterr_error= */ NULL, &data));
+
+        /* Skipped, adjacent field intact. */
+        ASSERT_EQ(data.guard, GUARD_PATTERN);
+}
+
+/* Scalar "t" against a declared "as" char** slot must be skipped, not planted+freed. */
+TEST(map_all_properties_pointer_type_confusion) {
+        _cleanup_(sd_bus_unrefp) sd_bus *bus = NULL;
+        _cleanup_(sd_bus_message_unrefp) sd_bus_message *m = NULL;
+
+        char *guard_marker = NULL;
+        struct strv_target data = { .guard = &guard_marker };
+
+        static const struct bus_properties_map map[] = {
+                { "List", "as", NULL, offsetof(struct strv_target, list) },
+                {},
+        };
+
+        map_properties_fake_bus(&bus);
+
+        ASSERT_OK(sd_bus_message_new_method_call(bus, &m, "foo.bar", "/", "foo.bar", "Get"));
+        ASSERT_OK(sd_bus_message_append(m, "a{sv}", 1, "List", "t", (uint64_t) 0xDEADBEEFCAFEBABEULL));
+        map_properties_seal_for_read(m);
+
+        ASSERT_OK(bus_message_map_all_properties(m, map, /* flags= */ 0, /* reterr_error= */ NULL, &data));
+
+        ASSERT_NULL(data.list);
+        ASSERT_PTR_EQ(data.guard, &guard_marker);
+}
+
+/* Mismatched array element type ("ao" vs "as") must be skipped. "ao" is one read_strv_extend()
+ * accepts, so the signature guard, not the reader, is what rejects it. */
+TEST(map_all_properties_array_type_confusion) {
+        _cleanup_(sd_bus_unrefp) sd_bus *bus = NULL;
+        _cleanup_(sd_bus_message_unrefp) sd_bus_message *m = NULL;
+
+        char *guard_marker = NULL;
+        struct strv_target data = { .guard = &guard_marker };
+
+        static const struct bus_properties_map map[] = {
+                { "List", "as", NULL, offsetof(struct strv_target, list) },
+                {},
+        };
+
+        map_properties_fake_bus(&bus);
+
+        ASSERT_OK(sd_bus_message_new_method_call(bus, &m, "foo.bar", "/", "foo.bar", "Get"));
+        ASSERT_OK(sd_bus_message_append(m, "a{sv}", 1, "List", "ao", 1, "/foo/bar"));
+        map_properties_seal_for_read(m);
+
+        ASSERT_OK(bus_message_map_all_properties(m, map, /* flags= */ 0, /* reterr_error= */ NULL, &data));
+
+        /* Skipped before map_basic()'s strv branch runs. */
+        ASSERT_NULL(data.list);
+        ASSERT_PTR_EQ(data.guard, &guard_marker);
+}
+
+/* Correctly typed "u" variant is still read into the slot. */
+TEST(map_all_properties_correct_type) {
+        _cleanup_(sd_bus_unrefp) sd_bus *bus = NULL;
+        _cleanup_(sd_bus_message_unrefp) sd_bus_message *m = NULL;
+
+        struct numeric_target data = { .value = 0, .guard = GUARD_PATTERN };
+
+        static const struct bus_properties_map map[] = {
+                { "Value", "u", NULL, offsetof(struct numeric_target, value) },
+                {},
+        };
+
+        map_properties_fake_bus(&bus);
+
+        ASSERT_OK(sd_bus_message_new_method_call(bus, &m, "foo.bar", "/", "foo.bar", "Get"));
+        ASSERT_OK(sd_bus_message_append(m, "a{sv}", 1, "Value", "u", (uint32_t) 42));
+        map_properties_seal_for_read(m);
+
+        ASSERT_OK(bus_message_map_all_properties(m, map, /* flags= */ 0, /* reterr_error= */ NULL, &data));
+
+        ASSERT_EQ(data.value, UINT32_C(42));
+        ASSERT_EQ(data.guard, GUARD_PATTERN);
+}
+
+static int record_set_called(sd_bus *bus, const char *member, sd_bus_message *m, sd_bus_error *reterr_error, void *userdata) {
+        bool *called = ASSERT_PTR(userdata);
+        int r;
+
+        /* Consume the value, like a real set callback would. */
+        r = sd_bus_message_skip(m, NULL);
+        if (r < 0)
+                return r;
+
+        *called = true;
+        return 0;
+}
+
+/* Wrong-type variant must be skipped before a property-set callback runs. */
+TEST(map_all_properties_set_callback_type_confusion) {
+        _cleanup_(sd_bus_unrefp) sd_bus *bus = NULL;
+        _cleanup_(sd_bus_message_unrefp) sd_bus_message *m = NULL;
+
+        bool called = false;
+
+        static const struct bus_properties_map map[] = {
+                { "List", "as", record_set_called, 0 },
+                {},
+        };
+
+        map_properties_fake_bus(&bus);
+
+        /* Wrong type: the set callback must not run. */
+        ASSERT_OK(sd_bus_message_new_method_call(bus, &m, "foo.bar", "/", "foo.bar", "Get"));
+        ASSERT_OK(sd_bus_message_append(m, "a{sv}", 1, "List", "t", (uint64_t) 0xDEADBEEFCAFEBABEULL));
+        map_properties_seal_for_read(m);
+
+        ASSERT_OK(bus_message_map_all_properties(m, map, /* flags= */ 0, /* reterr_error= */ NULL, &called));
+        ASSERT_FALSE(called);
+
+        /* Matching type: the set callback runs as before. */
+        m = sd_bus_message_unref(m);
+        ASSERT_OK(sd_bus_message_new_method_call(bus, &m, "foo.bar", "/", "foo.bar", "Get"));
+        ASSERT_OK(sd_bus_message_append(m, "a{sv}", 1, "List", "as", 1, "item"));
+        map_properties_seal_for_read(m);
+
+        ASSERT_OK(bus_message_map_all_properties(m, map, /* flags= */ 0, /* reterr_error= */ NULL, &called));
+        ASSERT_TRUE(called);
 }
 
 DEFINE_TEST_MAIN(LOG_DEBUG);


### PR DESCRIPTION
bus_message_map_all_properties() fed the peer-supplied wire signature straight into the variant dispatch and never compared it against the declared prop->signature, so map_basic() wrote at the wire type's native width into a slot sized for the declared type (over-wide numeric writes, peer-controlled pointers into char** slots later freed by strv_free()). Compare against prop->signature and skip the variant on mismatch.

This is in practice not a problem as the servers are trusted, and this only affects clients.

Follow-up for 9f6eb1cd58f2ddf2eb6ba0e4de056e13d938af75

Assisted-by: kres (claude-opus-4-7)
Co-developed-by: Claude Opus 4.8 <noreply@anthropic.com>