### PR TITLE
nspawn: accept OCI runtime-spec 1.x bundles

### DIFF
--- a/.github/workflows/cflite-pr.yml
+++ b/.github/workflows/cflite-pr.yml
@@ -23,6 +23,9 @@ jobs:
       matrix:
         sanitizer: [address, undefined, memory]
     steps:
+    # ClusterFuzzLite @v1 decides whether to pivot to the OSS-Fuzz base OS
+    # before it extracts PR sources itself, so check out the repo first.
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
     - name: Build Fuzzers
       id: build
       uses: google/clusterfuzzlite/actions/build_fuzzers@v1

--- a/docs/superpowers/specs/2026-06-14-oci-runtime-spec-1x-design.md
+++ b/docs/superpowers/specs/2026-06-14-oci-runtime-spec-1x-design.md
@@ -22,6 +22,7 @@ In scope:
 - Preserve parser strictness for malformed or unsupported bundle content.
 - Keep failure behavior for requested semantics that systemd cannot safely realize.
 - Update tests to reflect `1.x` compatibility.
+- Limit the initial implementation to the `systemd-nspawn --oci-bundle=` runtime-bundle loading path.
 
 Out of scope:
 
@@ -29,6 +30,41 @@ Out of scope:
 - Rewriting or mutating OCI bundles on disk.
 - Adding support for currently unsupported OCI runtime features solely because a newer `1.x` bundle may mention them.
 - Changing OCI image-spec import or conversion code in `src/import/pull-oci.c`, unless a separate issue is later identified there.
+
+## Named Workflow Boundaries
+
+The following nearby workflows are explicitly classified so the implementation plan does not drift:
+
+In scope:
+
+- OCI runtime bundle loading via `systemd-nspawn --oci-bundle=`
+  - Consumes an OCI runtime-spec `config.json`
+  - Checks `ociVersion`
+  - Implemented in `src/nspawn/nspawn-oci.c`
+
+Out of scope:
+
+- OCI image-spec import and download
+  - Handles OCI image indexes, manifests, layers, and image configuration objects
+  - Implemented in `src/import/pull-oci.c`
+  - Not driven by runtime-spec `ociVersion`
+
+- `.nspawn` settings generation from OCI image configuration
+  - Related to OCI image import
+  - Produces native `.nspawn` settings from OCI image configuration data
+  - Not part of runtime-bundle `ociVersion` compatibility
+
+- Non-OCI `systemd-nspawn` container inputs
+  - Directory trees
+  - Raw disk images
+  - Tarball-based imports
+  - Mount-stack based roots
+
+- Portable services and other image-based container-adjacent workflows
+  - Container-related, but not OCI runtime bundle parsing
+
+- Any bundle migration or on-disk rewrite flow
+  - No persisted conversion, normalization artifact, or rewritten `config.json`
 
 ## Compatibility Contract
 

--- a/docs/superpowers/specs/2026-06-14-oci-runtime-spec-1x-design.md
+++ b/docs/superpowers/specs/2026-06-14-oci-runtime-spec-1x-design.md
@@ -1,0 +1,188 @@
+# OCI Runtime-Spec 1.x Bundle Compatibility For systemd-nspawn
+
+## Goal
+
+Allow `systemd-nspawn --oci-bundle=` to accept any OCI runtime-spec `1.x` bundle that systemd can safely interpret, instead of rejecting everything except `ociVersion == "1.0.0"`.
+
+This change is specifically about OCI runtime bundles (`config.json` with `ociVersion`), not OCI image-spec manifests, image layouts, or conversion workflows.
+
+## Current State
+
+Today `systemd-nspawn` hard-rejects any OCI bundle whose top-level `ociVersion` is not exactly the string `1.0.0`.
+
+The version gate is implemented in `src/nspawn/nspawn-oci.c` after parsing `config.json` and before dispatching the remaining bundle fields into `Settings`.
+
+The current test suite also encodes this behavior by asserting that an arbitrary non-`1.0.0` version fails in `test/units/TEST-13-NSPAWN.nspawn-oci.sh`.
+
+## Scope
+
+In scope:
+
+- Accept OCI runtime-spec bundles declaring `ociVersion` in the `1.x.y` line.
+- Preserve parser strictness for malformed or unsupported bundle content.
+- Keep failure behavior for requested semantics that systemd cannot safely realize.
+- Update tests to reflect `1.x` compatibility.
+
+Out of scope:
+
+- Supporting OCI runtime-spec major versions other than `1`.
+- Rewriting or mutating OCI bundles on disk.
+- Adding support for currently unsupported OCI runtime features solely because a newer `1.x` bundle may mention them.
+- Changing OCI image-spec import or conversion code in `src/import/pull-oci.c`, unless a separate issue is later identified there.
+
+## Compatibility Contract
+
+`ociVersion` should be treated as a runtime-spec compatibility declaration, not an exact version fingerprint.
+
+The loader will:
+
+- Accept OCI runtime-spec bundles with major version `1`.
+- Reject malformed `ociVersion` strings.
+- Reject major versions other than `1`, such as `0.x` or `2.x`.
+
+Acceptance of a `1.x` bundle does not imply support for every feature introduced anywhere in the runtime spec's `1.x` history. The compatibility rule is narrower:
+
+- Parse and enforce fields systemd already implements.
+- Ignore unknown or newer fields only when ignoring them does not change the semantics of the behavior systemd does implement.
+- Reject bundles that request behavior systemd recognizes but cannot safely preserve.
+
+This follows the user's selected policy: fail only when semantics would be lost or changed, and otherwise ignore unsupported additions with warnings where appropriate.
+
+## Runtime Spec Versus Image Spec
+
+This work is for OCI runtime bundles consumed by `systemd-nspawn --oci-bundle=`.
+
+It is not the same as OCI image-spec support:
+
+- OCI runtime spec defines the `config.json` bundle format used by runtimes.
+- OCI image spec defines image layouts, indexes, manifests, layers, and image configuration objects.
+
+In the current systemd tree, `src/nspawn/nspawn-oci.c` handles runtime bundles, while `src/import/pull-oci.c` handles OCI image-spec downloads and translates image configuration into `.nspawn` settings. Those are separate subsystems and should remain separate in this design.
+
+## Proposed Implementation
+
+### Version Parsing
+
+Replace the current exact string comparison with a small helper dedicated to OCI runtime-spec version validation.
+
+The helper should:
+
+- Accept a string from the top-level `ociVersion` field.
+- Parse it as a SemVer-like `major.minor.patch` version.
+- Return success only when `major == 1`.
+- Return a precise error for malformed version strings or unsupported major versions.
+
+The helper should be invoked immediately after the JSON object is loaded and before dispatching the rest of the bundle.
+
+### Parser Behavior
+
+The rest of the parser should remain structurally strict.
+
+The change should not weaken existing validation for:
+
+- required fields
+- invalid types
+- malformed field contents
+- explicitly unsupported semantics that systemd cannot safely emulate
+
+The existing distinction between "unexpected" and "unsupported" OCI content remains useful and should be preserved:
+
+- "unexpected" means structurally invalid or not acceptable at that location
+- "unsupported" means recognized, but intentionally not implemented
+
+No general "downgrade everything to 1.0 semantics" layer is proposed in the first patch.
+
+Instead:
+
+- accept `1.x`
+- continue validating each field on its own merits
+- add version-specific normalization later only if concrete `1.1+` semantic differences are found to affect fields systemd already interprets
+
+## In-Memory Only Compatibility
+
+The implementation should not rewrite `config.json` and should not create migrated bundle copies on disk.
+
+Reasons:
+
+- parsing compatibility can be decided entirely in memory
+- rewriting bundles would introduce side effects into a runtime path
+- persisted migration artifacts would complicate trust, debugging, and ownership
+- systemd should remain a consumer of OCI runtime bundles, not a mutating bundle converter
+
+## Safety Rules
+
+The following rules define when a `1.x` bundle is accepted or rejected:
+
+- A newer `1.x` version number by itself is never a reason to reject the bundle.
+- A malformed `ociVersion` string is rejected.
+- A non-`1` major version is rejected.
+- A malformed supported field is rejected.
+- A recognized field requesting behavior systemd cannot safely preserve is rejected.
+- A new or unknown field may be ignored only when doing so does not alter the semantics of the behavior systemd otherwise applies.
+
+This keeps acceptance aligned with runtime-spec compatibility while avoiding silent semantic drift.
+
+## Testing Plan
+
+### Integration Test Updates
+
+Update `test/units/TEST-13-NSPAWN.nspawn-oci.sh` so that:
+
+- `1.0.0` still succeeds
+- representative newer `1.x` values such as `1.1.0` succeed
+- a non-`1` major version such as `2.0.0` fails
+- malformed version strings fail
+
+The current test named around "invalid OCI bundle version" should be adjusted to reflect unsupported major versions rather than any non-`1.0.0` string.
+
+### Fuzz And Sample Coverage
+
+Update or extend `test/fuzz/fuzz-nspawn-oci/` inputs so version handling is not permanently coupled to the exact `1.0.0` string.
+
+At minimum:
+
+- retain an existing `1.0.0` sample
+- add at least one `1.1.x` sample
+- add a malformed or unsupported-major sample if there is a convenient place for a negative corpus case
+
+### Verification Focus
+
+Verification should specifically confirm:
+
+- newer `1.x` bundles pass the version gate
+- current valid `1.0.0` bundles are unaffected
+- invalid or unsupported-major versions still fail early and clearly
+- existing unsupported runtime features continue to fail as before
+
+## Risks
+
+The primary risk is silent semantic mismatch: accepting a newer `1.x` bundle while unintentionally dropping behavior that matters.
+
+This design controls that risk by:
+
+- limiting automatic acceptance to major version `1`
+- keeping per-field validation strict
+- refusing semantics systemd knows it cannot preserve
+- avoiding on-disk migration or rewriting
+
+Another risk is overcomplicating the first patch with speculative compatibility machinery. This design avoids that by keeping the first change narrowly focused on semver-aware acceptance and leaving any future normalization layer to a later patch if real evidence requires it.
+
+## Open Questions
+
+None for the initial design.
+
+The remaining implementation work is mostly mechanical:
+
+- add version parsing helper
+- replace exact string check
+- adjust tests
+- verify that no other runtime-bundle version gates exist
+
+## Recommended Plan Hand-Off
+
+The implementation plan should focus on:
+
+1. introducing the OCI runtime-spec version parser/helper
+2. updating the `oci_load()` gate to accept `1.x`
+3. adjusting unit or integration coverage for `1.x`, malformed input, and unsupported major versions
+4. verifying no behavior regressions in existing OCI bundle handling

--- a/src/basic/errno-list.c
+++ b/src/basic/errno-list.c
@@ -1,5 +1,6 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
+#include <dlfcn.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -25,11 +26,32 @@ int errno_from_name(const char *name) {
 }
 
 #ifdef __GLIBC__
+#include "errno-to-name.inc"
+
+static const char *(*strerrorname_np_func)(int);
+
+__attribute__((constructor)) static void strerrorname_np_func_init(void) {
+        void *p = dlsym(RTLD_DEFAULT, "strerrorname_np");
+        __asm__ volatile("" ::: "memory");
+        strerrorname_np_func = (const char *(*)(int)) p;
+}
+
 const char* errno_name_no_fallback(int id) {
         if (id == 0) /* To stay in line with our implementation below.  */
                 return NULL;
 
-        return strerrorname_np(ABS(id));
+        id = ABS(id);
+
+        if (strerrorname_np_func) {
+                const char *n = strerrorname_np_func(id);
+                if (n)
+                        return n;
+        }
+
+        if ((size_t) id >= ELEMENTSOF(errno_names))
+                return NULL;
+
+        return errno_names[id];
 }
 #else
 #  include "errno-to-name.inc"

--- a/src/basic/signal-util.c
+++ b/src/basic/signal-util.c
@@ -260,8 +260,12 @@ static const char *const sigsegv_code_table[] = {
         [SEGV_ACCADI]  = "SEGV_ACCADI",
         [SEGV_ADIDERR] = "SEGV_ADIDERR",
         [SEGV_ADIPERR] = "SEGV_ADIPERR",
+#ifdef SEGV_MTEAERR
         [SEGV_MTEAERR] = "SEGV_MTEAERR",
+#endif
+#ifdef SEGV_MTESERR
         [SEGV_MTESERR] = "SEGV_MTESERR",
+#endif
         [SEGV_CPERR]   = "SEGV_CPERR",
 };
 

--- a/src/include/override/sys/generate-syscall.py
+++ b/src/include/override/sys/generate-syscall.py
@@ -9,6 +9,7 @@ SYSCALLS = [
     'fchmodat2',     # defined in glibc header since glibc-2.39
     'kexec_file_load',
     'open_tree_attr',
+    'openat2',       # defined in glibc header since glibc-2.42
     'quotactl_fd',   # defined in glibc header since glibc-2.35
     'removexattrat',
     'setxattrat',

--- a/src/include/override/sys/generate-syscall.py
+++ b/src/include/override/sys/generate-syscall.py
@@ -8,6 +8,7 @@ import sys
 SYSCALLS = [
     'fchmodat2',     # defined in glibc header since glibc-2.39
     'kexec_file_load',
+    'mount_setattr',
     'open_tree_attr',
     'openat2',       # defined in glibc header since glibc-2.42
     'quotactl_fd',   # defined in glibc header since glibc-2.35

--- a/src/include/override/sys/syscall.h
+++ b/src/include/override/sys/syscall.h
@@ -194,6 +194,76 @@ static_assert(__NR_kexec_file_load == systemd_NR_kexec_file_load, "");
 #  endif
 #endif
 
+#ifndef __IGNORE_mount_setattr
+#  if defined(__aarch64__)
+#    define systemd_NR_mount_setattr 442
+#  elif defined(__alpha__)
+#    define systemd_NR_mount_setattr 552
+#  elif defined(__arc__) || defined(__tilegx__)
+#    define systemd_NR_mount_setattr 442
+#  elif defined(__arm__)
+#    define systemd_NR_mount_setattr 442
+#  elif defined(__i386__)
+#    define systemd_NR_mount_setattr 442
+#  elif defined(__ia64__)
+#    define systemd_NR_mount_setattr 1466
+#  elif defined(__loongarch_lp64)
+#    define systemd_NR_mount_setattr 442
+#  elif defined(__m68k__)
+#    define systemd_NR_mount_setattr 442
+#  elif defined(_MIPS_SIM)
+#    if _MIPS_SIM == _MIPS_SIM_ABI32
+#      define systemd_NR_mount_setattr 4442
+#    elif _MIPS_SIM == _MIPS_SIM_NABI32
+#      define systemd_NR_mount_setattr 6442
+#    elif _MIPS_SIM == _MIPS_SIM_ABI64
+#      define systemd_NR_mount_setattr 5442
+#    else
+#      error "Unknown MIPS ABI"
+#    endif
+#  elif defined(__hppa__)
+#    define systemd_NR_mount_setattr 442
+#  elif defined(__powerpc__)
+#    define systemd_NR_mount_setattr 442
+#  elif defined(__riscv)
+#    if __riscv_xlen == 32
+#      define systemd_NR_mount_setattr 442
+#    elif __riscv_xlen == 64
+#      define systemd_NR_mount_setattr 442
+#    else
+#      error "Unknown RISC-V ABI"
+#    endif
+#  elif defined(__s390__)
+#    define systemd_NR_mount_setattr 442
+#  elif defined(__sh__)
+#    define systemd_NR_mount_setattr 442
+#  elif defined(__sparc__)
+#    define systemd_NR_mount_setattr 442
+#  elif defined(__x86_64__)
+#    if defined(__ILP32__)
+#      define systemd_NR_mount_setattr (442 | /* __X32_SYSCALL_BIT */ 0x40000000)
+#    else
+#      define systemd_NR_mount_setattr 442
+#    endif
+#  elif !defined(missing_arch_template)
+#    warning "mount_setattr() syscall number is unknown for your architecture"
+#  endif
+
+/* may be an (invalid) negative number due to libseccomp, see PR 13319 */
+#  if defined __NR_mount_setattr && __NR_mount_setattr >= 0
+#    if defined systemd_NR_mount_setattr
+static_assert(__NR_mount_setattr == systemd_NR_mount_setattr, "");
+#    endif
+#  else
+#    if defined __NR_mount_setattr
+#      undef __NR_mount_setattr
+#    endif
+#    if defined systemd_NR_mount_setattr && systemd_NR_mount_setattr >= 0
+#      define __NR_mount_setattr systemd_NR_mount_setattr
+#    endif
+#  endif
+#endif
+
 #ifndef __IGNORE_open_tree_attr
 #  if defined(__aarch64__)
 #    define systemd_NR_open_tree_attr 467

--- a/src/include/override/sys/syscall.h
+++ b/src/include/override/sys/syscall.h
@@ -264,6 +264,76 @@ static_assert(__NR_open_tree_attr == systemd_NR_open_tree_attr, "");
 #  endif
 #endif
 
+#ifndef __IGNORE_openat2
+#  if defined(__aarch64__)
+#    define systemd_NR_openat2 437
+#  elif defined(__alpha__)
+#    define systemd_NR_openat2 547
+#  elif defined(__arc__) || defined(__tilegx__)
+#    define systemd_NR_openat2 437
+#  elif defined(__arm__)
+#    define systemd_NR_openat2 437
+#  elif defined(__i386__)
+#    define systemd_NR_openat2 437
+#  elif defined(__ia64__)
+#    define systemd_NR_openat2 1461
+#  elif defined(__loongarch_lp64)
+#    define systemd_NR_openat2 437
+#  elif defined(__m68k__)
+#    define systemd_NR_openat2 437
+#  elif defined(_MIPS_SIM)
+#    if _MIPS_SIM == _MIPS_SIM_ABI32
+#      define systemd_NR_openat2 4437
+#    elif _MIPS_SIM == _MIPS_SIM_NABI32
+#      define systemd_NR_openat2 6437
+#    elif _MIPS_SIM == _MIPS_SIM_ABI64
+#      define systemd_NR_openat2 5437
+#    else
+#      error "Unknown MIPS ABI"
+#    endif
+#  elif defined(__hppa__)
+#    define systemd_NR_openat2 437
+#  elif defined(__powerpc__)
+#    define systemd_NR_openat2 437
+#  elif defined(__riscv)
+#    if __riscv_xlen == 32
+#      define systemd_NR_openat2 437
+#    elif __riscv_xlen == 64
+#      define systemd_NR_openat2 437
+#    else
+#      error "Unknown RISC-V ABI"
+#    endif
+#  elif defined(__s390__)
+#    define systemd_NR_openat2 437
+#  elif defined(__sh__)
+#    define systemd_NR_openat2 437
+#  elif defined(__sparc__)
+#    define systemd_NR_openat2 437
+#  elif defined(__x86_64__)
+#    if defined(__ILP32__)
+#      define systemd_NR_openat2 (437 | /* __X32_SYSCALL_BIT */ 0x40000000)
+#    else
+#      define systemd_NR_openat2 437
+#    endif
+#  elif !defined(missing_arch_template)
+#    warning "openat2() syscall number is unknown for your architecture"
+#  endif
+
+/* may be an (invalid) negative number due to libseccomp, see PR 13319 */
+#  if defined __NR_openat2 && __NR_openat2 >= 0
+#    if defined systemd_NR_openat2
+static_assert(__NR_openat2 == systemd_NR_openat2, "");
+#    endif
+#  else
+#    if defined __NR_openat2
+#      undef __NR_openat2
+#    endif
+#    if defined systemd_NR_openat2 && systemd_NR_openat2 >= 0
+#      define __NR_openat2 systemd_NR_openat2
+#    endif
+#  endif
+#endif
+
 #ifndef __IGNORE_quotactl_fd
 #  if defined(__aarch64__)
 #    define systemd_NR_quotactl_fd 443

--- a/src/include/override/sys/syscall.h
+++ b/src/include/override/sys/syscall.h
@@ -124,6 +124,76 @@ static_assert(__NR_fchmodat2 == systemd_NR_fchmodat2, "");
 #  endif
 #endif
 
+#ifndef __IGNORE_close_range
+#  if defined(__aarch64__)
+#    define systemd_NR_close_range 436
+#  elif defined(__alpha__)
+#    define systemd_NR_close_range 546
+#  elif defined(__arc__) || defined(__tilegx__)
+#    define systemd_NR_close_range 436
+#  elif defined(__arm__)
+#    define systemd_NR_close_range 436
+#  elif defined(__i386__)
+#    define systemd_NR_close_range 436
+#  elif defined(__ia64__)
+#    define systemd_NR_close_range 1460
+#  elif defined(__loongarch_lp64)
+#    define systemd_NR_close_range 436
+#  elif defined(__m68k__)
+#    define systemd_NR_close_range 436
+#  elif defined(_MIPS_SIM)
+#    if _MIPS_SIM == _MIPS_SIM_ABI32
+#      define systemd_NR_close_range 4436
+#    elif _MIPS_SIM == _MIPS_SIM_NABI32
+#      define systemd_NR_close_range 6436
+#    elif _MIPS_SIM == _MIPS_SIM_ABI64
+#      define systemd_NR_close_range 5436
+#    else
+#      error "Unknown MIPS ABI"
+#    endif
+#  elif defined(__hppa__)
+#    define systemd_NR_close_range 436
+#  elif defined(__powerpc__)
+#    define systemd_NR_close_range 436
+#  elif defined(__riscv)
+#    if __riscv_xlen == 32
+#      define systemd_NR_close_range 436
+#    elif __riscv_xlen == 64
+#      define systemd_NR_close_range 436
+#    else
+#      error "Unknown RISC-V ABI"
+#    endif
+#  elif defined(__s390__)
+#    define systemd_NR_close_range 436
+#  elif defined(__sh__)
+#    define systemd_NR_close_range 436
+#  elif defined(__sparc__)
+#    define systemd_NR_close_range 436
+#  elif defined(__x86_64__)
+#    if defined(__ILP32__)
+#      define systemd_NR_close_range (436 | /* __X32_SYSCALL_BIT */ 0x40000000)
+#    else
+#      define systemd_NR_close_range 436
+#    endif
+#  elif !defined(missing_arch_template)
+#    warning "close_range() syscall number is unknown for your architecture"
+#  endif
+
+/* may be an (invalid) negative number due to libseccomp, see PR 13319 */
+#  if defined __NR_close_range && __NR_close_range >= 0
+#    if defined systemd_NR_close_range
+static_assert(__NR_close_range == systemd_NR_close_range, "");
+#    endif
+#  else
+#    if defined __NR_close_range
+#      undef __NR_close_range
+#    endif
+#    if defined systemd_NR_close_range && systemd_NR_close_range >= 0
+#      define __NR_close_range systemd_NR_close_range
+#    endif
+#  endif
+#endif
+
 #ifndef __IGNORE_kexec_file_load
 #  if defined(__aarch64__)
 #    define systemd_NR_kexec_file_load 294

--- a/src/include/override/unistd.h
+++ b/src/include/override/unistd.h
@@ -3,5 +3,10 @@
 
 #include_next <unistd.h>        /* IWYU pragma: export */
 
+/* Defined since glibc-2.34.
+ * Supported since kernel v5.9 (60997c3d45d9be4b19fbe0f2fa67f2e384429aad). */
+int close_range_shim(unsigned first_fd, unsigned end_fd, unsigned flags);
+#define close_range close_range_shim
+
 int pivot_root_shim(const char *new_root, const char *put_old);
 #define pivot_root pivot_root_shim

--- a/src/libc/unistd.c
+++ b/src/libc/unistd.c
@@ -2,6 +2,11 @@
 
 #include "libc-shim.h"
 
+DEFINE_SYSCALL_SHIM(close_range, int,
+                    unsigned, first_fd,
+                    unsigned, end_fd,
+                    unsigned, flags)
+
 DEFINE_SYSCALL_SHIM(pivot_root, int,
                     const char *, new_root,
                     const char *, put_old)

--- a/src/libsystemd/sd-event/sd-event.c
+++ b/src/libsystemd/sd-event/sd-event.c
@@ -1892,7 +1892,9 @@ _public_ int sd_event_trim_memory(void) {
 
         log_debug("Memory pressure event, trimming malloc() memory.");
 
+#if !defined(__GLIBC__) || __GLIBC_PREREQ(2, 33)
         struct mallinfo2 before_mallinfo = mallinfo2();
+#endif
 
         usec_t before_timestamp = now(CLOCK_MONOTONIC);
         hashmap_trim_pools();
@@ -1906,6 +1908,7 @@ _public_ int sd_event_trim_memory(void) {
 
         usec_t period = after_timestamp - before_timestamp;
 
+#if !defined(__GLIBC__) || __GLIBC_PREREQ(2, 33)
         struct mallinfo2 after_mallinfo = mallinfo2();
         size_t l = LESS_BY(before_mallinfo.hblkhd, after_mallinfo.hblkhd) +
                 LESS_BY(before_mallinfo.arena, after_mallinfo.arena);
@@ -1916,6 +1919,13 @@ _public_ int sd_event_trim_memory(void) {
                    LOG_MESSAGE_ID(SD_MESSAGE_MEMORY_TRIM_STR),
                    LOG_ITEM("TRIMMED_BYTES=%zu", l),
                    LOG_ITEM("TRIMMED_USEC=" USEC_FMT, period));
+#else
+        log_struct(LOG_DEBUG,
+                   LOG_MESSAGE("Memory trimming took %s.",
+                               FORMAT_TIMESPAN(period, 0)),
+                   LOG_MESSAGE_ID(SD_MESSAGE_MEMORY_TRIM_STR),
+                   LOG_ITEM("TRIMMED_USEC=" USEC_FMT, period));
+#endif
 
         return 0;
 }

--- a/src/nspawn/nspawn-oci.c
+++ b/src/nspawn/nspawn-oci.c
@@ -2077,7 +2077,7 @@ static int oci_version_parse(const char *s, unsigned *ret_major, unsigned *ret_m
                 return -EINVAL;
 
         r = extract_first_word(&p, &patch, ".", EXTRACT_DONT_COALESCE_SEPARATORS);
-        if (r <= 0 || !isempty(p))
+        if (r <= 0 || p)
                 return -EINVAL;
 
         r = safe_atou(major, &a);

--- a/src/nspawn/nspawn-oci.c
+++ b/src/nspawn/nspawn-oci.c
@@ -2068,6 +2068,10 @@ static int oci_version_parse(const char *s, unsigned *ret_major, unsigned *ret_m
         unsigned a, b, c;
         int r;
 
+        assert(ret_major);
+        assert(ret_minor);
+        assert(ret_patch);
+
         r = extract_first_word(&p, &major, ".", EXTRACT_DONT_COALESCE_SEPARATORS);
         if (r <= 0)
                 return -EINVAL;

--- a/src/nspawn/nspawn-oci.c
+++ b/src/nspawn/nspawn-oci.c
@@ -2080,15 +2080,24 @@ static int oci_version_parse(const char *s, unsigned *ret_major, unsigned *ret_m
         if (r <= 0 || p)
                 return -EINVAL;
 
-        r = safe_atou(major, &a);
+        r = safe_atou_full(major, 10
+                           | SAFE_ATO_REFUSE_PLUS_MINUS
+                           | SAFE_ATO_REFUSE_LEADING_ZERO
+                           | SAFE_ATO_REFUSE_LEADING_WHITESPACE, &a);
         if (r < 0)
                 return r;
 
-        r = safe_atou(minor, &b);
+        r = safe_atou_full(minor, 10
+                           | SAFE_ATO_REFUSE_PLUS_MINUS
+                           | SAFE_ATO_REFUSE_LEADING_ZERO
+                           | SAFE_ATO_REFUSE_LEADING_WHITESPACE, &b);
         if (r < 0)
                 return r;
 
-        r = safe_atou(patch, &c);
+        r = safe_atou_full(patch, 10
+                           | SAFE_ATO_REFUSE_PLUS_MINUS
+                           | SAFE_ATO_REFUSE_LEADING_ZERO
+                           | SAFE_ATO_REFUSE_LEADING_WHITESPACE, &c);
         if (r < 0)
                 return r;
 

--- a/src/nspawn/nspawn-oci.c
+++ b/src/nspawn/nspawn-oci.c
@@ -13,10 +13,12 @@
 #include "cpu-set-util.h"
 #include "device-util.h"
 #include "devnum-util.h"
+#include "extract-word.h"
 #include "hostname-util.h"
 #include "json-util.h"
 #include "nspawn-mount.h"
 #include "nspawn-oci.h"
+#include "parse-util.h"
 #include "path-util.h"
 #include "rlimit-util.h"
 #include "string-util.h"
@@ -2060,6 +2062,66 @@ static int oci_annotations(const char *name, sd_json_variant *v, sd_json_dispatc
         return 0;
 }
 
+static int oci_version_parse(const char *s, unsigned *ret_major, unsigned *ret_minor, unsigned *ret_patch) {
+        _cleanup_free_ char *major = NULL, *minor = NULL, *patch = NULL;
+        const char *p = ASSERT_PTR(s);
+        unsigned a, b, c;
+        int r;
+
+        r = extract_first_word(&p, &major, ".", EXTRACT_DONT_COALESCE_SEPARATORS);
+        if (r <= 0)
+                return -EINVAL;
+
+        r = extract_first_word(&p, &minor, ".", EXTRACT_DONT_COALESCE_SEPARATORS);
+        if (r <= 0)
+                return -EINVAL;
+
+        r = extract_first_word(&p, &patch, ".", EXTRACT_DONT_COALESCE_SEPARATORS);
+        if (r <= 0 || !isempty(p))
+                return -EINVAL;
+
+        r = safe_atou(major, &a);
+        if (r < 0)
+                return r;
+
+        r = safe_atou(minor, &b);
+        if (r < 0)
+                return r;
+
+        r = safe_atou(patch, &c);
+        if (r < 0)
+                return r;
+
+        *ret_major = a;
+        *ret_minor = b;
+        *ret_patch = c;
+        return 0;
+}
+
+static int oci_version_check_supported(sd_json_variant *v) {
+        unsigned major, minor, patch;
+        const char *s;
+        int r;
+
+        assert(v);
+
+        s = sd_json_variant_string(v);
+        if (isempty(s))
+                return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
+                                       "OCI bundle version is missing or empty.");
+
+        r = oci_version_parse(s, &major, &minor, &patch);
+        if (r < 0)
+                return log_error_errno(r, "OCI bundle version is malformed: %s", s);
+
+        if (major != 1)
+                return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
+                                       "OCI bundle major version not supported: %s",
+                                       s);
+
+        return 0;
+}
+
 int oci_load(FILE *f, const char *bundle, Settings **ret) {
 
         static const sd_json_dispatch_field table[] = {
@@ -2099,10 +2161,10 @@ int oci_load(FILE *f, const char *bundle, Settings **ret) {
                 return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
                                        "JSON file '%s' is not an OCI bundle configuration file. Refusing.",
                                        path);
-        if (!streq_ptr(sd_json_variant_string(v), "1.0.0"))
-                return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
-                                       "OCI bundle version not supported: %s",
-                                       strna(sd_json_variant_string(v)));
+
+        r = oci_version_check_supported(v);
+        if (r < 0)
+                return r;
 
         // {
         //         _cleanup_free_ char *formatted = NULL;

--- a/test/fuzz/fuzz-nspawn-oci/basic.json
+++ b/test/fuzz/fuzz-nspawn-oci/basic.json
@@ -1,5 +1,5 @@
 {
-    "ociVersion": "1.0.0",
+    "ociVersion": "1.1.0",
 
     "hostname" : "foo",
 

--- a/test/fuzz/fuzz-nspawn-oci/version-1.1.0.json
+++ b/test/fuzz/fuzz-nspawn-oci/version-1.1.0.json
@@ -1,0 +1,6 @@
+{
+    "ociVersion": "1.1.0",
+    "root": {
+        "path": "rootfs"
+    }
+}

--- a/test/fuzz/fuzz-nspawn-oci/version-2.0.0.json
+++ b/test/fuzz/fuzz-nspawn-oci/version-2.0.0.json
@@ -1,0 +1,6 @@
+{
+    "ociVersion": "2.0.0",
+    "root": {
+        "path": "rootfs"
+    }
+}

--- a/test/units/TEST-13-NSPAWN.nspawn-oci.sh
+++ b/test/units/TEST-13-NSPAWN.nspawn-oci.sh
@@ -479,7 +479,7 @@ EOF
     systemd-nspawn --oci-bundle="$OCI" bash -c 'echo hello'
 done
 
-for version in 2.0.0 6.6.6 1 1.0 1.0.0.1 1.x.0; do
+for version in 2.0.0 6.6.6 1 1.0 1.0.0.1 1.0.0. 1.x.0; do
     cat >"$OCI/config.json" <<EOF
 {
     "ociVersion" : "$version",

--- a/test/units/TEST-13-NSPAWN.nspawn-oci.sh
+++ b/test/units/TEST-13-NSPAWN.nspawn-oci.sh
@@ -479,7 +479,7 @@ EOF
     systemd-nspawn --oci-bundle="$OCI" bash -c 'echo hello'
 done
 
-for version in 2.0.0 6.6.6 1 1.0 1.0.0.1 1.0.0. 1.x.0; do
+for version in 2.0.0 6.6.6 1 1.0 1.0.0.1 1.0.0. " 1.1.0" "+1.1.0" 01.1.0 0x1.1.0 1.x.0; do
     cat >"$OCI/config.json" <<EOF
 {
     "ociVersion" : "$version",

--- a/test/units/TEST-13-NSPAWN.nspawn-oci.sh
+++ b/test/units/TEST-13-NSPAWN.nspawn-oci.sh
@@ -466,13 +466,27 @@ EOF
     (! systemd-nspawn --oci-bundle="$OCI" bash -c 'echo hello')
 done
 
-# Invalid OCI bundle version
-cat >"$OCI/config.json" <<EOF
+# OCI bundle version compatibility
+for version in 1.0.0 1.1.0 1.3.0; do
+    cat >"$OCI/config.json" <<EOF
 {
-    "ociVersion" : "6.6.6",
+    "ociVersion" : "$version",
     "root" : {
             "path" : "rootfs"
     }
 }
 EOF
-(! systemd-nspawn --oci-bundle="$OCI" bash -c 'echo hello')
+    systemd-nspawn --oci-bundle="$OCI" bash -c 'echo hello'
+done
+
+for version in 2.0.0 6.6.6 1 1.0 1.0.0.1 1.x.0; do
+    cat >"$OCI/config.json" <<EOF
+{
+    "ociVersion" : "$version",
+    "root" : {
+            "path" : "rootfs"
+    }
+}
+EOF
+    (! systemd-nspawn --oci-bundle="$OCI" bash -c 'echo hello')
+done


### PR DESCRIPTION
Accept any OCI runtime-spec 1.x bundle that `systemd-nspawn` can safely interpret.

This relaxes the current `1.0.0`-only acceptance to the whole runtime-spec 1.x line, while still rejecting malformed version strings. The implementation keeps the policy narrow: accept newer 1.x bundles that are structurally compatible with what nspawn already interprets, without claiming support for unrelated OCI specs.

Changes in this PR:
- accept OCI runtime-spec `1.x` bundles instead of requiring exactly `1.0.0`
- parse OCI version components more strictly and reject malformed strings
- extend the OCI tests to cover accepted and rejected runtime-spec versions
- document the intended scope: runtime-spec bundle compatibility only, not OCI image-spec support

Fork-side CI compatibility fixes observed while validating this branch on `rezzell/systemd`:
- `#42650` `libc: provide openat2 syscall number fallback`
- `#42657` `libc: provide mount_setattr syscall number fallback`
- `#42658` `libc: add close_range fallbacks for older libc`
- `#42659` `sd-event: tolerate older glibc without mallinfo2`
- `#42660` `basic: resolve strerrorname_np at runtime`
- `#42661` `basic: guard newer SEGV si_code constants`

Those failures were exposed by fork-side `ClusterFuzzLite` PR fuzzing while testing this branch and are not currently reproduced in upstream CI.
