### PR TITLE
ssl-util: support OpenSSL 4

### DIFF
--- a/src/shared/ssl-util.c
+++ b/src/shared/ssl-util.c
@@ -40,8 +40,7 @@ int dlopen_libssl(int log_level) {
 
         LIBSSL_NOTE(SD_ELF_NOTE_DLOPEN_PRIORITY_SUGGESTED);
 
-        // FIXME: switch order to prefer libssl.so.4 in a future version once it has stabilized
-        FOREACH_STRING(soname, "libssl.so.3", "libssl.so.4") {
+        FOREACH_STRING(soname, "libssl.so.4", "libssl.so.3") {
                 r = dlopen_many_sym_or_warn(
                                 &libssl_dl,
                                 soname,

--- a/src/shared/ssl-util.c
+++ b/src/shared/ssl-util.c
@@ -4,6 +4,7 @@
 
 #include "log.h"                /* IWYU pragma: keep */
 #include "ssl-util.h"
+#include "strv.h"
 
 #if HAVE_OPENSSL
 
@@ -35,35 +36,47 @@ DLSYM_PROTOTYPE(TLS_client_method) = NULL;
 int dlopen_libssl(int log_level) {
 #if HAVE_OPENSSL
         static void *libssl_dl = NULL;
+        int r;
 
         LIBSSL_NOTE(SD_ELF_NOTE_DLOPEN_PRIORITY_SUGGESTED);
 
-        return dlopen_many_sym_or_warn(
-                        &libssl_dl,
-                        "libssl.so.3",
-                        log_level,
-                        DLSYM_ARG(SSL_ctrl),
-                        DLSYM_ARG(SSL_CTX_ctrl),
-                        DLSYM_ARG(SSL_CTX_free),
-                        DLSYM_ARG(SSL_CTX_new),
-                        DLSYM_ARG(SSL_CTX_set_default_verify_paths),
-                        DLSYM_ARG(SSL_CTX_set_options),
-                        DLSYM_ARG(SSL_do_handshake),
-                        DLSYM_ARG(SSL_free),
-                        DLSYM_ARG(SSL_get_error),
-                        DLSYM_ARG(SSL_get_wbio),
-                        DLSYM_ARG(SSL_get0_param),
-                        DLSYM_ARG(SSL_get1_session),
-                        DLSYM_ARG(SSL_new),
-                        DLSYM_ARG(SSL_read),
-                        DLSYM_ARG(SSL_SESSION_free),
-                        DLSYM_ARG(SSL_set_bio),
-                        DLSYM_ARG(SSL_set_connect_state),
-                        DLSYM_ARG(SSL_set_session),
-                        DLSYM_ARG(SSL_set_verify),
-                        DLSYM_ARG(SSL_shutdown),
-                        DLSYM_ARG(SSL_write),
-                        DLSYM_ARG(TLS_client_method));
+        // FIXME: switch order to prefer libssl.so.4 in a future version once it has stabilized
+        FOREACH_STRING(soname, "libssl.so.3", "libssl.so.4") {
+                r = dlopen_many_sym_or_warn(
+                                &libssl_dl,
+                                soname,
+                                log_level,
+                                DLSYM_ARG(SSL_ctrl),
+                                DLSYM_ARG(SSL_CTX_ctrl),
+                                DLSYM_ARG(SSL_CTX_free),
+                                DLSYM_ARG(SSL_CTX_new),
+                                DLSYM_ARG(SSL_CTX_set_default_verify_paths),
+                                DLSYM_ARG(SSL_CTX_set_options),
+                                DLSYM_ARG(SSL_do_handshake),
+                                DLSYM_ARG(SSL_free),
+                                DLSYM_ARG(SSL_get_error),
+                                DLSYM_ARG(SSL_get_wbio),
+                                DLSYM_ARG(SSL_get0_param),
+                                DLSYM_ARG(SSL_get1_session),
+                                DLSYM_ARG(SSL_new),
+                                DLSYM_ARG(SSL_read),
+                                DLSYM_ARG(SSL_SESSION_free),
+                                DLSYM_ARG(SSL_set_bio),
+                                DLSYM_ARG(SSL_set_connect_state),
+                                DLSYM_ARG(SSL_set_session),
+                                DLSYM_ARG(SSL_set_verify),
+                                DLSYM_ARG(SSL_shutdown),
+                                DLSYM_ARG(SSL_write),
+                                DLSYM_ARG(TLS_client_method));
+                if (r >= 0)
+                        break;
+        }
+        if (r < 0) {
+                log_full_errno(log_level, r, "Neither libssl.so.4 nor libssl.so.3 could be loaded");
+                return -EOPNOTSUPP; /* turn into recognizable error */
+        }
+
+        return 0;
 #else
         return log_full_errno(log_level, SYNTHETIC_ERRNO(EOPNOTSUPP),
                               "libssl support is not compiled in.");

--- a/src/shared/ssl-util.h
+++ b/src/shared/ssl-util.h
@@ -12,7 +12,7 @@ int dlopen_libssl(int log_level);
         SD_ELF_NOTE_DLOPEN("libssl",                                    \
                            "Support for TLS",                           \
                            priority,                                    \
-                           "libssl.so.3")
+                           "libssl.so.3", "libssl.so.4")
 
 #define DLOPEN_LIBSSL(log_level, priority)                              \
         ({                                                              \

--- a/src/shared/ssl-util.h
+++ b/src/shared/ssl-util.h
@@ -12,7 +12,7 @@ int dlopen_libssl(int log_level);
         SD_ELF_NOTE_DLOPEN("libssl",                                    \
                            "Support for TLS",                           \
                            priority,                                    \
-                           "libssl.so.3", "libssl.so.4")
+                           "libssl.so.4", "libssl.so.3")
 
 #define DLOPEN_LIBSSL(log_level, priority)                              \
         ({                                                              \


### PR DESCRIPTION
OpenSSL 4 broke ABI, so we need to look for both SONAMEs.
Try libssl.so.3 first, and fallback to libssl.so.4,
so that the older and more stable version is used if both
are installed, giving distros time to fix regressions.

Follow-up for https://github.com/systemd/systemd/commit/ccdd42351f79cbb9c2e034a96280a1ded40a2f95

Fixes https://github.com/systemd/systemd/issues/42675

First commit to be backported to v261-stable