### PR TITLE
man: note that sd-tmpfiles/sysusers --root is not a sandboxing feature

### DIFF
--- a/man/systemd-sysusers.xml
+++ b/man/systemd-sysusers.xml
@@ -66,6 +66,10 @@
         <replaceable>root</replaceable> path, including config search
         paths. </para>
 
+        <para>Note that this is not a sandboxing or security feature.
+        <citerefentry><refentrytitle>sysusers.d</refentrytitle><manvolnum>5</manvolnum></citerefentry>
+        definitions are potentially not processed in a hermetic fashion to the specified root.</para>
+
         <xi:include href="version-info.xml" xpointer="v215"/></listitem>
       </varlistentry>
 

--- a/man/systemd-tmpfiles.xml
+++ b/man/systemd-tmpfiles.xml
@@ -262,6 +262,10 @@
         or directories below mount points in the OS image operated on that are typically overmounted during
         runtime.</para>
 
+        <para>Note that this is not a sandboxing or security feature.
+        <citerefentry><refentrytitle>tmpfiles.d</refentrytitle><manvolnum>5</manvolnum></citerefentry>
+        definitions are potentially not processed in a hermetic fashion to the specified root.</para>
+
         <xi:include href="version-info.xml" xpointer="v212"/></listitem>
       </varlistentry>
 


### PR DESCRIPTION
This seems to be causing enough confusion that it is worth explicitly mentioning in the docs