### PR TITLE
terminal-util: avoid console_lock when reading active consoles

### DIFF
--- a/src/basic/terminal-util.c
+++ b/src/basic/terminal-util.c
@@ -1115,6 +1115,48 @@ bool tty_is_console(const char *tty) {
         return streq(skip_dev_prefix(tty), "console");
 }
 
+int read_console_active_cached(char **ret) {
+        static char *cache = NULL;
+
+        if (!cache) {
+                /* Try /proc/cmdline first to avoid /sys/class/tty/console/active which
+                 * takes the kernel console_lock and can block indefinitely under printk
+                 * pressure (e.g. nftables LOG flood on a serial console). */
+                _cleanup_strv_free_ char **args = NULL;
+                int r = proc_cmdline_strv(&args);
+                if (r >= 0) {
+                        _cleanup_free_ char *consoles = NULL;
+
+                        STRV_FOREACH(a, args) {
+                                const char *v = startswith(*a, "console=");
+                                if (!v)
+                                        continue;
+
+                                _cleanup_free_ char *dev = NULL;
+                                const char *comma = strchr(v, ',');
+                                dev = strndup(v, comma ? (size_t)(comma - v) : strlen(v));
+                                if (!dev)
+                                        return -ENOMEM;
+
+                                if (!strextend_with_separator(&consoles, " ", dev))
+                                        return -ENOMEM;
+                        }
+
+                        if (!isempty(consoles)) {
+                                cache = TAKE_PTR(consoles);
+                                return strdup_to(ret, cache);
+                        }
+                }
+
+                /* Fallback to sysfs */
+                r = read_one_line_file("/sys/class/tty/console/active", &cache);
+                if (r < 0)
+                        return r;
+        }
+
+        return strdup_to(ret, cache);
+}
+
 int resolve_dev_console(char **ret) {
         int r;
 
@@ -1141,10 +1183,10 @@ int resolve_dev_console(char **ret) {
                 return -ENOMEDIUM;
 
         _cleanup_free_ char *active = NULL;
-        r = read_one_line_file("/sys/class/tty/console/active", &active);
+        r = read_console_active_cached(&active);
         if (r < 0)
                 return r;
-        if (r == 0)
+        if (isempty(active))
                 return -ENXIO;
 
         /* If multiple log outputs are configured the last one is what /dev/console points to */
@@ -1188,7 +1230,7 @@ int get_kernel_consoles(char ***ret) {
         if (path_is_read_only_fs("/sys") > 0)
                 goto fallback;
 
-        r = read_one_line_file("/sys/class/tty/console/active", &line);
+        r = read_console_active_cached(&line);
         if (r < 0)
                 return r;
 

--- a/src/basic/terminal-util.h
+++ b/src/basic/terminal-util.h
@@ -103,6 +103,7 @@ int show_menu(char **x, size_t n_columns, size_t column_width, unsigned ellipsiz
 
 int vt_disallocate(const char *tty_path);
 
+int read_console_active_cached(char **ret);
 int resolve_dev_console(char **ret);
 int get_kernel_consoles(char ***ret);
 bool tty_is_vc(const char *tty);


### PR DESCRIPTION
Reading `/sys/class/tty/console/active` takes the kernel console_lock (via `show_cons_active()` in `drivers/tty/tty_io.c`). Under heavy `printk` pressure, the `console_lock` can be starved indefinitely by the `printk` spinning handoff mechanism (`console_trylock_spinning()` in `kernel/printk/printk.c`), causing PID 1 to hang in TASK_UNINTERRUPTIBLE for hours.

The starvation occurs because `printk` callers on different CPUs pass the `console_lock` between each other via a direct handoff (`console_lock_spinning_disable_and_check()`), bypassing `up_console_sem()` entirely. Tasks waiting in `down()` — including PID 1 — are never woken.

A real-world trigger is *nftables* LOG rules on systems with a serial console: each logged packet generates a `printk` that is slowly written to the UART, and under sufficient packet rate the handoff chain never breaks.

Fix this by parsing `/proc/cmdline` for `console=` parameters instead of reading the sysfs file. `/proc/cmdline` does not require any kernel locks. Fall back to the sysfs read only when `/proc/cmdline` has no `console=` entries.

The fallback is acceptable because the `console_lock` starvation requires a slow console driver (serial UART) to sustain the printk handoff chain. Serial consoles must be explicitly configured via `console=ttyS*` on the kernel command line, so they will always be found by the `/proc/cmdline` parser. Systems without `console=` on the command line use the default VGA/framebuffer console (`tty0`) which is fast and does not trigger the starvation.

Export `read_console_active_cached()` for downstream consumers (e.g. `getty-generator` variants with direct sysfs reads).

Reproducer (requires serial console and >= 8 CPUs for reliability):

    #!/bin/bash
    # 1. Slow down serial console
    stty -F /dev/ttyS0 9600
    # 2. Set up nftables LOG rule
    nft flush ruleset
    nft add table inet repro
    nft add chain inet repro input \
        '{ type filter hook input priority 0; policy drop; }'
    nft add rule inet repro input tcp dport 22 accept
    nft add rule inet repro input ct state established,related accept
    nft add rule inet repro input iif lo udp dport 10000-10099 \
        log prefix '"FLOOD: "' drop
    nft add rule inet repro input iif lo accept
    nft add rule inet repro input reject
    # 3. Flood to trigger LOG
    cat > /tmp/udpflood.c <<'EOF'
    #include <sys/socket.h>
    #include <netinet/in.h>
    #include <stdlib.h>
    int main(int argc, char **argv) {
        int fd = socket(AF_INET, SOCK_DGRAM, 0);
        struct sockaddr_in a = { .sin_family = AF_INET,
            .sin_port = htons(argc > 1 ? atoi(argv[1]) : 10001),
            .sin_addr.s_addr = htonl(0x7f000001) };
        char buf[8] = "x";
        while (1) sendto(fd, buf, 1, 0, (void*)&a, sizeof(a));
    }
    EOF
    gcc -O2 -o /tmp/udpflood /tmp/udpflood.c
    for i in $(seq 1 16); do /tmp/udpflood $((10000+i)) & done
    sleep 3
    # 4. This hangs without the fix
    timeout 30 systemctl daemon-reexec; echo "rc=$?"
    # 5. Cleanup
    killall udpflood; nft flush ruleset; stty -F /dev/ttyS0 115200


Tested on RHEL 8.10 (4.18), RHEL 9.8 (5.14), and RHEL 10.2 (6.12). Without fix: `daemon-reexec` hangs (30s+ timeout).
With fix: completes in ~4s.