### PR TITLE
growfs: downgrade dependency on libcryptsetup to optional

### DIFF
--- a/src/growfs/growfs.c
+++ b/src/growfs/growfs.c
@@ -33,7 +33,7 @@ static int resize_crypt_luks_device(dev_t devno, const char *fstype, dev_t main_
         uint64_t size;
         int r;
 
-        r = DLOPEN_CRYPTSETUP(LOG_ERR, SD_ELF_NOTE_DLOPEN_PRIORITY_REQUIRED);
+        r = DLOPEN_CRYPTSETUP(LOG_WARNING, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
         if (r < 0)
                 return r;
 


### PR DESCRIPTION
growfs actually gracefully skips when cryptsetup fails or is missing already, and it is only necessary when the device is a LUKS device anyway. Downgrade from required ro recommended.

Follow-up for b0ede9f9eebf3f5507e6b3cef9e1de33af7cea68