### PR TITLE
Add Elecom Huge Plus information for wired usb, wireless usb, and blu…

### DIFF
--- a/hwdb.d/70-mouse.hwdb
+++ b/hwdb.d/70-mouse.hwdb
@@ -280,6 +280,21 @@ mouse:usb:v056ep01a9:name:ELECOM ELECOM Bridge G1000 Mouse:*
 mouse:bluetooth:v056ep018a:name:ELECOM IST PRO Mouse:*
  ID_INPUT_TRACKBALL=1
 
+# Elecom HUGE Plus (via wired usb) (M-HT1MR)
+mouse:usb:v056ep01aa:name:HUGE PLUS HUGE PLUS:*
+ ID_INPUT_TRACKBALL=1
+ MOUSE_DPI=500 *1000 1500
+
+# Elecom HUGE Plus (via usb receiver) (M-HT1MR)
+mouse:usb:v056ep01ab:name:HUGE PLUS HUGE PLUS:*
+ ID_INPUT_TRACKBALL=1
+ MOUSE_DPI=500 *1000 1500
+
+# Elecom HUGE Plus (via Bluetooth) (M-HT1MR)
+mouse:bluetooth:v056ep01ac:name:HUGE PLUS:*
+ ID_INPUT_TRACKBALL=1
+ MOUSE_DPI=500 *1000 1500
+
 ##########################################
 # Fujitsu Siemens
 ##########################################


### PR DESCRIPTION
Added entries for the Elecom Huge Plus for its 3 connections methods.

The DPI was set to 1000 as default according to its manual. I hope this is helpful.