### PR TITLE
journald: add 'FDStore=' Varlink option to store shutdown journal in FD store

### DIFF
--- a/src/journal/journald-manager.c
+++ b/src/journal/journald-manager.c
@@ -17,6 +17,8 @@
 #include "alloc-util.h"
 #include "audit-util.h"
 #include "cgroup-util.h"
+#include "chase.h"
+#include "copy.h"
 #include "daemon-util.h"
 #include "dirent-util.h"
 #include "errno-util.h"
@@ -49,16 +51,19 @@
 #include "libaudit-util.h"
 #include "log.h"
 #include "log-ratelimit.h"
+#include "memfd-util.h"
 #include "memory-util.h"
 #include "mkdir.h"
 #include "path-util.h"
 #include "prioq.h"
 #include "process-util.h"
+#include "random-util.h"
 #include "rm-rf.h"
 #include "set.h"
 #include "selinux-util.h"
 #include "signal-util.h"
 #include "socket-util.h"
+#include "stat-util.h"
 #include "stdio-util.h"
 #include "string-util.h"
 #include "strv.h"
@@ -68,6 +73,8 @@
 #include "user-util.h"
 
 #define USER_JOURNALS_MAX 1024
+
+#define RUNTIME_JOURNAL_FDNAME "runtime-journal"
 
 #define DEFAULT_KMSG_OWN_INTERVAL (5 * USEC_PER_SEC)
 #define DEFAULT_KMSG_OWN_BURST 50
@@ -349,10 +356,127 @@ static void manager_drop_flushed_flag(Manager *m) {
                                             "Failed to unlink %s, ignoring: %m", fn);
 }
 
+static int manager_open_runtime_journal_memfd(Manager *m, const char *fn) {
+        _cleanup_(journal_file_offline_closep) JournalFile *f = NULL;
+        _cleanup_close_ int memfd = -EBADF;
+        int r;
+
+        assert(m);
+        assert(fn);
+
+        /* Use a memfd and push it to the FD store, so that we get it back afterwards with all entries. */
+
+        memfd = memfd_new_full("journal-runtime", MFD_ALLOW_SEALING);
+        if (memfd < 0)
+                return memfd;
+
+        /* An empty (zero-length) fd is treated as a newly created journal by journal_file_open(), which
+         * thus initializes a fresh journal structure on the memfd. The memfd is anonymous so it needs
+         * JOURNAL_ALLOW_UNLINKED. */
+        r = journal_file_open(
+                        memfd,
+                        fn,
+                        O_RDWR|O_CREAT,
+                        manager_get_file_flags(m, /* seal= */ false) | JOURNAL_ALLOW_UNLINKED,
+                        0640,
+                        m->config.compress.threshold_bytes,
+                        &m->runtime_storage.metrics,
+                        m->mmap,
+                        /* template= */ NULL,
+                        &f);
+        if (r < 0)
+                return r;
+
+        TAKE_FD(memfd); /* Donated to journal_file_open() above. */
+
+        r = journal_file_enable_post_change_timer(f, m->event, POST_CHANGE_TIMER_INTERVAL_USEC);
+        if (r < 0)
+                return r;
+
+        /* Rotation is disabled since it's a memfd used at shutdown, let it grow up to the runtime max */
+        f->metrics.max_size = f->metrics.max_use;
+        f->metrics.keep_free = 0;
+
+        /* Fall back to the on-disk runtime journal if there's no notify socket */
+        r = notify_push_fd(f->fd, RUNTIME_JOURNAL_FDNAME);
+        if (r <= 0)
+                return r < 0 ? r : -ENOTCONN;
+
+        m->runtime_journal = TAKE_PTR(f);
+        m->runtime_journal_memfd = true;
+
+        log_debug("Opened memfd-backed runtime journal, stored in the FD store.");
+        return 0;
+}
+
+static int manager_materialize_runtime_memfd(Manager *m, int memfd) {
+        _cleanup_close_ int parent_fd = -EBADF, dir_fd = -EBADF, dst = -EBADF;
+        _cleanup_free_ char *leaf = NULL, *fn = NULL;
+        int r;
+
+        assert(m);
+        assert(memfd >= 0);
+        assert(m->runtime_storage.path);
+
+        /* Dump the preserved shutdown journal memfd to /run/ so that the flush logic can handle it. */
+
+        if (m->config.storage == STORAGE_NONE) {
+                log_debug("Storage is set to none, not materializing preserved runtime journal.");
+                return 0;
+        }
+
+        r = fd_verify_regular(memfd);
+        if (r < 0)
+                return log_ratelimit_warning_errno(r, JOURNAL_LOG_RATELIMIT,
+                                                   "Preserved runtime journal fd is not a regular file, ignoring: %m");
+
+        parent_fd = chase_and_open_parent_at(AT_FDCWD, AT_FDCWD, m->runtime_storage.path,
+                                             CHASE_MKDIR_0755, &leaf);
+        if (parent_fd < 0)
+                return log_ratelimit_warning_errno(parent_fd, JOURNAL_LOG_RATELIMIT,
+                                                   "Failed to open parent of runtime journal directory %s: %m",
+                                                   m->runtime_storage.path);
+
+        dir_fd = open_mkdir_at(parent_fd, leaf, O_CLOEXEC, 0750);
+        if (dir_fd < 0)
+                return log_ratelimit_warning_errno(dir_fd, JOURNAL_LOG_RATELIMIT,
+                                                   "Failed to create runtime journal directory %s: %m",
+                                                   m->runtime_storage.path);
+
+        if (asprintf(&fn, "system@fdstore-%016" PRIx64 "-%016" PRIx64 ".journal",
+                     now(CLOCK_REALTIME), random_u64()) < 0)
+                return log_oom();
+
+        dst = openat(dir_fd, fn, O_WRONLY|O_CREAT|O_EXCL|O_CLOEXEC|O_NOFOLLOW, 0640);
+        if (dst < 0)
+                return log_ratelimit_warning_errno(errno, JOURNAL_LOG_RATELIMIT,
+                                                   "Failed to create %s/%s: %m", m->runtime_storage.path, fn);
+
+        if (lseek(memfd, 0, SEEK_SET) < 0)
+                return log_ratelimit_warning_errno(errno, JOURNAL_LOG_RATELIMIT,
+                                                   "Failed to rewind preserved runtime journal memfd: %m");
+
+        r = copy_bytes(memfd, dst, m->runtime_storage.metrics.max_use, COPY_REFLINK);
+        if (r < 0) {
+                (void) unlinkat(dir_fd, fn, 0);
+                return log_ratelimit_warning_errno(r, JOURNAL_LOG_RATELIMIT,
+                                                   "Failed to materialize preserved runtime journal to %s/%s: %m",
+                                                   m->runtime_storage.path, fn);
+        }
+        if (r > 0)
+                log_ratelimit_warning(JOURNAL_LOG_RATELIMIT,
+                                      "Preserved runtime journal larger than %s, truncated while materializing to %s/%s.",
+                                      FORMAT_BYTES(m->runtime_storage.metrics.max_use), m->runtime_storage.path, fn);
+
+        log_info("Materialized runtime journal from the FD store to %s/%s.", m->runtime_storage.path, fn);
+        return 1;
+}
+
 static int manager_system_journal_open(
                 Manager *m,
                 bool flush_requested,
-                bool relinquish_requested) {
+                bool relinquish_requested,
+                bool fdstore) {
 
         const char *fn;
         int r = 0;
@@ -414,17 +538,29 @@ static int manager_system_journal_open(
                         (void) mkdir_parents(m->runtime_storage.path, 0755);
                         (void) mkdir(m->runtime_storage.path, 0750);
 
-                        r = manager_open_journal(
-                                        m,
-                                        /* reliably= */ true,
-                                        fn,
-                                        O_RDWR|O_CREAT,
-                                        /* seal= */ false,
-                                        &m->runtime_storage.metrics,
-                                        &m->runtime_journal);
-                        if (r < 0)
-                                return log_ratelimit_warning_errno(r, JOURNAL_LOG_RATELIMIT,
-                                                                   "Failed to open runtime journal: %m");
+                        /* If the client requested it, back the runtime journal by a memfd and push it to
+                         * the FD store instead of using a file in /run/, so that we get the memfd back
+                         * afterwards with all entries intact. */
+                        if (relinquish_requested && fdstore) {
+                                r = manager_open_runtime_journal_memfd(m, fn);
+                                if (r < 0)
+                                        log_ratelimit_warning_errno(r, JOURNAL_LOG_RATELIMIT,
+                                                                    "Failed to open memfd-backed runtime journal, falling back to file: %m");
+                        }
+
+                        if (!m->runtime_journal) {
+                                r = manager_open_journal(
+                                                m,
+                                                /* reliably= */ true,
+                                                fn,
+                                                O_RDWR|O_CREAT,
+                                                /* seal= */ false,
+                                                &m->runtime_storage.metrics,
+                                                &m->runtime_journal);
+                                if (r < 0)
+                                        return log_ratelimit_warning_errno(r, JOURNAL_LOG_RATELIMIT,
+                                                                           "Failed to open runtime journal: %m");
+                        }
 
                 } else if (!manager_flushed_flag_is_set(m)) {
                         /* Try to open the runtime journal, but only if it already exists, so that we can
@@ -516,7 +652,7 @@ static JournalFile* manager_find_journal(Manager *m, uid_t uid) {
          * recover from failed rotates (or anything else that's left the journals as NULL).
          *
          * Fixes https://github.com/systemd/systemd/issues/3968 */
-        (void) manager_system_journal_open(m, /* flush_requested= */ false, /* relinquish_requested= */ false);
+        (void) manager_system_journal_open(m, /* flush_requested= */ false, /* relinquish_requested= */ false, /* fdstore= */ false);
 
         /* We split up user logs only on /var, not on /run. If the runtime file is open, we write to it
          * exclusively, in order to guarantee proper order as soon as we flush /run to /var and close the
@@ -545,6 +681,13 @@ static JournalFile* manager_find_journal(Manager *m, uid_t uid) {
         return m->system_journal;
 }
 
+static bool manager_journal_should_rotate(Manager *m, JournalFile *f) {
+        assert(m);
+
+        /* No point in rotating when using a memfd */
+        return !m->runtime_journal_memfd || f != m->runtime_journal;
+}
+
 static int manager_do_rotate(
                 Manager *m,
                 JournalFile **f,
@@ -559,6 +702,12 @@ static int manager_do_rotate(
 
         if (!*f)
                 return -EINVAL;
+
+        /* If we are using a memfd rotation makes no sense, as it's just an anonymous buffer */
+        if (!manager_journal_should_rotate(m, *f)) {
+                log_debug("Skipping rotation of memfd-backed runtime journal.");
+                return 0;
+        }
 
         log_debug("Rotating journal file %s.", (*f)->path);
 
@@ -974,7 +1123,8 @@ static void manager_write_to_journal(
         if (!f)
                 return;
 
-        if (journal_file_rotate_suggested(f, m->config.max_file_usec, LOG_DEBUG)) {
+        if (manager_journal_should_rotate(m, f) &&
+            journal_file_rotate_suggested(f, m->config.max_file_usec, LOG_DEBUG)) {
                 if (vacuumed) {
                         log_ratelimit_warning(JOURNAL_LOG_RATELIMIT,
                                               "Suppressing rotation, as we already rotated immediately before write attempt. Giving up.");
@@ -1011,6 +1161,8 @@ static void manager_write_to_journal(
         log_debug_errno(r, "Failed to write entry to %s (%zu items, %zu bytes): %m", f->path, n, iovec_total_size(iovec, n));
 
         if (!shall_try_append_again(f, r))
+                return;
+        if (!manager_journal_should_rotate(m, f))
                 return;
         if (vacuumed) {
                 log_ratelimit_warning_errno(r, JOURNAL_LOG_RATELIMIT,
@@ -1319,10 +1471,18 @@ int manager_flush_to_var(Manager *m, bool require_flag_file) {
         if (require_flag_file && !manager_flushed_flag_is_set(m))
                 return 0;
 
-        (void) manager_system_journal_open(m, /* flush_requested= */ true, /* relinquish_requested= */ false);
+        (void) manager_system_journal_open(m, /* flush_requested= */ true, /* relinquish_requested= */ false, /* fdstore= */ false);
 
         if (!m->system_journal)
                 return 0;
+
+        /* Dump the shutdown journal preserved in the FD store into /run/ so the normal logic can flush that too */
+        if (m->runtime_journal_memfd) {
+                (void) journal_file_set_offline(m->runtime_journal, /* wait= */ true);
+                (void) manager_materialize_runtime_memfd(m, m->runtime_journal->fd);
+                (void) notify_remove_fd_warn(RUNTIME_JOURNAL_FDNAME);
+                m->runtime_journal_memfd = false;
+        }
 
         /* Offline and close the 'main' runtime journal file to allow the runtime journal to be opened with
          * the SD_JOURNAL_ASSUME_IMMUTABLE flag in the below. */
@@ -1452,7 +1612,7 @@ finish:
         return r;
 }
 
-int manager_relinquish_var(Manager *m) {
+int manager_relinquish_var(Manager *m, bool fdstore) {
         assert(m);
 
         if (m->config.storage == STORAGE_NONE)
@@ -1466,7 +1626,7 @@ int manager_relinquish_var(Manager *m) {
 
         log_debug("Relinquishing %s...", m->system_storage.path);
 
-        (void) manager_system_journal_open(m, /* flush_requested= */ false, /* relinquish_requested= */ true);
+        (void) manager_system_journal_open(m, /* flush_requested= */ false, /* relinquish_requested= */ true, fdstore);
 
         m->system_journal = journal_file_offline_close(m->system_journal);
         ordered_hashmap_clear(m->user_journals);
@@ -2279,15 +2439,19 @@ void manager_reopen_journals(Manager *m, const JournalConfig *old) {
          * But only when volatile (or no) storage is requested. If auto or persistent storage is requested,
          * we may need to flush the runtime journal to the persistent storage, it will done through
          * manager_system_journal_open(). Hence, we should not touch the runtime journal here in that case. */
-        if (IN_SET(m->config.storage, STORAGE_VOLATILE, STORAGE_NONE))
+        if (IN_SET(m->config.storage, STORAGE_VOLATILE, STORAGE_NONE)) {
+                if (m->runtime_journal_memfd)
+                        (void) notify_remove_fd_warn(RUNTIME_JOURNAL_FDNAME);
                 m->runtime_journal = journal_file_offline_close(m->runtime_journal);
+                m->runtime_journal_memfd = false;
+        }
 
         /* Close other journals unconditionally to make the new settings applied. */
         m->system_journal = journal_file_offline_close(m->system_journal);
         ordered_hashmap_clear(m->user_journals);
         set_clear(m->deferred_closes);
 
-        (void) manager_system_journal_open(m, /* flush_requested= */ false, /* relinquish_requested= */ false);
+        (void) manager_system_journal_open(m, /* flush_requested= */ false, /* relinquish_requested= */ false, /* fdstore= */ false);
 
         /* To make the storage related settings applied, vacuum the storage. */
         cache_space_invalidate(&m->system_storage.space);
@@ -2340,6 +2504,8 @@ int manager_new(Manager **ret) {
 
 int manager_init(Manager *m) {
         const char *native_socket, *syslog_socket, *stdout_socket, *varlink_socket, *e;
+        _cleanup_strv_free_ char **fdnames = NULL;
+        _cleanup_close_ int restored_runtime_journal_fd = -EBADF;
         _cleanup_fdset_free_ FDSet *fds = NULL;
         int n, r, varlink_fd = -EBADF;
         bool no_sockets;
@@ -2374,7 +2540,7 @@ int manager_init(Manager *m) {
         if (r < 0)
                 return log_error_errno(r, "Failed to create event loop: %m");
 
-        n = sd_listen_fds(true);
+        n = sd_listen_fds_with_names(true, &fdnames);
         if (n < 0)
                 return log_error_errno(n, "Failed to read listening file descriptors from environment: %m");
 
@@ -2383,9 +2549,18 @@ int manager_init(Manager *m) {
         syslog_socket = strjoina(m->runtime_directory, "/dev-log");
         varlink_socket = strjoina(m->runtime_directory, "/io.systemd.journal");
 
-        for (int fd = SD_LISTEN_FDS_START; fd < SD_LISTEN_FDS_START + n; fd++)
+        for (int i = 0; i < n; i++) {
+                int fd = SD_LISTEN_FDS_START + i;
 
-                if (sd_is_socket_unix(fd, SOCK_DGRAM, -1, native_socket, 0) > 0) {
+                if (streq_ptr(fdnames[i], RUNTIME_JOURNAL_FDNAME)) {
+                        /* Runtime journal restored from the FD store */
+                        if (restored_runtime_journal_fd >= 0) {
+                                log_warning("Too many runtime journal memfds passed, closing extra one.");
+                                safe_close(fd);
+                        } else
+                                restored_runtime_journal_fd = fd;
+
+                } else if (sd_is_socket_unix(fd, SOCK_DGRAM, -1, native_socket, 0) > 0) {
 
                         if (m->native_fd >= 0)
                                 return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
@@ -2436,6 +2611,7 @@ int manager_init(Manager *m) {
                         if (r < 0)
                                 return log_oom();
                 }
+        }
 
         /* Try to restore streams, but don't bother if this fails */
         (void) manager_restore_streams(m, fds);
@@ -2532,7 +2708,13 @@ int manager_init(Manager *m) {
 
         client_context_acquire_default(m);
 
-        r = manager_system_journal_open(m, /* flush_requested= */ false, /* relinquish_requested= */ false);
+        /* Dump the shutdown journal preserved in the FD store into /run/ so the normal logic can flush it */
+        if (restored_runtime_journal_fd >= 0) {
+                (void) manager_materialize_runtime_memfd(m, restored_runtime_journal_fd);
+                restored_runtime_journal_fd = close_and_notify_warn(restored_runtime_journal_fd, RUNTIME_JOURNAL_FDNAME);
+        }
+
+        r = manager_system_journal_open(m, /* flush_requested= */ false, /* relinquish_requested= */ false, /* fdstore= */ false);
         if (r < 0)
                 return r;
 

--- a/src/journal/journald-manager.h
+++ b/src/journal/journald-manager.h
@@ -81,6 +81,9 @@ typedef struct Manager {
         bool sent_notify_ready;
         bool sync_scheduled;
 
+        /* Whether the current journal is entirely in memory (no file in /run/) */
+        bool runtime_journal_memfd;
+
         unsigned n_forward_syslog_missed;
         usec_t last_warn_forward_syslog_missed;
 
@@ -182,7 +185,7 @@ void manager_rotate(Manager *m);
 void manager_full_rotate(Manager *m);
 int manager_flush_to_var(Manager *m, bool require_flag_file);
 void manager_full_flush(Manager *m);
-int manager_relinquish_var(Manager *m);
+int manager_relinquish_var(Manager *m, bool fdstore);
 void manager_maybe_append_tags(Manager *m);
 int manager_process_datagram(sd_event_source *es, int fd, uint32_t revents, void *userdata);
 void manager_space_usage_message(Manager *m, JournalStorage *storage);

--- a/src/journal/journald-varlink.c
+++ b/src/journal/journald-varlink.c
@@ -126,12 +126,19 @@ static int vl_method_flush_to_var(sd_varlink *link, sd_json_variant *parameters,
 }
 
 static int vl_method_relinquish_var(sd_varlink *link, sd_json_variant *parameters, sd_varlink_method_flags_t flags, void *userdata) {
+        bool fdstore = false;
+
+        static const sd_json_dispatch_field dispatch_table[] = {
+                { "FDStore", SD_JSON_VARIANT_BOOLEAN, sd_json_dispatch_stdbool, 0, 0 },
+                {}
+        };
+
         Manager *m = ASSERT_PTR(userdata);
         int r;
 
         assert(link);
 
-        r = sd_varlink_dispatch(link, parameters, /* dispatch_table= */ NULL, /* userdata= */ NULL);
+        r = sd_varlink_dispatch(link, parameters, dispatch_table, &fdstore);
         if (r != 0)
                 return r;
 
@@ -142,8 +149,9 @@ static int vl_method_relinquish_var(sd_varlink *link, sd_json_variant *parameter
         if (m->namespace)
                 return sd_varlink_error(link, "io.systemd.Journal.NotSupportedByNamespaces", NULL);
 
-        log_info("Received client request to relinquish %s access.", m->system_storage.path);
-        manager_relinquish_var(m);
+        log_info("Received client request to relinquish %s access%s.",
+                 m->system_storage.path, fdstore ? " with FD store preservation" : "");
+        manager_relinquish_var(m, fdstore);
         log_debug("Client request to relinquish %s access completed.", m->system_storage.path);
 
         return sd_varlink_reply(link, NULL);

--- a/src/libsystemd/sd-journal/journal-file.c
+++ b/src/libsystemd/sd-journal/journal-file.c
@@ -762,10 +762,12 @@ int journal_file_fstat(JournalFile *f) {
         if (r < 0)
                 return r;
 
-        /* Refuse appending to files that are already deleted */
-        r = stat_verify_linked(&f->last_stat);
-        if (r < 0)
-                return r;
+        if (!f->allow_unlinked) {
+                /* Refuse appending to files that are already deleted */
+                r = stat_verify_linked(&f->last_stat);
+                if (r < 0)
+                        return r;
+        }
 
         return 0;
 }
@@ -4170,6 +4172,7 @@ int journal_file_open(
                                             DEFAULT_COMPRESS_THRESHOLD :
                                             MAX(MIN_COMPRESS_THRESHOLD, compress_threshold_bytes),
                 .strict_order = FLAGS_SET(file_flags, JOURNAL_STRICT_ORDER),
+                .allow_unlinked = FLAGS_SET(file_flags, JOURNAL_ALLOW_UNLINKED),
                 .newest_boot_id_prioq_idx = PRIOQ_IDX_NULL,
                 .last_direction = _DIRECTION_INVALID,
                 .tail_timestamp_ratelimit = { .interval = USEC_PER_SEC, .burst = 1 },

--- a/src/libsystemd/sd-journal/journal-file.h
+++ b/src/libsystemd/sd-journal/journal-file.h
@@ -61,6 +61,7 @@ typedef struct JournalFile {
         bool close_fd:1;
         bool archive:1;
         bool strict_order:1;
+        bool allow_unlinked:1;
 
         direction_t last_direction;
         LocationType location_type;
@@ -115,7 +116,8 @@ typedef enum JournalFileFlags {
         JOURNAL_COMPRESS        = 1 << 0,
         JOURNAL_SEAL            = 1 << 1,
         JOURNAL_STRICT_ORDER    = 1 << 2,
-        _JOURNAL_FILE_FLAGS_ALL = JOURNAL_COMPRESS|JOURNAL_SEAL|JOURNAL_STRICT_ORDER,
+        JOURNAL_ALLOW_UNLINKED  = 1 << 3,
+        _JOURNAL_FILE_FLAGS_ALL = JOURNAL_COMPRESS|JOURNAL_SEAL|JOURNAL_STRICT_ORDER|JOURNAL_ALLOW_UNLINKED,
 } JournalFileFlags;
 
 typedef struct {

--- a/src/shared/varlink-io.systemd.Journal.c
+++ b/src/shared/varlink-io.systemd.Journal.c
@@ -9,7 +9,11 @@ static SD_VARLINK_DEFINE_METHOD(
 
 static SD_VARLINK_DEFINE_METHOD(Rotate);
 static SD_VARLINK_DEFINE_METHOD(FlushToVar);
-static SD_VARLINK_DEFINE_METHOD(RelinquishVar);
+
+static SD_VARLINK_DEFINE_METHOD(
+                RelinquishVar,
+                SD_VARLINK_FIELD_COMMENT("Controls whether to preserve the late-shutdown journal by storing it in the service manager's file descriptor store instead of a file in /run/. Disabled by default."),
+                SD_VARLINK_DEFINE_INPUT(FDStore, SD_VARLINK_BOOL, SD_VARLINK_NULLABLE));
 
 static SD_VARLINK_DEFINE_ERROR(NotSupportedByNamespaces);
 

--- a/test/units/TEST-91-LIVEUPDATE.sh
+++ b/test/units/TEST-91-LIVEUPDATE.sh
@@ -75,6 +75,9 @@ EOF
 }
 
 if grep -qw luo_nboot=1 /proc/cmdline; then
+    journalctl --sync
+    timeout 10s bash -c "until journalctl -q --grep 'TEST-91-LIVEUPDATE-late-shutdown-marker' &>/dev/null; do sleep 0.5; done"
+
     # Verify that the fd store of the main test service survived the kexec.
     /usr/lib/systemd/tests/unit-tests/manual/test-luo check
 
@@ -338,6 +341,11 @@ EOF
     n_fds=$(systemctl show -P NFileDescriptorStore TEST-91-LIVEUPDATE-session.service)
     echo "Session unit fd store count: $n_fds"
     test "$n_fds" -eq 2  # test-session-1 and test-session-2
+
+    # Check that the late shutdown journal is preserved via the FD store
+    varlinkctl call /run/systemd/journal/io.systemd.journal io.systemd.Journal.RelinquishVar '{"FDStore": true}'
+    echo TEST-91-LIVEUPDATE-late-shutdown-marker | systemd-cat -t TEST-91-LIVEUPDATE-late-log
+    journalctl --sync
 
     # 'systemctl kexec' auto-loads the default boot entry (i.e. the booted UKI,
     # via EFI LoaderEntrySelected/LoaderEntryDefault). Append a marker to the


### PR DESCRIPTION
Currently the only way to preserve some logs from the late shutdown phase is via pstore, which is limited and very finicky.

Add a new bool parameter to the RelinquishVar Varlink API that, when set, after relinquishing /var/ moves the runtime journal to a memfd instead of a file in /run/, and stores it in the FD store. When the memfd is later passed back from the FD store, we materialize it to /run/ and proceed with the normal flushing.

When KHO/LUO are enabled, this seamlessly forwards the late shutdown journal across kexec to the next boot.