### PR TITLE
Revert "mkosi: Grow the root partition on boot"

### DIFF
--- a/mkosi.extra/usr/lib/repart.d/root.conf
+++ b/mkosi.extra/usr/lib/repart.d/root.conf
@@ -1,2 +1,0 @@
-[Partition]
-Type=root


### PR DESCRIPTION
This reverts commit 7f33ee8bb42a905f5c71bc0b49e946b527b3135a.

The file is located outside mkosi/ subdirectory, hence currently unused. If this is moved to mkosi/ subdirectory, the config conflicts with TEST-58-REPART. Let's remove it at least now, and reintroduce it later at correct place with test adjustment if this is really useful.