### PR TITLE
credentials: add policy that can allow key=null creds from the ESP

### DIFF
--- a/docs/CREDENTIALS.md
+++ b/docs/CREDENTIALS.md
@@ -274,6 +274,33 @@ SetCredentialEncrypted=foobar: \
 …
 ```
 
+### Null-Key Encryption and the Boot Policy
+
+In some situations a credential must be provisioned to a machine that does not
+yet (or does not at all) possess a key to encrypt against, for example before
+first boot completes, or on systems without a TPM2 device. For these cases
+`systemd-creds encrypt --with-key=null` produces a credential wrapped in the
+normal `systemd-creds` envelope, but encrypted with a fixed zero-length key.
+Such a credential travels through the same path as any other encrypted
+credential (e.g. it may be dropped into the ESP under `/loader/credentials/` or
+`*.efi.extra.d/`), but it offers neither confidentiality nor authenticity.
+Because of that, accepting it is risky on a system that could do better, and
+whether it is accepted at boot is controlled by the `systemd.credentials_boot_policy=`
+kernel command line option:
+
+| Mode      | A null-key credential is accepted when…           |
+|-----------|---------------------------------------------------|
+| `strict`  | never                                             |
+| `tofu`    | this is the first boot, or no TPM2 is available   |
+| `relaxed` | SecureBoot is off, or no TPM2 is available        |
+| `off`     | always                                            |
+
+The default is `relaxed`. This policy only governs the
+default acceptance decision; credentials encrypted against a host key or TPM2
+device are always accepted. See
+[systemd(1)](https://www.freedesktop.org/software/systemd/man/latest/systemd.html)
+for details.
+
 ## Inheritance from Container Managers, Hypervisors, Kernel Command Line, or the UEFI Boot Environment
 
 Sometimes it is useful to parameterize whole systems the same way as services,

--- a/man/kernel-command-line.xml
+++ b/man/kernel-command-line.xml
@@ -67,6 +67,7 @@
         <term><varname>systemd.set_credential=</varname></term>
         <term><varname>systemd.set_credential_binary=</varname></term>
         <term><varname>systemd.import_credentials=</varname></term>
+        <term><varname>systemd.credentials_boot_policy=</varname></term>
         <term><varname>systemd.reload_limit_interval_sec=</varname></term>
         <term><varname>systemd.reload_limit_burst=</varname></term>
         <term><varname>systemd.minimum_uptime_sec=</varname></term>

--- a/man/systemd.xml
+++ b/man/systemd.xml
@@ -966,6 +966,41 @@
       </varlistentry>
 
       <varlistentry>
+        <term><varname>systemd.credentials_boot_policy=</varname></term>
+
+        <listitem><para>Controls under which conditions a credential encrypted with a <literal>null</literal>
+        key (i.e. a credential wrapped in a <command>systemd-creds</command> envelope but offering neither
+        confidentiality nor authenticity, see
+        <citerefentry><refentrytitle>systemd-creds</refentrytitle><manvolnum>1</manvolnum></citerefentry>)
+        is accepted at boot. This provides a fallback for provisioning credentials before a machine has a key
+        to encrypt them against, for example during first boot or on systems without a TPM2 device. Takes
+        one of <option>strict</option>, <option>tofu</option>, <option>relaxed</option> or
+        <option>off</option>:</para>
+
+        <itemizedlist>
+          <listitem><para><option>strict</option> never accepts a <literal>null</literal> key, i.e. always
+          insists on proper encryption.</para></listitem>
+
+          <listitem><para><option>tofu</option> (trust on first use) accepts a <literal>null</literal> key
+          during first boot, or when no TPM2 device is available.</para></listitem>
+
+          <listitem><para><option>relaxed</option> accepts a <literal>null</literal> key when SecureBoot is
+          disabled, or when no TPM2 device is available.</para></listitem>
+
+          <listitem><para><option>off</option> always accepts a <literal>null</literal> key.</para></listitem>
+        </itemizedlist>
+
+        <para>Defaults to <option>relaxed</option>. Note that this policy only applies to the default acceptance
+        decision; it has no effect on credentials encrypted against a host key or TPM2 device, which are
+        always accepted.</para>
+
+        <para>For further information see <ulink url="https://systemd.io/CREDENTIALS">System and Service
+        Credentials</ulink> documentation.</para>
+
+        <xi:include href="version-info.xml" xpointer="v262"/></listitem>
+      </varlistentry>
+
+      <varlistentry>
         <term><varname>quiet</varname></term>
 
         <listitem><para>Turn off status output at boot, much like

--- a/src/basic/initrd-util.c
+++ b/src/basic/initrd-util.c
@@ -1,11 +1,13 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
+#include <stdlib.h>
 #include <unistd.h>
 
 #include "env-util.h"
 #include "errno-util.h"
 #include "initrd-util.h"
 #include "log.h"
+#include "parse-util.h"
 
 static int saved_in_initrd = -1;
 
@@ -37,4 +39,26 @@ bool in_initrd(void) {
 
 void in_initrd_force(bool value) {
         saved_in_initrd = value;
+}
+
+bool in_first_boot(void) {
+        static int first_boot = -1;
+        int r;
+
+        if (first_boot >= 0)
+                return first_boot;
+
+        const char *e = secure_getenv("SYSTEMD_FIRST_BOOT");
+        if (e) {
+                r = parse_boolean(e);
+                if (r < 0)
+                        log_debug_errno(r, "Failed to parse $SYSTEMD_FIRST_BOOT, ignoring: %m");
+                else
+                        return (first_boot = r);
+        }
+
+        r = RET_NERRNO(access("/run/systemd/first-boot", F_OK));
+        if (r < 0 && r != -ENOENT)
+                log_debug_errno(r, "Failed to check if /run/systemd/first-boot exists, assuming no: %m");
+        return r >= 0;
 }

--- a/src/basic/initrd-util.c
+++ b/src/basic/initrd-util.c
@@ -1,13 +1,11 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
-#include <stdlib.h>
 #include <unistd.h>
 
 #include "env-util.h"
 #include "errno-util.h"
 #include "initrd-util.h"
 #include "log.h"
-#include "parse-util.h"
 
 static int saved_in_initrd = -1;
 
@@ -41,24 +39,26 @@ void in_initrd_force(bool value) {
         saved_in_initrd = value;
 }
 
-bool in_first_boot(void) {
-        static int first_boot = -1;
+int in_first_boot(void) {
+        static int first_boot_env_parse_cached = -1;
         int r;
 
-        if (first_boot >= 0)
-                return first_boot;
+        if (first_boot_env_parse_cached >= 0)
+                return first_boot_env_parse_cached;
 
-        const char *e = secure_getenv("SYSTEMD_FIRST_BOOT");
-        if (e) {
-                r = parse_boolean(e);
-                if (r < 0)
-                        log_debug_errno(r, "Failed to parse $SYSTEMD_FIRST_BOOT, ignoring: %m");
-                else
-                        return (first_boot = r);
-        }
+        r = secure_getenv_bool("SYSTEMD_FIRST_BOOT");
+        if (r >= 0)
+                return (first_boot_env_parse_cached = r);
+        if (r != -ENXIO)
+                log_debug_errno(r, "Failed to parse $SYSTEMD_FIRST_BOOT, ignoring: %m");
 
+        /* This is not cached and must *never* be cached, other parts of systemd write it to signal
+         * an update to the first-boot state. */
         r = RET_NERRNO(access("/run/systemd/first-boot", F_OK));
-        if (r < 0 && r != -ENOENT)
-                log_debug_errno(r, "Failed to check if /run/systemd/first-boot exists, assuming no: %m");
-        return r >= 0;
+        if (r >= 0)
+                return true;
+        if (r == -ENOENT)
+                return false;
+
+        return log_debug_errno(r, "Failed to check /run/systemd/first-boot: %m");
 }

--- a/src/basic/initrd-util.h
+++ b/src/basic/initrd-util.h
@@ -6,4 +6,4 @@
 bool in_initrd(void);
 void in_initrd_force(bool value);
 
-bool in_first_boot(void);
+int in_first_boot(void);

--- a/src/basic/initrd-util.h
+++ b/src/basic/initrd-util.h
@@ -5,3 +5,5 @@
 
 bool in_initrd(void);
 void in_initrd_force(bool value);
+
+bool in_first_boot(void);

--- a/src/core/import-creds.c
+++ b/src/core/import-creds.c
@@ -148,6 +148,67 @@ static bool credential_size_ok(const ImportCredentialsContext *c, const char *na
         return true;
 }
 
+/* Copy a single credential. Returns 1 if the credential was copied, 0 if skipped < 0 on error. */
+static int copy_one_credential(
+                ImportCredentialsContext *c,
+                const char *target_dir,
+                bool with_mount,
+                int source_dir_fd,
+                const char *source_name,
+                const char *target_name) {
+
+        _cleanup_close_ int cfd = -EBADF, nfd = -EBADF;
+        struct stat st;
+        int r;
+
+        assert(c);
+        assert(target_dir);
+        assert(source_dir_fd >= 0);
+        assert(source_name);
+        assert(target_name);
+
+        cfd = openat(source_dir_fd, source_name, O_RDONLY|O_CLOEXEC);
+        if (cfd < 0) {
+                log_warning_errno(errno, "Failed to open %s, ignoring: %m", source_name);
+                return 0;
+        }
+
+        if (fstat(cfd, &st) < 0) {
+                log_warning_errno(errno, "Failed to stat %s, ignoring: %m", source_name);
+                return 0;
+        }
+
+        r = stat_verify_regular(&st);
+        if (r < 0) {
+                log_warning_errno(r, "Credential file %s is not a regular file, ignoring: %m", source_name);
+                return 0;
+        }
+
+        if (!credential_size_ok(c, target_name, st.st_size))
+                return 0;
+
+        r = acquire_credential_directory(c, target_dir, with_mount);
+        if (r < 0)
+                return r;
+
+        nfd = open_credential_file_for_write(c->target_dir_fd, target_dir, target_name);
+        if (nfd == -EEXIST)
+                return 0;
+        if (nfd < 0)
+                return nfd;
+
+        r = copy_bytes(cfd, nfd, st.st_size, 0);
+        if (r < 0) {
+                (void) unlinkat(c->target_dir_fd, target_name, 0);
+                return log_error_errno(r, "Failed to create credential '%s': %m", target_name);
+        }
+
+        c->size_sum += st.st_size;
+        c->n_credentials++;
+
+        return 1;
+}
+
 static int finalize_credentials_dir(const char *dir, const char *envvar) {
         int r;
 
@@ -210,10 +271,8 @@ static int import_credentials_boot(void) {
 
                 FOREACH_ARRAY(i, de->entries, de->n_entries) {
                         const struct dirent *d = *i;
-                        _cleanup_close_ int cfd = -EBADF, nfd = -EBADF;
                         _cleanup_free_ char *n = NULL;
                         const char *e;
-                        struct stat st;
 
                         e = endswith(d->d_name, ".cred");
                         if (!e)
@@ -230,46 +289,12 @@ static int import_credentials_boot(void) {
                                 continue;
                         }
 
-                        cfd = openat(source_dir_fd, d->d_name, O_RDONLY|O_CLOEXEC);
-                        if (cfd < 0) {
-                                log_warning_errno(errno, "Failed to open %s, ignoring: %m", d->d_name);
-                                continue;
-                        }
-
-                        if (fstat(cfd, &st) < 0) {
-                                log_warning_errno(errno, "Failed to stat %s, ignoring: %m", d->d_name);
-                                continue;
-                        }
-
-                        r = stat_verify_regular(&st);
-                        if (r < 0) {
-                                log_warning_errno(r, "Credential file %s is not a regular file, ignoring: %m", d->d_name);
-                                continue;
-                        }
-
-                        if (!credential_size_ok(&context, n, st.st_size))
-                                continue;
-
-                        r = acquire_credential_directory(&context, ENCRYPTED_SYSTEM_CREDENTIALS_DIRECTORY, /* with_mount= */ false);
+                        r = copy_one_credential(&context, ENCRYPTED_SYSTEM_CREDENTIALS_DIRECTORY, /* with_mount= */ false,
+                                                source_dir_fd, d->d_name, n);
                         if (r < 0)
                                 return r;
-
-                        nfd = open_credential_file_for_write(context.target_dir_fd, ENCRYPTED_SYSTEM_CREDENTIALS_DIRECTORY, n);
-                        if (nfd == -EEXIST)
-                                continue;
-                        if (nfd < 0)
-                                return nfd;
-
-                        r = copy_bytes(cfd, nfd, st.st_size, 0);
-                        if (r < 0) {
-                                (void) unlinkat(context.target_dir_fd, n, 0);
-                                return log_error_errno(r, "Failed to create credential '%s': %m", n);
-                        }
-
-                        context.size_sum += st.st_size;
-                        context.n_credentials++;
-
-                        log_debug("Successfully copied boot credential '%s'.", n);
+                        if (r > 0)
+                                log_debug("Successfully copied boot credential '%s'.", n);
                 }
         }
 
@@ -640,57 +665,22 @@ static int import_credentials_initrd(ImportCredentialsContext *c) {
         }
 
         FOREACH_ARRAY(entry, de->entries, de->n_entries) {
-                _cleanup_close_ int cfd = -EBADF, nfd = -EBADF;
                 const struct dirent *d = *entry;
-                struct stat st;
 
                 if (!credential_name_valid(d->d_name)) {
                         log_warning("Credential '%s' has invalid name, ignoring.", d->d_name);
                         continue;
                 }
 
-                cfd = openat(source_dir_fd, d->d_name, O_RDONLY|O_CLOEXEC);
-                if (cfd < 0) {
-                        log_warning_errno(errno, "Failed to open %s, ignoring: %m", d->d_name);
-                        continue;
-                }
-
-                if (fstat(cfd, &st) < 0) {
-                        log_warning_errno(errno, "Failed to stat %s, ignoring: %m", d->d_name);
-                        continue;
-                }
-
-                r = stat_verify_regular(&st);
-                if (r < 0) {
-                        log_warning_errno(r, "Credential file %s is not a regular file, ignoring: %m", d->d_name);
-                        continue;
-                }
-
-                if (!credential_size_ok(c, d->d_name, st.st_size))
-                        continue;
-
-                r = acquire_credential_directory(c, SYSTEM_CREDENTIALS_DIRECTORY, /* with_mount= */ true);
+                r = copy_one_credential(c, SYSTEM_CREDENTIALS_DIRECTORY, /* with_mount= */ true,
+                                        source_dir_fd, d->d_name, d->d_name);
                 if (r < 0)
                         return r;
+                if (r > 0) {
+                        log_debug("Successfully copied initrd credential '%s'.", d->d_name);
 
-                nfd = open_credential_file_for_write(c->target_dir_fd, SYSTEM_CREDENTIALS_DIRECTORY, d->d_name);
-                if (nfd == -EEXIST)
-                        continue;
-                if (nfd < 0)
-                        return nfd;
-
-                r = copy_bytes(cfd, nfd, st.st_size, 0);
-                if (r < 0) {
-                        (void) unlinkat(c->target_dir_fd, d->d_name, 0);
-                        return log_error_errno(r, "Failed to create credential '%s': %m", d->d_name);
+                        (void) unlinkat(source_dir_fd, d->d_name, 0);
                 }
-
-                c->size_sum += st.st_size;
-                c->n_credentials++;
-
-                log_debug("Successfully copied initrd credential '%s'.", d->d_name);
-
-                (void) unlinkat(source_dir_fd, d->d_name, 0);
         }
 
         source_dir_fd = safe_close(source_dir_fd);

--- a/src/core/import-creds.c
+++ b/src/core/import-creds.c
@@ -24,6 +24,7 @@
 #include "path-util.h"
 #include "proc-cmdline.h"
 #include "recurse-dir.h"
+#include "rm-rf.h"
 #include "smbios11.h"
 #include "stat-util.h"
 #include "string-util.h"
@@ -65,6 +66,10 @@
  *
  * Net result: the service manager can pick up trusted credentials from $CREDENTIALS_DIRECTORY afterwards,
  * and untrusted ones from $ENCRYPTED_CREDENTIALS_DIRECTORY. */
+
+/* Untrusted/unencrypted firstboot credentials. Get only imported if firstboot is not completed yet. */
+#define FIRSTBOOT_SYSTEM_CREDENTIALS_DIRECTORY "/run/credentials/@firstboot"
+#define FIRSTBOOT_CREDENTIAL_PREFIX "firstboot."
 
 typedef struct ImportCredentialsContext {
         int target_dir_fd;
@@ -229,8 +234,32 @@ static int finalize_credentials_dir(const char *dir, const char *envvar) {
         return 0;
 }
 
+static int boot_credential_is_encrypted(int dir_fd, const char *name) {
+        _cleanup_close_ int fd = -EBADF;
+        sd_id128_t id;
+        ssize_t n;
+
+        assert(dir_fd >= 0);
+        assert(name);
+
+        /* Encrypted credentials have UUID with encryption ID at the start */
+        fd = openat(dir_fd, name, O_RDONLY|O_CLOEXEC);
+        if (fd < 0)
+                return -errno;
+
+        n = pread(fd, &id, sizeof(id), 0);
+        if (n < 0)
+                return -errno;
+        if ((size_t) n < sizeof(id))
+                return false;
+
+        return CRED_KEY_IS_VALID(id);
+}
+
 static int import_credentials_boot(void) {
         _cleanup_(import_credentials_context_done) ImportCredentialsContext context = {
+                .target_dir_fd = -EBADF,
+        }, firstboot_context = {
                 .target_dir_fd = -EBADF,
         };
         int r;
@@ -244,6 +273,9 @@ static int import_credentials_boot(void) {
 
         if (!in_initrd())
                 return 0;
+
+        /* Never stage untrusted plaintext on a CVM, not even in /run. */
+        bool confidential_vm = detect_confidential_virtualization() > 0;
 
         FOREACH_STRING(p,
                        "/.extra/credentials/", /* specific to this boot menu */
@@ -289,8 +321,36 @@ static int import_credentials_boot(void) {
                                 continue;
                         }
 
-                        r = copy_one_credential(&context, ENCRYPTED_SYSTEM_CREDENTIALS_DIRECTORY, /* with_mount= */ false,
-                                                source_dir_fd, d->d_name, n);
+                        /* The boot loader / ESP is an untrusted source. Encrypted credentials are
+                         * authenticated later on read, so they go into the untrusted directory unchanged.
+                         *
+                         * Plaintext credentials are only accepted for the 'firstboot.' namespace. They
+                         * are put into the untrusted FIRSTBOOT_SYSTEM_CREDENTIALS_DIRECTORY directory
+                         * and only imported later if firstboot is not completed. */
+                        ImportCredentialsContext *cc;
+                        const char *dir;
+
+                        r = boot_credential_is_encrypted(source_dir_fd, d->d_name);
+                        if (r < 0) {
+                                log_warning_errno(r, "Failed to determine whether boot credential '%s' is encrypted, ignoring: %m", n);
+                                continue;
+                        }
+                        if (r > 0) {
+                                cc = &context;
+                                dir = ENCRYPTED_SYSTEM_CREDENTIALS_DIRECTORY;
+                        } else if (startswith(n, FIRSTBOOT_CREDENTIAL_PREFIX)) {
+                                if (confidential_vm) {
+                                        log_warning("Confidential VM detected: discarding plaintext firstboot credential '%s' from boot loader.", n);
+                                        continue;
+                                }
+                                cc = &firstboot_context;
+                                dir = FIRSTBOOT_SYSTEM_CREDENTIALS_DIRECTORY;
+                        } else {
+                                log_warning("Plaintext boot credential '%s' is not in the 'firstboot.' namespace, ignoring.", n);
+                                continue;
+                        }
+
+                        r = copy_one_credential(cc, dir, /* with_mount= */ false, source_dir_fd, d->d_name, n);
                         if (r < 0)
                                 return r;
                         if (r > 0)
@@ -305,6 +365,10 @@ static int import_credentials_boot(void) {
                 if (r < 0)
                         return r;
         }
+
+        if (firstboot_context.n_credentials > 0)
+                log_debug("Deferred %u plaintext firstboot credentials from boot loader for later processing.",
+                          firstboot_context.n_credentials);
 
         return 0;
 }
@@ -839,10 +903,94 @@ static void report_credentials(void) {
                  q > 0 ? q : 0);
 }
 
-int import_credentials(void) {
-        const char *received_creds_dir = NULL, *received_encrypted_creds_dir = NULL;
-        bool envvar_set = false;
+static int copy_deferred_firstboot_credentials(int source_dir_fd) {
+        _cleanup_(import_credentials_context_done) ImportCredentialsContext context = {
+                .target_dir_fd = -EBADF,
+        };
+        _cleanup_free_ DirectoryEntries *de = NULL;
         int r;
+
+        assert(source_dir_fd >= 0);
+
+        r = readdir_all(source_dir_fd, RECURSE_DIR_SORT|RECURSE_DIR_IGNORE_DOT, &de);
+        if (r < 0)
+                return log_warning_errno(r, "Failed to read '%s' contents, ignoring: %m", FIRSTBOOT_SYSTEM_CREDENTIALS_DIRECTORY);
+
+        FOREACH_ARRAY(i, de->entries, de->n_entries) {
+                const struct dirent *d = *i;
+
+                if (!credential_name_valid(d->d_name)) {
+                        log_warning("Deferred credential '%s' has invalid name, ignoring.", d->d_name);
+                        continue;
+                }
+
+                if (!startswith(d->d_name, FIRSTBOOT_CREDENTIAL_PREFIX)) {
+                        log_warning("Deferred credential '%s' is outside the 'firstboot.' namespace, ignoring.", d->d_name);
+                        continue;
+                }
+
+                r = copy_one_credential(&context, SYSTEM_CREDENTIALS_DIRECTORY, /* with_mount= */ true,
+                                        source_dir_fd, d->d_name, d->d_name);
+                if (r < 0)
+                        return r;
+                if (r > 0)
+                        log_debug("Promoted firstboot credential '%s' to the trusted store.", d->d_name);
+        }
+
+        if (context.n_credentials == 0)
+                return 0;
+
+        log_debug("Promoted %u plaintext firstboot credentials from boot loader to the trusted store.", context.n_credentials);
+        return finalize_credentials_dir(SYSTEM_CREDENTIALS_DIRECTORY, "CREDENTIALS_DIRECTORY");
+}
+
+static int promote_firstboot_credentials(bool first_boot, const char *received_creds_dir) {
+        _cleanup_close_ int source_dir_fd = -EBADF;
+        int ret = 0;
+
+        /* If firstboot was not run already, this will import credentials from /run/credentials/@firstboot/
+         * into our credentials directory and deletes the @firstboot directory. This is run once after
+         * the initrd → host transition. For confidential VMs import is always skipped. */
+
+        if (in_initrd())
+                return 0;
+
+        source_dir_fd = open(FIRSTBOOT_SYSTEM_CREDENTIALS_DIRECTORY, O_RDONLY|O_DIRECTORY|O_CLOEXEC|O_NOFOLLOW);
+        if (source_dir_fd < 0 && errno == ENOENT)
+                return 0; /* nothing staged */
+
+        /* On other open failures still tear down below, so staged plaintext isn't left behind. */
+        if (source_dir_fd < 0)
+                ret = log_warning_errno(errno, "Failed to open '%s': %m", FIRSTBOOT_SYSTEM_CREDENTIALS_DIRECTORY);
+        else if (!first_boot)
+                log_warning("Not firstboot: discarding plaintext firstboot credentials from boot loader.");
+        else if (detect_confidential_virtualization() > 0)
+                log_warning("Confidential VM detected: discarding plaintext firstboot credentials from boot loader.");
+        else if (received_creds_dir && !path_equal(received_creds_dir, SYSTEM_CREDENTIALS_DIRECTORY))
+                /* Promoting would repoint $CREDENTIALS_DIRECTORY and discard the foreign dir. */
+                log_warning("Foreign $CREDENTIALS_DIRECTORY is set: discarding plaintext firstboot credentials from boot loader.");
+        else
+                ret = copy_deferred_firstboot_credentials(source_dir_fd);
+
+        source_dir_fd = safe_close(source_dir_fd);
+        RET_GATHER(ret, rm_rf(FIRSTBOOT_SYSTEM_CREDENTIALS_DIRECTORY, REMOVE_ROOT|REMOVE_PHYSICAL));
+
+        return ret;
+}
+
+int import_credentials(bool first_boot) {
+        const char *received_creds_dir = NULL, *received_encrypted_creds_dir = NULL;
+        bool envvar_set = false, import;
+        int r;
+
+        /* Checked here so the opt-out also covers the firstboot promotion below. */
+        r = proc_cmdline_get_bool("systemd.import_credentials", PROC_CMDLINE_STRIP_RD_PREFIX|PROC_CMDLINE_TRUE_WHEN_MISSING, &import);
+        if (r < 0)
+                log_debug_errno(r, "Failed to check systemd.import_credentials= kernel command line option, proceeding: %m");
+        else if (!import) {
+                log_notice("systemd.import_credentials=no is set, skipping importing of credentials.");
+                return 0;
+        }
 
         r = get_credentials_dir(&received_creds_dir);
         if (r < 0 && r != -ENXIO) /* ENXIO → env var not set yet */
@@ -874,19 +1022,11 @@ int import_credentials(void) {
                 RET_GATHER(r, merge_credentials_trusted(received_creds_dir));
 
         } else {
-                bool import;
-
-                r = proc_cmdline_get_bool("systemd.import_credentials", PROC_CMDLINE_STRIP_RD_PREFIX|PROC_CMDLINE_TRUE_WHEN_MISSING, &import);
-                if (r < 0)
-                        log_debug_errno(r, "Failed to check systemd.import_credentials= kernel command line option, proceeding: %m");
-                else if (!import) {
-                        log_notice("systemd.import_credentials=no is set, skipping importing of credentials.");
-                        return 0;
-                }
-
                 r = import_credentials_boot();
                 RET_GATHER(r, import_credentials_trusted());
         }
+
+        RET_GATHER(r, promote_firstboot_credentials(first_boot, received_creds_dir));
 
         report_credentials();
 

--- a/src/core/import-creds.h
+++ b/src/core/import-creds.h
@@ -1,4 +1,4 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 #pragma once
 
-int import_credentials(void);
+int import_credentials(bool first_boot);

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -2614,6 +2614,11 @@ static void log_execution_mode(bool *ret_first_boot) {
                         }
                 }
 
+                /* Make the first-boot file visible now: the credential import
+                 * consults in_first_boot() for systemd.credentials_boot_policy= which runs
+                 * before the manager object is created. */
+                (void) update_first_boot_file(first_boot);
+
                 assert_se(uname(&uts) >= 0);
 
                 if (strverscmp_improved(uts.release, KERNEL_BASELINE_VERSION) < 0)

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -2572,7 +2572,7 @@ static int initialize_runtime(
                         /* Pull credentials from various sources into a common credential directory (we do
                          * this here, before setting up the machine ID, so that we can use credential info
                          * for setting up the machine ID) */
-                        (void) import_credentials();
+                        (void) import_credentials(first_boot);
 
                         (void) os_release_status();
                         (void) machine_id_setup(/* root= */ NULL, arg_machine_id,

--- a/src/core/manager.c
+++ b/src/core/manager.c
@@ -4842,19 +4842,30 @@ fail:
 }
 
 void manager_set_first_boot(Manager *m, bool b) {
+        int r;
+
         assert(m);
 
         if (!MANAGER_IS_SYSTEM(m))
                 return;
 
         if (m->first_boot != (int) b) {
-                if (b)
-                        (void) touch("/run/systemd/first-boot");
-                else
-                        (void) unlink("/run/systemd/first-boot");
+                r = update_first_boot_file(b);
+                if (r < 0)
+                        log_warning_errno(r, "Failed to update the first-boot file, ignoring: %m");
         }
 
         m->first_boot = b;
+}
+
+int update_first_boot_file(bool b) {
+        if (b)
+                return touch("/run/systemd/first-boot");
+
+        if (unlink("/run/systemd/first-boot") < 0 && errno != ENOENT)
+                return -errno;
+
+        return 0;
 }
 
 void manager_disable_confirm_spawn(void) {

--- a/src/core/manager.h
+++ b/src/core/manager.h
@@ -719,6 +719,8 @@ void manager_log_caller(Manager *manager, PidRef *caller, const char *method);
 
 int manager_allocate_idle_pipe(Manager *m);
 
+int update_first_boot_file(bool b);
+
 void unit_defaults_init(UnitDefaults *defaults, RuntimeScope scope);
 void unit_defaults_done(UnitDefaults *defaults);
 

--- a/src/random-seed/random-seed-tool.c
+++ b/src/random-seed/random-seed-tool.c
@@ -15,6 +15,7 @@
 #include "fd-util.h"
 #include "format-table.h"
 #include "fs-util.h"
+#include "initrd-util.h"
 #include "io-util.h"
 #include "log.h"
 #include "main-func.h"
@@ -88,8 +89,8 @@ static CreditEntropy may_credit(int seed_fd) {
         /* Don't credit the random seed if we are in first-boot mode, because we are supposed to start from
          * scratch. This is a safety precaution for cases where people ship "golden" images with empty
          * /etc but populated /var that contains a random seed. */
-        r = RET_NERRNO(access("/run/systemd/first-boot", F_OK));
-        if (r == -ENOENT)
+        r = in_first_boot();
+        if (r == 0)
                 /* All is good, we are not in first-boot mode. */
                 return CREDIT_ENTROPY_YES_PLEASE;
         if (r < 0) {

--- a/src/shared/condition.c
+++ b/src/shared/condition.c
@@ -960,28 +960,6 @@ static int condition_test_needs_update(Condition *c, char **env) {
         return timespec_load_nsec(&usr.st_mtim) > timestamp;
 }
 
-static bool in_first_boot(void) {
-        static int first_boot = -1;
-        int r;
-
-        if (first_boot >= 0)
-                return first_boot;
-
-        const char *e = secure_getenv("SYSTEMD_FIRST_BOOT");
-        if (e) {
-                r = parse_boolean(e);
-                if (r < 0)
-                        log_debug_errno(r, "Failed to parse $SYSTEMD_FIRST_BOOT, ignoring: %m");
-                else
-                        return (first_boot = r);
-        }
-
-        r = RET_NERRNO(access("/run/systemd/first-boot", F_OK));
-        if (r < 0 && r != -ENOENT)
-                log_debug_errno(r, "Failed to check if /run/systemd/first-boot exists, assuming no: %m");
-        return r >= 0;
-}
-
 static int condition_test_first_boot(Condition *c, char **env) {
         int r;
 

--- a/src/shared/condition.c
+++ b/src/shared/condition.c
@@ -974,7 +974,7 @@ static int condition_test_first_boot(Condition *c, char **env) {
         if (r < 0)
                 return r;
 
-        return in_first_boot() == r;
+        return (in_first_boot() > 0) == r;
 }
 
 static int condition_test_environment(Condition *c, char **env) {

--- a/src/shared/creds-util.c
+++ b/src/shared/creds-util.c
@@ -1277,7 +1277,10 @@ static int check_null_key_policy(CredentialFlags flags) {
          * exists yet); the decision itself is made in credential_boot_policy_accepts_null(). */
 
         CredentialBootPolicy policy = query_credential_boot_policy();
-        bool first_boot = in_first_boot(), have_tpm2 = efi_has_tpm2(), secure_boot = is_efi_secure_boot();
+
+        bool have_tpm2 = efi_has_tpm2(), secure_boot = is_efi_secure_boot();
+        /* in_first_boot() can return <0 on error: use the safe default in this case (not-first-boot). */
+        bool first_boot = in_first_boot() > 0;
 
         if (!credential_boot_policy_accepts_null(policy, first_boot, have_tpm2, secure_boot))
                 return log_error_errno(SYNTHETIC_ERRNO(EHWPOISON),

--- a/src/shared/creds-util.c
+++ b/src/shared/creds-util.c
@@ -24,6 +24,7 @@
 #include "find-esp.h"
 #include "format-util.h"
 #include "fs-util.h"
+#include "initrd-util.h"
 #include "io-util.h"
 #include "json-util.h"
 #include "log.h"
@@ -31,10 +32,12 @@
 #include "mkdir.h"
 #include "parse-util.h"
 #include "path-util.h"
+#include "proc-cmdline.h"
 #include "random-util.h"
 #include "recurse-dir.h"
 #include "sparse-endian.h"
 #include "stat-util.h"
+#include "string-table.h"
 #include "string-util.h"
 #include "tmpfile-util.h"
 #include "tpm2-pcr.h"
@@ -364,6 +367,39 @@ int get_credential_user_password(const char *username, char **ret_password, bool
         *ret_password = TAKE_PTR(creds_password);
 
         return r;
+}
+
+static const char* const credential_boot_policy_table[_CRED_BOOT_POLICY_MAX] = {
+        [CRED_BOOT_STRICT]  = "strict",
+        [CRED_BOOT_TOFU]    = "tofu",
+        [CRED_BOOT_RELAXED] = "relaxed",
+        [CRED_BOOT_OFF]     = "off",
+};
+
+DEFINE_STRING_TABLE_LOOKUP(credential_boot_policy, CredentialBootPolicy);
+
+bool credential_boot_policy_accepts_null(CredentialBootPolicy policy, bool first_boot, bool have_tpm2, bool secure_boot) {
+
+        /* Decides whether a null-key encrypted credential (which offers neither confidentiality nor
+         * authenticity) may be accepted, given the configured policy and the current system state. */
+
+        switch (policy) {
+
+        case CRED_BOOT_STRICT:
+                return false;
+
+        case CRED_BOOT_TOFU:
+                return first_boot || !have_tpm2;
+
+        case CRED_BOOT_RELAXED:
+                return !secure_boot || !have_tpm2;
+
+        case CRED_BOOT_OFF:
+                return true;
+
+        default:
+                assert_not_reached();
+        }
 }
 
 #if HAVE_OPENSSL
@@ -1195,6 +1231,72 @@ int encrypt_credential_and_warn(
         return 0;
 }
 
+static CredentialBootPolicy query_credential_boot_policy(void) {
+        static CredentialBootPolicy cached = _CRED_BOOT_POLICY_INVALID;
+        _cleanup_free_ char *value = NULL;
+        int r;
+
+        if (cached >= 0)
+                return cached;
+
+        /* default to RELAXED if invalid or unset */
+        cached = CRED_BOOT_RELAXED;
+        r = proc_cmdline_get_key("systemd.credentials_boot_policy", PROC_CMDLINE_STRIP_RD_PREFIX, &value);
+        if (r < 0)
+                log_debug_errno(r, "Failed to read systemd.credentials_boot_policy= from kernel command line, ignoring: %m");
+        else if (r > 0) {
+                CredentialBootPolicy p = credential_boot_policy_from_string(value);
+                if (p < 0)
+                        log_warning("Invalid systemd.credentials_boot_policy= value '%s', ignoring.", value);
+                else
+                        cached = p;
+        }
+
+        return cached;
+}
+
+static int check_null_key_policy(CredentialFlags flags) {
+        if (FLAGS_SET(flags, CREDENTIAL_REFUSE_NULL))
+                return log_error_errno(SYNTHETIC_ERRNO(EHWPOISON),
+                                       "Credential uses null key, but that's not allowed, refusing.");
+
+        if (FLAGS_SET(flags, CREDENTIAL_ALLOW_NULL))
+                return 0;
+
+        /* So this is a credential encrypted with a zero length key. We support this to cover for the
+         * case where neither a host key not a TPM2 are available (specifically: initrd environments
+         * where the host key is not yet accessible and no TPM2 chip exists at all), to minimize
+         * different codeflow for TPM2 and non-TPM2 codepaths. Of course, credentials encoded this
+         * way offer no confidentiality nor authenticity. Because of that it's important we refuse to
+         * use them on systems that actually *do* have a TPM2 chip – if we are in SecureBoot
+         * mode. Otherwise an attacker could hand us credentials like this and we'd use them thinking
+         * they are trusted, even though they are not.
+         *
+         * Which conditions actually lead us to accept a null-key credential is configurable via
+         * systemd.credentials_boot_policy=, which also covers the first boot case (before any key
+         * exists yet); the decision itself is made in credential_boot_policy_accepts_null(). */
+
+        CredentialBootPolicy policy = query_credential_boot_policy();
+        bool first_boot = in_first_boot(), have_tpm2 = efi_has_tpm2(), secure_boot = is_efi_secure_boot();
+
+        if (!credential_boot_policy_accepts_null(policy, first_boot, have_tpm2, secure_boot))
+                return log_error_errno(SYNTHETIC_ERRNO(EHWPOISON),
+                                       "Credential uses null key, but systemd.credentials_boot_policy=%s refuses it here (TPM2=%s, SecureBoot=%s, first boot=%s).",
+                                       credential_boot_policy_to_string(policy),
+                                       yes_no(have_tpm2), yes_no(secure_boot), yes_no(first_boot));
+
+        /* Accepting a null-key credential on a tpm2 host is undesired so keep it auditable */
+        if (have_tpm2 && !first_boot)
+                log_warning("Credential uses null key intended for use when TPM2 is absent, but TPM2 is present! "
+                            "Accepting anyway, under systemd.credentials_boot_policy=%s.",
+                            credential_boot_policy_to_string(policy));
+        else
+                log_debug("Credential uses null key, accepted under systemd.credentials_boot_policy=%s.",
+                          credential_boot_policy_to_string(policy));
+
+        return 0;
+}
+
 int decrypt_credential_and_warn(
                 const char *validate_name,
                 usec_t validate_timestamp,
@@ -1254,29 +1356,9 @@ int decrypt_credential_and_warn(
         }
 
         if (sd_id128_equal(h->id, CRED_AES256_GCM_BY_NULL)) {
-                if (FLAGS_SET(flags, CREDENTIAL_REFUSE_NULL))
-                        return log_error_errno(SYNTHETIC_ERRNO(EHWPOISON),
-                                               "Credential uses null key, but that's not allowed, refusing.");
-
-                if (!FLAGS_SET(flags, CREDENTIAL_ALLOW_NULL)) {
-                        /* So this is a credential encrypted with a zero length key. We support this to cover for the
-                         * case where neither a host key not a TPM2 are available (specifically: initrd environments
-                         * where the host key is not yet accessible and no TPM2 chip exists at all), to minimize
-                         * different codeflow for TPM2 and non-TPM2 codepaths. Of course, credentials encoded this
-                         * way offer no confidentiality nor authenticity. Because of that it's important we refuse to
-                         * use them on systems that actually *do* have a TPM2 chip – if we are in SecureBoot
-                         * mode. Otherwise an attacker could hand us credentials like this and we'd use them thinking
-                         * they are trusted, even though they are not. */
-
-                        if (efi_has_tpm2()) {
-                                if (is_efi_secure_boot())
-                                        return log_error_errno(SYNTHETIC_ERRNO(EHWPOISON),
-                                                               "Credential uses null key intended for fallback use when TPM2 is absent — but TPM2 is present, and SecureBoot is enabled, refusing.");
-
-                                log_warning("Credential uses null key intended for use when TPM2 is absent, but TPM2 is present! Accepting anyway, since SecureBoot is disabled.");
-                        } else
-                                log_debug("Credential uses null key intended for use when TPM2 is absent, and TPM2 indeed is absent. Accepting.");
-                }
+                r = check_null_key_policy(flags);
+                if (r < 0)
+                        return r;
         }
 
         if (CRED_KEY_IS_SCOPED(h->id)) {

--- a/src/shared/creds-util.h
+++ b/src/shared/creds-util.h
@@ -66,6 +66,19 @@ typedef enum CredentialFlags {
         CREDENTIAL_IPC_ALLOW_INTERACTIVE = 1 << 3,
 } CredentialFlags;
 
+typedef enum CredentialBootPolicy {
+        CRED_BOOT_STRICT,   /* never accept a null key */
+        CRED_BOOT_TOFU,     /* accept a null key during first boot or when no TPM2 is available */
+        CRED_BOOT_RELAXED,  /* accept a null key when SecureBoot is off or when no TPM2 is available */
+        CRED_BOOT_OFF,      /* always accept a null key */
+        _CRED_BOOT_POLICY_MAX,
+        _CRED_BOOT_POLICY_INVALID = -EINVAL,
+} CredentialBootPolicy;
+
+DECLARE_STRING_TABLE_LOOKUP(credential_boot_policy, CredentialBootPolicy);
+
+bool credential_boot_policy_accepts_null(CredentialBootPolicy policy, bool first_boot, bool have_tpm2, bool secure_boot);
+
 /* The four modes we support: keyed only by on-disk key, only by TPM2 HMAC key, and by the combination of
  * both, as well as one with a fixed zero length key if TPM2 is missing (the latter of course provides no
  * authenticity or confidentiality, but is still useful for integrity protection, and makes things simpler

--- a/src/test/test-creds.c
+++ b/src/test/test-creds.c
@@ -228,6 +228,35 @@ TEST(credential_encrypt_decrypt) {
                 ASSERT_OK_ERRNO(setenv("SYSTEMD_CREDENTIAL_SECRET", ec, true));
 }
 
+TEST(credential_boot_policy) {
+
+        /* String table round-trip */
+        for (CredentialBootPolicy p = 0; p < _CRED_BOOT_POLICY_MAX; p++) {
+                const char *s = credential_boot_policy_to_string(p);
+                ASSERT_NOT_NULL(s);
+                ASSERT_EQ(credential_boot_policy_from_string(s), p);
+        }
+        ASSERT_STREQ(credential_boot_policy_to_string(CRED_BOOT_TOFU), "tofu");
+        ASSERT_TRUE(credential_boot_policy_from_string("bogus") < 0);
+
+        /* Exhaustively check the accept decision against every (first_boot, have_tpm2, secure_boot) state */
+        for (int first_boot = 0; first_boot < 2; first_boot++)
+                for (int have_tpm2 = 0; have_tpm2 < 2; have_tpm2++)
+                        for (int secure_boot = 0; secure_boot < 2; secure_boot++) {
+                                /* strict never accepts a null key, off always does */
+                                ASSERT_FALSE(credential_boot_policy_accepts_null(CRED_BOOT_STRICT, first_boot, have_tpm2, secure_boot));
+                                ASSERT_TRUE(credential_boot_policy_accepts_null(CRED_BOOT_OFF, first_boot, have_tpm2, secure_boot));
+
+                                /* tofu accepts when first boot, or no TPM2 */
+                                ASSERT_EQ(credential_boot_policy_accepts_null(CRED_BOOT_TOFU, first_boot, have_tpm2, secure_boot),
+                                          first_boot || !have_tpm2);
+
+                                /* relaxed accepts when SecureBoot off, or no TPM2 */
+                                ASSERT_EQ(credential_boot_policy_accepts_null(CRED_BOOT_RELAXED, first_boot, have_tpm2, secure_boot),
+                                          !secure_boot || !have_tpm2);
+                        }
+}
+
 TEST(mime_type_matches) {
 
         static const sd_id128_t tags[] = {

--- a/test/units/TEST-54-CREDS.sh
+++ b/test/units/TEST-54-CREDS.sh
@@ -168,6 +168,48 @@ systemd-creds decrypt /tmp/cred.enc /tmp/cred.dec
 diff /tmp/cred.orig /tmp/cred.dec
 rm -f /tmp/cred.{enc,dec}
 
+# Null-key credentials and the systemd.credentials_boot_policy= setting.
+#
+# A null-key credential ("--with-key=null") is wrapped in the normal systemd-creds
+# envelope but offers neither confidentiality nor authenticity, so whether it is
+# accepted at decrypt time is governed by systemd.credentials_boot_policy= and the system
+# state. We only assert the branches that are deterministic regardless of the test
+# bed's TPM2/SecureBoot state (which is fixed and has no test override here); the
+# full accepts_null() truth table for all states is covered by test-creds.c.
+systemd-creds --name=nullcred --with-key=null encrypt /tmp/cred.orig /tmp/cred.enc
+
+# --allow-null bypasses the policy, even under the strictest setting.
+SYSTEMD_PROC_CMDLINE="systemd.credentials_boot_policy=strict" \
+    systemd-creds --name=nullcred --allow-null decrypt /tmp/cred.enc /tmp/cred.dec
+diff /tmp/cred.orig /tmp/cred.dec
+rm -f /tmp/cred.dec
+
+# --refuse-null always refuses, even under the most permissive setting.
+(! SYSTEMD_PROC_CMDLINE="systemd.credentials_boot_policy=off" \
+    systemd-creds --name=nullcred --refuse-null decrypt /tmp/cred.enc /tmp/cred.dec)
+
+# strict never accepts a null key, regardless of system state.
+(! SYSTEMD_PROC_CMDLINE="systemd.credentials_boot_policy=strict" \
+    systemd-creds --name=nullcred decrypt /tmp/cred.enc /tmp/cred.dec)
+
+# off always accepts a null key, regardless of system state.
+SYSTEMD_PROC_CMDLINE="systemd.credentials_boot_policy=off" \
+    systemd-creds --name=nullcred decrypt /tmp/cred.enc /tmp/cred.dec
+diff /tmp/cred.orig /tmp/cred.dec
+rm -f /tmp/cred.dec
+
+# An invalid policy value falls back to the default (relaxed), which accepts during first boot.
+SYSTEMD_PROC_CMDLINE="systemd.credentials_boot_policy=bogus" SYSTEMD_FIRST_BOOT=1 \
+    systemd-creds --name=nullcred decrypt /tmp/cred.enc /tmp/cred.dec
+diff /tmp/cred.orig /tmp/cred.dec
+rm -f /tmp/cred.dec
+
+# tofu accepts during first boot, independent of TPM2/SecureBoot.
+SYSTEMD_PROC_CMDLINE="systemd.credentials_boot_policy=tofu" SYSTEMD_FIRST_BOOT=1 \
+    systemd-creds --name=nullcred decrypt /tmp/cred.enc /tmp/cred.dec
+diff /tmp/cred.orig /tmp/cred.dec
+rm -f /tmp/cred.{enc,dec}
+
 (! unshare -m bash -exc "mount -t tmpfs tmpfs /run/credentials && systemd-creds list")
 (! unshare -m bash -exc "mount -t tmpfs tmpfs /run/credentials && systemd-creds --system list")
 (! CREDENTIALS_DIRECTORY="" systemd-creds list)


### PR DESCRIPTION
This PR only sets the default to "relaxed" - I can change the default
to "tofu" if desired. But for that we will also need to update the NEWS
file to ensure everyone is aware of this new default.

---

This PR adds a new `systemd.credentials-boot=` kernel
commandline that allows to control if credentials with
a `null` key are accepted.

The possible options are:
* strict: always insist on tpm encryption
* tofu: allow null encryption in firstboot mode and when no tpm is available
* relaxed: allow null encryption when sb is off, or no tpm is available
* off: allow null encryption always

The default is `relaxed` which is exactly the behavior we had before.

This replaces the initial idea of using plaintext credentials
at firstboot (thanks to Lennart for this nicer and simpler design).

---

With that we can drop `- firstboot: optionally accept credentials at firstboot without authentication` from TODO.md