### PR TITLE
udev: Tag debug appliance nodes as xaccess-debug-appliance

### DIFF
--- a/rules.d/70-uaccess.rules.in
+++ b/rules.d/70-uaccess.rules.in
@@ -130,6 +130,7 @@ SUBSYSTEM=="hidraw", ENV{ID_HARDWARE_WALLET}=="1", TAG+="uaccess"
 SUBSYSTEM=="hidraw", ENV{ID_INPUT_3D_MOUSE}=="1", TAG+="uaccess"
 
 # Debug interfaces (e.g. Android Debug Bridge)
-ENV{ID_DEBUG_APPLIANCE}=="?*", TAG+="uaccess"
+# Made available via xaccess additionally to support scenarios like headless testing machines.
+ENV{ID_DEBUG_APPLIANCE}=="?*", TAG+="uaccess", TAG+="xaccess-debug-appliance"
 
 LABEL="uaccess_end"


### PR DESCRIPTION
This is especially helpful for people who are running headless (i.e. SSH-only) Android platform development setups with testing devices attached.

Guidance on the tag naming would be well received, as well as some prognosis on whether this would be eligible for a backport.