### PR TITLE
hwdb: correctly map Bluetooth Key on MSI Modern 15 H AI C1MG laptop

### DIFF
--- a/hwdb.d/60-keyboard.hwdb
+++ b/hwdb.d/60-keyboard.hwdb
@@ -1670,6 +1670,10 @@ evdev:atkbd:dmi:bvn*:bvr*:bd*:svnMicro-Star*:pn*Modern*:*
  KEYBOARD_KEY_97=unknown                                # Lid close
  KEYBOARD_KEY_98=unknown                                # Lid open
 
+# Keymaps for MSI Modern 15 H AI C1MG
+evdev:atkbd:dmi:bvn*:bvr*:bd*:svnMicro-Star*:pnModern15HAIC1MG:*
+ KEYBOARD_KEY_d7=bluetooth                              # Fn+F6 Bluetooth key
+
 # MSI Claw A1M, MSI Claw 7 AI+ A2VM, MSI Claw 8 AI+ A2VM, MSI Claw A8 BZ2EM
 evdev:name:AT Translated Set 2 keyboard:dmi:*:rvnMicro-StarInternationalCo.,Ltd.:rnMS-1T41:*
 evdev:name:AT Translated Set 2 keyboard:dmi:*:rvnMicro-StarInternationalCo.,Ltd.:rnMS-1T42:*


### PR DESCRIPTION
Previously the key was unknown so add the correct mapping as it does not follow the general case for MSI Laptops.

  [  192.562000] atkbd serio0: Unknown key released (translated set 2, code 0xd7 on isa0060/serio0).
  [  192.562011] atkbd serio0: Use 'setkeycodes e057 <keycode>' to make it known.

Add it currently as a definition specific for this model but can be generalized to other MSI Laptops if this issue is present also elsewhere.