### PR TITLE
core: fix assertion when inactive unit pulled in by try-restart and sart at the same time

### DIFF
--- a/src/core/transaction.c
+++ b/src/core/transaction.c
@@ -263,11 +263,69 @@ static int transaction_ensure_mergeable(Transaction *tr, bool matters_to_anchor,
         return 0;
 }
 
+static void transaction_drop_nop(Transaction *tr) {
+        Job *j;
+        int r;
+
+        assert(tr);
+
+        /* While a transaction is being built, a NOP job sits in the same per-unit list in tr->jobs (linked
+         * via transaction_next/transaction_prev) as the regular jobs for that unit; the dedicated 'nop_job'
+         * slot in Unit is only populated later, at install time. JOB_NOP equals _JOB_TYPE_MAX_MERGING and is
+         * thus outside the domain of job_type_lookup_merge(), so it cannot be merged with a regular job and
+         * would trip the assertion there. A unit can end up with both a NOP job (e.g. a try-restart/try-reload
+         * anchor that collapsed to JOB_NOP because the unit is inactive) and a regular job (typically pulled
+         * in as a dependency by another job in the same transaction, which is possible since
+         * EnqueueUnitJobMany() allows more than one anchor). In that case the NOP carries no meaning of its
+         * own, as the regular job is what determines the fate of the unit, so drop it to keep each unit's
+         * transaction list mergeable. */
+
+        HASHMAP_FOREACH(j, tr->jobs) {
+                Job *nop = NULL, *regular = NULL;
+
+                LIST_FOREACH(transaction, k, j)
+                        if (k->type == JOB_NOP)
+                                nop = k; /* At most one NOP per unit, as jobs are deduplicated by type. */
+                        else
+                                regular = k;
+
+                /* Only drop the NOP when a regular job for the same unit remains. A lone NOP anchor must be
+                 * kept so that e.g. 'try-restart' on an inactive unit still completes successfully. */
+                if (!nop || !regular)
+                        continue;
+
+                log_unit_debug(nop->unit,
+                               "Dropping NOP job for %s, a regular job for the same unit is part of the transaction.",
+                               nop->unit->id);
+
+                /* A NOP job only ever enters the transaction as a client-requested anchor: propagated
+                 * try-restart/try-reload that would collapse to JOB_NOP is skipped before being added. Hand
+                 * the anchor identity over to the surviving regular job (which was pulled in by another job
+                 * and is not an anchor itself) so the unit the client explicitly named still shows up in the
+                 * set reported back by EnqueueUnitJobMany(). */
+                if (set_contains(tr->anchor_jobs, nop)) {
+                        r = set_remove_and_put(tr->anchor_jobs, nop, regular);
+                        if (r == -EEXIST)
+                                /* The regular job is already an anchor; just drop the about-to-be-freed NOP
+                                 * key so it doesn't linger. */
+                                (void) set_remove(tr->anchor_jobs, nop);
+                        else
+                                /* nop was present (we just checked) and put cannot fail after a remove. */
+                                assert(r >= 0);
+                }
+
+                transaction_delete_job(tr, nop, /* delete_dependencies= */ false);
+        }
+}
+
 static int transaction_merge_jobs(Transaction *tr, sd_bus_error *e) {
         Job *j;
         int r;
 
         assert(tr);
+
+        /* NOP jobs cannot be merged with regular jobs, so drop the ones that would collide first. */
+        transaction_drop_nop(tr);
 
         /* First step, try to drop unmergeable jobs for jobs that matter to anchor. */
         r = transaction_ensure_mergeable(tr, /* matters_to_anchor= */ true, e);

--- a/test/units/TEST-07-PID1.multi-units-transaction.sh
+++ b/test/units/TEST-07-PID1.multi-units-transaction.sh
@@ -24,14 +24,17 @@ at_exit() {
     systemctl stop issue8102-sock-foo.service issue8102-sock-foo.socket
     systemctl stop 'issue8102-many@*.service'
     systemctl stop issue8102-conflict-a.service issue8102-conflict-b.service
+    systemctl stop issue8102-nop-main.service issue8102-nop-dep.service
     systemctl reset-failed issue8102-second.service issue8102-first.service
     systemctl reset-failed issue8102-sock-foo.service issue8102-sock-foo.socket
     systemctl reset-failed 'issue8102-many@*.service'
     systemctl reset-failed issue8102-conflict-a.service issue8102-conflict-b.service
+    systemctl reset-failed issue8102-nop-main.service issue8102-nop-dep.service
     rm -f /run/systemd/system/issue8102-{first,second}.service
     rm -f /run/systemd/system/issue8102-sock-foo.{service,socket}
     rm -f /run/systemd/system/issue8102-many@.service
     rm -f /run/systemd/system/issue8102-conflict-{a,b}.service
+    rm -f /run/systemd/system/issue8102-nop-{main,dep}.service
     rm -rf "$MARKER_DIR" "$SOCK_DIR"
     systemctl daemon-reload
 }
@@ -373,3 +376,90 @@ busctl call \
     0 >/dev/null
 
 [[ "$(systemctl show -P ActiveState issue8102-first.service)" == inactive ]]
+
+# ---------------------------------------------------------------------------
+# Regression test: a try-restart anchor that collapses to a NOP job (because
+# the unit is inactive) must not crash PID1 when the very same unit is also
+# pulled into the transaction as a regular start job by another anchor.
+#
+# ---------------------------------------------------------------------------
+
+cat >/run/systemd/system/issue8102-nop-dep.service <<EOF
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/bin/true
+EOF
+
+cat >/run/systemd/system/issue8102-nop-main.service <<EOF
+[Unit]
+Wants=issue8102-nop-dep.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/bin/true
+EOF
+systemctl daemon-reload
+
+systemctl start issue8102-nop-main.service
+[[ "$(systemctl show -P ActiveState issue8102-nop-main.service)" == active ]]
+
+# Stop just the dependency. Wants= is a weak dependency, so the main unit stays
+# active while the dependency goes inactive.
+systemctl stop issue8102-nop-dep.service
+[[ "$(systemctl show -P ActiveState issue8102-nop-dep.service)" == inactive ]]
+[[ "$(systemctl show -P ActiveState issue8102-nop-main.service)" == active ]]
+
+# try-restart both in a single transaction: the inactive dependency collapses to
+# a NOP anchor, while restarting the active main unit pulls the dependency back
+# in as a regular start job.
+out=$(busctl call \
+    org.freedesktop.systemd1 \
+    /org/freedesktop/systemd1 \
+    org.freedesktop.systemd1.Manager \
+    EnqueueUnitJobMany \
+    assst \
+    2 issue8102-nop-dep.service issue8102-nop-main.service \
+    try-restart replace \
+    0)
+grep -F "issue8102-nop-dep.service" >/dev/null <<<"$out"
+grep -F "issue8102-nop-main.service" >/dev/null <<<"$out"
+
+# shellcheck disable=SC2016
+timeout 30s bash -c '
+    while [[ "$(systemctl show -P ActiveState issue8102-nop-dep.service)" != active ]] ||
+          [[ "$(systemctl show -P ActiveState issue8102-nop-main.service)" != active ]]; do
+        sleep 0.5
+    done
+'
+
+# Repeat with the two anchors swapped in the array. The per-unit transaction list
+# is built incrementally, so the NOP and the regular job end up in the opposite
+# order; transaction_drop_nop() must handle both cases.
+systemctl stop issue8102-nop-dep.service
+[[ "$(systemctl show -P ActiveState issue8102-nop-dep.service)" == inactive ]]
+[[ "$(systemctl show -P ActiveState issue8102-nop-main.service)" == active ]]
+
+out=$(busctl call \
+    org.freedesktop.systemd1 \
+    /org/freedesktop/systemd1 \
+    org.freedesktop.systemd1.Manager \
+    EnqueueUnitJobMany \
+    assst \
+    2 issue8102-nop-main.service issue8102-nop-dep.service \
+    try-restart replace \
+    0)
+grep -F "issue8102-nop-dep.service" >/dev/null <<<"$out"
+grep -F "issue8102-nop-main.service" >/dev/null <<<"$out"
+
+# shellcheck disable=SC2016
+timeout 30s bash -c '
+    while [[ "$(systemctl show -P ActiveState issue8102-nop-dep.service)" != active ]] ||
+          [[ "$(systemctl show -P ActiveState issue8102-nop-main.service)" != active ]]; do
+        sleep 0.5
+    done
+'
+
+# Ensure we are still running
+systemctl daemon-reload


### PR DESCRIPTION
With EnqueueUnitJobMany(), one anchor can collapse to NOP (inactive unit + try-restart) while another anchor pulls that same unit in as a regular start/restart job, leaving a NOP and a regular job in one unit's transaction list, hitting an assert:

```
 #11 0x00007f3fd2a446dc in __assert_fail (assertion=<optimized out>, file=<optimized out>, line=<optimized out>,
     function=<optimized out>) at ./assert/assert.c:127
 #12 0x00007f3fd326e872 in job_type_lookup_merge (a=<optimized out>, b=<optimized out>) at ../src/core/job.c:428
 #13 0x00007f3fd32e5641 in job_type_merge_and_collapse (a=0x7ffc7dda2430, b=<optimized out>, u=0x557bb11434c0)
     at ../src/core/job.c:523
 #14 0x00007f3fd335e4b3 in transaction_ensure_mergeable (tr=tr@entry=0x557bb0f6d150,
     matters_to_anchor=matters_to_anchor@entry=true, e=e@entry=0x7ffc7dda33e0) at ../src/core/transaction.c:241
 #15 0x00007f3fd3360242 in transaction_merge_jobs (tr=0x557bb0f6d150, e=0x7ffc7dda33e0)
     at ../src/core/transaction.c:273
 #16 transaction_activate (tr=0x557bb0f6d150, m=0x557bb0dd9c10, mode=JOB_REPLACE, affected_jobs=0x0, e=0x7ffc7dda33e0)
     at ../src/core/transaction.c:797
 #17 0x00007f3fd33091ed in manager_add_jobs (m=<optimized out>, type=<optimized out>, names=<optimized out>,
     reload_if_possible=false, mode=JOB_REPLACE, extra_flags=0, affected_jobs=0x0, reterr_error=0x7ffc7dda33e0,
     ret_jobs=0x557bb0fe8790) at ../src/core/manager.c:2386
```

Follow-up for 7d3b32daef3125e70dd3f1689fb563a06b0c6753