### PR TITLE
repart: allow empty EncryptedVolume= volume name

### DIFF
--- a/src/repart/repart.c
+++ b/src/repart/repart.c
@@ -2700,7 +2700,9 @@ static int config_parse_encrypted_volume(
                 return 0;
         }
 
-        if (!filename_is_valid(volume)) {
+        if (isempty(volume))
+                volume = mfree(volume);
+        else if (!filename_is_valid(volume)) {
                 log_syntax(unit, LOG_WARNING, filename, line, 0,
                            "Volume name %s is not valid, ignoring", volume);
                 return 0;

--- a/test/units/TEST-58-REPART.sh
+++ b/test/units/TEST-58-REPART.sh
@@ -2447,6 +2447,40 @@ EOF
     losetup -d "$loop"
 }
 
+testcase_encrypted_volume_empty_name() {
+    local defs imgs
+
+    defs="$(mktemp --directory "/tmp/test-repart.defs.XXXXXXXXXX")"
+    imgs="$(mktemp --directory "/var/tmp/test-repart.imgs.XXXXXXXXXX")"
+    # shellcheck disable=SC2064
+    trap "rm -rf '$defs' '$imgs'" RETURN
+    chmod 0755 "$defs"
+
+    echo "*** testcase for EncryptedVolume= with empty volume name ***"
+
+    tee "$defs/root.conf" <<EOF
+[Partition]
+Type=linux-generic
+Format=ext4
+Encrypt=key-file
+EncryptedVolume=:none:discard
+EOF
+
+    systemd-repart --pretty=yes \
+                   --definitions "$defs" \
+                   --empty=create \
+                   --size=100M \
+                   --seed="$seed" \
+                   --dry-run=no \
+                   --offline="$OFFLINE" \
+                   --generate-crypttab="$imgs/crypttab" \
+                   "$imgs/emptyvolname.img"
+
+    # systemd-repart should fill in volume name as luks-UUID
+    grep -Eq '^luks-[0-9a-f-]{36} UUID=[0-9a-f-]{36} none discard$' \
+        "$imgs/crypttab"
+}
+
 testcase_block_device_replace() {
     if [[ "$OFFLINE" == "yes" ]]; then
         return 0


### PR DESCRIPTION
Treat an empty volume name alongside other fields as unset instead of rejecting it as invalid.

Example use case:
```
EncryptedVolume=:none:discard
```

In this case, the volume name is not specified so it can be generated as luks-UUID.

From the docs:

> EncryptedVolume=
>    Specifies how the encrypted partition should be set up. Takes at least one and at most four fields separated with a colon (":"). The first field specifies the encrypted volume name under /dev/mapper/. If not specified, "luks-UUID" will be used where "UUID" is the LUKS UUID.