### PR TITLE
man: fix first argument in Environment= expansion example

### DIFF
--- a/man/systemd.service.xml
+++ b/man/systemd.service.xml
@@ -1618,7 +1618,7 @@ ExecStart=/bin/echo ${ONE} ${TWO} ${THREE}
 ExecStart=/bin/echo $ONE $TWO $THREE</programlisting>
     <para>This results in <filename>/bin/echo</filename> being
     called twice, the first time with arguments
-    <literal>'one'</literal>,
+    <literal>one</literal>,
     <literal>'two two' too</literal>, <literal></literal>,
     and the second time with arguments
     <literal>one</literal>, <literal>two two</literal>,


### PR DESCRIPTION
## Summary

In the environment-variable substitution example in `systemd.service(5)`, the first `/bin/echo` invocation (using `${ONE}`) is documented as receiving the argument `'one'` — with literal single quotes. This is incorrect.

`Environment=ONE='one'` strips the syntactic single quotes during unquoting (systemd.syntax(7): "Quotes themselves are removed"), so `ONE` holds the value `one`. `${ONE}` performs exact-value substitution (always a single argument), so the resulting argument is `one`, without quotes. The reporter verified this empirically on systemd 257 (journal output begins with `one`, not `'one'`).

Fix: drop the spurious single quotes around `one` in the first echo's argument list. The remaining arguments (`'two two' too` for `${TWO}` — the single quotes there are literal characters inside the double-quoted `Environment=` value — and the empty `${THREE}`) are already correct, as is the second echo line.

One token changed, single file.

Fixes #42442
