### PR TITLE
resolve: fix transaction leak in dns_transaction_new() error path

### DIFF
--- a/src/resolve/resolved-dns-transaction.c
+++ b/src/resolve/resolved-dns-transaction.c
@@ -326,6 +326,8 @@ int dns_transaction_new(
                 r = hashmap_replace(s->transactions_by_key, first->key, first);
                 if (r < 0) {
                         LIST_REMOVE(transactions_by_key, first, t);
+                        hashmap_remove(s->manager->dns_transactions, UINT_TO_PTR(t->id));
+                        t->id = 0;
                         return r;
                 }
         }


### PR DESCRIPTION
hashmap_replace() failure left t in s->manager->dns_transactions with t->scope still NULL, causing the destructor to skip hashmap_remove(). Add the missing cleanup mirroring the earlier error path in the same function.