### PR TITLE
pid1: unconditionally load tpm module

### DIFF
--- a/src/core/kmod-setup.c
+++ b/src/core/kmod-setup.c
@@ -4,7 +4,6 @@
 
 #include "alloc-util.h"
 #include "capability-util.h"
-#include "efi-api.h"
 #include "fileio.h"
 #include "kmod-setup.h"
 #include "log.h"
@@ -146,10 +145,8 @@ int kmod_setup(void) {
                 /* dmi-sysfs is needed to import credentials from it super early */
                 { "dmi-sysfs",                  "/sys/firmware/dmi/entries",    false, false, NULL                      },
 
-#if HAVE_TPM2
                 /* Make sure the tpm subsystem is available which ConditionSecurity=tpm2 depends on. */
-                { "tpm",                        "/sys/class/tpmrm",             false, false, efi_has_tpm2              },
-#endif
+                { "tpm",                        "/sys/class/tpmrm",             false, false, NULL                      },
         };
 
         int r;


### PR DESCRIPTION
postmarketOS/Alpine Linux provides TPM feature as a module, but the module is not loaded in initrd, as efi_has_tpm2() itself depends on tpm module. By inserting several debug logging in efi_has_tpm2(), we get the following:
```
[    0.852140] systemd[1]: efi_has_tpm2: access("/sys/kernel/security/tpm0/binary_bios_measurements"): no
```
Let's unconditionally load tpm kernel module when TPM support is enabled. IIUC, TPM module itself is independent of if the system is booted with EFI.