### PR TITLE
core: clear pending_reload_message_vl on manager varlink teardown

### DIFF
--- a/src/core/varlink.c
+++ b/src/core/varlink.c
@@ -616,6 +616,8 @@ void manager_varlink_done(Manager *m) {
          * installed (vl_disconnect() above) to be called, where we will unref it too. */
         sd_varlink_close_unref(TAKE_PTR(m->managed_oom_varlink));
 
+        m->pending_reload_message_vl = sd_varlink_unref(m->pending_reload_message_vl);
+
         m->varlink_server = sd_varlink_server_unref(m->varlink_server);
         m->managed_oom_varlink = sd_varlink_close_unref(m->managed_oom_varlink);
 


### PR DESCRIPTION
manager_varlink_done() tore down the varlink server without dropping the queued reload reply, unlike bus_done_api() which unrefs pending_reload_message_dbus. Unref it here too, so the slot consistently mirrors the D-Bus side at teardown.

Follow-up for 55a1b36e91944dd1bc7c0861b69cff20aff8554d

Assisted-by: kres (claude-opus-4-7)
Co-developed-by: Claude Opus 4.8 <noreply@anthropic.com>