### PR TITLE
luo-util: use new LIVEUPDATE_SESSION_GET_NAME ioctl to get session name if available

### DIFF
--- a/src/include/uapi/linux/liveupdate.h
+++ b/src/include/uapi/linux/liveupdate.h
@@ -8,8 +8,8 @@
  * Pasha Tatashin <pasha.tatashin@soleen.com>
  */
 
-#ifndef _LIVEUPDATE_H
-#define _LIVEUPDATE_H
+#ifndef _UAPI_LIVEUPDATE_H
+#define _UAPI_LIVEUPDATE_H
 
 #include <linux/ioctl.h>
 #include <linux/types.h>
@@ -59,6 +59,7 @@ enum {
 	LIVEUPDATE_CMD_SESSION_PRESERVE_FD = LIVEUPDATE_CMD_SESSION_BASE,
 	LIVEUPDATE_CMD_SESSION_RETRIEVE_FD = 0x41,
 	LIVEUPDATE_CMD_SESSION_FINISH = 0x42,
+	LIVEUPDATE_CMD_SESSION_GET_NAME = 0x43,
 };
 
 /**
@@ -168,7 +169,9 @@ struct liveupdate_session_preserve_fd {
  * associated with the token and populates the @fd field with a new file
  * descriptor referencing the restored resource in the current (new) kernel.
  * This operation must be performed *before* signaling completion via
- * %LIVEUPDATE_IOCTL_FINISH.
+ * %LIVEUPDATE_IOCTL_FINISH. If a retrieve of a token fails, subsequent
+ * attempts to retrieve the token fail with the same error code. Failed
+ * retrieves are not retried.
  *
  * Return: 0 on success, negative error code on failure (e.g., invalid token).
  */
@@ -213,4 +216,24 @@ struct liveupdate_session_finish {
 #define LIVEUPDATE_SESSION_FINISH					\
 	_IO(LIVEUPDATE_IOCTL_TYPE, LIVEUPDATE_CMD_SESSION_FINISH)
 
-#endif /* _LIVEUPDATE_H */
+/**
+ * struct liveupdate_session_get_name - ioctl(LIVEUPDATE_SESSION_GET_NAME)
+ * @size:  Input; sizeof(struct liveupdate_session_get_name)
+ * @reserved: Input; Must be zero. Reserved for future use.
+ * @name:  Output; A null-terminated string with the full session name.
+ *
+ * Retrieves the full name of the session associated with this file descriptor.
+ * This is useful because the kernel may truncate the name shown in /proc.
+ *
+ * Return: 0 on success, negative error code on failure.
+ */
+struct liveupdate_session_get_name {
+	__u32		size;
+	__u32		reserved;
+	__u8		name[LIVEUPDATE_SESSION_NAME_LENGTH];
+};
+
+#define LIVEUPDATE_SESSION_GET_NAME					\
+	_IO(LIVEUPDATE_IOCTL_TYPE, LIVEUPDATE_CMD_SESSION_GET_NAME)
+
+#endif /* _UAPI_LIVEUPDATE_H */

--- a/src/shared/luo-util.c
+++ b/src/shared/luo-util.c
@@ -377,6 +377,26 @@ int luo_preserve_fd_stores(sd_json_variant *serialization, int *ret_session_fd) 
         return 1;
 }
 
+static int luo_session_get_name(int session_fd, char **ret) {
+        struct liveupdate_session_get_name args = {
+                .size = sizeof(args),
+        };
+
+        assert(session_fd >= 0);
+
+        if (ioctl(session_fd, LIVEUPDATE_SESSION_GET_NAME, &args) < 0)
+                return -errno;
+
+        /* Paranonia check */
+        if (!memchr(args.name, 0, sizeof(args.name)))
+                return -EBADMSG;
+
+        if (ret)
+                return strdup_to(ret, (const char*) args.name);
+
+        return 0;
+}
+
 int fd_get_luo_session_name(int fd, char **ret) {
         _cleanup_free_ char *path = NULL;
         int r;
@@ -389,6 +409,14 @@ int fd_get_luo_session_name(int fd, char **ret) {
                 return r;
         if (r == 0)
                 return -EMEDIUMTYPE;
+
+        /* IOCTL is new in 7.2, fallback to parsing procfs */
+        // FIXME: drop fallback once baseline moves to 7.2+
+        r = luo_session_get_name(fd, ret);
+        if (r >= 0)
+                return 0;
+        if (!ERRNO_IS_NEG_IOCTL_NOT_SUPPORTED(r))
+                return r;
 
         r = fd_get_path(fd, &path);
         if (r < 0)


### PR DESCRIPTION
Added in kernel 7.2. Fallback can be removed once baseline moves above. Ubuntu 26.04 uses 7.0.

This is in rc1 now and the kernel will release before us, so should be safe to merge immediately. I do not expect changes.