### PR TITLE
sd-varlink: add VARLINK_PENDING_METHOD_ONEWAY server flag

### DIFF
--- a/man/sd_varlink_server_new.xml
+++ b/man/sd_varlink_server_new.xml
@@ -102,6 +102,16 @@
 
       <listitem><para><constant>SD_VARLINK_SERVER_HANDLE_SIGTERM</constant>: similar, but does the same for
       <constant>SIGTERM</constant>.</para></listitem>
+
+      <listitem><para><constant>SD_VARLINK_SERVER_ONEWAY_NEEDS_REPLY</constant>: if set, one-way method
+      calls (i.e. those made by the client via <function>sd_varlink_send()</function> and related calls) are
+      not considered complete once the method handler callback returns. Instead, the handler is expected to
+      signal completion explicitly, by enqueuing a reply via <function>sd_varlink_reply()</function> or an
+      error via <function>sd_varlink_error()</function> and related calls (the reply/error itself is
+      discarded, since one-way calls never send anything back to the client). Until then the connection is
+      parked, and no further pipelined method calls on the same connection are dispatched. If the flag is not
+      set (the default), one-way method calls are considered complete as soon as the callback
+      returns.</para></listitem>
     </itemizedlist>
   </refsect1>
 

--- a/src/journal/journalctl-varlink-server.c
+++ b/src/journal/journalctl-varlink-server.c
@@ -142,10 +142,6 @@ static int follow_state_setup(sd_varlink *link, sd_journal *_j /* donated! */) {
         assert(link);
         assert(j);
 
-        /* The varlink connection already requested the follow mode. Refusing. */
-        if (sd_varlink_get_userdata(link))
-                return -EBUSY;
-
         sd_varlink_server *server = ASSERT_PTR(sd_varlink_get_server(link));
         sd_event *event = ASSERT_PTR(sd_varlink_server_get_event(server));
 

--- a/src/journal/journalctl.c
+++ b/src/journal/journalctl.c
@@ -285,7 +285,7 @@ static int vl_server(void) {
         _cleanup_(sd_varlink_server_unrefp) sd_varlink_server *varlink_server = NULL;
         int r;
 
-        r = varlink_server_new(&varlink_server, /* flags= */ 0, /* userdata= */ NULL);
+        r = varlink_server_new(&varlink_server, SD_VARLINK_SERVER_ONEWAY_NEEDS_REPLY, /* userdata= */ NULL);
         if (r < 0)
                 return log_error_errno(r, "Failed to allocate Varlink server: %m");
 

--- a/src/journal/journald-varlink.c
+++ b/src/journal/journald-varlink.c
@@ -182,7 +182,7 @@ int manager_open_varlink(Manager *m, const char *socket, int fd) {
 
         r = varlink_server_new(
                         &m->varlink_server,
-                        SD_VARLINK_SERVER_ACCOUNT_UID,
+                        SD_VARLINK_SERVER_ACCOUNT_UID|SD_VARLINK_SERVER_ONEWAY_NEEDS_REPLY,
                         m);
         if (r < 0)
                 return log_error_errno(r, "Failed to allocate varlink server object: %m");

--- a/src/journal/journald-varlink.c
+++ b/src/journal/journald-varlink.c
@@ -46,10 +46,6 @@ static int vl_method_synchronize(sd_varlink *link, sd_json_variant *parameters, 
 
         Manager *m = ASSERT_PTR(sd_varlink_server_get_userdata(sd_varlink_get_server(link)));
 
-        /* The varlink connection already requested to sync journals. Refusing. */
-        if (sd_varlink_get_userdata(link))
-                return -EBUSY;
-
         r = sd_varlink_dispatch(link, parameters, dispatch_table, &offline);
         if (r != 0)
                 return r;

--- a/src/libsystemd/sd-varlink/sd-varlink.c
+++ b/src/libsystemd/sd-varlink/sd-varlink.c
@@ -65,6 +65,7 @@ static const char* const varlink_state_table[_VARLINK_STATE_MAX] = {
         [VARLINK_PROCESSED_METHOD_UPGRADE]  = "processed-method-upgrade",
         [VARLINK_PENDING_METHOD]            = "pending-method",
         [VARLINK_PENDING_METHOD_MORE]       = "pending-method-more",
+        [VARLINK_PENDING_METHOD_ONEWAY]     = "pending-method-oneway",
         [VARLINK_PENDING_METHOD_UPGRADE]    = "pending-method-upgrade",
         [VARLINK_UPGRADING]                 = "upgrading",
         [VARLINK_PENDING_DISCONNECT]        = "pending-disconnect",
@@ -116,7 +117,7 @@ static JsonStreamPhase varlink_phase(void *userdata) {
         if (v->state == VARLINK_IDLE_CLIENT)
                 return JSON_STREAM_PHASE_IDLE_CLIENT;
 
-        if (IN_SET(v->state, VARLINK_PENDING_METHOD, VARLINK_PENDING_METHOD_MORE, VARLINK_PENDING_METHOD_UPGRADE))
+        if (VARLINK_STATE_IS_PENDING_METHOD(v->state))
                 return JSON_STREAM_PHASE_PENDING_OUTPUT;
 
         return JSON_STREAM_PHASE_OTHER;
@@ -1094,12 +1095,55 @@ static void varlink_fiber_data_destroy(void *userdata) {
         varlink_fiber_data_free(userdata);
 }
 
+/* For oneway method calls no reply is ever sent to the client. But applications still call
+ * sd_varlink_reply()/sd_varlink_error() to signal completion of a deferred oneway method. In that case we
+ * discard the payload, but still drive the state machine forward, so the connection may dispatch the next
+ * queued method. Returns true if the connection was in a oneway state (and hence was handled here), false
+ * otherwise. */
+static bool varlink_oneway_complete(sd_varlink *v) {
+        assert(v);
+
+        if (!IN_SET(v->state, VARLINK_PROCESSING_METHOD_ONEWAY, VARLINK_PENDING_METHOD_ONEWAY))
+                return false;
+
+        /* The reply/error payload is discarded for a oneway call, drop any fds the handler pushed for it */
+        sd_varlink_reset_fds(v);
+
+        if (v->state == VARLINK_PENDING_METHOD_ONEWAY) {
+                /* Completion happened outside the varlink_dispatch_method() stack frame (e.g. from a timer
+                 * or fiber), so return to idle ourselves. */
+                varlink_clear_current(v);
+                varlink_set_state(v, VARLINK_IDLE_SERVER);
+
+                /* Since we are not on the sd_varlink_process() call stack that would otherwise carry on
+                 * reading the connection, re-arm the connection's deferred event source so the event loop
+                 * runs sd_varlink_process() once more and dispatches the next pipelined method. Only
+                 * relevant when the connection is attached to an event loop. */
+                if (v->defer_event_source)
+                        (void) sd_event_source_set_enabled(v->defer_event_source, SD_EVENT_ON);
+        } else
+                /* Still inside varlink_dispatch_method(), its post-callback switch returns us to idle. */
+                varlink_set_state(v, VARLINK_PROCESSED_METHOD);
+
+        return true;
+}
+
 static int varlink_fiber_entry(void *userdata) {
         VarlinkFiberData *d = ASSERT_PTR(userdata);
         sd_varlink *v = d->link;
         int r;
 
         r = d->callback(v, d->parameters, d->flags, d->userdata);
+
+        /* A deferred oneway method parks in VARLINK_PENDING_METHOD_ONEWAY. If the fiber generated a
+         * (discarded) reply, sd_varlink_reply() already returned us to idle, otherwise complete it here so
+         * the connection can dispatch the next queued method. A failing oneway fiber has no client to report
+         * to, so log the error to leave a trace before it is discarded. */
+        if (varlink_oneway_complete(v)) {
+                if (r < 0)
+                        varlink_log_errno(v, r, "Oneway fiber returned error, ignoring: %m");
+                return r;
+        }
 
         /* The fiber runs after varlink_dispatch_method() has already transitioned the state from
          * VARLINK_PROCESSING_METHOD{,_MORE} to VARLINK_PENDING_METHOD{,_MORE}, so that's what we match
@@ -1199,6 +1243,8 @@ static int varlink_dispatch_method(sd_varlink *v) {
         sd_json_variant *e;
         sd_varlink_method_t callback;
         const char *k;
+        /* Set when a oneway handler returns without replying, so it is parked (deferred) until it does. */
+        bool oneway_deferred = false;
         int r;
 
         assert(v);
@@ -1384,6 +1430,16 @@ static int varlink_dispatch_method(sd_varlink *v) {
                                 if (r < 0 && VARLINK_STATE_WANTS_REPLY(v->state))
                                         goto fail;
 
+                        } else if (v->state == VARLINK_PROCESSING_METHOD_ONEWAY) {
+                                assert(!v->previous);
+
+                                /* A oneway call sends nothing to the client. In
+                                 * SD_VARLINK_SERVER_ONEWAY_NEEDS_REPLY mode a handler that returned success
+                                 * without replying or setting a sentinel is treated as deferred: park it
+                                 * below and wait for it to signal completion later. Everything else is
+                                 * completed by the switch below. */
+                                if (r >= 0 && !v->sentinel && FLAGS_SET(v->server->flags, SD_VARLINK_SERVER_ONEWAY_NEEDS_REPLY))
+                                        oneway_deferred = true;
                         } else
                                 assert(!v->previous);
                 }
@@ -1396,8 +1452,19 @@ static int varlink_dispatch_method(sd_varlink *v) {
 
         switch (v->state) {
 
+        case VARLINK_PROCESSING_METHOD_ONEWAY:
+                /* A oneway call never sends anything to the client. A deferred call (see above) parks;
+                 * everything else — fire-and-forget, a failed handler, a set sentinel, an unknown method
+                 * or invalid parameters — is completed right away. */
+                if (oneway_deferred) {
+                        varlink_set_state(v, VARLINK_PENDING_METHOD_ONEWAY);
+                        break;
+                }
+
+                varlink_oneway_complete(v);
+                _fallthrough_;
+
         case VARLINK_PROCESSED_METHOD: /* Method call is fully processed */
-        case VARLINK_PROCESSING_METHOD_ONEWAY: /* ditto */
                 varlink_clear_current(v);
                 varlink_set_state(v, VARLINK_IDLE_SERVER);
                 break;
@@ -1622,6 +1689,9 @@ _public_ int sd_varlink_dispatch_again(sd_varlink *v) {
 
         if (v->state == VARLINK_DISCONNECTED)
                 return varlink_log_errno(v, SYNTHETIC_ERRNO(ENOTCONN), "Not connected.");
+        /* Deliberately not VARLINK_STATE_IS_PENDING_METHOD(): a parked oneway call must not be
+         * re-dispatched, as that would re-run its handler on the same message (double dispatch) and carry
+         * over any pushed fds. */
         if (!IN_SET(v->state, VARLINK_PENDING_METHOD, VARLINK_PENDING_METHOD_MORE, VARLINK_PENDING_METHOD_UPGRADE))
                 return varlink_log_errno(v, SYNTHETIC_ERRNO(EBUSY), "Connection has no pending method.");
 
@@ -2442,10 +2512,13 @@ static int varlink_reply_internal(sd_varlink *v, sd_json_variant *parameters, bo
         if (v->state == VARLINK_DISCONNECTED)
                 return varlink_log_errno(v, SYNTHETIC_ERRNO(ENOTCONN), "Not connected.");
 
-        if (!IN_SET(v->state,
-                    VARLINK_PROCESSING_METHOD, VARLINK_PROCESSING_METHOD_MORE, VARLINK_PROCESSING_METHOD_UPGRADE,
-                    VARLINK_PENDING_METHOD, VARLINK_PENDING_METHOD_MORE, VARLINK_PENDING_METHOD_UPGRADE))
+        if (!VARLINK_STATE_IS_PROCESSING_METHOD(v->state) && !VARLINK_STATE_IS_PENDING_METHOD(v->state))
                 return varlink_log_errno(v, SYNTHETIC_ERRNO(EBUSY), "Connection busy.");
+
+        /* The client of a oneway call isn't listening for a reply, so discard it but still advance the
+         * state machine, so a deferred oneway method's completion lets the connection proceed. */
+        if (varlink_oneway_complete(v))
+                return 1;
 
         bool more = IN_SET(v->state, VARLINK_PROCESSING_METHOD_MORE, VARLINK_PENDING_METHOD_MORE);
 
@@ -2548,9 +2621,7 @@ _public_ int sd_varlink_respond_and_upgrade(
                 return varlink_log_errno(v, SYNTHETIC_ERRNO(ENOTCONN), "Not connected.");
 
         /* Return -EBUSY if we are not processing methods at all */
-        if (!IN_SET(v->state,
-                    VARLINK_PROCESSING_METHOD, VARLINK_PROCESSING_METHOD_MORE, VARLINK_PROCESSING_METHOD_ONEWAY, VARLINK_PROCESSING_METHOD_UPGRADE,
-                    VARLINK_PENDING_METHOD, VARLINK_PENDING_METHOD_MORE, VARLINK_PENDING_METHOD_UPGRADE))
+        if (!VARLINK_STATE_IS_PROCESSING_METHOD(v->state) && !VARLINK_STATE_IS_PENDING_METHOD(v->state))
                 return varlink_log_errno(v, SYNTHETIC_ERRNO(EBUSY), "Connection busy.");
 
         /* Return -EPROTO if we are processing methods, but an upgrade was not requested. */
@@ -2682,10 +2753,15 @@ _public_ int sd_varlink_error(sd_varlink *v, const char *error_id, sd_json_varia
 
         if (v->state == VARLINK_DISCONNECTED)
                 return varlink_log_errno(v, SYNTHETIC_ERRNO(ENOTCONN), "Not connected.");
-        if (!IN_SET(v->state,
-                    VARLINK_PROCESSING_METHOD, VARLINK_PROCESSING_METHOD_MORE, VARLINK_PROCESSING_METHOD_UPGRADE,
-                    VARLINK_PENDING_METHOD, VARLINK_PENDING_METHOD_MORE, VARLINK_PENDING_METHOD_UPGRADE))
+        if (!VARLINK_STATE_IS_PROCESSING_METHOD(v->state) && !VARLINK_STATE_IS_PENDING_METHOD(v->state))
                 return varlink_log_errno(v, SYNTHETIC_ERRNO(EBUSY), "Connection busy.");
+
+        /* Discard errors for oneway calls too (the client isn't listening), but still advance the state
+         * machine so a deferred oneway method's completion lets the connection proceed. Keep returning the
+         * negative errno (unlike sd_varlink_reply()): the "return sd_varlink_error(...)" rejection idiom,
+         * e.g. varlink_check_privileged_peer(), relies on a negative return to propagate. */
+        if (varlink_oneway_complete(v))
+                return sd_varlink_error_to_errno(error_id, parameters);
 
         if (v->previous) {
                 r = sd_json_variant_set_field_boolean(&v->previous, "continues", true);
@@ -2958,16 +3034,13 @@ _public_ void* sd_varlink_get_userdata(sd_varlink *v) {
 _public_ int sd_varlink_set_sentinel(sd_varlink *v, const char *error_id) {
         assert_return(v, -EINVAL);
 
-        /* If the caller doesn't want a reply, then don't set a sentinel. */
-        if (v->state == VARLINK_PROCESSING_METHOD_ONEWAY)
-                return 0;
-
-        /* This has to be called during a callback, and not after it has exited. The PENDING states
-         * apply to fiber callbacks, which run after varlink_dispatch_method() has already transitioned
-         * the state from PROCESSING to PENDING. */
+        /* This has to be called during a callback, and not after it has exited. The PENDING states apply to
+         * fiber callbacks, which run after varlink_dispatch_method() has already transitioned the state from
+         * PROCESSING to PENDING. For oneway calls the sentinel error is never sent, but recording it still
+         * signals completion, so a SD_VARLINK_SERVER_ONEWAY_NEEDS_REPLY handler is not left parked. */
         assert_return(IN_SET(v->state,
-                             VARLINK_PROCESSING_METHOD, VARLINK_PROCESSING_METHOD_MORE,
-                             VARLINK_PENDING_METHOD, VARLINK_PENDING_METHOD_MORE),
+                             VARLINK_PROCESSING_METHOD, VARLINK_PROCESSING_METHOD_MORE, VARLINK_PROCESSING_METHOD_ONEWAY,
+                             VARLINK_PENDING_METHOD, VARLINK_PENDING_METHOD_MORE, VARLINK_PENDING_METHOD_ONEWAY),
                       -EUCLEAN);
 
         char *s = NULL;
@@ -3234,7 +3307,8 @@ _public_ int sd_varlink_server_new(sd_varlink_server **ret, sd_varlink_server_fl
                                  SD_VARLINK_SERVER_FD_PASSING_INPUT_STRICT|
                                  SD_VARLINK_SERVER_HANDLE_SIGINT|
                                  SD_VARLINK_SERVER_HANDLE_SIGTERM|
-                                 SD_VARLINK_SERVER_UPGRADABLE)) == 0, -EINVAL);
+                                 SD_VARLINK_SERVER_UPGRADABLE|
+                                 SD_VARLINK_SERVER_ONEWAY_NEEDS_REPLY)) == 0, -EINVAL);
 
         s = new(sd_varlink_server, 1);
         if (!s)

--- a/src/libsystemd/sd-varlink/test-varlink.c
+++ b/src/libsystemd/sd-varlink/test-varlink.c
@@ -21,6 +21,7 @@
 #include "rm-rf.h"
 #include "socket-util.h"
 #include "tests.h"
+#include "time-util.h"
 #include "tmpfile-util.h"
 #include "varlink-util.h"
 
@@ -644,8 +645,8 @@ TEST(sentinel_with_explicit_reply) {
 }
 
 static int method_with_oneway_sentinel(sd_varlink *link, sd_json_variant *parameters, sd_varlink_method_flags_t flags, void *userdata) {
-        /* The method was called oneway, so sd_varlink_set_sentinel() should be a no-op and the server should
-         * transition back to idle without sending any reply. */
+        /* The method was called oneway: the sentinel is recorded but no reply is ever sent to the client,
+         * so the server discards it and transitions back to idle. */
         ASSERT_TRUE(FLAGS_SET(flags, SD_VARLINK_METHOD_ONEWAY));
         ASSERT_OK(sd_varlink_set_sentinel(link, "io.test.SentinelError"));
         return 0;
@@ -693,6 +694,507 @@ TEST(sentinel_oneway) {
         ASSERT_OK(sd_varlink_invoke(c, "io.test.Pong", /* parameters= */ NULL));
 
         ASSERT_OK(sd_event_loop(e));
+}
+
+static int oneway_test_timeout(sd_event_source *s, uint64_t usec, void *userdata) {
+        /* Reached only if a test wedges (e.g. a connection stays parked): fail with a clear assertion
+         * instead of hanging until the meson test timeout. */
+        assert_not_reached();
+}
+
+static void oneway_test_setup(
+                sd_varlink_server_flags_t flags,
+                sd_event **ret_event,
+                sd_varlink_server **ret_server,
+                sd_varlink **ret_client) {
+
+        assert(ret_event);
+        assert(ret_server);
+        assert(ret_client);
+
+        _cleanup_(sd_event_unrefp) sd_event *e = NULL;
+        ASSERT_OK(sd_event_default(&e));
+
+        _cleanup_(sd_event_source_unrefp) sd_event_source *timer = NULL;
+        /* A few seconds, well under test-varlink's 30s binary-level meson timeout, so this fires first. */
+        ASSERT_OK(sd_event_add_time_relative(e, &timer, CLOCK_MONOTONIC, 5 * USEC_PER_SEC, 0, oneway_test_timeout, NULL));
+        ASSERT_OK(sd_event_source_set_floating(timer, true));
+
+        _cleanup_(sd_varlink_server_unrefp) sd_varlink_server *s = NULL;
+        ASSERT_OK(sd_varlink_server_new(&s, flags));
+        ASSERT_OK(sd_varlink_server_attach_event(s, e, 0));
+
+        int connfd[2];
+        ASSERT_OK_ERRNO(socketpair(AF_UNIX, SOCK_STREAM|SOCK_NONBLOCK|SOCK_CLOEXEC, 0, connfd));
+        ASSERT_OK(sd_varlink_server_add_connection(s, connfd[0], /* ret= */ NULL));
+
+        _cleanup_(sd_varlink_unrefp) sd_varlink *c = NULL;
+        ASSERT_OK(sd_varlink_connect_fd(&c, connfd[1]));
+        ASSERT_OK(sd_varlink_attach_event(c, e, 0));
+
+        *ret_event = TAKE_PTR(e);
+        *ret_server = TAKE_PTR(s);
+        *ret_client = TAKE_PTR(c);
+}
+
+static bool oneway_defer_dispatched;
+static bool oneway_ping_dispatched;
+static bool oneway_defer_completed;
+
+static int oneway_deferred_complete(sd_event_source *s, void *userdata) {
+        _cleanup_(sd_varlink_unrefp) sd_varlink *link = ASSERT_PTR(userdata);
+
+        sd_event_source_disable_unref(s);
+
+        /* While the oneway method was deferred, the connection must have parked: the pipelined Ping must
+         * not have been dispatched yet. */
+        ASSERT_FALSE(oneway_ping_dispatched);
+
+        /* Complete the deferred oneway call. The reply is discarded (the client isn't listening for a
+         * oneway reply), but it unparks the connection so the next queued method can be dispatched. */
+        ASSERT_OK_EQ(sd_varlink_reply(link, /* parameters= */ NULL), 1);
+        oneway_defer_completed = true;
+        return 0;
+}
+
+static int method_oneway_defer(sd_varlink *link, sd_json_variant *parameters, sd_varlink_method_flags_t flags, void *userdata) {
+        /* A oneway method that stashes the connection to finish asynchronously. Returning without a reply
+         * must park the connection in VARLINK_PENDING_METHOD_ONEWAY rather than immediately dispatching the
+         * next pipelined method. */
+        sd_event_source *source;
+
+        ASSERT_TRUE(FLAGS_SET(flags, SD_VARLINK_METHOD_ONEWAY));
+        oneway_defer_dispatched = true;
+
+        ASSERT_OK(sd_event_add_defer(sd_varlink_get_event(link), &source, oneway_deferred_complete, sd_varlink_ref(link)));
+        /* Run the completion at idle priority, so the connection has every chance to (wrongly) dispatch the
+         * pipelined Ping first if the parking were broken. */
+        ASSERT_OK(sd_event_source_set_priority(source, SD_EVENT_PRIORITY_IDLE));
+        ASSERT_OK(sd_event_source_set_enabled(source, SD_EVENT_ONESHOT));
+        return 0;
+}
+
+static int method_oneway_ping(sd_varlink *link, sd_json_variant *parameters, sd_varlink_method_flags_t flags, void *userdata) {
+        /* Must only ever run after the deferred oneway method completed. If parking regresses this runs
+         * before oneway_deferred_complete(), so assert the completion already happened. */
+        ASSERT_TRUE(oneway_defer_dispatched);
+        ASSERT_TRUE(oneway_defer_completed);
+        oneway_ping_dispatched = true;
+        return sd_varlink_replybo(link, SD_JSON_BUILD_PAIR_STRING("result", "pong"));
+}
+
+static int reply_oneway_ping(sd_varlink *link, sd_json_variant *parameters, const char *error_id, sd_varlink_reply_flags_t flags, void *userdata) {
+        ASSERT_NULL(error_id);
+        ASSERT_STREQ(sd_json_variant_string(sd_json_variant_by_key(parameters, "result")), "pong");
+        ASSERT_OK(sd_event_exit(sd_varlink_get_event(link), EXIT_SUCCESS));
+        return 0;
+}
+
+TEST(oneway_deferred_parks_connection) {
+        _cleanup_(sd_event_unrefp) sd_event *e = NULL;
+        _cleanup_(sd_varlink_server_unrefp) sd_varlink_server *s = NULL;
+        _cleanup_(sd_varlink_unrefp) sd_varlink *c = NULL;
+        oneway_test_setup(SD_VARLINK_SERVER_ONEWAY_NEEDS_REPLY, &e, &s, &c);
+
+        ASSERT_OK(sd_varlink_server_bind_method(s, "io.test.OnewayDefer", method_oneway_defer));
+        ASSERT_OK(sd_varlink_server_bind_method(s, "io.test.OnewayPing", method_oneway_ping));
+        ASSERT_OK(sd_varlink_bind_reply(c, reply_oneway_ping));
+
+        oneway_defer_dispatched = false;
+        oneway_ping_dispatched = false;
+        oneway_defer_completed = false;
+
+        /* Fire a deferred oneway call, immediately followed (pipelined) by a normal call on the same
+         * connection. The normal call must not be dispatched until the oneway call completes. */
+        ASSERT_OK(sd_varlink_send(c, "io.test.OnewayDefer", /* parameters= */ NULL));
+        ASSERT_OK(sd_varlink_invoke(c, "io.test.OnewayPing", /* parameters= */ NULL));
+
+        ASSERT_OK(sd_event_loop(e));
+        ASSERT_TRUE(oneway_ping_dispatched);
+        ASSERT_TRUE(oneway_defer_completed);
+}
+
+static bool oneway_error_ping_dispatched;
+static bool oneway_error_completed;
+
+static int oneway_deferred_error_complete(sd_event_source *s, void *userdata) {
+        _cleanup_(sd_varlink_unrefp) sd_varlink *link = ASSERT_PTR(userdata);
+
+        sd_event_source_disable_unref(s);
+
+        /* Complete the parked oneway call via the error route rather than a reply. The error is discarded
+         * (no client listens for a oneway reply) but must still unpark the connection. sd_varlink_error()
+         * keeps returning its negative errno so the "return sd_varlink_error(...)" rejection idiom works. */
+        ASSERT_ERROR(sd_varlink_error(link, "io.test.SomeError", /* parameters= */ NULL), EBADR);
+        oneway_error_completed = true;
+        return 0;
+}
+
+static int method_oneway_error_defer(sd_varlink *link, sd_json_variant *parameters, sd_varlink_method_flags_t flags, void *userdata) {
+        sd_event_source *source;
+
+        ASSERT_TRUE(FLAGS_SET(flags, SD_VARLINK_METHOD_ONEWAY));
+
+        ASSERT_OK(sd_event_add_defer(sd_varlink_get_event(link), &source, oneway_deferred_error_complete, sd_varlink_ref(link)));
+        ASSERT_OK(sd_event_source_set_priority(source, SD_EVENT_PRIORITY_IDLE));
+        ASSERT_OK(sd_event_source_set_enabled(source, SD_EVENT_ONESHOT));
+        return 0;
+}
+
+static int method_oneway_error_ping(sd_varlink *link, sd_json_variant *parameters, sd_varlink_method_flags_t flags, void *userdata) {
+        /* Must only run once the parked oneway call was completed via the error route. */
+        ASSERT_TRUE(oneway_error_completed);
+        oneway_error_ping_dispatched = true;
+        return sd_varlink_replybo(link, SD_JSON_BUILD_PAIR_STRING("result", "pong"));
+}
+
+TEST(oneway_deferred_error_completes) {
+        _cleanup_(sd_event_unrefp) sd_event *e = NULL;
+        _cleanup_(sd_varlink_server_unrefp) sd_varlink_server *s = NULL;
+        _cleanup_(sd_varlink_unrefp) sd_varlink *c = NULL;
+        oneway_test_setup(SD_VARLINK_SERVER_ONEWAY_NEEDS_REPLY, &e, &s, &c);
+
+        ASSERT_OK(sd_varlink_server_bind_method(s, "io.test.OnewayErrorDefer", method_oneway_error_defer));
+        ASSERT_OK(sd_varlink_server_bind_method(s, "io.test.OnewayErrorPing", method_oneway_error_ping));
+        ASSERT_OK(sd_varlink_bind_reply(c, reply_oneway_ping));
+
+        oneway_error_ping_dispatched = false;
+        oneway_error_completed = false;
+
+        /* Deferred oneway call completed later through sd_varlink_error(), immediately followed by a
+         * pipelined regular call that must wait for the completion. */
+        ASSERT_OK(sd_varlink_send(c, "io.test.OnewayErrorDefer", /* parameters= */ NULL));
+        ASSERT_OK(sd_varlink_invoke(c, "io.test.OnewayErrorPing", /* parameters= */ NULL));
+
+        ASSERT_OK(sd_event_loop(e));
+        ASSERT_TRUE(oneway_error_ping_dispatched);
+        ASSERT_TRUE(oneway_error_completed);
+}
+
+static bool oneway_errret_ping_dispatched;
+
+static int method_oneway_error_return(sd_varlink *link, sd_json_variant *parameters, sd_varlink_method_flags_t flags, void *userdata) {
+        /* Return a negative errno without replying. With the flag set the r >= 0 guard means no reply is
+         * coming, so the call must complete right away instead of parking forever. */
+        ASSERT_TRUE(FLAGS_SET(flags, SD_VARLINK_METHOD_ONEWAY));
+        return -ENOANO;
+}
+
+static int method_oneway_errret_ping(sd_varlink *link, sd_json_variant *parameters, sd_varlink_method_flags_t flags, void *userdata) {
+        oneway_errret_ping_dispatched = true;
+        return sd_varlink_replybo(link, SD_JSON_BUILD_PAIR_STRING("result", "pong"));
+}
+
+TEST(oneway_error_return_completes) {
+        _cleanup_(sd_event_unrefp) sd_event *e = NULL;
+        _cleanup_(sd_varlink_server_unrefp) sd_varlink_server *s = NULL;
+        _cleanup_(sd_varlink_unrefp) sd_varlink *c = NULL;
+        oneway_test_setup(SD_VARLINK_SERVER_ONEWAY_NEEDS_REPLY, &e, &s, &c);
+
+        ASSERT_OK(sd_varlink_server_bind_method(s, "io.test.OnewayErrorReturn", method_oneway_error_return));
+        ASSERT_OK(sd_varlink_server_bind_method(s, "io.test.OnewayErrRetPing", method_oneway_errret_ping));
+        ASSERT_OK(sd_varlink_bind_reply(c, reply_oneway_ping));
+
+        oneway_errret_ping_dispatched = false;
+
+        /* The oneway handler returns an error; the pipelined regular call must still be dispatched. */
+        ASSERT_OK(sd_varlink_send(c, "io.test.OnewayErrorReturn", /* parameters= */ NULL));
+        ASSERT_OK(sd_varlink_invoke(c, "io.test.OnewayErrRetPing", /* parameters= */ NULL));
+
+        ASSERT_OK(sd_event_loop(e));
+        ASSERT_TRUE(oneway_errret_ping_dispatched);
+}
+
+static int oneway_fd_deferred_complete(sd_event_source *s, void *userdata) {
+        _cleanup_(sd_varlink_unrefp) sd_varlink *link = ASSERT_PTR(userdata);
+
+        sd_event_source_disable_unref(s);
+        ASSERT_OK(sd_varlink_reply(link, /* parameters= */ NULL));
+        return 0;
+}
+
+static int method_oneway_push_fd(sd_varlink *link, sd_json_variant *parameters, sd_varlink_method_flags_t flags, void *userdata) {
+        _cleanup_close_ int fd = -EBADF;
+        sd_event_source *source;
+
+        ASSERT_TRUE(FLAGS_SET(flags, SD_VARLINK_METHOD_ONEWAY));
+
+        /* Push an fd for the (discarded) oneway reply. Completion must reset it, so it is not carried into
+         * the next enqueued message, i.e. the pipelined regular reply below. */
+        ASSERT_OK(fd = memfd_new_and_seal_string("data", "oneway"));
+        ASSERT_OK_EQ(sd_varlink_push_fd(link, fd), 0);
+        TAKE_FD(fd);
+
+        ASSERT_OK(sd_event_add_defer(sd_varlink_get_event(link), &source, oneway_fd_deferred_complete, sd_varlink_ref(link)));
+        ASSERT_OK(sd_event_source_set_enabled(source, SD_EVENT_ONESHOT));
+        return 0;
+}
+
+static bool oneway_fd_ping_dispatched;
+
+static int method_oneway_fd_ping(sd_varlink *link, sd_json_variant *parameters, sd_varlink_method_flags_t flags, void *userdata) {
+        oneway_fd_ping_dispatched = true;
+        return sd_varlink_replybo(link, SD_JSON_BUILD_PAIR_STRING("result", "pong"));
+}
+
+static int reply_oneway_fd_ping(sd_varlink *link, sd_json_variant *parameters, const char *error_id, sd_varlink_reply_flags_t flags, void *userdata) {
+        ASSERT_NULL(error_id);
+        ASSERT_STREQ(sd_json_variant_string(sd_json_variant_by_key(parameters, "result")), "pong");
+
+        /* The fd the oneway handler pushed was discarded on completion, so this reply carries none. */
+        ASSERT_ERROR(sd_varlink_peek_fd(link, 0), ENXIO);
+        ASSERT_OK(sd_event_exit(sd_varlink_get_event(link), EXIT_SUCCESS));
+        return 0;
+}
+
+TEST(oneway_deferred_resets_fds) {
+        _cleanup_(sd_event_unrefp) sd_event *e = NULL;
+        _cleanup_(sd_varlink_server_unrefp) sd_varlink_server *s = NULL;
+        _cleanup_(sd_varlink_unrefp) sd_varlink *c = NULL;
+        oneway_test_setup(SD_VARLINK_SERVER_ONEWAY_NEEDS_REPLY|
+                          SD_VARLINK_SERVER_ALLOW_FD_PASSING_INPUT|
+                          SD_VARLINK_SERVER_ALLOW_FD_PASSING_OUTPUT, &e, &s, &c);
+
+        ASSERT_OK(sd_varlink_server_bind_method(s, "io.test.OnewayPushFd", method_oneway_push_fd));
+        ASSERT_OK(sd_varlink_server_bind_method(s, "io.test.OnewayFdPing", method_oneway_fd_ping));
+        ASSERT_OK(sd_varlink_set_allow_fd_passing_input(c, true));
+        ASSERT_OK(sd_varlink_set_allow_fd_passing_output(c, true));
+        ASSERT_OK(sd_varlink_bind_reply(c, reply_oneway_fd_ping));
+
+        oneway_fd_ping_dispatched = false;
+
+        /* The oneway handler pushes an fd and defers; after completion the pipelined regular reply must
+         * carry no leftover fd. */
+        ASSERT_OK(sd_varlink_send(c, "io.test.OnewayPushFd", /* parameters= */ NULL));
+        ASSERT_OK(sd_varlink_invoke(c, "io.test.OnewayFdPing", /* parameters= */ NULL));
+
+        ASSERT_OK(sd_event_loop(e));
+        ASSERT_TRUE(oneway_fd_ping_dispatched);
+}
+
+static bool oneway_fiber_ran;
+static bool oneway_fiber_ping_dispatched;
+
+static int method_oneway_fiber_defer(sd_varlink *link, sd_json_variant *parameters, sd_varlink_method_flags_t flags, void *userdata) {
+        /* A fiber handling a oneway call. The fiber holds a ref, so with the flag set the call parks in
+         * VARLINK_PENDING_METHOD_ONEWAY; returning without a reply then completes it from the fiber.
+         * The sentinel set here is discarded for a oneway call and must not disturb this. */
+        ASSERT_TRUE(FLAGS_SET(flags, SD_VARLINK_METHOD_ONEWAY));
+        ASSERT_OK(sd_varlink_set_sentinel(link, "io.test.SentinelError"));
+        oneway_fiber_ran = true;
+        return 0;
+}
+
+static int method_oneway_fiber_ping(sd_varlink *link, sd_json_variant *parameters, sd_varlink_method_flags_t flags, void *userdata) {
+        /* Must only run once the fiber ran and its parked oneway call completed. */
+        ASSERT_TRUE(oneway_fiber_ran);
+        oneway_fiber_ping_dispatched = true;
+        return sd_varlink_replybo(link, SD_JSON_BUILD_PAIR_STRING("result", "pong"));
+}
+
+TEST(oneway_fiber_deferred_parks) {
+        _cleanup_(sd_event_unrefp) sd_event *e = NULL;
+        _cleanup_(sd_varlink_server_unrefp) sd_varlink_server *s = NULL;
+        _cleanup_(sd_varlink_unrefp) sd_varlink *c = NULL;
+        oneway_test_setup(SD_VARLINK_SERVER_ONEWAY_NEEDS_REPLY, &e, &s, &c);
+
+        ASSERT_OK(varlink_server_bind_fiber(s, "io.test.OnewayFiberDefer", method_oneway_fiber_defer));
+        ASSERT_OK(sd_varlink_server_bind_method(s, "io.test.OnewayFiberPing", method_oneway_fiber_ping));
+        ASSERT_OK(sd_varlink_bind_reply(c, reply_oneway_ping));
+
+        oneway_fiber_ran = false;
+        oneway_fiber_ping_dispatched = false;
+
+        /* Fire a oneway call handled by a fiber, immediately followed by a pipelined regular call that
+         * must wait for the fiber to complete the parked oneway call. */
+        ASSERT_OK(sd_varlink_send(c, "io.test.OnewayFiberDefer", /* parameters= */ NULL));
+        ASSERT_OK(sd_varlink_invoke(c, "io.test.OnewayFiberPing", /* parameters= */ NULL));
+
+        ASSERT_OK(sd_event_loop(e));
+        ASSERT_TRUE(oneway_fiber_ping_dispatched);
+        ASSERT_TRUE(oneway_fiber_ran);
+}
+
+static bool oneway_sentinel_ping_dispatched;
+
+static int method_oneway_sentinel_complete(sd_varlink *link, sd_json_variant *parameters, sd_varlink_method_flags_t flags, void *userdata) {
+        /* On a SD_VARLINK_SERVER_ONEWAY_NEEDS_REPLY server, setting a sentinel counts as completing the
+         * oneway call (the discarded error signals completion), so it must complete rather than park. */
+        ASSERT_TRUE(FLAGS_SET(flags, SD_VARLINK_METHOD_ONEWAY));
+        ASSERT_OK(sd_varlink_set_sentinel(link, "io.test.SentinelError"));
+        return 0;
+}
+
+static int method_oneway_sentinel_ping(sd_varlink *link, sd_json_variant *parameters, sd_varlink_method_flags_t flags, void *userdata) {
+        oneway_sentinel_ping_dispatched = true;
+        return sd_varlink_replybo(link, SD_JSON_BUILD_PAIR_STRING("result", "pong"));
+}
+
+TEST(oneway_sentinel_completes) {
+        _cleanup_(sd_event_unrefp) sd_event *e = NULL;
+        _cleanup_(sd_varlink_server_unrefp) sd_varlink_server *s = NULL;
+        _cleanup_(sd_varlink_unrefp) sd_varlink *c = NULL;
+        oneway_test_setup(SD_VARLINK_SERVER_ONEWAY_NEEDS_REPLY, &e, &s, &c);
+
+        ASSERT_OK(sd_varlink_server_bind_method(s, "io.test.OnewaySentinelComplete", method_oneway_sentinel_complete));
+        ASSERT_OK(sd_varlink_server_bind_method(s, "io.test.OnewaySentinelPing", method_oneway_sentinel_ping));
+        ASSERT_OK(sd_varlink_bind_reply(c, reply_oneway_ping));
+
+        oneway_sentinel_ping_dispatched = false;
+
+        /* A oneway handler that sets a sentinel completes immediately; the pipelined regular call must be
+         * dispatched rather than blocked behind a parked connection. */
+        ASSERT_OK(sd_varlink_send(c, "io.test.OnewaySentinelComplete", /* parameters= */ NULL));
+        ASSERT_OK(sd_varlink_invoke(c, "io.test.OnewaySentinelPing", /* parameters= */ NULL));
+
+        ASSERT_OK(sd_event_loop(e));
+        ASSERT_TRUE(oneway_sentinel_ping_dispatched);
+}
+
+static bool oneway_noflag_ping_dispatched;
+
+static int method_oneway_noflag(sd_varlink *link, sd_json_variant *parameters, sd_varlink_method_flags_t flags, void *userdata) {
+        /* Without SD_VARLINK_SERVER_ONEWAY_NEEDS_REPLY a oneway handler that returns without replying is
+         * fire-and-forget (e.g. systemd-oomd): it must complete immediately, not park. */
+        ASSERT_TRUE(FLAGS_SET(flags, SD_VARLINK_METHOD_ONEWAY));
+        return 0;
+}
+
+static int method_oneway_noflag_ping(sd_varlink *link, sd_json_variant *parameters, sd_varlink_method_flags_t flags, void *userdata) {
+        oneway_noflag_ping_dispatched = true;
+        return sd_varlink_replybo(link, SD_JSON_BUILD_PAIR_STRING("result", "pong"));
+}
+
+TEST(oneway_no_flag_completes) {
+        _cleanup_(sd_event_unrefp) sd_event *e = NULL;
+        _cleanup_(sd_varlink_server_unrefp) sd_varlink_server *s = NULL;
+        _cleanup_(sd_varlink_unrefp) sd_varlink *c = NULL;
+        oneway_test_setup(/* flags= */ 0, &e, &s, &c);
+
+        ASSERT_OK(sd_varlink_server_bind_method(s, "io.test.OnewayNoFlag", method_oneway_noflag));
+        ASSERT_OK(sd_varlink_server_bind_method(s, "io.test.OnewayNoFlagPing", method_oneway_noflag_ping));
+        ASSERT_OK(sd_varlink_bind_reply(c, reply_oneway_ping));
+
+        oneway_noflag_ping_dispatched = false;
+
+        /* The oneway handler returns without replying; on a default server it completes at once, so the
+         * pipelined regular call must be dispatched. */
+        ASSERT_OK(sd_varlink_send(c, "io.test.OnewayNoFlag", /* parameters= */ NULL));
+        ASSERT_OK(sd_varlink_invoke(c, "io.test.OnewayNoFlagPing", /* parameters= */ NULL));
+
+        ASSERT_OK(sd_event_loop(e));
+        ASSERT_TRUE(oneway_noflag_ping_dispatched);
+}
+
+static bool oneway_sync_ping_dispatched;
+
+static int method_oneway_sync_reply(sd_varlink *link, sd_json_variant *parameters, sd_varlink_method_flags_t flags, void *userdata) {
+        /* Complete the oneway call synchronously from inside the callback (state PROCESSING_METHOD_ONEWAY).
+         * The discarded reply must be accepted (returning 1), not refused with -EBUSY, so the call is not
+         * left parked. */
+        ASSERT_TRUE(FLAGS_SET(flags, SD_VARLINK_METHOD_ONEWAY));
+        ASSERT_OK_EQ(sd_varlink_reply(link, /* parameters= */ NULL), 1);
+        return 0;
+}
+
+static int method_oneway_sync_ping(sd_varlink *link, sd_json_variant *parameters, sd_varlink_method_flags_t flags, void *userdata) {
+        oneway_sync_ping_dispatched = true;
+        return sd_varlink_replybo(link, SD_JSON_BUILD_PAIR_STRING("result", "pong"));
+}
+
+TEST(oneway_sync_reply_completes) {
+        _cleanup_(sd_event_unrefp) sd_event *e = NULL;
+        _cleanup_(sd_varlink_server_unrefp) sd_varlink_server *s = NULL;
+        _cleanup_(sd_varlink_unrefp) sd_varlink *c = NULL;
+        oneway_test_setup(SD_VARLINK_SERVER_ONEWAY_NEEDS_REPLY, &e, &s, &c);
+
+        ASSERT_OK(sd_varlink_server_bind_method(s, "io.test.OnewaySyncReply", method_oneway_sync_reply));
+        ASSERT_OK(sd_varlink_server_bind_method(s, "io.test.OnewaySyncPing", method_oneway_sync_ping));
+        ASSERT_OK(sd_varlink_bind_reply(c, reply_oneway_ping));
+
+        oneway_sync_ping_dispatched = false;
+
+        /* A oneway handler that replies synchronously (like journald's Synchronize on an idle journal) must
+         * complete, so the pipelined regular call is dispatched. */
+        ASSERT_OK(sd_varlink_send(c, "io.test.OnewaySyncReply", /* parameters= */ NULL));
+        ASSERT_OK(sd_varlink_invoke(c, "io.test.OnewaySyncPing", /* parameters= */ NULL));
+
+        ASSERT_OK(sd_event_loop(e));
+        ASSERT_TRUE(oneway_sync_ping_dispatched);
+}
+
+static bool oneway_syncerr_ping_dispatched;
+
+static int method_oneway_sync_error(sd_varlink *link, sd_json_variant *parameters, sd_varlink_method_flags_t flags, void *userdata) {
+        /* Reject synchronously from inside the callback via the "return sd_varlink_error(...)" idiom (as a
+         * privilege check does). It must return a negative errno so a caller's "if (r < 0) return r;" guard
+         * fires; returning success here would silently bypass such checks. The call still completes. */
+        ASSERT_TRUE(FLAGS_SET(flags, SD_VARLINK_METHOD_ONEWAY));
+        int r = sd_varlink_error(link, "io.test.SomeError", /* parameters= */ NULL);
+        ASSERT_TRUE(r < 0);
+        return r;
+}
+
+static int method_oneway_syncerr_ping(sd_varlink *link, sd_json_variant *parameters, sd_varlink_method_flags_t flags, void *userdata) {
+        oneway_syncerr_ping_dispatched = true;
+        return sd_varlink_replybo(link, SD_JSON_BUILD_PAIR_STRING("result", "pong"));
+}
+
+TEST(oneway_sync_error_rejects) {
+        _cleanup_(sd_event_unrefp) sd_event *e = NULL;
+        _cleanup_(sd_varlink_server_unrefp) sd_varlink_server *s = NULL;
+        _cleanup_(sd_varlink_unrefp) sd_varlink *c = NULL;
+        oneway_test_setup(SD_VARLINK_SERVER_ONEWAY_NEEDS_REPLY, &e, &s, &c);
+
+        ASSERT_OK(sd_varlink_server_bind_method(s, "io.test.OnewaySyncError", method_oneway_sync_error));
+        ASSERT_OK(sd_varlink_server_bind_method(s, "io.test.OnewaySyncErrPing", method_oneway_syncerr_ping));
+        ASSERT_OK(sd_varlink_bind_reply(c, reply_oneway_ping));
+
+        oneway_syncerr_ping_dispatched = false;
+
+        /* The oneway handler rejects synchronously with an error; the pipelined regular call must still be
+         * dispatched (the call completes). */
+        ASSERT_OK(sd_varlink_send(c, "io.test.OnewaySyncError", /* parameters= */ NULL));
+        ASSERT_OK(sd_varlink_invoke(c, "io.test.OnewaySyncErrPing", /* parameters= */ NULL));
+
+        ASSERT_OK(sd_event_loop(e));
+        ASSERT_TRUE(oneway_syncerr_ping_dispatched);
+}
+
+static bool oneway_fibererr_ping_dispatched;
+
+static int method_oneway_fiber_error(sd_varlink *link, sd_json_variant *parameters, sd_varlink_method_flags_t flags, void *userdata) {
+        /* A fiber oneway handler that fails: the error can't be sent (no client), so it is logged and the
+         * call completes, letting the pipelined follow-up run — fail-open, unlike the non-oneway fiber
+         * path which propagates the error to the client and fails the connection. */
+        ASSERT_TRUE(FLAGS_SET(flags, SD_VARLINK_METHOD_ONEWAY));
+        return -ENOANO;
+}
+
+static int method_oneway_fibererr_ping(sd_varlink *link, sd_json_variant *parameters, sd_varlink_method_flags_t flags, void *userdata) {
+        oneway_fibererr_ping_dispatched = true;
+        return sd_varlink_replybo(link, SD_JSON_BUILD_PAIR_STRING("result", "pong"));
+}
+
+TEST(oneway_fiber_error_completes) {
+        _cleanup_(sd_event_unrefp) sd_event *e = NULL;
+        _cleanup_(sd_varlink_server_unrefp) sd_varlink_server *s = NULL;
+        _cleanup_(sd_varlink_unrefp) sd_varlink *c = NULL;
+        oneway_test_setup(SD_VARLINK_SERVER_ONEWAY_NEEDS_REPLY, &e, &s, &c);
+
+        ASSERT_OK(varlink_server_bind_fiber(s, "io.test.OnewayFiberError", method_oneway_fiber_error));
+        ASSERT_OK(sd_varlink_server_bind_method(s, "io.test.OnewayFiberErrPing", method_oneway_fibererr_ping));
+        ASSERT_OK(sd_varlink_bind_reply(c, reply_oneway_ping));
+
+        oneway_fibererr_ping_dispatched = false;
+
+        /* A fiber oneway handler returns an error; it is logged and discarded, so the pipelined regular call
+         * must still be dispatched. */
+        ASSERT_OK(sd_varlink_send(c, "io.test.OnewayFiberError", /* parameters= */ NULL));
+        ASSERT_OK(sd_varlink_invoke(c, "io.test.OnewayFiberErrPing", /* parameters= */ NULL));
+
+        ASSERT_OK(sd_event_loop(e));
+        ASSERT_TRUE(oneway_fibererr_ping_dispatched);
 }
 
 static int method_fiber_sentinel_error(sd_varlink *link, sd_json_variant *parameters, sd_varlink_method_flags_t flags, void *userdata) {

--- a/src/libsystemd/sd-varlink/varlink-internal.h
+++ b/src/libsystemd/sd-varlink/varlink-internal.h
@@ -31,6 +31,7 @@ typedef enum VarlinkState {
         VARLINK_PROCESSED_METHOD_UPGRADE,
         VARLINK_PENDING_METHOD,
         VARLINK_PENDING_METHOD_MORE,
+        VARLINK_PENDING_METHOD_ONEWAY,
         VARLINK_PENDING_METHOD_UPGRADE,
         VARLINK_UPGRADING,
 
@@ -69,6 +70,7 @@ typedef enum VarlinkState {
                VARLINK_PROCESSED_METHOD_UPGRADE,        \
                VARLINK_PENDING_METHOD,                  \
                VARLINK_PENDING_METHOD_MORE,             \
+               VARLINK_PENDING_METHOD_ONEWAY,           \
                VARLINK_PENDING_METHOD_UPGRADE,          \
                VARLINK_UPGRADING)
 
@@ -79,6 +81,22 @@ typedef enum VarlinkState {
                VARLINK_PROCESSING_METHOD,               \
                VARLINK_PROCESSING_METHOD_MORE,          \
                VARLINK_PROCESSING_METHOD_UPGRADE)
+
+/* Tests whether a method call callback is currently executing synchronously, regardless of its kind. */
+#define VARLINK_STATE_IS_PROCESSING_METHOD(state)       \
+        IN_SET(state,                                   \
+               VARLINK_PROCESSING_METHOD,               \
+               VARLINK_PROCESSING_METHOD_MORE,          \
+               VARLINK_PROCESSING_METHOD_ONEWAY,        \
+               VARLINK_PROCESSING_METHOD_UPGRADE)
+
+/* Tests whether a method call is parked, i.e. waiting to be completed asynchronously. */
+#define VARLINK_STATE_IS_PENDING_METHOD(state)          \
+        IN_SET(state,                                   \
+               VARLINK_PENDING_METHOD,                  \
+               VARLINK_PENDING_METHOD_MORE,             \
+               VARLINK_PENDING_METHOD_ONEWAY,           \
+               VARLINK_PENDING_METHOD_UPGRADE)
 
 typedef struct sd_varlink {
         unsigned n_ref;

--- a/src/systemd/sd-varlink.h
+++ b/src/systemd/sd-varlink.h
@@ -73,6 +73,7 @@ __extension__ typedef enum _SD_ENUM_TYPE_S64(sd_varlink_server_flags_t) {
         SD_VARLINK_SERVER_HANDLE_SIGINT           = 1 << 8, /* Exit cleanly on SIGINT */
         SD_VARLINK_SERVER_HANDLE_SIGTERM          = 1 << 9, /* Exit cleanly on SIGTERM */
         SD_VARLINK_SERVER_UPGRADABLE              = 1 << 10, /* Server has upgrade methods; avoid consuming post-upgrade data during reads */
+        SD_VARLINK_SERVER_ONEWAY_NEEDS_REPLY      = 1 << 11, /* Oneway method calls stay parked until the handler replies/errors, instead of completing when the callback returns */
         _SD_ENUM_FORCE_S64(SD_VARLINK_SERVER)
 } sd_varlink_server_flags_t;
 


### PR DESCRIPTION
A server method handler for a one-way call may defer completion by
stashing the connection and finishing asynchronously.
The connection returns to idle as soon as the handler returns, so a
pipelined follow-up method could be dispatched while the handler is
still mutating per-connection state, causing a type confusion.

Introduce VARLINK_PENDING_METHOD_ONEWAY to park the connection until the
deferred handler signals completion, just like VARLINK_PENDING_METHOD.
The reply is discarded, as one-way clients do not listen for one.

Parking is opt-in via the new SD_VARLINK_SERVER_ONEWAY_NEEDS_REPLY
server flag, without it a one-way call completes as soon as the handler
returns, keeping existing fire-and-forget handlers unaffected. With it,
a handler that returns without replying is parked until it replies or
errors.

Follow-up for fb687fe62a15604b6157783fb1c7820ad8c7ee71