### PR TITLE
crypto-util, ssl-util: set log level to debug in dlopen_many_sym_or_warn()

### DIFF
--- a/src/shared/crypto-util.c
+++ b/src/shared/crypto-util.c
@@ -362,7 +362,7 @@ int dlopen_libcrypto(int log_level) {
                 r = dlopen_many_sym_or_warn(
                         &libcrypto_dl,
                         soname,
-                        log_level,
+                        LOG_DEBUG,
                         DLSYM_ARG(ASN1_ANY_it),
                         DLSYM_ARG(ASN1_BIT_STRING_it),
                         DLSYM_ARG(ASN1_BMPSTRING_it),

--- a/src/shared/ssl-util.c
+++ b/src/shared/ssl-util.c
@@ -44,7 +44,7 @@ int dlopen_libssl(int log_level) {
                 r = dlopen_many_sym_or_warn(
                                 &libssl_dl,
                                 soname,
-                                log_level,
+                                LOG_DEBUG,
                                 DLSYM_ARG(SSL_ctrl),
                                 DLSYM_ARG(SSL_CTX_ctrl),
                                 DLSYM_ARG(SSL_CTX_free),


### PR DESCRIPTION
Otherwise in systems with OpenSSL 3 the journal contains multiple error entries because the preferred library libcrypto.so.4 is not present.

Follow-up for ccdd42351f79cbb9c2e034a96280a1ded40a2f95