### PR TITLE
meson: fix fs.exists() check for fuzz corpus samples

### DIFF
--- a/test/fuzz/meson.build
+++ b/test/fuzz/meson.build
@@ -51,7 +51,7 @@ foreach p : out.stdout().split()
         #
         # Also, backslashes get mangled, so skip test. See
         # https://github.com/mesonbuild/meson/issues/1564.
-        if p.contains('\\') or not fs.exists(p)
+        if p.contains('\\') or not fs.exists(meson.project_source_root() / p)
                 continue
         endif
         fuzzer = fs.name(fs.parent(p))


### PR DESCRIPTION
Commit 8355eb6e11 ("meson: Check if files returned by git ls-files
actually exist") checks the paths printed by git ls-files, which are
relative to the project root, with fs.exists(), which resolves them
relative to the test/fuzz subdirectory. As a result, every corpus
sample was silently skipped, and only the generated directives tests
were registered. Resolve the paths against the project source root
instead.
