### PR TITLE
shell-completion: add option completion for systemctl show in zsh

### DIFF
--- a/shell-completion/zsh/_systemctl.in
+++ b/shell-completion/zsh/_systemctl.in
@@ -271,23 +271,26 @@ done
 # Completion function for "show" with option support
 (( $+functions[_systemctl_show] )) || _systemctl_show()
 {
+    local curcontext="$curcontext" state line
+    local -A opt_args
+    local ret=1
     local -a _systemctl_show_options=(
         '(-p --property)'{-p+,--property=}'[Show only properties by specific name]:unit property:_systemctl_unit_properties'
-        '(-P --value)'{-P,--value}'[When showing properties, only print the value]'
+        '(-P)-P+[Equivalent to --value --property=NAME]:unit property:_systemctl_unit_properties'
+        '--value[When showing properties, only print the value]'
         '(-a --all)'{-a,--all}'[Show all properties/all units currently in memory]'
         '--no-pager[Do not pipe output into a pager]'
     )
     _arguments -s -C \
         "$_systemctl_show_options[@]" \
         '*:units:->units' && ret=0
-    if [[ -n "$state" ]]; then
-        case $state in
-            (units)
-                _wanted systemd-units expl unit \
-                        compadd "$@" - $(_systemctl_get_non_template_names)
-                ;;
-        esac
-    fi
+    case $state in
+        (units)
+            _wanted systemd-units expl unit \
+                    compadd "$@" - $(_systemctl_get_non_template_names)
+            ;;
+    esac
+    return ret
 }
 
 # Completion functions for NONTEMPLATE_UNITS

--- a/shell-completion/zsh/_systemctl.in
+++ b/shell-completion/zsh/_systemctl.in
@@ -268,8 +268,30 @@ for fun in cat mask ; do
     }
 done
 
+# Completion function for "show" with option support
+(( $+functions[_systemctl_show] )) || _systemctl_show()
+{
+    local -a _systemctl_show_options=(
+        '(-p --property)'{-p+,--property=}'[Show only properties by specific name]:unit property:_systemctl_unit_properties'
+        '(-P --value)'{-P,--value}'[When showing properties, only print the value]'
+        '(-a --all)'{-a,--all}'[Show all properties/all units currently in memory]'
+        '--no-pager[Do not pipe output into a pager]'
+    )
+    _arguments -s -C \
+        "$_systemctl_show_options[@]" \
+        '*:units:->units' && ret=0
+    if [[ -n "$state" ]]; then
+        case $state in
+            (units)
+                _wanted systemd-units expl unit \
+                        compadd "$@" - $(_systemctl_get_non_template_names)
+                ;;
+        esac
+    fi
+}
+
 # Completion functions for NONTEMPLATE_UNITS
-for fun in is-active is-failed is-enabled status show preset help list-dependencies edit revert add-wants add-requires set-property; do
+for fun in is-active is-failed is-enabled status preset help list-dependencies edit revert add-wants add-requires set-property; do
     (( $+functions[_systemctl_$fun] )) || _systemctl_$fun()
     {
         _wanted systemd-units expl unit \


### PR DESCRIPTION
## Summary
- Add zsh shell completion for `systemctl show` options (`--property`, `--value`, `--all`, `--no-pager`)

## Changes
| File | Change |
|------|--------|
| `shell-completion/zsh/_systemctl.in` | Define `_systemctl_show` function with `_arguments` for option completion; remove `show` from the generic NONTEMPLATE_UNITS loop |

## Problem
Currently, zsh completion for `systemctl show` only provides unit name completion. Bash completion already supports options like `--property`, `--value`, and `--no-pager`, but zsh does not.

## Solution
- Extract `show` from the generic NONTEMPLATE_UNITS for-loop
- Define `_systemctl_show()` with `_arguments` for `--property`, `--value`, `--all`, and `--no-pager`
- Follow the same pattern used by other subcommands with options

## Test Plan
- [x] `zsh -n` — no syntax errors
- [x] Function ` _systemctl_show` loads correctly after `source`
- [x] `_arguments` is called with correct options
- [x] State machine (`state`) handles option→unit name flow
- [x] `_wanted` provides unit name completion after options
- [x] `_systemctl_unit_properties` completer used for `--property` values
- [x] `show` removed from generic loop (verified grep)
- [x] `show` still registered as a subcommand
- [x] ShellCheck CI: PASS
- [x] Lint Code Base CI: PASS
- [x] Unit tests CI: PASS
- [x] Build (all architectures): PASS

### Manual testing
```zsh
# After installing the completion:
$ source shell-completion/zsh/_systemctl.in
$ systemctl show --<TAB>
--all      --no-pager  --property  --value
$ systemctl show --property <TAB>
Id  LoadState  ActiveState  SubState  ...
```

Fixes #37463
