### PR TITLE
mkosi: copy packaged test-fdstore if not build locally

### DIFF
--- a/mkosi/mkosi.images/minimal-base/mkosi.postinst
+++ b/mkosi/mkosi.images/minimal-base/mkosi.postinst
@@ -20,4 +20,8 @@ fi
 # For use in the minimal containers, only needs libsystemd and libc
 if [[ -x "$BUILDDIR/test-fdstore" ]]; then
     cp "$BUILDDIR/test-fdstore" "$BUILDROOT/usr/bin/test-fdstore"
+elif [[ -x "$BUILDROOT/usr/lib/systemd/tests/unit-tests/manual/test-fdstore" ]]; then
+    cp "$BUILDROOT/usr/lib/systemd/tests/unit-tests/manual/test-fdstore" "$BUILDROOT/usr/bin/test-fdstore"
+elif [[ -x /usr/lib/systemd/tests/unit-tests/manual/test-fdstore ]]; then
+    cp /usr/lib/systemd/tests/unit-tests/manual/test-fdstore "$BUILDROOT/usr/bin/test-fdstore"
 fi


### PR DESCRIPTION
On Ubuntu autopkgtest, TEST-91-LIVEUPDATE fails because test-fdstore is not found in the dummy container.

I don't think this is a complete fix, but it should get it further along.