### PR TITLE
uid-range: fix heap overflow in uid_range_partition() on mixed-size input

### DIFF
--- a/src/basic/uid-range.c
+++ b/src/basic/uid-range.c
@@ -392,22 +392,23 @@ int uid_range_partition(UIDRange *range, uid_t size) {
                 return 0;
         }
 
-        if (n_new_entries > range->n_entries && !GREEDY_REALLOC(range->entries, n_new_entries))
+        _cleanup_free_ UIDRangeEntry *new_entries = new(UIDRangeEntry, n_new_entries);
+        if (!new_entries)
                 return -ENOMEM;
 
-        /* Work backwards to avoid overwriting entries we still need to read */
-        size_t t = n_new_entries;
-        for (size_t i = range->n_entries; i > 0; i--) {
-                UIDRangeEntry *e = range->entries + i - 1;
+        size_t t = 0;
+        FOREACH_ARRAY(e, range->entries, range->n_entries) {
                 unsigned n_parts = e->nr / size;
 
-                for (unsigned j = n_parts; j > 0; j--)
-                        range->entries[--t] = (UIDRangeEntry) {
-                                .start = e->start + (j - 1) * size,
+                for (unsigned j = 0; j < n_parts; j++)
+                        new_entries[t++] = (UIDRangeEntry) {
+                                .start = e->start + j * size,
                                 .nr = size,
                         };
         }
+        assert(t == n_new_entries);
 
+        free_and_replace(range->entries, new_entries);
         range->n_entries = n_new_entries;
 
         return 0;

--- a/src/test/test-uid-range.c
+++ b/src/test/test-uid-range.c
@@ -328,6 +328,51 @@ TEST(uid_range_partition) {
         ASSERT_EQ(p->entries[1].nr, 1U);
         ASSERT_EQ(p->entries[2].start, 102U);
         ASSERT_EQ(p->entries[2].nr, 1U);
+
+        p = uid_range_free(p);
+
+        /* A too-small entry between two partitionable entries is dropped; the others still partition. */
+        ASSERT_OK(uid_range_add_str(&p, "0-4"));        /* nr=5  < size -> dropped */
+        ASSERT_OK(uid_range_add_str(&p, "50-69"));      /* nr=20       -> 2 parts */
+        ASSERT_OK(uid_range_add_str(&p, "200-204"));    /* nr=5  < size -> dropped */
+        ASSERT_OK(uid_range_add_str(&p, "1000-1029"));  /* nr=30       -> 3 parts */
+        ASSERT_EQ(uid_range_entries(p), 4U);
+        ASSERT_OK(uid_range_partition(p, 10));
+        ASSERT_EQ(uid_range_entries(p), 5U);
+        ASSERT_EQ(p->entries[0].start, 50U);
+        ASSERT_EQ(p->entries[0].nr, 10U);
+        ASSERT_EQ(p->entries[1].start, 60U);
+        ASSERT_EQ(p->entries[1].nr, 10U);
+        ASSERT_EQ(p->entries[2].start, 1000U);
+        ASSERT_EQ(p->entries[2].nr, 10U);
+        ASSERT_EQ(p->entries[3].start, 1010U);
+        ASSERT_EQ(p->entries[3].nr, 10U);
+        ASSERT_EQ(p->entries[4].start, 1020U);
+        ASSERT_EQ(p->entries[4].nr, 10U);
+
+        p = uid_range_free(p);
+
+        /* A too-small entry before a partitionable entry is dropped. */
+        ASSERT_OK(uid_range_add_str(&p, "0-4"));        /* nr=5  < size -> dropped */
+        ASSERT_OK(uid_range_add_str(&p, "100-119"));    /* nr=20       -> 2 parts */
+        ASSERT_OK(uid_range_partition(p, 10));
+        ASSERT_EQ(uid_range_entries(p), 2U);
+        ASSERT_EQ(p->entries[0].start, 100U);
+        ASSERT_EQ(p->entries[0].nr, 10U);
+        ASSERT_EQ(p->entries[1].start, 110U);
+        ASSERT_EQ(p->entries[1].nr, 10U);
+
+        p = uid_range_free(p);
+
+        /* A too-small entry after a partitionable entry is dropped. */
+        ASSERT_OK(uid_range_add_str(&p, "0-199"));      /* nr=200 -> 2 parts */
+        ASSERT_OK(uid_range_add_str(&p, "1000-1004"));  /* nr=5  < size -> dropped */
+        ASSERT_OK(uid_range_partition(p, 100));
+        ASSERT_EQ(uid_range_entries(p), 2U);
+        ASSERT_EQ(p->entries[0].start, 0U);
+        ASSERT_EQ(p->entries[0].nr, 100U);
+        ASSERT_EQ(p->entries[1].start, 100U);
+        ASSERT_EQ(p->entries[1].nr, 100U);
 }
 
 TEST(uid_range_copy) {


### PR DESCRIPTION
When a too-small entry (dropped) preceded a partitionable one, the in-place backwards rewrite clobbered entries it had not read yet and underflowed its write cursor, writing a UIDRangeEntry before the allocation. Build the partitioned result in a fresh array instead. Reachable by unprivileged users via systemd-nsresourced. Add regression tests covering a dropped entry before, between, and after partitionable entries.