### PR TITLE
sysext,sysusers: fix wrong error variable in two error paths

### DIFF
--- a/src/sysext/sysext.c
+++ b/src/sysext/sysext.c
@@ -1395,7 +1395,7 @@ static int store_info_in_meta(
 
         /* Make sure the top-level dir has an mtime marking the point we established the merge */
         if (utimensat(AT_FDCWD, meta_path, NULL, AT_SYMLINK_NOFOLLOW) < 0)
-                return log_error_errno(r, "Failed to fix mtime of '%s': %m", meta_path);
+                return log_error_errno(errno, "Failed to fix mtime of '%s': %m", meta_path);
 
         return 0;
 }

--- a/src/sysusers/sysusers.c
+++ b/src/sysusers/sysusers.c
@@ -352,7 +352,7 @@ static int make_backup(const char *target, const char *x) {
                 return r;
 
         if (rename(dst_tmp, backup) < 0)
-                return errno;
+                return -errno;
 
         dst_tmp = mfree(dst_tmp); /* disable the unlink_and_freep() hook now that the file has been renamed */
         return 0;


### PR DESCRIPTION
sysext,sysusers: fix wrong error variable in two error paths
sysext: utimensat() failure was logged with stale r (which is 0 after
the preceding successful write_backing_file call). Pass errno instead
so the actual failure reason is recorded and returned.

sysusers: rename() failure in make_backup() returned the raw positive
errno value. All callers check 'if (r < 0)', so the error was silently
ignored, allowing execution to continue after a failed backup. Return
-errno instead.