### PR TITLE
network: fix log message

### DIFF
--- a/src/network/networkd-neighbor.c
+++ b/src/network/networkd-neighbor.c
@@ -268,7 +268,7 @@ static void neighbor_forget(Link *link, Neighbor *neighbor, const char *msg) {
                 return;
 
         neighbor_enter_removed(neighbor);
-        log_neighbor_debug(neighbor, "Forgetting", link);
+        log_neighbor_debug(neighbor, msg, link);
         neighbor_detach(neighbor);
 }
 

--- a/src/network/networkd-routing-policy-rule.c
+++ b/src/network/networkd-routing-policy-rule.c
@@ -564,7 +564,7 @@ static void routing_policy_rule_forget(Manager *manager, RoutingPolicyRule *rule
                 return;
 
         routing_policy_rule_enter_removed(rule);
-        log_routing_policy_rule_debug(rule, "Forgetting", NULL, manager);
+        log_routing_policy_rule_debug(rule, msg, NULL, manager);
         routing_policy_rule_detach(rule);
 }
 


### PR DESCRIPTION
Use passed message string, rather than fixed "Forgetting".

Follow-up for a4feabd85d4d136d68ee9c8438eeac86bfd174f6.