### PR TITLE
pcrlock: reject device path node shorter than its header

### DIFF
--- a/src/pcrlock/pcrlock.c
+++ b/src/pcrlock/pcrlock.c
@@ -837,7 +837,9 @@ static int event_log_record_extract_firmware_description(EventLogRecord *rec) {
                                 goto invalid;
                         }
 
-                        if (left < offsetof(packed_EFI_DEVICE_PATH, path) || left < dp->length) {
+                        if (left < offsetof(packed_EFI_DEVICE_PATH, path) ||
+                            dp->length < offsetof(packed_EFI_DEVICE_PATH, path) ||
+                            left < dp->length) {
                                 log_warning("Device path element too short, ignoring.");
                                 goto invalid;
                         }


### PR DESCRIPTION
The device-path loop in event_log_record_extract_firmware_description() checks each node against the bytes remaining but never that the node's own length covers the 4-byte header:
- a Media/File-Path node (type 4, sub-type 4) with length 3 makes `dp->length - offsetof(packed_EFI_DEVICE_PATH, path)` wrap to SIZE_MAX, so utf16_to_utf8() falls back to char16_strlen() and reads past the firmware measurement-log buffer
- a node with length 0 never advances `dp`, so the loop spins forever
- efi_get_boot_option() in src/shared/efi-api.c already guards the same parse with `if (dpath->length < 4) break;`

Reject any node whose length is below the header size.