### PR TITLE
bpf: group restrict-fsaccess globals into a single struct to prevent …

### DIFF
--- a/src/bpf/restrict-fsaccess.bpf.c
+++ b/src/bpf/restrict-fsaccess.bpf.c
@@ -49,23 +49,24 @@ struct {
 
 /* ---- Globals (set by PID1 via skeleton) ---- */
 
-/* Device number of the initramfs superblock. PID1 sets this at load time and
- * clears it (to 0) after switch_root. A value of 0 means "no initramfs trust
- * — the window is closed." */
-volatile __u32 initramfs_s_dev;
-
-/* ---- Self-protection guard globals (set by PID1 after attach) ----
- *
- * While all IDs are 0 (the .bss default), the guard is inactive — no real BPF
- * object has ID 0, so no comparisons match. PID1 populates these after
- * attaching all programs. */
-volatile __u32 protected_map_id_verity;
-volatile __u32 protected_map_id_bss;
-
 /* Must equal _RESTRICT_FILESYSTEM_ACCESS_LINK_MAX in bpf-restrict-fsaccess.h — update when adding programs */
 #define NUM_PROTECTED_OBJS 9 /* 5 enforcement + 4 guard (bpf, bpf_map, bpf_prog, ptrace) */
-volatile __u32 protected_prog_ids[NUM_PROTECTED_OBJS];
-volatile __u32 protected_link_ids[NUM_PROTECTED_OBJS];
+
+/* All .bss globals in one struct to prevent the compiler from reordering them.
+ * Field order must match struct restrict_fsaccess_bss in bpf-restrict-fsaccess.h. */
+struct {
+        /* Device number of the initramfs superblock. PID1 sets this at load
+         * time and clears it (to 0) after switch_root. 0 means no trust. */
+        __u32 initramfs_s_dev;
+
+        /* Self-protection guard globals (set by PID1 after attach).
+         * All IDs default to 0 — no real BPF object has ID 0, so the guard is
+         * inactive until PID1 populates these after attaching all programs. */
+        __u32 protected_map_id_verity;
+        __u32 protected_map_id_bss;
+        __u32 protected_prog_ids[NUM_PROTECTED_OBJS];
+        __u32 protected_link_ids[NUM_PROTECTED_OBJS];
+} g;
 
 /* ---- Integrity tracking hooks ---- */
 
@@ -126,7 +127,7 @@ static __always_inline int check_trusted_file(struct file *file)
         BPF_CORE_READ_INTO(&s_dev, file, f_inode, i_sb, s_dev);
 
         /* Check initramfs trust (active only during early boot) */
-        if (initramfs_s_dev != 0 && s_dev == initramfs_s_dev)
+        if (g.initramfs_s_dev != 0 && s_dev == g.initramfs_s_dev)
                 return 0;
 
         /* Check verity device map */
@@ -247,8 +248,8 @@ int BPF_PROG(restrict_fsaccess_bpf_map_guard, struct bpf_map *map,
                 return 0;
 
         id = map->id;
-        if (id != 0 && (id == protected_map_id_verity ||
-                        id == protected_map_id_bss))
+        if (id != 0 && (id == g.protected_map_id_verity ||
+                        id == g.protected_map_id_bss))
                 return -EPERM;
 
         return 0;
@@ -267,7 +268,7 @@ int BPF_PROG(restrict_fsaccess_bpf_prog_guard, struct bpf_prog *prog)
                 return 0;
 
         for (int i = 0; i < NUM_PROTECTED_OBJS; i++)
-                if (id == protected_prog_ids[i])
+                if (id == g.protected_prog_ids[i])
                         return -EPERM;
 
         return 0;
@@ -291,7 +292,7 @@ int BPF_PROG(restrict_fsaccess_bpf_guard, int cmd, union bpf_attr *attr,
                 return 0;
 
         for (int i = 0; i < NUM_PROTECTED_OBJS; i++)
-                if (id == protected_link_ids[i])
+                if (id == g.protected_link_ids[i])
                         return -EPERM;
 
         return 0;

--- a/src/core/bpf-restrict-fsaccess.c
+++ b/src/core/bpf-restrict-fsaccess.c
@@ -48,19 +48,19 @@ static struct restrict_fsaccess_bpf *restrict_fsaccess_bpf_free(struct restrict_
 
 DEFINE_TRIVIAL_CLEANUP_FUNC(struct restrict_fsaccess_bpf *, restrict_fsaccess_bpf_free);
 
-/* Verify that restrict_fsaccess_bss matches the skeleton's .bss layout. The sizeof
+/* Verify that restrict_fsaccess_bss matches the skeleton's bss[0].g layout. The sizeof
  * check catches field additions/removals; the offsetof checks catch field
- * reordering. Field order in restrict_fsaccess_bss must match the BPF global
- * declaration order in restrict-fsaccess.bpf.c — this is what bpftool uses for the
- * generated struct. The read-modify-write in restrict_fsaccess_clear_initramfs_trust()
- * depends on this layout. */
-assert_cc(sizeof(struct restrict_fsaccess_bss) == sizeof_field(struct restrict_fsaccess_bpf, bss[0]));
+ * reordering. Field order in restrict_fsaccess_bss must match struct g in
+ * restrict-fsaccess.bpf.c — this is what bpftool uses for the generated struct.
+ * The read-modify-write in restrict_fsaccess_clear_initramfs_trust() depends on
+ * this layout. */
+assert_cc(sizeof(struct restrict_fsaccess_bss) == sizeof_field(struct restrict_fsaccess_bpf, bss[0].g));
 assert_cc(offsetof(struct restrict_fsaccess_bss, initramfs_s_dev) ==
-          offsetof(typeof_field(struct restrict_fsaccess_bpf, bss[0]), initramfs_s_dev));
+          offsetof(typeof_field(struct restrict_fsaccess_bpf, bss[0].g), initramfs_s_dev));
 assert_cc(offsetof(struct restrict_fsaccess_bss, protected_map_id_verity) ==
-          offsetof(typeof_field(struct restrict_fsaccess_bpf, bss[0]), protected_map_id_verity));
+          offsetof(typeof_field(struct restrict_fsaccess_bpf, bss[0].g), protected_map_id_verity));
 assert_cc(offsetof(struct restrict_fsaccess_bss, protected_map_id_bss) ==
-          offsetof(typeof_field(struct restrict_fsaccess_bpf, bss[0]), protected_map_id_bss));
+          offsetof(typeof_field(struct restrict_fsaccess_bpf, bss[0].g), protected_map_id_bss));
 
 /* Build the skeleton links array indexed by the link enum.
  * For BDEV_SETINTEGRITY, use whichever variant was loaded (full or compat).
@@ -295,11 +295,11 @@ int bpf_restrict_fsaccess_populate_guard(struct restrict_fsaccess_bpf *obj) {
         assert_cc(ELEMENTSOF(links) == _RESTRICT_FILESYSTEM_ACCESS_LINK_MAX);
 
         /* Map IDs */
-        r = bpf_get_map_id(sym_bpf_map__fd(obj->maps.verity_devices), &obj->bss->protected_map_id_verity);
+        r = bpf_get_map_id(sym_bpf_map__fd(obj->maps.verity_devices), &obj->bss->g.protected_map_id_verity);
         if (r < 0)
                 return log_error_errno(r, "bpf-restrict-fsaccess: Failed to get verity_devices map ID: %m");
 
-        r = bpf_get_map_id(sym_bpf_map__fd(obj->maps.bss), &obj->bss->protected_map_id_bss);
+        r = bpf_get_map_id(sym_bpf_map__fd(obj->maps.bss), &obj->bss->g.protected_map_id_bss);
         if (r < 0)
                 return log_error_errno(r, "bpf-restrict-fsaccess: Failed to get .bss map ID: %m");
 
@@ -315,16 +315,16 @@ int bpf_restrict_fsaccess_populate_guard(struct restrict_fsaccess_bpf *obj) {
                                                restrict_fsaccess_link_names[idx]);
 
                 r = bpf_get_link_ids(sym_bpf_link__fd(*link),
-                                     &obj->bss->protected_link_ids[idx],
-                                     &obj->bss->protected_prog_ids[idx]);
+                                     &obj->bss->g.protected_link_ids[idx],
+                                     &obj->bss->g.protected_prog_ids[idx]);
                 if (r < 0)
                         return log_error_errno(r, "bpf-restrict-fsaccess: Failed to get link/prog IDs for %s: %m",
                                                restrict_fsaccess_link_names[idx]);
         }
 
         log_info("bpf-restrict-fsaccess: Guard globals populated (verity_map=%u, bss_map=%u)",
-                 (unsigned) obj->bss->protected_map_id_verity,
-                 (unsigned) obj->bss->protected_map_id_bss);
+                 (unsigned) obj->bss->g.protected_map_id_verity,
+                 (unsigned) obj->bss->g.protected_map_id_bss);
         return 0;
 }
 
@@ -429,7 +429,7 @@ int bpf_restrict_fsaccess_setup(Manager *m) {
                 if (r < 0)
                         return r;
 
-                obj->bss->initramfs_s_dev = root_dev;
+                obj->bss->g.initramfs_s_dev = root_dev;
                 log_info("bpf-restrict-fsaccess: Initramfs trusted (s_dev=%" PRIu32 ":%" PRIu32 ")",
                          root_dev >> 20, root_dev & 0xFFFFF);
         }

--- a/src/test/test-bpf-restrict-fsaccess.c
+++ b/src/test/test-bpf-restrict-fsaccess.c
@@ -119,9 +119,9 @@ static int do_attach(void) {
         if (stat("/", &st) < 0)
                 return log_error_errno(errno, "Failed to stat /: %m");
 
-        obj->bss->initramfs_s_dev = STAT_DEV_TO_KERNEL(st.st_dev);
+        obj->bss->g.initramfs_s_dev = STAT_DEV_TO_KERNEL(st.st_dev);
         log_info("Set initramfs_s_dev to %u:%u (kernel dev_t=0x%x)",
-                 major(st.st_dev), minor(st.st_dev), obj->bss->initramfs_s_dev);
+                 major(st.st_dev), minor(st.st_dev), obj->bss->g.initramfs_s_dev);
 
         r = restrict_fsaccess_bpf__attach(obj);
         if (r < 0)
@@ -132,18 +132,18 @@ static int do_attach(void) {
         if (r < 0)
                 return log_error_errno(r, "Failed to populate guard globals: %m");
 
-        printf("VERITY_MAP_ID=%u\n", (unsigned) obj->bss->protected_map_id_verity);
-        printf("BSS_MAP_ID=%u\n", (unsigned) obj->bss->protected_map_id_bss);
+        printf("VERITY_MAP_ID=%u\n", (unsigned) obj->bss->g.protected_map_id_verity);
+        printf("BSS_MAP_ID=%u\n", (unsigned) obj->bss->g.protected_map_id_bss);
 
         /* Print comma-separated prog and link IDs for guard tests */
         printf("PROG_IDS=\"");
         for (size_t i = 0; i < _RESTRICT_FILESYSTEM_ACCESS_LINK_MAX; i++)
-                printf("%s%u", i > 0 ? "," : "", (unsigned) obj->bss->protected_prog_ids[i]);
+                printf("%s%u", i > 0 ? "," : "", (unsigned) obj->bss->g.protected_prog_ids[i]);
         printf("\"\n");
 
         printf("LINK_IDS=\"");
         for (size_t i = 0; i < _RESTRICT_FILESYSTEM_ACCESS_LINK_MAX; i++)
-                printf("%s%u", i > 0 ? "," : "", (unsigned) obj->bss->protected_link_ids[i]);
+                printf("%s%u", i > 0 ? "," : "", (unsigned) obj->bss->g.protected_link_ids[i]);
         printf("\"\n");
 
         fflush(stdout);


### PR DESCRIPTION
bpf: group restrict-fsaccess globals into a single struct to prevent reordering

GCC 16.1 targeting BPF may reorder individual volatile __u32 globals in
the .bss section (e.g. placing arrays before scalars), causing the
bpftool-generated skeleton struct to have a different field order and
offsets than the hand-written mirror struct restrict_fsaccess_bss.
This breaks the assert_cc() layout checks added in 68fe7fa.

Fix by grouping all .bss globals into a single anonymous struct g.
C struct members are guaranteed to appear in declaration order with no
compiler-imposed reordering, so bpftool always generates a skeleton
whose g field matches restrict_fsaccess_bss exactly.

Update all BPF program accesses (g.field) and host-side skeleton
accesses (obj->bss->g.field) accordingly.

Fixes: 68fe7fa ("core/bpf: add layout assertions for restrict_fsaccess_bss")

eg:
```#include <stdint.h>
#include <stddef.h>
#define NUM 9

/* GCC 16.1 BPF: arrays sorted first in .bss */
struct skel_bss_buggy {uint32_t protected_prog_ids[NUM];
        uint32_t protected_link_ids[NUM];
        uint32_t initramfs_s_dev;/* not at offset 0 */
        uint32_t protected_map_id_verity;
        uint32_t protected_map_id_bss;
};
/* fix: struct g preserves declaration order */
struct g_type {
        uint32_t initramfs_s_dev;
        uint32_t protected_map_id_verity;
        uint32_t protected_map_id_bss;
        uint32_t protected_prog_ids[NUM];
        uint32_t protected_link_ids[NUM];
};
/* hand-written mirror in bpf-restrict-fsaccess.h */
struct mirror_bss {
        uint32_t initramfs_s_dev;
        uint32_t protected_map_id_verity;
        uint32_t protected_map_id_bss;
        uint32_t protected_prog_ids[NUM];
        uint32_t protected_link_ids[NUM];
};

#ifdef SHOW_BUG
_Static_assert(offsetof(struct mirror_bss, initramfs_s_dev) ==
               offsetof(struct skel_bss_buggy, initramfs_s_dev),
               "BUG: initramfs_s_dev reordered");
_Static_assert(offsetof(struct mirror_bss, protected_map_id_verity) ==
               offsetof(struct skel_bss_buggy, protected_map_id_verity),
               "BUG: protected_map_id_verity reordered");
_Static_assert(offsetof(struct mirror_bss, protected_map_id_bss) ==
               offsetof(struct skel_bss_buggy, protected_map_id_bss),
               "BUG: protected_map_id_bss reordered");
#else
_Static_assert(sizeof(struct mirror_bss) == sizeof(struct g_type), "size");
_Static_assert(offsetof(struct mirror_bss, initramfs_s_dev) ==
               offsetof(struct g_type, initramfs_s_dev), "offset0");
_Static_assert(offsetof(struct mirror_bss, protected_map_id_verity) ==
               offsetof(struct g_type, protected_map_id_verity), "offset1");
_Static_assert(offsetof(struct mirror_bss, protected_map_id_bss) ==
               offsetof(struct g_type, protected_map_id_bss), "offset2");
#endif
```

Reproduction steps:/* gcc -DSHOW_BUG -c repro.c  →  all three assertions fail (reproduces the bug) */
/repro.c:29:1: error: static assertion failed: "BUG: initramfs_s_dev reordered"
   29 | _Static_assert(offsetof(struct mirror_bss, initramfs_s_dev) ==
      | ^~~~~~~~~~~~~~
/home/ut006346@uos/pr/systemd_/repro.c:31:1: error: static assertion failed: "BUG: protected_map_id_verity reordered"
   31 | _Static_assert(offsetof(struct mirror_bss, protected_map_id_verity) ==
      | ^~~~~~~~~~~~~~
/home/ut006346@uos/pr/systemd_/repro.c:33:1: error: static assertion failed: "BUG: protected_map_id_bss reordered"
   33 | _Static_assert(offsetof(struct mirror_bss, protected_map_id_bss) ==

/* gcc -c repro.c  →  all pass (verifies the fix) */