### PR TITLE
test-varlink-idl: add missing IDL files to test-varlink-idl

### DIFF
--- a/src/libsystemd/sd-varlink/test-varlink-idl.c
+++ b/src/libsystemd/sd-varlink/test-varlink-idl.c
@@ -31,8 +31,10 @@
 #include "varlink-io.systemd.Login.h"
 #include "varlink-io.systemd.Machine.h"
 #include "varlink-io.systemd.MachineImage.h"
+#include "varlink-io.systemd.MachineInstance.h"
 #include "varlink-io.systemd.ManagedOOM.h"
 #include "varlink-io.systemd.Manager.h"
+#include "varlink-io.systemd.Metrics.h"
 #include "varlink-io.systemd.MountFileSystem.h"
 #include "varlink-io.systemd.MuteConsole.h"
 #include "varlink-io.systemd.NamespaceResource.h"
@@ -44,10 +46,12 @@
 #include "varlink-io.systemd.Resolve.h"
 #include "varlink-io.systemd.Resolve.Hook.h"
 #include "varlink-io.systemd.Resolve.Monitor.h"
+#include "varlink-io.systemd.Shutdown.h"
 #include "varlink-io.systemd.StorageProvider.h"
 #include "varlink-io.systemd.Udev.h"
 #include "varlink-io.systemd.Unit.h"
 #include "varlink-io.systemd.UserDatabase.h"
+#include "varlink-io.systemd.VirtualMachineInstance.h"
 #include "varlink-io.systemd.oom.h"
 #include "varlink-io.systemd.oom.Prekill.h"
 #include "varlink-io.systemd.service.h"
@@ -200,8 +204,10 @@ TEST(parse_format) {
                 &vl_interface_io_systemd_Login,
                 &vl_interface_io_systemd_Machine,
                 &vl_interface_io_systemd_MachineImage,
+                &vl_interface_io_systemd_MachineInstance,
                 &vl_interface_io_systemd_ManagedOOM,
                 &vl_interface_io_systemd_Manager,
+                &vl_interface_io_systemd_Metrics,
                 &vl_interface_io_systemd_MountFileSystem,
                 &vl_interface_io_systemd_MuteConsole,
                 &vl_interface_io_systemd_NamespaceResource,
@@ -213,10 +219,12 @@ TEST(parse_format) {
                 &vl_interface_io_systemd_Resolve,
                 &vl_interface_io_systemd_Resolve_Hook,
                 &vl_interface_io_systemd_Resolve_Monitor,
+                &vl_interface_io_systemd_Shutdown,
                 &vl_interface_io_systemd_StorageProvider,
                 &vl_interface_io_systemd_Udev,
                 &vl_interface_io_systemd_Unit,
                 &vl_interface_io_systemd_UserDatabase,
+                &vl_interface_io_systemd_VirtualMachineInstance,
                 &vl_interface_io_systemd_oom,
                 &vl_interface_io_systemd_oom_Prekill,
                 &vl_interface_io_systemd_service,


### PR DESCRIPTION
The test case is supposed to validate all IDLs we ship. But a bunch were added to the tree without hooking them up here. Fix that.