### PR TITLE
test-execute: use per-Exec timeout instead of per-service timeout

### DIFF
--- a/src/test/test-execute.c
+++ b/src/test/test-execute.c
@@ -86,12 +86,21 @@ static void wait_for_service_finish(Manager *m, Unit *unit) {
         printf("%s\n", unit->id);
         exec_context_dump(&service->exec_context, stdout, "\t");
 
+        /* Use a per-Exec timeout rather than a service timeout, as especially under sanitizers some test
+         * units running many commands can hit the service timeout. */
         _cleanup_(sd_event_source_unrefp) sd_event_source *s = NULL;
         ASSERT_OK(sd_event_add_time_relative(m->event, &s, CLOCK_MONOTONIC, timeout, 0, time_handler, unit));
 
         /* Here, sd_event_loop() cannot be used, as the sd_event object will be reused in the next test case. */
-        while (!IN_SET(service->state, SERVICE_DEAD, SERVICE_FAILED))
+        ExecCommand *last_command = service->main_command;
+        while (!IN_SET(service->state, SERVICE_DEAD, SERVICE_FAILED)) {
                 ASSERT_OK(sd_event_run(m->event, 100 * USEC_PER_MSEC));
+
+                if (service->main_command != last_command) {
+                        last_command = service->main_command;
+                        ASSERT_OK(sd_event_source_set_time_relative(s, timeout));
+                }
+        }
 }
 
 static void check_main_result(const char *file, unsigned line, const char *func,


### PR DESCRIPTION
The previous x2 was still not enough, and the test is still killed often in slow GHA CI workers, eg:

https://github.com/systemd/systemd/actions/runs/28012425459/job/82908555094?pr=42705

This happens in test units with many commands, so reset the timer when
a command completes and the test advances. The number of Exec
instructions is bounded so this will terminate jobs that are really
stuck anyway.

Follow-up for 3b00327fe6004b03c4a963de3df51998cf0c79b4