### PR TITLE
hwdb: add touchpad toggle mapping for MSI Katana GF66 12UD

### DIFF
--- a/hwdb.d/60-keyboard.hwdb
+++ b/hwdb.d/60-keyboard.hwdb
@@ -1631,8 +1631,8 @@ evdev:atkbd:dmi:bvn*:bvr*:bd*:svnMICRO-STAR*:pnGE60*:*
 evdev:atkbd:dmi:bvn*:bvr*:bd*:svnMICRO-STAR*:pnGE70*:*
  KEYBOARD_KEY_c2=ejectcd
 
-# MSI GE76 Raider 10UG uses Fn+F3 for touchpad and Fn+F6 and Fn+F7 
-# for crosshair-mode and gaming-mode respectively but the latter 
+# MSI GE76 Raider 10UG uses Fn+F3 for touchpad and Fn+F6 and Fn+F7
+# for crosshair-mode and gaming-mode respectively but the latter
 # two were previously not generating any keycodes under Linux
 evdev:atkbd:dmi:bvn*:bvr*:bd*:svnMicro-Star*:pnGE76Raider10UG:*
  KEYBOARD_KEY_76=touchpad_toggle
@@ -1681,6 +1681,10 @@ evdev:name:AT Translated Set 2 keyboard:dmi:*:rvnMicro-StarInternationalCo.,Ltd.
 evdev:name:AT Translated Set 2 keyboard:dmi:*:rvnMicro-StarInternationalCo.,Ltd.:rnMS-1T8K:*
  KEYBOARD_KEY_b9=f15                                   # Right Face Button
  KEYBOARD_KEY_ba=f16                                   # Left Face Button
+
+# MSI Katana GF66 12UD toggles touchpad using Fn+F4 where the keyboard key is 76
+evdev:atkbd:dmi:*svnMicro-Star*:pnKatanaGF6612UD:*
+ KEYBOARD_KEY_76=touchpad_toggle                       # Toggle touchpad
 
 ##########################################
 # NEC


### PR DESCRIPTION
This commit adds a hardware database (hwdb) entry for the MSI Katana GF66 12UD laptop to correctly map the Fn+F4 key to the touchpad toggle function.

On this device, pressing Fn+F4 generates scancode 0x76, which is currently interpreted as KEY_F24 by default. This prevents the touchpad toggle functionality from working as intended.

This patch remaps the scancode to KEY_TOUCHPAD_TOGGLE so that the touchpad can be properly enabled or disabled using the dedicated hotkey.

Tested on:
- MSI Katana GF66 12UD
- Vendor: Micro-Star International Co., Ltd.
- DMI product name: Katana GF66 12UD

Before:
- Fn+F4 → KEY_F24 (no touchpad action)

After:
- Fn+F4 → KEY_TOUCHPAD_TOGGLE (touchpad toggles correctly)

Scancode:
- 0x76

Fixes expected behavior for MSI laptops where Fn+F4 is intended as a touchpad toggle key.

Signed-off-by: Dirham Triyadi <dirhamtriyadi@gmail.com>