### PR TITLE
kernel-install: `env` verb

### DIFF
--- a/man/kernel-install.xml
+++ b/man/kernel-install.xml
@@ -52,6 +52,14 @@
     <cmdsynopsis>
       <command>kernel-install</command>
       <arg choice="opt" rep="repeat">OPTIONS</arg>
+      <arg choice="plain">env</arg>
+      <arg choice="opt"><replaceable>KERNEL-VERSION</replaceable></arg>
+      <arg choice="opt"><replaceable>KERNEL-IMAGE</replaceable></arg>
+      <arg choice="opt" rep="repeat"><replaceable>INITRD-FILE</replaceable></arg>
+    </cmdsynopsis>
+    <cmdsynopsis>
+      <command>kernel-install</command>
+      <arg choice="opt" rep="repeat">OPTIONS</arg>
       <arg choice="plain">list</arg>
     </cmdsynopsis>
   </refsynopsisdiv>
@@ -253,6 +261,23 @@
           of this verb as a JSON object.</para>
 
           <xi:include href="version-info.xml" xpointer="v251"/>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>
+          <command>env [[[<replaceable>KERNEL-VERSION</replaceable>] <replaceable>KERNEL-IMAGE</replaceable>] [<replaceable>INITRD-FILE</replaceable> ...]]</command>
+        </term>
+        <listitem>
+          <para>Takes the same parameters as <command>add</command>.</para>
+
+          <para>Prints the environment variables that would be passed to plugins as shell-compatible
+          variable assignments, suitable for sourcing in shell scripts via
+          <command>eval $(kernel-install env)</command>. This is useful for external scripts that
+          need to access the same paths and settings that <command>kernel-install</command> plugins
+          use, such as <varname>$KERNEL_INSTALL_BOOT_ROOT</varname>, without reimplementing the
+          discovery logic.</para>
+
+          <xi:include href="version-info.xml" xpointer="v261"/>
         </listitem>
       </varlistentry>
       <varlistentry>

--- a/man/kernel-install.xml
+++ b/man/kernel-install.xml
@@ -52,6 +52,14 @@
     <cmdsynopsis>
       <command>kernel-install</command>
       <arg choice="opt" rep="repeat">OPTIONS</arg>
+      <arg choice="plain">env</arg>
+      <arg choice="opt"><replaceable>KERNEL-VERSION</replaceable></arg>
+      <arg choice="opt"><replaceable>KERNEL-IMAGE</replaceable></arg>
+      <arg choice="opt" rep="repeat"><replaceable>INITRD-FILE</replaceable></arg>
+    </cmdsynopsis>
+    <cmdsynopsis>
+      <command>kernel-install</command>
+      <arg choice="opt" rep="repeat">OPTIONS</arg>
       <arg choice="plain">list</arg>
     </cmdsynopsis>
   </refsynopsisdiv>
@@ -253,6 +261,23 @@
           of this verb as a JSON object.</para>
 
           <xi:include href="version-info.xml" xpointer="v251"/>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>
+          <command>env [[[<replaceable>KERNEL-VERSION</replaceable>] <replaceable>KERNEL-IMAGE</replaceable>] [<replaceable>INITRD-FILE</replaceable> ...]]</command>
+        </term>
+        <listitem>
+          <para>Takes the same parameters as <command>inspect</command>.</para>
+
+          <para>Prints the environment variables that would be passed to plugins as shell-compatible
+          variable assignments, suitable for sourcing in shell scripts via
+          <command>eval $(kernel-install env)</command>. This is useful for external scripts that
+          need to access the same paths and settings that <command>kernel-install</command> plugins
+          use, such as <varname>$KERNEL_INSTALL_BOOT_ROOT</varname>, without reimplementing the
+          discovery logic.</para>
+
+          <xi:include href="version-info.xml" xpointer="v261"/>
         </listitem>
       </varlistentry>
       <varlistentry>

--- a/src/kernel-install/kernel-install.c
+++ b/src/kernel-install/kernel-install.c
@@ -15,6 +15,7 @@
 #include "dissect-image.h"
 #include "env-file.h"
 #include "env-util.h"
+#include "escape.h"
 #include "exec-util.h"
 #include "extract-word.h"
 #include "fd-util.h"
@@ -1465,6 +1466,72 @@ static int verb_inspect(int argc, char *argv[], uintptr_t _data, void *userdata)
         }
 
         return table_print_with_pager(t, arg_json_format_flags, arg_pager_flags, /* show_header= */ false);
+}
+
+VERB(verb_env, "env", "[[[KERNEL-VERSION] KERNEL-IMAGE] [INITRD ...]]", 1, VERB_ANY, 0,
+     "Print environment variables passed to plugins");
+static int verb_env(int argc, char *argv[], uintptr_t _data, void *userdata) {
+        _cleanup_free_ char *vmlinuz = NULL;
+        const char *version, *kernel;
+        char **initrds;
+        struct utsname un;
+        int r;
+
+        _cleanup_(context_done) Context c = CONTEXT_NULL;
+        r = context_from_cmdline(&c, ACTION_INSPECT);
+        if (r < 0)
+                return r;
+
+        /* See comment in verb_inspect() for why kernel image is the first optional arg, not the version. */
+        version = argc > 2 ? empty_or_dash_to_null(argv[1]) : NULL;
+        kernel = argc > 2 ? empty_or_dash_to_null(argv[2]) :
+                (argc > 1 ? empty_or_dash_to_null(argv[1]) : NULL);
+        initrds = strv_skip(argv, 3);
+
+        if (!version && !arg_root) {
+                assert_se(uname(&un) >= 0);
+                version = un.release;
+        }
+
+        if (!kernel && version) {
+                r = kernel_from_version(version, &vmlinuz);
+                if (r < 0)
+                        return r;
+
+                kernel = vmlinuz;
+        }
+
+        r = context_set_version(&c, version);
+        if (r < 0)
+                return r;
+
+        r = context_set_kernel(&c, kernel);
+        if (r < 0)
+                return r;
+
+        r = context_set_initrds(&c, initrds);
+        if (r < 0)
+                return r;
+
+        r = context_prepare_execution(&c);
+        if (r < 0)
+                return r;
+
+        STRV_FOREACH(e, c.envp) {
+                const char *sep;
+                _cleanup_free_ char *esc = NULL;
+
+                sep = strchr(*e, '=');
+                assert(sep); /* strv_env_assign_many() always produces KEY=VALUE */
+
+                esc = shell_maybe_quote(sep + 1, SHELL_ESCAPE_POSIX);
+                if (!esc)
+                        return log_oom();
+
+                printf("%.*s=%s\n", (int)(sep - *e), *e, esc);
+        }
+
+        return 0;
 }
 
 VERB_NOARG(verb_list, "list",

--- a/src/kernel-install/kernel-install.c
+++ b/src/kernel-install/kernel-install.c
@@ -1353,30 +1353,25 @@ static int verb_remove(int argc, char *argv[], uintptr_t _data, void *userdata) 
         return context_execute(&c);
 }
 
-VERB(verb_inspect, "inspect", "[[[KERNEL-VERSION] KERNEL-IMAGE] [INITRD ...]]", 1, VERB_ANY, VERB_DEFAULT,
-     "Print details about the installation");
-static int verb_inspect(int argc, char *argv[], uintptr_t _data, void *userdata) {
-        _cleanup_(table_unrefp) Table *t = NULL;
+/* When only a single parameter is specified for 'inspect'/'env' it's the kernel image path, and not the
+ * kernel version. i.e. it's the first argument that is optional, not the 2nd. That's a bit unfortunate, but
+ * we keep the behaviour for compatibility. If users want to specify only the version (and have the kernel
+ * image path derived automatically), then they may specify an empty string or "dash" as kernel image path. */
+static int context_init_from_argv(Context *c, int argc, char *argv[]) {
         _cleanup_free_ char *vmlinuz = NULL;
         const char *version, *kernel;
-        char **initrds;
         struct utsname un;
         int r;
 
-        _cleanup_(context_done) Context c = CONTEXT_NULL;
-        r = context_from_cmdline(&c, ACTION_INSPECT);
+        assert(c);
+
+        r = context_from_cmdline(c, ACTION_INSPECT);
         if (r < 0)
                 return r;
 
-        /* When only a single parameter is specified 'inspect' it's the kernel image path, and not the kernel
-         * version. i.e. it's the first argument that is optional, not the 2nd. That's a bit unfortunate, but
-         * we keep the behaviour for compatibility. If users want to specify only the version (and have the
-         * kernel image path derived automatically), then they may specify an empty string or "dash" as
-         * kernel image path. */
         version = argc > 2 ? empty_or_dash_to_null(argv[1]) : NULL;
         kernel = argc > 2 ? empty_or_dash_to_null(argv[2]) :
                 (argc > 1 ? empty_or_dash_to_null(argv[1]) : NULL);
-        initrds = strv_skip(argv, 3);
 
         if (!version && !arg_root) {
                 assert_se(uname(&un) >= 0);
@@ -1391,19 +1386,29 @@ static int verb_inspect(int argc, char *argv[], uintptr_t _data, void *userdata)
                 kernel = vmlinuz;
         }
 
-        r = context_set_version(&c, version);
+        r = context_set_version(c, version);
         if (r < 0)
                 return r;
 
-        r = context_set_kernel(&c, kernel);
+        r = context_set_kernel(c, kernel);
         if (r < 0)
                 return r;
 
-        r = context_set_initrds(&c, initrds);
+        r = context_set_initrds(c, strv_skip(argv, 3));
         if (r < 0)
                 return r;
 
-        r = context_prepare_execution(&c);
+        return context_prepare_execution(c);
+}
+
+VERB(verb_inspect, "inspect", "[[[KERNEL-VERSION] KERNEL-IMAGE] [INITRD ...]]", 1, VERB_ANY, VERB_DEFAULT,
+     "Print details about the installation");
+static int verb_inspect(int argc, char *argv[], uintptr_t _data, void *userdata) {
+        _cleanup_(table_unrefp) Table *t = NULL;
+        int r;
+
+        _cleanup_(context_done) Context c = CONTEXT_NULL;
+        r = context_init_from_argv(&c, argc, argv);
         if (r < 0)
                 return r;
 
@@ -1471,49 +1476,10 @@ static int verb_inspect(int argc, char *argv[], uintptr_t _data, void *userdata)
 VERB(verb_env, "env", "[[[KERNEL-VERSION] KERNEL-IMAGE] [INITRD ...]]", 1, VERB_ANY, 0,
      "Print environment variables passed to plugins");
 static int verb_env(int argc, char *argv[], uintptr_t _data, void *userdata) {
-        _cleanup_free_ char *vmlinuz = NULL;
-        const char *version, *kernel;
-        char **initrds;
-        struct utsname un;
         int r;
 
         _cleanup_(context_done) Context c = CONTEXT_NULL;
-        r = context_from_cmdline(&c, ACTION_INSPECT);
-        if (r < 0)
-                return r;
-
-        /* See comment in verb_inspect() for why kernel image is the first optional arg, not the version. */
-        version = argc > 2 ? empty_or_dash_to_null(argv[1]) : NULL;
-        kernel = argc > 2 ? empty_or_dash_to_null(argv[2]) :
-                (argc > 1 ? empty_or_dash_to_null(argv[1]) : NULL);
-        initrds = strv_skip(argv, 3);
-
-        if (!version && !arg_root) {
-                assert_se(uname(&un) >= 0);
-                version = un.release;
-        }
-
-        if (!kernel && version) {
-                r = kernel_from_version(version, &vmlinuz);
-                if (r < 0)
-                        return r;
-
-                kernel = vmlinuz;
-        }
-
-        r = context_set_version(&c, version);
-        if (r < 0)
-                return r;
-
-        r = context_set_kernel(&c, kernel);
-        if (r < 0)
-                return r;
-
-        r = context_set_initrds(&c, initrds);
-        if (r < 0)
-                return r;
-
-        r = context_prepare_execution(&c);
+        r = context_init_from_argv(&c, argc, argv);
         if (r < 0)
                 return r;
 

--- a/src/kernel-install/test-kernel-install.sh
+++ b/src/kernel-install/test-kernel-install.sh
@@ -329,6 +329,33 @@ diff -u <(echo "$output") - >&2 <<EOF
 EOF
 
 ###########################################
+# tests for env
+###########################################
+output="$("$kernel_install" -v env 1.1.1 "$D/sources/linux")"
+
+diff -u <(echo "$output") - >&2 <<EOF
+LC_COLLATE=$SYSTEMD_DEFAULT_LOCALE
+KERNEL_INSTALL_VERBOSE=1
+KERNEL_INSTALL_IMAGE_TYPE=unknown
+KERNEL_INSTALL_MACHINE_ID=3e0484f3634a418b8e6a39e8828b03e3
+KERNEL_INSTALL_ENTRY_TOKEN=the-token
+KERNEL_INSTALL_BOOT_ROOT=$BOOT_ROOT
+KERNEL_INSTALL_LAYOUT=other
+KERNEL_INSTALL_INITRD_GENERATOR=none
+KERNEL_INSTALL_UKI_GENERATOR=
+KERNEL_INSTALL_STAGING_AREA=${TMPDIR:-/var/tmp}/kernel-install.staging.XXXXXX
+EOF
+
+# test that values with shell specials are quoted
+spaced_boot_root="$D/boot (with spaces & 'quotes')"
+mkdir -p "$spaced_boot_root"
+output="$(BOOT_ROOT="$spaced_boot_root" "$kernel_install" -v env 1.1.1 "$D/sources/linux")"
+
+echo "$output" | grep >/dev/null "^KERNEL_INSTALL_BOOT_ROOT=\\\$'"
+eval "$(echo "$output" | grep '^KERNEL_INSTALL_BOOT_ROOT=')"
+test "$KERNEL_INSTALL_BOOT_ROOT" = "$spaced_boot_root"
+
+###########################################
 # tests for propagation of plugin failure (issue #30087)
 ###########################################
 cat >"$D/00-plugin-skip" <<EOF


### PR DESCRIPTION
Add an `env` verb to the `kernel-install` executable. This verb can be used to directly source the environment `kernel-install` sets up for plugins in external scripts.

For example:

```
eval $(kernel-install env)
```

The usecase here is that `kernel-install` has logic to determine a bunch of variables (most importantly to me `KERNEL_INSTALL_BOOT_ROOT`) including overriding these (through `BOOT_ROOT`).

I have packages which need to copy firmware files into the ESP, currently in Fedora the ESP path is hardcoded in a separate package which means I have to rebuild them and the ESP mountpoint can't be changed at runtime.

My (kinda funky) idea is to instead install the files into `/usr` which is always a good idea and then to move them into the correct places in a post-trans scriptlet.

I don't want to re-implement the BOOT_ROOT finding logic that kernel-install already provides; thus this commit so I can `eval` the result of the new subcommand.

The added value here is perhaps minor; as I could also require `jq` at build time and parse the output of `inspect --json=...`. The added convenience is however quite large.

As for why the moving of this firmware wouldn't be a `kernel-install` plugin by itself; that would couple firmware updates to kernel updates instead of to the firmware package being updated.