### PR TITLE
Add empty token slot to cryptsetup

### DIFF
--- a/man/systemd-cryptenroll.xml
+++ b/man/systemd-cryptenroll.xml
@@ -320,7 +320,8 @@
       <varlistentry>
         <term><option>--password</option></term>
 
-        <listitem><para>Enroll a regular password/passphrase. This command is mostly equivalent to
+        <listitem><para>Enroll a regular password/passphrase. If an empty password is provided this has
+        the same effect as <option>--empty</option>. This command is mostly equivalent to
         <command>cryptsetup luksAddKey</command>, however may be combined with
         <option>--wipe-slot=</option> in one call, see below.</para>
 
@@ -344,9 +345,7 @@
         <listitem><para>Enroll an empty key. This allows the volume to be unlocked without a key,
         which effectively disables the confidentiality protections of encryption. The encryption is not
         removed, however, so confidentiality protections can be reenabled by removing the empty
-        key enrollment (i.e. via <option>--wipe-slot=empty</option>). Unlike a blank <option>--password</option>,
-        a key enrolled via this option will automatically unlock the volume with no user input and no
-        performance penalty.</para>
+        key enrollment (i.e. via <option>--wipe-slot=empty</option>).</para>
 
         <xi:include href="version-info.xml" xpointer="v261"/></listitem>
       </varlistentry>

--- a/man/systemd-cryptenroll.xml
+++ b/man/systemd-cryptenroll.xml
@@ -337,6 +337,19 @@
 
         <xi:include href="version-info.xml" xpointer="v248"/></listitem>
       </varlistentry>
+
+      <varlistentry>
+        <term><option>--empty</option></term>
+
+        <listitem><para>Enroll an empty key. This allows the volume to be unlocked without a key,
+        which effectively disables the confidentiality protections of encryption. The encryption is not
+        removed, however, so confidentiality protections can be reenabled by removing the empty
+        key enrollment (i.e. via <option>--wipe-slot=empty</option>). Unlike a blank <option>--password</option>,
+        a key enrolled via this option will automatically unlock the volume with no user input and no
+        performance penalty.</para>
+
+        <xi:include href="version-info.xml" xpointer="v261"/></listitem>
+      </varlistentry>
     </variablelist>
   </refsect1>
 
@@ -683,7 +696,8 @@
 
         <listitem><para>Wipes one or more LUKS2 key slots. Takes a comma separated list of numeric slot
         indexes, or the special strings <literal>all</literal> (for wiping all key slots),
-        <literal>empty</literal> (for wiping all key slots that are unlocked by an empty passphrase),
+        <literal>empty</literal> (for wiping all key slots that are unlocked by an empty passphrase; not
+        just those enrolled via <option>--empty</option>),
         <literal>password</literal> (for wiping all key slots that are unlocked by a traditional passphrase),
         <literal>recovery</literal> (for wiping all key slots that are unlocked by a recovery key),
         <literal>pkcs11</literal> (for wiping all key slots that are unlocked by a PKCS#11 token),

--- a/src/cryptenroll/cryptenroll-empty.c
+++ b/src/cryptenroll/cryptenroll-empty.c
@@ -1,0 +1,50 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include "cryptenroll-empty.h"
+#include "cryptsetup-util.h"
+#include "iovec-util.h"
+#include "log.h"
+
+int enroll_empty(
+                struct crypt_device *cd,
+                const struct iovec *volume_key) {
+
+        int keyslot, r, q;
+        const char *node;
+
+        assert_se(cd);
+        assert_se(iovec_is_set(volume_key));
+
+        assert_se(node = sym_crypt_get_device_name(cd));
+
+        /* No need to robustly protect against brute-force attacks... */
+        r = cryptsetup_set_minimal_pbkdf(cd);
+        if (r < 0)
+                return log_error_errno(r, "Failed to set minimal PBKDF: %m");
+
+        keyslot = sym_crypt_keyslot_add_by_volume_key(
+                        cd,
+                        CRYPT_ANY_SLOT,
+                        volume_key->iov_base,
+                        volume_key->iov_len,
+                        /* passphrase= */ "",
+                        /* passphrase_size= */ 0);
+        if (keyslot < 0)
+                return log_error_errno(keyslot, "Failed to add empty key to %s: %m", node);
+
+        r = cryptsetup_add_token_empty(cd, keyslot);
+        if (r < 0) {
+                log_error_errno(r, "Failed to add empty JSON token to LUKS2 header: %m");
+                goto rollback;
+        }
+
+        log_warning("New empty key enrolled as key slot %i. Warning: This disables confidentiality protections!", keyslot);
+        return keyslot;
+
+rollback:
+        q = sym_crypt_keyslot_destroy(cd, keyslot);
+        if (q < 0)
+                log_debug_errno(q, "Unable to remove key slot we just added again, can't rollback, sorry: %m");
+
+        return r;
+}

--- a/src/cryptenroll/cryptenroll-empty.h
+++ b/src/cryptenroll/cryptenroll-empty.h
@@ -1,0 +1,6 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#pragma once
+
+#include "shared-forward.h"
+
+int enroll_empty(struct crypt_device *cd, const struct iovec *volume_key);

--- a/src/cryptenroll/cryptenroll-password.c
+++ b/src/cryptenroll/cryptenroll-password.c
@@ -206,6 +206,15 @@ int enroll_password(
         if (keyslot < 0)
                 return log_error_errno(keyslot, "Failed to add new password to %s: %m", node);
 
-        log_info("New password enrolled as key slot %i.", keyslot);
+        if (isempty(new_password)) {
+                r = cryptsetup_add_token_empty(cd, keyslot);
+                if (r < 0) {
+                        log_error_errno(r, "Failed to add empty JSON token to LUKS2 header: %m");
+                        return keyslot;
+                }
+                log_warning("New empty key enrolled as key slot %i. Warning: This disables confidentiality protections!", keyslot);
+        } else
+                log_info("New password enrolled as key slot %i.", keyslot);
+
         return keyslot;
 }

--- a/src/cryptenroll/cryptenroll.c
+++ b/src/cryptenroll/cryptenroll.c
@@ -8,6 +8,7 @@
 #include "blockdev-util.h"
 #include "build.h"
 #include "cryptenroll.h"
+#include "cryptenroll-empty.h"
 #include "cryptenroll-fido2.h"
 #include "cryptenroll-list.h"
 #include "cryptenroll-password.h"
@@ -96,6 +97,7 @@ static const char* const enroll_type_table[_ENROLL_TYPE_MAX] = {
         [ENROLL_PKCS11]   = "pkcs11",
         [ENROLL_FIDO2]    = "fido2",
         [ENROLL_TPM2]     = "tpm2",
+        [ENROLL_EMPTY]    = "empty",
 };
 
 DEFINE_STRING_TABLE_LOOKUP(enroll_type, EnrollType);
@@ -106,6 +108,7 @@ static const char *const luks2_token_type_table[_ENROLL_TYPE_MAX] = {
         [ENROLL_PKCS11]   = "systemd-pkcs11",
         [ENROLL_FIDO2]    = "systemd-fido2",
         [ENROLL_TPM2]     = "systemd-tpm2",
+        [ENROLL_EMPTY]    = "systemd-empty",
 };
 
 DEFINE_STRING_TABLE_LOOKUP(luks2_token_type, EnrollType);
@@ -380,6 +383,15 @@ static int parse_argv(int argc, char *argv[]) {
                                                        "Multiple operations specified at once, refusing.");
 
                         arg_enroll_type = ENROLL_RECOVERY;
+                        break;
+
+                OPTION_LONG("empty", NULL,
+                            "Enroll an empty key"):
+                        if (arg_enroll_type >= 0)
+                                return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
+                                                       "Multiple operations specified at once, refusing.");
+
+                        arg_enroll_type = ENROLL_EMPTY;
                         break;
 
                 OPTION_GROUP("PKCS#11 Enrollment"): {}
@@ -802,6 +814,10 @@ static int run(int argc, char *argv[]) {
 
         case ENROLL_RECOVERY:
                 slot = enroll_recovery(cd, &vk);
+                break;
+
+        case ENROLL_EMPTY:
+                slot = enroll_empty(cd, &vk);
                 break;
 
         case ENROLL_PKCS11:

--- a/src/cryptenroll/cryptenroll.h
+++ b/src/cryptenroll/cryptenroll.h
@@ -9,6 +9,7 @@ typedef enum EnrollType {
         ENROLL_PKCS11,
         ENROLL_FIDO2,
         ENROLL_TPM2,
+        ENROLL_EMPTY,
         _ENROLL_TYPE_MAX,
         _ENROLL_TYPE_INVALID = -EINVAL,
 } EnrollType;

--- a/src/cryptenroll/meson.build
+++ b/src/cryptenroll/meson.build
@@ -6,6 +6,7 @@ endif
 
 systemd_cryptenroll_sources = files(
         'cryptenroll.c',
+        'cryptenroll-empty.c',
         'cryptenroll-fido2.c',
         'cryptenroll-list.c',
         'cryptenroll-password.c',

--- a/src/cryptsetup/cryptsetup-tokens/cryptsetup-token-systemd-empty.c
+++ b/src/cryptsetup/cryptsetup-tokens/cryptsetup-token-systemd-empty.c
@@ -1,0 +1,97 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include <libcryptsetup.h>
+
+#include "alloc-util.h"
+#include "cryptsetup-token.h"
+#include "cryptsetup-token-util.h"
+#include "memory-util.h"
+#include "version.h"
+
+#define TOKEN_VERSION_MAJOR "1"
+#define TOKEN_VERSION_MINOR "0"
+
+/* for libcryptsetup debug purpose */
+_public_ const char *cryptsetup_token_version(void) {
+        return TOKEN_VERSION_MAJOR "." TOKEN_VERSION_MINOR " systemd-v" PROJECT_VERSION_FULL " (" GIT_VERSION ")";
+}
+
+_public_ int cryptsetup_token_open_pin(
+                struct crypt_device *cd, /* is always LUKS2 context */
+                int token /* is always >= 0 */,
+                const char *pin,
+                size_t pin_size,
+                char **ret_password, /* freed by cryptsetup_token_buffer_free */
+                size_t *ret_password_len,
+                void *usrptr /* plugin defined parameter passed to crypt_activate_by_token*() API */) {
+
+        _cleanup_free_ char *p = NULL;
+
+        assert(token >= 0);
+        assert(pin || pin_size == 0);
+        assert(ret_password);
+        assert(ret_password_len);
+
+        p = strdup("");
+        if (!p)
+                return crypt_log_oom(cd);
+
+        *ret_password = TAKE_PTR(p);
+        *ret_password_len = 0;
+        return 0;
+}
+
+/*
+ * This function is called from within following libcryptsetup calls
+ * provided conditions further below are met:
+ *
+ * crypt_activate_by_token(), crypt_activate_by_token_type(type == 'systemd-empty'):
+ *
+ * - token is assigned to at least one luks2 keyslot eligible to activate LUKS2 device
+ *   (alternatively: name is set to null, flags contains CRYPT_ACTIVATE_ALLOW_UNBOUND_KEY
+ *   and token is assigned to at least single keyslot).
+ *
+ * - if plugin defines validate function (see cryptsetup_token_validate below) it must have
+ *   passed the check (aka return 0)
+ */
+_public_ int cryptsetup_token_open(
+                struct crypt_device *cd, /* is always LUKS2 context */
+                int token /* is always >= 0 */,
+                char **ret_password, /* freed by cryptsetup_token_buffer_free */
+                size_t *ret_password_len,
+                void *usrptr /* plugin defined parameter passed to crypt_activate_by_token*() API */) {
+
+        return cryptsetup_token_open_pin(cd, token, NULL, 0, ret_password, ret_password_len, usrptr);
+}
+
+/*
+ * libcryptsetup callback for memory deallocation of 'password' parameter passed in
+ * any crypt_token_open_* plugin function
+ */
+_public_ void cryptsetup_token_buffer_free(void *buffer, size_t buffer_len) {
+        free(buffer);
+}
+
+/*
+ * Note:
+ *   If plugin is available in library path, it's called in before following libcryptsetup calls:
+ *
+ *   crypt_token_json_set, crypt_dump, any crypt_activate_by_token_* flavour
+ */
+_public_ int cryptsetup_token_validate(
+                struct crypt_device *cd, /* is always LUKS2 context */
+                const char *json /* contains valid 'type' and 'keyslots' fields. 'type' is 'systemd-empty' */) {
+
+        return 0; /* Nothing to validate */
+}
+
+/*
+ * prints systemd-empty token content in crypt_dump().
+ * 'type' and 'keyslots' fields are printed by libcryptsetup
+ */
+_public_ void cryptsetup_token_dump(
+                struct crypt_device *cd /* is always LUKS2 context */,
+                const char *json /* validated 'systemd-empty' token if cryptsetup_token_validate is defined */) {
+
+        /* Nothing to dump */
+}

--- a/src/cryptsetup/cryptsetup-tokens/meson.build
+++ b/src/cryptsetup/cryptsetup-tokens/meson.build
@@ -9,6 +9,10 @@ lib_cryptsetup_token_common = static_library(
         link_with : libshared,
         build_by_default : false)
 
+cryptsetup_token_systemd_empty_sources = files(
+        'cryptsetup-token-systemd-empty.c'
+)
+
 cryptsetup_token_systemd_tpm2_sources = files(
         'cryptsetup-token-systemd-tpm2.c',
         'luks2-tpm2.c',
@@ -37,6 +41,16 @@ template = {
 }
 
 modules += [
+        template + {
+                'name' : 'cryptsetup-token-systemd-empty',
+                'conditions' : [
+                        'HAVE_LIBCRYPTSETUP_PLUGINS',
+                ],
+                'sources' : cryptsetup_token_systemd_empty_sources,
+                'dependencies' : [
+                        libcryptsetup_cflags,
+                ],
+        },
         template + {
                 'name' : 'cryptsetup-token-systemd-tpm2',
                 'conditions' : [

--- a/src/repart/repart.c
+++ b/src/repart/repart.c
@@ -5605,16 +5605,30 @@ static int partition_encrypt(Context *context, Partition *p, PartitionTarget *ta
         if (IN_SET(p->encrypt, ENCRYPT_KEY_FILE, ENCRYPT_KEY_FILE_TPM2)) {
                 /* Use partition-specific key if available, otherwise fall back to global key */
                 struct iovec *iovec_key = arg_key.iov_base ? &arg_key : &p->key;
+                int keyslot;
 
-                r = sym_crypt_keyslot_add_by_volume_key(
+                if (iovec_key->iov_len == 0) {
+                        /* No need for robust protection against brute-force... */
+                        r = cryptsetup_set_minimal_pbkdf(cd);
+                        if (r < 0)
+                                return log_error_errno(r, "Failed to set minimal PBKDF: %m");
+                }
+
+                keyslot = sym_crypt_keyslot_add_by_volume_key(
                                 cd,
                                 CRYPT_ANY_SLOT,
                                 NULL,
                                 /* volume_key_size= */ volume_key_size,
                                 strempty(iovec_key->iov_base),
                                 iovec_key->iov_len);
-                if (r < 0)
-                        return log_error_errno(r, "Failed to add LUKS2 key: %m");
+                if (keyslot < 0)
+                        return log_error_errno(keyslot, "Failed to add LUKS2 key: %m");
+
+                if (iovec_key->iov_len == 0) {
+                        r = cryptsetup_add_token_empty(cd, keyslot);
+                        if (r < 0)
+                                return log_error_errno(r, "Failed to add empty JSON token to LUKS2 header: %m");
+                }
 
                 passphrase = strempty(iovec_key->iov_base);
                 passphrase_size = iovec_key->iov_len;

--- a/src/shared/cryptsetup-util.c
+++ b/src/shared/cryptsetup-util.c
@@ -11,6 +11,7 @@
 #include "escape.h"
 #include "hexdecoct.h"
 #include "hmac.h"
+#include "json-util.h"
 #include "log.h"
 #include "parse-util.h"
 #include "string-util.h"
@@ -206,6 +207,25 @@ int cryptsetup_add_token_json(struct crypt_device *cd, sd_json_variant *v) {
                 return log_debug_errno(r, "Failed to write token data to LUKS: %m");
 
         return 0;
+}
+
+int cryptsetup_add_token_empty(struct crypt_device *cd, int keyslot) {
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *v = NULL;
+        _cleanup_free_ char *keyslot_as_string = NULL;
+        int r;
+
+        r = asprintf(&keyslot_as_string, "%i", keyslot);
+        if (r < 0)
+                return log_oom_debug();
+
+        r = sd_json_buildo(
+                        &v,
+                        SD_JSON_BUILD_PAIR("type", JSON_BUILD_CONST_STRING("systemd-empty")),
+                        SD_JSON_BUILD_PAIR("keyslots", SD_JSON_BUILD_ARRAY(SD_JSON_BUILD_STRING(keyslot_as_string))));
+        if (r < 0)
+                return log_debug_errno(r, "Failed to prepare empty key JSON token object: %m");
+
+        return cryptsetup_add_token_json(cd, v);
 }
 
 int cryptsetup_get_volume_key_prefix(

--- a/src/shared/cryptsetup-util.h
+++ b/src/shared/cryptsetup-util.h
@@ -88,6 +88,7 @@ int cryptsetup_set_minimal_pbkdf(struct crypt_device *cd);
 
 int cryptsetup_get_token_as_json(struct crypt_device *cd, int idx, const char *verify_type, sd_json_variant **ret);
 int cryptsetup_add_token_json(struct crypt_device *cd, sd_json_variant *v);
+int cryptsetup_add_token_empty(struct crypt_device *cd, int keyslot);
 int cryptsetup_get_volume_key_prefix(struct crypt_device *cd, const char *volume_name, char **ret);
 int cryptsetup_get_volume_key_id(struct crypt_device *cd, const char *volume_name, const void *volume_key,
                                  size_t volume_key_size,  char **ret);

--- a/test/units/TEST-24-CRYPTSETUP.sh
+++ b/test/units/TEST-24-CRYPTSETUP.sh
@@ -92,10 +92,10 @@ WORKDIR="$(mktemp -d)"
 # Prepare a couple of LUKS2-encrypted disk images
 #
 # 1) Image with an empty password
-IMAGE_EMPTY="$WORKDIR/empty.img)"
+IMAGE_EMPTY="$WORKDIR/empty.img"
 IMAGE_EMPTY_KEYFILE="$WORKDIR/empty.keyfile"
 IMAGE_EMPTY_KEYFILE_ERASE="$WORKDIR/empty-erase.keyfile"
-IMAGE_EMPTY_KEYFILE_ERASE_FAIL="$WORKDIR/empty-erase-fail.keyfile)"
+IMAGE_EMPTY_KEYFILE_ERASE_FAIL="$WORKDIR/empty-erase-fail.keyfile"
 truncate -s 32M "$IMAGE_EMPTY"
 echo -n passphrase >"$IMAGE_EMPTY_KEYFILE"
 chmod 0600 "$IMAGE_EMPTY_KEYFILE"

--- a/test/units/TEST-24-CRYPTSETUP.sh
+++ b/test/units/TEST-24-CRYPTSETUP.sh
@@ -91,26 +91,36 @@ WORKDIR="$(mktemp -d)"
 
 # Prepare a couple of LUKS2-encrypted disk images
 #
-# 1) Image with an empty password
-IMAGE_EMPTY="$WORKDIR/empty.img"
-IMAGE_EMPTY_KEYFILE="$WORKDIR/empty.keyfile"
-IMAGE_EMPTY_KEYFILE_ERASE="$WORKDIR/empty-erase.keyfile"
-IMAGE_EMPTY_KEYFILE_ERASE_FAIL="$WORKDIR/empty-erase-fail.keyfile"
-truncate -s 32M "$IMAGE_EMPTY"
-echo -n passphrase >"$IMAGE_EMPTY_KEYFILE"
-chmod 0600 "$IMAGE_EMPTY_KEYFILE"
+# 1) Image with both a password and an empty password
+IMAGE_PASS="$WORKDIR/password.img"
+IMAGE_PASS_KEYFILE="$WORKDIR/password.keyfile"
+IMAGE_PASS_KEYFILE_ERASE="$WORKDIR/password-erase.keyfile"
+IMAGE_PASS_KEYFILE_ERASE_FAIL="$WORKDIR/password-erase-fail.keyfile"
+truncate -s 32M "$IMAGE_PASS"
+echo -n passphrase >"$IMAGE_PASS_KEYFILE"
+chmod 0600 "$IMAGE_PASS_KEYFILE"
 cryptsetup luksFormat --batch-mode \
                       --pbkdf pbkdf2 \
                       --pbkdf-force-iterations 1000 \
                       --use-urandom \
-                      "$IMAGE_EMPTY" "$IMAGE_EMPTY_KEYFILE"
-PASSWORD=passphrase NEWPASSWORD="" systemd-cryptenroll --password "$IMAGE_EMPTY"
+                      "$IMAGE_PASS" "$IMAGE_PASS_KEYFILE"
+PASSWORD=passphrase NEWPASSWORD="" systemd-cryptenroll --password "$IMAGE_PASS"
 # Duplicate the key file to test keyfile-erase as well
-cp -v "$IMAGE_EMPTY_KEYFILE" "$IMAGE_EMPTY_KEYFILE_ERASE"
+cp -v "$IMAGE_PASS_KEYFILE" "$IMAGE_PASS_KEYFILE_ERASE"
 # The key should get erased even on a failed attempt, so test that too
-cp -v "$IMAGE_EMPTY_KEYFILE" "$IMAGE_EMPTY_KEYFILE_ERASE_FAIL"
+cp -v "$IMAGE_PASS_KEYFILE" "$IMAGE_PASS_KEYFILE_ERASE_FAIL"
 
-# 2) Image with a detached header and a key file offset + size
+# 2) Image with a systemd-empty slot
+IMAGE_EMPTY="$WORKDIR/empty.img"
+truncate -s 32M "$IMAGE_EMPTY"
+cryptsetup luksFormat --batch-mode \
+                      --pbkdf pbkdf2 \
+                      --pbkdf-force-iterations 1000 \
+                      --use-urandom \
+                      "$IMAGE_EMPTY" "$IMAGE_PASS_KEYFILE"
+PASSWORD=passphrase systemd-cryptenroll --wipe-slot=password --empty "$IMAGE_EMPTY"
+
+# 3) Image with a detached header and a key file offset + size
 IMAGE_DETACHED="$WORKDIR/detached.img"
 IMAGE_DETACHED_KEYFILE="$WORKDIR/detached.keyfile"
 IMAGE_DETACHED_KEYFILE2="$WORKDIR/detached.keyfile2"
@@ -173,31 +183,33 @@ udevadm settle --timeout=60
 [[ -e /etc/crypttab ]] && cp -fv /etc/crypttab /tmp/crypttab.bak
 cat >/etc/crypttab <<EOF
 # headless should translate to headless=1
-empty_key            $IMAGE_EMPTY    $IMAGE_EMPTY_KEYFILE            headless,x-systemd.device-timeout=1m
-empty_key_erase      $IMAGE_EMPTY    $IMAGE_EMPTY_KEYFILE_ERASE      headless=1,keyfile-erase=1
-empty_key_erase_fail $IMAGE_EMPTY    $IMAGE_EMPTY_KEYFILE_ERASE_FAIL headless=1,keyfile-erase=1,keyfile-offset=4
+pass_key                 $IMAGE_PASS     $IMAGE_PASS_KEYFILE             headless,x-systemd.device-timeout=1m
+pass_key_erase           $IMAGE_PASS     $IMAGE_PASS_KEYFILE_ERASE       headless=1,keyfile-erase=1
+pass_key_erase_fail      $IMAGE_PASS     $IMAGE_PASS_KEYFILE_ERASE_FAIL  headless=1,keyfile-erase=1,keyfile-offset=4
 # Empty passphrase without try-empty-password(=yes) shouldn't work
-empty_fail0          $IMAGE_EMPTY    -                               headless=1
-empty_fail1          $IMAGE_EMPTY    -                               headless=1,try-empty-password=0
-empty0               $IMAGE_EMPTY    -                               headless=1,try-empty-password
-empty1               $IMAGE_EMPTY    -                               headless=1,try-empty-password=1
-# This one expects the key to be under /{etc,run}/cryptsetup-keys.d/empty_nokey.key
-empty_nokey          $IMAGE_EMPTY    -                               headless=1
-empty_pkcs11_auto    $IMAGE_EMPTY    -                               headless=1,pkcs11-uri=auto
+pass_empty_fail0         $IMAGE_PASS     -                               headless=1
+pass_empty_fail1         $IMAGE_PASS     -                               headless=1,try-empty-password=0
+pass_empty0              $IMAGE_PASS     -                               headless=1,try-empty-password
+pass_empty1              $IMAGE_PASS     -                               headless=1,try-empty-password=1
+# This one expects the key to be under /{etc,run}/cryptsetup-keys.d/pass_nokey.key
+pass_nokey               $IMAGE_PASS     -                               headless=1
+pass_empty_pkcs11_auto   $IMAGE_PASS     -                               headless=1,pkcs11-uri=auto
+# Unlike the empty passphrase, an image with an empty slot should automatically unlock w/o try-empty-password
+empty                    $IMAGE_EMPTY    -                               headless=1
 
-detached             $IMAGE_DETACHED $IMAGE_DETACHED_KEYFILE         headless=1,header=$IMAGE_DETACHED_HEADER,keyfile-offset=32,keyfile-size=16
-detached_store0      $IMAGE_DETACHED $IMAGE_DETACHED_KEYFILE         headless=1,header=/header:LABEL=header_store,keyfile-offset=32,keyfile-size=16
-detached_store1      $IMAGE_DETACHED /keyfile:LABEL=keyfile_store    headless=1,header=$IMAGE_DETACHED_HEADER
-detached_store2      $IMAGE_DETACHED /keyfile:LABEL=keyfile_store    headless=1,header=/header:LABEL=header_store
-detached_fail0       $IMAGE_DETACHED $IMAGE_DETACHED_KEYFILE         headless=1,header=$IMAGE_DETACHED_HEADER,keyfile-offset=32
-detached_fail1       $IMAGE_DETACHED $IMAGE_DETACHED_KEYFILE         headless=1,header=$IMAGE_DETACHED_HEADER
-detached_fail2       $IMAGE_DETACHED $IMAGE_DETACHED_KEYFILE         headless=1
-detached_fail3       $IMAGE_DETACHED $IMAGE_DETACHED_KEYFILE         headless=1,header=$IMAGE_DETACHED_HEADER,keyfile-offset=16,keyfile-size=16
-detached_fail4       $IMAGE_DETACHED $IMAGE_DETACHED_KEYFILE         headless=1,header=$IMAGE_DETACHED_HEADER,keyfile-offset=32,keyfile-size=8
-detached_slot0       $IMAGE_DETACHED $IMAGE_DETACHED_KEYFILE2        headless=1,header=$IMAGE_DETACHED_HEADER
-detached_slot1       $IMAGE_DETACHED $IMAGE_DETACHED_KEYFILE2        headless=1,header=$IMAGE_DETACHED_HEADER,key-slot=8
-detached_slot_fail   $IMAGE_DETACHED $IMAGE_DETACHED_KEYFILE2        headless=1,header=$IMAGE_DETACHED_HEADER,key-slot=0
-detached_nofail      $IMAGE_DETACHED $TMPFS_DETACHED_KEYFILE/keyfile headless=1,header=$TMPFS_DETACHED_HEADER/header,keyfile-offset=32,keyfile-size=16,nofail
+detached                 $IMAGE_DETACHED $IMAGE_DETACHED_KEYFILE         headless=1,header=$IMAGE_DETACHED_HEADER,keyfile-offset=32,keyfile-size=16
+detached_store0          $IMAGE_DETACHED $IMAGE_DETACHED_KEYFILE         headless=1,header=/header:LABEL=header_store,keyfile-offset=32,keyfile-size=16
+detached_store1          $IMAGE_DETACHED /keyfile:LABEL=keyfile_store    headless=1,header=$IMAGE_DETACHED_HEADER
+detached_store2          $IMAGE_DETACHED /keyfile:LABEL=keyfile_store    headless=1,header=/header:LABEL=header_store
+detached_fail0           $IMAGE_DETACHED $IMAGE_DETACHED_KEYFILE         headless=1,header=$IMAGE_DETACHED_HEADER,keyfile-offset=32
+detached_fail1           $IMAGE_DETACHED $IMAGE_DETACHED_KEYFILE         headless=1,header=$IMAGE_DETACHED_HEADER
+detached_fail2           $IMAGE_DETACHED $IMAGE_DETACHED_KEYFILE         headless=1
+detached_fail3           $IMAGE_DETACHED $IMAGE_DETACHED_KEYFILE         headless=1,header=$IMAGE_DETACHED_HEADER,keyfile-offset=16,keyfile-size=16
+detached_fail4           $IMAGE_DETACHED $IMAGE_DETACHED_KEYFILE         headless=1,header=$IMAGE_DETACHED_HEADER,keyfile-offset=32,keyfile-size=8
+detached_slot0           $IMAGE_DETACHED $IMAGE_DETACHED_KEYFILE2        headless=1,header=$IMAGE_DETACHED_HEADER
+detached_slot1           $IMAGE_DETACHED $IMAGE_DETACHED_KEYFILE2        headless=1,header=$IMAGE_DETACHED_HEADER,key-slot=8
+detached_slot_fail       $IMAGE_DETACHED $IMAGE_DETACHED_KEYFILE2        headless=1,header=$IMAGE_DETACHED_HEADER,key-slot=0
+detached_nofail          $IMAGE_DETACHED $TMPFS_DETACHED_KEYFILE/keyfile headless=1,header=$TMPFS_DETACHED_HEADER/header,keyfile-offset=32,keyfile-size=16,nofail
 EOF
 
 # Temporarily drop luks.name=/luks.uuid= from the kernel command line, as it makes
@@ -212,82 +224,82 @@ mkdir -p /tmp/systemd-cryptsetup-generator.out
 systemctl daemon-reload
 systemctl list-unit-files "systemd-cryptsetup@*"
 
-cryptsetup_start_and_check empty_key
-test -e "$IMAGE_EMPTY_KEYFILE_ERASE"
-cryptsetup_start_and_check empty_key_erase
-test ! -e "$IMAGE_EMPTY_KEYFILE_ERASE"
-test -e "$IMAGE_EMPTY_KEYFILE_ERASE_FAIL"
-cryptsetup_start_and_check -f empty_key_erase_fail
-test ! -e "$IMAGE_EMPTY_KEYFILE_ERASE_FAIL"
-cryptsetup_start_and_check -f empty_fail{0..1}
-cryptsetup_start_and_check empty{0..1}
+cryptsetup_start_and_check pass_key
+test -e "$IMAGE_PASS_KEYFILE_ERASE"
+cryptsetup_start_and_check pass_key_erase
+test ! -e "$IMAGE_PASS_KEYFILE_ERASE"
+test -e "$IMAGE_PASS_KEYFILE_ERASE_FAIL"
+cryptsetup_start_and_check -f pass_key_erase_fail
+test ! -e "$IMAGE_PASS_KEYFILE_ERASE_FAIL"
+cryptsetup_start_and_check -f pass_empty_fail{0..1}
+cryptsetup_start_and_check pass_empty{0..1}
 # First, check if we correctly fail without any key
-cryptsetup_start_and_check -f empty_nokey
+cryptsetup_start_and_check -f pass_nokey
 # And now provide the key via /{etc,run}/cryptsetup-keys.d/
 mkdir -p /run/cryptsetup-keys.d
-cp "$IMAGE_EMPTY_KEYFILE" /run/cryptsetup-keys.d/empty_nokey.key
-cryptsetup_start_and_check empty_nokey
+cp "$IMAGE_PASS_KEYFILE" /run/cryptsetup-keys.d/pass_nokey.key
+cryptsetup_start_and_check pass_nokey
 
 if [[ -d /usr/lib/softhsm/tokens ]]; then
     # Test unlocking with a PKCS#11 token
     export SOFTHSM2_CONF="/etc/softhsm2.conf"
 
-    PIN="1234" systemd-cryptenroll --pkcs11-token-uri="pkcs11:token=TestToken;object=RSATestKey" --unlock-key-file="$IMAGE_EMPTY_KEYFILE" "$IMAGE_EMPTY"
-    cryptsetup_start_and_check empty_pkcs11_auto
-    cryptsetup luksKillSlot -q "$IMAGE_EMPTY" 2
-    cryptsetup token remove --token-id 0 "$IMAGE_EMPTY"
+    PIN="1234" systemd-cryptenroll --pkcs11-token-uri="pkcs11:token=TestToken;object=RSATestKey" --unlock-key-file="$IMAGE_PASS_KEYFILE" "$IMAGE_PASS"
+    cryptsetup_start_and_check pass_empty_pkcs11_auto
+    cryptsetup luksKillSlot -q "$IMAGE_PASS" 2
+    cryptsetup token remove --token-id 0 "$IMAGE_PASS"
 
-    PIN="1234" systemd-cryptenroll --pkcs11-token-uri="pkcs11:token=TestToken;object=RSATestKey;type=cert" --unlock-key-file="$IMAGE_EMPTY_KEYFILE" "$IMAGE_EMPTY"
-    cryptsetup_start_and_check empty_pkcs11_auto
-    cryptsetup luksKillSlot -q "$IMAGE_EMPTY" 2
-    cryptsetup token remove --token-id 0 "$IMAGE_EMPTY"
+    PIN="1234" systemd-cryptenroll --pkcs11-token-uri="pkcs11:token=TestToken;object=RSATestKey;type=cert" --unlock-key-file="$IMAGE_PASS_KEYFILE" "$IMAGE_PASS"
+    cryptsetup_start_and_check pass_empty_pkcs11_auto
+    cryptsetup luksKillSlot -q "$IMAGE_PASS" 2
+    cryptsetup token remove --token-id 0 "$IMAGE_PASS"
 
-    PIN="1234" systemd-cryptenroll --pkcs11-token-uri="pkcs11:token=TestToken;object=RSATestKey;type=public" --unlock-key-file="$IMAGE_EMPTY_KEYFILE" "$IMAGE_EMPTY"
-    cryptsetup_start_and_check empty_pkcs11_auto
-    cryptsetup luksKillSlot -q "$IMAGE_EMPTY" 2
-    cryptsetup token remove --token-id 0 "$IMAGE_EMPTY"
+    PIN="1234" systemd-cryptenroll --pkcs11-token-uri="pkcs11:token=TestToken;object=RSATestKey;type=public" --unlock-key-file="$IMAGE_PASS_KEYFILE" "$IMAGE_PASS"
+    cryptsetup_start_and_check pass_empty_pkcs11_auto
+    cryptsetup luksKillSlot -q "$IMAGE_PASS" 2
+    cryptsetup token remove --token-id 0 "$IMAGE_PASS"
 
-    PIN="1234" systemd-cryptenroll --pkcs11-token-uri="pkcs11:token=TestToken;object=ECTestKey" --unlock-key-file="$IMAGE_EMPTY_KEYFILE" "$IMAGE_EMPTY"
-    cryptsetup_start_and_check empty_pkcs11_auto
-    cryptsetup luksKillSlot -q "$IMAGE_EMPTY" 2
-    cryptsetup token remove --token-id 0 "$IMAGE_EMPTY"
+    PIN="1234" systemd-cryptenroll --pkcs11-token-uri="pkcs11:token=TestToken;object=ECTestKey" --unlock-key-file="$IMAGE_PASS_KEYFILE" "$IMAGE_PASS"
+    cryptsetup_start_and_check pass_empty_pkcs11_auto
+    cryptsetup luksKillSlot -q "$IMAGE_PASS" 2
+    cryptsetup token remove --token-id 0 "$IMAGE_PASS"
 
-    PIN="1234" systemd-cryptenroll --pkcs11-token-uri="pkcs11:token=TestToken;object=ECTestKey;type=cert" --unlock-key-file="$IMAGE_EMPTY_KEYFILE" "$IMAGE_EMPTY"
-    cryptsetup_start_and_check empty_pkcs11_auto
-    cryptsetup luksKillSlot -q "$IMAGE_EMPTY" 2
-    cryptsetup token remove --token-id 0 "$IMAGE_EMPTY"
+    PIN="1234" systemd-cryptenroll --pkcs11-token-uri="pkcs11:token=TestToken;object=ECTestKey;type=cert" --unlock-key-file="$IMAGE_PASS_KEYFILE" "$IMAGE_PASS"
+    cryptsetup_start_and_check pass_empty_pkcs11_auto
+    cryptsetup luksKillSlot -q "$IMAGE_PASS" 2
+    cryptsetup token remove --token-id 0 "$IMAGE_PASS"
 
-    PIN="1234" systemd-cryptenroll --pkcs11-token-uri="pkcs11:token=TestToken;object=ECTestKey;type=public" --unlock-key-file="$IMAGE_EMPTY_KEYFILE" "$IMAGE_EMPTY"
-    cryptsetup_start_and_check empty_pkcs11_auto
-    cryptsetup luksKillSlot -q "$IMAGE_EMPTY" 2
-    cryptsetup token remove --token-id 0 "$IMAGE_EMPTY"
+    PIN="1234" systemd-cryptenroll --pkcs11-token-uri="pkcs11:token=TestToken;object=ECTestKey;type=public" --unlock-key-file="$IMAGE_PASS_KEYFILE" "$IMAGE_PASS"
+    cryptsetup_start_and_check pass_empty_pkcs11_auto
+    cryptsetup luksKillSlot -q "$IMAGE_PASS" 2
+    cryptsetup token remove --token-id 0 "$IMAGE_PASS"
 
     # Verify that new RSA enrollments tag the LUKS2 token with the OAEP padding scheme. Old systemd
     # versions ignore this field and fall back to PKCS#1 v1.5, which causes the token to refuse to
     # decrypt the OAEP-wrapped blob, so this metadata is what makes graceful rejection on old systems
     # possible. The actual OAEP hash variant (SHA-1 vs SHA-256) is probed at enrollment time and
     # depends on what the token supports, but SoftHSM through at least 2.7.0 only accepts SHA-1
-    PIN="1234" systemd-cryptenroll --pkcs11-token-uri="pkcs11:token=TestToken;object=RSATestKey" --unlock-key-file="$IMAGE_EMPTY_KEYFILE" "$IMAGE_EMPTY"
-    cryptsetup luksDump --dump-json-metadata "$IMAGE_EMPTY" |
+    PIN="1234" systemd-cryptenroll --pkcs11-token-uri="pkcs11:token=TestToken;object=RSATestKey" --unlock-key-file="$IMAGE_PASS_KEYFILE" "$IMAGE_PASS"
+    cryptsetup luksDump --dump-json-metadata "$IMAGE_PASS" |
         jq -e '.tokens | with_entries(select(.value.type == "systemd-pkcs11"))[]["pkcs11-padding"] | select(. == "oaep-sha256" or . == "oaep-sha1")' >/dev/null
 
     # Forward-compat negative check: tampering with the padding tag must cause unlocking to fail
     # cleanly (the token rejects the OAEP blob when asked to do PKCS#1 v1.5, and vice versa).
-    TOKEN_ID=$(cryptsetup luksDump --dump-json-metadata "$IMAGE_EMPTY" |
+    TOKEN_ID=$(cryptsetup luksDump --dump-json-metadata "$IMAGE_PASS" |
         jq -r '.tokens | to_entries[] | select(.value.type == "systemd-pkcs11") | .key' | head -n1)
-    cryptsetup token export --token-id "$TOKEN_ID" "$IMAGE_EMPTY" |
+    cryptsetup token export --token-id "$TOKEN_ID" "$IMAGE_PASS" |
         jq '. + {"pkcs11-padding": "pkcs1"}' >"$WORKDIR/tampered-token.json"
-    cryptsetup token remove --token-id "$TOKEN_ID" "$IMAGE_EMPTY"
-    cryptsetup token import --json-file="$WORKDIR/tampered-token.json" --token-id "$TOKEN_ID" "$IMAGE_EMPTY"
-    cryptsetup_start_and_check -f empty_pkcs11_auto
+    cryptsetup token remove --token-id "$TOKEN_ID" "$IMAGE_PASS"
+    cryptsetup token import --json-file="$WORKDIR/tampered-token.json" --token-id "$TOKEN_ID" "$IMAGE_PASS"
+    cryptsetup_start_and_check -f pass_empty_pkcs11_auto
     # Restore the correct token and confirm unlock works again.
-    cryptsetup token remove --token-id "$TOKEN_ID" "$IMAGE_EMPTY"
-    cryptsetup luksKillSlot -q "$IMAGE_EMPTY" 2
+    cryptsetup token remove --token-id "$TOKEN_ID" "$IMAGE_PASS"
+    cryptsetup luksKillSlot -q "$IMAGE_PASS" 2
 
-    PIN="1234" systemd-cryptenroll --pkcs11-token-uri="pkcs11:token=TestToken;object=RSATestKey" --unlock-key-file="$IMAGE_EMPTY_KEYFILE" "$IMAGE_EMPTY"
-    cryptsetup_start_and_check empty_pkcs11_auto
-    cryptsetup luksKillSlot -q "$IMAGE_EMPTY" 2
-    cryptsetup token remove --token-id 0 "$IMAGE_EMPTY"
+    PIN="1234" systemd-cryptenroll --pkcs11-token-uri="pkcs11:token=TestToken;object=RSATestKey" --unlock-key-file="$IMAGE_PASS_KEYFILE" "$IMAGE_PASS"
+    cryptsetup_start_and_check pass_empty_pkcs11_auto
+    cryptsetup luksKillSlot -q "$IMAGE_PASS" 2
+    cryptsetup token remove --token-id 0 "$IMAGE_PASS"
 
     # Backward-compat check: mock a legacy LUKS2 token wrapped with PKCS#1 v1.5 (no
     # 'pkcs11-padding' field) and verify the new code can still decrypt it
@@ -303,8 +315,8 @@ if [[ -d /usr/lib/softhsm/tokens ]]; then
                     -pkeyopt rsa_padding_mode:pkcs1 \
                     -in "$WORKDIR/decrypted.bin" -out "$WORKDIR/encrypted.bin"
     base64 -w0 "$WORKDIR/decrypted.bin" >"$WORKDIR/passphrase"
-    cryptsetup luksAddKey --batch-mode --key-file="$IMAGE_EMPTY_KEYFILE" "$IMAGE_EMPTY" "$WORKDIR/passphrase"
-    LEGACY_SLOT=$(cryptsetup luksDump --dump-json-metadata "$IMAGE_EMPTY" |
+    cryptsetup luksAddKey --batch-mode --key-file="$IMAGE_PASS_KEYFILE" "$IMAGE_PASS" "$WORKDIR/passphrase"
+    LEGACY_SLOT=$(cryptsetup luksDump --dump-json-metadata "$IMAGE_PASS" |
         jq -r '.keyslots | keys | map(tonumber) | max')
     ENCRYPTED_B64=$(base64 -w0 "$WORKDIR/encrypted.bin")
     cat >"$WORKDIR/legacy-token.json" <<EOF
@@ -315,11 +327,13 @@ if [[ -d /usr/lib/softhsm/tokens ]]; then
     "pkcs11-key": "$ENCRYPTED_B64"
 }
 EOF
-    cryptsetup token import --json-file="$WORKDIR/legacy-token.json" "$IMAGE_EMPTY"
-    cryptsetup_start_and_check empty_pkcs11_auto
-    cryptsetup luksKillSlot -q "$IMAGE_EMPTY" "$LEGACY_SLOT"
-    cryptsetup token remove --token-id 0 "$IMAGE_EMPTY"
+    cryptsetup token import --json-file="$WORKDIR/legacy-token.json" "$IMAGE_PASS"
+    cryptsetup_start_and_check pass_empty_pkcs11_auto
+    cryptsetup luksKillSlot -q "$IMAGE_PASS" "$LEGACY_SLOT"
+    cryptsetup token remove --token-id 0 "$IMAGE_PASS"
 fi
+
+cryptsetup_start_and_check empty
 
 cryptsetup_start_and_check detached
 cryptsetup_start_and_check detached_store{0..2}


### PR DESCRIPTION
Replaces https://github.com/systemd/systemd/pull/28061

This creates a new systemd-empty token type, which cryptsetup can then automatically unlock.

Enrolling an empty password behaves exactly as before: nothing is automatically unlocked unless try-empty-password is enabled on that volume.

I think i addressed all blocking comments in https://github.com/systemd/systemd/pull/28061