### PR TITLE
tpm2-setup: call DLOPEN_TPM2 to add dependency and fail immediately if not present

### DIFF
--- a/src/tpm2-setup/tpm2-setup.c
+++ b/src/tpm2-setup/tpm2-setup.c
@@ -573,6 +573,10 @@ static int run(int argc, char *argv[]) {
         if (r < 0)
                 return r;
 
+        r = DLOPEN_TPM2(LOG_ERR, SD_ELF_NOTE_DLOPEN_PRIORITY_REQUIRED);
+        if (r < 0)
+                return r;
+
         umask(0022);
 
         /* Execute both jobs, and then return unlisted errors preferably, and listed errors


### PR DESCRIPTION
tpm2-setup requires both libcrypto and the tpm2-tss libraries, but so far it only directly dlopen'ed libcrypto, with a clear error on startup if missing, and a dependency added via dlopen notes. Do the same for the tpm2-tss dlopens, to get a clear error and the required dependencies.