### PR TITLE
crypto-util: support OpenSSL 4

### DIFF
--- a/src/shared/crypto-util.c
+++ b/src/shared/crypto-util.c
@@ -335,12 +335,15 @@ DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_RENAME(UI_METHOD*, sym_UI_destroy_method, UI_de
 int dlopen_libcrypto(int log_level) {
 #if HAVE_OPENSSL
         static void *libcrypto_dl = NULL;
+        int r;
 
         LIBCRYPTO_NOTE(SD_ELF_NOTE_DLOPEN_PRIORITY_SUGGESTED);
 
-        return dlopen_many_sym_or_warn(
+        // FIXME: switch order to prefer libcrypto.so.4 in a future version once it has stabilized
+        FOREACH_STRING(soname, "libcrypto.so.3", "libcrypto.so.4") {
+                r = dlopen_many_sym_or_warn(
                         &libcrypto_dl,
-                        "libcrypto.so.3",
+                        soname,
                         log_level,
                         DLSYM_ARG(ASN1_ANY_it),
                         DLSYM_ARG(ASN1_BIT_STRING_it),
@@ -617,6 +620,15 @@ int dlopen_libcrypto(int log_level) {
                         DLSYM_ARG(X509_VERIFY_PARAM_set_hostflags),
                         DLSYM_ARG(X509_VERIFY_PARAM_set1_host),
                         DLSYM_ARG(X509_VERIFY_PARAM_set1_ip));
+                if (r >= 0)
+                        break;
+        }
+        if (r < 0) {
+                log_full_errno(log_level, r, "Neither libcrypto.so.4 nor libcrypto.so.3 could be loaded");
+                return -EOPNOTSUPP; /* turn into recognizable error */
+        }
+
+        return r;
 #else
         return log_full_errno(log_level, SYNTHETIC_ERRNO(EOPNOTSUPP),
                               "libcrypto support is not compiled in.");

--- a/src/shared/crypto-util.h
+++ b/src/shared/crypto-util.h
@@ -37,7 +37,7 @@ int dlopen_libcrypto(int log_level);
         SD_ELF_NOTE_DLOPEN("libcrypto",                                 \
                            "Support for cryptographic operations",      \
                            priority,                                    \
-                           "libcrypto.so.3")
+                           "libcrypto.so.3", "libcrypto.so.4")
 
 #define DLOPEN_LIBCRYPTO(log_level, priority)                           \
         ({                                                              \

--- a/src/test/test-crypto-util.c
+++ b/src/test/test-crypto-util.c
@@ -101,9 +101,11 @@ static const struct {
         const char *alg;
         size_t size;
 } digest_size_table[] = {
+#ifndef OPENSSL_NO_SHA1
         /* SHA1 "family" */
         { "sha1",     20, },
         { "sha-1",    20, },
+#endif
         /* SHA2 family */
         { "sha224",   28, },
         { "sha256",   32, },
@@ -122,10 +124,14 @@ static const struct {
         { "sha3-256", 32, },
         { "sha3-384", 48, },
         { "sha3-512", 64, },
+#ifndef OPENSSL_NO_SM3
         /* SM3 family */
         { "sm3",      32, },
+#endif
+#ifndef OPENSSL_NO_MD5
         /* MD5 family */
         { "md5",      16, },
+#endif
 };
 
 TEST(digest_size) {


### PR DESCRIPTION
OpenSSL 4 broke ABI, so we need to try libcrypto.so.4 first, and fallback to libcrypto.so.3