### PR TITLE
TEST-64-UDEV-STORAGE: skip multipath test if multipathd.service does not exist

### DIFF
--- a/test/units/TEST-64-UDEV-STORAGE.sh
+++ b/test/units/TEST-64-UDEV-STORAGE.sh
@@ -266,9 +266,8 @@ EOF
 testcase_multipath_basic_failover() {
     local dmpath i path wwid
 
-    . /etc/os-release
-    if [[ "${ID_LIKE:-}" == "alpine" ]]; then
-        echo "multipath on alpine/postmarketos is broken, skipping the test" | tee --append /skipped
+    if ! systemctl list-unit-files multipathd.service >/dev/null; then
+        echo "This test requires multipathd.service but it is not installed, skipping ..." | tee --append /skipped
         exit 77
     fi
 


### PR DESCRIPTION
Rather than checking os-release, but let's check if we have necessary service unit.