### PR TITLE
Add handling for '-1' when parsing vsock CID

### DIFF
--- a/src/basic/socket-util.c
+++ b/src/basic/socket-util.c
@@ -1738,7 +1738,7 @@ int vsock_parse_cid(const char *s, unsigned *ret) {
                 *ret = VMADDR_CID_LOCAL;
         else if (streq(s, "host"))
                 *ret = VMADDR_CID_HOST;
-        else if (streq(s, "any") || streq(s, "-1"))
+        else if (STR_IN_SET(s, "any", "-1"))
                 *ret = VMADDR_CID_ANY;
         else
                 return safe_atou(s, ret);

--- a/src/basic/socket-util.c
+++ b/src/basic/socket-util.c
@@ -1724,14 +1724,13 @@ int vsock_parse_port(const char *s, unsigned *ret) {
 }
 
 int vsock_parse_cid(const char *s, unsigned *ret) {
-        int cid, r;
         assert(ret);
 
         if (!s)
                 return -EINVAL;
 
         /* Parsed an AF_VSOCK "CID". This is a 32bit entity, and the usual type is "unsigned". We recognize
-         * the three special CIDs as strings, and otherwise parse the numeric CIDs. */
+         * the four special CIDs as strings, and otherwise parse the numeric CIDs. */
 
         if (streq(s, "hypervisor"))
                 *ret = VMADDR_CID_HYPERVISOR;
@@ -1739,16 +1738,10 @@ int vsock_parse_cid(const char *s, unsigned *ret) {
                 *ret = VMADDR_CID_LOCAL;
         else if (streq(s, "host"))
                 *ret = VMADDR_CID_HOST;
-        else if (streq(s, "any"))
+        else if (streq(s, "any") || streq(s, "-1"))
                 *ret = VMADDR_CID_ANY;
-        else {
-                /* The CID needs to wrap to support VMADDR_CID_ANY for instance. */
-                r = safe_atoi(s, &cid);
-                if (r < 0)
-                        return r;
-
-                *ret = (unsigned int) cid;
-        }
+        else
+                return safe_atou(s, ret);
 
         return 0;
 }

--- a/src/basic/socket-util.c
+++ b/src/basic/socket-util.c
@@ -1724,6 +1724,7 @@ int vsock_parse_port(const char *s, unsigned *ret) {
 }
 
 int vsock_parse_cid(const char *s, unsigned *ret) {
+        int cid, r;
         assert(ret);
 
         if (!s)
@@ -1738,8 +1739,16 @@ int vsock_parse_cid(const char *s, unsigned *ret) {
                 *ret = VMADDR_CID_LOCAL;
         else if (streq(s, "host"))
                 *ret = VMADDR_CID_HOST;
-        else
-                return safe_atou(s, ret);
+        else if (streq(s, "any"))
+                *ret = VMADDR_CID_ANY;
+        else {
+                /* The CID needs to wrap to support VMADDR_CID_ANY for instance. */
+                r = safe_atoi(s, &cid);
+                if (r < 0)
+                        return r;
+
+                *ret = (unsigned int) cid;
+        }
 
         return 0;
 }


### PR DESCRIPTION
Currently `systemd-ssh-generator` supports `systemd.ssh_listen=vsock::22` and aliases the "empty CID" towards `VMADDR_CID_ANY`. VMADDR_CID_ANY is -1, so it's confusing from a user experience that `systemd.ssh_listen=vsock:-1:22` isn't supported.