### PR TITLE
mkosi: fix escape in suse repackaging script

### DIFF
--- a/mkosi/mkosi.images/build/mkosi.conf.d/opensuse/mkosi.build.chroot
+++ b/mkosi/mkosi.images/build/mkosi.conf.d/opensuse/mkosi.build.chroot
@@ -120,7 +120,7 @@ if ! build; then
         exit 1
     fi
 
-    grep -v ".debug" /tmp/unpackaged-files >>"pkg/$PKG_SUBDIR${GIT_SUBDIR:+/$GIT_SUBDIR}/files.systemd"
+    grep -v "\.debug" /tmp/unpackaged-files >>"pkg/$PKG_SUBDIR${GIT_SUBDIR:+/$GIT_SUBDIR}/files.systemd"
     build --noprep --nocheck
 fi
 


### PR DESCRIPTION
Otherwise it trips on files such as:

 Installed (but unpackaged) file(s) found:
 /usr/lib/udev/hwdb.d/70-debug-appliance.hwdb

Follow-up for 4d0f1451b58dbd4b94da579b800adef4f4e42c34