### PR TITLE
sysupdate: refuse reboot/pending logic when --component= is used

### DIFF
--- a/man/systemd-sysupdate.xml
+++ b/man/systemd-sysupdate.xml
@@ -239,7 +239,9 @@
         updated together in a synchronous fashion. Simply define multiple transfer files within the same
         <filename>sysupdate.d/</filename> directory for these cases.</para>
 
-        <para>This option may not be combined with <option>--definitions=</option>.</para>
+        <para>This option may not be combined with <option>--definitions=</option>, nor with the
+        <command>pending</command> and <command>reboot</command> commands or the <option>--reboot</option>
+        switch, which only apply to the booted OS version.</para>
 
         <xi:include href="version-info.xml" xpointer="v251"/></listitem>
       </varlistentry>
@@ -314,7 +316,8 @@
         <term><option>--reboot</option></term>
 
         <listitem><para>When used in combination with the <command>update</command> commands and a new version is
-        installed, automatically reboots the system immediately afterwards.</para>
+        installed, automatically reboots the system immediately afterwards. This switch may not be combined with
+        <option>--component=</option>, as it only applies to the booted OS version.</para>
 
         <xi:include href="version-info.xml" xpointer="v251"/></listitem>
       </varlistentry>

--- a/src/sysupdate/sysupdate.c
+++ b/src/sysupdate/sysupdate.c
@@ -1555,10 +1555,6 @@ static int verb_update_impl(int argc, char **argv, UpdateActionFlags action_flag
                 return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
                                       "The --instances-max argument must be >= 2 while updating");
 
-        if (arg_reboot && arg_component)
-                return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
-                                       "The --reboot switch may not be combined with --component=, as automatic reboots only apply to the booted OS version.");
-
         if (arg_reboot) {
                 /* If automatic reboot on completion is requested, let's first determine the currently booted image */
 
@@ -2022,6 +2018,9 @@ static int parse_argv(int argc, char *argv[], char ***remaining_args) {
 
         if ((arg_image || arg_root) && arg_reboot)
                 return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "The --reboot switch may not be combined with --root= or --image=.");
+
+        if (arg_reboot && arg_component)
+                return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "The --reboot switch may not be combined with --component=, as automatic reboots only apply to the booted OS version.");
 
         if (arg_definitions && arg_component)
                 return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "The --definitions= and --component= switches may not be combined.");

--- a/src/sysupdate/sysupdate.c
+++ b/src/sysupdate/sysupdate.c
@@ -1555,6 +1555,10 @@ static int verb_update_impl(int argc, char **argv, UpdateActionFlags action_flag
                 return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
                                       "The --instances-max argument must be >= 2 while updating");
 
+        if (arg_reboot && arg_component)
+                return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
+                                       "The --reboot switch may not be combined with --component=, as automatic reboots only apply to the booted OS version.");
+
         if (arg_reboot) {
                 /* If automatic reboot on completion is requested, let's first determine the currently booted image */
 
@@ -1663,6 +1667,10 @@ static int verb_pending_or_reboot(int argc, char *argv[], uintptr_t _data, void 
         if (arg_image || arg_root)
                 return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
                                        "The --root=/--image= switches may not be combined with the '%s' operation.", argv[0]);
+
+        if (arg_component)
+                return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
+                                       "The --component= switch may not be combined with the '%s' operation, which only applies to the booted OS version.", argv[0]);
 
         r = context_make_offline(&context, /* node= */ NULL,
                                  READ_DEFINITIONS_REQUIRES_ENABLED_TRANSFERS | READ_DEFINITIONS_REQUIRES_ANY_TRANSFERS);

--- a/test/units/TEST-72-SYSUPDATE.sh
+++ b/test/units/TEST-72-SYSUPDATE.sh
@@ -579,6 +579,15 @@ EOF
 mkdir /run/sysupdate.d
 "$SYSUPDATE" --json=short components | grep -F '{"default":false,"components":["some-component"]}' >/dev/null
 
+# Regression test for https://github.com/systemd/systemd/issues/42330 — the
+# 'pending'/'reboot' verbs and the '--reboot' switch compare the newest installed
+# version against the booted OS version (IMAGE_VERSION= from os-release), which is
+# unrelated to component versions. Selecting a component must therefore be refused
+# rather than silently performing a bogus comparison.
+(! "$SYSUPDATE" --component=some-component pending)
+(! "$SYSUPDATE" --component=some-component reboot)
+(! "$SYSUPDATE" --component=some-component update --reboot)
+
 # Clean up regression test
 rmdir /run/sysupdate.d
 rm -rf /run/sysupdate.some-component.d

--- a/test/units/TEST-72-SYSUPDATE.sh
+++ b/test/units/TEST-72-SYSUPDATE.sh
@@ -584,9 +584,9 @@ mkdir /run/sysupdate.d
 # version against the booted OS version (IMAGE_VERSION= from os-release), which is
 # unrelated to component versions. Selecting a component must therefore be refused
 # rather than silently performing a bogus comparison.
-(! "$SYSUPDATE" --component=some-component pending)
-(! "$SYSUPDATE" --component=some-component reboot)
-(! "$SYSUPDATE" --component=some-component update --reboot)
+(! "$SYSUPDATE" --component=some-component pending) |& grep -F 'may not be combined' >/dev/null
+(! "$SYSUPDATE" --component=some-component reboot) |& grep -F 'may not be combined' >/dev/null
+(! "$SYSUPDATE" --component=some-component update --reboot) |& grep -F 'may not be combined' >/dev/null
 
 # Clean up regression test
 rmdir /run/sysupdate.d


### PR DESCRIPTION
Fixes #42330

The `pending` and `reboot` verbs, and the `--reboot` switch, decide whether to reboot by comparing the newest installed version against the booted OS version (`IMAGE_VERSION=` from os-release). When a component is selected via
`--component=`, this ends up comparing the component's version against the unrelated host OS version; by design these live in separate version spaces, so the comparison is meaningless and reboot decisions become arbitrary: depending on the relative version strings, sysupdate either always reboots or never does.

### Example from the issue:

% /usr/lib/systemd/systemd-sysupdate --component=containerd reboot
Newest installed version '2.3.0' is older than booted version '20260527200656'.

This refuses the combination with a clear error instead of silently performing a bogus comparison:

- `verb_pending_or_reboot()` rejects `--component=` for the `pending`/`reboot` verbs (mirroring the existing `--root=`/`--image=` rejection).
- `verb_update_impl()` rejects `--reboot` combined with `--component=`, before any update work is done.

Correctly tracking a per-component "booted" version (which could be "none", making a reboot always apply) is a larger feature and left for the future, as the reporter suggested.

The daemon (`sysupdated`) and `updatectl` don't perform this host-version comparison, so the change is confined to the `systemd-sysupdate` CLI.

Documentation and a negative regression test (TEST-72) are included.

### AI-use Disclosure:

I took assistance from Claude Opus 4.8 to scope out the issue, help with writing proper comments/documentation, and help with writing the PR description.