### PR TITLE
basic: guard newer SEGV si_code constants

### DIFF
--- a/src/basic/signal-util.c
+++ b/src/basic/signal-util.c
@@ -260,8 +260,12 @@ static const char *const sigsegv_code_table[] = {
         [SEGV_ACCADI]  = "SEGV_ACCADI",
         [SEGV_ADIDERR] = "SEGV_ADIDERR",
         [SEGV_ADIPERR] = "SEGV_ADIPERR",
+#ifdef SEGV_MTEAERR
         [SEGV_MTEAERR] = "SEGV_MTEAERR",
+#endif
+#ifdef SEGV_MTESERR
         [SEGV_MTESERR] = "SEGV_MTESERR",
+#endif
         [SEGV_CPERR]   = "SEGV_CPERR",
 };
 


### PR DESCRIPTION
## Summary
Guard the newer SEGV si_code table entries so the build does not assume headers that define SEGV_MTEAERR and SEGV_MTESERR.

## Root cause
Fork-side ClusterFuzzLite PR builds compile against an older userspace header set than current upstream development environments. signal-util.c indexed the SIGSEGV code table with SEGV_MTEAERR and SEGV_MTESERR unconditionally, which caused compilation to fail when those constants were absent.

## Fix
Wrap those two table entries with preprocessor guards and leave the rest of the table unchanged.

## Verification
This exact change was part of the fix set that took fork PR rezzell/systemd#1 from repeated ClusterFuzzLite failures to a fully green run in 27808503529.

This is intended as a narrow compatibility follow-up separate from the OCI runtime-spec parser change that exposed it in fork CI.
