### PR TITLE
mkosi: fix license of mkosi.finalize

### DIFF
--- a/mkosi/mkosi.finalize
+++ b/mkosi/mkosi.finalize
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# SPDX-License-Identifier: CC-0
+# SPDX-License-Identifier: LGPL-2.1-or-later
 set -e
 
 touch -r "$BUILDROOT/usr" "$BUILDROOT/etc/.updated" "$BUILDROOT/var/.updated"


### PR DESCRIPTION
Every mkosi file/script is LGPL-2.1-or-later, but this one is CC-0, fix it

Follow-up for 858e59c82c2246d34d84bd495f46c971d9303dba