### PR TITLE
coredumpctl: use break instead of continue for time bound checks

### DIFF
--- a/src/coredump/coredumpctl.c
+++ b/src/coredump/coredumpctl.c
@@ -1076,7 +1076,7 @@ static int verb_dump_list(int argc, char *argv[], uintptr_t _data, void *userdat
                                 if (r < 0)
                                         return log_error_errno(r, "Failed to determine timestamp: %m");
                                 if (usec > arg_until)
-                                        continue;
+                                        break;
                         }
 
                         if (arg_since != USEC_INFINITY && arg_reverse) {
@@ -1086,7 +1086,7 @@ static int verb_dump_list(int argc, char *argv[], uintptr_t _data, void *userdat
                                 if (r < 0)
                                         return log_error_errno(r, "Failed to determine timestamp: %m");
                                 if (usec < arg_since)
-                                        continue;
+                                        break;
                         }
 
                         r = print_entry(j, n_found++, t);


### PR DESCRIPTION
Fixes: #42808