### PR TITLE
basic: resolve strerrorname_np at runtime

### DIFF
--- a/src/basic/errno-list.c
+++ b/src/basic/errno-list.c
@@ -1,5 +1,6 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
+#include <dlfcn.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -25,11 +26,32 @@ int errno_from_name(const char *name) {
 }
 
 #ifdef __GLIBC__
+#include "errno-to-name.inc"
+
+static const char *(*strerrorname_np_func)(int);
+
+__attribute__((constructor)) static void strerrorname_np_func_init(void) {
+        void *p = dlsym(RTLD_DEFAULT, "strerrorname_np");
+        __asm__ volatile("" ::: "memory");
+        strerrorname_np_func = (const char *(*)(int)) p;
+}
+
 const char* errno_name_no_fallback(int id) {
         if (id == 0) /* To stay in line with our implementation below.  */
                 return NULL;
 
-        return strerrorname_np(ABS(id));
+        id = ABS(id);
+
+        if (strerrorname_np_func) {
+                const char *n = strerrorname_np_func(id);
+                if (n)
+                        return n;
+        }
+
+        if ((size_t) id >= ELEMENTSOF(errno_names))
+                return NULL;
+
+        return errno_names[id];
 }
 #else
 #  include "errno-to-name.inc"


### PR DESCRIPTION
## Summary
Resolve strerrorname_np at runtime and fall back to the generated errno name table when the libc symbol is unavailable.

## Root cause
Fork-side ClusterFuzzLite PR builds eventually moved past the earlier compile-time issues and then failed at fuzzer startup because the runtime libc in that environment did not export strerrorname_np. errno_name_no_fallback linked against the symbol directly, so every fuzz target failed before exercising the code under test.

## Fix
Resolve strerrorname_np with dlsym at load time. If the symbol is unavailable, or if libc returns NULL for a specific errno value, fall back to the existing generated errno_names table.

## Verification
This exact change was part of the fix set that took fork PR rezzell/systemd#1 from repeated ClusterFuzzLite failures to a fully green run in 27808503529.

This is intended as a narrow compatibility follow-up separate from the OCI runtime-spec parser change that exposed it in fork CI.
