### PR TITLE
libc: add close_range fallbacks for older libc

### DIFF
--- a/src/include/override/sys/generate-syscall.py
+++ b/src/include/override/sys/generate-syscall.py
@@ -6,6 +6,7 @@ import sys
 
 # We only generate numbers for a dozen or so syscalls
 SYSCALLS = [
+    'close_range',
     'fchmodat2',     # defined in glibc header since glibc-2.39
     'kexec_file_load',
     'open_tree_attr',

--- a/src/include/override/sys/syscall.h
+++ b/src/include/override/sys/syscall.h
@@ -124,6 +124,76 @@ static_assert(__NR_fchmodat2 == systemd_NR_fchmodat2, "");
 #  endif
 #endif
 
+#ifndef __IGNORE_close_range
+#  if defined(__aarch64__)
+#    define systemd_NR_close_range 436
+#  elif defined(__alpha__)
+#    define systemd_NR_close_range 546
+#  elif defined(__arc__) || defined(__tilegx__)
+#    define systemd_NR_close_range 436
+#  elif defined(__arm__)
+#    define systemd_NR_close_range 436
+#  elif defined(__i386__)
+#    define systemd_NR_close_range 436
+#  elif defined(__ia64__)
+#    define systemd_NR_close_range 1460
+#  elif defined(__loongarch_lp64)
+#    define systemd_NR_close_range 436
+#  elif defined(__m68k__)
+#    define systemd_NR_close_range 436
+#  elif defined(_MIPS_SIM)
+#    if _MIPS_SIM == _MIPS_SIM_ABI32
+#      define systemd_NR_close_range 4436
+#    elif _MIPS_SIM == _MIPS_SIM_NABI32
+#      define systemd_NR_close_range 6436
+#    elif _MIPS_SIM == _MIPS_SIM_ABI64
+#      define systemd_NR_close_range 5436
+#    else
+#      error "Unknown MIPS ABI"
+#    endif
+#  elif defined(__hppa__)
+#    define systemd_NR_close_range 436
+#  elif defined(__powerpc__)
+#    define systemd_NR_close_range 436
+#  elif defined(__riscv)
+#    if __riscv_xlen == 32
+#      define systemd_NR_close_range 436
+#    elif __riscv_xlen == 64
+#      define systemd_NR_close_range 436
+#    else
+#      error "Unknown RISC-V ABI"
+#    endif
+#  elif defined(__s390__)
+#    define systemd_NR_close_range 436
+#  elif defined(__sh__)
+#    define systemd_NR_close_range 436
+#  elif defined(__sparc__)
+#    define systemd_NR_close_range 436
+#  elif defined(__x86_64__)
+#    if defined(__ILP32__)
+#      define systemd_NR_close_range (436 | /* __X32_SYSCALL_BIT */ 0x40000000)
+#    else
+#      define systemd_NR_close_range 436
+#    endif
+#  elif !defined(missing_arch_template)
+#    warning "close_range() syscall number is unknown for your architecture"
+#  endif
+
+/* may be an (invalid) negative number due to libseccomp, see PR 13319 */
+#  if defined __NR_close_range && __NR_close_range >= 0
+#    if defined systemd_NR_close_range
+static_assert(__NR_close_range == systemd_NR_close_range, "");
+#    endif
+#  else
+#    if defined __NR_close_range
+#      undef __NR_close_range
+#    endif
+#    if defined systemd_NR_close_range && systemd_NR_close_range >= 0
+#      define __NR_close_range systemd_NR_close_range
+#    endif
+#  endif
+#endif
+
 #ifndef __IGNORE_kexec_file_load
 #  if defined(__aarch64__)
 #    define systemd_NR_kexec_file_load 294

--- a/src/include/override/unistd.h
+++ b/src/include/override/unistd.h
@@ -3,5 +3,10 @@
 
 #include_next <unistd.h>        /* IWYU pragma: export */
 
+/* Defined since glibc-2.34.
+ * Supported since kernel v5.9 (60997c3d45d9be4b19fbe0f2fa67f2e384429aad). */
+int close_range_shim(unsigned first_fd, unsigned end_fd, unsigned flags);
+#define close_range close_range_shim
+
 int pivot_root_shim(const char *new_root, const char *put_old);
 #define pivot_root pivot_root_shim

--- a/src/libc/unistd.c
+++ b/src/libc/unistd.c
@@ -2,6 +2,11 @@
 
 #include "libc-shim.h"
 
+DEFINE_SYSCALL_SHIM(close_range, int,
+                    unsigned, first_fd,
+                    unsigned, end_fd,
+                    unsigned, flags)
+
 DEFINE_SYSCALL_SHIM(pivot_root, int,
                     const char *, new_root,
                     const char *, put_old)


### PR DESCRIPTION
## Summary
Add a runtime shim for close_range and teach the syscall override generator to provide __NR_close_range when older libc headers do not define it.

## Root cause
The fork-side ClusterFuzzLite PR runs first failed at runtime because libsystemd-shared had a hard dependency on the libc close_range symbol. After routing the call through the libc shim layer, the next failing runs then exposed the second half of the same compatibility gap: older build headers still did not define __NR_close_range, so the fallback path itself could not compile.

## Fix
- route close_range through the libc syscall shim in src/libc/unistd.c and src/include/override/unistd.h
- add close_range to src/include/override/sys/generate-syscall.py and regenerate src/include/override/sys/syscall.h

## Verification
These exact changes were part of the fix set that took fork PR rezzell/systemd#1 from repeated ClusterFuzzLite failures to a fully green run in 27808503529.

This is intended as a narrow follow-up separate from the OCI runtime-spec parser change that exposed it in fork CI.
