### PR TITLE
firstboot: use absolute targets to prevent incorrect SELinux labeling

### DIFF
--- a/src/firstboot/firstboot.c
+++ b/src/firstboot/firstboot.c
@@ -987,7 +987,7 @@ static int write_root_passwd(int rfd, int etc_fd, const char *password, const ch
         int r;
         bool found = false;
 
-        r = fopen_temporary_at_label(etc_fd, "passwd", "passwd", &passwd, &passwd_tmp);
+        r = fopen_temporary_at_label(etc_fd, "/etc/passwd", "passwd", &passwd, &passwd_tmp);
         if (r < 0)
                 return r;
 
@@ -1058,7 +1058,7 @@ static int write_root_shadow(int etc_fd, const char *hashed_password) {
         int r;
         bool found = false;
 
-        r = fopen_temporary_at_label(etc_fd, "shadow", "shadow", &shadow, &shadow_tmp);
+        r = fopen_temporary_at_label(etc_fd, "/etc/shadow", "shadow", &shadow, &shadow_tmp);
         if (r < 0)
                 return r;
 


### PR DESCRIPTION
Change the target path passed to `mac_selinux_create_file_prepare_at` so it works better when used in combination with the `--image` argument.

Without this change the label was looked up relatively and when the lookup fails we inherit the label from the running process. This is wrong and thus the file is labeled wrong which leads to issues in the image during boot as certain contexts are not allowed to read the file anymore.

Closes #42643.

---

Here's some output showing the different behavior from the 259.6 version vs a version built from this PR:

```
€ sudo systemd-firstboot --image prepatch.raw --root-password=root
/home/user/src/github.com/teamsbc/artifacts/prepatch.raw: /etc/passwd written.
/home/user/src/github.com/teamsbc/artifacts/prepatch.raw: /etc/shadow written.
€ sudo ~/src/github.com/systemd/systemd/build/systemd-firstboot --image patched.raw --root-password=root
/home/user/src/github.com/teamsbc/artifacts/patched.raw: /etc/passwd written.
/home/user/src/github.com/teamsbc/artifacts/patched.raw: /etc/shadow written.
€ sudo systemd-dissect --mount prepatch.raw mnt-prepatch
€ ls -Zlart mnt-prepatch/etc/shadow
----------. 1 root root system_u:object_r:init_var_run_t:s0 579 Jun 18 11:09 mnt-prepatch/etc/shadow
€ sudo systemd-dissect --mount patched.raw mnt-patched 
€ ls -Zlart mnt-patched/etc/shadow
----------. 1 root root system_u:object_r:shadow_t:s0 579 Jun 18 11:10 mnt-patched/etc/shadow
```

---

Note that this issue is likely larger in scope than only this specific function from a look around it seems to me that `process_(hostname|machine_id|machine_tags|kernel_cmdline|locale|keymap|timezone)` are also affected.

Addressing all of them probably needs a bit more holistic approach. I'm willing to make it part of this PR but I'd need some guidance. It can either be fixed at the caller level by passing an appropriate `label_fn` or add knowledge to the labeling fucntion about the root prefix.

There's also the problem that this (but it always did so) looks up in the policy of the host; not the image. If the host and the image would disagree about what labels a certain path needs to have there would still be issues.