### PR TITLE
tmpfiles: do not fail when trying to apply ACL during mkosi build

### DIFF
--- a/src/tmpfiles/tmpfiles.c
+++ b/src/tmpfiles/tmpfiles.c
@@ -1422,16 +1422,20 @@ static int path_set_acl(
                    strna(t), pretty);
 
         if (!arg_dry_run &&
-            sym_acl_set_file(path, type, dup) < 0) {
-                if (ERRNO_IS_NOT_SUPPORTED(errno))
+            (r = RET_NERRNO(sym_acl_set_file(path, type, dup))) < 0) {
+                if (ERRNO_IS_NOT_SUPPORTED(r))
                         /* No error if filesystem doesn't support ACLs. Return negative. */
-                        return -errno;
-                else
-                        /* Return positive to indicate we already warned */
-                        return -log_error_errno(errno,
-                                                "Setting %s ACL \"%s\" on %s failed: %m",
-                                                type == ACL_TYPE_ACCESS ? "access" : "default",
-                                                strna(t), pretty);
+                        return r;
+                if (r == -EINVAL && running_in_chroot() > 0)
+                        return log_warning_errno(SYNTHETIC_ERRNO(EOPNOTSUPP),
+                                                 "Setting %s ACL \"%s\" on %s failed. A chroot environment was detected, ignoring.",
+                                                 type == ACL_TYPE_ACCESS ? "access" : "default",
+                                                 strna(t), pretty);
+                /* Return positive to indicate we already warned */
+                return -log_error_errno(r,
+                                        "Setting %s ACL \"%s\" on %s failed: %m",
+                                        type == ACL_TYPE_ACCESS ? "access" : "default",
+                                        strna(t), pretty);
         }
         return 0;
 }


### PR DESCRIPTION
When running in a mkosi namespaced env tmpfiles fails to set ACLs:

```
Running create action for entry a /buildroot/var/log/journal
Setting access ACL u::rwx,g::r-x,g:adm:r-x,m::r-x,o::r-x on /buildroot/var/log/journal
Setting access ACL "u::rwx,g::r-x,g:adm:r-x,m::r-x,o::r-x" on /buildroot/var/log/journal failed: Invalid argument
```

If EINVAL is returned and we are in a chroot, skip gracefully via EOPNOTSUPP. The ACLs will be set on first boot.