### PR TITLE
sysupdate: do not fail when no transfers are defined

### DIFF
--- a/src/sysupdate/sysupdate.c
+++ b/src/sysupdate/sysupdate.c
@@ -1965,8 +1965,7 @@ static int verb_list(int argc, char *argv[], uintptr_t _data, void *userdata) {
         r = context_load_online(
                         &context,
                         PROCESS_IMAGE_READ_ONLY,
-                        READ_DEFINITIONS_REQUIRES_ENABLED_TRANSFERS|
-                        READ_DEFINITIONS_REQUIRES_ANY_TRANSFERS);
+                        READ_DEFINITIONS_REQUIRES_ENABLED_TRANSFERS);
         if (r < 0)
                 return r;
 
@@ -2511,8 +2510,7 @@ static int verb_check_new(int argc, char *argv[], uintptr_t _data, void *userdat
         r = context_load_online(
                         &context,
                         PROCESS_IMAGE_READ_ONLY,
-                        READ_DEFINITIONS_REQUIRES_ENABLED_TRANSFERS|
-                        READ_DEFINITIONS_REQUIRES_ANY_TRANSFERS);
+                        READ_DEFINITIONS_REQUIRES_ENABLED_TRANSFERS);
         if (r < 0)
                 return r;
 
@@ -2577,8 +2575,7 @@ static int vl_method_check_new(sd_varlink *link, sd_json_variant *parameters, sd
         r = context_load_online_from_target(
                         &context,
                         PROCESS_IMAGE_READ_ONLY,
-                        READ_DEFINITIONS_REQUIRES_ENABLED_TRANSFERS|
-                        READ_DEFINITIONS_REQUIRES_ANY_TRANSFERS);
+                        READ_DEFINITIONS_REQUIRES_ENABLED_TRANSFERS);
         if (r == -ENOENT)
                 return sd_varlink_error(link, "io.systemd.SysUpdate.NoSuchTarget", NULL);
         if (r < 0)
@@ -2615,7 +2612,6 @@ static int context_update(
                         c,
                         /* process_image_flags= */ 0,
                         READ_DEFINITIONS_REQUIRES_ENABLED_TRANSFERS|
-                        READ_DEFINITIONS_REQUIRES_ANY_TRANSFERS|
                         READ_DEFINITIONS_REQUIRES_ENABLED_COMPONENT);
         if (r < 0) {
                 if (r != -ENOENT)
@@ -2898,7 +2894,6 @@ static int verb_pending_or_reboot(int argc, char *argv[], uintptr_t _data, void 
                         &context,
                         /* process_image_flags= */ 0,
                         READ_DEFINITIONS_REQUIRES_ENABLED_TRANSFERS|
-                        READ_DEFINITIONS_REQUIRES_ANY_TRANSFERS|
                         READ_DEFINITIONS_REQUIRES_ENABLED_COMPONENT);
         if (r < 0)
                 return r;
@@ -2908,8 +2903,13 @@ static int verb_pending_or_reboot(int argc, char *argv[], uintptr_t _data, void 
         r = context_discover_update_sets_by_flag(&context, UPDATE_INSTALLED);
         if (r < 0)
                 return r;
-        if (!context.newest_installed)
+        if (!context.newest_installed) {
+                if (context.n_transfers == 0) {
+                        log_warning("Couldn't find any suitable installed versions.");
+                        return 0;
+                }
                 return log_error_errno(SYNTHETIC_ERRNO(ENODATA), "Couldn't find any suitable installed versions.");
+        }
 
         r = parse_os_release(context.root, "IMAGE_VERSION", &booted_version);
         if (r < 0) /* yes, context.root is NULL here, but we have to pass something, and it's a lot more readable


### PR DESCRIPTION
`sysupdate` operations like 'list', 'reboot', etc. should not fail when no transfers are defined.

We can still warn but this should not fail.

---

Hello folks, in this PR, we avoid systemd-sysupdate to return an exit-code different from 0 when thre is no transfer definition. This has been tested on Flatcar CI: https://github.com/flatcar/scripts/pull/4118

cc @chewi @pothos 

Related to: https://github.com/flatcar/Flatcar/issues/1979