### PR TITLE
portable: fix double-free in normalize_portable_changes()

### DIFF
--- a/src/portable/portabled-image-bus.c
+++ b/src/portable/portabled-image-bus.c
@@ -591,14 +591,6 @@ static int normalize_portable_changes(
 
         CLEANUP_ARRAY(changes, n_changes, portable_changes_free);
 
-        /* Corner case: only detached, nothing attached */
-        if (n_changes_attached == 0) {
-                memcpy(changes, changes_detached, sizeof(PortableChange) * n_changes_detached);
-                *ret_changes = TAKE_PTR(changes);
-                *ret_n_changes = n_changes_detached;
-                return 0;
-        }
-
         for (size_t i = 0; i < n_changes_detached; ++i) {
                 bool found = false;
 


### PR DESCRIPTION
Now that the fast path performs a deep copy identical to the general loop (when n_changes_attached==0, found stays false for all entries),the block is redundant. Remove it and let the general loop handle this case.

Signed-off-by: dongshengyuan <dongshengyuan@uniontech.com>
Co-developed-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>