### PR TITLE
src/libc/epoll.c: __USE_TIME_BITS64 is the wrong preprocessor guard for the __epoll_pwait2_time64 dlsym path - also require __TIMESIZE == 32

### DIFF
--- a/src/libc/epoll.c
+++ b/src/libc/epoll.c
@@ -9,7 +9,7 @@
  * struct timespec ABI matches our 64-bit time_t. dlsym() can't see that header-level rename, so
  * we have to spell out the right name here, otherwise we'd silently dispatch a 64-bit timespec to
  * the legacy 32-bit-time_t entry point. */
-#ifdef __USE_TIME_BITS64
+#if defined __USE_TIME_BITS64 && defined __TIMESIZE && __TIMESIZE == 32
 DEFINE_LIBC_ERRNO_SHIM_NAMED(epoll_pwait2, "__epoll_pwait2_time64", int,
                              int, fd,
                              struct epoll_event *, events,


### PR DESCRIPTION
__USE_TIME_BITS64 is set on all 64-bit targets (where __TIMESIZE == 64), not only on 32-bit targets built with _TIME_BITS=64. Using it as the guard for the __epoll_pwait2_time64 dlsym path causes libsystemd to look up a 32-bit-only ABI symbol on 64-bit glibc, where it does not exist.

__USE_TIME64_REDIRECTS is only defined when both __USE_TIME_BITS64 and __TIMESIZE == 32 hold, which is exactly the 32-bit _TIME_BITS=64 case this shim was written for. It is also the same guard glibc itself uses in <sys/epoll.h> when redirecting epoll_pwait2 to __epoll_pwait2_time64.

Fixes: a05fe6684ae0 ("libc: dlsym the time64 alias for epoll_pwait2() on 32-bit _TIME_BITS=64")