### PR TITLE
executor: also preload libcrypto

### DIFF
--- a/src/core/exec-invoke.c
+++ b/src/core/exec-invoke.c
@@ -33,6 +33,7 @@
 #include "constants.h"
 #include "copy.h"
 #include "coredump-util.h"
+#include "crypto-util.h"
 #include "cryptsetup-util.h"
 #include "dissect-image.h"
 #include "dynamic-user.h"
@@ -6002,6 +6003,8 @@ int exec_invoke(
         (void) DLOPEN_CRYPTSETUP(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
         (void) DLOPEN_LIBMOUNT(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
         (void) DLOPEN_LIBSECCOMP(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+        /* Needed for userspace verity verification fallback */
+        (void) DLOPEN_LIBCRYPTO(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
 
         /* Let's now disable further dlopen()ing of libraries, since we are about to do namespace
          * shenanigans, and do not want to mix resources from host and namespace */


### PR DESCRIPTION
It's needed for the userspace fallback verity verification, so it needs to be pre-loaded to avoid getting blocked by RTLD_NOLOAD:

 [   57.163995] (cat)[1560]: minimal-app0-foo.service: Validation of dm-verity signature failed via the kernel, trying userspace validation instead: Required key not available
 [   57.194696] (cat)[1560]: minimal-app0-foo.service: Refusing loading of 'libcrypto.so.3', as loading further dlopen() modules has been blocked.
 [   57.197940] (cat)[1560]: minimal-app0-foo.service: Shared library 'libcrypto.so.3' is not available: Operation not permitted
 [   57.204283] (cat)[1560]: minimal-app0-foo.service: Failed to activate verity device /dev/mapper/2b2fd83f324c3aa2ea1a979899f9c630761f1de3c5e00ce8c6bb36f4d137f450-verity: Operation not supported
 [   57.272782] (cat)[1560]: minimal-app0-foo.service: Failed to set up mount namespacing: Operation not supported
 [   57.274250] (cat)[1560]: minimal-app0-foo.service: Failed at step NAMESPACE spawning cat: Operation not supported

Follow-up for efaf5a763d6a06645dba8e88ebc15e887d59cbef

e.g.: https://github.com/systemd/systemd/actions/runs/27830819740/job/82366860982?pr=42656#step:14:359