### PR TITLE
journald: bound field length in extra-fields reader

### DIFF
--- a/src/journal/journald-context.c
+++ b/src/journal/journald-context.c
@@ -443,9 +443,12 @@ static int client_context_read_extra_fields(
                 if (v < 2)
                         return -EBADMSG;
 
-                n = sizeof(uint64_t) + v;
-                if (left < n)
+                /* left >= sizeof(uint64_t) here, so the subtraction is safe and we avoid
+                 * overflowing sizeof(uint64_t) + v when v is close to UINT64_MAX. */
+                if (v > left - sizeof(uint64_t))
                         return -EBADMSG;
+
+                n = sizeof(uint64_t) + v;
 
                 field = q + sizeof(uint64_t);
 


### PR DESCRIPTION
client_context_read_extra_fields() reads a 64-bit field length from the per-unit log-extra-fields file:
- n = sizeof(uint64_t) + v wraps for v near UINT64_MAX, so the `left < n` check is skipped
- memchr() then scans v bytes past the end of the buffer

Bound v against the remaining bytes instead. The sibling parsers (get_data_size(), the native protocol reader) already bound the declared length the same way.