### PR TITLE
basic: use assert_se in alloca_safe()

### DIFF
--- a/src/basic/alloc-util.h
+++ b/src/basic/alloc-util.h
@@ -21,7 +21,7 @@
 #define alloca_safe(n)                                                  \
         ({                                                              \
                 size_t _nn_ = (n);                                      \
-                assert(_nn_ <= ALLOCA_MAX);                             \
+                assert_se(_nn_ <= ALLOCA_MAX);                          \
                 alloca(_nn_ == 0 ? 1 : _nn_);                           \
         })                                                              \
 


### PR DESCRIPTION
Ensure it cannot get compiled out regardless of build options

Follow-up for 9e1a759903a3ff9943334d25de19b06afc40c11e

Assisted-by: kres (claude-opus-4-7)