### PR TITLE
hwdb: add IMDS properties for Vultr

### DIFF
--- a/hwdb.d/40-imds.hwdb
+++ b/hwdb.d/40-imds.hwdb
@@ -129,3 +129,15 @@ dmi:*:svnAlibabaCloud:*
  IMDS_KEY_IPV4_PUBLIC=/meta-data/eipv4
  IMDS_KEY_SSH_KEY=/meta-data/public-keys/0/openssh-key
  IMDS_KEY_USERDATA=/user-data
+
+# https://www.vultr.com/metadata/
+dmi:bvnVultr:*
+ IMDS_VENDOR=vultr
+ IMDS_DATA_URL=http://169.254.169.254
+ IMDS_ADDRESS_IPV4=169.254.169.254
+ IMDS_KEY_HOSTNAME=/v1/hostname
+ IMDS_KEY_REGION=/v1/region/regioncode
+ IMDS_KEY_IPV4_PUBLIC=/v1/interfaces/0/ipv4/address
+ IMDS_KEY_IPV6_PUBLIC=/v1/interfaces/0/ipv6/address
+ IMDS_KEY_SSH_KEY=/v1/public-keys
+ IMDS_KEY_USERDATA=/user-data/user-data


### PR DESCRIPTION
This PR adds IMDS entries for Vultr.

```console
$ cat /sys/devices/virtual/dmi/id/modalias
dmi:bvnVultr:bvr:bd:br0.0:svnVultr:pnVC2:pvrpc-q35-8.2:cvnQEMU:ct1:cvrpc-q35-8.2:sku:
```

Tested on a Vultr instance with the following `User-Data`:
```
#systemd-userdata
{"systemd.credentials": [{"name": "login.issue", "text": "Hello world from user-data"}]}
```

resulted in:

```console
$ cat /run/credstore/firstboot.hostname
systemd-imds-test
```

```console
$ cat /run/systemd/resolve/static.d/imds-public.rr 
[{"key":{"class":1,"type":1,"name":"_public"},"address":[45,76,195,18]},{"key":{"class":1,"type":28,"name":"_public"},"address":[36,1,192,128,16,0,42,144,84,0,6,255,254,63,172,122]}]
```

```console
$ cat /run/credstore/ssh.authorized_keys.root
ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIAXXPT4CkTISCXiDDlFWCYIJczLV+Hzp4rquLHudGNu
```

```console
$ cat /run/credstore/login.issue
Hello world from user-data
```