### PR TITLE
Default protect settings

### DIFF
--- a/src/core/dbus-manager.c
+++ b/src/core/dbus-manager.c
@@ -3113,6 +3113,7 @@ const sd_bus_vtable bus_manager_vtable[] = {
         SD_BUS_PROPERTY("DefaultOOMScoreAdjust", "i", property_get_oom_score_adjust, 0, SD_BUS_VTABLE_PROPERTY_CONST),
         SD_BUS_PROPERTY("DefaultRestrictSUIDSGID", "b", bus_property_get_bool, offsetof(Manager, defaults.restrict_suid_sgid), SD_BUS_VTABLE_PROPERTY_CONST),
         SD_BUS_PROPERTY("DefaultProtectKernelTunables", "b", bus_property_get_bool, offsetof(Manager, defaults.protect_kernel_tunables), SD_BUS_VTABLE_PROPERTY_CONST),
+        SD_BUS_PROPERTY("DefaultProtectKernelModules", "b", bus_property_get_bool, offsetof(Manager, defaults.protect_kernel_modules), SD_BUS_VTABLE_PROPERTY_CONST),
         SD_BUS_PROPERTY("CtrlAltDelBurstAction", "s", bus_property_get_emergency_action, offsetof(Manager, cad_burst_action), SD_BUS_VTABLE_PROPERTY_CONST),
         SD_BUS_PROPERTY("SoftRebootsCount", "u", bus_property_get_unsigned, offsetof(Manager, soft_reboots_count), SD_BUS_VTABLE_PROPERTY_CONST),
         SD_BUS_PROPERTY("KExecsCount", "u", bus_property_get_unsigned, offsetof(Manager, kexecs_count), SD_BUS_VTABLE_PROPERTY_CONST),

--- a/src/core/dbus-manager.c
+++ b/src/core/dbus-manager.c
@@ -3112,6 +3112,7 @@ const sd_bus_vtable bus_manager_vtable[] = {
         SD_BUS_PROPERTY("DefaultOOMPolicy", "s", bus_property_get_oom_policy, offsetof(Manager, defaults.oom_policy), SD_BUS_VTABLE_PROPERTY_CONST),
         SD_BUS_PROPERTY("DefaultOOMScoreAdjust", "i", property_get_oom_score_adjust, 0, SD_BUS_VTABLE_PROPERTY_CONST),
         SD_BUS_PROPERTY("DefaultRestrictSUIDSGID", "b", bus_property_get_bool, offsetof(Manager, defaults.restrict_suid_sgid), SD_BUS_VTABLE_PROPERTY_CONST),
+        SD_BUS_PROPERTY("DefaultProtectKernelTunables", "b", bus_property_get_bool, offsetof(Manager, defaults.protect_kernel_tunables), SD_BUS_VTABLE_PROPERTY_CONST),
         SD_BUS_PROPERTY("CtrlAltDelBurstAction", "s", bus_property_get_emergency_action, offsetof(Manager, cad_burst_action), SD_BUS_VTABLE_PROPERTY_CONST),
         SD_BUS_PROPERTY("SoftRebootsCount", "u", bus_property_get_unsigned, offsetof(Manager, soft_reboots_count), SD_BUS_VTABLE_PROPERTY_CONST),
         SD_BUS_PROPERTY("KExecsCount", "u", bus_property_get_unsigned, offsetof(Manager, kexecs_count), SD_BUS_VTABLE_PROPERTY_CONST),

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -871,6 +871,7 @@ static int parse_config_file(void) {
                 { "Manager", "DefaultStartLimitBurst",            config_parse_unsigned,              0,                        &arg_defaults.start_limit.burst                        },
                 { "Manager", "DefaultRestrictSUIDSGID",           config_parse_bool,                  0,                        &arg_defaults.restrict_suid_sgid                       },
                 { "Manager", "DefaultProtectKernelTunables",      config_parse_bool,                  0,                        &arg_defaults.protect_kernel_tunables                  },
+                { "Manager", "DefaultProtectKernelModules",       config_parse_bool,                  0,                        &arg_defaults.protect_kernel_modules                   },
                 { "Manager", "DefaultEnvironment",                config_parse_environ,               arg_runtime_scope,        &arg_default_environment                               },
                 { "Manager", "ManagerEnvironment",                config_parse_environ,               arg_runtime_scope,        &arg_manager_environment                               },
                 { "Manager", "DefaultLimitCPU",                   config_parse_rlimit,                RLIMIT_CPU,               arg_defaults.rlimit                                    },

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -870,6 +870,7 @@ static int parse_config_file(void) {
                 { "Manager", "DefaultStartLimitIntervalSec",      config_parse_sec,                   0,                        &arg_defaults.start_limit.interval                     },
                 { "Manager", "DefaultStartLimitBurst",            config_parse_unsigned,              0,                        &arg_defaults.start_limit.burst                        },
                 { "Manager", "DefaultRestrictSUIDSGID",           config_parse_bool,                  0,                        &arg_defaults.restrict_suid_sgid                       },
+                { "Manager", "DefaultProtectKernelTunables",      config_parse_bool,                  0,                        &arg_defaults.protect_kernel_tunables                  },
                 { "Manager", "DefaultEnvironment",                config_parse_environ,               arg_runtime_scope,        &arg_default_environment                               },
                 { "Manager", "ManagerEnvironment",                config_parse_environ,               arg_runtime_scope,        &arg_manager_environment                               },
                 { "Manager", "DefaultLimitCPU",                   config_parse_rlimit,                RLIMIT_CPU,               arg_defaults.rlimit                                    },

--- a/src/core/manager.c
+++ b/src/core/manager.c
@@ -4614,6 +4614,7 @@ int manager_set_unit_defaults(Manager *m, const UnitDefaults *defaults) {
         m->defaults.restrict_suid_sgid = defaults->restrict_suid_sgid;
 
         m->defaults.protect_kernel_tunables = defaults->protect_kernel_tunables;
+        m->defaults.protect_kernel_modules = defaults->protect_kernel_modules;
 
         m->defaults.start_limit = defaults->start_limit;
 

--- a/src/core/manager.c
+++ b/src/core/manager.c
@@ -4613,6 +4613,8 @@ int manager_set_unit_defaults(Manager *m, const UnitDefaults *defaults) {
 
         m->defaults.restrict_suid_sgid = defaults->restrict_suid_sgid;
 
+        m->defaults.protect_kernel_tunables = defaults->protect_kernel_tunables;
+
         m->defaults.start_limit = defaults->start_limit;
 
         m->defaults.memory_accounting = defaults->memory_accounting;

--- a/src/core/manager.h
+++ b/src/core/manager.h
@@ -167,6 +167,8 @@ typedef struct UnitDefaults {
 
         bool restrict_suid_sgid;
 
+        bool protect_kernel_tunables;
+
         OOMPolicy oom_policy;
         int oom_score_adjust;
         bool oom_score_adjust_set;

--- a/src/core/manager.h
+++ b/src/core/manager.h
@@ -168,6 +168,7 @@ typedef struct UnitDefaults {
         bool restrict_suid_sgid;
 
         bool protect_kernel_tunables;
+        bool protect_kernel_modules;
 
         OOMPolicy oom_policy;
         int oom_score_adjust;

--- a/src/core/system.conf.in
+++ b/src/core/system.conf.in
@@ -87,6 +87,7 @@
 #DefaultSmackProcessLabel=
 #DefaultRestrictSUIDSGID=
 #DefaultProtectKernelTunables=
+#DefaultProtectKernelModules=
 #ReloadLimitIntervalSec=
 #ReloadLimitBurst=
 #EventLoopRateLimitIntervalSec=1s

--- a/src/core/system.conf.in
+++ b/src/core/system.conf.in
@@ -86,6 +86,7 @@
 #DefaultOOMPolicy=stop
 #DefaultSmackProcessLabel=
 #DefaultRestrictSUIDSGID=
+#DefaultProtectKernelTunables=
 #ReloadLimitIntervalSec=
 #ReloadLimitBurst=
 #EventLoopRateLimitIntervalSec=1s

--- a/src/core/unit.c
+++ b/src/core/unit.c
@@ -198,6 +198,7 @@ static void unit_init(Unit *u) {
                 ec->restrict_suid_sgid = u->manager->defaults.restrict_suid_sgid;
 
                 ec->protect_kernel_tunables = u->manager->defaults.protect_kernel_tunables;
+                ec->protect_kernel_modules = u->manager->defaults.protect_kernel_modules;
 
                 if (MANAGER_IS_SYSTEM(u->manager))
                         ec->keyring_mode = EXEC_KEYRING_SHARED;

--- a/src/core/unit.c
+++ b/src/core/unit.c
@@ -197,6 +197,8 @@ static void unit_init(Unit *u) {
 
                 ec->restrict_suid_sgid = u->manager->defaults.restrict_suid_sgid;
 
+                ec->protect_kernel_tunables = u->manager->defaults.protect_kernel_tunables;
+
                 if (MANAGER_IS_SYSTEM(u->manager))
                         ec->keyring_mode = EXEC_KEYRING_SHARED;
                 else {

--- a/src/core/user.conf.in
+++ b/src/core/user.conf.in
@@ -60,6 +60,7 @@
 #DefaultIOPressureWatch=auto
 #DefaultSmackProcessLabel=
 #DefaultRestrictSUIDSGID=
+#DefaultProtectKernelTunables=
 #ReloadLimitIntervalSec=
 #ReloadLimitBurst=
 #EventLoopRateLimitIntervalSec=1s

--- a/src/core/user.conf.in
+++ b/src/core/user.conf.in
@@ -61,6 +61,7 @@
 #DefaultSmackProcessLabel=
 #DefaultRestrictSUIDSGID=
 #DefaultProtectKernelTunables=
+#DefaultProtectKernelModules=
 #ReloadLimitIntervalSec=
 #ReloadLimitBurst=
 #EventLoopRateLimitIntervalSec=1s

--- a/src/core/varlink-manager.c
+++ b/src/core/varlink-manager.c
@@ -123,6 +123,7 @@ static int manager_context_build_json(sd_json_variant **ret, const char *name, v
                         SD_JSON_BUILD_PAIR_INTEGER("DefaultOOMScoreAdjust", m->defaults.oom_score_adjust),
                         SD_JSON_BUILD_PAIR_BOOLEAN("DefaultRestrictSUIDSGID", m->defaults.restrict_suid_sgid),
                         SD_JSON_BUILD_PAIR_BOOLEAN("DefaultProtectKernelTunables", m->defaults.protect_kernel_tunables),
+                        SD_JSON_BUILD_PAIR_BOOLEAN("DefaultProtectKernelModules", m->defaults.protect_kernel_modules),
                         JSON_BUILD_PAIR_ENUM("CtrlAltDelBurstAction", emergency_action_to_string(m->cad_burst_action)),
                         SD_JSON_BUILD_PAIR_BOOLEAN("DefaultMemoryZSwapWriteback", m->defaults.memory_zswap_writeback),
                         JSON_BUILD_PAIR_STRING_NON_EMPTY("ConfirmSpawn", manager_get_confirm_spawn(m)),

--- a/src/core/varlink-manager.c
+++ b/src/core/varlink-manager.c
@@ -122,6 +122,7 @@ static int manager_context_build_json(sd_json_variant **ret, const char *name, v
                         JSON_BUILD_PAIR_ENUM("DefaultOOMPolicy", oom_policy_to_string(m->defaults.oom_policy)),
                         SD_JSON_BUILD_PAIR_INTEGER("DefaultOOMScoreAdjust", m->defaults.oom_score_adjust),
                         SD_JSON_BUILD_PAIR_BOOLEAN("DefaultRestrictSUIDSGID", m->defaults.restrict_suid_sgid),
+                        SD_JSON_BUILD_PAIR_BOOLEAN("DefaultProtectKernelTunables", m->defaults.protect_kernel_tunables),
                         JSON_BUILD_PAIR_ENUM("CtrlAltDelBurstAction", emergency_action_to_string(m->cad_burst_action)),
                         SD_JSON_BUILD_PAIR_BOOLEAN("DefaultMemoryZSwapWriteback", m->defaults.memory_zswap_writeback),
                         JSON_BUILD_PAIR_STRING_NON_EMPTY("ConfirmSpawn", manager_get_confirm_spawn(m)),

--- a/src/shared/varlink-io.systemd.Manager.c
+++ b/src/shared/varlink-io.systemd.Manager.c
@@ -104,6 +104,8 @@ static SD_VARLINK_DEFINE_STRUCT_TYPE(
                 SD_VARLINK_DEFINE_FIELD(DefaultOOMScoreAdjust, SD_VARLINK_INT, 0),
                 SD_VARLINK_FIELD_COMMENT("https://www.freedesktop.org/software/systemd/man/"PROJECT_VERSION_STR"/systemd-system.conf.html#DefaultRestrictSUIDSGID="),
                 SD_VARLINK_DEFINE_FIELD(DefaultRestrictSUIDSGID, SD_VARLINK_BOOL, 0),
+                SD_VARLINK_FIELD_COMMENT("https://www.freedesktop.org/software/systemd/man/"PROJECT_VERSION_STR"/systemd-system.conf.html#DefaultProtectKernelTunables="),
+                SD_VARLINK_DEFINE_FIELD(DefaultProtectKernelTunables, SD_VARLINK_BOOL, 0),
                 SD_VARLINK_FIELD_COMMENT("https://www.freedesktop.org/software/systemd/man/"PROJECT_VERSION_STR"/systemd-system.conf.html#CtrlAltDelBurstAction="),
                 SD_VARLINK_DEFINE_FIELD_BY_TYPE(CtrlAltDelBurstAction, EmergencyAction, 0),
                 SD_VARLINK_FIELD_COMMENT("The console on which systemd asks for confirmation when spawning processes"),

--- a/src/shared/varlink-io.systemd.Manager.c
+++ b/src/shared/varlink-io.systemd.Manager.c
@@ -106,6 +106,8 @@ static SD_VARLINK_DEFINE_STRUCT_TYPE(
                 SD_VARLINK_DEFINE_FIELD(DefaultRestrictSUIDSGID, SD_VARLINK_BOOL, 0),
                 SD_VARLINK_FIELD_COMMENT("https://www.freedesktop.org/software/systemd/man/"PROJECT_VERSION_STR"/systemd-system.conf.html#DefaultProtectKernelTunables="),
                 SD_VARLINK_DEFINE_FIELD(DefaultProtectKernelTunables, SD_VARLINK_BOOL, 0),
+                SD_VARLINK_FIELD_COMMENT("https://www.freedesktop.org/software/systemd/man/"PROJECT_VERSION_STR"/systemd-system.conf.html#DefaultProtectKernelModules="),
+                SD_VARLINK_DEFINE_FIELD(DefaultProtectKernelModules, SD_VARLINK_BOOL, 0),
                 SD_VARLINK_FIELD_COMMENT("https://www.freedesktop.org/software/systemd/man/"PROJECT_VERSION_STR"/systemd-system.conf.html#CtrlAltDelBurstAction="),
                 SD_VARLINK_DEFINE_FIELD_BY_TYPE(CtrlAltDelBurstAction, EmergencyAction, 0),
                 SD_VARLINK_FIELD_COMMENT("The console on which systemd asks for confirmation when spawning processes"),


### PR DESCRIPTION
# PR: Add global defaults for service sandboxing settings to support following "opt-out" model

## Summary

Add four new `[Manager]` configuration options to `system.conf` / `user.conf`:

- `DefaultProtectKernelTunables=`
- `DefaultProtectKernelModules=`
- `DefaultPrivateTmp=`
- `DefaultProtectHome=`

**Note:** This PR only adds the feature and **does not change the default behavior**. The feature allows to configure systems with an "opt-out" of security default settings.

When enabled, all service units inherit the corresponding sandboxing setting unless they explicitly override it in their unit file. This allows distributions to ship a hardened default posture with a single configuration file, while services that genuinely need the restricted capabilities opt out explicitly.

The PR follows the pattern established by `DefaultRestrictSUIDSGID=` (merged in PR #38126).

## Motivation: Post-exploitation defense for network-facing services

### The problem

Network-facing services (nginx, httpd, redis, postgres, sshd) are the primary attack surface on Linux servers. When a remote code execution vulnerability is exploited, the attacker gains a shell running as the service's user. On a default systemd system, that shell can:

1. **Modify kernel tunables** — disable ASLR, enable IP forwarding, weaken security sysctls
2. **Load kernel modules** — install rootkits that survive service restarts and hide from detection
3. **Read /home directories** — steal SSH keys, cloud credentials, application secrets
4. **Access other services' temp files** — stage malware, exploit symlink races, steal session data

None of these capabilities are needed by most network-facing application service during normal operation.

### Real-world evidence: CVE-2026-42945 (NGINX Rift)

On May 13, 2026, a critical heap buffer overflow (CVSS 9.2) was disclosed in nginx's `ngx_http_rewrite_module`. The vulnerability allows **unauthenticated remote code execution** via a crafted HTTP request.

**Without these defaults**, an attacker who exploits this vulnerability can immediately:

```
# As the compromised nginx worker process:
echo 0 > /proc/sys/kernel/randomize_va_space    # disable ASLR system-wide
insmod /tmp/rootkit.ko                          # load kernel module rootkit
ls /tmp/                                        # see all services' temp files
```

**With these defaults enabled**, the same attacker is blocked at every step:

```
echo 0 > /proc/sys/kernel/randomize_va_space    # EPERM: read-only mount
insmod /tmp/rootkit.ko                          # EPERM: syscall blocked
ls /home/                                       # empty (inaccessible)
ls /tmp/                                        # only nginx's own files visible
```

### Other campaigns that could be blocked with these settings

| Campaign / CVE | Date | What it does | Setting that blocks it |
|---|---|---|---|
| PCPJack cloud worm | Apr–Jun 2026 | Compromises Redis/nginx/Docker, persists in `/var/tmp/`, reads credentials from `/home/` | `ProtectHome`, `PrivateTmp` |
| various | 2021–2026 | Enables `ip_forward`, modifies `rp_filter` for lateral movement between cloud instances | `ProtectKernelTunables` |
| CVE-2025-10279 (MLflow) | 2025 | Exploits world-writable `/tmp` with race condition for RCE | `PrivateTmp` |
| CVE-2024-45339 (glog) | 2024 | Symlink attack in shared `/tmp` for privilege escalation | `PrivateTmp` |

### Mechanism

Each setting adds a boolean field to `ManagerDefaults`. During unit initialization, the exec context inherits the manager's default unless the unit file provides an explicit override. This is identical to how `DefaultRestrictSUIDSGID=` works.

## Safety assessment

In case an admin would enable these global settings, below questions might be relevant.

| Question | Answer |
|---|---|
| What's the failure mode? | `EPERM`/`EACCES` with audit trail in journal. |
| Can users override? | Yes — single-line drop-in, or disable global default entirely. |
