### PR TITLE
run: do not munge user.slice with --slice-inherit

### DIFF
--- a/src/run/run.c
+++ b/src/run/run.c
@@ -1049,7 +1049,7 @@ static int parse_argv_sudo_mode(int argc, char *argv[]) {
 
         strv_free_and_replace(arg_cmdline, l);
 
-        if (!arg_slice) {
+        if (!custom_slice) {
                 arg_slice = strdup(SPECIAL_USER_SLICE);
                 if (!arg_slice)
                         return log_oom();


### PR DESCRIPTION
When using --slice-inherit, setting arg_slice would inadvertently munge user.slice into the current user slice, usually producing a slice name like user-1000-user.slice. This is treated as a user-UID slice by user-.slice.d/10-defaults.conf, resulting in a strange description: literally "User slice for UID user" (instead of an actual user UID).

Keep arg_slice empty when using --slice-inherit so that we actually inherit from the relevant slice instead of a munged version.

Fixes: #42601

---
Compare:

```
# old
$ ARGV0=run0 ./build/systemd-run --slice-inherit cat /proc/self/cgroup
0::/user.slice/user-1000.slice/user-1000-user.slice/run-p20907-i9197.service
# new
$ ARGV0=run0 ./build/systemd-run --slice-inherit cat /proc/self/cgroup
0::/user.slice/user-1000.slice/run-p21233-i13565.service
```