### PR TITLE
report: disable json normalization

### DIFF
--- a/src/report/report-generate.c
+++ b/src/report/report-generate.c
@@ -30,9 +30,10 @@ int context_build_report(Context *context, sd_json_variant **ret) {
 
         /* Normalize the report, to make signing more robust (note that we sign a specific binary formatting
          * of it though, this is hence not load bearing, but still useful) */
-        r = sd_json_variant_normalize(&report);
-        if (r < 0)
-                return log_error_errno(r, "Failed to normalize report JSON: %m");
+        // FIXME: this causes a test failure https://github.com/systemd/systemd/issues/42669
+        // r = sd_json_variant_normalize(&report);
+        // if (r < 0)
+        //         return log_error_errno(r, "Failed to normalize report JSON: %m");
 
         *ret = TAKE_PTR(report);
         return 0;


### PR DESCRIPTION
Two PRs got merged at the same time, which cause a test to fail, as they work individually but fail when combined

```
TEST-74-AUX-UTILS.sh[1688]: + /usr/lib/systemd/systemd-report generate io.systemd.Manager.UnitsTotal
TEST-74-AUX-UTILS.sh[1805]: {"mediaType":"application/vnd.io.systemd.report","metrics":[{"name":"io.systemd.Manager.UnitsTotal","value":249}],"timestamp":"Fri 2026-06-19 19:50:48 UTC"}
TEST-74-AUX-UTILS.sh[1806]: + /usr/lib/systemd/systemd-report generate io.systemd.Manager.UnitsTotal
TEST-74-AUX-UTILS.sh[1807]: + jq .
TEST-74-AUX-UTILS.sh[1807]: {
TEST-74-AUX-UTILS.sh[1807]:   "mediaType": "application/vnd.io.systemd.report",
TEST-74-AUX-UTILS.sh[1807]:   "metrics": [
TEST-74-AUX-UTILS.sh[1807]:     {
TEST-74-AUX-UTILS.sh[1807]:       "name": "io.systemd.Manager.UnitsTotal",
TEST-74-AUX-UTILS.sh[1807]:       "value": 249
TEST-74-AUX-UTILS.sh[1807]:     }
TEST-74-AUX-UTILS.sh[1807]:   ],
TEST-74-AUX-UTILS.sh[1807]:   "timestamp": "Fri 2026-06-19 19:50:48 UTC"
TEST-74-AUX-UTILS.sh[1807]: }
TEST-74-AUX-UTILS.sh[1688]: + /usr/lib/systemd/systemd-report upload --url=http://localhost:8089/
TEST-74-AUX-UTILS.sh[1808]: Failed to normalize report JSON: Wrong medium type
```

https://github.com/systemd/systemd/pull/42594
https://github.com/systemd/systemd/pull/42595

Disable normalization for now, and track the issue at
https://github.com/systemd/systemd/issues/42669

Follow-up for 3c2f7c6002254fa7108e186aeedf2b2c6a86bd4f