### PR TITLE
journal: fix byte-order conversion in journal_file_append_data()

### DIFF
--- a/src/libsystemd/sd-journal/journal-file.c
+++ b/src/libsystemd/sd-journal/journal-file.c
@@ -1915,7 +1915,7 @@ static int journal_file_append_data(
 
         /* ... and link it in. */
         o->data.next_field_offset = fo->field.head_data_offset;
-        fo->field.head_data_offset = le64toh(p);
+        fo->field.head_data_offset = htole64(p);
 
         if (ret_object)
                 *ret_object = o;


### PR DESCRIPTION
head_data_offset is declared as le64_t in journal-def.h, so it must be assigned with htole64(p), not le64toh(p). All other le64_t field assignments in this file (hash, next_hash_offset) consistently use htole64().

On little-endian systems this makes no difference, but on big-endian systems the field->data link would be stored with incorrect byte order, corrupting journal file traversal.

Assisted-by: claude-opus-4-8 <noreply@anthropic.com>
Signed-off-by: dongshengyuan dongshengyuan@uniontech.com