### PR TITLE
sd-journal: skip tail timestamp refresh during iteration

### DIFF
--- a/src/libsystemd/sd-journal/journal-file.c
+++ b/src/libsystemd/sd-journal/journal-file.c
@@ -4142,6 +4142,7 @@ int journal_file_open(
                 .strict_order = FLAGS_SET(file_flags, JOURNAL_STRICT_ORDER),
                 .newest_boot_id_prioq_idx = PRIOQ_IDX_NULL,
                 .last_direction = _DIRECTION_INVALID,
+                .tail_timestamp_ratelimit = { .interval = USEC_PER_SEC, .burst = 1 },
         };
 
         if (f->fd < 0) {

--- a/src/libsystemd/sd-journal/journal-file.h
+++ b/src/libsystemd/sd-journal/journal-file.h
@@ -9,6 +9,7 @@
 #include "gcrypt-util.h"
 #include "journal-def.h"
 #include "mmap-cache.h"
+#include "ratelimit.h"
 #include "sparse-endian.h"
 
 typedef struct JournalMetrics {
@@ -121,6 +122,7 @@ typedef struct JournalFile {
         unsigned newest_boot_id_prioq_idx;
         uint64_t newest_entry_offset;
         uint8_t newest_state;
+        RateLimit tail_timestamp_ratelimit; /* rate-limits journal_file_read_tail_timestamp() calls during iteration */
 } JournalFile;
 
 typedef enum JournalFileFlags {

--- a/src/libsystemd/sd-journal/sd-journal.c
+++ b/src/libsystemd/sd-journal/sd-journal.c
@@ -1004,7 +1004,12 @@ static int next_beyond_location(sd_journal *j, JournalFile *f, direction_t direc
         assert(j);
         assert(f);
 
-        (void) journal_file_read_tail_timestamp(j, f);
+        /* Rate-limit tail timestamp refreshes during iteration. Calling this unconditionally is
+         * O(N x files) volatile mmap overhead that makes large 'journalctl -n N' queries unusably
+         * slow. Periodic refresh keeps cross-boot ordering reasonably fresh and provides a fallback
+         * for any missed inotify events. */
+        if (ratelimit_below(&f->tail_timestamp_ratelimit))
+                (void) journal_file_read_tail_timestamp(j, f);
 
         n_entries = le64toh(f->header->n_entries);
 


### PR DESCRIPTION
```
Test@Test-PC:~$ sudo time journalctl -n 1000000 > /dev/null
124.70user 199.71system 5:24.54elapsed 99%CPU (0avgtext+0avgdata 136080maxresident)k
0inputs+0outputs (0major+759856minor)pagefaults 0swaps
```
```
Test@Test-PC:~$ sudo time journalctl -n 1000000 > /dev/null
74.10user 82.99system 2:39.07elapsed 98%CPU (0avgtext+0avgdata 125116maxresident)k
763608inputs+0outputs (4949major+529400minor)pagefaults 0swaps
```
Measured improvement on a real system: 5:24 -> 2:39 (-51%) for 'journalctl -n 1000000'.

Fixes: #42521
Regression introduced in: #26355 (34af74946e)