### PR TITLE
efivars: persist EFI variable writes on firmware with a file-backed variable store (EBBR)

### DIFF
--- a/src/basic/efivars.c
+++ b/src/basic/efivars.c
@@ -8,12 +8,9 @@
 #include <unistd.h>
 
 #include "alloc-util.h"
-#include "chattr-util.h"
 #include "efivars.h"
 #include "fd-util.h"
-#include "io-util.h"
 #include "log.h"
-#include "memory-util.h"
 #include "stat-util.h"
 #include "string-util.h"
 #include "time-util.h"
@@ -202,121 +199,6 @@ int efi_get_variable_path(const char *variable, char **ret) {
                 efi_tilt_backslashes(*ret);
 
         return r;
-}
-
-static int efi_verify_variable(const char *variable, uint32_t attr, const void *value, size_t size) {
-        _cleanup_free_ void *buf = NULL;
-        size_t n;
-        uint32_t a;
-        int r;
-
-        assert(variable);
-        assert(value || size == 0);
-
-        r = efi_get_variable(variable, &a, &buf, &n);
-        if (r < 0)
-                return r;
-
-        return a == attr && memcmp_nn(buf, n, value, size) == 0;
-}
-
-int efi_set_variable(const char *variable, const void *value, size_t size) {
-        static const uint32_t attr = EFI_VARIABLE_NON_VOLATILE|EFI_VARIABLE_BOOTSERVICE_ACCESS|EFI_VARIABLE_RUNTIME_ACCESS;
-
-        _cleanup_free_ struct var {
-                uint32_t attr;
-                char buf[];
-        } _packed_ *buf = NULL;
-        _cleanup_close_ int fd = -EBADF;
-        bool saved_flags_valid = false;
-        unsigned saved_flags;
-        int r;
-
-        assert(variable);
-        assert(value || size == 0);
-
-        /* size 0 means removal, empty variable would not be enough for that */
-        if (size > 0 && efi_verify_variable(variable, attr, value, size) > 0) {
-                log_debug("Variable '%s' is already in wanted state, skipping write.", variable);
-                return 0;
-        }
-
-        const char *p = strjoina("/sys/firmware/efi/efivars/", variable);
-
-        /* Newer efivarfs protects variables that are not in an allow list with FS_IMMUTABLE_FL by default,
-         * to protect them for accidental removal and modification. We are not changing these variables
-         * accidentally however, hence let's unset the bit first. */
-
-        r = chattr_full(AT_FDCWD, p,
-                        /* value= */ 0,
-                        /* mask= */ FS_IMMUTABLE_FL,
-                        /* ret_previous= */ &saved_flags,
-                        /* ret_final= */ NULL,
-                        /* flags= */ 0);
-        if (r < 0 && r != -ENOENT)
-                log_debug_errno(r, "Failed to drop FS_IMMUTABLE_FL flag from '%s', ignoring: %m", p);
-
-        saved_flags_valid = r >= 0;
-
-        if (size == 0) {
-                if (unlink(p) < 0) {
-                        r = -errno;
-                        goto finish;
-                }
-
-                return 0;
-        }
-
-        fd = open(p, O_WRONLY|O_CREAT|O_NOCTTY|O_CLOEXEC, 0644);
-        if (fd < 0) {
-                r = -errno;
-                goto finish;
-        }
-
-        buf = malloc(sizeof(uint32_t) + size);
-        if (!buf) {
-                r = -ENOMEM;
-                goto finish;
-        }
-
-        buf->attr = attr;
-        memcpy(buf->buf, value, size);
-
-        r = loop_write(fd, buf, sizeof(uint32_t) + size);
-        if (r < 0)
-                goto finish;
-
-        /* For some reason efivarfs doesn't update mtime automatically. Let's do it manually then. This is
-         * useful for processes that cache EFI variables to detect when changes occurred. */
-        if (futimens(fd, /* times= */ NULL) < 0)
-                log_debug_errno(errno, "Failed to update mtime/atime on %s, ignoring: %m", p);
-
-        r = 0;
-
-finish:
-        if (saved_flags_valid) {
-                int q;
-
-                /* Restore the original flags field, just in case */
-                if (fd < 0)
-                        q = chattr_path(p, saved_flags, FS_IMMUTABLE_FL);
-                else
-                        q = chattr_fd(fd, saved_flags, FS_IMMUTABLE_FL);
-                if (q < 0)
-                        log_debug_errno(q, "Failed to restore FS_IMMUTABLE_FL on '%s', ignoring: %m", p);
-        }
-
-        return r;
-}
-
-int efi_set_variable_string(const char *variable, const char *value) {
-        _cleanup_free_ char16_t *u16 = NULL;
-
-        u16 = utf8_to_utf16(value, SIZE_MAX);
-        if (!u16)
-                return -ENOMEM;
-
-        return efi_set_variable(variable, u16, (char16_strlen(u16) + 1) * sizeof(char16_t));
 }
 
 static int cache_efi_boot = -1;

--- a/src/basic/efivars.c
+++ b/src/basic/efivars.c
@@ -19,11 +19,6 @@
 
 #if ENABLE_EFI
 
-/* Reads from efivarfs sometimes fail with EINTR. Retry that many times. */
-#define EFI_N_RETRIES_NO_DELAY 20
-#define EFI_N_RETRIES_TOTAL 25
-#define EFI_RETRY_DELAY (50 * USEC_PER_MSEC)
-
 int efi_get_variable(
                 const char *variable,
                 uint32_t *ret_attribute,

--- a/src/basic/efivars.h
+++ b/src/basic/efivars.h
@@ -42,8 +42,6 @@
 int efi_get_variable(const char *variable, uint32_t *attribute, void **ret_value, size_t *ret_size);
 int efi_get_variable_string(const char *variable, char **ret);
 int efi_get_variable_path(const char *variable, char **ret);
-int efi_set_variable(const char *variable, const void *value, size_t size) _nonnull_if_nonzero_(2, 3);
-int efi_set_variable_string(const char *variable, const char *value);
 
 bool set_efi_boot(bool b);
 bool is_efi_boot(void);
@@ -61,14 +59,6 @@ static inline int efi_get_variable_string(const char *variable, char **ret) {
 }
 
 static inline int efi_get_variable_path(const char *variable, char **ret) {
-        return -EOPNOTSUPP;
-}
-
-static inline int efi_set_variable(const char *variable, const void *value, size_t size) {
-        return -EOPNOTSUPP;
-}
-
-static inline int efi_set_variable_string(const char *variable, const char *p) {
         return -EOPNOTSUPP;
 }
 

--- a/src/basic/efivars.h
+++ b/src/basic/efivars.h
@@ -37,6 +37,11 @@
 #define EFIVAR_PATH(variable) "/sys/firmware/efi/efivars/" variable
 #define EFIVAR_CACHE_PATH(variable) "/run/systemd/efivars/" variable
 
+/* Reads from efivarfs sometimes fail with EINTR. Retry that many times. */
+#define EFI_N_RETRIES_NO_DELAY 20
+#define EFI_N_RETRIES_TOTAL 25
+#define EFI_RETRY_DELAY (50 * USEC_PER_MSEC)
+
 #if ENABLE_EFI
 
 int efi_get_variable(const char *variable, uint32_t *attribute, void **ret_value, size_t *ret_size);

--- a/src/shared/efivars.c
+++ b/src/shared/efivars.c
@@ -1,0 +1,134 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "alloc-util.h"
+#include "chattr-util.h"
+#include "efivars.h"
+#include "fd-util.h"
+#include "io-util.h"
+#include "log.h"
+#include "memory-util.h"
+#include "string-util.h"
+#include "utf8.h"
+
+#if ENABLE_EFI
+
+static int efi_verify_variable(const char *variable, uint32_t attr, const void *value, size_t size) {
+        _cleanup_free_ void *buf = NULL;
+        size_t n;
+        uint32_t a;
+        int r;
+
+        assert(variable);
+        assert(value || size == 0);
+
+        r = efi_get_variable(variable, &a, &buf, &n);
+        if (r < 0)
+                return r;
+
+        return a == attr && memcmp_nn(buf, n, value, size) == 0;
+}
+
+int efi_set_variable(const char *variable, const void *value, size_t size) {
+        static const uint32_t attr = EFI_VARIABLE_NON_VOLATILE|EFI_VARIABLE_BOOTSERVICE_ACCESS|EFI_VARIABLE_RUNTIME_ACCESS;
+
+        _cleanup_free_ struct var {
+                uint32_t attr;
+                char buf[];
+        } _packed_ *buf = NULL;
+        _cleanup_close_ int fd = -EBADF;
+        bool saved_flags_valid = false;
+        unsigned saved_flags;
+        int r;
+
+        assert(variable);
+        assert(value || size == 0);
+
+        /* size 0 means removal, empty variable would not be enough for that */
+        if (size > 0 && efi_verify_variable(variable, attr, value, size) > 0) {
+                log_debug("Variable '%s' is already in wanted state, skipping write.", variable);
+                return 0;
+        }
+
+        const char *p = strjoina("/sys/firmware/efi/efivars/", variable);
+
+        /* Newer efivarfs protects variables that are not in an allow list with FS_IMMUTABLE_FL by default,
+         * to protect them for accidental removal and modification. We are not changing these variables
+         * accidentally however, hence let's unset the bit first. */
+
+        r = chattr_full(AT_FDCWD, p,
+                        /* value= */ 0,
+                        /* mask= */ FS_IMMUTABLE_FL,
+                        /* ret_previous= */ &saved_flags,
+                        /* ret_final= */ NULL,
+                        /* flags= */ 0);
+        if (r < 0 && r != -ENOENT)
+                log_debug_errno(r, "Failed to drop FS_IMMUTABLE_FL flag from '%s', ignoring: %m", p);
+
+        saved_flags_valid = r >= 0;
+
+        if (size == 0) {
+                if (unlink(p) < 0) {
+                        r = -errno;
+                        goto finish;
+                }
+
+                return 0;
+        }
+
+        fd = open(p, O_WRONLY|O_CREAT|O_NOCTTY|O_CLOEXEC, 0644);
+        if (fd < 0) {
+                r = -errno;
+                goto finish;
+        }
+
+        buf = malloc(sizeof(uint32_t) + size);
+        if (!buf) {
+                r = -ENOMEM;
+                goto finish;
+        }
+
+        buf->attr = attr;
+        memcpy(buf->buf, value, size);
+
+        r = loop_write(fd, buf, sizeof(uint32_t) + size);
+        if (r < 0)
+                goto finish;
+
+        /* For some reason efivarfs doesn't update mtime automatically. Let's do it manually then. This is
+         * useful for processes that cache EFI variables to detect when changes occurred. */
+        if (futimens(fd, /* times= */ NULL) < 0)
+                log_debug_errno(errno, "Failed to update mtime/atime on %s, ignoring: %m", p);
+
+        r = 0;
+
+finish:
+        if (saved_flags_valid) {
+                int q;
+
+                /* Restore the original flags field, just in case */
+                if (fd < 0)
+                        q = chattr_path(p, saved_flags, FS_IMMUTABLE_FL);
+                else
+                        q = chattr_fd(fd, saved_flags, FS_IMMUTABLE_FL);
+                if (q < 0)
+                        log_debug_errno(q, "Failed to restore FS_IMMUTABLE_FL on '%s', ignoring: %m", p);
+        }
+
+        return r;
+}
+
+int efi_set_variable_string(const char *variable, const char *value) {
+        _cleanup_free_ char16_t *u16 = NULL;
+
+        u16 = utf8_to_utf16(value, SIZE_MAX);
+        if (!u16)
+                return -ENOMEM;
+
+        return efi_set_variable(variable, u16, (char16_strlen(u16) + 1) * sizeof(char16_t));
+}
+
+#endif

--- a/src/shared/efivars.c
+++ b/src/shared/efivars.c
@@ -7,14 +7,172 @@
 #include "alloc-util.h"
 #include "chattr-util.h"
 #include "efivars.h"
+#include "errno-util.h"
 #include "fd-util.h"
+#include "fileio.h"
+#include "find-esp.h"
+#include "fs-util.h"
 #include "io-util.h"
 #include "log.h"
 #include "memory-util.h"
+#include "path-util.h"
 #include "string-util.h"
+#include "sync-util.h"
+#include "time-util.h"
+#include "tmpfile-util.h"
 #include "utf8.h"
 
 #if ENABLE_EFI
+
+/* Vendor GUID of the variables through which firmware keeping its variable store in a file on the ESP (see
+ * "File Format For Storing EFI Variables" in the EBBR specification,
+ * https://arm-software.github.io/ebbr/) hands the store over to the OS for persisting. */
+#define EFI_VENDOR_VARIABLE_STORE_STR SD_ID128_MAKE_UUID_STR(b2,ac,5f,c9,92,b7,4a,cd,ae,ac,11,e8,18,c3,13,0c)
+#define EFI_VARIABLE_STORE_VARIABLE_STR(name) EFI_VENDOR_VARIABLE_STR(EFI_VENDOR_VARIABLE_STORE_STR, name)
+
+static int variable_store_flush_internal(void) {
+        _cleanup_free_ void *name_raw = NULL;
+        _cleanup_free_ char *name = NULL, *esp_path = NULL, *path = NULL, *blob = NULL;
+        _cleanup_(unlink_and_freep) char *t = NULL;
+        _cleanup_close_ int fd = -EBADF;
+        size_t name_size = 0, blob_size = 0;
+        int r;
+
+        /* Firmware that has no access to its EFI variable store at runtime (common on EBBR systems, where
+         * the store lives in a file on the ESP the firmware cannot safely write to once the OS owns the
+         * device) accepts runtime SetVariable() calls into an in-memory store only, and exports a
+         * serialized copy of it through the volatile VarToFile variable. For a change to survive a reboot,
+         * the OS has to write that blob into the store file — named by the RTStorageVolatile variable —
+         * from which the firmware loads the variables on the next boot. The file format is specified in
+         * the EBBR specification ("File Format For Storing EFI Variables"); the blob is opaque to us. */
+
+        r = efi_get_variable(EFI_VARIABLE_STORE_VARIABLE_STR("RTStorageVolatile"), NULL, &name_raw, &name_size);
+        if (r < 0) {
+                /* Be strict only once the mechanism is positively identified: -ENOENT means the
+                 * firmware persists variables itself, and any other lookup failure means the
+                 * mechanism cannot be confirmed to be in use — either way, don't turn the variable
+                 * write that just succeeded into an error over it. */
+                if (r != -ENOENT)
+                        log_debug_errno(r, "Failed to read RTStorageVolatile EFI variable, ignoring: %m");
+                return 0;
+        }
+
+        /* An ASCII file name, possibly NUL-terminated. */
+        name = memdup_suffix0(name_raw, name_size);
+        if (!name)
+                return -ENOMEM;
+
+        if (!filename_is_valid(name) || !ascii_is_valid(name))
+                return log_debug_errno(SYNTHETIC_ERRNO(EINVAL),
+                                       "RTStorageVolatile contains an invalid file name, refusing.");
+
+        r = find_esp_and_warn(/* root= */ NULL, /* path= */ NULL, /* unprivileged_mode= */ false,
+                              &esp_path, /* ret_fd= */ NULL);
+        if (r < 0)
+                return r;
+
+        path = path_join(esp_path, name);
+        if (!path)
+                return -ENOMEM;
+
+        /* The store file is created by the firmware (or when the ESP is assembled); we only ever update
+         * it, so that a bogus RTStorageVolatile value cannot make us place new files on the ESP. */
+        if (access(path, W_OK) < 0)
+                return log_debug_errno(errno,
+                                       "EFI variable store file '%s' not accessible, changes will not persist: %m",
+                                       path);
+
+        /* The firmware grows VarToFile behind the kernel's back on every SetVariable() call, while
+         * efivarfs only refreshes the inode size for writes going through the file system. Hence read the
+         * file to EOF instead of trusting st_size the way efi_get_variable() does, which would truncate
+         * the blob to the size the variable had when it was first enumerated. The kernel rate-limits
+         * efivarfs reads and transiently fails them with EINTR, hence retry like efi_get_variable()
+         * does; every attempt rereads a fresh snapshot. */
+        for (unsigned try = 0;; try++) {
+                r = read_full_file(EFIVAR_PATH(EFI_VARIABLE_STORE_VARIABLE_STR("VarToFile")), &blob, &blob_size);
+                if (r != -EINTR)
+                        break;
+                if (try >= EFI_N_RETRIES_TOTAL)
+                        return log_debug_errno(SYNTHETIC_ERRNO(EBUSY),
+                                               "Reading VarToFile EFI variable failed even after %u tries, giving up.", try);
+                if (try >= EFI_N_RETRIES_NO_DELAY)
+                        (void) usleep_safe(EFI_RETRY_DELAY);
+        }
+        if (r < 0)
+                return log_debug_errno(r, "Failed to read VarToFile EFI variable: %m");
+        if (blob_size <= sizeof(uint32_t))
+                return log_debug_errno(SYNTHETIC_ERRNO(ENODATA), "VarToFile EFI variable has no payload, refusing.");
+
+        /* Nothing to do if the store file already carries the current serialized store. This keeps
+         * retried and skipped writes from rewriting the ESP over and over. */
+        _cleanup_free_ char *current = NULL;
+        size_t current_size = 0;
+        if (read_full_file(path, &current, &current_size) >= 0 &&
+            memcmp_nn(current, current_size, (uint8_t*) blob + sizeof(uint32_t), blob_size - sizeof(uint32_t)) == 0)
+                return 0;
+
+        /* Replace the store file atomically so that a crash in the middle cannot corrupt it. */
+        r = tempfn_random(path, NULL, &t);
+        if (r < 0)
+                return r;
+
+        fd = open(t, O_WRONLY|O_CREAT|O_EXCL|O_NOFOLLOW|O_CLOEXEC, 0600);
+        if (fd < 0)
+                return log_debug_errno(errno, "Failed to create '%s': %m", t);
+
+        /* Skip the 4 bytes of variable attributes that efivarfs prepends. */
+        r = loop_write(fd, (uint8_t*) blob + sizeof(uint32_t), blob_size - sizeof(uint32_t));
+        if (r < 0)
+                return log_debug_errno(r, "Failed to write '%s': %m", t);
+
+        r = fsync_full(fd);
+        if (r < 0)
+                return log_debug_errno(r, "Failed to sync '%s': %m", t);
+
+        /* Exchange rather than rename the temporary file into place: RENAME_EXCHANGE fails if the
+         * target does not exist, which enforces the update-only invariant atomically at the operation
+         * itself — the access() check above cannot guarantee it on its own. The displaced old store
+         * contents end up at the temporary path and are removed below. */
+        if (renameat2(AT_FDCWD, t, AT_FDCWD, path, RENAME_EXCHANGE) < 0) {
+                if (!ERRNO_IS_NOT_SUPPORTED(errno) && errno != EINVAL)
+                        return log_debug_errno(errno, "Failed to exchange '%s' and '%s': %m", t, path);
+
+                /* Fall back to a plain rename — and the raciness of the access() check — on file
+                 * systems without RENAME_EXCHANGE support (vfat gained it in kernel 5.19). */
+                if (access(path, W_OK) < 0)
+                        return log_debug_errno(errno,
+                                               "EFI variable store file '%s' vanished, refusing to create it: %m",
+                                               path);
+
+                if (rename(t, path) < 0)
+                        return log_debug_errno(errno, "Failed to rename '%s' to '%s': %m", t, path);
+        }
+
+        /* Remove the displaced old store contents (or, on the fallback path, nothing) before syncing
+         * the directory, so that one sync covers all of it. */
+        t = unlink_and_free(t);
+
+        r = fsync_parent_at(AT_FDCWD, path);
+        if (r < 0)
+                return log_debug_errno(r, "Failed to sync parent directory of '%s': %m", path);
+
+        return 0;
+}
+
+static int efi_variable_store_flush(void) {
+        int r;
+
+        r = variable_store_flush_internal();
+        if (r == -ENOENT)
+                /* Never fail with -ENOENT, whatever its source — the store file disappearing before the
+                 * exchange, VarToFile vanishing, …: efi_set_variable() returns -ENOENT from the removal
+                 * path when the variable to remove didn't exist in the first place, and callers
+                 * rightfully treat that as success — while a removal that could not be flushed would
+                 * resurface on the next boot and hence must be reported. */
+                return -ENOMEDIUM;
+
+        return r;
+}
 
 static int efi_verify_variable(const char *variable, uint32_t attr, const void *value, size_t size) {
         _cleanup_free_ void *buf = NULL;
@@ -50,7 +208,11 @@ int efi_set_variable(const char *variable, const void *value, size_t size) {
         /* size 0 means removal, empty variable would not be enough for that */
         if (size > 0 && efi_verify_variable(variable, attr, value, size) > 0) {
                 log_debug("Variable '%s' is already in wanted state, skipping write.", variable);
-                return 0;
+                /* The runtime store matching the wanted value says nothing about the on-ESP store
+                 * file: if a previous flush failed, this is exactly where the retry of the same value
+                 * ends up, hence flush anyway. The flush itself detects an up-to-date store file and
+                 * turns into a no-op then. */
+                return efi_variable_store_flush();
         }
 
         const char *p = strjoina("/sys/firmware/efi/efivars/", variable);
@@ -76,7 +238,7 @@ int efi_set_variable(const char *variable, const void *value, size_t size) {
                         goto finish;
                 }
 
-                return 0;
+                return efi_variable_store_flush();
         }
 
         fd = open(p, O_WRONLY|O_CREAT|O_NOCTTY|O_CLOEXEC, 0644);
@@ -117,6 +279,11 @@ finish:
                 if (q < 0)
                         log_debug_errno(q, "Failed to restore FS_IMMUTABLE_FL on '%s', ignoring: %m", p);
         }
+
+        if (r >= 0)
+                /* Flush only after the immutable flag is restored: the flush does slow, unrelated ESP
+                 * I/O and never touches the variable, so don't leave it unprotected while it runs. */
+                r = efi_variable_store_flush();
 
         return r;
 }

--- a/src/shared/efivars.h
+++ b/src/shared/efivars.h
@@ -1,0 +1,26 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#pragma once
+
+#include "../basic/efivars.h"   /* IWYU pragma: export */
+
+/* These functions extend the basic efivars.h API with the variable setters, which live in the shared tier
+ * because persisting writes on firmware with a file-backed variable store requires ESP discovery via
+ * find-esp.c. Targets that link libshared automatically pick up this version via -Isrc/shared; targets
+ * that only have src/basic on their include path fall through to the basic header. */
+
+#if ENABLE_EFI
+
+int efi_set_variable(const char *variable, const void *value, size_t size) _nonnull_if_nonzero_(2, 3);
+int efi_set_variable_string(const char *variable, const char *value);
+
+#else
+
+static inline int efi_set_variable(const char *variable, const void *value, size_t size) {
+        return -EOPNOTSUPP;
+}
+
+static inline int efi_set_variable_string(const char *variable, const char *p) {
+        return -EOPNOTSUPP;
+}
+
+#endif

--- a/src/shared/meson.build
+++ b/src/shared/meson.build
@@ -73,6 +73,7 @@ shared_sources = files(
         'edit-util.c',
         'efi-api.c',
         'efi-loader.c',
+        'efivars.c',
         'elf-util.c',
         'enable-mempool.c',
         'ethtool-util.c',

--- a/test/units/TEST-87-AUX-UTILS-VM.bootctl.sh
+++ b/test/units/TEST-87-AUX-UTILS-VM.bootctl.sh
@@ -369,6 +369,91 @@ testcase_bootctl_varlink() {
     SYSTEMD_LOG_TARGET=console varlinkctl call --json=short /run/systemd/io.systemd.BootControl io.systemd.BootControl.SetRebootToFirmware '{"state":false}' --graceful=io.systemd.BootControl.RebootToFirmwareNotSupported
 }
 
+cleanup_varstore() {
+    chattr -i "$RTSV" "$VTF" 2>/dev/null || :
+    rm -f "$RTSV" "$VTF"
+
+    # With the fake mechanism variables gone this is a plain variable removal again.
+    bootctl --variables=yes set-timeout "" || :
+
+    rm -f "$STORE"
+
+    unset RTSV VTF STORE
+}
+
+testcase_bootctl_file_backed_varstore() {
+    # Exercise the file-backed variable store flush (efi_variable_store_flush() in
+    # src/shared/efivars.c): firmware that keeps its EFI variable store in a file on the
+    # ESP (see "File Format For Storing EFI Variables" in the EBBR specification) exports
+    # the serialized store through the volatile VarToFile variable and names the store
+    # file in RTStorageVolatile; after every variable write systemd has to copy the blob
+    # into that file, or the write does not survive a reboot. Fake the firmware side of
+    # the mechanism with real efivarfs variables and verify the store file is maintained.
+    if [[ ! -d /sys/firmware/efi ]]; then
+        echo "Not booted with EFI, skipping file-backed variable store tests."
+        return 0
+    fi
+
+    local efivars=/sys/firmware/efi/efivars
+    local store_guid=b2ac5fc9-92b7-4acd-aeac-11e818c3130c
+    local esp
+    esp="$(bootctl --print-esp-path)"
+    STORE="$esp/ubootefi.var"
+    RTSV="$efivars/RTStorageVolatile-$store_guid"
+    VTF="$efivars/VarToFile-$store_guid"
+
+    trap cleanup_varstore RETURN ERR
+
+    # efivarfs file layout is 4 bytes of attributes followed by the payload. The store
+    # file name is NUL-terminated, as U-Boot serves it.
+    printf '\x07\x00\x00\x00ubootefi.var\x00' >"$RTSV"
+    printf '\x07\x00\x00\x00EBBR-VARSTORE-BLOB-0123456789abcdef' >"$VTF"
+
+    # The store file is created by the firmware (or when the ESP is assembled).
+    echo garbage >"$STORE"
+
+    # A variable write must replace the store file with VarToFile minus the attributes.
+    bootctl --variables=yes set-timeout 5
+    # Strip the 4-byte attribute header with dd: efivarfs does not support seeking, which
+    # rules out tail -c +5 (dd falls back to reading and discarding on non-seekable input).
+    cmp <(dd if="$VTF" bs=4 skip=1 status=none) "$STORE"
+
+    # A variable removal must flush the store file too.
+    echo garbage >"$STORE"
+    bootctl --variables=yes set-timeout ""
+    cmp <(dd if="$VTF" bs=4 skip=1 status=none) "$STORE"
+
+    # Without the store file the write must fail, since it would not survive a reboot;
+    # the file is only ever updated, never created.
+    rm "$STORE"
+    (! bootctl --variables=yes set-timeout 5)
+    [[ ! -e "$STORE" ]]
+
+    # The failed write above still reached the runtime store, so retrying the same value is
+    # skipped as "already in wanted state" — but it must flush nevertheless, or a retry after
+    # a transient flush failure would report success without persisting anything.
+    echo garbage >"$STORE"
+    bootctl --variables=yes set-timeout 5
+    cmp <(dd if="$VTF" bs=4 skip=1 status=none) "$STORE"
+
+    # And when the store file is already up to date, the flush must not rewrite it.
+    local ino
+    ino="$(stat -c %i "$STORE")"
+    bootctl --variables=yes set-timeout 5
+    [[ "$(stat -c %i "$STORE")" == "$ino" ]]
+
+    # A removal that cannot be flushed must fail too — in particular it must not be
+    # mistaken for "the variable didn't exist" (which callers rightfully ignore).
+    rm "$STORE"
+    (! bootctl --variables=yes set-timeout "")
+
+    # Without RTStorageVolatile the whole mechanism is a no-op and writes succeed again.
+    chattr -i "$RTSV" 2>/dev/null || :
+    rm "$RTSV"
+    bootctl --variables=yes set-timeout 5
+    [[ ! -e "$STORE" ]]
+}
+
 testcase_bootctl_secure_boot_auto_enroll() {
     # mkosi can also add keys here, so back them up and restored them
     backup_esp


### PR DESCRIPTION
On firmware that keeps its EFI variable store in a file on the ESP — as described in the
EBBR specification's ["File Format For Storing EFI Variables"](https://arm-software.github.io/ebbr/)
and implemented by both U-Boot's EFI implementation and EDK2-based vendor firmware — the
firmware cannot safely write the store file once the OS owns the storage device. Runtime
SetVariable() calls go into an in-memory store only, and the firmware exports a serialized
copy of that store through the volatile `VarToFile` variable, naming the store file on the
ESP in the companion `RTStorageVolatile` variable. For a change to survive a reboot, the OS
has to write the blob into that file.

libefivar implements this handover since
[rhboot/efivar#282](https://github.com/rhboot/efivar/pull/282), so `efivar -w` persists on
this class of firmware — while every systemd writer (`bootctl set-default/set-oneshot/
set-timeout`, `LoaderSystemToken`, `OsIndications`/reboot-to-firmware, `HibernateLocation`,
`FactoryResetRequest`, `Boot####` options) silently loses its writes on reboot: the efivarfs
write succeeds and is visible in the runtime store, but reverts on reset. That makes boot
entry control from the OS unusable on EBBR systems.

This PR teaches `efi_set_variable()` to do the same handover: after every successful
variable write or removal it looks up `RTStorageVolatile` and, when present, atomically
updates the named store file with the current `VarToFile` content, discovering the ESP with
the usual find-esp logic. Since that requires ESP discovery, the EFI variable setters move
from src/basic/ to src/shared/ (following the established tier-split header pattern, no
callers change). An integration test in TEST-87 fakes the firmware side of the mechanism
with real efivarfs variables and verifies the store file is maintained through real
`bootctl` writes and removals, including the failure and no-op paths.

Design notes:

* On firmware without the mechanism the `RTStorageVolatile` lookup fails with -ENOENT and the
  hook is a no-op: no ESP discovery, no I/O beyond one failed efivarfs open per write. The
  lookup itself is best-effort — any other lookup failure also cannot confirm the mechanism is
  in use and does not fail the (successful) variable write.
* Once the mechanism is confirmed active, a failed flush is reported as an error, since the
  write would not survive a reboot. Flush failures are remapped away from -ENOENT so a
  non-persisted removal cannot masquerade as "variable didn't exist", which callers rightfully
  ignore.
* The store file is only ever updated, never created, so a bogus `RTStorageVolatile` value
  cannot drop new files onto the ESP; the update is atomic (temp file + rename + fsync) so a
  crash mid-write cannot corrupt the firmware's variable store.
* The flush runs per write, matching libefivar's behavior. Multi-variable operations
  (`bootctl install/remove`) therefore flush several times; batching would need an explicit
  flush API and is left as a possible follow-up, as is an env-var opt-out if that's wanted.

Verified on EDK2-based EBBR firmware (writes now survive reboots, matching `efivar -w`
behavior), plus the new TEST-87 testcase for the mechanics. On firmware without the mechanism
the existing TEST-86/TEST-87 bootctl coverage exercises the no-op path under OVMF.
