### PR TITLE
journalctl: dlopen gcrypt in the --setup-keys path

### DIFF
--- a/src/basic/gcrypt-util.c
+++ b/src/basic/gcrypt-util.c
@@ -47,11 +47,7 @@ int dlopen_gcrypt(int log_level) {
 #if HAVE_GCRYPT
         static void *gcrypt_dl = NULL;
 
-        SD_ELF_NOTE_DLOPEN(
-                        "gcrypt",
-                        "Support for journald forward-sealing",
-                        SD_ELF_NOTE_DLOPEN_PRIORITY_SUGGESTED,
-                        "libgcrypt.so.20");
+        GCRYPT_NOTE(SD_ELF_NOTE_DLOPEN_PRIORITY_SUGGESTED);
 
         return dlopen_many_sym_or_warn(
                         &gcrypt_dl,

--- a/src/basic/gcrypt-util.h
+++ b/src/basic/gcrypt-util.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include "sd-dlopen.h"
+
 #include "basic-forward.h"
 
 int dlopen_gcrypt(int log_level);
@@ -9,6 +11,18 @@ int dlopen_gcrypt(int log_level);
 int initialize_libgcrypt(bool secmem);
 
 #if HAVE_GCRYPT
+#define GCRYPT_NOTE(priority)                                           \
+        SD_ELF_NOTE_DLOPEN("gcrypt",                                    \
+                           "Support for journald forward-sealing",      \
+                           priority,                                    \
+                           "libgcrypt.so.20")
+
+#define DLOPEN_GCRYPT(log_level, priority)                              \
+        ({                                                              \
+                GCRYPT_NOTE(priority);                                  \
+                dlopen_gcrypt(log_level);                               \
+        })
+
 #include <gcrypt.h> /* IWYU pragma: export */
 
 #include "dlfcn-util.h"
@@ -53,6 +67,8 @@ extern DLSYM_PROTOTYPE(gcry_strerror);
                 (h__)->buf[(h__)->bufpos++] = (c) & 0xff;  \
         } while(false)
 #else
+#define DLOPEN_GCRYPT(log_level, priority) dlopen_gcrypt(log_level)
+
 typedef struct gcry_md_handle *gcry_md_hd_t;
 
 static inline void sym_gcry_md_close(gcry_md_hd_t h) {

--- a/src/journal/journalctl-authenticate.c
+++ b/src/journal/journalctl-authenticate.c
@@ -11,6 +11,7 @@
 #include "fd-util.h"
 #include "fs-util.h"
 #include "fsprg.h"
+#include "gcrypt-util.h"
 #include "hostname-setup.h"
 #include "hostname-util.h"
 #include "io-util.h"
@@ -71,6 +72,10 @@ int action_setup_keys(void) {
         int r;
 
         assert(arg_action == ACTION_SETUP_KEYS);
+
+        r = DLOPEN_GCRYPT(LOG_ERR, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+        if (r < 0)
+                return r;
 
         r = is_dir("/var/log/journal/", /* follow= */ false);
         if (r == 0)


### PR DESCRIPTION
journalctl needs gcrypt to set up the journal sealing keys and other such operations, but gets no dlopen note with the dependency. Add the dlopen macro with a recommends level so it can be skipped, but gets pulled in by default on user/desktop systems.