### PR TITLE
hwdb: map mic-mute key on Logitech K950 (Bluetooth)

### DIFF
--- a/hwdb.d/60-keyboard.hwdb
+++ b/hwdb.d/60-keyboard.hwdb
@@ -1432,6 +1432,10 @@ evdev:input:b0005v046DpB317*
  KEYBOARD_KEY_70047=brightnessdown
  KEYBOARD_KEY_70048=brightnessup
 
+# Logitech K950
+evdev:input:b0005v046DpB388*
+ KEYBOARD_KEY_100e1=micmute                             # Mic-mute key emits BTN_0
+
 # iTouch
 evdev:input:b0003v046DpC308*
  KEYBOARD_KEY_90001=shop                                # Shopping


### PR DESCRIPTION
The mic-mute key on the Logitech K950 (046D:B388, Bluetooth) emits `BTN_0` (scancode `0x100e1`) and therefore does nothing under GNOME/KDE. This maps it to `KEY_MICMUTE`.

Scancode captured with `evtest` on the actual device and verified working after `systemd-hwdb update`. Only the Bluetooth connection (bus `0005`) is covered — I don't have the Bolt/USB receiver to confirm that variant.

> ⚠️ **Disclaimer:** This one-line fix was prepared with AI assistance (Claude Code). The scancode was captured and verified on real hardware.
