### PR TITLE
shell-completion: add tdx to systemd-vmspawn --coco values

### DIFF
--- a/shell-completion/bash/systemd-vmspawn
+++ b/shell-completion/bash/systemd-vmspawn
@@ -70,7 +70,7 @@ _systemd_vmspawn() {
     elif __contains_word "$prev" ${OPTS[IMAGE_DISK_TYPE]}; then
         comps='virtio-blk virtio-scsi nvme'
     elif __contains_word "$prev" ${OPTS[COCO]}; then
-        comps='no sev-snp'
+        comps='no sev-snp tdx'
     elif __contains_word "$prev" ${OPTS[ARG]}; then
         comps=''
     else


### PR DESCRIPTION
Missed in https://github.com/systemd/systemd/commit/a78afc16168bdded6c8376d6bde9121719b24537 ("vmspawn: add Intel TDX confidential VM support")