### PR TITLE
core: derive restrict-fsaccess initramfs_s_dev offset from skeleton

### DIFF
--- a/src/core/bpf-restrict-fsaccess.c
+++ b/src/core/bpf-restrict-fsaccess.c
@@ -60,6 +60,10 @@ DEFINE_TRIVIAL_CLEANUP_FUNC(struct restrict_fsaccess_bpf *, restrict_fsaccess_bp
 /* The single aligned 32-bit store in restrict_fsaccess_clear_initramfs_trust()
  * is only atomic if the field is 4-byte aligned. */
 assert_cc(INITRAMFS_S_DEV_OFF % sizeof(uint32_t) == 0);
+/* The store is a fixed 4-byte write; pin its width to the skeleton's field
+ * width so widening initramfs_s_dev fails the build instead of silently
+ * clearing only the low bytes. */
+assert_cc(sizeof_field(typeof_field(struct restrict_fsaccess_bpf, bss[0]), initramfs_s_dev) == sizeof(uint32_t));
 
 /* Build the skeleton links array indexed by the link enum.
  * For BDEV_SETINTEGRITY, use whichever variant was loaded (full or compat).

--- a/src/core/bpf-restrict-fsaccess.c
+++ b/src/core/bpf-restrict-fsaccess.c
@@ -49,19 +49,17 @@ static struct restrict_fsaccess_bpf *restrict_fsaccess_bpf_free(struct restrict_
 
 DEFINE_TRIVIAL_CLEANUP_FUNC(struct restrict_fsaccess_bpf *, restrict_fsaccess_bpf_free);
 
-/* Verify that restrict_fsaccess_bss matches the skeleton's .bss layout. The sizeof
- * check catches field additions/removals; the offsetof checks catch field
- * reordering. Field order in restrict_fsaccess_bss must match the BPF global
- * declaration order in restrict-fsaccess.bpf.c — this is what bpftool uses for the
- * generated struct. The read-modify-write in restrict_fsaccess_clear_initramfs_trust()
- * depends on this layout. */
-assert_cc(sizeof(struct restrict_fsaccess_bss) == sizeof_field(struct restrict_fsaccess_bpf, bss[0]));
-assert_cc(offsetof(struct restrict_fsaccess_bss, initramfs_s_dev) ==
-          offsetof(typeof_field(struct restrict_fsaccess_bpf, bss[0]), initramfs_s_dev));
-assert_cc(offsetof(struct restrict_fsaccess_bss, protected_map_id_verity) ==
-          offsetof(typeof_field(struct restrict_fsaccess_bpf, bss[0]), protected_map_id_verity));
-assert_cc(offsetof(struct restrict_fsaccess_bss, protected_map_id_bss) ==
-          offsetof(typeof_field(struct restrict_fsaccess_bpf, bss[0]), protected_map_id_bss));
+/* Offset of initramfs_s_dev within the BPF program's .bss section, taken from
+ * the generated skeleton so it matches whichever BPF compiler (clang or gcc)
+ * emitted the object. clang and gcc do not necessarily place .bss globals in
+ * source declaration order, so the offset must come from the skeleton rather
+ * than a hand-maintained mirror struct. restrict_fsaccess_clear_initramfs_trust()
+ * mmaps the .bss map and clears this field via a single store. */
+#define INITRAMFS_S_DEV_OFF                                            \
+        offsetof(typeof_field(struct restrict_fsaccess_bpf, bss[0]), initramfs_s_dev)
+/* The single aligned 32-bit store in restrict_fsaccess_clear_initramfs_trust()
+ * is only atomic if the field is 4-byte aligned. */
+assert_cc(INITRAMFS_S_DEV_OFF % sizeof(uint32_t) == 0);
 
 /* Build the skeleton links array indexed by the link enum.
  * For BDEV_SETINTEGRITY, use whichever variant was loaded (full or compat).
@@ -227,16 +225,15 @@ static int restrict_fsaccess_clear_initramfs_trust(int bss_map_fd) {
         void *p;
 
         assert(bss_map_fd >= 0);
-        assert_cc(offsetof(struct restrict_fsaccess_bss, initramfs_s_dev) == 0);
 
         p = mmap(NULL, page_size(), PROT_READ | PROT_WRITE, MAP_SHARED, bss_map_fd, 0);
         if (p == MAP_FAILED)
                 return log_error_errno(errno, "bpf-restrict-fsaccess: Failed to mmap .bss map: %m");
 
-        /* initramfs_s_dev is at offset 0 in the .bss layout. Single aligned
-         * 32-bit store is atomic — BPF programs see either the old or new value,
-         * no torn reads possible. Guard globals are untouched. */
-        *(uint32_t *) p = 0;
+        /* Single aligned 32-bit store at INITRAMFS_S_DEV_OFF is atomic — BPF
+         * programs see either the old or new value, no torn reads possible.
+         * Guard globals are untouched. */
+        *(uint32_t *) ((uint8_t *) p + INITRAMFS_S_DEV_OFF) = 0;
 
         /* munmap failure here is harmless: the clear above already landed in
          * the kernel, and the mapping is discarded by exec anyway. */

--- a/src/core/bpf-restrict-fsaccess.h
+++ b/src/core/bpf-restrict-fsaccess.h
@@ -31,16 +31,6 @@ enum {
 /* Maximum number of dm-verity devices tracked in the BPF hash map. */
 #define DMVERITY_DEVICES_MAX (16U*1024U)
 
-/* Mirrors the BPF program's .bss section layout for read-modify-write via
- * bpf_map_lookup_elem/bpf_map_update_elem on the serialized .bss map FD. */
-struct restrict_fsaccess_bss {
-        uint32_t initramfs_s_dev; /* kernel dev_t encoding: (major << 20) | minor */
-        uint32_t protected_map_id_verity;
-        uint32_t protected_map_id_bss;
-        uint32_t protected_prog_ids[_RESTRICT_FILESYSTEM_ACCESS_LINK_MAX];
-        uint32_t protected_link_ids[_RESTRICT_FILESYSTEM_ACCESS_LINK_MAX];
-};
-
 extern const char* const restrict_fsaccess_link_names[_RESTRICT_FILESYSTEM_ACCESS_LINK_MAX];
 
 bool dm_verity_require_signatures(void);


### PR DESCRIPTION
Fixes #42689.

Building with `-Dbpf=enabled -Dbpf_compiler=gcc` (GCC's BPF backend) fails on the static assertions in `bpf-restrict-fsaccess.c` (introduced by 68fe7fa4d6 / #41340):

```
macro.h:154:25: error: static assertion failed:
"offsetof(struct restrict_fsaccess_bss, initramfs_s_dev) ==
 offsetof(typeof_field(struct restrict_fsaccess_bpf, bss[0]), initramfs_s_dev)"
```

### Root cause

`struct restrict_fsaccess_bss` is a hand-maintained mirror of the BPF program's `.bss` section, with fields listed in source-declaration order. It is checked against the skeleton's generated `bss` struct via `assert_cc(offsetof(...) == offsetof(...))`.

`bpftool gen skeleton` emits the skeleton struct from the BTF `.bss` DATASEC, whose member order reflects the *physical* order the compiler placed the variables in the section — not the source order. Clang's BPF backend preserves declaration order, so the assertions hold. GCC's BPF backend reorders `.bss`/`.data` globals (by alignment class, etc.), so `initramfs_s_dev` no longer sits at offset 0 and the build breaks.

### Why this is a correctness bug, not just a build break

`restrict_fsaccess_clear_initramfs_trust()` closes the initramfs trust window after `switch_root` by `mmap()`ing the `.bss` map and writing `0` at a **hardcoded offset 0**:

```c
assert_cc(offsetof(struct restrict_fsaccess_bss, initramfs_s_dev) == 0);
...
*(uint32_t *) p = 0;
```

Under the GCC layout that store would land on the wrong global, silently leaving `initramfs_s_dev` set — i.e. the initramfs trust window stays open after `switch_root` instead of being closed. The `assert_cc`s were correctly catching this; simply deleting them to make the GCC build pass would introduce the bug.

### Fix

Stop maintaining a parallel mirror struct and use the generated skeleton as the single source of truth for the offset:

- Drop `struct restrict_fsaccess_bss` and the four field-order `assert_cc()`s.
- Take the offset from the skeleton: `INITRAMFS_S_DEV_OFF = offsetof(typeof_field(struct restrict_fsaccess_bpf, bss[0]), initramfs_s_dev)` — a compile-time constant that tracks whatever the BPF compiler (clang *or* gcc) actually emitted.
- Store at `p + INITRAMFS_S_DEV_OFF` instead of `p + 0`.
- Keep one `assert_cc(INITRAMFS_S_DEV_OFF % sizeof(uint32_t) == 0)` documenting the 4-byte alignment the single-store atomicity relies on.

All other accesses already go through `obj->bss->...` (the skeleton struct) and were already compiler-correct; only this one mmap-based path assumed offset 0. With clang the offset is still 0, so behaviour is unchanged; with gcc the correct field is cleared.

### Verification

I don't have a BPF toolchain locally, so I verified the mechanism with a standalone model covering both a clang-style (declaration-order) and a gcc-style (reordered) skeleton layout: the skeleton-derived offset clears `initramfs_s_dev` and leaves the guard globals intact in both cases, whereas a hardcoded offset 0 under the GCC layout clobbers `protected_prog_ids[0]` and leaves `initramfs_s_dev` set. A CI pass on a `bpf_compiler=gcc` configuration would be appreciated.

Signed-off-by: tunaichao <tunaichao@uniontech.com>
Assistant: glm-5.2