### PR TITLE
locale-util: handle musl's built-in libintl

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1011,10 +1011,13 @@ endif
 
 libm = cc.find_library('m')
 
-# Header presence check only — dgettext itself is resolved via dlopen_libintl() at runtime, so we never
-# link against libintl. On glibc dgettext lives in libc; on musl gettext-dev provides libintl.h alongside
-# libintl.so.8 which we dlopen() if present.
-if not cc.has_header('libintl.h')
+# On some distributions that use musl (e.g. Alpine), libintl.h may be provided by gettext rather than musl.
+# In that case, we need to dlopen libintl.so.
+if cc.has_function('dgettext',
+                   prefix : '''#include <libintl.h>''',
+                   args : '-D_GNU_SOURCE')
+        conf.set10('HAVE_LIBINTL_IN_LIBC', true)
+elif not cc.has_header('libintl.h')
         error('libintl.h not found (install gettext / gettext-dev)')
 endif
 

--- a/src/basic/locale-util.c
+++ b/src/basic/locale-util.c
@@ -7,7 +7,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-#ifndef __GLIBC__
+#ifndef HAVE_LIBINTL_IN_LIBC
 #include "sd-dlopen.h"
 #endif
 
@@ -27,14 +27,14 @@
 #include "strv.h"
 #include "utf8.h"
 
-#ifdef __GLIBC__
+#ifdef HAVE_LIBINTL_IN_LIBC
 DLSYM_PROTOTYPE(dgettext) = dgettext;
 #else
 DLSYM_PROTOTYPE(dgettext) = NULL;
 #endif
 
 int dlopen_libintl(int log_level) {
-#ifdef __GLIBC__
+#ifdef HAVE_LIBINTL_IN_LIBC
         return 1;
 #else
         static void *libintl_dl = NULL;


### PR DESCRIPTION
When we know libc provides libintl, it's pointless to try to dlopen gettext for it and to emit .note.dlopen metadata for it.  Upstream musl provides libintl.  Alpine separates it out and instead largely uses gettext's, but other musl distros do not.