### PR TITLE
ci/unit-tests: drop unnecessary RepositoryKeyFetch=yes for postmarketOS

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -83,11 +83,6 @@ jobs:
           ToolsTreeDistribution=postmarketos
           EOF
 
-          tee mkosi/mkosi.tools.conf/mkosi.local.conf <<EOF
-          [Distribution]
-          RepositoryKeyFetch=yes
-          EOF
-
           mkosi -f box -- true
 
       - name: Build


### PR DESCRIPTION
It is enabled by default since
https://github.com/systemd/mkosi/commit/c4af878bcb8c79bf0494d022b8580bdcef4edf47