### PR TITLE
units: tag more units correctly with varlink xattrs

### DIFF
--- a/units/systemd-journalctl-metrics.socket
+++ b/units/systemd-journalctl-metrics.socket
@@ -19,10 +19,13 @@ ListenStream=/run/systemd/report/io.systemd.Journal
 FileDescriptorName=varlink
 # Same permissions as systemd-journalctl.socket for io.systemd.JournalAccess
 SocketGroup=systemd-journal
-SocketMode=0660
+SocketMode=0664
 Accept=yes
 MaxConnectionsPerSource=16
 RemoveOnStop=yes
+XAttrEntryPoint=user.varlink=entrypoint
+XAttrListen=user.varlink=listen
+XAttrAccept=user.varlink=server
 
 [Install]
 WantedBy=sockets.target

--- a/units/systemd-report-sign-tsm.socket
+++ b/units/systemd-report-sign-tsm.socket
@@ -18,7 +18,7 @@ ConditionSecurity=cvm
 [Socket]
 ListenStream=/run/systemd/report.sign/tsm
 FileDescriptorName=varlink
-SocketMode=0600
+SocketMode=0644
 Accept=yes
 MaxConnectionsPerSource=16
 RemoveOnStop=yes

--- a/units/systemd-report.socket
+++ b/units/systemd-report.socket
@@ -15,10 +15,13 @@ Before=sockets.target
 [Socket]
 ListenStream=/run/systemd/io.systemd.Report
 FileDescriptorName=varlink
-SocketMode=0600
+SocketMode=0644
 Accept=yes
 MaxConnectionsPerSource=16
 RemoveOnStop=yes
+XAttrEntryPoint=user.varlink=entrypoint
+XAttrListen=user.varlink=listen
+XAttrAccept=user.varlink=server
 
 [Install]
 WantedBy=sockets.target


### PR DESCRIPTION
These were added in parallel to #42454, hence catch up and add missing xattrs.

Follow-up for 53fc4c48e7d40293e8f79392e2da91323dd50268