### PR TITLE
sbsign: write unaligned signature size into WIN_CERTIFICATE header (#42884)

### DIFF
--- a/src/sbsign/sbsign.c
+++ b/src/sbsign/sbsign.c
@@ -633,7 +633,7 @@ static int verb_sign(int argc, char *argv[], uintptr_t _data, void *userdata) {
                    &(WIN_CERTIFICATE_HEADER) {
                            .wRevision = htole16(0x200),
                            .wCertificateType = htole16(0x0002), /* PKCS7 signedData */
-                           .dwLength = htole32(ROUND_UP(certsz, 8)),
+                           .dwLength = htole32(certsz),
                    },
                    sizeof(WIN_CERTIFICATE_HEADER),
                    end);


### PR DESCRIPTION
The inclusion of padding bytes in the signature size can lead to the signature being rejected by strict PKCS7 parsers. Meanwhile, according to [1], the parser of the WIN_CERTIFICATE structure is expected to round up the value of dwLength to an 8-byte multiple. This also matches the behaviour of the sbsign tool from sbsigntools.

Fixes #42884

[1] https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#the-attribute-certificate-table-image-only