### PR TITLE
hwdb: Map Acer Nitro AN515-58 NitroSense button to prog1

### DIFF
--- a/hwdb.d/60-keyboard.hwdb
+++ b/hwdb.d/60-keyboard.hwdb
@@ -241,6 +241,7 @@ evdev:atkbd:dmi:bvn*:bvr*:bd*:svnAcer*:pnNitro*AN*515-58:pvr*
  KEYBOARD_KEY_f0=!kbdillumdown                          # Fn+F9
  KEYBOARD_KEY_8a=micmute                                # Microphone mute button
  KEYBOARD_KEY_55=power
+ KEYBOARD_KEY_f5=prog1                                  # NitroSense button
 
 # Nitro AN517-54
 evdev:atkbd:dmi:bvn*:bvr*:bd*:svnAcer*:pnNitro*AN*517-54:pvr*


### PR DESCRIPTION
The Acer Nitro AN515-58 has a dedicated NitroSense button (scan code 0xf5) with no entry in its device-specific block. It currently falls through to the generic Acer rule:

  KEYBOARD_KEY_f5=presentation

This is semantically wrong — the button has no relation to presentation mode. Other Nitro models (AN515-47, AN517-54, ANV15-51) already map it to prog1 (XF86Launch1), making it a user-programmable button that desktop environments (KDE, GNOME, etc.) can bind to any action.

Add the same mapping for AN515-58 for consistency:

  KEYBOARD_KEY_f5=prog1   # NitroSense button

Tested on Acer Nitro AN515-58 with Linux 7.0.12 and KDE Plasma 6.7