### PR TITLE
test: skip fdstore tests if test-fdstore is not available

### DIFF
--- a/mkosi/mkosi.images/minimal-base/mkosi.postinst
+++ b/mkosi/mkosi.images/minimal-base/mkosi.postinst
@@ -24,4 +24,6 @@ elif [[ -x "$BUILDROOT/usr/lib/systemd/tests/unit-tests/manual/test-fdstore" ]];
     cp "$BUILDROOT/usr/lib/systemd/tests/unit-tests/manual/test-fdstore" "$BUILDROOT/usr/bin/test-fdstore"
 elif [[ -x /usr/lib/systemd/tests/unit-tests/manual/test-fdstore ]]; then
     cp /usr/lib/systemd/tests/unit-tests/manual/test-fdstore "$BUILDROOT/usr/bin/test-fdstore"
+else
+    echo >&2 "WARNING: test-fdstore binary not found, fdstore container tests will be skipped"
 fi

--- a/test/units/TEST-13-NSPAWN.unpriv.sh
+++ b/test/units/TEST-13-NSPAWN.unpriv.sh
@@ -37,6 +37,7 @@ at_exit() {
     rm -rf /var/tmp/mangletest
     rm -f /var/tmp/mangletest.tar.gz
     rm -f /shouldnotwork
+    loginctl disable-linger testuser
 }
 
 trap at_exit EXIT
@@ -316,6 +317,10 @@ cmp /var/tmp/mangletest/mangletest-0.1/usr/lib/os-release /home/testuser/.local/
 # Then restart the nspawn service and verify the inner payload actually
 # receives the preserved fds back via LISTEN_FDS, with their original content.
 create_dummy_container /home/testuser/.local/state/machines/fdstore
+if [[ ! -x /home/testuser/.local/state/machines/fdstore/usr/bin/test-fdstore ]]; then
+    echo >&2 "test-fdstore not available in the minimal container, skipping fdstore tests"
+    exit 0
+fi
 # The container init execs the helper directly so the FDSTORE notification is
 # sent from PID 1 (nspawn rejects notify messages from anyone but the inner
 # payload's init). The helper itself execs sleep on success to keep the
@@ -404,5 +409,3 @@ assert_eq "$(run0 -u testuser systemctl --user show -P SubState systemd-nspawn@f
 run0 -u testuser systemctl --user reset-failed systemd-nspawn@fdstore.service
 
 machinectl terminate fdstore 2>/dev/null || true
-
-loginctl disable-linger testuser

--- a/test/units/TEST-91-LIVEUPDATE.sh
+++ b/test/units/TEST-91-LIVEUPDATE.sh
@@ -112,21 +112,25 @@ if grep -qw luo_nboot=1 /proc/cmdline; then
     # then forwards the preserved fds via LISTEN_FDS to a fresh nspawn payload,
     # which verifies the content is intact.
     create_dummy_container /var/lib/machines/fdstore
-    cat >/var/lib/machines/fdstore/sbin/init <<'EOF'
+    if [[ -x /var/lib/machines/fdstore/usr/bin/test-fdstore ]]; then
+        cat >/var/lib/machines/fdstore/sbin/init <<'EOF'
 #!/usr/bin/env bash
 set -e
 exec /usr/bin/test-fdstore check
 EOF
-    chmod +x /var/lib/machines/fdstore/sbin/init
-    mkdir -p /run/systemd/nspawn
-    cat >/run/systemd/nspawn/fdstore.nspawn <<EOF
+        chmod +x /var/lib/machines/fdstore/sbin/init
+        mkdir -p /run/systemd/nspawn
+        cat >/run/systemd/nspawn/fdstore.nspawn <<EOF
 [Exec]
 KillSignal=SIGTERM
 EOF
-    n_nspawn_fds=$(systemctl show -P NFileDescriptorStore systemd-nspawn@fdstore.service)
-    test "${n_nspawn_fds}" -ge 2
-    systemctl start systemd-nspawn@fdstore.service
-    systemctl is-active systemd-nspawn@fdstore.service
+        n_nspawn_fds=$(systemctl show -P NFileDescriptorStore systemd-nspawn@fdstore.service)
+        test "${n_nspawn_fds}" -ge 2
+        systemctl start systemd-nspawn@fdstore.service
+        systemctl is-active systemd-nspawn@fdstore.service
+    else
+        echo >&2 "test-fdstore not available in the minimal container, skipping fdstore tests"
+    fi
 
     # late.service: rewrite the fragment with the second-boot ExecStart and
     # exercise the daemon-reload + daemon-reexec preservation paths.
@@ -271,22 +275,26 @@ else
     #   → LUO → after kexec PID 1 restores the fdstore → systemd-nspawn →
     #   payload verifies content matches.
     create_dummy_container /var/lib/machines/fdstore
-    cat >/var/lib/machines/fdstore/sbin/init <<'EOF'
+    if [[ -x /var/lib/machines/fdstore/usr/bin/test-fdstore ]]; then
+        cat >/var/lib/machines/fdstore/sbin/init <<'EOF'
 #!/usr/bin/env bash
 set -e
 exec /usr/bin/test-fdstore store
 EOF
-    chmod +x /var/lib/machines/fdstore/sbin/init
+        chmod +x /var/lib/machines/fdstore/sbin/init
 
-    mkdir -p /run/systemd/nspawn
-    cat >/run/systemd/nspawn/fdstore.nspawn <<EOF
+        mkdir -p /run/systemd/nspawn
+        cat >/run/systemd/nspawn/fdstore.nspawn <<EOF
 [Exec]
 KillSignal=SIGTERM
 EOF
 
-    systemctl start systemd-nspawn@fdstore.service
-    timeout 30s bash -c \
-        "until [[ \"\$(systemctl show -P NFileDescriptorStore systemd-nspawn@fdstore.service)\" -ge 2 ]]; do sleep 0.5; done"
+        systemctl start systemd-nspawn@fdstore.service
+        timeout 30s bash -c \
+            "until [[ \"\$(systemctl show -P NFileDescriptorStore systemd-nspawn@fdstore.service)\" -ge 2 ]]; do sleep 0.5; done"
+    else
+        echo >&2 "test-fdstore not available in the minimal container, skipping fdstore tests"
+    fi
 
     # Negative path: store a fd store entry that holds a child LUO session named
     # like PID 1's own ("systemd"). On kexec PID 1 must refuse to serialize it


### PR DESCRIPTION
~~TEST-13 and TEST-91 were failing in Fedora CI, because they need test-fdstore that wasn't being installed into the image, because the job doesn't rebuild systemd and the we didn't install the systemd-tests package into the minimal-base container.~~

~~Follow-up for 3405c9da339104c197a4eb74f72384916f2d5c1e.~~

---

I'm not really thrilled about this, since it pulls in a lot of unnecessary crap into the minimal-base image, and it also feels a "bit" hacky. If there's a better way, please let me know.

@bluca - your comment in https://github.com/systemd/systemd/pull/42656#pullrequestreview-4533196268 suggests that the changes from 3405c9da339104c197a4eb74f72384916f2d5c1e alone should be enough to make the tests work in a "standalone" mode, so maybe I'm missing something here? I thought that the `$BUILDROOT/...` branch would mitigate this, but the contents of the systemd-tests package are not there (even though the package is installed on the host system). I suspect `$BUILDROOT` in this case is not the host system, but maybe the tools tree? :shrug: 