### PR TITLE
report: place Upload() on io.systemd.Report.Uploader rather than io.sys…

### DIFF
--- a/man/systemd-report.xml
+++ b/man/systemd-report.xml
@@ -89,7 +89,7 @@
         <literal>https://</literal> URL is specified with <option>--url=</option>, an HTTP upload will be
         performed to the specified location. Otherwise, any sockets under
         <filename>/run/systemd/metrics-upload/</filename> will be used to call
-        <function>io.systemd.Report.Upload()</function>.</para>
+        <function>io.systemd.Report.Uploader.Upload()</function>.</para>
 
         <para>Match expressions supported by <command>metrics</command> are supported here too.</para>
 

--- a/man/systemd-report.xml
+++ b/man/systemd-report.xml
@@ -89,7 +89,7 @@
         <literal>https://</literal> URL is specified with <option>--url=</option>, an HTTP upload will be
         performed to the specified location. Otherwise, any sockets under
         <filename>/run/systemd/metrics-upload/</filename> will be used to call
-        <function>io.systemd.Report.Upload()</function>.</para>
+        <function>io.systemd.Report.Upload.Upload()</function>.</para>
 
         <para>Match expressions supported by <command>metrics</command> are supported here too.</para>
 

--- a/man/systemd-report.xml
+++ b/man/systemd-report.xml
@@ -88,7 +88,7 @@
         to an external server. Two upload mechanisms are supported. If an <literal>http://</literal> or
         <literal>https://</literal> URL is specified with <option>--url=</option>, an HTTP upload will be
         performed to the specified location. Otherwise, any sockets under
-        <filename>/run/systemd/metrics-upload/</filename> will be used to call
+        <filename>/run/systemd/report.upload/</filename> will be used to call
         <function>io.systemd.Report.Upload.Upload()</function>.</para>
 
         <para>Match expressions supported by <command>metrics</command> are supported here too.</para>

--- a/man/systemd-report.xml
+++ b/man/systemd-report.xml
@@ -88,7 +88,7 @@
         to an external server. Two upload mechanisms are supported. If an <literal>http://</literal> or
         <literal>https://</literal> URL is specified with <option>--url=</option>, an HTTP upload will be
         performed to the specified location. Otherwise, any sockets under
-        <filename>/run/systemd/metrics-upload/</filename> will be used to call
+        <filename>/run/systemd/report.upload/</filename> will be used to call
         <function>io.systemd.Report.Uploader.Upload()</function>.</para>
 
         <para>Match expressions supported by <command>metrics</command> are supported here too.</para>

--- a/src/report/report-upload.c
+++ b/src/report/report-upload.c
@@ -249,7 +249,7 @@ static int upload_collected(Context *context, sd_json_variant *report) {
 
         ssize_t jobs = varlink_execute_directory(
                         REPORT_UPLOAD_DIR,
-                        "io.systemd.Report.Upload",
+                        "io.systemd.Report.Upload.Upload",
                         params,
                         /* more= */ false,
                         arg_network_timeout_usec,

--- a/src/report/report-upload.c
+++ b/src/report/report-upload.c
@@ -249,7 +249,7 @@ static int upload_collected(Context *context, sd_json_variant *report) {
 
         ssize_t jobs = varlink_execute_directory(
                         REPORT_UPLOAD_DIR,
-                        "io.systemd.Report.Upload",
+                        "io.systemd.Report.Uploader.Upload",
                         params,
                         /* more= */ false,
                         arg_network_timeout_usec,

--- a/src/report/report.h
+++ b/src/report/report.h
@@ -9,7 +9,7 @@
 #define REPORT_CERT_FILE     CERTIFICATE_ROOT "/certs/systemd-report.pem"
 #define REPORT_TRUST_FILE    CERTIFICATE_ROOT "/ca/trusted.pem"
 
-#define REPORT_UPLOAD_DIR "/run/systemd/metrics-upload"
+#define REPORT_UPLOAD_DIR "/run/systemd/report.upload"
 
 extern sd_json_format_flags_t arg_json_format_flags;
 extern char *arg_url, *arg_key, *arg_cert, *arg_trust;


### PR DESCRIPTION
…temd.Report interface

We really want to use io.systemd.Report for the interface provided by systemd-report itself, not by its backend. hence, rename the interface that uploading plugins shall implement to io.systemd.Report.Uploader.

Note that we ideally should have a varlink interface definition for that interface. if we had, we'd have noticed that earlier.