### PR TITLE
homed: fix home_unlocking_finish reporting success as failure

### DIFF
--- a/src/home/homed-home.c
+++ b/src/home/homed-home.c
@@ -1091,9 +1091,8 @@ static void home_unlocking_finish(Home *h, int ret, UserRecord *hr) {
 
         log_debug("Unlocking operation of %s completed.", h->user_name);
 
-        h->current_operation = operation_result_unref(h->current_operation, r, &error);
+        h->current_operation = operation_result_unref(h->current_operation, 0, NULL);
         home_set_state(h, _HOME_STATE_INVALID);
-        return;
 }
 
 static void home_authenticating_finish(Home *h, int ret, UserRecord *hr) {


### PR DESCRIPTION
In home_unlocking_finish(), the success path calls operation_result_unref() with the local variable r and the uninitialized error object. If either user_record_good_authentication() or home_save_record() fails (both are logged as "ignoring"), r is left negative and the D-Bus caller receives an error reply despite the home having been unlocked successfully.

This causes PAM to reject the session even though the home directory is mounted and accessible.

Fix by passing 0 and NULL — consistent with every other success path in the file (home_locking_finish(), home_activation_finish(), etc.).