### PR TITLE
sysupdate: handle slashes after pattern fields

### DIFF
--- a/src/sysupdate/sysupdate-pattern.c
+++ b/src/sysupdate/sysupdate-pattern.c
@@ -248,12 +248,14 @@ int pattern_match(const char *pattern, const char *s, InstanceMetadata *ret) {
                 }
 
                 if (e->elements_next) {
-                        /* The next element must be literal, as we use it to determine where to split */
-                        assert(e->elements_next->type == PATTERN_LITERAL);
-
-                        n = strstr(p, e->elements_next->literal);
-                        if (!n)
-                                goto nope;
+                        if (e->elements_next->type == PATTERN_LITERAL) {
+                                n = strstr(p, e->elements_next->literal);
+                                if (!n)
+                                        goto nope;
+                        } else if (e->elements_next->type == PATTERN_SLASH)
+                                n = strchrnul(p, '/');
+                        else
+                                assert_not_reached();
 
                 } else
                         /* End of the string */


### PR DESCRIPTION
before fix:
```
$ SYSUPDATE="$(command -v systemd-sysupdate || echo /usr/lib/systemd/systemd-sysupdate)"

rm -rf /tmp/sysupdate-repro
mkdir -p /tmp/sysupdate-repro/{defs,source/foo_1,target}

echo test >/tmp/sysupdate-repro/source/foo_1/bar.efi

cat >/tmp/sysupdate-repro/defs/01-repro.transfer <<'EOF'
[Source]
Type=regular-file
Path=/tmp/sysupdate-repro/source
MatchPattern=foo_@v/bar.efi

[Target]
Type=regular-file
Path=/tmp/sysupdate-repro/target
MatchPattern=foo_@v/bar.efi
InstancesMax=2
EOF

"$SYSUPDATE" --definitions=/tmp/sysupdate-repro/defs --verify=no list
Discovering installed instances…
Discovering available instances…
Assertion 'e->elements_next->type == PATTERN_LITERAL' failed at src/sysupdate/sysupdate-pattern.c:252, function pattern_match(). Aborting.
Aborted                  (core dumped) "$SYSUPDATE" --definitions=/tmp/sysupdate-repro/defs --verify=no list
```
after fix:
```
$ SYSUPDATE="$(command -v systemd-sysupdate || echo /usr/lib/systemd/systemd-sysupdate)"

rm -rf /tmp/sysupdate-repro
mkdir -p /tmp/sysupdate-repro/{defs,source/foo_1,target}

echo test >/tmp/sysupdate-repro/source/foo_1/bar.efi

cat >/tmp/sysupdate-repro/defs/01-repro.transfer <<'EOF'
[Source]
Type=regular-file
Path=/tmp/sysupdate-repro/source
MatchPattern=foo_@v/bar.efi

[Target]
Type=regular-file
Path=/tmp/sysupdate-repro/target
MatchPattern=foo_@v/bar.efi
InstancesMax=2
EOF

"$SYSUPDATE" --definitions=/tmp/sysupdate-repro/defs --verify=no list
Discovering installed instances…
Discovering available instances…
Determining installed update sets…
Determining available update sets…
  VERSION INSTALLED AVAILABLE ASSESSMENT
↻ 1                     ✓     candidate 
```
Fixes #42895.