### PR TITLE
sd-dlopen: fix build on 'hppa'

### DIFF
--- a/src/systemd/sd-dlopen.h
+++ b/src/systemd/sd-dlopen.h
@@ -57,6 +57,15 @@ extern "C" {
 #  define _SD_ELF_NOTE_DLOPEN_SECTION_FLAGS "aGR"
 #endif
 
+/* This guard tag ensures the assembler folds identical notes when compiling. Unfortunately hppa redefines
+ * '.equ' so it cannot be used. '.equiv' works on all arches, but it breaks with binutils 2.35 which is used
+ * on CentOS 9, so we need an ifdef here until the binutils baseline is updated, as above. */
+#if defined(__hppa__) || defined(__hppa64__)
+#  define _SD_ELF_NOTE_DLOPEN_GUARD ".set"
+#else
+#  define _SD_ELF_NOTE_DLOPEN_GUARD ".equ"
+#endif
+
 /* The json argument is a C string containing already backslash-escaped double quotes (i.e. the bytes
  * [{\"feature\"...), so that once it is pasted into the assembler's .asciz directive the assembler decodes
  * them back to plain quotes. The note is emitted into a COMDAT group keyed on the payload itself, which
@@ -68,7 +77,7 @@ extern "C" {
 #define _SD_ELF_NOTE_DLOPEN(json)                                                                                               \
         __asm__ (                                                                                                               \
                 ".ifndef \"sd_dlopen:" json "\"\n"                                                                              \
-                ".equ \"sd_dlopen:" json "\", 1\n" /* guard tag, avoid using 'set' as it breaks builds on alpha */              \
+                _SD_ELF_NOTE_DLOPEN_GUARD " \"sd_dlopen:" json "\", 1\n" /* guard tag, to fold identical notes */               \
                 ".pushsection .note.dlopen, \"" _SD_ELF_NOTE_DLOPEN_SECTION_FLAGS "\", %note, \"sd_dlopen:" json "\", comdat\n" \
                 ".balign 4\n"         /* notes require 4-byte alignment for the header and fields */                            \
                 ".long 884f - 883f\n" /* n_namesz: byte length of the vendor name (label 883->884) */                           \


### PR DESCRIPTION
On hppa '.equ' is overridden, so even this workaround ('.set' is overridden on alpha) causes a build failure:

```
cc -Isrc/basic/libbasic.a.p -Isrc/basic -I../src/basic -Isrc/fundamental -I../src/fundamental -Isrc/systemd -I../src/systemd -Isrc/version -I../src/version -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -std=gnu17 -O0 -g -Wno-missing-field-initializers -Wno-unused-parameter -Wno-nonnull-compare -Warray-bounds -Warray-bounds=2 -Wdate-time -Wendif-labels -Werror=bool-compare -Werror=discarded-qualifiers -Werror=flex-array-member-not-at-end -Werror=format=2 -Werror=format-signedness -Werror=implicit-function-declaration -Werror=implicit-int -Werror=incompatible-pointer-types -Werror=int-conversion -Werror=missing-declarations -Werror=missing-parameter-name -Werror=missing-prototypes -Werror=overflow -Werror=override-init -Werror=pointer-sign -Werror=return-type -Werror=sequence-point -Werror=shift-count-overflow -Werror=shift-overflow=2 -Werror=strict-flex-arrays -Werror=undef -Wfloat-equal -Wimplicit-fallthrough=5 -Winit-self -Wlogical-op -Wmissing-include-dirs -Wmissing-noreturn -Wnested-externs -Wold-style-definition -Wpointer-arith -Wredundant-decls -Wshadow -Wstrict-aliasing=2 -Wstrict-prototypes -Wsuggest-attribute=noreturn -Wunterminated-string-initialization -Wunused-function -Wwrite-strings -Wzero-as-null-pointer-constant -Wzero-length-bounds -fdiagnostics-show-option -fexcess-precision=standard -fno-common -fstack-protector -fstack-protector-strong -fstrict-flex-arrays=3 -fno-math-errno --param=ssp-buffer-size=4 -Wno-unused-result -Werror=shadow -fPIC -fno-strict-aliasing -fstrict-flex-arrays=1 -fvisibility=hidden -fno-omit-frame-pointer -include config.h -isystem../src/include/glibc -isystem../src/include/override -isystemsrc/include/override -isystem../src/include/uapi -fvisibility=default -MD -MQ src/basic/libbasic.a.p/compress.c.o -MF src/basic/libbasic.a.p/compress.c.o.d -o src/basic/libbasic.a.p/compress.c.o -c ../src/basic/compress.c
/tmp/ccxm7Waj.s: Assembler messages:
/tmp/ccxm7Waj.s:2085: Error: bad or irreducible absolute expression; zero assumed
/tmp/ccxm7Waj.s:2085: Error: junk at end of line, first unrecognized character is `,'
/tmp/ccxm7Waj.s:2268: Error: bad or irreducible absolute expression; zero assumed
/tmp/ccxm7Waj.s:2268: Error: junk at end of line, first unrecognized character is `,'
/tmp/ccxm7Waj.s:2544: Error: bad or irreducible absolute expression; zero assumed
/tmp/ccxm7Waj.s:2544: Error: junk at end of line, first unrecognized character is `,'
/tmp/ccxm7Waj.s:2800: Error: bad or irreducible absolute expression; zero assumed
/tmp/ccxm7Waj.s:2800: Error: junk at end of line, first unrecognized character is `,'
/tmp/ccxm7Waj.s:2956: Error: bad or irreducible absolute expression; zero assumed
/tmp/ccxm7Waj.s:2956: Error: junk at end of line, first unrecognized character is `,'
```

Switch to .equiv, which seems equivalent, and not overridden according to a quick scan of binutils.

Follow-up for 7590eb0c749090948776ff8c0dbf43c579a55980

Co-developed-by: Claude Opus 4.8 <noreply@anthropic.com>