### PR TITLE
man: add thread-awareness note to sd_bus/sd_event manpages

### DIFF
--- a/man/libsystemd-notes.xml
+++ b/man/libsystemd-notes.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<!DOCTYPE refsect1 PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+  "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
+<!-- SPDX-License-Identifier: LGPL-2.1-or-later -->
+
+<refsect1 xmlns:xi="http://www.w3.org/2001/XInclude">
+  <title>Notes</title>
+  <xi:include href="libsystemd-pkgconfig.xml" xpointer="pkgconfig-text"/>
+  <xi:include href="threads-aware.xml" xpointer="strict"/>
+  <xi:include href="threads-aware.xml" xpointer="getenv"/>
+</refsect1>

--- a/man/sd_bus_add_match.xml
+++ b/man/sd_bus_add_match.xml
@@ -151,7 +151,7 @@
     </para>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_add_node_enumerator.xml
+++ b/man/sd_bus_add_node_enumerator.xml
@@ -122,7 +122,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_add_object.xml
+++ b/man/sd_bus_add_object.xml
@@ -675,7 +675,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_add_object_manager.xml
+++ b/man/sd_bus_add_object_manager.xml
@@ -101,7 +101,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_attach_event.xml
+++ b/man/sd_bus_attach_event.xml
@@ -100,7 +100,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_call.xml
+++ b/man/sd_bus_call.xml
@@ -183,7 +183,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_call_method.xml
+++ b/man/sd_bus_call_method.xml
@@ -124,7 +124,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>Examples</title>

--- a/man/sd_bus_can_send.xml
+++ b/man/sd_bus_can_send.xml
@@ -78,7 +78,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_close.xml
+++ b/man/sd_bus_close.xml
@@ -103,7 +103,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_creds_get_pid.xml
+++ b/man/sd_bus_creds_get_pid.xml
@@ -515,7 +515,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_creds_new_from_pid.xml
+++ b/man/sd_bus_creds_new_from_pid.xml
@@ -280,7 +280,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_default.xml
+++ b/man/sd_bus_default.xml
@@ -328,7 +328,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_emit_signal.xml
+++ b/man/sd_bus_emit_signal.xml
@@ -255,7 +255,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_enqueue_for_read.xml
+++ b/man/sd_bus_enqueue_for_read.xml
@@ -73,7 +73,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_error.xml
+++ b/man/sd_bus_error.xml
@@ -392,7 +392,7 @@
     </example>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_error_add_map.xml
+++ b/man/sd_bus_error_add_map.xml
@@ -116,7 +116,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_get_current_handler.xml
+++ b/man/sd_bus_get_current_handler.xml
@@ -72,7 +72,7 @@
     <constant>NULL</constant>.</para>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_get_fd.xml
+++ b/man/sd_bus_get_fd.xml
@@ -156,7 +156,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_get_n_queued_read.xml
+++ b/man/sd_bus_get_n_queued_read.xml
@@ -3,7 +3,7 @@
   "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
 <!-- SPDX-License-Identifier: LGPL-2.1-or-later -->
 
-<refentry id="sd_bus_get_n_queued_read">
+<refentry id="sd_bus_get_n_queued_read" xmlns:xi="http://www.w3.org/2001/XInclude">
 
   <refentryinfo>
     <title>sd_bus_get_fd</title>
@@ -84,6 +84,8 @@
       </variablelist>
     </refsect2>
   </refsect1>
+
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_get_name_creds.xml
+++ b/man/sd_bus_get_name_creds.xml
@@ -107,7 +107,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_get_name_machine_id.xml
+++ b/man/sd_bus_get_name_machine_id.xml
@@ -84,7 +84,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_interface_name_is_valid.xml
+++ b/man/sd_bus_interface_name_is_valid.xml
@@ -83,7 +83,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_is_open.xml
+++ b/man/sd_bus_is_open.xml
@@ -89,7 +89,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_list_names.xml
+++ b/man/sd_bus_list_names.xml
@@ -96,7 +96,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_message_append.xml
+++ b/man/sd_bus_message_append.xml
@@ -222,7 +222,7 @@ sd_bus_message_append(m, "ynqiuxtd", y, n, q, i, u, x, t, d);</programlisting>
     <xi:include href="sd_bus_message_append_basic.xml" xpointer="errors" />
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>See Also</title>

--- a/man/sd_bus_message_append_array.xml
+++ b/man/sd_bus_message_append_array.xml
@@ -161,7 +161,7 @@
     <xi:include href="sd_bus_message_append_basic.xml" xpointer="errors" />
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>See Also</title>

--- a/man/sd_bus_message_append_basic.xml
+++ b/man/sd_bus_message_append_basic.xml
@@ -244,7 +244,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>See Also</title>

--- a/man/sd_bus_message_append_string_memfd.xml
+++ b/man/sd_bus_message_append_string_memfd.xml
@@ -103,7 +103,7 @@
     <xi:include href="sd_bus_message_append_basic.xml" xpointer="errors" />
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>See Also</title>

--- a/man/sd_bus_message_append_strv.xml
+++ b/man/sd_bus_message_append_strv.xml
@@ -64,7 +64,7 @@
     <xi:include href="sd_bus_message_append_basic.xml" xpointer="errors" />
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>See Also</title>

--- a/man/sd_bus_message_at_end.xml
+++ b/man/sd_bus_message_at_end.xml
@@ -76,7 +76,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_message_copy.xml
+++ b/man/sd_bus_message_copy.xml
@@ -96,7 +96,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>See Also</title>

--- a/man/sd_bus_message_dump.xml
+++ b/man/sd_bus_message_dump.xml
@@ -119,7 +119,7 @@
     errno-style error code. No error codes are currently defined.</para>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>See Also</title>

--- a/man/sd_bus_message_get_cookie.xml
+++ b/man/sd_bus_message_get_cookie.xml
@@ -92,7 +92,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_message_get_monotonic_usec.xml
+++ b/man/sd_bus_message_get_monotonic_usec.xml
@@ -123,7 +123,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_message_get_signature.xml
+++ b/man/sd_bus_message_get_signature.xml
@@ -96,7 +96,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_message_get_type.xml
+++ b/man/sd_bus_message_get_type.xml
@@ -149,7 +149,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_message_new.xml
+++ b/man/sd_bus_message_new.xml
@@ -169,7 +169,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_message_new_method_call.xml
+++ b/man/sd_bus_message_new_method_call.xml
@@ -142,7 +142,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>Examples</title>

--- a/man/sd_bus_message_new_method_error.xml
+++ b/man/sd_bus_message_new_method_error.xml
@@ -173,7 +173,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>See Also</title>

--- a/man/sd_bus_message_new_signal.xml
+++ b/man/sd_bus_message_new_signal.xml
@@ -109,7 +109,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>Examples</title>

--- a/man/sd_bus_message_open_container.xml
+++ b/man/sd_bus_message_open_container.xml
@@ -177,7 +177,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>Examples</title>

--- a/man/sd_bus_message_read.xml
+++ b/man/sd_bus_message_read.xml
@@ -193,7 +193,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>Examples</title>

--- a/man/sd_bus_message_read_array.xml
+++ b/man/sd_bus_message_read_array.xml
@@ -3,7 +3,7 @@
   "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
 <!-- SPDX-License-Identifier: LGPL-2.1-or-later -->
 
-<refentry id="sd_bus_message_read_array">
+<refentry id="sd_bus_message_read_array" xmlns:xi="http://www.w3.org/2001/XInclude">
 
   <refentryinfo>
     <title>sd_bus_message_read_array</title>
@@ -101,6 +101,8 @@
       </variablelist>
     </refsect2>
   </refsect1>
+
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_message_read_basic.xml
+++ b/man/sd_bus_message_read_basic.xml
@@ -8,7 +8,7 @@
   Copyright © 2016 Julian Orth
 -->
 
-<refentry id="sd_bus_message_read_basic">
+<refentry id="sd_bus_message_read_basic" xmlns:xi="http://www.w3.org/2001/XInclude">
 
   <refentryinfo>
     <title>sd_bus_message_read_basic</title>
@@ -221,6 +221,8 @@
       </variablelist>
     </refsect2>
   </refsect1>
+
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_message_read_strv.xml
+++ b/man/sd_bus_message_read_strv.xml
@@ -110,6 +110,8 @@
     </refsect2>
   </refsect1>
 
+  <xi:include href="libsystemd-notes.xml"/>
+
   <refsect1>
     <title>History</title>
     <para><function>sd_bus_message_read_strv()</function> was added in version 246.</para>

--- a/man/sd_bus_message_rewind.xml
+++ b/man/sd_bus_message_rewind.xml
@@ -73,7 +73,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_message_seal.xml
+++ b/man/sd_bus_message_seal.xml
@@ -95,7 +95,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_message_sensitive.xml
+++ b/man/sd_bus_message_sensitive.xml
@@ -72,7 +72,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_message_set_destination.xml
+++ b/man/sd_bus_message_set_destination.xml
@@ -135,7 +135,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_message_set_expect_reply.xml
+++ b/man/sd_bus_message_set_expect_reply.xml
@@ -133,7 +133,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_message_skip.xml
+++ b/man/sd_bus_message_skip.xml
@@ -92,7 +92,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_message_verify_type.xml
+++ b/man/sd_bus_message_verify_type.xml
@@ -84,7 +84,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>See Also</title>

--- a/man/sd_bus_negotiate_fds.xml
+++ b/man/sd_bus_negotiate_fds.xml
@@ -149,7 +149,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_new.xml
+++ b/man/sd_bus_new.xml
@@ -180,7 +180,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_path_encode.xml
+++ b/man/sd_bus_path_encode.xml
@@ -138,7 +138,7 @@
     by the caller.</para>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_pending_method_calls.xml
+++ b/man/sd_bus_pending_method_calls.xml
@@ -68,7 +68,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_process.xml
+++ b/man/sd_bus_process.xml
@@ -126,7 +126,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_query_sender_creds.xml
+++ b/man/sd_bus_query_sender_creds.xml
@@ -124,7 +124,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_reply_method_error.xml
+++ b/man/sd_bus_reply_method_error.xml
@@ -161,7 +161,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>See Also</title>

--- a/man/sd_bus_reply_method_return.xml
+++ b/man/sd_bus_reply_method_return.xml
@@ -116,7 +116,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>See Also</title>

--- a/man/sd_bus_request_name.xml
+++ b/man/sd_bus_request_name.xml
@@ -200,7 +200,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_send.xml
+++ b/man/sd_bus_send.xml
@@ -164,7 +164,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_set_address.xml
+++ b/man/sd_bus_set_address.xml
@@ -185,7 +185,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_set_close_on_exit.xml
+++ b/man/sd_bus_set_close_on_exit.xml
@@ -91,7 +91,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_set_connected_signal.xml
+++ b/man/sd_bus_set_connected_signal.xml
@@ -92,7 +92,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_set_description.xml
+++ b/man/sd_bus_set_description.xml
@@ -235,7 +235,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_set_exit_on_disconnect.xml
+++ b/man/sd_bus_set_exit_on_disconnect.xml
@@ -104,7 +104,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_set_fd.xml
+++ b/man/sd_bus_set_fd.xml
@@ -114,7 +114,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_set_method_call_timeout.xml
+++ b/man/sd_bus_set_method_call_timeout.xml
@@ -92,7 +92,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_set_property.xml
+++ b/man/sd_bus_set_property.xml
@@ -158,7 +158,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_set_sender.xml
+++ b/man/sd_bus_set_sender.xml
@@ -88,7 +88,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_set_server.xml
+++ b/man/sd_bus_set_server.xml
@@ -189,7 +189,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_set_watch_bind.xml
+++ b/man/sd_bus_set_watch_bind.xml
@@ -98,7 +98,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>Example</title>

--- a/man/sd_bus_slot_get_bus.xml
+++ b/man/sd_bus_slot_get_bus.xml
@@ -76,7 +76,7 @@
     they return <constant>NULL</constant>.</para>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_slot_ref.xml
+++ b/man/sd_bus_slot_ref.xml
@@ -77,7 +77,7 @@
     <para><function>sd_bus_slot_unref()</function> always returns <constant>NULL</constant>.</para>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_slot_set_description.xml
+++ b/man/sd_bus_slot_set_description.xml
@@ -89,7 +89,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_slot_set_destroy_callback.xml
+++ b/man/sd_bus_slot_set_destroy_callback.xml
@@ -111,7 +111,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_slot_set_floating.xml
+++ b/man/sd_bus_slot_set_floating.xml
@@ -101,7 +101,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_slot_set_userdata.xml
+++ b/man/sd_bus_slot_set_userdata.xml
@@ -71,7 +71,7 @@
     from the userdata field value being <constant>NULL</constant>.</para>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_start.xml
+++ b/man/sd_bus_start.xml
@@ -116,7 +116,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_track_add_name.xml
+++ b/man/sd_bus_track_add_name.xml
@@ -213,7 +213,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_track_new.xml
+++ b/man/sd_bus_track_new.xml
@@ -222,7 +222,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_bus_wait.xml
+++ b/man/sd_bus_wait.xml
@@ -95,7 +95,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_event_add_child.xml
+++ b/man/sd_event_add_child.xml
@@ -301,7 +301,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>Example</title>

--- a/man/sd_event_add_defer.xml
+++ b/man/sd_event_add_defer.xml
@@ -175,7 +175,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_event_add_inotify.xml
+++ b/man/sd_event_add_inotify.xml
@@ -230,7 +230,7 @@
     </example>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_event_add_io.xml
+++ b/man/sd_event_add_io.xml
@@ -296,7 +296,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_event_add_memory_pressure.xml
+++ b/man/sd_event_add_memory_pressure.xml
@@ -360,7 +360,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_event_add_signal.xml
+++ b/man/sd_event_add_signal.xml
@@ -178,7 +178,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_event_add_time.xml
+++ b/man/sd_event_add_time.xml
@@ -299,7 +299,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_event_exit.xml
+++ b/man/sd_event_exit.xml
@@ -132,7 +132,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_event_get_fd.xml
+++ b/man/sd_event_get_fd.xml
@@ -94,7 +94,7 @@
     </example>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_event_new.xml
+++ b/man/sd_event_new.xml
@@ -196,7 +196,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_event_now.xml
+++ b/man/sd_event_now.xml
@@ -97,7 +97,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_event_run.xml
+++ b/man/sd_event_run.xml
@@ -139,7 +139,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_event_set_exit_on_idle.xml
+++ b/man/sd_event_set_exit_on_idle.xml
@@ -88,7 +88,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_event_set_signal_exit.xml
+++ b/man/sd_event_set_signal_exit.xml
@@ -89,7 +89,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_event_set_watchdog.xml
+++ b/man/sd_event_set_watchdog.xml
@@ -121,7 +121,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_event_source_get_event.xml
+++ b/man/sd_event_source_get_event.xml
@@ -54,7 +54,7 @@
     <constant>NULL</constant>.</para>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_event_source_get_pending.xml
+++ b/man/sd_event_source_get_pending.xml
@@ -117,7 +117,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_event_source_set_description.xml
+++ b/man/sd_event_source_set_description.xml
@@ -120,7 +120,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_event_source_set_destroy_callback.xml
+++ b/man/sd_event_source_set_destroy_callback.xml
@@ -91,7 +91,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_event_source_set_enabled.xml
+++ b/man/sd_event_source_set_enabled.xml
@@ -135,7 +135,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_event_source_set_exit_on_failure.xml
+++ b/man/sd_event_source_set_exit_on_failure.xml
@@ -93,7 +93,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_event_source_set_floating.xml
+++ b/man/sd_event_source_set_floating.xml
@@ -101,7 +101,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_event_source_set_prepare.xml
+++ b/man/sd_event_source_set_prepare.xml
@@ -120,7 +120,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_event_source_set_priority.xml
+++ b/man/sd_event_source_set_priority.xml
@@ -147,7 +147,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_event_source_set_ratelimit.xml
+++ b/man/sd_event_source_set_ratelimit.xml
@@ -160,7 +160,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_event_source_set_userdata.xml
+++ b/man/sd_event_source_set_userdata.xml
@@ -73,7 +73,7 @@
     <constant>NULL</constant>.</para>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_event_source_unref.xml
+++ b/man/sd_event_source_unref.xml
@@ -112,7 +112,7 @@
     <function>sd_event_source_ref()</function> always returns the event source object passed in.</para>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>

--- a/man/sd_event_wait.xml
+++ b/man/sd_event_wait.xml
@@ -315,7 +315,7 @@
     </refsect2>
   </refsect1>
 
-  <xi:include href="libsystemd-pkgconfig.xml" />
+  <xi:include href="libsystemd-notes.xml"/>
 
   <refsect1>
     <title>History</title>


### PR DESCRIPTION
This question comes up every now and then, and it is not clearly documented,
so include the thread-aware tag in all bus/event manpages. Some are
thread-safe, so the relevant note is used instead. And one is
completely thread-unsafe as it has a process-global object, so
that one gets a special mention.

Also the getenv note is retained only for functions that actually
call getenv.