### PR TITLE
run0: emit OSC 3008 context when elevating to root by default

### DIFF
--- a/src/run/run.c
+++ b/src/run/run.c
@@ -941,14 +941,20 @@ static int parse_argv_sudo_mode(int argc, char *argv[]) {
                         arg_working_directory = mfree(arg_working_directory);
         }
 
-        if (!arg_exec_user && (arg_area || arg_empower)) {
+        if (!arg_exec_user) {
                 /* If the user specifies --area= but not --user= then consider this an area switch request,
                  * and default to logging into our own account.
                  *
                  * If the user specifies --empower but not --user= then consider this a request to empower
-                 * the current user. */
+                 * the current user.
+                 *
+                 * If neither --user=, --area= nor --empower is specified, default to switching to root
+                 * explicitly. */
 
-                arg_exec_user = getusername_malloc();
+                if (arg_area || arg_empower)
+                        arg_exec_user = getusername_malloc();
+                else
+                        arg_exec_user = strdup("root");
                 if (!arg_exec_user)
                         return log_oom();
         }


### PR DESCRIPTION
When invoked as run0 without an explicit -u, arg_exec_user stays NULL even though the target user is effectively root. As a result the existing `if (arg_exec_user && ...)` guard in start_transient_service() silently skipped osc_context_open_chpriv(), so terminals never received the 3008 elevate sequence for the most common run0 use case.

Therefore, when arg_exec_user is NULL and the current state is run0,
it is necessary to use become_root() to check whether it will automatically escalate privileges to root.

Fixes #40468