### PR TITLE
shared/varlink: fix license of varlink-io.systemd.Udev.c

### DIFF
--- a/src/shared/varlink-io.systemd.Udev.c
+++ b/src/shared/varlink-io.systemd.Udev.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: GPL-2.0-or-later */
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
 
 #include "varlink-io.systemd.Udev.h"
 

--- a/src/shared/varlink-io.systemd.Udev.h
+++ b/src/shared/varlink-io.systemd.Udev.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: GPL-2.0-or-later */
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
 #pragma once
 
 #include "sd-varlink-idl.h"


### PR DESCRIPTION
Sources in src/shared need to be licensed LGPL-2.1-or-later, not GPL-2.0-or-later, which is the license for src/udev. Fix it.

Follow-up for 2f0aa9a80445ef18086260a60fad71920ad9486c