### PR TITLE
measure-smbios: bound type 1 length before zeroing wake-up type

### DIFF
--- a/src/boot/measure-smbios.c
+++ b/src/boot/measure-smbios.c
@@ -41,14 +41,27 @@ static void measure_smbios_type1(const SmbiosHeader *header, size_t size, bool *
 
         /* The wake-up type field varies depending on how the machine was powered on (cold boot, resume
          * from sleep, AC restore, …), which would make the measurement non-reproducible. Hence measure a
-         * copy with that field zeroed out. */
+         * copy with that field zeroed out.
+         *
+         * Whether the field is present is governed by the formatted-area length header->length (as in
+         * get_smbios_table()), not the total size which also covers the trailing string set. If the
+         * formatted area is too short to reach it (e.g. a legacy SMBIOS 2.0 record), there's nothing to
+         * normalize, so measure the structure as-is. This length comes from the (untrusted) firmware
+         * SMBIOS table and assert() is a no-op in release sd-boot builds, so it must be checked here
+         * before the copy is written to at a fixed offset. */
 
-        assert(size >= sizeof(SmbiosTableType1));
+        _cleanup_free_ SmbiosTableType1 *copy = NULL;
+        const void *p = header;
 
-        _cleanup_free_ SmbiosTableType1 *copy = xmemdup(header, size);
-        copy->wake_up_type = 0;
+        if (header->length > offsetof(SmbiosTableType1, wake_up_type)) {
+                copy = xmemdup(header, size);
+                memzero((uint8_t*) copy + offsetof(SmbiosTableType1, wake_up_type),
+                        MIN(sizeof_field(SmbiosTableType1, wake_up_type),
+                            header->length - offsetof(SmbiosTableType1, wake_up_type)));
+                p = copy;
+        }
 
-        measure_smbios_raw(copy, size, SMBIOS_TYPE1_EVENT_TAG_ID, u"smbios:type1", measured);
+        measure_smbios_raw(p, size, SMBIOS_TYPE1_EVENT_TAG_ID, u"smbios:type1", measured);
 }
 
 static bool measure_smbios_object(const SmbiosHeader *header, size_t size, void *userdata) {


### PR DESCRIPTION
**Heap overflow zeroing wake-up type on a short SMBIOS type 1**
The structure length comes from the firmware SMBIOS table and the only bound before the copy is written to is an `assert()`, which is a no-op in release sd-boot builds. A type 1 record shorter than the struct (an old SMBIOS 2.0 one, or a crafted 6-byte header + empty string set) makes the fixed-offset `wake_up_type` write at offset 24 land past the `xmemdup()` copy. `get_smbios_table()` already rejects short structures with `header->length < min_size`; the measurement path had no equivalent. Short records are now measured as-is.