### PR TITLE
boot: Fix gdb support for RISC-V

### DIFF
--- a/src/boot/util.c
+++ b/src/boot/util.c
@@ -402,6 +402,8 @@ __attribute__((noinline)) void notify_debugger(const char *identity, volatile bo
                 asm volatile("pause");
 #  elif defined(__aarch64__)
                 asm volatile("wfi");
+#  elif defined(__riscv)
+                asm volatile(".insn i 0x0F, 0, x0, x0, 0x010");
 #  else
                 BS->Stall(5000);
 #  endif


### PR DESCRIPTION
This will also allow debugging systemd-boot easily on RISC-V.

Note that the following much simpler variant won't work, as we might be missing the optional 'zihintpause' extension:

    asm volatile("pause");

This was tested on QEMU when working on the following article:

https://www.codethink.co.uk/articles/2026/deep-dive-into-upstream-risc-v-boot-chain.html