### PR TITLE
Revert "units: drop After=network-online.target from imds services"

### DIFF
--- a/units/systemd-imds-import.service.in
+++ b/units/systemd-imds-import.service.in
@@ -11,10 +11,9 @@
 Description=Import System Credentials from IMDS
 Documentation=man:systemd-imds(1)
 Documentation=man:systemd.system-credentials(7)
-
 DefaultDependencies=no
-Wants=systemd-imdsd.socket
-After=systemd-imdsd.socket
+Wants=systemd-imdsd.socket network-online.target
+After=systemd-imdsd.socket network-online.target
 Before=sysinit.target systemd-firstboot.service
 Conflicts=shutdown.target
 Before=shutdown.target


### PR DESCRIPTION
IMDS access requires networking, hence we need to run after network-online.target. Everything else would be racy and result in likely timeouts, because we might try to contact the network too early.

This reverts commit 3f33f4d057506970682e9de4eff06881d678f18a.