### PR TITLE
vmspawn: complain loudly if we can't prepare a unix socket for virtiofsd

### DIFF
--- a/src/vmspawn/vmspawn.c
+++ b/src/vmspawn/vmspawn.c
@@ -1719,7 +1719,7 @@ static int start_virtiofsd(
         union sockaddr_union su;
         r = sockaddr_un_set_path(&su.un, listen_address);
         if (r < 0)
-                return r;
+                return log_error_errno(r, "Failed to prepare unix socket '%s': %m", listen_address);
 
         _cleanup_close_ int sock = socket(AF_UNIX, SOCK_STREAM|SOCK_CLOEXEC, 0);
         if (sock < 0)


### PR DESCRIPTION
I couldn't convince vmspawn to start a VM on a Fedora image I just downloaded, and it was pretty light on any useful details:
```
$ build/systemd-vmspawn --image ~/Downloads/Fedora-Server-Guest-Generic-Rawhide-20260627.n.0.x86_64.qcow2 --image-format=qcow2 --bind-ro=/tmp/bar; echo $?
░ Spawning VM Fedora-Server-Guest-Generic-Rawhide-20260627.n.0.x8664.qcow2 on /home/mrc0mmand/Downloads/Fedora-Server-Guest-Generic-Rawhide-20260627.n.0.x86_64.qcow2.
░ Press Ctrl-] three times within 1s to kill VM.
1
```
Turns out that the unix socket path vmspawn generates for the virtiofsd socket is too long. Let's relay this information to the user as well to make debugging this a little less painful:
```
$ build/systemd-vmspawn --image ~/Downloads/Fedora-Server-Guest-Generic-Rawhide-20260627.n.0.x86_64.qcow2 --image-format=qcow2 --bind-ro=/tmp/bar
░ Spawning VM Fedora-Server-Guest-Generic-Rawhide-20260627.n.0.x8664.qcow2 on /home/mrc0mmand/Downloads/Fedora-Server-Guest-Generic-Rawhide-20260627.n.0.x86_64.qcow2.
░ Press Ctrl-] three times within 1s to kill VM.
Failed to prepare unix socket '/run/user/1000/systemd/vmspawn/Fedora-Server-Guest-Generic-Rawhide-20260627.n.0.x8664.qcow2/sock-9594581dcf598992': File name too long
```