### PR TITLE
man: note about ordering using systemd.device

### DIFF
--- a/man/systemd.device.xml
+++ b/man/systemd.device.xml
@@ -60,6 +60,11 @@
     corresponding device generates a <literal>changed</literal> event.
     Other units can use <varname>ReloadPropagatedFrom=</varname> to react
     to that event.</para>
+
+    <para>To order a unit with respect to a device unit, use
+    <literal>Before=</literal> / <literal>After=</literal> and
+    <literal>Wants=</literal> / <literal>Requires=</literal> / <literal>BindsTo=</literal>,
+    but not <literal>Requisite=</literal>.</para>
   </refsect1>
 
   <refsect1>


### PR DESCRIPTION
I just ran into the same issue as #4756.
If I read the discussion correctly, `After=` has no effect on a `.device` unit without a requirement dependency, which creates start job in the queue to wait for the device.

Added a minimal note about this in `systemd.device`. Not sure if it's correct or good... feel free to change it.