### PR TITLE
mount: log control command before clearing it in mount_sigchld_event()

### DIFF
--- a/src/core/mount.c
+++ b/src/core/mount.c
@@ -1554,12 +1554,8 @@ static void mount_sigchld_event(Unit *u, pid_t pid, int code, int status) {
                 /* MOUNT_MOUNTING and MOUNT_UNMOUNTING states need to be patched, see below. */
                 m->result = f;
 
-        if (m->control_command) {
+        if (m->control_command)
                 exec_status_exit(&m->control_command->exec_status, &m->exec_context, pid, code, status);
-
-                m->control_command = NULL;
-                m->control_command_id = _MOUNT_EXEC_COMMAND_INVALID;
-        }
 
         unit_log_process_exit(
                         u,
@@ -1567,6 +1563,9 @@ static void mount_sigchld_event(Unit *u, pid_t pid, int code, int status) {
                         mount_exec_command_to_string(m->control_command_id),
                         f == MOUNT_SUCCESS,
                         code, status);
+
+        m->control_command = NULL;
+        m->control_command_id = _MOUNT_EXEC_COMMAND_INVALID;
 
         /* Note that due to the io event priority logic, we can be sure the new mountinfo is loaded
          * before we process the SIGCHLD for the mount command. */


### PR DESCRIPTION
mount: log control command before clearing it in mount_sigchld_event()
control_command_id was cleared to _MOUNT_EXEC_COMMAND_INVALID before
being passed to unit_log_process_exit(), so the log always showed an
invalid/unknown command name.

Move the clear after the log call, matching the ordering in
socket_sigchld_event() and service_sigchld_event() which both log
before clearing.