### PR TITLE
boot: measure SMBIOS via non-TPM runtime measurements

### DIFF
--- a/src/boot/measure-smbios.c
+++ b/src/boot/measure-smbios.c
@@ -78,7 +78,7 @@ static bool measure_smbios_object(const SmbiosHeader *header, size_t size, void 
 void measure_smbios(void) {
         bool measured = false;
 
-        if (!tpm_present())
+        if (!runtime_measurement_available())
                 return;
 
         /* If the measurement was already done this boot (e.g. by sd-boot before it chainloaded us), don't

--- a/src/boot/measure.c
+++ b/src/boot/measure.c
@@ -187,6 +187,10 @@ bool tpm_present(void) {
         return tcg2_interface_check(/* ret_version= */ NULL);
 }
 
+bool runtime_measurement_available(void) {
+        return tpm_present() || cc_interface_check();
+}
+
 uint32_t tpm_get_active_pcr_banks(void) {
         EFI_STATUS err;
 

--- a/src/boot/measure.h
+++ b/src/boot/measure.h
@@ -6,6 +6,7 @@
 #if ENABLE_TPM
 
 bool tpm_present(void);
+bool runtime_measurement_available(void);
 uint32_t tpm_get_active_pcr_banks(void);
 
 /* Routines for boot-time TPM PCR measurement as well as submitting an event log entry about it. The latter
@@ -26,6 +27,10 @@ EFI_STATUS tpm_log_load_options(const char16_t *load_options, bool *ret_measured
 #else
 
 static inline bool tpm_present(void) {
+        return false;
+}
+
+static inline bool runtime_measurement_available(void) {
         return false;
 }
 


### PR DESCRIPTION
In commit 29c6d1c12549 ("boot: measure select SMBIOS objects explicitly") we added an explicit SMBIOS measurement in systemd-boot and systemd-stub, covering cases where firmware doesn't measure SMBIOS itself. measure_smbios() bailed unless a TPM was present, so it skipped the measurement on confidential guests that only expose a CC measurement protocol (e.g. Intel TDX RTMRs).

We can have much higher expectations of the virtual firmware used for confidential computing, and the firmware is attested, so we can expect it to always measure SMBIOS in this case. We still do our own measurement to get a measurement structure similar to that of non-confidential guests, and as another line of defense.