### PR TITLE
libc: provide mount_setattr syscall number fallback

### DIFF
--- a/src/include/override/sys/generate-syscall.py
+++ b/src/include/override/sys/generate-syscall.py
@@ -8,6 +8,7 @@ import sys
 SYSCALLS = [
     'fchmodat2',     # defined in glibc header since glibc-2.39
     'kexec_file_load',
+    'mount_setattr',
     'open_tree_attr',
     'quotactl_fd',   # defined in glibc header since glibc-2.35
     'removexattrat',

--- a/src/include/override/sys/syscall.h
+++ b/src/include/override/sys/syscall.h
@@ -194,6 +194,76 @@ static_assert(__NR_kexec_file_load == systemd_NR_kexec_file_load, "");
 #  endif
 #endif
 
+#ifndef __IGNORE_mount_setattr
+#  if defined(__aarch64__)
+#    define systemd_NR_mount_setattr 442
+#  elif defined(__alpha__)
+#    define systemd_NR_mount_setattr 552
+#  elif defined(__arc__) || defined(__tilegx__)
+#    define systemd_NR_mount_setattr 442
+#  elif defined(__arm__)
+#    define systemd_NR_mount_setattr 442
+#  elif defined(__i386__)
+#    define systemd_NR_mount_setattr 442
+#  elif defined(__ia64__)
+#    define systemd_NR_mount_setattr 1466
+#  elif defined(__loongarch_lp64)
+#    define systemd_NR_mount_setattr 442
+#  elif defined(__m68k__)
+#    define systemd_NR_mount_setattr 442
+#  elif defined(_MIPS_SIM)
+#    if _MIPS_SIM == _MIPS_SIM_ABI32
+#      define systemd_NR_mount_setattr 4442
+#    elif _MIPS_SIM == _MIPS_SIM_NABI32
+#      define systemd_NR_mount_setattr 6442
+#    elif _MIPS_SIM == _MIPS_SIM_ABI64
+#      define systemd_NR_mount_setattr 5442
+#    else
+#      error "Unknown MIPS ABI"
+#    endif
+#  elif defined(__hppa__)
+#    define systemd_NR_mount_setattr 442
+#  elif defined(__powerpc__)
+#    define systemd_NR_mount_setattr 442
+#  elif defined(__riscv)
+#    if __riscv_xlen == 32
+#      define systemd_NR_mount_setattr 442
+#    elif __riscv_xlen == 64
+#      define systemd_NR_mount_setattr 442
+#    else
+#      error "Unknown RISC-V ABI"
+#    endif
+#  elif defined(__s390__)
+#    define systemd_NR_mount_setattr 442
+#  elif defined(__sh__)
+#    define systemd_NR_mount_setattr 442
+#  elif defined(__sparc__)
+#    define systemd_NR_mount_setattr 442
+#  elif defined(__x86_64__)
+#    if defined(__ILP32__)
+#      define systemd_NR_mount_setattr (442 | /* __X32_SYSCALL_BIT */ 0x40000000)
+#    else
+#      define systemd_NR_mount_setattr 442
+#    endif
+#  elif !defined(missing_arch_template)
+#    warning "mount_setattr() syscall number is unknown for your architecture"
+#  endif
+
+/* may be an (invalid) negative number due to libseccomp, see PR 13319 */
+#  if defined __NR_mount_setattr && __NR_mount_setattr >= 0
+#    if defined systemd_NR_mount_setattr
+static_assert(__NR_mount_setattr == systemd_NR_mount_setattr, "");
+#    endif
+#  else
+#    if defined __NR_mount_setattr
+#      undef __NR_mount_setattr
+#    endif
+#    if defined systemd_NR_mount_setattr && systemd_NR_mount_setattr >= 0
+#      define __NR_mount_setattr systemd_NR_mount_setattr
+#    endif
+#  endif
+#endif
+
 #ifndef __IGNORE_open_tree_attr
 #  if defined(__aarch64__)
 #    define systemd_NR_open_tree_attr 467


### PR DESCRIPTION
## Summary
Add mount_setattr to the generated syscall override header so the runtime libc shim can fall back to syscall(__NR_mount_setattr, ...) even when the build environment headers do not define __NR_mount_setattr.

## Root cause
src/libc/mount.c uses DEFINE_SYSCALL_SHIM(mount_setattr, ...), which falls back to the raw syscall when the libc symbol is unavailable at runtime. The generated override header in src/include/override/sys/syscall.h fills in missing __NR_* values for selected newer syscalls, but mount_setattr was not in the generator input list.

That left fork-side ClusterFuzzLite PR builds unable to compile the fallback path once the OCI runtime-spec parser work reached this codepath.

## Fix
Add mount_setattr to src/include/override/sys/generate-syscall.py and regenerate src/include/override/sys/syscall.h.

## Verification
This exact change was part of the fix set that took fork PR rezzell/systemd#1 from repeated ClusterFuzzLite build failures to a fully green run in 27808503529.

This is intended as a narrow follow-up separate from the OCI runtime-spec parser change that exposed it in fork CI.
