### PR TITLE
libc: provide openat2 syscall number fallback

### DIFF
--- a/src/include/override/sys/generate-syscall.py
+++ b/src/include/override/sys/generate-syscall.py
@@ -9,6 +9,7 @@ SYSCALLS = [
     'fchmodat2',     # defined in glibc header since glibc-2.39
     'kexec_file_load',
     'open_tree_attr',
+    'openat2',       # defined in glibc header since glibc-2.42
     'quotactl_fd',   # defined in glibc header since glibc-2.35
     'removexattrat',
     'setxattrat',

--- a/src/include/override/sys/syscall.h
+++ b/src/include/override/sys/syscall.h
@@ -264,6 +264,76 @@ static_assert(__NR_open_tree_attr == systemd_NR_open_tree_attr, "");
 #  endif
 #endif
 
+#ifndef __IGNORE_openat2
+#  if defined(__aarch64__)
+#    define systemd_NR_openat2 437
+#  elif defined(__alpha__)
+#    define systemd_NR_openat2 547
+#  elif defined(__arc__) || defined(__tilegx__)
+#    define systemd_NR_openat2 437
+#  elif defined(__arm__)
+#    define systemd_NR_openat2 437
+#  elif defined(__i386__)
+#    define systemd_NR_openat2 437
+#  elif defined(__ia64__)
+#    define systemd_NR_openat2 1461
+#  elif defined(__loongarch_lp64)
+#    define systemd_NR_openat2 437
+#  elif defined(__m68k__)
+#    define systemd_NR_openat2 437
+#  elif defined(_MIPS_SIM)
+#    if _MIPS_SIM == _MIPS_SIM_ABI32
+#      define systemd_NR_openat2 4437
+#    elif _MIPS_SIM == _MIPS_SIM_NABI32
+#      define systemd_NR_openat2 6437
+#    elif _MIPS_SIM == _MIPS_SIM_ABI64
+#      define systemd_NR_openat2 5437
+#    else
+#      error "Unknown MIPS ABI"
+#    endif
+#  elif defined(__hppa__)
+#    define systemd_NR_openat2 437
+#  elif defined(__powerpc__)
+#    define systemd_NR_openat2 437
+#  elif defined(__riscv)
+#    if __riscv_xlen == 32
+#      define systemd_NR_openat2 437
+#    elif __riscv_xlen == 64
+#      define systemd_NR_openat2 437
+#    else
+#      error "Unknown RISC-V ABI"
+#    endif
+#  elif defined(__s390__)
+#    define systemd_NR_openat2 437
+#  elif defined(__sh__)
+#    define systemd_NR_openat2 437
+#  elif defined(__sparc__)
+#    define systemd_NR_openat2 437
+#  elif defined(__x86_64__)
+#    if defined(__ILP32__)
+#      define systemd_NR_openat2 (437 | /* __X32_SYSCALL_BIT */ 0x40000000)
+#    else
+#      define systemd_NR_openat2 437
+#    endif
+#  elif !defined(missing_arch_template)
+#    warning "openat2() syscall number is unknown for your architecture"
+#  endif
+
+/* may be an (invalid) negative number due to libseccomp, see PR 13319 */
+#  if defined __NR_openat2 && __NR_openat2 >= 0
+#    if defined systemd_NR_openat2
+static_assert(__NR_openat2 == systemd_NR_openat2, "");
+#    endif
+#  else
+#    if defined __NR_openat2
+#      undef __NR_openat2
+#    endif
+#    if defined systemd_NR_openat2 && systemd_NR_openat2 >= 0
+#      define __NR_openat2 systemd_NR_openat2
+#    endif
+#  endif
+#endif
+
 #ifndef __IGNORE_quotactl_fd
 #  if defined(__aarch64__)
 #    define systemd_NR_quotactl_fd 443


### PR DESCRIPTION
## Summary
Add openat2 to the generated syscall override header so the runtime libc shim can fall back to syscall(__NR_openat2, ...) even when the host libc headers do not define __NR_openat2.

## Root cause
src/libc/fcntl.c now uses DEFINE_SYSCALL_SHIM(openat2, ...), which falls back to the raw syscall when the libc symbol is unavailable at runtime. The generated override header in src/include/override/sys/syscall.h already patches in missing __NR_* values for several newer syscalls, but openat2 was omitted from the hard-coded generator input list even though the syscall tables already contain it.

That leaves some build environments unable to compile the fallback path, which showed up in fork-side ClusterFuzzLite PR builds as:

```text
../../src/systemd/src/libc/fcntl.c:7:1: error: use of undeclared identifier '__NR_openat2'
```

## Fix
Add openat2 to src/include/override/sys/generate-syscall.py and regenerate src/include/override/sys/syscall.h.

## Verification
Confirmed locally with a preprocessor check that the override layer now provides:

```text
#define __NR_openat2 systemd_NR_openat2
#define systemd_NR_openat2 437
```

This is intended as a standalone fix separate from the OCI runtime-spec parser work that exposed it in fork CI.
