### PR TITLE
hwdb: map Brazilian ThinkPad T14 Gen 1 slash key to KEY_RO

### DIFF
--- a/hwdb.d/60-keyboard.hwdb
+++ b/hwdb.d/60-keyboard.hwdb
@@ -1083,6 +1083,10 @@ evdev:atkbd:dmi:bvn*:bvr*:bd*:svnLENOVO*:pn*3000*:pvr*
 evdev:atkbd:dmi:bvn*:bvr*:bd*:svnLENOVO:pn0769AP2:pvr3000N200:*
  KEYBOARD_KEY_b4=prog1
 
+# Lenovo ThinkPad T14 Gen 1 AMD, Brazilian keyboard
+evdev:atkbd:dmi:bvn*:bvr*:bd*:svnLENOVO:pn20UES5TQ00:pvr*
+ KEYBOARD_KEY_9d=ro                                     # slash/question key
+
 # Lenovo IdeaPad
 evdev:atkbd:dmi:bvn*:bvr*:bd*:svnLENOVO*:pn*IdeaPad*:pvr*
 evdev:atkbd:dmi:bvn*:bvr*:bd*:svnLENOVO*:pnS10-*:*


### PR DESCRIPTION
On Lenovo ThinkPad T14 Gen 1 AMD model 20UES5TQ00 with the Brazilian keyboard, the physical slash/question key reports as KEY_RIGHTCTRL.

This keyboard layout has no physical Right Ctrl key in that position. The key after Space is AltGr, then PrtSc, then the slash/question key. Map the AT keyboard scancode 0x9d to KEY_RO, matching the ABNT slash/question key used by Brazilian keyboard layouts.

Verified with evtest:

Event: type 4 (EV_MSC), code 4 (MSC_SCAN), value 9d
Event: type 1 (EV_KEY), code 97 (KEY_RIGHTCTRL), value 1

After applying the hwdb mapping, the key reports as KEY_RO.

DMI: svnLENOVO:pn20UES5TQ00:pvrThinkPadT14Gen1
AT keyboard scancode: 0x9d