### PR TITLE
run: make --slice-inherit imply XDG_SESSION_CLASS=none

### DIFF
--- a/man/run0.xml
+++ b/man/run0.xml
@@ -108,7 +108,9 @@
         <term><option>--slice=</option></term>
 
         <listitem><para>Make the new <filename>.service</filename> unit part of the specified slice, instead
-        of <filename>user.slice</filename>.</para>
+        of <filename>user.slice</filename>. This option conflicts with <option>--lightweight=</option> and
+        <option>--area=</option>, and implies <literal>XDG_SESSION_CLASS=none</literal>,
+        to keep the new process within the specified slice instead of a new session scope.</para>
 
         <xi:include href="version-info.xml" xpointer="v256"/>
         </listitem>
@@ -120,7 +122,9 @@
         <listitem><para>Make the new <filename>.service</filename> unit part of the slice the
         <command>run0</command> itself has been invoked in. This option may be combined with
         <option>--slice=</option>, in which case the slice specified via <option>--slice=</option> is placed
-        within the slice the <command>run0</command> command is invoked in.</para>
+        within the slice the <command>run0</command> command is invoked in. Also conflicts with
+        <option>--lightweight=</option> and <option>--area=</option> and implies
+        <literal>XDG_SESSION_CLASS=none</literal>, similar to <option>--slice=</option>.</para>
 
         <para>Example: consider <command>run0</command> being invoked in the slice
         <filename>foo.slice</filename>, and the <option>--slice=</option> argument is

--- a/src/run/run.c
+++ b/src/run/run.c
@@ -992,6 +992,14 @@ static int parse_argv_sudo_mode(int argc, char *argv[]) {
 
         _cleanup_strv_free_ char **l = NULL;
         char **args = option_parser_get_args(&opts);
+        bool custom_slice = arg_slice_inherit || arg_slice;
+        if (custom_slice && arg_lightweight >= 0)
+                return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
+                                "--lightweight= may not be combined with a custom slice");
+        if (custom_slice && !isempty(arg_area))
+                return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
+                                "--area= may not be combined with a custom slice");
+
         if (!strv_isempty(args)) {
                 if (arg_validate)
                         return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
@@ -1108,9 +1116,12 @@ static int parse_argv_sudo_mode(int argc, char *argv[]) {
         }
 
         if (!strv_env_get(arg_environment, "XDG_SESSION_CLASS")) {
+                const char *class = NULL;
+                if (custom_slice)
+                        class = "none";
 
                 /* If logging into an area, imply lightweight mode */
-                if (arg_lightweight < 0 && !isempty(arg_area))
+                else if (arg_lightweight < 0 && !isempty(arg_area))
                         arg_lightweight = true;
 
                 /* When using run0 to acquire privileges temporarily, let's not pull in session manager by
@@ -1120,14 +1131,14 @@ static int parse_argv_sudo_mode(int argc, char *argv[]) {
                  * this for root or --empower though, under the assumption that if a regular user temporarily
                  * transitions into another regular user it's a better default that the full user environment is
                  * uniformly available. */
-                if (arg_lightweight < 0 && (become_root() || arg_empower))
+                else if (arg_lightweight < 0 && (become_root() || arg_empower))
                         arg_lightweight = true;
 
-                if (arg_lightweight >= 0) {
-                        const char *class =
-                                arg_lightweight ? (arg_stdio == ARG_STDIO_PTY ? (become_root() ? "user-early-light" : "user-light") : "background-light") :
+                if (arg_lightweight >= 0)
+                        class = arg_lightweight ? (arg_stdio == ARG_STDIO_PTY ? (become_root() ? "user-early-light" : "user-light") : "background-light") :
                                                   (arg_stdio == ARG_STDIO_PTY ? (become_root() ? "user-early" : "user") : "background");
 
+                if (class) {
                         log_debug("Setting XDG_SESSION_CLASS to '%s'.", class);
 
                         r = strv_env_assign(&arg_environment, "XDG_SESSION_CLASS", class);


### PR DESCRIPTION
slice inherit is intended to make the new service unit part of the same slice that invoked run0. Logind is incompatible with that goal, as a session of any kind will prompt logind to immediately yoink the new command from the service unit into a new session scope, which does not inherit from run0's own slice.

---

I noticed this while looking into #42601. IMO this is a problem with or without --slice-inherit. No matter where the service group is placed, it will be immediately emptied out by logind:

```
$ run0 cat /proc/self/cgroup
0::/user.slice/user-0.slice/session-12.scope
$ run0 --unit empty wc -l /sys/fs/cgroup/user.slice/empty.service/cgroup.threads
0 /sys/fs/cgroup/user.slice/empty.service/cgroup.threads
```

This seems obviously wrong to me, and it means many of the cgroup-based --property fields will not be effective as well. I would be in favor of making XDG_SESSION_CLASS=none always the default (which could be done with class=none argument in the pam config), but if memory serves @poettering has [argued against this](https://github.com/systemd/systemd/issues/34988#issuecomment-2472857728) in the past, so I'm submitting this change which I hope is more palatable.