### PR TITLE
musl: fix build on 32-bit architecture

### DIFF
--- a/src/include/musl/limits.h
+++ b/src/include/musl/limits.h
@@ -1,0 +1,16 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#pragma once
+
+#include_next <limits.h>        /* IWYU pragma: export */
+
+#include <assert.h>
+#include <sys/types.h>
+
+/* musl defines SSIZE_MAX as LONG_MAX, so its type is always long. However, on 32-bit architectures, musl
+ * defines ssize_t as int. Strictly speaking, this is not a bug in musl. POSIX only requires SSIZE_MAX to
+ * evaluate to the maximum value representable by ssize_t; it does not require SSIZE_MAX itself to have type
+ * ssize_t. However, our code assumes that SSIZE_MAX has type ssize_t, as is the case with glibc. Cast the
+ * value explicitly so that SSIZE_MAX has type ssize_t. */
+static_assert(SSIZE_MAX == LONG_MAX, "");
+#undef SSIZE_MAX
+#define SSIZE_MAX ((ssize_t) LONG_MAX)


### PR DESCRIPTION
```
../src/boot/test-efi-string.c: In function 'test_xvasprintf_status':
../src/boot/test-efi-string.c:744:34: error: format '%zi' expects argument of type 'signed size_t', but argument 4 has type 'long int' [-Werror=format=]
  744 |         test_printf_one("%i %i %zi", INT_MIN, INT_MAX, SSIZE_MAX);
      |                                ~~^
      |                                  |
      |                                  int
      |                                %li
cc1: some warnings being treated as errors
ninja: subcommand failed
```