### PR TITLE
network: drop nonexisting section name

### DIFF
--- a/src/network/networkd-network.c
+++ b/src/network/networkd-network.c
@@ -554,7 +554,6 @@ int network_load_one(Manager *manager, OrderedHashmap **networks, const char *fi
                         "DHCPServer\0"
                         "DHCPServerStaticLease\0"
                         "IPv6AcceptRA\0"
-                        "IPv6NDPProxyAddress\0"
                         "Bridge\0"
                         "BridgeFDB\0"
                         "BridgeMDB\0"


### PR DESCRIPTION
Follow-up for a0e5c15d4f5eb47ddb26850c6b99b1e110e0c270.