### PR TITLE
Double unescape in deserialize

### DIFF
--- a/src/basic/extract-word.c
+++ b/src/basic/extract-word.c
@@ -78,7 +78,7 @@ int extract_first_word(const char **p, char **ret, const char *separators, Extra
                                 return -EINVAL;
                         }
 
-                        if (flags & (EXTRACT_CUNESCAPE|EXTRACT_UNESCAPE_SEPARATORS)) {
+                        if (flags & (EXTRACT_CUNESCAPE | EXTRACT_UNESCAPE_SEPARATORS | EXTRACT_UNESCAPE_RELAX)) {
                                 bool eight_bit = false;
                                 char32_t u;
 

--- a/src/basic/extract-word.h
+++ b/src/basic/extract-word.h
@@ -14,7 +14,9 @@ typedef enum ExtractFlags {
         EXTRACT_RETAIN_ESCAPE            = 1 << 7, /* Treat escape character '\' as any other character without special meaning */
         EXTRACT_RETAIN_SEPARATORS        = 1 << 8, /* Do not advance the original string pointer past the separator(s) */
 
-        /* Note that if no flags are specified, escaped escape characters will be silently stripped. */
+        /* Note that if none of EXTRACT_CUNESCAPE, EXTRACT_UNESCAPE_RELAX, EXTRACT_UNESCAPE_SEPARATORS, EXTRACT_RETAIN_ESCAPE are
+         * specified, escape characters will be stripped. With either only EXTRACT_UNESCAPE_RELAX or EXTRACT_RETAIN_ESCAPE, no
+         * unescaping is done, but escaped separators are ignored with the former and not with the latter. */
 } ExtractFlags;
 
 int extract_first_word(const char **p, char **ret, const char *separators, ExtractFlags flags);

--- a/src/core/execute-serialize.c
+++ b/src/core/execute-serialize.c
@@ -2830,15 +2830,15 @@ static int exec_context_deserialize(ExecContext *c, FILE *f) {
                                 ExecDirectoryFlags exec_directory_flags = 0;
                                 const char *p;
 
-                                /* Use EXTRACT_UNESCAPE_RELAX here, as we unescape the colons in subsequent calls */
-                                r = extract_first_word(&val, &tuple, WHITESPACE, EXTRACT_UNESCAPE_SEPARATORS|EXTRACT_UNESCAPE_RELAX);
+                                /* Use only EXTRACT_UNESCAPE_RELAX here, as we do all unescaping in subsequent calls. */
+                                r = extract_first_word(&val, &tuple, NULL, EXTRACT_UNESCAPE_RELAX);
                                 if (r < 0)
                                         return r;
                                 if (r == 0)
                                         break;
 
                                 p = tuple;
-                                r = extract_many_words(&p, ":", EXTRACT_UNESCAPE_SEPARATORS, &path, &only_create, &read_only);
+                                r = extract_many_words(&p, ":" WHITESPACE, EXTRACT_UNESCAPE_SEPARATORS, &path, &only_create, &read_only);
                                 if (r < 0)
                                         return r;
                                 if (r < 2)
@@ -2866,7 +2866,7 @@ static int exec_context_deserialize(ExecContext *c, FILE *f) {
                                 for (;;) {
                                         _cleanup_free_ char *link = NULL;
 
-                                        r = extract_first_word(&p, &link, ":", EXTRACT_UNESCAPE_SEPARATORS);
+                                        r = extract_first_word(&p, &link, ":" WHITESPACE, EXTRACT_UNESCAPE_SEPARATORS);
                                         if (r < 0)
                                                 return r;
                                         if (r == 0)

--- a/src/test/test-extract-word.c
+++ b/src/test/test-extract-word.c
@@ -247,13 +247,13 @@ TEST(extract_first_word) {
 
         p = original = "fooo\\ bar quux";
         assert_se(extract_first_word(&p, &t, NULL, EXTRACT_UNESCAPE_RELAX) > 0);
-        ASSERT_STREQ(t, "fooo bar");
+        ASSERT_STREQ(t, "fooo\\ bar");
         free(t);
         assert_se(p == original + 10);
 
         p = original = "fooo\\ bar quux";
         assert_se(extract_first_word(&p, &t, NULL, EXTRACT_UNESCAPE_RELAX|EXTRACT_RELAX) > 0);
-        ASSERT_STREQ(t, "fooo bar");
+        ASSERT_STREQ(t, "fooo\\ bar");
         free(t);
         assert_se(p == original + 10);
 
@@ -585,6 +585,13 @@ TEST(extract_first_word) {
         ASSERT_OK_POSITIVE(extract_first_word(&p, &t, NULL, EXTRACT_UNQUOTE | EXTRACT_CUNESCAPE));
         ASSERT_STREQ(t, "test4@/pure/path/like/data.service");
         free(t);
+
+        /* For issue #41853. */
+        p = original = "foo\\ bar\\:qu\\\\x2dux:y:z waldo:a:b:c";
+        ASSERT_OK_POSITIVE(extract_first_word(&p, &t, NULL, EXTRACT_UNESCAPE_RELAX));
+        ASSERT_STREQ(t, "foo\\ bar\\:qu\\\\x2dux:y:z");
+        free(t);
+        /* Continued below with extract_many_words. */
 }
 
 TEST(extract_first_word_and_warn) {
@@ -817,6 +824,17 @@ TEST(extract_many_words) {
         ASSERT_STREQ(a, "gęślą");
         ASSERT_STREQ(b, "👊🔪💐");
         ASSERT_STREQ(c, "가너도루");
+        free(a);
+        free(b);
+        free(c);
+
+        /* For issue #41853. */
+        p = original = "foo\\ bar\\:qu\\\\x2dux:y:z"; /* i.e. shell_escape("foo bar:qu\\x2dux", ":" WHITESPACE) + ":y:z" */
+        assert_se(extract_many_words(&p, ":" WHITESPACE, EXTRACT_UNESCAPE_SEPARATORS, &a, &b, &c) == 3);
+        assert_se(isempty(p));
+        ASSERT_STREQ(a, "foo bar:qu\\x2dux"); /* Shell escaping undone. */
+        ASSERT_STREQ(b, "y");
+        ASSERT_STREQ(c, "z");
         free(a);
         free(b);
         free(c);


### PR DESCRIPTION
Serialization uses `shell_escape()` to hide colons and whitespace in directory names. If those names contained backslashes, they would be escaped too. Regardless of the separators in use, extracting a word with `EXTRACT_UNESCAPE_SEPARATORS` would undo the latter escaping. Therefore, it is incorrect to extract words on the same string multiple times with `EXTRACT_UNESCAPE_SEPARATORS`.

Fixes #41853
