### PR TITLE
misc: fix minor error handling issues

### DIFF
--- a/src/fstab-generator/fstab-generator.c
+++ b/src/fstab-generator/fstab-generator.c
@@ -801,7 +801,7 @@ static int do_daemon_reload(void) {
 
                 k = bus_call_method(bus, bus_systemd_mgr, "StartUnit", &error, NULL, "ss", unit, "replace");
                 if (k < 0) {
-                        log_error_errno(k, "Failed to (re)start %s: %s", unit, bus_error_message(&error, r));
+                        log_error_errno(k, "Failed to (re)start %s: %s", unit, bus_error_message(&error, k));
                         RET_GATHER(r, k);
                 }
         }

--- a/src/network/networkd-ndisc.c
+++ b/src/network/networkd-ndisc.c
@@ -2243,7 +2243,7 @@ static int sd_dns_resolver_copy(const sd_dns_resolver *a, sd_dns_resolver *b) {
         /* addrs, n_addrs */
         c.addrs = newdup(union in_addr_union, a->addrs, a->n_addrs);
         if (!c.addrs)
-                return r;
+                return -ENOMEM;
         c.n_addrs = a->n_addrs;
 
         /* dohpath */

--- a/src/storagetm/storagetm.c
+++ b/src/storagetm/storagetm.c
@@ -258,6 +258,8 @@ static int nvme_subsystem_write_metadata(int subsystem_fd, sd_device *device) {
         }
         if (w) {
                 _cleanup_free_ char *truncated = strndup(w, 40); /* kernel refuses more than 40 chars (as per nvme spec) */
+                if (!truncated)
+                        return log_oom();
 
                 /* The default string stored in 'attr_model' is "Linux" btw. */
                 r = write_string_file_at(subsystem_fd, "attr_model", truncated, WRITE_STRING_FILE_DISABLE_BUFFER);


### PR DESCRIPTION
fstab-generator: pass k instead of r to bus_error_message() so the
fallback error string reflects the actual bus call failure, not the
accumulated result that was reset to 0 earlier.

networkd-ndisc: return -ENOMEM when newdup() fails, since r is 0 at
that point and the OOM would otherwise be reported as success.

storagetm: add missing NULL check after strndup() for attr_model,
matching the pattern already used for attr_firmware and attr_serial.
