### PR TITLE
loop-util: shortcut also when invoked on btrfs

### DIFF
--- a/src/shared/loop-util.c
+++ b/src/shared/loop-util.c
@@ -446,6 +446,38 @@ static int probe_sector_size_harder(int fd, uint32_t *ret) {
         return probe_sector_size(probe_fd, ret);
 }
 
+static int fd_is_btrfs(int fd) {
+        _cleanup_close_ int non_direct_io_fd = -EBADF;
+        _cleanup_free_ char *fstype = NULL;
+        int probe_fd, f_flags, r;
+
+        assert(fd >= 0);
+
+        f_flags = fcntl(fd, F_GETFL);
+        if (f_flags < 0)
+                return -errno;
+
+        if (FLAGS_SET(f_flags, O_DIRECT)) {
+                non_direct_io_fd = fd_reopen(fd, O_RDONLY|O_CLOEXEC|O_NONBLOCK);
+                if (non_direct_io_fd < 0)
+                        return non_direct_io_fd;
+
+                probe_fd = non_direct_io_fd;
+        } else
+                probe_fd = fd;
+
+        r = probe_filesystem_full(probe_fd,
+                                  /* path= */ NULL,
+                                  /* offset= */ 0,
+                                  /* size= */ UINT64_MAX,
+                                  /* restrict_fstypes= */ true,
+                                  &fstype);
+        if (r < 0)
+                return r;
+
+        return streq_ptr(fstype, "btrfs");
+}
+
 static int loop_device_can_shortcut(
                 int fd,
                 uint64_t offset,
@@ -457,10 +489,8 @@ static int loop_device_can_shortcut(
         int r;
 
         /* Returns whether we can hand back the original block device fd instead of allocating a real
-         * loopback device for it: it must cover the whole device, the requested sector size must match the
-         * device's sector size, and if partscan was requested it must already be enabled on the device
-         * (otherwise e.g. partition block devices or loop devices created without LO_FLAGS_PARTSCAN would
-         * be reused even though they cannot expose nested partitions). */
+         * loopback device for it: it must cover the whole device and the requested sector size must match
+         * the device's sector size. */
 
         assert(fd >= 0);
 
@@ -475,8 +505,15 @@ static int loop_device_can_shortcut(
                 r = blockdev_partscan_enabled_fd(fd);
                 if (r < 0)
                         return r;
-                if (r == 0)
-                        return false;
+                if (r == 0) {
+                        /* Partscan was requested but isn't enabled, check if we are dealing with btrfs and
+                         * if so avoid a loopdev: https://github.com/systemd/systemd/issues/42520. */
+                        r = fd_is_btrfs(fd);
+                        if (r < 0)
+                                log_debug_errno(r, "Failed to check whether device carries a btrfs file system, ignoring: %m");
+                        if (r <= 0) /* Not btrfs or check didn't work? Do not shortcut */
+                                return false;
+                }
         }
 
         return true;

--- a/src/test/test-loop-util.c
+++ b/src/test/test-loop-util.c
@@ -571,4 +571,44 @@ TEST(partscan_required) {
         loop = loop_device_unref(loop);
 }
 
+TEST(partscan_not_needed_for_btrfs) {
+        _cleanup_(loop_device_unrefp) LoopDevice *block_loop = NULL, *loop = NULL;
+        _cleanup_free_ char *p = NULL, *fstype = NULL;
+        _cleanup_close_ int fd = -EBADF;
+        int r;
+
+        if (have_effective_cap(CAP_SYS_ADMIN) <= 0)
+                return (void) log_tests_skipped("not running privileged");
+
+        if (detect_container() != 0 || running_in_chroot() != 0)
+                return (void) log_tests_skipped("Test not supported in a container/chroot, requires udev/uevent notifications");
+
+        if (ASSERT_OK(mkfs_exists("btrfs")) == 0)
+                return (void) log_tests_skipped("mkfs.btrfs not available");
+
+        ASSERT_OK(tempfn_random_child("/var/tmp", "loop-util", &p));
+        fd = ASSERT_OK_ERRNO(open(p, O_CREAT|O_EXCL|O_RDWR|O_CLOEXEC|O_NOFOLLOW, 0666));
+        ASSERT_OK_ERRNO(ftruncate(fd, 256*1024*1024));
+        ASSERT_OK(make_filesystem(p, "btrfs", "test", /* root= */ NULL, SD_ID128_NULL, MKFS_QUIET,
+                                  /* sector_size= */ 0, /* compression= */ NULL, /* compression_level= */ NULL,
+                                  /* extra_mkfs_args= */ NULL));
+        (void) unlink(p);
+
+        /* The shortcut relies on detection via blkid, which might not be available since it's optional */
+        r = probe_filesystem_full(fd, /* path= */ NULL, /* offset= */ 0, /* size= */ UINT64_MAX, /* restrict_fstypes= */ true, &fstype);
+        if (r < 0)
+                return (void) log_tests_skipped("btrfs file system detection not available");
+        ASSERT_STREQ(fstype, "btrfs");
+
+        /* Set up a backing loop device without LO_FLAGS_PARTSCAN. */
+        ASSERT_OK(loop_device_make(fd, O_RDWR, 0, UINT64_MAX, 0, 0, LOCK_EX, &block_loop));
+        ASSERT_TRUE(block_loop->created);
+        ASSERT_OK(loop_device_flock(block_loop, LOCK_SH));
+
+        /* LO_FLAGS_PARTSCAN is requested but there's no partition table to scan, so the shortcut must be
+         * taken (reuse the device) without using a loopdev */
+        ASSERT_OK(loop_device_make(block_loop->fd, O_RDWR, 0, UINT64_MAX, 0, LO_FLAGS_PARTSCAN, LOCK_SH, &loop));
+        ASSERT_FALSE(loop->created);
+}
+
 DEFINE_TEST_MAIN_WITH_INTRO(LOG_DEBUG, intro);

--- a/test/units/TEST-50-DISSECT.dissect.sh
+++ b/test/units/TEST-50-DISSECT.dissect.sh
@@ -1250,3 +1250,39 @@ rm -rf "$defs" "$imgs"
 (! systemd-run -P -p ExtensionImages="/this/should/definitely/not/exist.img" false)
 (! systemd-run -P -p RootImage="/this/should/definitely/not/exist.img" false)
 (! systemd-run -P -p ExtensionDirectories="/foo/bar /foo/baz" false)
+
+# Ensure a multi-device btrfs doesn't fail to mount due to loopdev
+# https://github.com/systemd/systemd/issues/42520:
+if [[ -f "${BTRFS_MEMBER1:-}" ]]; then
+    img="$(mktemp /var/tmp/test-50-mountimages-btrfs.img.XXXXXXXXXX)"
+    truncate -s 600M "$img"
+    echo -e 'label: gpt\nsize=280MiB, type=0FC63DAF-8483-4772-8E79-3D69D8477DE4, name=data1\ntype=0FC63DAF-8483-4772-8E79-3D69D8477DE4, name=data2' | sfdisk "$img"
+    loop="$(losetup --show -P -f "$img")"
+    udevadm wait --timeout=60 --settle --initialized=no "${loop}p1" "${loop}p2"
+    udevadm lock --timeout=60 --device="$loop" dd if="$BTRFS_MEMBER1" of="${loop}p1" bs=4M
+    udevadm lock --timeout=60 --device="$loop" dd if="$BTRFS_MEMBER2" of="${loop}p2" bs=4M
+    udevadm settle --timeout=60
+    btrfs device scan "${loop}p1" "${loop}p2"
+
+    mnt="$(mktemp -d "$IMAGE_DIR/test-50-mountimages-btrfs.mnt.XXXXXXXXXX")"
+    mount -t btrfs "${loop}p1" "$mnt"
+    btrfs subvolume create "$mnt/@demo"
+    echo "MARKER=1" >"$mnt/@demo/os-release"
+    btrfs subvolume create "$mnt/@"
+    btrfs subvolume set-default "$mnt/@"
+    umount "$mnt"
+    mount -t btrfs "${loop}p1" "$mnt"
+
+    systemd-run -P \
+                -p MountImages="${loop}p1:/run/img-btrfs:subvol=@demo" \
+                cat /run/img-btrfs/os-release | grep -F "MARKER=1" >/dev/null
+    # Double check that there's no loopdev
+    src="$(systemd-run -P \
+                    -p MountImages="${loop}p1:/run/img-btrfs:subvol=@demo" \
+                    findmnt -n -o SOURCE /run/img-btrfs)"
+    assert_eq "${src%%\[*}" "${loop}p1"
+
+    umount "$mnt"
+    losetup -d "$loop"
+    rm -f "$img"
+fi

--- a/test/units/TEST-50-DISSECT.sh
+++ b/test/units/TEST-50-DISSECT.sh
@@ -14,6 +14,8 @@ set -o pipefail
 at_exit() {
     set +e
 
+    rm -f "${BTRFS_MEMBER1:-}" "${BTRFS_MEMBER2:-}"
+
     if [[ -z "${IMAGE_DIR:-}" ]]; then
         return
     fi
@@ -265,6 +267,17 @@ udevadm lock --timeout=60 --device="${loop}p2" dd if="$MINIMAL_IMAGE.verity" of=
 udevadm lock --timeout=60 --device="${loop}p3" dd if="$MINIMAL_IMAGE.verity-sig" of="${loop}p3"
 losetup -d "$loop"
 udevadm settle --timeout=60
+
+# Pre-build the multi-device (raid1) btrfs members as mkfs.btrfs barfs later when there's a bunch of mounts
+# for some reason
+if command -v mkfs.btrfs >/dev/null; then
+    BTRFS_MEMBER1="$(mktemp /var/tmp/test-50-btrfs-member1.XXXXXXXXXX)"
+    BTRFS_MEMBER2="$(mktemp /var/tmp/test-50-btrfs-member2.XXXXXXXXXX)"
+    export BTRFS_MEMBER1
+    export BTRFS_MEMBER2
+    truncate -s 256M "$BTRFS_MEMBER1" "$BTRFS_MEMBER2"
+    mkfs.btrfs -draid1 -mraid1 "$BTRFS_MEMBER1" "$BTRFS_MEMBER2"
+fi
 
 : "Run subtests"
 


### PR DESCRIPTION
MountImages= et al. can be used with btrfs subvolumes that span multiple devices. Using a loopdev for those cases breaks it:

```
Jun 08 20:54:56 systemd[1]: Starting service with a btrfs subvolume mounted...
Jun 08 20:54:56 kernel: loop: module loaded
Jun 08 20:54:56 kernel: loop0: detected capacity change from 0 to 2093056
Jun 08 20:54:56 kernel: BTRFS warning: duplicate device /proc/self/fd/4 devid 2 generation 10 scanned by (ls) (566)
Jun 08 20:54:56 kernel: BTRFS warning: duplicate device /dev/loop0 devid 2 generation 10 scanned by (udev-worker) (572)
Jun 08 20:54:56 (ls)[566]: demo.service: Failed to set up mount namespacing: /run/demo/mnt: File exists
Jun 08 20:54:56 (ls)[566]: demo.service: Failed at step NAMESPACE spawning ls: File exists
Jun 08 20:54:56 systemd[1]: demo.service: Control process exited, code=exited, status=226/NAMESPACE
Jun 08 20:54:56 systemd[1]: demo.service: Failed with result 'exit-code'.
Jun 08 20:54:56 systemd[1]: Failed to start service with a btrfs subvolume mounted.
```

If the fd is a btrfs volume, then shortcut and use it directly, as a loop device is not needed.

Fixes https://github.com/systemd/systemd/issues/42520

Follow-up for 663f0bf5cb79ecaf6dd71441ecdc9dc401e7eae6

Co-developed-by: Claude Opus 4.8 <noreply@anthropic.com>