### PR TITLE
sd-netlink: fix use-after-free

### DIFF
--- a/src/libsystemd/sd-netlink/netlink-slot.c
+++ b/src/libsystemd/sd-netlink/netlink-slot.c
@@ -61,7 +61,7 @@ void netlink_slot_disconnect(sd_netlink_slot *slot, bool unref) {
         switch (slot->type) {
 
         case NETLINK_REPLY_CALLBACK:
-                (void) hashmap_remove(nl->reply_callbacks, &slot->reply_callback.serial);
+                (void) hashmap_remove(nl->reply_callbacks, UINT32_TO_PTR(slot->reply_callback.serial));
 
                 if (slot->reply_callback.timeout != USEC_INFINITY)
                         prioq_remove(nl->reply_callbacks_prioq, &slot->reply_callback, &slot->reply_callback.prioq_idx);


### PR DESCRIPTION
When a slot is disconnected, previously we tried to remove the slot from the hashmap with a wrong key. Hence, the pointer to the freed slot object remained in the hashmap.