### PR TITLE
LCD Steam Deck Mount Matrix.

### DIFF
--- a/hwdb.d/60-sensor.hwdb
+++ b/hwdb.d/60-sensor.hwdb
@@ -1101,6 +1101,14 @@ sensor:modalias:acpi:MXC6655*:dmi:*:svnUMAX:pnVisionbook12WrTab:*
  ACCEL_MOUNT_MATRIX=0, 1, 0; 1, 0, 0; 0, 0, 1
 
 #########################################
+# Valve
+#########################################
+
+# Lizard mode must be off for the IMU to activate
+evdev:input:b0003v28DEp1205*
+ ACCEL_MOUNT_MATRIX=0, -1, 0; 1, 0, 0; 0, 0, 1
+
+#########################################
 # Voyo
 #########################################
 


### PR DESCRIPTION
Steam deck lcd screen is a tablet LCD rotated in the kernel into portrait mode.

The IMU is not active in lizard mode. The command below disables lizard mode and activates the IMU.

echo N | sudo tee /sys/module/hid_steam/parameters/lizard_mode.


Closes #42586
Related Issue: https://gitlab.freedesktop.org/hadess/iio-sensor-proxy/-/work_items/416