### PR TITLE
pam: use default auth pam_deny.so

### DIFF
--- a/src/login/systemd-user.in
+++ b/src/login/systemd-user.in
@@ -8,6 +8,8 @@
 {% endif %}
 account  required   pam_unix.so no_pass_expiry
 
+auth     required   pam_deny.so
+
 {% if HAVE_SELINUX %}
 session  required   pam_selinux.so close
 session  required   pam_selinux.so nottys open

--- a/src/run/systemd-run0.in
+++ b/src/run/systemd-run0.in
@@ -8,6 +8,8 @@
 {% endif %}
 account  required   pam_unix.so
 
+auth     required   pam_deny.so
+
 {% if HAVE_SELINUX %}
 session  required   pam_selinux.so close
 session  required   pam_selinux.so open


### PR DESCRIPTION
run0 doesn't actually use the auth pam stack, since polkit does the requisite authorization. However, if the service type is left undefined pam falls back to the definitions of the "other" service, which, at least in Arch Linux but possibly more, includes pam_warn.so to notify the user about this apparent error.

This creates a bit of logspam, as systemd does actually call pam_setcred in its generic pam code, which depends on the auth pam stack, creating a warning message in the journal on every invocation of run0.

pam_deny.so is a no-op, which avoids falling back to the other pam service.