### PR TITLE
journalctl: add follow mode to the varlink method

### DIFF
--- a/src/journal/journalctl-varlink-server.c
+++ b/src/journal/journalctl-varlink-server.c
@@ -1,5 +1,6 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
+#include "sd-event.h"
 #include "sd-journal.h"
 #include "sd-varlink.h"
 
@@ -22,6 +23,7 @@ typedef struct GetEntriesParameters {
         uid_t uid;
         int priority;
         uint64_t limit;
+        bool follow;
 } GetEntriesParameters;
 
 static void get_entries_parameters_done(GetEntriesParameters *p) {
@@ -29,6 +31,148 @@ static void get_entries_parameters_done(GetEntriesParameters *p) {
 
         p->units = strv_free(p->units);
         p->user_units = strv_free(p->user_units);
+}
+
+typedef struct FollowState {
+        sd_journal *journal;
+        sd_varlink *link;
+        sd_event_source *io_event_source;
+} FollowState;
+
+static FollowState* follow_state_free(FollowState *fs) {
+        if (!fs)
+                return NULL;
+
+        sd_event_source_disable_unref(fs->io_event_source);
+        sd_journal_close(fs->journal);
+        sd_varlink_unref(fs->link);
+
+        return mfree(fs);
+}
+
+DEFINE_TRIVIAL_CLEANUP_FUNC(FollowState*, follow_state_free);
+
+void vl_on_disconnect(sd_varlink_server *server, sd_varlink *link, void *userdata) {
+        assert(server);
+        assert(link);
+
+        follow_state_free(sd_varlink_set_userdata(link, NULL));
+}
+
+static int entry_to_json_and_send(sd_journal *j, sd_varlink *link, bool follow) {
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *entry = NULL;
+        int r;
+
+        assert(j);
+        assert(link);
+
+        r = journal_entry_to_json(j, OUTPUT_SHOW_ALL, /* output_fields= */ NULL, &entry);
+        if (r <= 0)
+                return r; /* 0: skip corrupted entry */
+
+        if (follow)
+                r = sd_varlink_notifybo(link, SD_JSON_BUILD_PAIR_VARIANT("entry", entry));
+        else
+                r = sd_varlink_replybo(link, SD_JSON_BUILD_PAIR_VARIANT("entry", entry));
+        if (r < 0)
+                return r;
+
+        return 1;
+}
+
+static int follow_drain(FollowState *fs) {
+        int r;
+
+        assert(fs);
+
+        for (;;) {
+                r = sd_journal_next(fs->journal);
+                if (r < 0)
+                        return r;
+                if (r == 0)
+                        return 0;
+
+                r = entry_to_json_and_send(fs->journal, fs->link, /* follow= */ true);
+                if (r < 0)
+                        return r;
+        }
+}
+
+static int follow_dispatch(FollowState *fs) {
+        int r;
+
+        assert(fs);
+
+        r = sd_journal_process(fs->journal);
+        if (r < 0)
+                goto fail;
+
+        if (r != SD_JOURNAL_NOP) {
+                r = follow_drain(fs);
+                if (r < 0)
+                        goto fail;
+        }
+
+        return 0;
+
+fail:
+        log_warning_errno(r, "Failed to stream journal entries, completing call: %m");
+
+        _cleanup_(sd_varlink_unrefp) sd_varlink *link = sd_varlink_ref(fs->link);
+
+        /* drop our state before replying, so that the disconnect callback won't free it a second time */
+        follow_state_free(sd_varlink_set_userdata(link, NULL));
+
+        (void) sd_varlink_error_errno(link, r);
+
+        return 0;
+}
+
+static int follow_on_journal_io(sd_event_source *s, int fd, uint32_t revents, void *userdata) {
+        FollowState *fs = ASSERT_PTR(userdata);
+
+        return follow_dispatch(fs);
+}
+
+static int follow_state_setup(sd_varlink *link, sd_journal *_j /* donated! */) {
+        _cleanup_(sd_journal_closep) sd_journal *j = TAKE_PTR(_j); /* take possession in all cases */
+        _cleanup_(follow_state_freep) FollowState *fs = NULL;
+        int r;
+
+        assert(link);
+        assert(j);
+
+        sd_varlink_server *server = ASSERT_PTR(sd_varlink_get_server(link));
+        sd_event *event = ASSERT_PTR(sd_varlink_server_get_event(server));
+
+        fs = new(FollowState, 1);
+        if (!fs)
+                return -ENOMEM;
+
+        *fs = (FollowState) {
+                .journal = TAKE_PTR(j),
+                .link = sd_varlink_ref(link),
+        };
+
+        int fd = sd_journal_get_fd(fs->journal);
+        if (fd < 0)
+                return fd;
+
+        int events = sd_journal_get_events(fs->journal);
+        if (events < 0)
+                return events;
+
+        r = sd_event_add_io(event, &fs->io_event_source, fd, (uint32_t) events, follow_on_journal_io, fs);
+        if (r < 0)
+                return r;
+
+        (void) sd_event_source_set_description(fs->io_event_source, "journal-follow-io");
+
+        /* stashed on the link for vl_on_disconnect(); the link ref taken above also tells the varlink
+         * dispatcher that the call is deliberately left pending */
+        sd_varlink_set_userdata(link, TAKE_PTR(fs));
+
+        return 0;
 }
 
 int vl_method_get_entries(sd_varlink *link, sd_json_variant *parameters, sd_varlink_method_flags_t flags, void *userdata) {
@@ -40,6 +184,7 @@ int vl_method_get_entries(sd_varlink *link, sd_json_variant *parameters, sd_varl
                 { "namespace", SD_JSON_VARIANT_STRING,        sd_json_dispatch_const_string, offsetof(GetEntriesParameters, namespace),  0 },
                 { "priority",  _SD_JSON_VARIANT_TYPE_INVALID, json_dispatch_log_level,       offsetof(GetEntriesParameters, priority),   0 },
                 { "limit",     _SD_JSON_VARIANT_TYPE_INVALID, sd_json_dispatch_uint64,       offsetof(GetEntriesParameters, limit),      0 },
+                { "follow",    SD_JSON_VARIANT_BOOLEAN,       sd_json_dispatch_stdbool,      offsetof(GetEntriesParameters, follow),     0 },
                 {}
         };
 
@@ -62,7 +207,7 @@ int vl_method_get_entries(sd_varlink *link, sd_json_variant *parameters, sd_varl
 
         /* systemd ships with sensible defaults for the system/user services and the socket permissions so we
          * do not need to do extra sd_varlink_get_peer_uid() or policykit checks here */
-        r = sd_journal_open_namespace(&j, p.namespace, SD_JOURNAL_LOCAL_ONLY | SD_JOURNAL_ASSUME_IMMUTABLE);
+        r = sd_journal_open_namespace(&j, p.namespace, SD_JOURNAL_LOCAL_ONLY | (p.follow ? 0 : SD_JOURNAL_ASSUME_IMMUTABLE));
         if (r < 0)
                 return r;
 
@@ -84,6 +229,13 @@ int vl_method_get_entries(sd_varlink *link, sd_json_variant *parameters, sd_varl
                         return r;
         }
 
+        /* create the inotify watch before draining the backlog, so entries logged in between wake us up */
+        if (p.follow) {
+                r = sd_journal_get_fd(j);
+                if (r < 0)
+                        return r;
+        }
+
         /* this simulates "journalctl -n $p.limit" */
         r = sd_journal_seek_tail(j);
         if (r < 0)
@@ -99,28 +251,40 @@ int vl_method_get_entries(sd_varlink *link, sd_json_variant *parameters, sd_varl
         if (r < 0)
                 return r;
 
-        r = sd_varlink_set_sentinel(link, "io.systemd.JournalAccess.NoEntries");
-        if (r < 0)
-                return r;
+        /* no sentinel in follow mode: an empty backlog is fine, the stream simply stays open */
+        if (!p.follow) {
+                r = sd_varlink_set_sentinel(link, "io.systemd.JournalAccess.NoEntries");
+                if (r < 0)
+                        return r;
+        }
 
+        uint64_t n_sent = 0;
         for (uint64_t i = 0; i < n; i++) {
-                _cleanup_(sd_json_variant_unrefp) sd_json_variant *entry = NULL;
-
                 r = sd_journal_next(j);
                 if (r < 0)
                         return r;
                 if (r == 0)
                         break;
 
-                r = journal_entry_to_json(j, OUTPUT_SHOW_ALL, /* output_fields= */ NULL, &entry);
+                r = entry_to_json_and_send(j, link, p.follow);
                 if (r < 0)
                         return r;
-                if (r == 0)
-                        continue; /* skip corrupted entry */
 
-                r = sd_varlink_replybo(link, SD_JSON_BUILD_PAIR_VARIANT("entry", entry));
-                if (r < 0)
-                        return r;
+                n_sent++;
+        }
+
+        if (p.follow) {
+                if (n_sent == 0) {
+                        /* The backlog matched nothing, hence the journal contains no matching entry at all
+                         * and anything that matches from now on is new. Seek to head like journalctl's
+                         * on_first_event() does, instead of to the current realtime, which would race
+                         * against entries logged while we were setting up. */
+                        r = sd_journal_seek_head(j);
+                        if (r < 0)
+                                return r;
+                }
+
+                return follow_state_setup(link, TAKE_PTR(j));
         }
 
         return 0;

--- a/src/journal/journalctl-varlink-server.h
+++ b/src/journal/journalctl-varlink-server.h
@@ -4,3 +4,4 @@
 #include "sd-varlink.h"
 
 int vl_method_get_entries(sd_varlink *link, sd_json_variant *parameters, sd_varlink_method_flags_t flags, void *userdata);
+void vl_on_disconnect(sd_varlink_server *server, sd_varlink *link, void *userdata);

--- a/src/journal/journalctl.c
+++ b/src/journal/journalctl.c
@@ -334,6 +334,11 @@ static int vl_server(void) {
         if (r < 0)
                 return log_error_errno(r, "Failed to bind Varlink methods: %m");
 
+        /* tears down the streaming state of GetEntries follow=true calls when the client goes away */
+        r = sd_varlink_server_bind_disconnect(varlink_server, vl_on_disconnect);
+        if (r < 0)
+                return log_error_errno(r, "Failed to bind Varlink disconnect handler: %m");
+
         r = sd_varlink_server_loop_auto(varlink_server);
         if (r < 0)
                 return log_error_errno(r, "Failed to run Varlink event loop: %m");

--- a/src/shared/varlink-io.systemd.JournalAccess.c
+++ b/src/shared/varlink-io.systemd.JournalAccess.c
@@ -17,6 +17,8 @@ static SD_VARLINK_DEFINE_METHOD_FULL(
                 SD_VARLINK_DEFINE_INPUT(priority, SD_VARLINK_INT, SD_VARLINK_NULLABLE),
                 SD_VARLINK_FIELD_COMMENT("Maximum number of entries to return. Defaults to 100, capped at 10000."),
                 SD_VARLINK_DEFINE_INPUT(limit, SD_VARLINK_INT, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("If true, do not complete after sending the newest entries: keep the call open and stream new entries as they are logged, until the client disconnects. The limit parameter then bounds only the initial backlog."),
+                SD_VARLINK_DEFINE_INPUT(follow, SD_VARLINK_BOOL, SD_VARLINK_NULLABLE),
                 SD_VARLINK_FIELD_COMMENT("The journal entry in flat JSON format, matching journalctl --output=json."),
                 SD_VARLINK_DEFINE_OUTPUT(entry, SD_VARLINK_OBJECT, 0));
 

--- a/test/units/TEST-04-JOURNAL.journalctl-varlink.sh
+++ b/test/units/TEST-04-JOURNAL.journalctl-varlink.sh
@@ -79,3 +79,56 @@ varlinkctl_get_entries '{"priority": 4, "limit": 1000}' | grep "varlink-test-war
 
 # NoEntries error is raised if there is no result
 (! varlinkctl call --more "$VARLINK_SOCKET" io.systemd.JournalAccess.GetEntries '{"units": ["nonexistent-unit-that-should-have-no-entries.service"]}' 2>&1 | grep io.systemd.JournalAccess.NoEntries )
+
+# follow mode: after the backlog the call stays open and new entries are streamed
+FOLLOW_OUT="$(mktemp)"
+FOLLOW_UNIT_OUT="$(mktemp)"
+FOLLOW_PID=""
+FOLLOW_UNIT_PID=""
+cleanup_follow() {
+    [[ -n "$FOLLOW_PID" ]] && kill "$FOLLOW_PID" 2>/dev/null || :
+    [[ -n "$FOLLOW_UNIT_PID" ]] && kill "$FOLLOW_UNIT_PID" 2>/dev/null || :
+    rm -f "$FOLLOW_OUT" "$FOLLOW_UNIT_OUT"
+}
+trap cleanup_follow EXIT
+
+# -E is short for --more --timeout=infinity: without it varlinkctl gives up on quiet streams after 45s.
+# Filter by our own unit: with debug logging the server instance traces every message it sends into
+# the very journal it is following, feeding back on itself until the output queue limit (-ENOBUFS)
+# kills the connection.
+varlinkctl call -E "$VARLINK_SOCKET" io.systemd.JournalAccess.GetEntries \
+    '{"follow": true, "limit": 2, "units": ["TEST-04-JOURNAL.service"]}' >"$FOLLOW_OUT" &
+FOLLOW_PID=$!
+
+# the backlog arrives quickly and the call does not complete
+timeout 30 bash -c "until [[ \$(wc -l <'$FOLLOW_OUT') -ge 2 ]]; do sleep .5; done"
+kill -0 "$FOLLOW_PID"
+
+# new entries are pushed into the stream as they are logged
+echo "varlink-follow-live-1" | systemd-cat -t "$TAG"
+journalctl --sync
+timeout 30 bash -c "until grep -q varlink-follow-live-1 '$FOLLOW_OUT'; do sleep .5; done"
+echo "varlink-follow-live-2" | systemd-cat -t "$TAG"
+journalctl --sync
+timeout 30 bash -c "until grep -q varlink-follow-live-2 '$FOLLOW_OUT'; do sleep .5; done"
+kill -0 "$FOLLOW_PID"
+
+# follow composes with filters, and an empty backlog does not complete the call
+FOLLOW_UNIT="test-journalctl-varlink-follow-$RANDOM.service"
+varlinkctl call -E "$VARLINK_SOCKET" io.systemd.JournalAccess.GetEntries "{\"follow\": true, \"units\": [\"$FOLLOW_UNIT\"]}" >"$FOLLOW_UNIT_OUT" &
+FOLLOW_UNIT_PID=$!
+sleep 1
+kill -0 "$FOLLOW_UNIT_PID"
+test ! -s "$FOLLOW_UNIT_OUT"
+
+systemd-run --unit="$FOLLOW_UNIT" --wait bash -c 'echo hello-from-follow-test'
+journalctl --sync
+timeout 30 bash -c "until grep -q hello-from-follow-test '$FOLLOW_UNIT_OUT'; do sleep .5; done"
+(! grep -q varlink-follow-live-1 "$FOLLOW_UNIT_OUT")
+
+# on client disconnect the socket-activated server instances exit again (exit-on-idle)
+kill "$FOLLOW_PID" "$FOLLOW_UNIT_PID"
+FOLLOW_PID=""
+FOLLOW_UNIT_PID=""
+# shellcheck disable=SC2016
+timeout 30 bash -c 'until [[ $(systemctl list-units --no-legend --plain "systemd-journalctl@*.service" | wc -l) -eq 0 ]]; do sleep .5; done'


### PR DESCRIPTION
This commit implements `journalctl -f` like behavior for the varlink API of journalctl. It is used via:
```
$ varlinkctl call -E \
    /run/systemd/io.systemd.JournalAccess \
    io.systemd.JournalAccess.GetEntries '{"follow": true, "limit": 10}'
```
This gives the last 10 message and then it keeps the connection open and output each new log line that matches the set filters.

The code is modeled after `journalctl -f`. It seems there is little to extract into shared code here so I left it for now.