### PR TITLE
run: refuse --no-block when combined with --scope

### DIFF
--- a/man/systemd-run.xml
+++ b/man/systemd-run.xml
@@ -511,7 +511,7 @@
           <para>Do not synchronously wait for the unit start operation to finish. If this option is not specified, the
           start request for the transient unit will be verified, enqueued and <command>systemd-run</command> will wait
           until the unit's start-up is completed. By passing this argument, it is only verified and enqueued. This
-          option may not be combined with <option>--wait</option>.</para>
+          option may not be combined with <option>--wait</option> or <option>--scope</option>.</para>
 
           <xi:include href="version-info.xml" xpointer="v220"/>
         </listitem>

--- a/src/run/run.c
+++ b/src/run/run.c
@@ -694,6 +694,10 @@ static int parse_argv(int argc, char *argv[]) {
                 return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
                                        "--remain-after-exit and --service-type= are not supported in --scope mode.");
 
+        if (arg_scope && arg_no_block)
+                return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
+                                       "--no-block is not supported in --scope mode.");
+
         if (arg_stdio != ARG_STDIO_NONE) {
                 if (with_trigger || arg_scope)
                         return log_error_errno(SYNTHETIC_ERRNO(EINVAL),


### PR DESCRIPTION
Regarding the issue described in #42806：
In the systemd-run `--scope` mode, the shell is waiting for the systemd-run process itself (which is actually sleeping indefinitely)，and the `--no-block` option does not affect this. 

However, since the `--no-block` option is not applicable in the `--scope mode`, I think we can provide a warning message to reject this `--scope` + `--no-block` combination, otherwise it may cause confusion.

Fixes: #42806