### PR TITLE
portable: leave room for trailing NUL in metadata receive buffer

### DIFF
--- a/src/portable/portable.c
+++ b/src/portable/portable.c
@@ -214,8 +214,8 @@ static int receive_portable_metadata(
                  * but according to suggestions from the SELinux people this will change and it will probably
                  * be identical to NAME_MAX. For now we use that, but this should be updated one day when the
                  * final limit is known. */
-                char iov_buffer[PATH_MAX + NAME_MAX + 2];
-                struct iovec iov = IOVEC_MAKE(iov_buffer, sizeof(iov_buffer));
+                char iov_buffer[PATH_MAX + NAME_MAX + 2 + 1]; /* One extra byte for the trailing NUL we add below. */
+                struct iovec iov = IOVEC_MAKE(iov_buffer, sizeof(iov_buffer) - 1);
 
                 ssize_t n = receive_one_fd_iov(socket_fd, &iov, 1, 0, &fd);
                 if (n == -EIO)


### PR DESCRIPTION
Off-by-one when receiving portable image metadata over the worker socket:
- receive_portable_metadata() sizes iov_buffer at PATH_MAX + NAME_MAX + 2 but hands recvmsg the full sizeof() as the iovec length
- a record that fills the buffer makes recvmsg return n == sizeof(iov_buffer), so the trailing iov_buffer[n] = 0 writes one byte past the stack buffer
- reachable on SELinux systems: each unit record is name + NUL + the unit file's security.selinux xattr (read with fgetfilecon_raw), which a portable image controls and can push past the buffer
Capped the iovec at sizeof - 1 so the NUL always fits, like the journald-manager.c and coredump-receive.c readers.