### PR TITLE
gpt-auto-generator: fix error propagation in add_root_mount()

### DIFF
--- a/src/gpt-auto-generator/gpt-auto-generator.c
+++ b/src/gpt-auto-generator/gpt-auto-generator.c
@@ -882,7 +882,7 @@ static int add_root_mount(void) {
         if (in_initrd()) {
                 r = generator_write_initrd_root_device_deps(arg_dest_late, bdev);
                 if (r < 0)
-                        return 0;
+                        return r;
 
                 r = add_root_cryptsetup();
                 if (r < 0)


### PR DESCRIPTION
gpt-auto-generator: fix error propagation in add_root_mount() 
When generator_write_initrd_root_device_deps() fails, the error was swallowed by returning 0 (success) instead of r. 
The two subsequent calls in the same block correctly return r on failure.