### PR TITLE
Optimize dlopen ELF notes via anchoring and explicitly embed them into executables

### DIFF
--- a/.github/workflows/unit-tests.sh
+++ b/.github/workflows/unit-tests.sh
@@ -132,6 +132,12 @@ for phase in "${PHASES[@]}"; do
             ninja -C build -v
             # Ensure setting a timezone (like the reproducible build tests do) does not break time/date unit tests
             TZ=GMT+12 meson test "${MESON_TEST_ARGS[@]}" -C build --print-errorlogs --no-stdsplit --quiet
+
+            # Linker garbage collection for unused symbols appears to be broken on ppc64le (both GCC and CLANG) or s390x (GCC).
+            # Skip the dlopen note verification test in those specific configurations.
+            if ! [[ "$(uname -m)" == "ppc64le" || ( "$(uname -m)" == "s390x" && "$phase" == "RUN_GCC" ) ]]; then
+                meson test -C build --suite=dlopen --print-errorlogs --no-stdsplit --quiet
+            fi
             ;;
         RUN_ASAN_UBSAN|RUN_GCC_ASAN_UBSAN|RUN_CLANG_ASAN_UBSAN|RUN_CLANG_ASAN_UBSAN_NO_DEPS)
             # TODO: drop after we switch to ubuntu 26.04

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -99,3 +99,6 @@ jobs:
 
       - name: Test
         run: mkosi box -- meson test -C build --print-errorlogs --no-stdsplit --quiet
+
+      - name: Test (dlopen)
+        run: mkosi box -- meson test -C build --print-errorlogs --no-stdsplit --quiet --suite=dlopen

--- a/README
+++ b/README
@@ -256,9 +256,10 @@ REQUIREMENTS:
         ninja
         gcc >= 8.4
             >= 13.1.0 is required to build BPF program by using GCC
+        binutils >= 2.35
         awk, sed, grep, and similar tools
-        clang >= 10.0, llvm >= 10.0 (optional, required to build BPF programs
-                from source code in C)
+        clang,llvm >= 10 (optional, required to build BPF programs)
+                   >= 13 (optional, required to build the entire project)
 
         During runtime, you need the following additional
         dependencies:

--- a/meson.build
+++ b/meson.build
@@ -15,7 +15,7 @@ project('systemd', 'c',
 
 add_test_setup(
         'default',
-        exclude_suites : ['clang-tidy', 'coccinelle', 'unused-symbols', 'integration-tests'],
+        exclude_suites : ['clang-tidy', 'coccinelle', 'dlopen', 'unused-symbols', 'integration-tests'],
         exe_wrapper : find_program('tools/test-crash-trace.sh'),
         is_default : true,
 )

--- a/meson.build
+++ b/meson.build
@@ -1416,11 +1416,11 @@ endif
 # In the dlopen ELF note we save the default compression library with a
 # higher priority, so that packages can give it priority over the
 # secondary libraries.
-conf.set_quoted('COMPRESSION_PRIORITY_ZSTD',
+conf.set('COMPRESSION_PRIORITY_ZSTD',
                 compression == 'zstd' ? 'recommended' : 'suggested')
-conf.set_quoted('COMPRESSION_PRIORITY_LZ4',
+conf.set('COMPRESSION_PRIORITY_LZ4',
                 compression == 'lz4' ? 'recommended' : 'suggested')
-conf.set_quoted('COMPRESSION_PRIORITY_XZ',
+conf.set('COMPRESSION_PRIORITY_XZ',
                 compression == 'xz' ? 'recommended' : 'suggested')
 conf.set('DEFAULT_COMPRESSION', 'COMPRESSION_@0@'.format(compression.to_upper()))
 

--- a/meson.build
+++ b/meson.build
@@ -2019,11 +2019,21 @@ endif
 
 #####################################################################
 
+# The 'install' field is extended to also control whether the automatically
+# added variant, which is statically linked with libsystemd-shared, is installed:
+#   'yes'    : Mapped to true. The static variant will not be installed.
+#   'no'     : Mapped to false. The static variant will not be installed either.
+#   'both'   : Mapped to true. The static variant will also be installed.
+#   'static' : Mapped to false, and its target name is suffixed with '.shared'.
+#              The static variant will be installed instead using the original name
+#              (without the '.standalone' suffix).
+# Currently, test and fuzzer executables only support 'yes' or 'no'.
 executable_template = {
         'include_directories' : includes,
-        'link_with' : libshared,
+        'link_with' : [libshared],
         'install_rpath' : pkglibdir,
-        'install' : true,
+        'install' : 'yes',
+        'build_by_default' : true,
 }
 
 generator_template = executable_template + {
@@ -2040,7 +2050,7 @@ executable_additional_kwargs = {
 
 test_template = executable_template + {
         'build_by_default' : want_tests != 'false',
-        'install' : install_tests,
+        'install' : install_tests ? 'yes' : 'no',
         'install_dir' : unittestsdir,
 }
 
@@ -2051,7 +2061,7 @@ test_additional_kwargs = {
 
 fuzz_template = executable_template + {
         'build_by_default' : want_fuzz_tests,
-        'install' : false,
+        'install' : 'no',
 }
 
 if want_ossfuzz
@@ -2263,7 +2273,6 @@ foreach dict : executables
 
         is_test = name.startswith('test-')
         is_fuzz = name.startswith('fuzz-')
-        is_standalone = name.endswith('.standalone')
 
         build = true
         foreach cond : dict.get('conditions', [])
@@ -2276,20 +2285,22 @@ foreach dict : executables
                 continue
         endif
 
-        exe_sources = dict.get('sources', []) + dict.get('export', [])
+        exe_sources_static = dict.get('sources', [])
 
         foreach bpf_name : dict.get('bpf_programs', [])
                 if bpf_name in bpf_programs_by_name
-                        exe_sources += bpf_programs_by_name[bpf_name]
+                        exe_sources_static += bpf_programs_by_name[bpf_name]
                 endif
         endforeach
+
+        exe_sources = exe_sources_static + dict.get('export', [])
 
         kwargs = {}
         foreach key, val : dict
                 if key in ['name', 'dbus', 'public', 'conditions', 'type', 'suite',
                            'timeout', 'parallel', 'sources', 'import', 'export',
                            'include_directories', 'build_by_default', 'install',
-                           'bpf_programs']
+                           'bpf_programs', 'link_args_static']
                         continue
                 endif
 
@@ -2329,30 +2340,54 @@ foreach dict : executables
                 endforeach
         endif
 
-        build_by_default = dict.get('build_by_default',
-                                    have_standalone_binaries or not is_standalone)
-
-        if not is_standalone
-                install = dict.get('install', true)
+        name_shared = name
+        name_static = name + '.standalone'
+        install = dict.get('install')
+        build_by_default = dict.get('build_by_default')
+        if install == 'yes'
+                install_shared = true
+                install_static = false
+                build_by_default_shared = build_by_default
+                build_by_default_static = false
+        elif install == 'no'
+                install_shared = false
+                install_static = false
+                build_by_default_shared = build_by_default
+                build_by_default_static = false
+        elif install == 'both'
+                if is_test or is_fuzz
+                        error('Install mode "@0@" is not supported for test or fuzzer target "@1@"'.format(install, name))
+                endif
+                install_shared = true
+                install_static = true
+                build_by_default_shared = build_by_default
+                build_by_default_static = build_by_default
+        elif install == 'static'
+                if is_test or is_fuzz
+                        error('Install mode "@0@" is not supported for test or fuzzer target "@1@"'.format(install, name))
+                endif
+                name_shared = name + '.shared'
+                name_static = name
+                install_shared = false
+                install_static = true
+                build_by_default_shared = false
+                build_by_default_static = build_by_default
         else
-                install = have_standalone_binaries
+                error('Unknown install mode "@0@" for target "@1@"'.format(install, name))
         endif
 
         exe = executable(
-                name,
+                name_shared,
                 sources : exe_sources,
                 kwargs : kwargs,
                 implicit_include_directories : false,
                 include_directories : include_directories,
-                build_by_default: build_by_default,
-                install: install,
+                build_by_default: build_by_default_shared,
+                install: install_shared,
         )
 
-        executables_by_name += { name : exe }
-
-        if not is_standalone
-                sources += exe_sources
-        endif
+        executables_by_name += { name_shared : exe }
+        sources += exe_sources
 
         if 'export' in dict
                 exported_by_name += {
@@ -2363,12 +2398,62 @@ foreach dict : executables
                 }
         endif
 
-        if build_by_default
+        if build_by_default_shared
                 if dict.get('dbus', false)
                         dbus_programs += exe
                 endif
                 if dict.get('public', false)
                         public_programs += exe
+                endif
+        endif
+
+        if not is_test and not is_fuzz
+                kwargs_static = kwargs
+
+                if 'export' in dict
+                        obj = exported_by_name[name]
+                        kwargs_static += { 'objects' : kwargs_static.get('objects', []) + obj['exported'] }
+                        include_directories += obj['include_directories']
+                endif
+
+                link_with_static = []
+                foreach obj : kwargs_static.get('link_with', [])
+                        if obj.full_path() == libshared.full_path()
+                                link_with_static += [
+                                        libshared_static,
+                                        libsystemd_static,
+                                ]
+                        elif obj.full_path() == libcore.full_path()
+                                link_with_static += libcore_static
+                        else
+                                link_with_static += obj
+                        endif
+                endforeach
+
+                kwargs_static += {
+                        'link_with' : link_with_static,
+                        'link_args' : dict.get('link_args_static', kwargs_static.get('link_args', [])),
+                }
+
+                exe = executable(
+                        name_static,
+                        sources : exe_sources_static,
+                        kwargs : kwargs_static,
+                        implicit_include_directories : false,
+                        include_directories : include_directories,
+                        build_by_default: build_by_default_static,
+                        install: install_static,
+                )
+
+                executables_by_name += { name_static : exe }
+
+                if build_by_default_static
+                        if dict.get('dbus', false) and not build_by_default_shared
+                                dbus_programs += exe
+                        endif
+                        if dict.get('public', false)
+                                public_programs += exe
+                        endif
                 endif
         endif
 

--- a/meson.build
+++ b/meson.build
@@ -2525,6 +2525,7 @@ test_dlopen = executables_by_name.get('test-dlopen')
 nss_targets = []
 pam_targets = []
 module_targets = []
+modules_by_name = {}
 foreach dict : modules
         name = dict.get('name')
         is_nss = name.startswith('nss_')
@@ -2570,6 +2571,40 @@ foreach dict : modules
         )
 
         module_targets += lib
+        modules_by_name += { name : lib }
+
+        if not is_nss and not is_pam
+                # Typically for cryptsetup token modules.
+
+                name_static = name + '.standalone'
+                kwargs_static = kwargs
+
+                link_with_static = []
+                foreach obj : kwargs_static.get('link_with', [])
+                        if obj.full_path() == libshared.full_path()
+                                link_with_static += [
+                                        libshared_static,
+                                        libsystemd_static,
+                                ]
+                        else
+                                link_with_static += obj
+                        endif
+                endforeach
+
+                kwargs_static += {
+                        'link_with' : link_with_static,
+                        'install' : false,
+                        'build_by_default' : false,
+                }
+
+                lib_static = shared_library(
+                        name_static,
+                        kwargs : kwargs_static,
+                        implicit_include_directories : false,
+                )
+
+                modules_by_name += { name_static : lib_static }
+        endif
 
         if is_nss
                 # We cannot use shared_module because it does not support version suffix.

--- a/meson.build
+++ b/meson.build
@@ -431,7 +431,9 @@ possible_common_cc_flags = [
         '-Wno-string-plus-int',  # clang
 
         '-fdiagnostics-show-option',
+        '-fdata-sections',
         '-fexcess-precision=standard',
+        '-ffunction-sections',
         '-fno-common',
         '-fstack-protector',
         '-fstack-protector-strong',

--- a/src/analyze/analyze-security.c
+++ b/src/analyze/analyze-security.c
@@ -626,7 +626,7 @@ static int assess_system_call_filter(
         uint64_t b;
         int r;
 
-        r = DLOPEN_LIBSECCOMP(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+        r = DLOPEN_LIBSECCOMP(LOG_DEBUG, recommended);
         if (r < 0) {
                 *ret_badness = UINT64_MAX;
                 *ret_description = NULL;
@@ -2604,7 +2604,7 @@ static int get_security_info(Unit *u, ExecContext *c, CGroupContext *g, RuntimeS
                 info->_umask = c->umask;
 
 #if HAVE_SECCOMP
-                if (DLOPEN_LIBSECCOMP(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED) >= 0) {
+                if (DLOPEN_LIBSECCOMP(LOG_DEBUG, recommended) >= 0) {
                         SET_FOREACH(key, c->syscall_archs) {
                                 const char *name;
 

--- a/src/analyze/analyze.c
+++ b/src/analyze/analyze.c
@@ -55,6 +55,7 @@
 #include "bus-util.h"
 #include "calendarspec.h"
 #include "dissect-image.h"
+#include "dlopen-note.h"
 #include "extract-word.h"
 #include "format-table.h"
 #include "help-util.h"
@@ -684,6 +685,20 @@ static int run(int argc, char *argv[]) {
         _cleanup_(umount_and_freep) char *mounted_dir = NULL;
         _cleanup_strv_free_ char **args = NULL;
         int r;
+
+        LIBACL_NOTE(recommended);
+        LIBAPPARMOR_NOTE(recommended);
+        LIBAUDIT_NOTE(recommended);
+        LIBBLKID_NOTE(recommended);
+        LIBBPF_NOTE(recommended);
+        LIBCRYPTO_NOTE(suggested);
+        LIBCRYPTSETUP_NOTE(recommended);
+        LIBDW_NOTE(suggested);
+        LIBELF_NOTE(suggested);
+        LIBMOUNT_NOTE(recommended);
+        LIBPCRE2_NOTE(suggested);
+        LIBSELINUX_NOTE(recommended);
+        TPM2_NOTE(suggested);
 
         setlocale(LC_ALL, "");
         setlocale(LC_NUMERIC, "C"); /* we want to format/parse floats in C style */

--- a/src/analyze/meson.build
+++ b/src/analyze/meson.build
@@ -59,7 +59,7 @@ executables += [
                         libseccomp_cflags,
                         tpm2_cflags,
                 ],
-                'install' : conf.get('ENABLE_ANALYZE') == 1,
+                'install' : conf.get('ENABLE_ANALYZE') == 1 ? 'yes' : 'no',
         },
         core_test_template + {
                 'sources' : files('test-verify.c'),

--- a/src/basic/compress.c
+++ b/src/basic/compress.c
@@ -43,12 +43,11 @@
 #include <bzlib.h>
 #endif
 
-#include "sd-dlopen.h"
-
 #include "alloc-util.h"
 #include "bitfield.h"
 #include "compress.h"
 #include "dlfcn-util.h"
+#include "dlopen-note.h"
 #include "io-util.h"
 #include "log.h"
 #include "string-table.h"
@@ -293,11 +292,7 @@ int dlopen_xz(int log_level) {
 #if HAVE_XZ
         static void *lzma_dl = NULL;
 
-        SD_ELF_NOTE_DLOPEN(
-                        "lzma",
-                        "Support lzma compression in journal and coredump files",
-                        COMPRESSION_PRIORITY_XZ,
-                        "liblzma.so.5");
+        LIBLZMA_NOTE(COMPRESSION_PRIORITY_XZ);
 
         return dlopen_many_sym_or_warn(
                         &lzma_dl,
@@ -318,11 +313,7 @@ int dlopen_lz4(int log_level) {
 #if HAVE_LZ4
         static void *lz4_dl = NULL;
 
-        SD_ELF_NOTE_DLOPEN(
-                        "lz4",
-                        "Support lz4 compression in journal and coredump files",
-                        COMPRESSION_PRIORITY_LZ4,
-                        "liblz4.so.1");
+        LIBLZ4_NOTE(COMPRESSION_PRIORITY_LZ4);
 
         return dlopen_many_sym_or_warn(
                         &lz4_dl,
@@ -352,11 +343,7 @@ int dlopen_zstd(int log_level) {
 #if HAVE_ZSTD
         static void *zstd_dl = NULL;
 
-        SD_ELF_NOTE_DLOPEN(
-                        "zstd",
-                        "Support zstd compression in journal and coredump files",
-                        COMPRESSION_PRIORITY_ZSTD,
-                        "libzstd.so.1");
+        LIBZSTD_NOTE(COMPRESSION_PRIORITY_ZSTD);
 
         return dlopen_many_sym_or_warn(
                         &zstd_dl,
@@ -387,11 +374,7 @@ int dlopen_zlib(int log_level) {
 #if HAVE_ZLIB
         static void *zlib_dl = NULL;
 
-        SD_ELF_NOTE_DLOPEN(
-                        "zlib",
-                        "Support gzip compression and decompression",
-                        SD_ELF_NOTE_DLOPEN_PRIORITY_SUGGESTED,
-                        "libz.so.1");
+        LIBZ_NOTE(suggested);
 
         return dlopen_many_sym_or_warn(
                         &zlib_dl,
@@ -412,11 +395,7 @@ int dlopen_bzip2(int log_level) {
 #if HAVE_BZIP2
         static void *bzip2_dl = NULL;
 
-        SD_ELF_NOTE_DLOPEN(
-                        "bzip2",
-                        "Support bzip2 compression and decompression",
-                        SD_ELF_NOTE_DLOPEN_PRIORITY_SUGGESTED,
-                        "libbz2.so.1");
+        LIBBZ2_NOTE(suggested);
 
         return dlopen_many_sym_or_warn(
                         &bzip2_dl,

--- a/src/basic/compress.c
+++ b/src/basic/compress.c
@@ -47,7 +47,6 @@
 #include "bitfield.h"
 #include "compress.h"
 #include "dlfcn-util.h"
-#include "dlopen-note.h"
 #include "io-util.h"
 #include "log.h"
 #include "string-table.h"

--- a/src/basic/compress.c
+++ b/src/basic/compress.c
@@ -254,6 +254,19 @@ Compression compression_from_filename(const char *filename) {
         return c;
 }
 
+bool compression_supported_journal(Compression c) {
+        static const unsigned supported =
+                (1U << COMPRESSION_NONE) |
+                (1U << COMPRESSION_XZ) * HAVE_XZ |
+                (1U << COMPRESSION_LZ4) * HAVE_LZ4 |
+                (1U << COMPRESSION_ZSTD) * HAVE_ZSTD;
+
+        assert(c >= 0);
+        assert(c < _COMPRESSION_MAX);
+
+        return BIT_SET(supported, c);
+}
+
 bool compression_supported(Compression c) {
         static const unsigned supported =
                 (1U << COMPRESSION_NONE) |
@@ -639,7 +652,7 @@ static int compress_blob_bzip2(
 #endif
 }
 
-int compress_blob(
+int compress_blob_journal(
                 Compression compression,
                 const void *src, uint64_t src_size,
                 void *dst, size_t dst_alloc_size, size_t *dst_size, int level) {
@@ -651,12 +664,23 @@ int compress_blob(
                 return compress_blob_lz4(src, src_size, dst, dst_alloc_size, dst_size, level);
         case COMPRESSION_ZSTD:
                 return compress_blob_zstd(src, src_size, dst, dst_alloc_size, dst_size, level);
+        default:
+                return -EOPNOTSUPP;
+        }
+}
+
+int compress_blob(
+                Compression compression,
+                const void *src, uint64_t src_size,
+                void *dst, size_t dst_alloc_size, size_t *dst_size, int level) {
+
+        switch (compression) {
         case COMPRESSION_GZIP:
                 return compress_blob_gzip(src, src_size, dst, dst_alloc_size, dst_size, level);
         case COMPRESSION_BZIP2:
                 return compress_blob_bzip2(src, src_size, dst, dst_alloc_size, dst_size, level);
         default:
-                return -EOPNOTSUPP;
+                return compress_blob_journal(compression, src, src_size, dst, dst_alloc_size, dst_size, level);
         }
 }
 
@@ -1033,7 +1057,7 @@ static int decompress_blob_bzip2(
 #endif
 }
 
-int decompress_blob(
+int decompress_blob_journal(
                 Compression compression,
                 const void *src,
                 uint64_t src_size,
@@ -1054,6 +1078,20 @@ int decompress_blob(
                 return decompress_blob_zstd(
                                 src, src_size,
                                 dst, dst_size, dst_max);
+        default:
+                return -EPROTONOSUPPORT;
+        }
+}
+
+int decompress_blob(
+                Compression compression,
+                const void *src,
+                uint64_t src_size,
+                void **dst,
+                size_t *dst_size,
+                size_t dst_max) {
+
+        switch (compression) {
         case COMPRESSION_GZIP:
                 return decompress_blob_gzip(
                                 src, src_size,
@@ -1063,7 +1101,10 @@ int decompress_blob(
                                 src, src_size,
                                 dst, dst_size, dst_max);
         default:
-                return -EPROTONOSUPPORT;
+                return decompress_blob_journal(
+                                compression,
+                                src, src_size,
+                                dst, dst_size, dst_max);
         }
 }
 
@@ -1452,7 +1493,7 @@ static int decompress_startswith_bzip2(
 #endif
 }
 
-int decompress_startswith(
+int decompress_startswith_journal(
                 Compression compression,
                 const void *src, uint64_t src_size,
                 void **buffer,
@@ -1466,12 +1507,25 @@ int decompress_startswith(
                 return decompress_startswith_lz4(src, src_size, buffer, prefix, prefix_len, extra);
         case COMPRESSION_ZSTD:
                 return decompress_startswith_zstd(src, src_size, buffer, prefix, prefix_len, extra);
+        default:
+                return -EOPNOTSUPP;
+        }
+}
+
+int decompress_startswith(
+                Compression compression,
+                const void *src, uint64_t src_size,
+                void **buffer,
+                const void *prefix, size_t prefix_len,
+                uint8_t extra) {
+
+        switch (compression) {
         case COMPRESSION_GZIP:
                 return decompress_startswith_gzip(src, src_size, buffer, prefix, prefix_len, extra);
         case COMPRESSION_BZIP2:
                 return decompress_startswith_bzip2(src, src_size, buffer, prefix, prefix_len, extra);
         default:
-                return -EOPNOTSUPP;
+                return decompress_startswith_journal(compression, src, src_size, buffer, prefix, prefix_len, extra);
         }
 }
 

--- a/src/basic/compress.h
+++ b/src/basic/compress.h
@@ -27,6 +27,7 @@ Compression compression_from_string_harder(const char *s);
  * filename does not carry a recognized compression suffix. */
 Compression compression_from_filename(const char *filename);
 
+bool compression_supported_journal(Compression c);
 bool compression_supported(Compression c);
 
 /* Buffer size used by streaming compression APIs and pipeline stages that feed into them. Sized to
@@ -59,9 +60,17 @@ Compression compressor_type(const Compressor *c);
 
 /* Blob compression/decompression */
 
+int compress_blob_journal(
+                Compression compression,
+                const void *src, uint64_t src_size,
+                void *dst, size_t dst_alloc_size, size_t *dst_size, int level);
 int compress_blob(Compression compression,
                   const void *src, uint64_t src_size,
                   void *dst, size_t dst_alloc_size, size_t *dst_size, int level);
+int decompress_blob_journal(
+                Compression compression,
+                const void *src, uint64_t src_size,
+                void **dst, size_t *dst_size, size_t dst_max);
 int decompress_blob(Compression compression,
                     const void *src, uint64_t src_size,
                     void **dst, size_t *dst_size, size_t dst_max);
@@ -69,6 +78,12 @@ int decompress_blob(Compression compression,
 int decompress_zlib_raw(const void *src, uint64_t src_size,
                         void *dst, size_t dst_size, int wbits);
 
+int decompress_startswith_journal(
+                Compression compression,
+                const void *src, uint64_t src_size,
+                void **buffer,
+                const void *prefix, size_t prefix_len,
+                uint8_t extra);
 int decompress_startswith(Compression compression,
                           const void *src, uint64_t src_size,
                           void **buffer,

--- a/src/basic/compress.h
+++ b/src/basic/compress.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "basic-forward.h"
+#include "dlopen-note.h"
 
 typedef enum Compression {
         COMPRESSION_NONE,
@@ -80,11 +81,11 @@ int compress_stream(Compression type, int fdf, int fdt, uint64_t max_bytes, uint
 int decompress_stream(Compression type, int fdf, int fdt, uint64_t max_bytes);
 int decompress_stream_by_filename(const char *filename, int fdf, int fdt, uint64_t max_bytes);
 
-int dlopen_xz(int log_level);
-int dlopen_lz4(int log_level);
-int dlopen_zstd(int log_level);
-int dlopen_zlib(int log_level);
-int dlopen_bzip2(int log_level);
+int dlopen_xz(int log_level) _dlopen_loader_;
+int dlopen_lz4(int log_level) _dlopen_loader_;
+int dlopen_zstd(int log_level) _dlopen_loader_;
+int dlopen_zlib(int log_level) _dlopen_loader_;
+int dlopen_bzip2(int log_level) _dlopen_loader_;
 
 static inline const char* default_compression_extension(void) {
         return compression_extension_to_string(DEFAULT_COMPRESSION) ?: "";

--- a/src/basic/dlopen-note.h
+++ b/src/basic/dlopen-note.h
@@ -94,8 +94,11 @@
         LIBZSTD_NOTE(priority)
 
 #define COMPRESS_DEFAULT_NOTE                           \
+        COMPRESS_JOURNAL_NOTE;                          \
         LIBBZ2_NOTE(suggested);                         \
+        LIBZ_NOTE(suggested)
+
+#define COMPRESS_JOURNAL_NOTE                           \
         LIBLZ4_NOTE(COMPRESSION_PRIORITY_LZ4);          \
         LIBLZMA_NOTE(COMPRESSION_PRIORITY_XZ);          \
-        LIBZ_NOTE(suggested);                           \
         LIBZSTD_NOTE(COMPRESSION_PRIORITY_ZSTD)

--- a/src/basic/dlopen-note.h
+++ b/src/basic/dlopen-note.h
@@ -1,0 +1,91 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#pragma once
+
+#include "sd-dlopen.h"
+
+#include "basic-forward.h"
+#include "strv.h"
+
+/* Avoid invalid priority. */
+#define _DLOPEN_CHECK_PRIORITY_required    1
+#define _DLOPEN_CHECK_PRIORITY_recommended 1
+#define _DLOPEN_CHECK_PRIORITY_suggested   1
+
+/* Unlike SD_ELF_NOTE_DLOPEN_ANCHORED(), this takes feature and priority without quotation. */
+#define ELF_NOTE_DLOPEN_ANCHORED(feature, description, priority, ...)   \
+        assert_cc(_DLOPEN_CHECK_PRIORITY_##priority);                   \
+        SD_ELF_NOTE_DLOPEN_ANCHORED(                                    \
+                        feature##_##priority,                           \
+                        STRINGIFY(feature),                             \
+                        description,                                    \
+                        STRINGIFY(priority),                            \
+                        __VA_ARGS__)
+
+#if HAVE_BZIP2
+#  define LIBBZ2_NOTE(priority)                                         \
+        ELF_NOTE_DLOPEN_ANCHORED(                                       \
+                        bzip2,                                          \
+                        "Support bzip2 compression and decompression",  \
+                        priority,                                       \
+                        "libbz2.so.1")
+#else
+#  define LIBBZ2_NOTE(priority)
+#endif
+
+#if HAVE_LZ4
+#  define LIBLZ4_NOTE(priority)                                         \
+        ELF_NOTE_DLOPEN_ANCHORED(                                       \
+                        lz4,                                            \
+                        "Support lz4 compression in journal and coredump files", \
+                        priority,                                       \
+                        "liblz4.so.1")
+#else
+#  define LIBLZ4_NOTE(priority)
+#endif
+
+#if HAVE_XZ
+#  define LIBLZMA_NOTE(priority)                                        \
+        ELF_NOTE_DLOPEN_ANCHORED(                                       \
+                        lzma,                                           \
+                        "Support lzma compression in journal and coredump files", \
+                        priority,                                       \
+                        "liblzma.so.5")
+#else
+#  define LIBLZMA_NOTE(priority)
+#endif
+
+#if HAVE_ZLIB
+#  define LIBZ_NOTE(priority)                                           \
+        ELF_NOTE_DLOPEN_ANCHORED(                                       \
+                        zlib,                                           \
+                        "Support gzip compression and decompression",   \
+                        priority,                                       \
+                        "libz.so.1")
+#else
+#  define LIBZ_NOTE(priority)
+#endif
+
+#if HAVE_ZSTD
+#  define LIBZSTD_NOTE(priority)                                        \
+        ELF_NOTE_DLOPEN_ANCHORED(                                       \
+                        zstd,                                           \
+                        "Support zstd compression in journal and coredump files", \
+                        priority,                                       \
+                        "libzstd.so.1")
+#else
+#  define LIBZSTD_NOTE(priority)
+#endif
+
+#define COMPRESS_NOTE(priority)                         \
+        LIBBZ2_NOTE(priority);                          \
+        LIBLZ4_NOTE(priority);                          \
+        LIBLZMA_NOTE(priority);                         \
+        LIBZ_NOTE(priority);                            \
+        LIBZSTD_NOTE(priority)
+
+#define COMPRESS_DEFAULT_NOTE                           \
+        LIBBZ2_NOTE(suggested);                         \
+        LIBLZ4_NOTE(COMPRESSION_PRIORITY_LZ4);          \
+        LIBLZMA_NOTE(COMPRESSION_PRIORITY_XZ);          \
+        LIBZ_NOTE(suggested);                           \
+        LIBZSTD_NOTE(COMPRESSION_PRIORITY_ZSTD)

--- a/src/basic/dlopen-note.h
+++ b/src/basic/dlopen-note.h
@@ -6,6 +6,16 @@
 #include "basic-forward.h"
 #include "strv.h"
 
+/* Prevent dlopen helper functions (e.g., dlopen_libfoo()) from being inlined or cloned by the compiler/LTO.
+ * This ensures that their specific symbols remain intact in the final executable, allowing the developer
+ * test utility to verify that the functions corresponding to the dlopen ELF notes are actually invoked.
+ * This is restricted to BUILD_MODE_DEVELOPER to avoid degrading production performance. */
+#if BUILD_MODE_DEVELOPER
+#  define _dlopen_loader_ _noclone_ _noinline_
+#else
+#  define _dlopen_loader_
+#endif
+
 /* Avoid invalid priority. */
 #define _DLOPEN_CHECK_PRIORITY_required    1
 #define _DLOPEN_CHECK_PRIORITY_recommended 1

--- a/src/bless-boot/bless-boot.c
+++ b/src/bless-boot/bless-boot.c
@@ -5,6 +5,7 @@
 #include "alloc-util.h"
 #include "build.h"
 #include "devnum-util.h"
+#include "dlopen-note.h"
 #include "efivars.h"
 #include "fd-util.h"
 #include "find-esp.h"
@@ -565,6 +566,8 @@ exists:
 static int run(int argc, char *argv[]) {
         char **args = NULL;
         int r;
+
+        LIBBLKID_NOTE(recommended);
 
         log_setup();
 

--- a/src/bless-boot/meson.build
+++ b/src/bless-boot/meson.build
@@ -1,14 +1,5 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-if get_option('link-boot-shared')
-        boot_link_with = [libshared]
-else
-        boot_link_with = [
-                libshared_static,
-                libsystemd_static,
-        ]
-endif
-
 executables += [
         libexec_template + {
                 'name' : 'systemd-bless-boot',
@@ -18,7 +9,7 @@ executables += [
                         'ENABLE_BOOTLOADER',
                 ],
                 'sources' : files('bless-boot.c'),
-                'link_with' : boot_link_with,
+                'install' : get_option('link-boot-shared') ? 'yes' : 'static',
         },
         generator_template + {
                 'name' : 'systemd-bless-boot-generator',
@@ -27,7 +18,7 @@ executables += [
                         'ENABLE_BOOTLOADER',
                 ],
                 'sources' : files('bless-boot-generator.c'),
-                'link_with' : boot_link_with,
+                'install' : get_option('link-boot-shared') ? 'yes' : 'static',
         },
         libexec_template + {
                 'name' : 'systemd-boot-check-no-failures',

--- a/src/bootctl/bootctl-install.c
+++ b/src/bootctl/bootctl-install.c
@@ -1085,7 +1085,7 @@ static int install_secure_boot_auto_enroll(InstallContext *c) {
         if (!c->secure_boot_certificate || !c->secure_boot_private_key)
                 return 0;
 
-        r = DLOPEN_LIBCRYPTO(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+        r = DLOPEN_LIBCRYPTO(LOG_DEBUG, recommended);
         if (r < 0)
                 return r;
 

--- a/src/bootctl/bootctl.c
+++ b/src/bootctl/bootctl.c
@@ -22,6 +22,7 @@
 #include "crypto-util.h"
 #include "devnum-util.h"
 #include "dissect-image.h"
+#include "dlopen-note.h"
 #include "efi-loader.h"
 #include "efivars.h"
 #include "escape.h"
@@ -857,6 +858,13 @@ static int run(int argc, char *argv[]) {
         _cleanup_(loop_device_unrefp) LoopDevice *loop_device = NULL;
         _cleanup_(umount_and_freep) char *mounted_dir = NULL;
         int r;
+
+        LIBBLKID_NOTE(recommended);
+        LIBCRYPTSETUP_NOTE(suggested);
+        LIBMOUNT_NOTE(recommended);
+        LIBTSS2_ESYS_NOTE(suggested);
+        LIBTSS2_MU_NOTE(suggested);
+        LIBTSS2_RC_NOTE(suggested);
 
         log_setup();
 

--- a/src/bootctl/meson.build
+++ b/src/bootctl/meson.build
@@ -23,11 +23,11 @@ executables += [
                           'HAVE_BLKID',
                 ],
                 'sources' : bootctl_sources,
-                'link_with' : boot_link_with,
                 'dependencies' : [
                         libopenssl_cflags,
                         tpm2_cflags,
                 ],
+                'install' : get_option('link-boot-shared') ? 'yes' : 'static',
         },
         test_template + {
                 'sources' : files(

--- a/src/core/bpf-bind-iface.c
+++ b/src/core/bpf-bind-iface.c
@@ -31,7 +31,7 @@ int bpf_bind_network_interface_supported(void) {
         if (supported >= 0)
                 return supported;
 
-        if (DLOPEN_BPF(LOG_WARNING, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED) < 0)
+        if (DLOPEN_BPF(LOG_WARNING, recommended) < 0)
                 return (supported = false);
 
         obj = bind_iface_bpf__open();

--- a/src/core/bpf-restrict-fs.c
+++ b/src/core/bpf-restrict-fs.c
@@ -78,7 +78,7 @@ bool bpf_restrict_fs_supported(bool initialize) {
         if (!initialize)
                 return false;
 
-        if (DLOPEN_BPF(LOG_WARNING, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED) < 0)
+        if (DLOPEN_BPF(LOG_WARNING, recommended) < 0)
                 return (supported = false);
 
         r = lsm_supported("bpf");

--- a/src/core/bpf-restrict-fsaccess.c
+++ b/src/core/bpf-restrict-fsaccess.c
@@ -171,7 +171,7 @@ bool bpf_restrict_fsaccess_supported(void) {
 
         if (supported >= 0)
                 return supported;
-        if (DLOPEN_BPF(LOG_WARNING, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED) < 0)
+        if (DLOPEN_BPF(LOG_WARNING, recommended) < 0)
                 return (supported = false);
 
         r = lsm_supported("bpf");
@@ -340,7 +340,7 @@ static int restrict_fsaccess_validate_deserialized_fds(Manager *m) {
 
         assert(m);
 
-        r = DLOPEN_BPF(LOG_WARNING, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+        r = DLOPEN_BPF(LOG_WARNING, recommended);
         if (r < 0)
                 return log_error_errno(SYNTHETIC_ERRNO(ENOTRECOVERABLE),
                                        "bpf-restrict-fsaccess: Failed to load libbpf for FD validation, aborting.");

--- a/src/core/bpf-restrict-ifaces.c
+++ b/src/core/bpf-restrict-ifaces.c
@@ -86,7 +86,7 @@ int bpf_restrict_ifaces_supported(void) {
         if (supported >= 0)
                 return supported;
 
-        if (DLOPEN_BPF(LOG_WARNING, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED) < 0)
+        if (DLOPEN_BPF(LOG_WARNING, recommended) < 0)
                 return (supported = false);
 
         r = prepare_restrict_ifaces_bpf(NULL, true, NULL, &obj);

--- a/src/core/bpf-socket-bind.c
+++ b/src/core/bpf-socket-bind.c
@@ -125,7 +125,7 @@ int bpf_socket_bind_supported(void) {
         _cleanup_(socket_bind_bpf_freep) struct socket_bind_bpf *obj = NULL;
         int r;
 
-        if (DLOPEN_BPF(LOG_WARNING, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED) < 0)
+        if (DLOPEN_BPF(LOG_WARNING, recommended) < 0)
                 return false;
 
         r = prepare_socket_bind_bpf(/* unit= */ NULL, /* allow_rules= */ NULL, /* deny_rules= */ NULL, &obj);

--- a/src/core/exec-invoke.c
+++ b/src/core/exec-invoke.c
@@ -1310,7 +1310,7 @@ static int setup_pam(
          * parent process will exec() the actual daemon. We do things this way to ensure that the main PID of
          * the daemon is the one we initially fork()ed. */
 
-        r = DLOPEN_LIBPAM(LOG_ERR, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+        r = DLOPEN_LIBPAM(LOG_ERR, recommended);
         if (r < 0)
                 return r;
 
@@ -1576,7 +1576,7 @@ static bool seccomp_allows_drop_privileges(const ExecContext *c) {
         assert(c);
 
         /* No libseccomp, all is fine */
-        if (DLOPEN_LIBSECCOMP(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED) < 0)
+        if (DLOPEN_LIBSECCOMP(LOG_DEBUG, recommended) < 0)
                 return true;
 
         /* No syscall filter, we are allowed to drop privileges */
@@ -1886,7 +1886,7 @@ static int apply_restrict_filesystems(const ExecContext *c, const ExecParameters
         }
 
         /* We are in a new binary, so dl-open again */
-        r = DLOPEN_BPF(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+        r = DLOPEN_BPF(LOG_DEBUG, recommended);
         if (r < 0)
                 return r;
 
@@ -6000,12 +6000,12 @@ int exec_invoke(
         }
 
         /* Load a bunch of libraries we'll possibly need later, before we turn off dlopen() */
-        (void) DLOPEN_BPF(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
-        (void) DLOPEN_CRYPTSETUP(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
-        (void) DLOPEN_LIBMOUNT(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
-        (void) DLOPEN_LIBSECCOMP(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+        (void) DLOPEN_BPF(LOG_DEBUG, recommended);
+        (void) DLOPEN_CRYPTSETUP(LOG_DEBUG, recommended);
+        (void) DLOPEN_LIBMOUNT(LOG_DEBUG, recommended);
+        (void) DLOPEN_LIBSECCOMP(LOG_DEBUG, recommended);
         /* Needed for userspace verity verification fallback */
-        (void) DLOPEN_LIBCRYPTO(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+        (void) DLOPEN_LIBCRYPTO(LOG_DEBUG, recommended);
 
         /* Let's now disable further dlopen()ing of libraries, since we are about to do namespace
          * shenanigans, and do not want to mix resources from host and namespace */

--- a/src/core/execute.c
+++ b/src/core/execute.c
@@ -1575,7 +1575,7 @@ void exec_context_dump(const ExecContext *c, FILE* f, const char *prefix) {
                         fputc('~', f);
 
 #if HAVE_SECCOMP
-                if (DLOPEN_LIBSECCOMP(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED) >= 0) {
+                if (DLOPEN_LIBSECCOMP(LOG_DEBUG, recommended) >= 0) {
                         void *id, *val;
                         bool first = true;
                         HASHMAP_FOREACH_KEY(val, id, c->syscall_filter) {
@@ -1994,7 +1994,7 @@ char** exec_context_get_syscall_filter(const ExecContext *c) {
         assert(c);
 
 #if HAVE_SECCOMP
-        if (DLOPEN_LIBSECCOMP(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED) < 0)
+        if (DLOPEN_LIBSECCOMP(LOG_DEBUG, recommended) < 0)
                 return strv_new(NULL);
 
         void *id, *val;
@@ -2063,7 +2063,7 @@ char** exec_context_get_syscall_log(const ExecContext *c) {
         assert(c);
 
 #if HAVE_SECCOMP
-        if (DLOPEN_LIBSECCOMP(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED) < 0)
+        if (DLOPEN_LIBSECCOMP(LOG_DEBUG, recommended) < 0)
                 return strv_new(NULL);
 
         void *id, *val;

--- a/src/core/executor.c
+++ b/src/core/executor.c
@@ -9,6 +9,7 @@
 #include "build.h"
 #include "capability-util.h"
 #include "cgroup.h"
+#include "dlopen-note.h"
 #include "dynamic-user.h"
 #include "exec-invoke.h"
 #include "execute.h"
@@ -231,6 +232,12 @@ static int run(int argc, char *argv[]) {
 
 int run_executor(int argc, char *argv[]) {
         int r;
+
+        LIBACL_NOTE(recommended);
+        LIBAPPARMOR_NOTE(recommended);
+        LIBBLKID_NOTE(recommended);
+        LIBSELINUX_NOTE(recommended);
+        TPM2_NOTE(suggested);
 
         /* We use safe_fork() for spawning sd-pam helper process, which internally calls rename_process().
          * As the last step of renaming, all saved argvs are memzero()-ed. Hence, we need to save the argv

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -41,6 +41,7 @@
 #include "dbus.h"
 #include "dbus-manager.h"
 #include "dev-setup.h"
+#include "dlopen-note.h"
 #include "efi-random.h"
 #include "emergency-action.h"
 #include "env-util.h"
@@ -4018,6 +4019,18 @@ finish:
 }
 
 int main(int argc, char *argv[]) {
+        LIBACL_NOTE(recommended);
+        LIBAPPARMOR_NOTE(recommended);
+        LIBAUDIT_NOTE(recommended);
+        LIBBLKID_NOTE(recommended);
+        LIBBPF_NOTE(recommended);
+        LIBCRYPTO_NOTE(suggested);
+        LIBCRYPTSETUP_NOTE(recommended);
+        LIBKMOD_NOTE(recommended);
+        LIBPCRE2_NOTE(suggested);
+        LIBSECCOMP_NOTE(recommended);
+        TPM2_NOTE(suggested);
+
 #if SYSTEMD_MULTICALL_BINARY
         if (invoked_as(argv, "executor"))
                 return run_executor(argc, argv);

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -3814,7 +3814,7 @@ static int run_systemd(int argc, char *argv[]) {
         }
 
         /* Building without libmount is allowed, but if it is compiled in, then we must be able to load it */
-        r = DLOPEN_LIBMOUNT(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_REQUIRED);
+        r = DLOPEN_LIBMOUNT(LOG_DEBUG, required);
         if (r < 0 && !ERRNO_IS_NEG_NOT_SUPPORTED(r)) {
                 error_message = "Failed to load libmount.so";
                 goto finish;

--- a/src/core/meson.build
+++ b/src/core/meson.build
@@ -200,18 +200,6 @@ libcore = shared_library(
         install : true,
         install_dir : pkglibdir)
 
-core_libs_static = [
-        libc_wrapper_static,
-        libcore_static,
-        libshared_static,
-        libbasic_static,
-        libsystemd_static,
-]
-core_libs_shared = [
-        libcore,
-        libshared,
-]
-
 systemd_deps = [
         libapparmor_cflags,
         libaudit_cflags,
@@ -220,11 +208,6 @@ systemd_deps = [
         libseccomp_cflags,
         libselinux_cflags,
 ]
-
-systemd_link_args = get_option('build-static') ? ['-static'] : []
-systemd_libs = get_option('build-static') ? core_libs_static : core_libs_shared
-
-executor_libs = get_option('link-executor-shared') ? core_libs_shared : core_libs_static
 
 if conf.get('SYSTEMD_MULTICALL_BINARY') == 1
         systemd_sources += systemd_executor_sources
@@ -242,16 +225,20 @@ executables += [
                 'dbus' : true,
                 'public' : true,
                 'sources' : systemd_sources,
-                'link_args' : systemd_link_args,
-                'link_with' : systemd_libs,
+                'link_args_static' : get_option('build-static') ? ['-static'] : [],
+                'link_with' : [
+                        libcore,
+                        libshared,
+                ],
                 'dependencies' : systemd_deps,
+                'install' : get_option('build-static') ? 'static' : 'yes',
         },
 
         fuzz_template + {
                 'sources' : files('fuzz-unit-file.c'),
                 'link_with' : [
                         libcore,
-                        libshared
+                        libshared,
                 ],
                 'dependencies' : libmount_cflags,
         },
@@ -259,14 +246,14 @@ executables += [
                 'sources' : files('fuzz-manager-serialize.c'),
                 'link_with' : [
                         libcore,
-                        libshared
+                        libshared,
                 ],
         },
         fuzz_template + {
                 'sources' : files('fuzz-execute-serialize.c'),
                 'link_with' : [
                         libcore,
-                        libshared
+                        libshared,
                 ],
         },
 ]
@@ -282,7 +269,10 @@ else
                         'name' : 'systemd-executor',
                         'public' : true,
                         'sources' : systemd_executor_sources,
-                        'link_with' : executor_libs,
+                        'link_with' : [
+                                libcore,
+                                libshared,
+                        ],
                         'dependencies' : [
                                 libapparmor_cflags,
                                 libbpf_cflags,
@@ -293,6 +283,7 @@ else
                                 libseccomp_cflags,
                                 libselinux_cflags,
                         ],
+                        'install' : get_option('link-executor-shared') ? 'yes' : 'static',
                 },
         ]
 endif

--- a/src/core/mount.c
+++ b/src/core/mount.c
@@ -2407,7 +2407,7 @@ static int mount_test_startable(Unit *u) {
 }
 
 static bool mount_supported(void) {
-        return DLOPEN_LIBMOUNT(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED) >= 0;
+        return DLOPEN_LIBMOUNT(LOG_DEBUG, recommended) >= 0;
 }
 
 static int mount_subsystem_ratelimited(Manager *m) {

--- a/src/core/namespace.c
+++ b/src/core/namespace.c
@@ -3986,7 +3986,7 @@ int refresh_extensions_in_namespace(
         if (r > 0)
                 return log_debug_errno(SYNTHETIC_ERRNO(EINVAL), "Target namespace is not separate, cannot reload extensions");
 
-        (void) DLOPEN_CRYPTSETUP(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+        (void) DLOPEN_CRYPTSETUP(LOG_DEBUG, recommended);
 
         extension_dir = path_join(p->private_namespace_dir, "unit-extensions");
         if (!extension_dir)

--- a/src/core/selinux-setup.c
+++ b/src/core/selinux-setup.c
@@ -17,7 +17,7 @@ int mac_selinux_setup(bool *loaded_policy) {
 
         assert(loaded_policy);
 
-        r = DLOPEN_LIBSELINUX(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+        r = DLOPEN_LIBSELINUX(LOG_DEBUG, recommended);
         if (r < 0)
                 return 0;
 

--- a/src/coredump/coredump.c
+++ b/src/coredump/coredump.c
@@ -6,12 +6,19 @@
 #include "coredump-kernel-helper.h"
 #include "coredump-receive.h"
 #include "coredump-util.h"
+#include "dlopen-note.h"
 #include "log.h"
 #include "main-func.h"
 #include "string-util.h"
 
 static int run(int argc, char *argv[]) {
         int r;
+
+        COMPRESS_DEFAULT_NOTE;
+        LIBACL_NOTE(recommended);
+        LIBDW_NOTE(suggested);
+        LIBELF_NOTE(suggested);
+        LIBSELINUX_NOTE(recommended);
 
         /* When running as backtrace mode, it is not necessary to use kmsg, not necessary to disable coredump
          * from the command, and unexpectedly passed file descriptors can be silently ignored. */

--- a/src/coredump/coredumpctl.c
+++ b/src/coredump/coredumpctl.c
@@ -21,6 +21,7 @@
 #include "chase.h"
 #include "compress.h"
 #include "dissect-image.h"
+#include "dlopen-note.h"
 #include "errno-util.h"
 #include "escape.h"
 #include "extract-word.h"
@@ -1488,6 +1489,13 @@ static int run(int argc, char *argv[]) {
         _cleanup_(umount_and_freep) char *mounted_dir = NULL;
         char **args = NULL;
         int r, units_active;
+
+        COMPRESS_DEFAULT_NOTE;
+        LIBACL_NOTE(recommended);
+        LIBBLKID_NOTE(recommended);
+        LIBCRYPTO_NOTE(suggested);
+        LIBCRYPTSETUP_NOTE(suggested);
+        LIBMOUNT_NOTE(recommended);
 
         setlocale(LC_ALL, "");
         log_setup();

--- a/src/creds/creds.c
+++ b/src/creds/creds.c
@@ -188,7 +188,7 @@ static int is_tmpfs_with_noswap(dev_t devno) {
         _cleanup_(mnt_free_tablep) struct libmnt_table *table = NULL;
         int r;
 
-        r = DLOPEN_LIBMOUNT(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+        r = DLOPEN_LIBMOUNT(LOG_DEBUG, recommended);
         if (r < 0)
                 return r;
 

--- a/src/creds/creds.c
+++ b/src/creds/creds.c
@@ -12,6 +12,7 @@
 #include "bus-util.h"
 #include "creds-util.h"
 #include "dirent-util.h"
+#include "dlopen-note.h"
 #include "errno-util.h"
 #include "escape.h"
 #include "fileio.h"
@@ -1466,6 +1467,9 @@ static int vl_server(void) {
 
 static int run(int argc, char *argv[]) {
         int r;
+
+        LIBCRYPTO_NOTE(suggested);
+        TPM2_NOTE(suggested);
 
         log_setup();
 

--- a/src/cryptenroll/cryptenroll-varlink.c
+++ b/src/cryptenroll/cryptenroll-varlink.c
@@ -344,7 +344,7 @@ static int vl_method_enroll(
         if (FLAGS_SET(flags, SD_VARLINK_METHOD_MORE))
                 c.link = sd_varlink_ref(link);
 
-        r = DLOPEN_CRYPTSETUP(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_REQUIRED);
+        r = DLOPEN_CRYPTSETUP(LOG_DEBUG, required);
         if (r < 0)
                 return r;
 
@@ -421,7 +421,7 @@ static int vl_method_list_slots(
         if (strdup_to(&c.node, node) < 0)
                 return -ENOMEM;
 
-        r = DLOPEN_CRYPTSETUP(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_REQUIRED);
+        r = DLOPEN_CRYPTSETUP(LOG_DEBUG, required);
         if (r < 0)
                 return r;
 

--- a/src/cryptenroll/cryptenroll.c
+++ b/src/cryptenroll/cryptenroll.c
@@ -21,6 +21,7 @@
 #include "cryptenroll-varlink.h"
 #include "cryptenroll-wipe.h"
 #include "cryptsetup-util.h"
+#include "dlopen-note.h"
 #include "extract-word.h"
 #include "format-table.h"
 #include "help-util.h"
@@ -1018,6 +1019,13 @@ static int run(int argc, char *argv[]) {
         _cleanup_(iovec_done_erase) struct iovec vk = {};
         _cleanup_(enroll_context_done) EnrollContext c = ENROLL_CONTEXT_NULL;
         int slot, r;
+
+        LIBCRYPTO_NOTE(suggested);
+        LIBFIDO2_NOTE(suggested);
+        LIBP11KIT_NOTE(suggested);
+        LIBQRENCODE_NOTE(suggested);
+        PASSWORD_NOTE(suggested);
+        TPM2_NOTE(suggested);
 
         log_setup();
 

--- a/src/cryptenroll/cryptenroll.c
+++ b/src/cryptenroll/cryptenroll.c
@@ -1036,7 +1036,7 @@ static int run(int argc, char *argv[]) {
         if (r <= 0)
                 return r;
 
-        r = DLOPEN_CRYPTSETUP(LOG_ERR, SD_ELF_NOTE_DLOPEN_PRIORITY_REQUIRED);
+        r = DLOPEN_CRYPTSETUP(LOG_ERR, required);
         if (r < 0)
                 return r;
 

--- a/src/cryptsetup/cryptsetup-tokens/cryptsetup-token-systemd-fido2.c
+++ b/src/cryptsetup/cryptsetup-tokens/cryptsetup-token-systemd-fido2.c
@@ -8,6 +8,7 @@
 #include "alloc-util.h"
 #include "cryptsetup-token.h"
 #include "cryptsetup-token-util.h"
+#include "dlopen-note.h"
 #include "luks2-fido2.h"
 #include "memory-util.h"
 #include "version.h"
@@ -17,7 +18,9 @@
 #define TOKEN_VERSION_MINOR "0"
 
 /* for libcryptsetup debug purpose */
-_public_ const char *cryptsetup_token_version(void) {
+_public_ const char* cryptsetup_token_version(void) {
+        LIBFIDO2_NOTE(suggested);
+
         return TOKEN_VERSION_MAJOR "." TOKEN_VERSION_MINOR " systemd-v" PROJECT_VERSION_FULL " (" GIT_VERSION ")";
 }
 

--- a/src/cryptsetup/cryptsetup-tokens/cryptsetup-token-systemd-fido2.c
+++ b/src/cryptsetup/cryptsetup-tokens/cryptsetup-token-systemd-fido2.c
@@ -37,7 +37,7 @@ _public_ int cryptsetup_token_open_pin(
         assert(pin || pin_size == 0);
         assert(token >= 0);
 
-        r = DLOPEN_CRYPTSETUP(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_REQUIRED);
+        r = DLOPEN_CRYPTSETUP(LOG_DEBUG, required);
         if (r < 0)
                 return r;
 
@@ -102,7 +102,7 @@ _public_ void cryptsetup_token_dump(
 
         assert(json);
 
-        if (DLOPEN_CRYPTSETUP(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_REQUIRED) < 0)
+        if (DLOPEN_CRYPTSETUP(LOG_DEBUG, required) < 0)
                 return;
 
         r = parse_luks2_fido2_data(cd, json, &rp_id, &salt, &salt_size, &cid, &cid_size, &required);
@@ -169,7 +169,7 @@ _public_ int cryptsetup_token_validate(
 
         assert(json);
 
-        r = DLOPEN_CRYPTSETUP(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_REQUIRED);
+        r = DLOPEN_CRYPTSETUP(LOG_DEBUG, required);
         if (r < 0)
                 return r;
 

--- a/src/cryptsetup/cryptsetup-tokens/cryptsetup-token-systemd-pkcs11.c
+++ b/src/cryptsetup/cryptsetup-tokens/cryptsetup-token-systemd-pkcs11.c
@@ -7,6 +7,7 @@
 #include "alloc-util.h"
 #include "cryptsetup-token.h"
 #include "cryptsetup-token-util.h"
+#include "dlopen-note.h"
 #include "luks2-pkcs11.h"
 #include "memory-util.h"
 #include "pkcs11-util.h"
@@ -17,7 +18,10 @@
 #define TOKEN_VERSION_MINOR "0"
 
 /* for libcryptsetup debug purpose */
-_public_ const char *cryptsetup_token_version(void) {
+_public_ const char* cryptsetup_token_version(void) {
+        LIBCRYPTO_NOTE(suggested);
+        LIBP11KIT_NOTE(suggested);
+
         return TOKEN_VERSION_MAJOR "." TOKEN_VERSION_MINOR " systemd-v" PROJECT_VERSION_FULL " (" GIT_VERSION ")";
 }
 

--- a/src/cryptsetup/cryptsetup-tokens/cryptsetup-token-systemd-pkcs11.c
+++ b/src/cryptsetup/cryptsetup-tokens/cryptsetup-token-systemd-pkcs11.c
@@ -36,7 +36,7 @@ _public_ int cryptsetup_token_open_pin(
         assert(pin || pin_size == 0);
         assert(token >= 0);
 
-        r = DLOPEN_CRYPTSETUP(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_REQUIRED);
+        r = DLOPEN_CRYPTSETUP(LOG_DEBUG, required);
         if (r < 0)
                 return r;
 
@@ -94,7 +94,7 @@ _public_ void cryptsetup_token_dump(
         _cleanup_free_ void *pkcs11_key = NULL;
         Pkcs11RsaPadding rsa_padding = PKCS11_RSA_PADDING_PKCS1V15;
 
-        if (DLOPEN_CRYPTSETUP(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_REQUIRED) < 0)
+        if (DLOPEN_CRYPTSETUP(LOG_DEBUG, required) < 0)
                 return;
 
         r = parse_luks2_pkcs11_data(cd, json, &pkcs11_uri, &pkcs11_key, &pkcs11_key_size, &rsa_padding);
@@ -124,7 +124,7 @@ _public_ int cryptsetup_token_validate(
         sd_json_variant *w;
         _cleanup_(sd_json_variant_unrefp) sd_json_variant *v = NULL;
 
-        r = DLOPEN_CRYPTSETUP(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_REQUIRED);
+        r = DLOPEN_CRYPTSETUP(LOG_DEBUG, required);
         if (r < 0)
                 return r;
 

--- a/src/cryptsetup/cryptsetup-tokens/cryptsetup-token-systemd-tpm2.c
+++ b/src/cryptsetup/cryptsetup-tokens/cryptsetup-token-systemd-tpm2.c
@@ -5,6 +5,7 @@
 #include "alloc-util.h"
 #include "cryptsetup-token.h"
 #include "cryptsetup-token-util.h"
+#include "dlopen-note.h"
 #include "hexdecoct.h"
 #include "json-util.h"
 #include "luks2-tpm2.h"
@@ -18,7 +19,9 @@
 #define TOKEN_VERSION_MINOR "0"
 
 /* for libcryptsetup debug purpose */
-_public_ const char *cryptsetup_token_version(void) {
+_public_ const char* cryptsetup_token_version(void) {
+        LIBCRYPTO_NOTE(suggested);
+        TPM2_NOTE(suggested);
 
         return TOKEN_VERSION_MAJOR "." TOKEN_VERSION_MINOR " systemd-v" PROJECT_VERSION_FULL " (" GIT_VERSION ")";
 }

--- a/src/cryptsetup/cryptsetup-tokens/cryptsetup-token-systemd-tpm2.c
+++ b/src/cryptsetup/cryptsetup-tokens/cryptsetup-token-systemd-tpm2.c
@@ -70,7 +70,7 @@ _public_ int cryptsetup_token_open_pin(
         assert(ret_password);
         assert(ret_password_len);
 
-        r = DLOPEN_CRYPTSETUP(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_REQUIRED);
+        r = DLOPEN_CRYPTSETUP(LOG_DEBUG, required);
         if (r < 0)
                 return r;
 
@@ -210,7 +210,7 @@ _public_ void cryptsetup_token_dump(
 
         assert(json);
 
-        if (DLOPEN_CRYPTSETUP(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_REQUIRED) < 0)
+        if (DLOPEN_CRYPTSETUP(LOG_DEBUG, required) < 0)
                 return;
 
         r = sd_json_parse(json, SD_JSON_PARSE_MUST_BE_OBJECT, &v, /* reterr_line= */ NULL, /* reterr_column= */ NULL);
@@ -304,7 +304,7 @@ _public_ int cryptsetup_token_validate(
 
         assert(json);
 
-        r = DLOPEN_CRYPTSETUP(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_REQUIRED);
+        r = DLOPEN_CRYPTSETUP(LOG_DEBUG, required);
         if (r < 0)
                 return r;
 

--- a/src/cryptsetup/cryptsetup-tokens/meson.build
+++ b/src/cryptsetup/cryptsetup-tokens/meson.build
@@ -9,7 +9,6 @@ lib_cryptsetup_token_common = static_library(
                 libcryptsetup_cflags,
                 userspace,
         ],
-        link_with : libshared,
         build_by_default : false)
 
 cryptsetup_token_systemd_tpm2_sources = files(

--- a/src/cryptsetup/cryptsetup.c
+++ b/src/cryptsetup/cryptsetup.c
@@ -18,6 +18,7 @@
 #include "cryptsetup-pkcs11.h"
 #include "cryptsetup-tpm2.h"
 #include "cryptsetup-util.h"
+#include "dlopen-note.h"
 #include "efi-api.h"
 #include "efi-loader.h"
 #include "efivars.h"
@@ -2883,6 +2884,12 @@ static int verb_detach(int argc, char *argv[], uintptr_t _data, void *userdata) 
 
 static int run(int argc, char *argv[]) {
         int r;
+
+        LIBBLKID_NOTE(recommended);
+        LIBFIDO2_NOTE(suggested);
+        LIBMOUNT_NOTE(recommended);
+        LIBP11KIT_NOTE(suggested);
+        TPM2_NOTE(suggested);
 
         log_setup();
 

--- a/src/cryptsetup/cryptsetup.c
+++ b/src/cryptsetup/cryptsetup.c
@@ -538,7 +538,7 @@ static int parse_one_option(const char *option) {
 #if HAVE_OPENSSL
                 _cleanup_strv_free_ char **l = NULL;
 
-                r = DLOPEN_LIBCRYPTO(LOG_ERR, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+                r = DLOPEN_LIBCRYPTO(LOG_ERR, recommended);
                 if (r < 0)
                         return r;
 
@@ -2893,7 +2893,7 @@ static int run(int argc, char *argv[]) {
         if (r <= 0)
                 return r;
 
-        r = DLOPEN_CRYPTSETUP(LOG_ERR, SD_ELF_NOTE_DLOPEN_PRIORITY_REQUIRED);
+        r = DLOPEN_CRYPTSETUP(LOG_ERR, required);
         if (r < 0)
                 return r;
 

--- a/src/debug-generator/debug-generator.c
+++ b/src/debug-generator/debug-generator.c
@@ -5,6 +5,7 @@
 #include "alloc-util.h"
 #include "bitfield.h"
 #include "creds-util.h"
+#include "dlopen-note.h"
 #include "dropin.h"
 #include "errno-util.h"
 #include "extract-word.h"
@@ -363,6 +364,9 @@ static int process_unit_credentials(const char *credentials_dir) {
 static int run(const char *dest, const char *dest_early, const char *dest_late) {
         const char *credentials_dir;
         int r;
+
+        LIBCRYPTO_NOTE(suggested);
+        TPM2_NOTE(suggested);
 
         assert_se(arg_dest = dest_early);
 

--- a/src/dissect/dissect.c
+++ b/src/dissect/dissect.c
@@ -493,7 +493,7 @@ static int parse_argv(int argc, char *argv[]) {
                         break;
 
                 OPTION_LONG("make-archive", NULL, "Convert the DDI to an archive file"):
-                        r = DLOPEN_LIBARCHIVE(LOG_ERR, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+                        r = DLOPEN_LIBARCHIVE(LOG_ERR, recommended);
                         if (r < 0)
                                 return r;
 

--- a/src/dissect/dissect.c
+++ b/src/dissect/dissect.c
@@ -19,6 +19,7 @@
 #include "device-util.h"
 #include "discover-image.h"
 #include "dissect-image.h"
+#include "dlopen-note.h"
 #include "env-util.h"
 #include "errno-util.h"
 #include "escape.h"
@@ -1967,6 +1968,13 @@ static int run(int argc, char *argv[]) {
         _cleanup_(loop_device_unrefp) LoopDevice *d = NULL;
         _cleanup_close_ int userns_fd = -EBADF;
         int r;
+
+        LIBACL_NOTE(recommended);
+        LIBBLKID_NOTE(recommended);
+        LIBCRYPTO_NOTE(suggested);
+        LIBCRYPTSETUP_NOTE(suggested);
+        LIBMOUNT_NOTE(recommended);
+        LIBSELINUX_NOTE(recommended);
 
         log_setup();
 

--- a/src/firstboot/firstboot.c
+++ b/src/firstboot/firstboot.c
@@ -20,6 +20,7 @@
 #include "copy.h"
 #include "creds-util.h"
 #include "dissect-image.h"
+#include "dlopen-note.h"
 #include "env-file.h"
 #include "errno-util.h"
 #include "fd-util.h"
@@ -1701,6 +1702,14 @@ static int run(int argc, char *argv[]) {
         _cleanup_(umount_and_freep) char *mounted_dir = NULL;
         _cleanup_close_ int rfd = -EBADF;
         int r;
+
+        LIBBLKID_NOTE(recommended);
+        LIBCRYPT_NOTE(recommended);
+        LIBCRYPTO_NOTE(suggested);
+        LIBCRYPTSETUP_NOTE(suggested);
+        LIBMOUNT_NOTE(recommended);
+        LIBSELINUX_NOTE(recommended);
+        PASSWORD_NOTE(suggested);
 
         r = parse_argv(argc, argv);
         if (r <= 0)

--- a/src/fstab-generator/fstab-generator.c
+++ b/src/fstab-generator/fstab-generator.c
@@ -14,6 +14,7 @@
 #include "bus-util.h"
 #include "chase.h"
 #include "creds-util.h"
+#include "dlopen-note.h"
 #include "efi-loader.h"
 #include "env-util.h"
 #include "errno-util.h"
@@ -1729,6 +1730,11 @@ static int run_generator(void) {
 }
 
 static int run(int argc, char **argv) {
+        LIBCRYPTO_NOTE(suggested);
+        LIBMOUNT_NOTE(recommended);
+        LIBSELINUX_NOTE(recommended);
+        TPM2_NOTE(suggested);
+
         arg_sysroot_check = invoked_as(argv, "systemd-sysroot-fstab-check");
 
         if (arg_sysroot_check) {

--- a/src/fundamental/macro.h
+++ b/src/fundamental/macro.h
@@ -83,6 +83,11 @@
 #define _hidden_ __attribute__((__visibility__("hidden")))
 #define _likely_(x) (__builtin_expect(!!(x), 1))
 #define _malloc_ __attribute__((__malloc__))
+#ifdef __clang__
+#  define _noclone_
+#else
+#  define _noclone_ __attribute__((noclone))
+#endif
 #define _noinline_ __attribute__((noinline))
 #define _noreturn_ _Noreturn
 #define _packed_ __attribute__((__packed__))

--- a/src/getty-generator/getty-generator.c
+++ b/src/getty-generator/getty-generator.c
@@ -5,6 +5,7 @@
 
 #include "alloc-util.h"
 #include "creds-util.h"
+#include "dlopen-note.h"
 #include "extract-word.h"
 #include "fd-util.h"
 #include "fileio.h"
@@ -276,6 +277,9 @@ static int run(const char *dest, const char *dest_early, const char *dest_late) 
         int r;
 
         assert_se(arg_dest = dest);
+
+        LIBCRYPTO_NOTE(suggested);
+        TPM2_NOTE(suggested);
 
         if (in_initrd()) {
                 log_debug("Skipping generator, running in the initrd.");

--- a/src/gpt-auto-generator/gpt-auto-generator.c
+++ b/src/gpt-auto-generator/gpt-auto-generator.c
@@ -9,6 +9,7 @@
 #include "device-util.h"
 #include "devnum-util.h"
 #include "dissect-image.h"
+#include "dlopen-note.h"
 #include "dropin.h"
 #include "efi-loader.h"
 #include "efivars.h"
@@ -1358,6 +1359,10 @@ static int parse_proc_cmdline_item(const char *key, const char *value, void *dat
 
 static int run(const char *dest, const char *dest_early, const char *dest_late) {
         int r;
+
+        LIBBLKID_NOTE(recommended);
+        LIBMOUNT_NOTE(recommended);
+        LIBSELINUX_NOTE(recommended);
 
         assert_se(arg_dest = dest);
         assert_se(arg_dest_late = dest_late);

--- a/src/growfs/growfs.c
+++ b/src/growfs/growfs.c
@@ -33,7 +33,7 @@ static int resize_crypt_luks_device(dev_t devno, const char *fstype, dev_t main_
         uint64_t size;
         int r;
 
-        r = DLOPEN_CRYPTSETUP(LOG_WARNING, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+        r = DLOPEN_CRYPTSETUP(LOG_WARNING, recommended);
         if (r < 0)
                 return r;
 

--- a/src/growfs/growfs.c
+++ b/src/growfs/growfs.c
@@ -11,6 +11,7 @@
 #include "device-util.h"
 #include "devnum-util.h"
 #include "dissect-image.h"
+#include "dlopen-note.h"
 #include "fd-util.h"
 #include "format-table.h"
 #include "format-util.h"
@@ -191,6 +192,8 @@ static int run(int argc, char *argv[]) {
         uint64_t size, newsize;
         dev_t devno;
         int r;
+
+        LIBBLKID_NOTE(recommended);
 
         log_setup();
 

--- a/src/growfs/makefs.c
+++ b/src/growfs/makefs.c
@@ -7,6 +7,7 @@
 #include "alloc-util.h"
 #include "blockdev-util.h"
 #include "dissect-image.h"
+#include "dlopen-note.h"
 #include "fd-util.h"
 #include "log.h"
 #include "main-func.h"
@@ -19,6 +20,9 @@ static int run(int argc, char *argv[]) {
         sd_id128_t uuid;
         struct stat st;
         int r;
+
+        LIBBLKID_NOTE(recommended);
+        LIBMOUNT_NOTE(recommended);
 
         log_setup();
 

--- a/src/home/homectl.c
+++ b/src/home/homectl.c
@@ -2501,7 +2501,7 @@ static int verb_list_signing_keys(int argc, char *argv[], uintptr_t _data, void 
                         /* Let's decode the PEM key to DER (so that we lose prefix/suffix), then truncate it
                          * for display reasons. */
 
-                        r = DLOPEN_LIBCRYPTO(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+                        r = DLOPEN_LIBCRYPTO(LOG_DEBUG, recommended);
                         if (r < 0)
                                 return r;
 

--- a/src/home/homectl.c
+++ b/src/home/homectl.c
@@ -19,6 +19,7 @@
 #include "creds-util.h"
 #include "crypto-util.h"
 #include "dirent-util.h"
+#include "dlopen-note.h"
 #include "dns-domain.h"
 #include "env-util.h"
 #include "errno-util.h"
@@ -5182,6 +5183,12 @@ static int fallback_shell(int argc, char *argv[]) {
 static int run(int argc, char *argv[]) {
         char **args = NULL;
         int r;
+
+        LIBCRYPT_NOTE(recommended);
+        LIBFIDO2_NOTE(suggested);
+        LIBP11KIT_NOTE(suggested);
+        LIBQRENCODE_NOTE(suggested);
+        PASSWORD_NOTE(suggested);
 
         log_setup();
 

--- a/src/home/homed-manager.c
+++ b/src/home/homed-manager.c
@@ -1537,7 +1537,7 @@ int manager_startup(Manager *m) {
 
         assert(m);
 
-        r = DLOPEN_LIBCRYPTO(LOG_ERR, SD_ELF_NOTE_DLOPEN_PRIORITY_REQUIRED);
+        r = DLOPEN_LIBCRYPTO(LOG_ERR, required);
         if (r < 0)
                 return r;
 

--- a/src/home/homed.c
+++ b/src/home/homed.c
@@ -7,6 +7,7 @@
 #include "bus-log-control-api.h"
 #include "bus-object.h"
 #include "daemon-util.h"
+#include "dlopen-note.h"
 #include "homed-manager.h"
 #include "homed-manager-bus.h"
 #include "log.h"
@@ -17,6 +18,9 @@ static int run(int argc, char *argv[]) {
         _cleanup_(manager_freep) Manager *m = NULL;
         _unused_ _cleanup_(notify_on_cleanup) const char *notify_stop = NULL;
         int r;
+
+        LIBCRYPT_NOTE(recommended);
+        PASSWORD_NOTE(suggested);
 
         log_setup();
 

--- a/src/home/homework-fscrypt.c
+++ b/src/home/homework-fscrypt.c
@@ -232,7 +232,7 @@ static int fscrypt_slot_try_v1(
         assert(encrypted_size > 0);
         assert(match_key_descriptor);
 
-        r = DLOPEN_LIBCRYPTO(LOG_ERR, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+        r = DLOPEN_LIBCRYPTO(LOG_ERR, recommended);
         if (r < 0)
                 return r;
 
@@ -331,7 +331,7 @@ static int fscrypt_slot_try_v2(
         assert(iovec_is_set(tag));
         assert(match_key_descriptor);
 
-        r = DLOPEN_LIBCRYPTO(LOG_ERR, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+        r = DLOPEN_LIBCRYPTO(LOG_ERR, recommended);
         if (r < 0)
                 return r;
 
@@ -700,7 +700,7 @@ static int fscrypt_slot_set(
         size_t encrypted_size;
         ssize_t ss;
 
-        r = DLOPEN_LIBCRYPTO(LOG_ERR, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+        r = DLOPEN_LIBCRYPTO(LOG_ERR, recommended);
         if (r < 0)
                 return r;
 
@@ -813,7 +813,7 @@ int home_create_fscrypt(
         assert(setup);
         assert(ret_home);
 
-        r = DLOPEN_LIBCRYPTO(LOG_ERR, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+        r = DLOPEN_LIBCRYPTO(LOG_ERR, recommended);
         if (r < 0)
                 return r;
 

--- a/src/home/homework-luks.c
+++ b/src/home/homework-luks.c
@@ -146,7 +146,7 @@ static int probe_file_system_by_fd(
         assert(ret_fstype);
         assert(ret_uuid);
 
-        r = DLOPEN_LIBBLKID(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+        r = DLOPEN_LIBBLKID(LOG_DEBUG, recommended);
         if (r < 0)
                 return r;
 
@@ -529,7 +529,7 @@ static int acquire_open_luks_device(
         assert(setup);
         assert(!setup->crypt_device);
 
-        r = DLOPEN_CRYPTSETUP(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+        r = DLOPEN_CRYPTSETUP(LOG_DEBUG, recommended);
         if (r < 0)
                 return r;
 
@@ -684,7 +684,7 @@ static int luks_validate(
         assert(ret_size);
         assert(sector_size > 0);
 
-        r = DLOPEN_LIBBLKID(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+        r = DLOPEN_LIBBLKID(LOG_DEBUG, recommended);
         if (r < 0)
                 return r;
 
@@ -805,7 +805,7 @@ static int crypt_device_to_evp_cipher(struct crypt_device *cd, const EVP_CIPHER 
         assert(cd);
         assert(ret);
 
-        r = DLOPEN_LIBCRYPTO(LOG_ERR, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+        r = DLOPEN_LIBCRYPTO(LOG_ERR, recommended);
         if (r < 0)
                 return r;
 
@@ -1293,7 +1293,7 @@ int home_setup_luks(
         assert(setup);
         assert(user_record_storage(h) == USER_LUKS);
 
-        r = DLOPEN_CRYPTSETUP(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+        r = DLOPEN_CRYPTSETUP(LOG_DEBUG, recommended);
         if (r < 0)
                 return r;
 
@@ -1594,7 +1594,7 @@ int home_activate_luks(
         assert(setup);
         assert(ret_home);
 
-        r = DLOPEN_CRYPTSETUP(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+        r = DLOPEN_CRYPTSETUP(LOG_DEBUG, recommended);
         if (r < 0)
                 return r;
 
@@ -2211,11 +2211,11 @@ int home_create_luks(
         assert(setup->image_fd < 0);
         assert(ret_home);
 
-        r = DLOPEN_FDISK(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+        r = DLOPEN_FDISK(LOG_DEBUG, recommended);
         if (r < 0)
                 return r;
 
-        r = DLOPEN_CRYPTSETUP(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+        r = DLOPEN_CRYPTSETUP(LOG_DEBUG, recommended);
         if (r < 0)
                 return r;
 
@@ -3250,11 +3250,11 @@ int home_resize_luks(
         assert(user_record_storage(h) == USER_LUKS);
         assert(setup);
 
-        r = DLOPEN_FDISK(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+        r = DLOPEN_FDISK(LOG_DEBUG, recommended);
         if (r < 0)
                 return r;
 
-        r = DLOPEN_CRYPTSETUP(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+        r = DLOPEN_CRYPTSETUP(LOG_DEBUG, recommended);
         if (r < 0)
                 return r;
 
@@ -3712,7 +3712,7 @@ int home_passwd_luks(
         assert(user_record_storage(h) == USER_LUKS);
         assert(setup);
 
-        r = DLOPEN_CRYPTSETUP(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+        r = DLOPEN_CRYPTSETUP(LOG_DEBUG, recommended);
         if (r < 0)
                 return r;
 

--- a/src/home/homework.c
+++ b/src/home/homework.c
@@ -13,6 +13,7 @@
 #include "chown-recursive.h"
 #include "copy.h"
 #include "cryptsetup-util.h"
+#include "dlopen-note.h"
 #include "env-util.h"
 #include "errno-util.h"
 #include "fd-util.h"
@@ -1997,6 +1998,12 @@ static int run(int argc, char *argv[]) {
         usec_t start;
         sd_json_variant *fdmap, *blob_fd_variant;
         int r;
+
+        LIBCRYPT_NOTE(recommended);
+        LIBFIDO2_NOTE(suggested);
+        LIBMOUNT_NOTE(recommended);
+        LIBP11KIT_NOTE(suggested);
+        LIBSELINUX_NOTE(recommended);
 
         start = now(CLOCK_MONOTONIC);
 

--- a/src/home/homework.c
+++ b/src/home/homework.c
@@ -1328,7 +1328,7 @@ static int determine_default_storage(UserStorage *ret) {
                         if (r < 0)
                                 log_warning_errno(r, "Failed to determine if %s is encrypted, ignoring: %m", get_home_root());
 
-                        r = DLOPEN_CRYPTSETUP(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+                        r = DLOPEN_CRYPTSETUP(LOG_DEBUG, recommended);
                         if (r < 0)
                                 log_info("Not using '%s' storage, since libcryptsetup could not be loaded.", user_storage_to_string(USER_LUKS));
                         else {

--- a/src/home/pam_systemd_home.c
+++ b/src/home/pam_systemd_home.c
@@ -786,7 +786,7 @@ _public_ PAM_EXTERN int pam_sm_authenticate(
         bool debug = false;
         int r;
 
-        r = DLOPEN_LIBPAM(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_REQUIRED);
+        r = DLOPEN_LIBPAM(LOG_DEBUG, required);
         if (r < 0)
                 return PAM_SERVICE_ERR;
 
@@ -851,7 +851,7 @@ _public_ PAM_EXTERN int pam_sm_open_session(
         bool debug = false;
         int r;
 
-        r = DLOPEN_LIBPAM(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_REQUIRED);
+        r = DLOPEN_LIBPAM(LOG_DEBUG, required);
         if (r < 0)
                 return PAM_SERVICE_ERR;
 
@@ -908,7 +908,7 @@ _public_ PAM_EXTERN int pam_sm_close_session(
         bool debug = false;
         int r;
 
-        r = DLOPEN_LIBPAM(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_REQUIRED);
+        r = DLOPEN_LIBPAM(LOG_DEBUG, required);
         if (r < 0)
                 return PAM_SERVICE_ERR;
 
@@ -973,7 +973,7 @@ _public_ PAM_EXTERN int pam_sm_acct_mgmt(
         usec_t t;
         int r;
 
-        r = DLOPEN_LIBPAM(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_REQUIRED);
+        r = DLOPEN_LIBPAM(LOG_DEBUG, required);
         if (r < 0)
                 return PAM_SERVICE_ERR;
 
@@ -1092,7 +1092,7 @@ _public_ PAM_EXTERN int pam_sm_chauthtok(
         bool debug = false;
         int r;
 
-        r = DLOPEN_LIBPAM(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_REQUIRED);
+        r = DLOPEN_LIBPAM(LOG_DEBUG, required);
         if (r < 0)
                 return PAM_SERVICE_ERR;
 

--- a/src/hostname/hostnamed.c
+++ b/src/hostname/hostnamed.c
@@ -22,6 +22,7 @@
 #include "daemon-util.h"
 #include "device-private.h"
 #include "device-util.h"
+#include "dlopen-note.h"
 #include "env-file.h"
 #include "env-util.h"
 #include "extract-word.h"
@@ -2658,6 +2659,8 @@ static int run(int argc, char *argv[]) {
                 .hostname_source = _HOSTNAME_INVALID, /* appropriate value will be set later */
         };
         int r;
+
+        LIBSELINUX_NOTE(recommended);
 
         log_setup();
 

--- a/src/hwdb/hwdb.c
+++ b/src/hwdb/hwdb.c
@@ -2,6 +2,7 @@
 
 #include "alloc-util.h"
 #include "build.h"
+#include "dlopen-note.h"
 #include "format-table.h"
 #include "hwdb-util.h"
 #include "label-util.h"
@@ -113,6 +114,8 @@ static int parse_argv(int argc, char *argv[], char ***ret_args) {
 
 static int run(int argc, char *argv[]) {
         int r;
+
+        LIBSELINUX_NOTE(recommended);
 
         log_setup();
 

--- a/src/hwdb/meson.build
+++ b/src/hwdb/meson.build
@@ -6,8 +6,7 @@ executables += [
                 'public' : true,
                 'conditions' : ['ENABLE_HWDB'],
                 'sources' : files('hwdb.c'),
-                'link_with' : udev_link_with,
-                'install_rpath' : udev_rpath,
+                'install' : get_option('link-udev-shared') ? 'yes' : 'static',
                 'install_tag' : 'hwdb',
         },
 ]

--- a/src/imds/imdsd.c
+++ b/src/imds/imdsd.c
@@ -3053,7 +3053,7 @@ static int run(int argc, char* argv[]) {
         if (r <= 0)
                 return r;
 
-        r = DLOPEN_CURL(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_REQUIRED);
+        r = DLOPEN_CURL(LOG_DEBUG, required);
         if (r < 0)
                 return r;
 

--- a/src/import/export.c
+++ b/src/import/export.c
@@ -9,6 +9,7 @@
 #include "ansi-color.h"
 #include "build.h"
 #include "discover-image.h"
+#include "dlopen-note.h"
 #include "export-raw.h"
 #include "export-tar.h"
 #include "fd-util.h"
@@ -281,6 +282,9 @@ static int parse_argv(int argc, char *argv[], char ***ret_args) {
 
 static int run(int argc, char *argv[]) {
         int r;
+
+        ARCHIVE_NOTE(recommended);
+        LIBSELINUX_NOTE(recommended);
 
         setlocale(LC_ALL, "");
         log_setup();

--- a/src/import/import-common.c
+++ b/src/import/import-common.c
@@ -32,7 +32,7 @@ int import_fork_tar_x(int tree_fd, int userns_fd, PidRef *ret_pid) {
         assert(tree_fd >= 0);
         assert(ret_pid);
 
-        r = DLOPEN_LIBARCHIVE(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+        r = DLOPEN_LIBARCHIVE(LOG_DEBUG, recommended);
         if (r < 0)
                 return r;
 
@@ -99,7 +99,7 @@ int import_fork_tar_c(int tree_fd, int userns_fd, PidRef *ret_pid) {
         assert(tree_fd >= 0);
         assert(ret_pid);
 
-        r = DLOPEN_LIBARCHIVE(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+        r = DLOPEN_LIBARCHIVE(LOG_DEBUG, recommended);
         if (r < 0)
                 return r;
 

--- a/src/import/import-fs.c
+++ b/src/import/import-fs.c
@@ -9,6 +9,7 @@
 #include "build.h"
 #include "copy.h"
 #include "discover-image.h"
+#include "dlopen-note.h"
 #include "fd-util.h"
 #include "format-table.h"
 #include "format-util.h"
@@ -391,6 +392,8 @@ static int parse_argv(int argc, char *argv[], char ***ret_args) {
 
 static int run(int argc, char *argv[]) {
         int r;
+
+        LIBSELINUX_NOTE(recommended);
 
         setlocale(LC_ALL, "");
         log_setup();

--- a/src/import/import-generator.c
+++ b/src/import/import-generator.c
@@ -5,6 +5,7 @@
 #include "alloc-util.h"
 #include "creds-util.h"
 #include "discover-image.h"
+#include "dlopen-note.h"
 #include "efivars.h"
 #include "errno-util.h"
 #include "extract-word.h"
@@ -425,6 +426,9 @@ static int generate(void) {
 
 static int run(const char *dest, const char *dest_early, const char *dest_late) {
         int r;
+
+        LIBCRYPTO_NOTE(suggested);
+        TPM2_NOTE(suggested);
 
         assert_se(arg_dest = dest);
 

--- a/src/import/import.c
+++ b/src/import/import.c
@@ -9,6 +9,7 @@
 #include "ansi-color.h"
 #include "build.h"
 #include "discover-image.h"
+#include "dlopen-note.h"
 #include "env-util.h"
 #include "fd-util.h"
 #include "format-table.h"
@@ -468,6 +469,9 @@ static void parse_env(void) {
 
 static int run(int argc, char *argv[]) {
         int r;
+
+        ARCHIVE_NOTE(recommended);
+        LIBSELINUX_NOTE(recommended);
 
         setlocale(LC_ALL, "");
         log_setup();

--- a/src/import/importd.c
+++ b/src/import/importd.c
@@ -19,6 +19,7 @@
 #include "constants.h"
 #include "daemon-util.h"
 #include "discover-image.h"
+#include "dlopen-note.h"
 #include "env-util.h"
 #include "event-util.h"
 #include "fd-util.h"
@@ -2080,6 +2081,8 @@ static int run(int argc, char *argv[]) {
         _cleanup_(manager_unrefp) Manager *m = NULL;
         RuntimeScope scope = RUNTIME_SCOPE_SYSTEM;
         int r;
+
+        LIBSELINUX_NOTE(recommended);
 
         log_setup();
 

--- a/src/import/meson.build
+++ b/src/import/meson.build
@@ -10,7 +10,6 @@ executables += [
                 'dbus' : true,
                 'sources' : files(
                         'importd.c',
-                        'oci-util.c',
                 ),
                 'export' : files(
                         'oci-util.c',

--- a/src/import/pull-job.c
+++ b/src/import/pull-job.c
@@ -281,7 +281,7 @@ static int pull_job_open_disk(PullJob *j) {
         }
 
         if (j->calc_checksum) {
-                r = DLOPEN_LIBCRYPTO(LOG_ERR, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+                r = DLOPEN_LIBCRYPTO(LOG_ERR, recommended);
                 if (r < 0)
                         return r;
 

--- a/src/import/pull.c
+++ b/src/import/pull.c
@@ -9,6 +9,7 @@
 #include "ansi-color.h"
 #include "build.h"
 #include "discover-image.h"
+#include "dlopen-note.h"
 #include "env-util.h"
 #include "format-table.h"
 #include "hexdecoct.h"
@@ -607,6 +608,10 @@ static void parse_env(void) {
 
 static int run(int argc, char *argv[]) {
         int r;
+
+        ARCHIVE_NOTE(recommended);
+        LIBCURL_NOTE(suggested);
+        LIBSELINUX_NOTE(recommended);
 
         setlocale(LC_ALL, "");
         log_setup();

--- a/src/integritysetup/integritysetup.c
+++ b/src/integritysetup/integritysetup.c
@@ -204,7 +204,7 @@ static int run(int argc, char *argv[]) {
 
         log_setup();
 
-        r = DLOPEN_CRYPTSETUP(LOG_ERR, SD_ELF_NOTE_DLOPEN_PRIORITY_REQUIRED);
+        r = DLOPEN_CRYPTSETUP(LOG_ERR, required);
         if (r < 0)
                 return r;
 

--- a/src/journal-remote/journal-gatewayd.c
+++ b/src/journal-remote/journal-gatewayd.c
@@ -1259,6 +1259,9 @@ static int run(int argc, char *argv[]) {
                 MHD_USE_THREAD_PER_CONNECTION;
         int r, n;
 
+        COMPRESS_DEFAULT_NOTE;
+        LIBGNUTLS_NOTE(suggested);
+
         log_setup();
 
         r = parse_argv(argc, argv);

--- a/src/journal-remote/journal-gatewayd.c
+++ b/src/journal-remote/journal-gatewayd.c
@@ -1259,7 +1259,7 @@ static int run(int argc, char *argv[]) {
                 MHD_USE_THREAD_PER_CONNECTION;
         int r, n;
 
-        COMPRESS_DEFAULT_NOTE;
+        COMPRESS_JOURNAL_NOTE;
         LIBGNUTLS_NOTE(suggested);
 
         log_setup();

--- a/src/journal-remote/journal-gatewayd.c
+++ b/src/journal-remote/journal-gatewayd.c
@@ -1265,7 +1265,7 @@ static int run(int argc, char *argv[]) {
         if (r <= 0)
                 return r;
 
-        r = DLOPEN_MICROHTTPD(LOG_ERR, SD_ELF_NOTE_DLOPEN_PRIORITY_REQUIRED);
+        r = DLOPEN_MICROHTTPD(LOG_ERR, required);
         if (r < 0)
                 return r;
 

--- a/src/journal-remote/journal-remote-main.c
+++ b/src/journal-remote/journal-remote-main.c
@@ -468,7 +468,7 @@ static int setup_microhttpd_server(RemoteServer *s,
 #if HAVE_MICROHTTPD
         int r;
 
-        r = DLOPEN_MICROHTTPD(LOG_ERR, SD_ELF_NOTE_DLOPEN_PRIORITY_REQUIRED);
+        r = DLOPEN_MICROHTTPD(LOG_ERR, required);
         if (r < 0)
                 return r;
 

--- a/src/journal-remote/journal-remote-main.c
+++ b/src/journal-remote/journal-remote-main.c
@@ -9,6 +9,7 @@
 #include "build.h"
 #include "conf-parser.h"
 #include "daemon-util.h"
+#include "dlopen-note.h"
 #include "extract-word.h"
 #include "fd-util.h"
 #include "format-table.h"
@@ -1164,6 +1165,11 @@ static int run(int argc, char **argv) {
         _cleanup_(erase_and_freep) char *key = NULL;
         _cleanup_free_ char *cert = NULL, *trust = NULL;
         int r;
+
+        COMPRESS_DEFAULT_NOTE;
+        LIBCRYPTO_NOTE(suggested);
+        LIBGNUTLS_NOTE(suggested);
+        LIBSELINUX_NOTE(recommended);
 
         log_setup();
 

--- a/src/journal-remote/journal-upload.c
+++ b/src/journal-remote/journal-upload.c
@@ -12,6 +12,7 @@
 #include "conf-parser.h"
 #include "curl-util.h"
 #include "daemon-util.h"
+#include "dlopen-note.h"
 #include "env-file.h"
 #include "extract-word.h"
 #include "fd-util.h"
@@ -868,6 +869,8 @@ static int run(int argc, char **argv) {
         char **args = NULL;
         bool use_journal;
         int r;
+
+        COMPRESS_DEFAULT_NOTE;
 
         log_setup();
 

--- a/src/journal-remote/journal-upload.c
+++ b/src/journal-remote/journal-upload.c
@@ -879,7 +879,7 @@ static int run(int argc, char **argv) {
         if (r <= 0)
                 return r;
 
-        r = DLOPEN_CURL(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_REQUIRED);
+        r = DLOPEN_CURL(LOG_DEBUG, required);
         if (r < 0)
                 return r;
 

--- a/src/journal-remote/meson.build
+++ b/src/journal-remote/meson.build
@@ -44,7 +44,7 @@ executables += [
                 # We always build systemd-journal-remote regardless of ENABLE_REMOTE because we have to build
                 # fuzz-journal-remote even when --auto-features=disabled (see tools/oss-fuzz.sh for why).
                 # Instead, we make sure we don't install it when the remote feature is disabled.
-                'install' : conf.get('ENABLE_REMOTE') == 1,
+                'install' : conf.get('ENABLE_REMOTE') == 1 ? 'yes' : 'no',
                 'sources' : systemd_journal_remote_sources,
                 'export' : systemd_journal_remote_export_sources,
                 'dependencies' : common_deps + [libmicrohttpd_cflags],

--- a/src/journal/bsod.c
+++ b/src/journal/bsod.c
@@ -288,7 +288,7 @@ static int run(int argc, char *argv[]) {
         _cleanup_free_ char *message = NULL;
         int r;
 
-        COMPRESS_DEFAULT_NOTE;
+        COMPRESS_JOURNAL_NOTE;
         LIBQRENCODE_NOTE(suggested);
 
         log_setup();

--- a/src/journal/bsod.c
+++ b/src/journal/bsod.c
@@ -8,6 +8,7 @@
 
 #include "alloc-util.h"
 #include "build.h"
+#include "dlopen-note.h"
 #include "fd-util.h"
 #include "fileio.h"
 #include "format-table.h"
@@ -286,6 +287,9 @@ static int run(int argc, char *argv[]) {
         };
         _cleanup_free_ char *message = NULL;
         int r;
+
+        COMPRESS_DEFAULT_NOTE;
+        LIBQRENCODE_NOTE(suggested);
 
         log_setup();
 

--- a/src/journal/journalctl-authenticate.c
+++ b/src/journal/journalctl-authenticate.c
@@ -70,7 +70,7 @@ int action_setup_keys(void) {
 
         assert(arg_action == ACTION_SETUP_KEYS);
 
-        r = DLOPEN_LIBCRYPTO(LOG_ERR, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+        r = DLOPEN_LIBCRYPTO(LOG_ERR, recommended);
         if (r < 0)
                 return r;
 

--- a/src/journal/journalctl.c
+++ b/src/journal/journalctl.c
@@ -7,6 +7,7 @@
 
 #include "build.h"
 #include "dissect-image.h"
+#include "dlopen-note.h"
 #include "extract-word.h"
 #include "format-table.h"
 #include "glob-util.h"
@@ -1020,6 +1021,14 @@ static int run(int argc, char *argv[]) {
         _cleanup_(umount_and_freep) char *mounted_dir = NULL;
         _cleanup_strv_free_ char **args = NULL;
         int r;
+
+        COMPRESS_DEFAULT_NOTE;
+        LIBACL_NOTE(recommended);
+        LIBBLKID_NOTE(recommended);
+        LIBCRYPTSETUP_NOTE(suggested);
+        LIBMOUNT_NOTE(recommended);
+        LIBPCRE2_NOTE(suggested);
+        LIBQRENCODE_NOTE(suggested);
 
         setlocale(LC_ALL, "");
         log_setup();

--- a/src/journal/journalctl.c
+++ b/src/journal/journalctl.c
@@ -1022,7 +1022,7 @@ static int run(int argc, char *argv[]) {
         _cleanup_strv_free_ char **args = NULL;
         int r;
 
-        COMPRESS_DEFAULT_NOTE;
+        COMPRESS_JOURNAL_NOTE;
         LIBACL_NOTE(recommended);
         LIBBLKID_NOTE(recommended);
         LIBCRYPTSETUP_NOTE(suggested);

--- a/src/journal/journald.c
+++ b/src/journal/journald.c
@@ -6,6 +6,7 @@
 #include "sd-event.h"
 #include "sd-messages.h"
 
+#include "dlopen-note.h"
 #include "format-util.h"
 #include "journal-authenticate.h"
 #include "journald-kmsg.h"
@@ -24,6 +25,12 @@ static int run(int argc, char *argv[]) {
         const char *namespace;
         LogTarget log_target;
         int r;
+
+        COMPRESS_DEFAULT_NOTE;
+        LIBACL_NOTE(recommended);
+        LIBCRYPTO_NOTE(suggested);
+        LIBPCRE2_NOTE(suggested);
+        LIBSELINUX_NOTE(recommended);
 
         if (argc > 2)
                 return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "This program takes one or no arguments.");

--- a/src/journal/journald.c
+++ b/src/journal/journald.c
@@ -26,7 +26,7 @@ static int run(int argc, char *argv[]) {
         LogTarget log_target;
         int r;
 
-        COMPRESS_DEFAULT_NOTE;
+        COMPRESS_JOURNAL_NOTE;
         LIBACL_NOTE(recommended);
         LIBCRYPTO_NOTE(suggested);
         LIBPCRE2_NOTE(suggested);

--- a/src/journal/meson.build
+++ b/src/journal/meson.build
@@ -68,15 +68,6 @@ journalctl_sources = files(
         'journalctl-varlink-server.c',
 )
 
-if get_option('link-journalctl-shared')
-        journalctl_link_with = [libshared]
-else
-        journalctl_link_with = [
-                libshared_static,
-                libsystemd_static,
-        ]
-endif
-
 journal_test_template = test_template + {
         'import' : ['systemd-journald'],
 }
@@ -123,7 +114,6 @@ executables += [
                 'name' : 'journalctl',
                 'public' : true,
                 'sources' : journalctl_sources,
-                'link_with' : journalctl_link_with,
                 'dependencies' : [
                         liblz4_cflags,
                         libopenssl_cflags,
@@ -131,6 +121,7 @@ executables += [
                         libxz_cflags,
                         libzstd_cflags,
                 ],
+                'install' : get_option('link-journalctl-shared') ? 'yes' : 'static',
         },
         journal_test_template + {
                 'sources' : files('test-audit-type.c'),

--- a/src/kernel-install/kernel-install.c
+++ b/src/kernel-install/kernel-install.c
@@ -12,6 +12,7 @@
 #include "chase.h"
 #include "conf-files.h"
 #include "dissect-image.h"
+#include "dlopen-note.h"
 #include "env-file.h"
 #include "env-util.h"
 #include "exec-util.h"
@@ -1663,6 +1664,11 @@ static int parse_argv(int argc, char *argv[], char ***remaining_args) {
 
 static int run(int argc, char* argv[]) {
         int r;
+
+        LIBBLKID_NOTE(recommended);
+        LIBCRYPTO_NOTE(suggested);
+        LIBCRYPTSETUP_NOTE(suggested);
+        LIBMOUNT_NOTE(recommended);
 
         log_setup();
 

--- a/src/keyutil/keyutil.c
+++ b/src/keyutil/keyutil.c
@@ -233,7 +233,7 @@ static int verb_extract_public(int argc, char *argv[], uintptr_t _data, void *us
                                 return r;
                 }
 
-                r = DLOPEN_LIBCRYPTO(LOG_ERR, SD_ELF_NOTE_DLOPEN_PRIORITY_REQUIRED);
+                r = DLOPEN_LIBCRYPTO(LOG_ERR, required);
                 if (r < 0)
                         return r;
 

--- a/src/libsystemd/sd-journal/journal-file.c
+++ b/src/libsystemd/sd-journal/journal-file.c
@@ -365,7 +365,7 @@ static Compression getenv_compression(void) {
                 return DEFAULT_COMPRESSION;
         }
 
-        if (!compression_supported(c)) {
+        if (!compression_supported_journal(c)) {
                 log_debug("Unsupported compression algorithm specified, ignoring: %s", e);
                 return DEFAULT_COMPRESSION;
         }
@@ -1861,7 +1861,7 @@ static int maybe_compress_payload(
                 return 0;
         }
 
-        r = compress_blob(c, src, size, dst, size - 1, rsize, /* level= */ -1);
+        r = compress_blob_journal(c, src, size, dst, size - 1, rsize, /* level= */ -1);
         if (r < 0)
                 return log_debug_errno(r, "Failed to compress data object using %s, ignoring: %m", compression_to_string(c));
 
@@ -1983,7 +1983,7 @@ static int maybe_decompress_payload(
                 int r;
 
                 if (field) {
-                        r = decompress_startswith(compression, payload, size, &f->compress_buffer, field,
+                        r = decompress_startswith_journal(compression, payload, size, &f->compress_buffer, field,
                                                   field_length, '=');
                         if (r < 0)
                                 return log_debug_errno(r,
@@ -2003,7 +2003,7 @@ static int maybe_decompress_payload(
                                 return 1;
                 }
 
-                r = decompress_blob(compression, payload, size, &f->compress_buffer, &rsize, DATA_SIZE_MAX);
+                r = decompress_blob_journal(compression, payload, size, &f->compress_buffer, &rsize, DATA_SIZE_MAX);
                 if (r < 0)
                         return r;
 

--- a/src/libsystemd/sd-journal/journal-verify.c
+++ b/src/libsystemd/sd-journal/journal-verify.c
@@ -125,7 +125,7 @@ static int hash_payload(JournalFile *f, Object *o, uint64_t offset, const uint8_
                 _cleanup_free_ void *b = NULL;
                 size_t b_size;
 
-                r = decompress_blob(c, src, size, &b, &b_size, DATA_SIZE_MAX);
+                r = decompress_blob_journal(c, src, size, &b, &b_size, DATA_SIZE_MAX);
                 if (r < 0) {
                         error_errno(offset, r, "%s decompression failed: %m",
                                     compression_to_string(c));

--- a/src/locale/localed.c
+++ b/src/locale/localed.c
@@ -15,6 +15,7 @@
 #include "bus-util.h"
 #include "constants.h"
 #include "daemon-util.h"
+#include "dlopen-note.h"
 #include "hashmap.h"
 #include "label-util.h"
 #include "localed-util.h"
@@ -631,6 +632,8 @@ static int run(int argc, char *argv[]) {
         _cleanup_(sd_event_unrefp) sd_event *event = NULL;
         _cleanup_(sd_bus_flush_close_unrefp) sd_bus *bus = NULL;
         int r;
+
+        LIBSELINUX_NOTE(recommended);
 
         log_setup();
 

--- a/src/locale/xkbcommon-util.c
+++ b/src/locale/xkbcommon-util.c
@@ -13,6 +13,7 @@ DLSYM_PROTOTYPE(xkb_context_set_log_fn) = NULL;
 DLSYM_PROTOTYPE(xkb_keymap_new_from_names) = NULL;
 DLSYM_PROTOTYPE(xkb_keymap_unref) = NULL;
 
+_dlopen_loader_
 static int dlopen_xkbcommon(int log_level) {
         static void *xkbcommon_dl = NULL;
 

--- a/src/locale/xkbcommon-util.c
+++ b/src/locale/xkbcommon-util.c
@@ -1,8 +1,7 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
-#include "sd-dlopen.h"
-
 #include "dlfcn-util.h"
+#include "dlopen-note.h"
 #include "log.h"
 #include "string-util.h"
 #include "xkbcommon-util.h"
@@ -17,10 +16,7 @@ DLSYM_PROTOTYPE(xkb_keymap_unref) = NULL;
 static int dlopen_xkbcommon(int log_level) {
         static void *xkbcommon_dl = NULL;
 
-        SD_ELF_NOTE_DLOPEN(
-                        "xkbcommon",
-                        "Support for keyboard locale descriptions",
-                        SD_ELF_NOTE_DLOPEN_PRIORITY_SUGGESTED, "libxkbcommon.so.0");
+        LIBXKBCOMMON_NOTE(suggested);
 
         return dlopen_many_sym_or_warn(
                         &xkbcommon_dl, "libxkbcommon.so.0", log_level,

--- a/src/login/loginctl.c
+++ b/src/login/loginctl.c
@@ -1662,7 +1662,7 @@ static int run(int argc, char *argv[]) {
         char **args = NULL;
         int r;
 
-        COMPRESS_DEFAULT_NOTE;
+        COMPRESS_JOURNAL_NOTE;
 
         setlocale(LC_ALL, "");
         log_setup();

--- a/src/login/loginctl.c
+++ b/src/login/loginctl.c
@@ -17,6 +17,7 @@
 #include "bus-util.h"
 #include "cgroup-show.h"
 #include "cgroup-util.h"
+#include "dlopen-note.h"
 #include "format-table.h"
 #include "format-util.h"
 #include "help-util.h"
@@ -1660,6 +1661,8 @@ static int run(int argc, char *argv[]) {
         _cleanup_(sd_bus_flush_close_unrefp) sd_bus *bus = NULL;
         char **args = NULL;
         int r;
+
+        COMPRESS_DEFAULT_NOTE;
 
         setlocale(LC_ALL, "");
         log_setup();

--- a/src/login/logind.c
+++ b/src/login/logind.c
@@ -17,6 +17,7 @@
 #include "device-util.h"
 #include "devnum-util.h"
 #include "dirent-util.h"
+#include "dlopen-note.h"
 #include "errno-util.h"
 #include "escape.h"
 #include "fd-util.h"
@@ -1350,6 +1351,10 @@ static int run(int argc, char *argv[]) {
         _cleanup_(manager_freep) Manager *m = NULL;
         _unused_ _cleanup_(notify_on_cleanup) const char *notify_message = NULL;
         int r;
+
+        LIBACL_NOTE(recommended);
+        LIBBLKID_NOTE(recommended);
+        LIBSELINUX_NOTE(recommended);
 
         log_set_facility(LOG_AUTH);
         log_setup();

--- a/src/login/pam_systemd.c
+++ b/src/login/pam_systemd.c
@@ -1807,7 +1807,7 @@ _public_ PAM_EXTERN int pam_sm_open_session(
 
         assert(pamh);
 
-        r = DLOPEN_LIBPAM(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_REQUIRED);
+        r = DLOPEN_LIBPAM(LOG_DEBUG, required);
         if (r < 0)
                 return PAM_SERVICE_ERR;
 
@@ -1915,7 +1915,7 @@ _public_ PAM_EXTERN int pam_sm_close_session(
 
         assert(pamh);
 
-        r = DLOPEN_LIBPAM(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_REQUIRED);
+        r = DLOPEN_LIBPAM(LOG_DEBUG, required);
         if (r < 0)
                 return PAM_SERVICE_ERR;
 

--- a/src/login/pam_systemd_loadkey.c
+++ b/src/login/pam_systemd_loadkey.c
@@ -19,7 +19,7 @@ _public_ PAM_EXTERN int pam_sm_authenticate(
 
         assert(pamh);
 
-        r = DLOPEN_LIBPAM(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_REQUIRED);
+        r = DLOPEN_LIBPAM(LOG_DEBUG, required);
         if (r < 0)
                 return PAM_SERVICE_ERR;
 

--- a/src/login/user-runtime-dir.c
+++ b/src/login/user-runtime-dir.c
@@ -8,6 +8,7 @@
 #include "bus-error.h"
 #include "bus-locator.h"
 #include "devnum-util.h"
+#include "dlopen-note.h"
 #include "errno-util.h"
 #include "fd-util.h"
 #include "format-util.h"
@@ -326,6 +327,9 @@ static int do_tmpfs_quota(UserRecord *ur) {
 
 static int run(int argc, char *argv[]) {
         int r;
+
+        LIBMOUNT_NOTE(recommended);
+        LIBSELINUX_NOTE(recommended);
 
         log_setup();
 

--- a/src/machine-id-setup/machine-id-setup-main.c
+++ b/src/machine-id-setup/machine-id-setup-main.c
@@ -5,6 +5,7 @@
 #include "alloc-util.h"
 #include "build.h"
 #include "dissect-image.h"
+#include "dlopen-note.h"
 #include "format-table.h"
 #include "id128-util.h"
 #include "image-policy.h"
@@ -130,6 +131,12 @@ static int run(int argc, char *argv[]) {
         _cleanup_(loop_device_unrefp) LoopDevice *loop_device = NULL;
         _cleanup_(umount_and_freep) char *mounted_dir = NULL;
         int r;
+
+        LIBBLKID_NOTE(recommended);
+        LIBCRYPTO_NOTE(suggested);
+        LIBCRYPTSETUP_NOTE(suggested);
+        LIBMOUNT_NOTE(recommended);
+        TPM2_NOTE(suggested);
 
         log_setup();
 

--- a/src/machine/machinectl.c
+++ b/src/machine/machinectl.c
@@ -2635,7 +2635,7 @@ static int run(int argc, char *argv[]) {
         _cleanup_strv_free_ char **args = NULL;
         int r;
 
-        COMPRESS_DEFAULT_NOTE;
+        COMPRESS_JOURNAL_NOTE;
         LIBSELINUX_NOTE(recommended);
 
         setlocale(LC_ALL, "");

--- a/src/machine/machinectl.c
+++ b/src/machine/machinectl.c
@@ -26,6 +26,7 @@
 #include "bus-wait-for-jobs.h"
 #include "cgroup-show.h"
 #include "cgroup-util.h"
+#include "dlopen-note.h"
 #include "edit-util.h"
 #include "env-util.h"
 #include "fd-util.h"
@@ -2633,6 +2634,9 @@ static int run(int argc, char *argv[]) {
         _cleanup_(sd_bus_flush_close_unrefp) sd_bus *bus = NULL;
         _cleanup_strv_free_ char **args = NULL;
         int r;
+
+        COMPRESS_DEFAULT_NOTE;
+        LIBSELINUX_NOTE(recommended);
 
         setlocale(LC_ALL, "");
         log_setup();

--- a/src/machine/machined.c
+++ b/src/machine/machined.c
@@ -16,6 +16,7 @@
 #include "constants.h"
 #include "daemon-util.h"
 #include "dirent-util.h"
+#include "dlopen-note.h"
 #include "errno-util.h"
 #include "fd-util.h"
 #include "hash-funcs.h"
@@ -346,6 +347,12 @@ static int run(int argc, char *argv[]) {
         _cleanup_(manager_unrefp) Manager *m = NULL;
         RuntimeScope scope = RUNTIME_SCOPE_SYSTEM;
         int r;
+
+        LIBBLKID_NOTE(recommended);
+        LIBCRYPTO_NOTE(suggested);
+        LIBCRYPTSETUP_NOTE(suggested);
+        LIBMOUNT_NOTE(recommended);
+        LIBSELINUX_NOTE(recommended);
 
         log_set_facility(LOG_AUTH);
         log_setup();

--- a/src/measure/measure-tool.c
+++ b/src/measure/measure-tool.c
@@ -178,7 +178,7 @@ static int parse_argv(int argc, char *argv[], char ***ret_args) {
                             "Select TPM bank (SHA1, SHA256, SHA384, SHA512)"): {
                         const EVP_MD *implementation;
 
-                        r = DLOPEN_LIBCRYPTO(LOG_ERR, SD_ELF_NOTE_DLOPEN_PRIORITY_REQUIRED);
+                        r = DLOPEN_LIBCRYPTO(LOG_ERR, required);
                         if (r < 0)
                                 return r;
 
@@ -1137,7 +1137,7 @@ static int run(int argc, char *argv[]) {
         if (r <= 0)
                 return r;
 
-        r = DLOPEN_LIBCRYPTO(LOG_ERR, SD_ELF_NOTE_DLOPEN_PRIORITY_REQUIRED);
+        r = DLOPEN_LIBCRYPTO(LOG_ERR, required);
         if (r < 0)
                 return r;
 

--- a/src/measure/measure-tool.c
+++ b/src/measure/measure-tool.c
@@ -8,6 +8,7 @@
 #include "ask-password-api.h"
 #include "build.h"
 #include "crypto-util.h"
+#include "dlopen-note.h"
 #include "efi-loader.h"
 #include "efivars.h"
 #include "fd-util.h"
@@ -1129,6 +1130,8 @@ static int verb_policy_digest(int argc, char *argv[], uintptr_t _data, void *use
 
 static int run(int argc, char *argv[]) {
         int r;
+
+        TPM2_NOTE(suggested);
 
         log_setup();
 

--- a/src/modules-load/modules-load.c
+++ b/src/modules-load/modules-load.c
@@ -12,6 +12,7 @@
 #include "conf-files.h"
 #include "constants.h"
 #include "cpu-set-util.h"
+#include "dlopen-note.h"
 #include "errno-util.h"
 #include "fd-util.h"
 #include "fileio.h"
@@ -389,6 +390,8 @@ static int run(int argc, char *argv[]) {
         size_t n_threads = 0;
         char *module;
         int ret = 0, r;
+
+        LIBKMOD_NOTE(required);
 
         char **args = NULL;
         r = parse_argv(argc, argv, &args);

--- a/src/mount/mount-tool.c
+++ b/src/mount/mount-tool.c
@@ -14,6 +14,7 @@
 #include "chase.h"
 #include "device-private.h"
 #include "device-util.h"
+#include "dlopen-note.h"
 #include "errno-util.h"
 #include "escape.h"
 #include "fd-util.h"
@@ -1478,6 +1479,8 @@ static int run(int argc, char* argv[]) {
         _cleanup_(sd_bus_flush_close_unrefp) sd_bus *bus = NULL;
         char **args = NULL;
         int r;
+
+        LIBMOUNT_NOTE(recommended);
 
         log_setup();
 

--- a/src/mountfsd/mountwork.c
+++ b/src/mountfsd/mountwork.c
@@ -15,6 +15,7 @@
 #include "chase.h"
 #include "discover-image.h"
 #include "dissect-image.h"
+#include "dlopen-note.h"
 #include "env-util.h"
 #include "errno-util.h"
 #include "escape.h"
@@ -1488,6 +1489,11 @@ static int run(int argc, char *argv[]) {
         _cleanup_(pidref_done) PidRef parent = PIDREF_NULL;
         unsigned n_iterations = 0;
         int m, listen_fd, r;
+
+        LIBBLKID_NOTE(recommended);
+        LIBCRYPTO_NOTE(suggested);
+        LIBCRYPTSETUP_NOTE(suggested);
+        LIBMOUNT_NOTE(recommended);
 
         log_setup();
 

--- a/src/mstack/mstack-tool.c
+++ b/src/mstack/mstack-tool.c
@@ -6,6 +6,7 @@
 #include "argv-util.h"
 #include "build.h"
 #include "chase.h"
+#include "dlopen-note.h"
 #include "errno-util.h"
 #include "extract-word.h"
 #include "fd-util.h"
@@ -375,6 +376,11 @@ static int umount_mstack(void) {
 
 static int run(int argc, char *argv[]) {
         int r;
+
+        LIBBLKID_NOTE(recommended);
+        LIBCRYPTO_NOTE(suggested);
+        LIBCRYPTSETUP_NOTE(suggested);
+        LIBMOUNT_NOTE(recommended);
 
         log_setup();
 

--- a/src/network/generator/network-generator-main.c
+++ b/src/network/generator/network-generator-main.c
@@ -5,6 +5,7 @@
 #include "alloc-util.h"
 #include "build.h"
 #include "creds-util.h"
+#include "dlopen-note.h"
 #include "errno-util.h"
 #include "fd-util.h"
 #include "format-table.h"
@@ -196,6 +197,8 @@ static int parse_argv(int argc, char *argv[], char ***ret_args) {
 static int run(int argc, char *argv[]) {
         _cleanup_(context_clear) Context context = {};
         int r, ret = 0;
+
+        LIBSELINUX_NOTE(recommended);
 
         log_setup();
 

--- a/src/network/meson.build
+++ b/src/network/meson.build
@@ -163,19 +163,12 @@ netdev_gperf_c = custom_target(
 generated_sources += [networkd_gperf_c, networkd_network_gperf_c, netdev_gperf_c]
 systemd_networkd_export_sources += [networkd_gperf_c, networkd_network_gperf_c, netdev_gperf_c]
 
-if get_option('link-networkd-shared')
-        networkd_link_with = [libshared]
-else
-        networkd_link_with = [libsystemd_static,
-                              libshared_static]
-endif
-
 network_includes = [include_directories(['.', 'netdev', 'tc']), libsystemd_network_includes]
 
 network_test_template = test_template + {
         'conditions' : ['ENABLE_NETWORKD'],
         'link_with' : [
-                networkd_link_with,
+                libshared,
                 libsystemd_network,
         ],
         'import' : ['systemd-networkd'],
@@ -185,7 +178,7 @@ network_test_template = test_template + {
 network_fuzz_template = fuzz_template + {
         'conditions' : ['ENABLE_NETWORKD'],
         'link_with' : [
-                networkd_link_with,
+                libshared,
                 libsystemd_network,
         ],
         'import' : ['systemd-networkd'],
@@ -201,8 +194,8 @@ executables += [
                 'export' : systemd_networkd_export_sources,
                 'include_directories' : network_includes,
                 'link_with' : [
+                        libshared,
                         libsystemd_network,
-                        networkd_link_with,
                 ],
                 'dependencies' : [
                         libbpf_cflags,
@@ -210,13 +203,14 @@ executables += [
                 'bpf_programs': [
                         'sysctl-monitor',
                 ],
+                'install' : get_option('link-networkd-shared') ? 'yes' : 'static',
         },
         libexec_template + {
                 'name' : 'systemd-networkd-wait-online',
                 'public' : true,
                 'conditions' : ['ENABLE_NETWORKD'],
                 'sources' : systemd_networkd_wait_online_sources,
-                'link_with' : networkd_link_with,
+                'install' : get_option('link-networkd-shared') ? 'yes' : 'static',
         },
         executable_template + {
                 'name' : 'networkctl',
@@ -225,18 +219,19 @@ executables += [
                 'sources' : networkctl_sources,
                 'include_directories' : libsystemd_network_includes,
                 'link_with' : [
+                        libshared,
                         libsystemd_network,
-                        networkd_link_with,
                 ],
                 'dependencies' : [
                         libselinux_cflags,
                 ],
+                'install' : get_option('link-networkd-shared') ? 'yes' : 'static',
         },
         libexec_template + {
                 'name' : 'systemd-network-generator',
                 'sources' : files('generator/network-generator-main.c'),
                 'export' : files('generator/network-generator.c'),
-                'link_with' : networkd_link_with,
+                'install' : get_option('link-networkd-shared') ? 'yes' : 'static',
         },
         test_template + {
                 'sources' : files('generator/test-network-generator.c'),
@@ -263,7 +258,6 @@ executables += [
         test_template + {
                 'sources' : files('test-modem-manager-mock.c'),
                 'conditions' : ['ENABLE_NETWORKD'],
-                'link_with' : [libshared],
                 'type' : 'manual',
         },
         network_fuzz_template + {

--- a/src/network/netdev/netdev.c
+++ b/src/network/netdev/netdev.c
@@ -1044,7 +1044,7 @@ int netdev_load_one(Manager *manager, const char *filename, NetDev **ret) {
                 return r; /* config_parse_many() logs internally. */
 
         /* skip out early if configuration does not match the environment */
-        if (!condition_test_list(netdev_raw->conditions, environ, NULL, NULL, NULL))
+        if (!condition_test_list_net(netdev_raw->conditions, environ, NULL, NULL, NULL))
                 return log_debug_errno(SYNTHETIC_ERRNO(ESTALE), "%s: Conditions in the file do not match the system environment, skipping.", filename);
 
         if (netdev_raw->kind == _NETDEV_KIND_INVALID)

--- a/src/network/networkctl.c
+++ b/src/network/networkctl.c
@@ -209,7 +209,7 @@ static int run(int argc, char* argv[]) {
         char **args = NULL;
         int r;
 
-        COMPRESS_DEFAULT_NOTE;
+        COMPRESS_JOURNAL_NOTE;
         LIBSELINUX_NOTE(recommended);
 
         log_setup();

--- a/src/network/networkctl.c
+++ b/src/network/networkctl.c
@@ -4,6 +4,7 @@
 
 #include "alloc-util.h"
 #include "build.h"
+#include "dlopen-note.h"
 #include "format-table.h"
 #include "help-util.h"
 #include "log.h"
@@ -207,6 +208,9 @@ static int parse_argv(int argc, char *argv[], char ***remaining_args) {
 static int run(int argc, char* argv[]) {
         char **args = NULL;
         int r;
+
+        COMPRESS_DEFAULT_NOTE;
+        LIBSELINUX_NOTE(recommended);
 
         log_setup();
 

--- a/src/network/networkd-network.c
+++ b/src/network/networkd-network.c
@@ -138,7 +138,7 @@ int network_verify(Network *network) {
                                          network->filename);
 
         /* skip out early if configuration does not match the environment */
-        if (!condition_test_list(network->conditions, environ, NULL, NULL, NULL))
+        if (!condition_test_list_net(network->conditions, environ, NULL, NULL, NULL))
                 return log_debug_errno(SYNTHETIC_ERRNO(EINVAL),
                                        "%s: Conditions in the file do not match the system environment, skipping.",
                                        network->filename);

--- a/src/network/networkd-sysctl.c
+++ b/src/network/networkd-sysctl.c
@@ -108,7 +108,7 @@ int manager_install_sysctl_monitor(Manager *manager) {
 
         assert(manager);
 
-        r = DLOPEN_BPF(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+        r = DLOPEN_BPF(LOG_DEBUG, recommended);
         if (ERRNO_IS_NEG_NOT_SUPPORTED(r))
                 return log_debug_errno(r, "sysctl monitor disabled, as BPF support is not available.");
         if (r < 0)

--- a/src/network/networkd.c
+++ b/src/network/networkd.c
@@ -9,6 +9,7 @@
 #include "bus-object.h"
 #include "capability-util.h"
 #include "daemon-util.h"
+#include "dlopen-note.h"
 #include "main-func.h"
 #include "mkdir.h"
 #include "networkd-conf.h"
@@ -23,6 +24,15 @@ static int run(int argc, char *argv[]) {
         _cleanup_(manager_freep) Manager *m = NULL;
         _unused_ _cleanup_(notify_on_cleanup) const char *notify_message = NULL;
         int r;
+
+        LIBAPPARMOR_NOTE(recommended);
+        LIBAUDIT_NOTE(recommended);
+        LIBIDN2_NOTE(suggested);
+        LIBMOUNT_NOTE(recommended);
+        LIBSELINUX_NOTE(recommended);
+        LIBTSS2_ESYS_NOTE(suggested);
+        LIBTSS2_MU_NOTE(suggested);
+        LIBTSS2_RC_NOTE(suggested);
 
         log_setup();
 

--- a/src/network/networkd.c
+++ b/src/network/networkd.c
@@ -25,14 +25,9 @@ static int run(int argc, char *argv[]) {
         _unused_ _cleanup_(notify_on_cleanup) const char *notify_message = NULL;
         int r;
 
-        LIBAPPARMOR_NOTE(recommended);
-        LIBAUDIT_NOTE(recommended);
         LIBIDN2_NOTE(suggested);
         LIBMOUNT_NOTE(recommended);
         LIBSELINUX_NOTE(recommended);
-        LIBTSS2_ESYS_NOTE(suggested);
-        LIBTSS2_MU_NOTE(suggested);
-        LIBTSS2_RC_NOTE(suggested);
 
         log_setup();
 

--- a/src/nspawn/meson.build
+++ b/src/nspawn/meson.build
@@ -47,7 +47,11 @@ executables += [
                         executable_template['include_directories'],
                 ],
                 'dependencies' : [
+                        libacl_cflags,
+                        libblkid_cflags,
+                        libcryptsetup_cflags,
                         libmount_cflags,
+                        libopenssl_cflags,
                         libseccomp_cflags,
                         libselinux_cflags,
                 ],

--- a/src/nspawn/nspawn-oci.c
+++ b/src/nspawn/nspawn-oci.c
@@ -1826,7 +1826,7 @@ static int oci_seccomp(const char *name, sd_json_variant *v, sd_json_dispatch_fl
         if (r < 0)
                 return json_log(def, flags, r, "Unknown default action: %s", sd_json_variant_string(def));
 
-        r = DLOPEN_LIBSECCOMP(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+        r = DLOPEN_LIBSECCOMP(LOG_DEBUG, recommended);
         if (r < 0)
                 return json_log(def, flags, r, "No support for libseccomp: %m");
 

--- a/src/nspawn/nspawn.c
+++ b/src/nspawn/nspawn.c
@@ -20,9 +20,11 @@
 #include "sd-path.h"
 #include "sd-varlink.h"
 
+#include "acl-util.h"
 #include "alloc-util.h"
 #include "barrier.h"
 #include "base-filesystem.h"
+#include "blkid-util.h"
 #include "btrfs-util.h"
 #include "build.h"
 #include "bus-error.h"
@@ -36,12 +38,13 @@
 #include "constants.h"
 #include "copy.h"
 #include "cpu-set-util.h"
+#include "crypto-util.h"
+#include "cryptsetup-util.h"
 #include "daemon-util.h"
 #include "dev-setup.h"
 #include "devnum-util.h"
 #include "discover-image.h"
 #include "dissect-image.h"
-#include "dlfcn-util.h"
 #include "env-util.h"
 #include "escape.h"
 #include "ether-addr-util.h"
@@ -6141,6 +6144,10 @@ static int run(int argc, char *argv[]) {
         if (arg_cleanup)
                 return do_cleanup();
 
+        (void) DLOPEN_CRYPTSETUP(LOG_DEBUG, suggested);
+        (void) DLOPEN_LIBACL(LOG_DEBUG, recommended);
+        (void) DLOPEN_LIBBLKID(LOG_DEBUG, recommended);
+        (void) DLOPEN_LIBCRYPTO(LOG_WARNING, recommended);
         (void) DLOPEN_LIBMOUNT(LOG_DEBUG, recommended);
         (void) DLOPEN_LIBSECCOMP(LOG_DEBUG, recommended);
         (void) DLOPEN_LIBSELINUX(LOG_DEBUG, recommended);

--- a/src/nspawn/nspawn.c
+++ b/src/nspawn/nspawn.c
@@ -6141,9 +6141,9 @@ static int run(int argc, char *argv[]) {
         if (arg_cleanup)
                 return do_cleanup();
 
-        (void) DLOPEN_LIBMOUNT(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
-        (void) DLOPEN_LIBSECCOMP(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
-        (void) DLOPEN_LIBSELINUX(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+        (void) DLOPEN_LIBMOUNT(LOG_DEBUG, recommended);
+        (void) DLOPEN_LIBSECCOMP(LOG_DEBUG, recommended);
+        (void) DLOPEN_LIBSELINUX(LOG_DEBUG, recommended);
 
         r = cg_has_legacy();
         if (r < 0)

--- a/src/nsresourced/userns-restrict.c
+++ b/src/nsresourced/userns-restrict.c
@@ -68,7 +68,7 @@ int userns_restrict_install(
         if (r == 0)
                 return log_error_errno(SYNTHETIC_ERRNO(EOPNOTSUPP), "bpf-lsm not supported, can't lock down user namespace.");
 
-        r = DLOPEN_BPF(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+        r = DLOPEN_BPF(LOG_DEBUG, recommended);
         if (r < 0)
                 return r;
 

--- a/src/pcrextend/pcrextend.c
+++ b/src/pcrextend/pcrextend.c
@@ -90,7 +90,7 @@ static int parse_argv(int argc, char *argv[], char ***ret_args) {
                 OPTION_LONG("bank", "DIGEST", "Select TPM PCR bank (SHA1, SHA256)"): {
                         const EVP_MD *implementation;
 
-                        r = DLOPEN_LIBCRYPTO(LOG_ERR, SD_ELF_NOTE_DLOPEN_PRIORITY_REQUIRED);
+                        r = DLOPEN_LIBCRYPTO(LOG_ERR, required);
                         if (r < 0)
                                 return r;
 

--- a/src/pcrextend/pcrextend.c
+++ b/src/pcrextend/pcrextend.c
@@ -7,6 +7,7 @@
 #include "alloc-util.h"
 #include "build.h"
 #include "crypto-util.h"
+#include "dlopen-note.h"
 #include "efi-loader.h"
 #include "escape.h"
 #include "format-table.h"
@@ -511,6 +512,9 @@ static int run(int argc, char *argv[]) {
         _cleanup_free_ char *word = NULL;
         Tpm2UserspaceEventType event = _TPM2_USERSPACE_EVENT_TYPE_INVALID;
         int r;
+
+        LIBBLKID_NOTE(recommended);
+        TPM2_NOTE(suggested);
 
         log_setup();
 

--- a/src/pcrlock/pcrlock.c
+++ b/src/pcrlock/pcrlock.c
@@ -5709,7 +5709,7 @@ static int run(int argc, char *argv[]) {
         if (r <= 0)
                 return r;
 
-        r = DLOPEN_LIBCRYPTO(LOG_ERR, SD_ELF_NOTE_DLOPEN_PRIORITY_REQUIRED);
+        r = DLOPEN_LIBCRYPTO(LOG_ERR, required);
         if (r < 0)
                 return r;
 

--- a/src/pcrlock/pcrlock.c
+++ b/src/pcrlock/pcrlock.c
@@ -21,6 +21,7 @@
 #include "copy.h"
 #include "creds-util.h"
 #include "crypto-util.h"
+#include "dlopen-note.h"
 #include "efi-api.h"
 #include "efivars.h"
 #include "env-util.h"
@@ -5697,6 +5698,10 @@ static int vl_method_on_completed_update(sd_varlink *link, sd_json_variant *para
 
 static int run(int argc, char *argv[]) {
         int r;
+
+        LIBBLKID_NOTE(recommended);
+        LIBSELINUX_NOTE(recommended);
+        TPM2_NOTE(suggested);
 
         log_setup();
 

--- a/src/portable/meson.build
+++ b/src/portable/meson.build
@@ -13,32 +13,23 @@ systemd_portabled_sources = files(
         'portabled.c',
 )
 
-if get_option('link-portabled-shared')
-        portabled_link_with = [libshared]
-else
-        portabled_link_with = [
-                libshared_static,
-                libsystemd_static,
-        ]
-endif
-
 executables += [
         libexec_template + {
                 'name' : 'systemd-portabled',
                 'dbus' : true,
                 'sources' : systemd_portabled_sources,
-                'link_with' : portabled_link_with,
                 'dependencies' : [
                         libcryptsetup_cflags,
                         libmount_cflags,
                         libselinux_cflags,
                 ],
+                'install' : get_option('link-portabled-shared') ? 'yes' : 'static',
         },
         executable_template + {
                 'name' : 'portablectl',
                 'public' : true,
                 'sources' : files('portablectl.c'),
-                'link_with' : portabled_link_with,
+                'install' : get_option('link-portabled-shared') ? 'yes' : 'static',
         },
 ]
 

--- a/src/portable/portable.c
+++ b/src/portable/portable.c
@@ -610,8 +610,8 @@ static int portable_extract_by_path(
                  * there, and extract the metadata we need. The metadata is sent from the child back to us. */
 
                 /* Load some libraries before we fork workers off that want to use them */
-                (void) DLOPEN_CRYPTSETUP(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
-                (void) DLOPEN_LIBMOUNT(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_REQUIRED);
+                (void) DLOPEN_CRYPTSETUP(LOG_DEBUG, recommended);
+                (void) DLOPEN_LIBMOUNT(LOG_DEBUG, required);
 
                 r = mkdtemp_malloc("/tmp/inspect-XXXXXX", &tmpdir);
                 if (r < 0)

--- a/src/portable/portabled.c
+++ b/src/portable/portabled.c
@@ -12,6 +12,7 @@
 #include "common-signal.h"
 #include "constants.h"
 #include "daemon-util.h"
+#include "dlopen-note.h"
 #include "hashmap.h"
 #include "log.h"
 #include "main-func.h"
@@ -142,6 +143,10 @@ static int run(int argc, char *argv[]) {
         _cleanup_(manager_unrefp) Manager *m = NULL;
         RuntimeScope scope = RUNTIME_SCOPE_SYSTEM;
         int r;
+
+        LIBBLKID_NOTE(recommended);
+        LIBCRYPTO_NOTE(suggested);
+        LIBSELINUX_NOTE(recommended);
 
         log_setup();
 

--- a/src/pstore/pstore.c
+++ b/src/pstore/pstore.c
@@ -13,6 +13,7 @@
 #include "conf-parser.h"
 #include "copy.h"
 #include "dirent-util.h"
+#include "dlopen-note.h"
 #include "fd-util.h"
 #include "fileio.h"
 #include "iovec-util.h"
@@ -308,6 +309,8 @@ static int list_files(PStoreList *list, const char *sourcepath) {
 static int run(int argc, char *argv[]) {
         _cleanup_(pstore_entries_reset) PStoreList list = {};
         int r;
+
+        LIBSELINUX_NOTE(recommended);
 
         log_setup();
 

--- a/src/remount-fs/remount-fs.c
+++ b/src/remount-fs/remount-fs.c
@@ -5,6 +5,7 @@
 #include <unistd.h>
 
 #include "alloc-util.h"
+#include "dlopen-note.h"
 #include "env-util.h"
 #include "exit-status.h"
 #include "format-util.h"
@@ -121,6 +122,8 @@ static int remount_by_fstab(Hashmap **ret_pids) {
 static int run(int argc, char *argv[]) {
         _cleanup_hashmap_free_ Hashmap *pids = NULL;
         int r;
+
+        LIBMOUNT_NOTE(recommended);
 
         log_setup();
 

--- a/src/repart/meson.build
+++ b/src/repart/meson.build
@@ -21,25 +21,7 @@ executables += [
                         libopenssl_cflags,
                         tpm2_cflags,
                 ],
-        },
-        executable_template + {
-                'name' : 'systemd-repart.standalone',
-                'public' : true,
-                'import' : ['systemd-repart'],
-                'link_with' : [
-                        libc_wrapper_static,
-                        libbasic_static,
-                        libshared_static,
-                        libsystemd_static,
-                ],
-                'dependencies' : [
-                        libblkid_cflags,
-                        libcryptsetup_cflags,
-                        libfdisk_cflags,
-                        libmount_cflags,
-                        libopenssl_cflags,
-                        tpm2_cflags,
-                ],
+                'install' : have_standalone_binaries ? 'both' : 'yes',
         },
 ]
 

--- a/src/repart/repart.c
+++ b/src/repart/repart.c
@@ -11614,6 +11614,9 @@ static int run(int argc, char *argv[]) {
         bool node_is_our_loop = false;
         int r;
 
+        LIBSELINUX_NOTE(recommended);
+        TPM2_NOTE(suggested);
+
         log_setup();
 
         r = parse_argv(argc, argv);

--- a/src/repart/repart.c
+++ b/src/repart/repart.c
@@ -3120,7 +3120,7 @@ static int partition_read_definition(
                                   "Cannot format %s filesystem without source files, refusing.", p->format);
 
         if (p->verity != VERITY_OFF || p->encrypt != ENCRYPT_OFF) {
-                r = DLOPEN_CRYPTSETUP(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+                r = DLOPEN_CRYPTSETUP(LOG_DEBUG, recommended);
                 if (r < 0)
                         return log_syntax(NULL, LOG_ERR, path, 1, r,
                                           "libcryptsetup not found, Verity=/Encrypt= are not supported: %m");
@@ -4739,7 +4739,7 @@ static int context_wipe_range(Context *context, uint64_t offset, uint64_t size) 
         assert(offset != UINT64_MAX);
         assert(size != UINT64_MAX);
 
-        r = DLOPEN_LIBBLKID(LOG_ERR, SD_ELF_NOTE_DLOPEN_PRIORITY_REQUIRED);
+        r = DLOPEN_LIBBLKID(LOG_ERR, required);
         if (r < 0)
                 return r;
 
@@ -5431,7 +5431,7 @@ static int partition_encrypt(Context *context, Partition *p, PartitionTarget *ta
         assert(p);
         assert(p->encrypt != ENCRYPT_OFF);
 
-        r = DLOPEN_CRYPTSETUP(LOG_ERR, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+        r = DLOPEN_CRYPTSETUP(LOG_ERR, recommended);
         if (r < 0)
                 return r;
 
@@ -5973,7 +5973,7 @@ static int partition_format_verity_hash(
 
         (void) partition_hint(p, node, &hint);
 
-        r = DLOPEN_CRYPTSETUP(LOG_ERR, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+        r = DLOPEN_CRYPTSETUP(LOG_ERR, recommended);
         if (r < 0)
                 return r;
 
@@ -6075,7 +6075,7 @@ static int sign_verity_roothash(
         assert(iovec_is_set(roothash));
         assert(ret_signature);
 
-        r = DLOPEN_LIBCRYPTO(LOG_ERR, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+        r = DLOPEN_LIBCRYPTO(LOG_ERR, recommended);
         if (r < 0)
                 return r;
 
@@ -7167,7 +7167,7 @@ static int partition_populate_filesystem(Context *context, Partition *p, const c
          * appear in the host namespace. Hence we fork a child that has its own file system namespace and
          * detached mount propagation. */
 
-        (void) DLOPEN_LIBMOUNT(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_REQUIRED);
+        (void) DLOPEN_LIBMOUNT(LOG_DEBUG, required);
 
         r = pidref_safe_fork(
                         "(sd-copy)",
@@ -8798,7 +8798,7 @@ static int resolve_copy_blocks_auto_candidate(
                 return log_error_errno(r, "Failed to open block device " DEVNUM_FORMAT_STR ": %m",
                                        DEVNUM_FORMAT_VAL(whole_devno));
 
-        r = DLOPEN_LIBBLKID(LOG_ERR, SD_ELF_NOTE_DLOPEN_PRIORITY_REQUIRED);
+        r = DLOPEN_LIBBLKID(LOG_ERR, required);
         if (r < 0)
                 return r;
 
@@ -11620,7 +11620,7 @@ static int run(int argc, char *argv[]) {
         if (r <= 0)
                 return r;
 
-        r = DLOPEN_FDISK(LOG_ERR, SD_ELF_NOTE_DLOPEN_PRIORITY_REQUIRED);
+        r = DLOPEN_FDISK(LOG_ERR, required);
         if (r < 0)
                 return r;
 

--- a/src/report/meson.build
+++ b/src/report/meson.build
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-report_executables = [
-        {
+executables += [
+        libexec_template + {
                 'name' : 'systemd-report',
                 'public' : true,
                 'export' : files(
@@ -13,64 +13,47 @@ report_executables = [
                 'dependencies' : [
                         libcurl_cflags,
                 ],
+                'install' : have_standalone_binaries ? 'both' : 'yes',
         },
-        {
+        libexec_template + {
                 'name' : 'systemd-report-basic',
                 'public' : true,
                 'export' : files(
                         'report-basic.c',
                         'report-basic-server.c',
                 ),
+                'install' : have_standalone_binaries ? 'both' : 'yes',
         },
-        {
+        libexec_template + {
                 'name' : 'systemd-report-cgroup',
                 'export' : files(
                         'report-cgroup.c',
                         'report-cgroup-server.c',
                 ),
+                'install' : have_standalone_binaries ? 'both' : 'yes',
         },
-        {
+        libexec_template + {
                 'name' : 'systemd-report-files',
                 'export' : files(
                         'report-files.c',
                         'report-files-server.c',
                 ),
+                'install' : have_standalone_binaries ? 'both' : 'yes',
         },
-        {
+        libexec_template + {
                 'name' : 'systemd-report-sign-plain',
                 'export' : files(
                         'report-sign-plain.c',
                 ),
                 'dependencies' : libopenssl_cflags,
                 'conditions' : ['HAVE_OPENSSL'],
+                'install' : have_standalone_binaries ? 'both' : 'yes',
         },
-        {
+        libexec_template + {
                 'name' : 'systemd-report-sign-tsm',
                 'export' : files(
                         'report-sign-tsm.c',
                 ),
+                'install' : have_standalone_binaries ? 'both' : 'yes',
         },
 ]
-
-foreach exe : report_executables
-        exe2 = {
-                'name' : exe['name'] + '.standalone',
-                'import' : [exe['name']],
-                'link_with' : [
-                        libc_wrapper_static,
-                        libbasic_static,
-                        libshared_static,
-                        libsystemd_static,
-                ]
-        }
-        foreach optional : ['public', 'dependencies', 'conditions']
-                if optional in exe
-                        exe2 += { optional : exe[optional] }
-                endif
-        endforeach
-
-        executables += [
-                libexec_template + exe,
-                libexec_template + exe2,
-        ]
-endforeach

--- a/src/report/report-sign-plain.c
+++ b/src/report/report-sign-plain.c
@@ -304,7 +304,7 @@ static int vl_server(void) {
         _cleanup_(sd_varlink_server_unrefp) sd_varlink_server *vs = NULL;
         int r;
 
-        r = DLOPEN_LIBCRYPTO(LOG_ERR, SD_ELF_NOTE_DLOPEN_PRIORITY_REQUIRED);
+        r = DLOPEN_LIBCRYPTO(LOG_ERR, required);
         if (r < 0)
                 return r;
 

--- a/src/report/report-upload.c
+++ b/src/report/report-upload.c
@@ -64,7 +64,7 @@ static int http_upload_report(Context *context, sd_json_variant *report) {
         char error[CURL_ERROR_SIZE] = {};
         int r;
 
-        r = DLOPEN_CURL(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_REQUIRED);
+        r = DLOPEN_CURL(LOG_DEBUG, required);
         if (r < 0)
                 return r;
 

--- a/src/resolve/resolvectl.c
+++ b/src/resolve/resolvectl.c
@@ -20,6 +20,7 @@
 #include "bus-locator.h"
 #include "bus-util.h"
 #include "crypto-util.h"
+#include "dlopen-note.h"
 #include "dns-configuration.h"
 #include "dns-domain.h"
 #include "dns-packet.h"
@@ -3791,6 +3792,8 @@ static int run(int argc, char **argv) {
         char **args = NULL;
         bool compat = false;
         int r;
+
+        LIBCRYPTO_NOTE(suggested);
 
         setlocale(LC_ALL, "");
         log_setup();

--- a/src/resolve/resolved-dns-dnssec.c
+++ b/src/resolve/resolved-dns-dnssec.c
@@ -735,7 +735,7 @@ int dnssec_verify_rrset(
         assert(dnskey);
         assert(result);
 
-        r = DLOPEN_LIBCRYPTO(LOG_WARNING, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+        r = DLOPEN_LIBCRYPTO(LOG_WARNING, recommended);
         if (r < 0)
                 return r;
 
@@ -1092,7 +1092,7 @@ int dnssec_verify_dnskey_by_ds(DnsResourceRecord *dnskey, DnsResourceRecord *ds,
         assert(dnskey);
         assert(ds);
 
-        r = DLOPEN_LIBCRYPTO(LOG_WARNING, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+        r = DLOPEN_LIBCRYPTO(LOG_WARNING, recommended);
         if (r < 0)
                 return r;
 
@@ -1232,7 +1232,7 @@ int dnssec_nsec3_hash(DnsResourceRecord *nsec3, const char *name, void *ret) {
         assert(name);
         assert(ret);
 
-        r = DLOPEN_LIBCRYPTO(LOG_WARNING, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+        r = DLOPEN_LIBCRYPTO(LOG_WARNING, recommended);
         if (r < 0)
                 return r;
 

--- a/src/resolve/resolved-dnstls.c
+++ b/src/resolve/resolved-dnstls.c
@@ -412,11 +412,11 @@ int dnstls_manager_init(Manager *manager) {
         if (manager->dnstls_data.ctx)
                 return 0;
 
-        r = DLOPEN_LIBCRYPTO(LOG_WARNING, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+        r = DLOPEN_LIBCRYPTO(LOG_WARNING, recommended);
         if (r < 0)
                 return r;
 
-        r = DLOPEN_LIBSSL(LOG_WARNING, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+        r = DLOPEN_LIBSSL(LOG_WARNING, recommended);
         if (r < 0)
                 return r;
 

--- a/src/resolve/resolved-util.c
+++ b/src/resolve/resolved-util.c
@@ -36,7 +36,7 @@ int resolve_system_hostname(char **full_hostname, char **first_label) {
 #if HAVE_LIBIDN2
         _cleanup_free_ char *utf8 = NULL;
 
-        if (DLOPEN_IDN(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED) >= 0) {
+        if (DLOPEN_IDN(LOG_DEBUG, recommended) >= 0) {
                 r = sym_idn2_to_unicode_8z8z(label, &utf8, 0);
                 if (r != IDN2_OK)
                         return log_debug_errno(SYNTHETIC_ERRNO(EUCLEAN),

--- a/src/resolve/resolved.c
+++ b/src/resolve/resolved.c
@@ -9,6 +9,7 @@
 #include "bus-object.h"
 #include "capability-util.h"
 #include "daemon-util.h"
+#include "dlopen-note.h"
 #include "label-util.h"
 #include "log.h"
 #include "main-func.h"
@@ -23,6 +24,8 @@ static int run(int argc, char *argv[]) {
         _cleanup_(manager_freep) Manager *m = NULL;
         _unused_ _cleanup_(notify_on_cleanup) const char *notify_stop = NULL;
         int r;
+
+        LIBSELINUX_NOTE(recommended);
 
         log_setup();
 

--- a/src/resolve/test-dnssec-crypto.c
+++ b/src/resolve/test-dnssec-crypto.c
@@ -393,7 +393,7 @@ TEST(dnssec_ecdsa_verify_raw) {
 }
 
 static int intro(void) {
-        if (DLOPEN_LIBCRYPTO(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED) < 0)
+        if (dlopen_libcrypto(LOG_DEBUG) < 0)
                 return EXIT_TEST_SKIP;
 
         return EXIT_SUCCESS;

--- a/src/sbsign/sbsign.c
+++ b/src/sbsign/sbsign.c
@@ -406,7 +406,7 @@ static int verb_sign(int argc, char *argv[], uintptr_t _data, void *userdata) {
         _cleanup_(iovec_done) struct iovec signed_attributes_signature = {};
         int r;
 
-        r = DLOPEN_LIBCRYPTO(LOG_ERR, SD_ELF_NOTE_DLOPEN_PRIORITY_REQUIRED);
+        r = DLOPEN_LIBCRYPTO(LOG_ERR, required);
         if (r < 0)
                 return r;
 

--- a/src/shared/acl-util.c
+++ b/src/shared/acl-util.c
@@ -3,8 +3,6 @@
 #include <sys/stat.h>
 #include <sys/syslog.h>
 
-#include "sd-dlopen.h"
-
 #include "acl-util.h"
 #include "alloc-util.h"
 #include "errno-util.h"
@@ -49,7 +47,7 @@ int dlopen_libacl(int log_level) {
 #if HAVE_ACL
         static void *libacl_dl = NULL;
 
-        LIBACL_NOTE(SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+        LIBACL_NOTE(recommended);
 
         return dlopen_many_sym_or_warn(
                         &libacl_dl,

--- a/src/shared/acl-util.h
+++ b/src/shared/acl-util.h
@@ -97,7 +97,7 @@ static inline int fd_add_uid_acl_permission(int fd, uid_t uid, unsigned mask) {
 }
 #endif
 
-int dlopen_libacl(int log_level);
+int dlopen_libacl(int log_level) _dlopen_loader_;
 
 #define DLOPEN_LIBACL(log_level, priority)                              \
         ({                                                              \

--- a/src/shared/acl-util.h
+++ b/src/shared/acl-util.h
@@ -1,8 +1,7 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 #pragma once
 
-#include "sd-dlopen.h"
-
+#include "dlopen-note.h"
 #include "shared-forward.h"
 
 #if HAVE_ACL
@@ -66,17 +65,6 @@ static inline int acl_set_perm(acl_permset_t ps, acl_perm_t p, bool b) {
         return (b ? sym_acl_add_perm : sym_acl_delete_perm)(ps, p);
 }
 
-#define LIBACL_NOTE(priority)                                           \
-        SD_ELF_NOTE_DLOPEN("acl",                                       \
-                           "Support for file Access Control Lists (ACLs)", \
-                           priority,                                    \
-                           "libacl.so.1")
-
-#define DLOPEN_LIBACL(log_level, priority)                              \
-        ({                                                              \
-                LIBACL_NOTE(priority);                                  \
-                dlopen_libacl(log_level);                               \
-        })
 #else
 
 typedef void* acl_t;
@@ -107,11 +95,15 @@ static inline int devnode_acl(int fd, const Set *uids) {
 static inline int fd_add_uid_acl_permission(int fd, uid_t uid, unsigned mask) {
         return -EOPNOTSUPP;
 }
-
-#define DLOPEN_LIBACL(log_level, priority) dlopen_libacl(log_level)
 #endif
 
 int dlopen_libacl(int log_level);
+
+#define DLOPEN_LIBACL(log_level, priority)                              \
+        ({                                                              \
+                LIBACL_NOTE(priority);                                  \
+                dlopen_libacl(log_level);                               \
+        })
 
 int fd_acl_make_read_only(int fd);
 int fd_acl_make_writable(int fd);

--- a/src/shared/apparmor-util.c
+++ b/src/shared/apparmor-util.c
@@ -1,7 +1,6 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
 #include "apparmor-util.h"
-#include "dlopen-note.h"
 #include "log.h"
 
 #if HAVE_APPARMOR

--- a/src/shared/apparmor-util.c
+++ b/src/shared/apparmor-util.c
@@ -1,13 +1,12 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
 #include "apparmor-util.h"
+#include "dlopen-note.h"
 #include "log.h"
 
 #if HAVE_APPARMOR
 
 #include <syslog.h>
-
-#include "sd-dlopen.h"
 
 #include "fileio.h"
 
@@ -48,11 +47,7 @@ int dlopen_libapparmor(int log_level) {
 #if HAVE_APPARMOR
         static void *libapparmor_dl = NULL;
 
-        SD_ELF_NOTE_DLOPEN(
-                        "apparmor",
-                        "Support for AppArmor policies",
-                        SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED,
-                        "libapparmor.so.1");
+        LIBAPPARMOR_NOTE(recommended);
 
         return dlopen_many_sym_or_warn(
                         &libapparmor_dl,

--- a/src/shared/apparmor-util.h
+++ b/src/shared/apparmor-util.h
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 #pragma once
 
+#include "dlopen-note.h"
 #include "shared-forward.h"
 
 #if HAVE_APPARMOR
@@ -30,4 +31,4 @@ static inline bool mac_apparmor_use(void) {
 }
 #endif
 
-int dlopen_libapparmor(int log_level);
+int dlopen_libapparmor(int log_level) _dlopen_loader_;

--- a/src/shared/blkid-util.c
+++ b/src/shared/blkid-util.c
@@ -1,6 +1,5 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
-#include "sd-dlopen.h"
 #include "sd-id128.h"
 
 #include "blkid-util.h"
@@ -99,7 +98,7 @@ int dlopen_libblkid(int log_level) {
 #if HAVE_BLKID
         static void *libblkid_dl = NULL;
 
-        LIBBLKID_NOTE(SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+        LIBBLKID_NOTE(recommended);
 
         return dlopen_many_sym_or_warn(
                         &libblkid_dl,

--- a/src/shared/blkid-util.h
+++ b/src/shared/blkid-util.h
@@ -69,7 +69,7 @@ int blkid_probe_lookup_value_id128(blkid_probe b, const char *field, sd_id128_t 
 int blkid_probe_lookup_value_u64(blkid_probe b, const char *field, uint64_t *ret);
 #endif
 
-int dlopen_libblkid(int log_level);
+int dlopen_libblkid(int log_level) _dlopen_loader_;
 
 #define DLOPEN_LIBBLKID(log_level, priority)                            \
         ({                                                              \

--- a/src/shared/blkid-util.h
+++ b/src/shared/blkid-util.h
@@ -1,8 +1,7 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 #pragma once
 
-#include "sd-dlopen.h"
-
+#include "dlopen-note.h"
 #include "shared-forward.h"
 
 #if HAVE_BLKID
@@ -68,20 +67,12 @@ enum {
 
 int blkid_probe_lookup_value_id128(blkid_probe b, const char *field, sd_id128_t *ret);
 int blkid_probe_lookup_value_u64(blkid_probe b, const char *field, uint64_t *ret);
+#endif
 
-#define LIBBLKID_NOTE(priority)                                         \
-        SD_ELF_NOTE_DLOPEN("blkid",                                     \
-                           "Support for block device identification",   \
-                           priority,                                    \
-                           "libblkid.so.1")
+int dlopen_libblkid(int log_level);
 
 #define DLOPEN_LIBBLKID(log_level, priority)                            \
         ({                                                              \
                 LIBBLKID_NOTE(priority);                                \
                 dlopen_libblkid(log_level);                             \
         })
-#else
-#define DLOPEN_LIBBLKID(log_level, priority) dlopen_libblkid(log_level)
-#endif
-
-int dlopen_libblkid(int log_level);

--- a/src/shared/bpf-util.c
+++ b/src/shared/bpf-util.c
@@ -76,7 +76,10 @@ static int bpf_print_func(enum libbpf_print_level level, const char *fmt, va_lis
         return log_internalv(LOG_DEBUG, errno, NULL, 0, NULL, fmt, ap);
 }
 
+#endif
+
 int dlopen_bpf(int log_level) {
+#if HAVE_LIBBPF
         static void *bpf_dl = NULL;
         static int cached = 0;
         int r = -ENOENT;
@@ -153,8 +156,13 @@ int dlopen_bpf(int log_level) {
         (void) sym_libbpf_set_print(bpf_print_func);
 
         return 1;
+#else
+        return log_once_errno(log_level, SYNTHETIC_ERRNO(EOPNOTSUPP),
+                              "libbpf support is not compiled in, cgroup BPF features disabled.");
+#endif
 }
 
+#if HAVE_LIBBPF
 int bpf_get_error_translated(const void *ptr) {
         int r;
 
@@ -170,12 +178,5 @@ int bpf_get_error_translated(const void *ptr) {
         default:
                 return r;
         }
-}
-
-#else
-
-int dlopen_bpf(int log_level) {
-        return log_once_errno(log_level, SYNTHETIC_ERRNO(EOPNOTSUPP),
-                              "libbpf support is not compiled in, cgroup BPF features disabled.");
 }
 #endif

--- a/src/shared/bpf-util.c
+++ b/src/shared/bpf-util.c
@@ -1,7 +1,5 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
-#include "sd-dlopen.h"
-
 #include "bpf-util.h"
 #include "dlfcn-util.h"
 #include "initrd-util.h"
@@ -90,7 +88,7 @@ int dlopen_bpf(int log_level) {
         if (cached < 0)
                 return cached; /* Already tried, and failed. */
 
-        BPF_NOTE(SD_ELF_NOTE_DLOPEN_PRIORITY_SUGGESTED);
+        LIBBPF_NOTE(suggested);
 
         DISABLE_WARNING_DEPRECATED_DECLARATIONS;
 

--- a/src/shared/bpf-util.h
+++ b/src/shared/bpf-util.h
@@ -94,7 +94,7 @@ static inline int compat_bpf_map_create(
 int bpf_get_error_translated(const void *ptr);
 #endif
 
-int dlopen_bpf(int log_level);
+int dlopen_bpf(int log_level) _dlopen_loader_;
 
 #define DLOPEN_BPF(log_level, priority)                                 \
         ({                                                              \

--- a/src/shared/bpf-util.h
+++ b/src/shared/bpf-util.h
@@ -3,7 +3,8 @@
 
 #include <syslog.h>
 
-#include "sd-dlopen.h"
+#include "dlopen-note.h"
+#include "shared-forward.h"
 
 #if HAVE_LIBBPF
 #ifndef SYSTEMD_CFLAGS_MARKER_LIBBPF
@@ -14,7 +15,6 @@
 #include <bpf/libbpf.h> /* IWYU pragma: export */
 
 #include "dlfcn-util.h"
-#include "shared-forward.h"
 
 /* Always redeclare these so DLSYM_PROTOTYPE's typeof() resolves regardless of libbpf version;
  * suppress the warning when the libbpf headers already declare them.
@@ -92,20 +92,12 @@ static inline int compat_bpf_map_create(
  * this helper instead of libbpf_get_error() to ensure some of the known ones are translated into errnos
  * we understand. */
 int bpf_get_error_translated(const void *ptr);
-
-#define BPF_NOTE(priority)                                              \
-        SD_ELF_NOTE_DLOPEN("bpf",                                       \
-                           "Support firewalling and sandboxing with BPF", \
-                           priority,                                    \
-                           "libbpf.so.1", "libbpf.so.0")
-
-#define DLOPEN_BPF(log_level, priority)                                 \
-        ({                                                              \
-                BPF_NOTE(priority);                                     \
-                dlopen_bpf(log_level);                                  \
-        })
-#else
-#define DLOPEN_BPF(log_level, priority) dlopen_bpf(log_level)
 #endif
 
 int dlopen_bpf(int log_level);
+
+#define DLOPEN_BPF(log_level, priority)                                 \
+        ({                                                              \
+                LIBBPF_NOTE(priority);                                  \
+                dlopen_bpf(log_level);                                  \
+        })

--- a/src/shared/condition.c
+++ b/src/shared/condition.c
@@ -1340,9 +1340,45 @@ static int condition_test_kernel_module_loaded(Condition *c, char **env) {
         return true;
 }
 
-int condition_test(Condition *c, char **env) {
+typedef int (*condition_test_func_t)(Condition *c, char **env);
 
-        static int (*const condition_tests[_CONDITION_TYPE_MAX])(Condition *c, char **env) = {
+static int condition_test_impl(Condition *c, char **env, const condition_test_func_t table[]) {
+        int r, b;
+
+        assert(c);
+        assert(c->type >= 0);
+        assert(c->type < _CONDITION_TYPE_MAX);
+        assert(table);
+        assert(table[c->type]);
+
+        r = table[c->type](c, env);
+        if (r < 0) {
+                c->result = CONDITION_ERROR;
+                return r;
+        }
+
+        b = (r > 0) == !c->negate;
+        c->result = b ? CONDITION_SUCCEEDED : CONDITION_FAILED;
+        return b;
+}
+
+static int condition_test_net(Condition *c, char **env) {
+        static const condition_test_func_t table_net[_CONDITION_TYPE_MAX] = {
+                [CONDITION_KERNEL_COMMAND_LINE]      = condition_test_kernel_command_line,
+                [CONDITION_VERSION]                  = condition_test_version,
+                [CONDITION_CREDENTIAL]               = condition_test_credential,
+                [CONDITION_VIRTUALIZATION]           = condition_test_virtualization,
+                [CONDITION_HOST]                     = condition_test_host,
+                [CONDITION_ARCHITECTURE]             = condition_test_architecture,
+                [CONDITION_FIRMWARE]                 = condition_test_firmware,
+                [CONDITION_MACHINE_TAG]              = condition_test_machine_tag,
+        };
+
+        return condition_test_impl(c, env, table_net);
+}
+
+int condition_test(Condition *c, char **env) {
+        static const condition_test_func_t table[_CONDITION_TYPE_MAX] = {
                 [CONDITION_PATH_EXISTS]              = condition_test_path_exists,
                 [CONDITION_PATH_EXISTS_GLOB]         = condition_test_path_exists_glob,
                 [CONDITION_PATH_IS_DIRECTORY]        = condition_test_path_is_directory,
@@ -1382,28 +1418,15 @@ int condition_test(Condition *c, char **env) {
                 [CONDITION_KERNEL_MODULE_LOADED]     = condition_test_kernel_module_loaded,
         };
 
-        int r, b;
-
-        assert(c);
-        assert(c->type >= 0);
-        assert(c->type < _CONDITION_TYPE_MAX);
-
-        r = condition_tests[c->type](c, env);
-        if (r < 0) {
-                c->result = CONDITION_ERROR;
-                return r;
-        }
-
-        b = (r > 0) == !c->negate;
-        c->result = b ? CONDITION_SUCCEEDED : CONDITION_FAILED;
-        return b;
+        return condition_test_impl(c, env, table);
 }
 
-bool condition_test_list(
+static bool condition_test_list_impl(
                 Condition *first,
                 char **env,
                 condition_to_string_t to_string,
                 condition_test_logger_t logger,
+                condition_test_func_t tester,
                 void *userdata) {
 
         int triggered = -1;
@@ -1418,7 +1441,7 @@ bool condition_test_list(
         LIST_FOREACH(conditions, c, first) {
                 int r;
 
-                r = condition_test(c, env);
+                r = tester(c, env);
 
                 if (logger) {
                         if (r < 0)
@@ -1446,6 +1469,26 @@ bool condition_test_list(
         }
 
         return triggered != 0;
+}
+
+bool condition_test_list_net(
+                Condition *first,
+                char **env,
+                condition_to_string_t to_string,
+                condition_test_logger_t logger,
+                void *userdata) {
+
+        return condition_test_list_impl(first, env, to_string, logger, condition_test_net, userdata);
+}
+
+bool condition_test_list(
+                Condition *first,
+                char **env,
+                condition_to_string_t to_string,
+                condition_test_logger_t logger,
+                void *userdata) {
+
+        return condition_test_list_impl(first, env, to_string, logger, condition_test, userdata);
 }
 
 void condition_dump(Condition *c, FILE *f, const char *prefix, condition_to_string_t to_string) {

--- a/src/shared/condition.h
+++ b/src/shared/condition.h
@@ -85,6 +85,7 @@ int condition_test(Condition *c, char **env);
 
 typedef int (*condition_test_logger_t)(void *userdata, int level, int error, const char *file, int line, const char *func, const char *format, ...) _printf_(7, 8);
 typedef const char* (*condition_to_string_t)(ConditionType t) _const_;
+bool condition_test_list_net(Condition *first, char **env, condition_to_string_t to_string, condition_test_logger_t logger, void *userdata);
 bool condition_test_list(Condition *first, char **env, condition_to_string_t to_string, condition_test_logger_t logger, void *userdata);
 
 void condition_dump(Condition *c, FILE *f, const char *prefix, condition_to_string_t to_string);

--- a/src/shared/crypto-util.c
+++ b/src/shared/crypto-util.c
@@ -1,7 +1,5 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
-#include "sd-dlopen.h"
-
 #include "alloc-util.h"
 #include "ask-password-api.h"
 #include "crypto-util.h"
@@ -348,7 +346,7 @@ int dlopen_libcrypto(int log_level) {
         static void *libcrypto_dl = NULL;
         int r;
 
-        LIBCRYPTO_NOTE(SD_ELF_NOTE_DLOPEN_PRIORITY_SUGGESTED);
+        LIBCRYPTO_NOTE(suggested);
 
         FOREACH_STRING(soname, "libcrypto.so.4", "libcrypto.so.3") {
                 r = dlopen_many_sym_or_warn(

--- a/src/shared/crypto-util.h
+++ b/src/shared/crypto-util.h
@@ -1,11 +1,10 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 #pragma once
 
-#include "sd-dlopen.h"
-
-#include "shared-forward.h"
+#include "dlopen-note.h"
 #include "iovec-util.h"
 #include "sha256.h"
+#include "shared-forward.h"
 
 typedef enum CertificateSourceType {
         OPENSSL_CERTIFICATE_SOURCE_FILE,
@@ -28,26 +27,12 @@ int parse_openssl_certificate_source_argument(const char *argument, char **certi
 
 int parse_openssl_key_source_argument(const char *argument, char **private_key_source, KeySourceType *private_key_source_type);
 
-int dlopen_libcrypto(int log_level);
-
 #define X509_FINGERPRINT_SIZE SHA256_DIGEST_SIZE
 
 #if HAVE_OPENSSL
 #ifndef SYSTEMD_CFLAGS_MARKER_LIBOPENSSL
 #  error "missing libopenssl_cflags in meson dependency."
 #endif
-
-#define LIBCRYPTO_NOTE(priority)                                        \
-        SD_ELF_NOTE_DLOPEN("libcrypto",                                 \
-                           "Support for cryptographic operations",      \
-                           priority,                                    \
-                           "libcrypto.so.4", "libcrypto.so.3")
-
-#define DLOPEN_LIBCRYPTO(log_level, priority)                           \
-        ({                                                              \
-                LIBCRYPTO_NOTE(priority);                               \
-                dlopen_libcrypto(log_level);                            \
-        })
 
 #  include <openssl/bio.h>              /* IWYU pragma: export */
 #  include <openssl/bn.h>               /* IWYU pragma: export */
@@ -459,7 +444,12 @@ int openssl_extract_public_key(EVP_PKEY *private_key, EVP_PKEY **ret);
 
 OpenSSLAskPasswordUI* openssl_ask_password_ui_free(OpenSSLAskPasswordUI *ui);
 DEFINE_TRIVIAL_CLEANUP_FUNC_FULL(OpenSSLAskPasswordUI*, openssl_ask_password_ui_free, NULL);
-
-#else
-#define DLOPEN_LIBCRYPTO(log_level, priority) dlopen_libcrypto(log_level)
 #endif
+
+int dlopen_libcrypto(int log_level);
+
+#define DLOPEN_LIBCRYPTO(log_level, priority)                           \
+        ({                                                              \
+                LIBCRYPTO_NOTE(priority);                               \
+                dlopen_libcrypto(log_level);                            \
+        })

--- a/src/shared/crypto-util.h
+++ b/src/shared/crypto-util.h
@@ -446,7 +446,7 @@ OpenSSLAskPasswordUI* openssl_ask_password_ui_free(OpenSSLAskPasswordUI *ui);
 DEFINE_TRIVIAL_CLEANUP_FUNC_FULL(OpenSSLAskPasswordUI*, openssl_ask_password_ui_free, NULL);
 #endif
 
-int dlopen_libcrypto(int log_level);
+int dlopen_libcrypto(int log_level) _dlopen_loader_;
 
 #define DLOPEN_LIBCRYPTO(log_level, priority)                           \
         ({                                                              \

--- a/src/shared/cryptsetup-util.c
+++ b/src/shared/cryptsetup-util.c
@@ -2,7 +2,6 @@
 
 #include <stdlib.h>
 
-#include "sd-dlopen.h"
 #include "sd-json.h"
 
 #include "alloc-util.h"
@@ -282,7 +281,7 @@ int dlopen_cryptsetup(int log_level) {
          * still available though, and given we want to support 2.2.0 for a while longer, we'll use the old
          * symbol if the new one is not available. */
 
-        CRYPTSETUP_NOTE(SD_ELF_NOTE_DLOPEN_PRIORITY_SUGGESTED);
+        LIBCRYPTSETUP_NOTE(suggested);
 
         r = dlopen_many_sym_or_warn(
                         &cryptsetup_dl, "libcryptsetup.so.12", log_level,

--- a/src/shared/cryptsetup-util.h
+++ b/src/shared/cryptsetup-util.h
@@ -99,7 +99,7 @@ int cryptsetup_get_volume_key_id(struct crypt_device *cd, const char *volume_nam
                                  size_t volume_key_size,  char **ret);
 #endif
 
-int dlopen_cryptsetup(int log_level);
+int dlopen_cryptsetup(int log_level) _dlopen_loader_;
 
 #define DLOPEN_CRYPTSETUP(log_level, priority)                          \
         ({                                                              \

--- a/src/shared/cryptsetup-util.h
+++ b/src/shared/cryptsetup-util.h
@@ -1,9 +1,8 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 #pragma once
 
-#include "sd-dlopen.h"
-
 #include "dlfcn-util.h"
+#include "dlopen-note.h"
 #include "shared-forward.h"
 
 #if HAVE_LIBCRYPTSETUP
@@ -98,23 +97,15 @@ int cryptsetup_add_token_json(struct crypt_device *cd, sd_json_variant *v);
 int cryptsetup_get_volume_key_prefix(struct crypt_device *cd, const char *volume_name, char **ret);
 int cryptsetup_get_volume_key_id(struct crypt_device *cd, const char *volume_name, const void *volume_key,
                                  size_t volume_key_size,  char **ret);
-
-#define CRYPTSETUP_NOTE(priority)                                       \
-        SD_ELF_NOTE_DLOPEN("cryptsetup",                                \
-                           "Support for disk encryption, integrity, and authentication", \
-                           priority,                                    \
-                           "libcryptsetup.so.12")
-
-#define DLOPEN_CRYPTSETUP(log_level, priority)                          \
-        ({                                                              \
-                CRYPTSETUP_NOTE(priority);                              \
-                dlopen_cryptsetup(log_level);                           \
-        })
-#else
-#define DLOPEN_CRYPTSETUP(log_level, priority) dlopen_cryptsetup(log_level)
 #endif
 
 int dlopen_cryptsetup(int log_level);
+
+#define DLOPEN_CRYPTSETUP(log_level, priority)                          \
+        ({                                                              \
+                LIBCRYPTSETUP_NOTE(priority);                           \
+                dlopen_cryptsetup(log_level);                           \
+        })
 
 int cryptsetup_get_keyslot_from_token(sd_json_variant *v);
 

--- a/src/shared/curl-util.c
+++ b/src/shared/curl-util.c
@@ -5,7 +5,6 @@
 
 #if HAVE_LIBCURL
 
-#include "sd-dlopen.h"
 #include "sd-event.h"
 
 #include "alloc-util.h"
@@ -604,7 +603,7 @@ int dlopen_curl(int log_level) {
 #if HAVE_LIBCURL
         static void *curl_dl = NULL;
 
-        CURL_NOTE(SD_ELF_NOTE_DLOPEN_PRIORITY_SUGGESTED);
+        LIBCURL_NOTE(suggested);
 
         return dlopen_many_sym_or_warn(
                         &curl_dl,

--- a/src/shared/curl-util.h
+++ b/src/shared/curl-util.h
@@ -77,7 +77,7 @@ DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_RENAME(CURL*, sym_curl_easy_cleanup, curl_easy_
 DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_RENAME(struct curl_slist*, sym_curl_slist_free_all, curl_slist_free_allp, NULL);
 #endif
 
-int dlopen_curl(int log_level);
+int dlopen_curl(int log_level) _dlopen_loader_;
 
 #define DLOPEN_CURL(log_level, priority)                                \
         ({                                                              \

--- a/src/shared/curl-util.h
+++ b/src/shared/curl-util.h
@@ -1,8 +1,7 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 #pragma once
 
-#include "sd-dlopen.h"
-
+#include "dlopen-note.h"
 #include "shared-forward.h"
 
 #if HAVE_LIBCURL
@@ -76,20 +75,12 @@ int curl_append_to_header(struct curl_slist **list, char **headers);
 
 DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_RENAME(CURL*, sym_curl_easy_cleanup, curl_easy_cleanupp, NULL);
 DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_RENAME(struct curl_slist*, sym_curl_slist_free_all, curl_slist_free_allp, NULL);
-
-#define CURL_NOTE(priority)                                             \
-        SD_ELF_NOTE_DLOPEN("curl",                                      \
-                           "Support for downloading and uploading files over HTTP", \
-                           priority,                                    \
-                           "libcurl.so.4")
-
-#define DLOPEN_CURL(log_level, priority)                                \
-        ({                                                              \
-                CURL_NOTE(priority);                                    \
-                dlopen_curl(log_level);                                 \
-        })
-#else
-#define DLOPEN_CURL(log_level, priority) dlopen_curl(log_level)
 #endif
 
 int dlopen_curl(int log_level);
+
+#define DLOPEN_CURL(log_level, priority)                                \
+        ({                                                              \
+                LIBCURL_NOTE(priority);                                 \
+                dlopen_curl(log_level);                                 \
+        })

--- a/src/shared/dlopen-note.h
+++ b/src/shared/dlopen-note.h
@@ -1,0 +1,381 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#pragma once
+
+#include "../basic/dlopen-note.h"       /* IWYU pragma: export */
+#include "shared-forward.h"
+
+#if HAVE_ACL
+#  define LIBACL_NOTE(priority)                                         \
+        ELF_NOTE_DLOPEN_ANCHORED(                                       \
+                        acl,                                            \
+                        "Support for file Access Control Lists (ACLs)", \
+                        priority,                                       \
+                        "libacl.so.1")
+#else
+#  define LIBACL_NOTE(priority)
+#endif
+
+#if HAVE_APPARMOR
+#  define LIBAPPARMOR_NOTE(priority)                                    \
+        ELF_NOTE_DLOPEN_ANCHORED(                                       \
+                        apparmor,                                       \
+                        "Support for AppArmor policies",                \
+                        priority,                                       \
+                        "libapparmor.so.1")
+#else
+#  define LIBAPPARMOR_NOTE(priority)
+#endif
+
+#if HAVE_LIBARCHIVE
+#  define LIBARCHIVE_NOTE(priority)                                     \
+        ELF_NOTE_DLOPEN_ANCHORED(                                       \
+                        archive,                                        \
+                        "Support for decompressing archive files",      \
+                        priority,                                       \
+                        "libarchive.so.13")
+#else
+#  define LIBARCHIVE_NOTE(priority)
+#endif
+
+#if HAVE_AUDIT
+#  define LIBAUDIT_NOTE(priority)                     \
+        ELF_NOTE_DLOPEN_ANCHORED(                     \
+                        audit,                        \
+                        "Support for Audit logging",  \
+                        priority,                     \
+                        "libaudit.so.1")
+#else
+#  define LIBAUDIT_NOTE(priority)
+#endif
+
+#if HAVE_BLKID
+#  define LIBBLKID_NOTE(priority)                                       \
+        ELF_NOTE_DLOPEN_ANCHORED(                                       \
+                        blkid,                                          \
+                        "Support for block device identification",      \
+                        priority,                                       \
+                        "libblkid.so.1")
+#else
+#  define LIBBLKID_NOTE(priority)
+#endif
+
+#if HAVE_LIBBPF
+#  define LIBBPF_NOTE(priority)                                         \
+        ELF_NOTE_DLOPEN_ANCHORED(                                       \
+                        bpf,                                            \
+                        "Support firewalling and sandboxing with BPF",  \
+                        priority,                                       \
+                        "libbpf.so.1", "libbpf.so.0")
+#else
+#  define LIBBPF_NOTE(priority)
+#endif
+
+#if HAVE_LIBCRYPT && defined(__GLIBC__)
+#  define LIBCRYPT_NOTE(priority)                                       \
+        ELF_NOTE_DLOPEN_ANCHORED(                                       \
+                        crypt,                                          \
+                        "Support for hashing passwords",                \
+                        priority,                                       \
+                        "libcrypt.so.2", "libcrypt.so.1", "libcrypt.so.1.1")
+#else
+#  define LIBCRYPT_NOTE(priority)
+#endif
+
+#if HAVE_OPENSSL
+#  define LIBCRYPTO_NOTE(priority)                                      \
+        ELF_NOTE_DLOPEN_ANCHORED(                                       \
+                        libcrypto,                                      \
+                        "Support for cryptographic operations",         \
+                        priority,                                       \
+                        "libcrypto.so.4", "libcrypto.so.3")
+#else
+#  define LIBCRYPTO_NOTE(priority)
+#endif
+
+#if HAVE_LIBCRYPTSETUP
+#  define LIBCRYPTSETUP_NOTE(priority)                                  \
+        ELF_NOTE_DLOPEN_ANCHORED(                                       \
+                        cryptsetup,                                     \
+                        "Support for disk encryption, integrity, and authentication", \
+                        priority,                                       \
+                        "libcryptsetup.so.12")
+#else
+#  define LIBCRYPTSETUP_NOTE(priority)
+#endif
+
+#if HAVE_LIBCURL
+#  define LIBCURL_NOTE(priority)                                        \
+        ELF_NOTE_DLOPEN_ANCHORED(                                       \
+                        curl,                                           \
+                        "Support for downloading and uploading files over HTTP", \
+                        priority,                                       \
+                        "libcurl.so.4")
+#else
+#  define LIBCURL_NOTE(priority)
+#endif
+
+#if HAVE_LIBFDISK
+#  define LIBFDISK_NOTE(priority)                                       \
+        ELF_NOTE_DLOPEN_ANCHORED(                                       \
+                        fdisk,                                          \
+                        "Support for reading and writing partition tables", \
+                        priority,                                       \
+                        "libfdisk.so.1")
+#else
+#  define LIBFDISK_NOTE(priority)
+#endif
+
+#if HAVE_ELFUTILS
+#  define LIBDW_NOTE(priority)                                          \
+        ELF_NOTE_DLOPEN_ANCHORED(                                       \
+                        dw,                                             \
+                        "Support for backtrace and ELF package metadata decoding from core files", \
+                        priority,                                       \
+                        "libdw.so.1")
+#else
+#  define LIBDW_NOTE(priority)
+#endif
+
+#if HAVE_ELFUTILS
+#  define LIBELF_NOTE(priority)                                         \
+        ELF_NOTE_DLOPEN_ANCHORED(                                       \
+                        elf,                                            \
+                        "Support for backtraces and reading ELF package metadata from core files", \
+                        priority,                                       \
+                        "libelf.so.1")
+#else
+#  define LIBELF_NOTE(priority)
+#endif
+
+#if HAVE_LIBFIDO2
+#  define LIBFIDO2_NOTE(priority)                                       \
+        ELF_NOTE_DLOPEN_ANCHORED(                                       \
+                        fido2,                                          \
+                        "Support fido2 for encryption and authentication", \
+                        priority,                                       \
+                        "libfido2.so.1")
+#else
+#  define LIBFIDO2_NOTE(priority)
+#endif
+
+#if HAVE_GNUTLS
+#  define LIBGNUTLS_NOTE(priority)                              \
+        ELF_NOTE_DLOPEN_ANCHORED(                               \
+                        gnutls,                                 \
+                        "Support for TLS via GnuTLS",           \
+                        priority,                               \
+                        "libgnutls.so.30")
+#else
+#  define LIBGNUTLS_NOTE(priority)
+#endif
+
+#if HAVE_LIBIDN2
+#  define LIBIDN2_NOTE(priority)                                        \
+        ELF_NOTE_DLOPEN_ANCHORED(                                       \
+                        idn,                                            \
+                        "Support for internationalized domain names",   \
+                        priority,                                       \
+                        "libidn2.so.0")
+#else
+#  define LIBIDN2_NOTE(priority)
+#endif
+
+#if HAVE_KMOD
+#  define LIBKMOD_NOTE(priority)                                        \
+        ELF_NOTE_DLOPEN_ANCHORED(                                       \
+                        kmod,                                           \
+                        "Support for loading kernel modules",           \
+                        priority,                                       \
+                        "libkmod.so.2")
+#else
+#  define LIBKMOD_NOTE(priority)
+#endif
+
+#if HAVE_MICROHTTPD
+#  define LIBMICROHTTPD_NOTE(priority)                                  \
+        ELF_NOTE_DLOPEN_ANCHORED(                                       \
+                        microhttpd,                                     \
+                        "Support for embedded HTTP server via libmicrohttpd", \
+                        priority,                                       \
+                        "libmicrohttpd.so.12")
+#else
+#  define LIBMICROHTTPD_NOTE(priority)
+#endif
+
+#if HAVE_LIBMOUNT
+#  define LIBMOUNT_NOTE(priority)                                       \
+        ELF_NOTE_DLOPEN_ANCHORED(                                       \
+                        mount,                                          \
+                        "Support for mount enumeration",                \
+                        priority,                                       \
+                        "libmount.so.1")
+#else
+#  define LIBMOUNT_NOTE(priority)
+#endif
+
+#if HAVE_P11KIT
+#  define LIBP11KIT_NOTE(priority)                                 \
+        SD_ELF_NOTE_DLOPEN_ANCHORED(                               \
+                        p11kit_##priority,                         \
+                        "p11-kit",                                 \
+                        "Support for PKCS11 hardware tokens",      \
+                        STRINGIFY(priority),                       \
+                        "libp11-kit.so.0")
+#else
+#  define LIBP11KIT_NOTE(priority)
+#endif
+
+#if HAVE_PAM
+#  define LIBPAM_NOTE(priority)                                         \
+        ELF_NOTE_DLOPEN_ANCHORED(                                       \
+                        pam,                                            \
+                        "Support for LinuxPAM",                         \
+                        priority,                                       \
+                        "libpam.so.0")
+#else
+#  define LIBPAM_NOTE(priority)
+#endif
+
+#if HAVE_PASSWDQC
+#  define LIBPASSWDQC_NOTE(priority)                            \
+        ELF_NOTE_DLOPEN_ANCHORED(                               \
+                        passwdqc,                               \
+                        "Support for password quality checks",  \
+                        priority,                               \
+                        "libpasswdqc.so.1")
+#else
+#  define LIBPASSWDQC_NOTE(priority)
+#endif
+
+#if HAVE_PCRE2
+#  define LIBPCRE2_NOTE(priority)                               \
+        ELF_NOTE_DLOPEN_ANCHORED(                               \
+                        pcre2,                                  \
+                        "Support for regular expressions",      \
+                        priority,                               \
+                        "libpcre2-8.so.0")
+#else
+#  define LIBPCRE2_NOTE(priority)
+#endif
+
+#if HAVE_PWQUALITY
+#  define LIBPWQUALITY_NOTE(priority)                           \
+        ELF_NOTE_DLOPEN_ANCHORED(                               \
+                        pwquality,                              \
+                        "Support for password quality checks",  \
+                        priority,                               \
+                        "libpwquality.so.1")
+#else
+#  define LIBPWQUALITY_NOTE(priority)
+#endif
+
+#if HAVE_QRENCODE
+#  define LIBQRENCODE_NOTE(priority)                            \
+        ELF_NOTE_DLOPEN_ANCHORED(                               \
+                        qrencode,                               \
+                        "Support for generating QR codes",      \
+                        priority,                               \
+                        "libqrencode.so.4", "libqrencode.so.3")
+#else
+#  define LIBQRENCODE_NOTE(priority)
+#endif
+
+#if HAVE_SECCOMP
+#  define LIBSECCOMP_NOTE(priority)                                     \
+        ELF_NOTE_DLOPEN_ANCHORED(                                       \
+                        seccomp,                                        \
+                        "Support for Seccomp Sandboxes",                \
+                        priority,                                       \
+                        "libseccomp.so.2")
+#else
+#  define LIBSECCOMP_NOTE(priority)
+#endif
+
+#if HAVE_SELINUX
+#  define LIBSELINUX_NOTE(priority)                                     \
+        ELF_NOTE_DLOPEN_ANCHORED(                                       \
+                        selinux,                                        \
+                        "Support for SELinux",                          \
+                        priority,                                       \
+                        "libselinux.so.1")
+#else
+#  define LIBSELINUX_NOTE(priority)
+#endif
+
+#if HAVE_OPENSSL
+#  define LIBSSL_NOTE(priority)                                         \
+        ELF_NOTE_DLOPEN_ANCHORED(                                       \
+                        libssl,                                         \
+                        "Support for TLS",                              \
+                        priority,                                       \
+                        "libssl.so.4", "libssl.so.3")
+#else
+#  define LIBSSL_NOTE(priority)
+#endif
+
+#if HAVE_TPM2
+#  define LIBTSS2_ESYS_NOTE(priority)           \
+        SD_ELF_NOTE_DLOPEN_ANCHORED(            \
+                        tpm2_esys_##priority,   \
+                        "tpm",                  \
+                        "Support for TPM",      \
+                        STRINGIFY(priority),    \
+                        "libtss2-esys.so.0")
+#  define LIBTSS2_RC_NOTE(priority)             \
+        SD_ELF_NOTE_DLOPEN_ANCHORED(            \
+                        tpm2_rc_##priority,     \
+                        "tpm",                  \
+                        "Support for TPM",      \
+                        STRINGIFY(priority),    \
+                        "libtss2-rc.so.0")
+#  define LIBTSS2_MU_NOTE(priority)               \
+        SD_ELF_NOTE_DLOPEN_ANCHORED(              \
+                        tpm2_mu_##priority,       \
+                        "tpm",                    \
+                        "Support for TPM",        \
+                        STRINGIFY(priority),      \
+                        "libtss2-mu.so.0")
+#  define LIBTSS2_TCTI_DEVICE_NOTE(priority)            \
+        SD_ELF_NOTE_DLOPEN_ANCHORED(                    \
+                        tpm2_tcti_device_##priority,    \
+                        "tpm",                          \
+                        "Support for TPM",              \
+                        STRINGIFY(priority),            \
+                        "libtss2-tcti-device.so.0")
+#else
+#  define LIBTSS2_ESYS_NOTE(priority)
+#  define LIBTSS2_RC_NOTE(priority)
+#  define LIBTSS2_MU_NOTE(priority)
+#  define LIBTSS2_TCTI_DEVICE_NOTE(priority)
+#endif
+
+#if HAVE_XKBCOMMON
+#  define LIBXKBCOMMON_NOTE(priority)                                   \
+        ELF_NOTE_DLOPEN_ANCHORED(                                       \
+                        xkbcommon,                                      \
+                        "Support for keyboard locale descriptions",     \
+                        priority,                                       \
+                        "libxkbcommon.so.0")
+#else
+#  define LIBXKBCOMMON_NOTE(priority)
+#endif
+
+#if HAVE_LIBARCHIVE
+#  define ARCHIVE_NOTE(priority)                \
+        COMPRESS_NOTE(priority);                \
+        LIBACL_NOTE(priority);                  \
+        LIBARCHIVE_NOTE(priority)
+#else
+#  define ARCHIVE_NOTE(priority)                \
+        COMPRESS_NOTE(priority)
+#endif
+
+#define PASSWORD_NOTE(priority)                 \
+        LIBPASSWDQC_NOTE(priority);             \
+        LIBPWQUALITY_NOTE(priority)
+
+#define TPM2_NOTE(priority)                                             \
+        LIBTSS2_ESYS_NOTE(priority);                                    \
+        LIBTSS2_RC_NOTE(priority);                                      \
+        LIBTSS2_MU_NOTE(priority);                                      \
+        LIBTSS2_TCTI_DEVICE_NOTE(priority)

--- a/src/shared/dns-configuration.c
+++ b/src/shared/dns-configuration.c
@@ -155,7 +155,7 @@ static int dispatch_search_domain_array(const char *name, sd_json_variant *varia
         return 0;
 }
 
-DNSScope* dns_scope_free(DNSScope *s) {
+static DNSScope* dns_scope_free(DNSScope *s) {
         if (!s)
                 return NULL;
 
@@ -166,6 +166,8 @@ DNSScope* dns_scope_free(DNSScope *s) {
 
         return mfree(s);
 }
+
+DEFINE_TRIVIAL_CLEANUP_FUNC(DNSScope*, dns_scope_free);
 
 DEFINE_PRIVATE_HASH_OPS_WITH_VALUE_DESTRUCTOR(
         dns_scope_hash_ops,

--- a/src/shared/dns-configuration.h
+++ b/src/shared/dns-configuration.h
@@ -25,6 +25,9 @@ typedef struct SearchDomain {
         int ifindex;
 } SearchDomain;
 
+SearchDomain* search_domain_free(SearchDomain *d);
+DEFINE_TRIVIAL_CLEANUP_FUNC(SearchDomain*, search_domain_free);
+
 typedef struct DNSScope {
         char *ifname;
         int ifindex;
@@ -33,12 +36,6 @@ typedef struct DNSScope {
         char *dnssec_mode_str;
         char *dns_over_tls_mode_str;
 } DNSScope;
-
-DNSScope* dns_scope_free(DNSScope *s);
-DEFINE_TRIVIAL_CLEANUP_FUNC(DNSScope*, dns_scope_free);
-
-SearchDomain* search_domain_free(SearchDomain *d);
-DEFINE_TRIVIAL_CLEANUP_FUNC(SearchDomain*, search_domain_free);
 
 typedef struct DNSConfiguration {
         char *ifname;

--- a/src/shared/elf-util.c
+++ b/src/shared/elf-util.c
@@ -17,7 +17,6 @@
 #include "alloc-util.h"
 #include "coredump-util.h"
 #include "dlfcn-util.h"
-#include "dlopen-note.h"
 #include "elf-util.h"
 #include "errno-util.h"
 #include "escape.h"

--- a/src/shared/elf-util.c
+++ b/src/shared/elf-util.c
@@ -12,12 +12,12 @@
 #endif
 #include <unistd.h>
 
-#include "sd-dlopen.h"
 #include "sd-json.h"
 
 #include "alloc-util.h"
 #include "coredump-util.h"
 #include "dlfcn-util.h"
+#include "dlopen-note.h"
 #include "elf-util.h"
 #include "errno-util.h"
 #include "escape.h"
@@ -100,11 +100,7 @@ int dlopen_dw(int log_level) {
         static void *dw_dl = NULL;
         int r;
 
-        SD_ELF_NOTE_DLOPEN(
-                        "dw",
-                        "Support for backtrace and ELF package metadata decoding from core files",
-                        SD_ELF_NOTE_DLOPEN_PRIORITY_SUGGESTED,
-                        "libdw.so.1");
+        LIBDW_NOTE(suggested);
 
         r = dlopen_many_sym_or_warn(
                         &dw_dl, "libdw.so.1", log_level,
@@ -166,11 +162,7 @@ int dlopen_elf(int log_level) {
         static void *elf_dl = NULL;
         int r;
 
-        SD_ELF_NOTE_DLOPEN(
-                        "elf",
-                        "Support for backtraces and reading ELF package metadata from core files",
-                        SD_ELF_NOTE_DLOPEN_PRIORITY_SUGGESTED,
-                        "libelf.so.1");
+        LIBELF_NOTE(suggested);
 
         r = dlopen_many_sym_or_warn(
                         &elf_dl, "libelf.so.1", log_level,

--- a/src/shared/elf-util.h
+++ b/src/shared/elf-util.h
@@ -1,10 +1,11 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 #pragma once
 
+#include "dlopen-note.h"
 #include "shared-forward.h"
 
-int dlopen_dw(int log_level);
-int dlopen_elf(int log_level);
+int dlopen_dw(int log_level) _dlopen_loader_;
+int dlopen_elf(int log_level) _dlopen_loader_;
 
 bool dlopen_dw_has_dwfl_set_sysroot(void);
 

--- a/src/shared/fdisk-util.c
+++ b/src/shared/fdisk-util.c
@@ -5,8 +5,6 @@
 
 #if HAVE_LIBFDISK
 
-#include "sd-dlopen.h"
-
 #include "alloc-util.h"
 #include "bitfield.h"
 #include "dissect-image.h"
@@ -83,7 +81,7 @@ int dlopen_fdisk(int log_level) {
 #if HAVE_LIBFDISK
         static void *fdisk_dl = NULL;
 
-        FDISK_NOTE(SD_ELF_NOTE_DLOPEN_PRIORITY_SUGGESTED);
+        LIBFDISK_NOTE(suggested);
 
         return dlopen_many_sym_or_warn(
                         &fdisk_dl,

--- a/src/shared/fdisk-util.h
+++ b/src/shared/fdisk-util.h
@@ -1,8 +1,7 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 #pragma once
 
-#include "sd-dlopen.h"
-
+#include "dlopen-note.h"
 #include "shared-forward.h"
 
 #if HAVE_LIBFDISK
@@ -88,20 +87,12 @@ int fdisk_partition_get_type_as_id128(struct fdisk_partition *p, sd_id128_t *ret
 
 int fdisk_partition_get_attrs_as_uint64(struct fdisk_partition *pa, uint64_t *ret);
 int fdisk_partition_set_attrs_as_uint64(struct fdisk_partition *pa, uint64_t flags);
-
-#define FDISK_NOTE(priority)                                            \
-        SD_ELF_NOTE_DLOPEN("fdisk",                                     \
-                           "Support for reading and writing partition tables", \
-                           priority,                                    \
-                           "libfdisk.so.1")
-
-#define DLOPEN_FDISK(log_level, priority)                               \
-        ({                                                              \
-                FDISK_NOTE(priority);                                   \
-                dlopen_fdisk(log_level);                                \
-        })
-#else
-#define DLOPEN_FDISK(log_level, priority) dlopen_fdisk(log_level)
 #endif
 
 int dlopen_fdisk(int log_level);
+
+#define DLOPEN_FDISK(log_level, priority)                               \
+        ({                                                              \
+                LIBFDISK_NOTE(priority);                                \
+                dlopen_fdisk(log_level);                                \
+        })

--- a/src/shared/fdisk-util.h
+++ b/src/shared/fdisk-util.h
@@ -89,7 +89,7 @@ int fdisk_partition_get_attrs_as_uint64(struct fdisk_partition *pa, uint64_t *re
 int fdisk_partition_set_attrs_as_uint64(struct fdisk_partition *pa, uint64_t flags);
 #endif
 
-int dlopen_fdisk(int log_level);
+int dlopen_fdisk(int log_level) _dlopen_loader_;
 
 #define DLOPEN_FDISK(log_level, priority)                               \
         ({                                                              \

--- a/src/shared/gnutls-util.c
+++ b/src/shared/gnutls-util.c
@@ -1,6 +1,5 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
-#include "dlopen-note.h"
 #include "gnutls-util.h"
 #include "log.h"                /* IWYU pragma: keep */
 

--- a/src/shared/gnutls-util.c
+++ b/src/shared/gnutls-util.c
@@ -1,7 +1,6 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
-#include "sd-dlopen.h"
-
+#include "dlopen-note.h"
 #include "gnutls-util.h"
 #include "log.h"                /* IWYU pragma: keep */
 
@@ -23,11 +22,7 @@ int dlopen_gnutls(int log_level) {
 #if HAVE_GNUTLS
         static void *gnutls_dl = NULL;
 
-        SD_ELF_NOTE_DLOPEN(
-                        "gnutls",
-                        "Support for TLS via GnuTLS",
-                        SD_ELF_NOTE_DLOPEN_PRIORITY_SUGGESTED,
-                        "libgnutls.so.30");
+        LIBGNUTLS_NOTE(suggested);
 
         return dlopen_many_sym_or_warn(
                         &gnutls_dl,

--- a/src/shared/gnutls-util.h
+++ b/src/shared/gnutls-util.h
@@ -1,9 +1,10 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 #pragma once
 
+#include "dlopen-note.h"
 #include "shared-forward.h"
 
-int dlopen_gnutls(int log_level);
+int dlopen_gnutls(int log_level) _dlopen_loader_;
 
 #if HAVE_GNUTLS
 #  ifndef SYSTEMD_CFLAGS_MARKER_LIBGNUTLS

--- a/src/shared/idn-util.c
+++ b/src/shared/idn-util.c
@@ -5,8 +5,6 @@
 
 #if HAVE_LIBIDN2
 
-#include "sd-dlopen.h"
-
 static void* idn_dl = NULL;
 
 DLSYM_PROTOTYPE(idn2_lookup_u8) = NULL;
@@ -17,7 +15,7 @@ DLSYM_PROTOTYPE(idn2_to_unicode_8z8z) = NULL;
 
 int dlopen_idn(int log_level) {
 #if HAVE_LIBIDN2
-        IDN_NOTE(SD_ELF_NOTE_DLOPEN_PRIORITY_SUGGESTED);
+        LIBIDN2_NOTE(suggested);
 
         return dlopen_many_sym_or_warn(
                         &idn_dl, "libidn2.so.0", log_level,

--- a/src/shared/idn-util.h
+++ b/src/shared/idn-util.h
@@ -18,7 +18,7 @@ extern const char *(*sym_idn2_strerror)(int rc) _const_;
 extern DLSYM_PROTOTYPE(idn2_to_unicode_8z8z);
 #endif
 
-int dlopen_idn(int log_level);
+int dlopen_idn(int log_level) _dlopen_loader_;
 
 #define DLOPEN_IDN(log_level, priority)                                 \
         ({                                                              \

--- a/src/shared/idn-util.h
+++ b/src/shared/idn-util.h
@@ -1,8 +1,7 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 #pragma once
 
-#include "sd-dlopen.h"
-
+#include "dlopen-note.h"
 #include "shared-forward.h"
 
 #if HAVE_LIBIDN2
@@ -17,20 +16,12 @@
 extern DLSYM_PROTOTYPE(idn2_lookup_u8);
 extern const char *(*sym_idn2_strerror)(int rc) _const_;
 extern DLSYM_PROTOTYPE(idn2_to_unicode_8z8z);
-
-#define IDN_NOTE(priority)                                              \
-        SD_ELF_NOTE_DLOPEN("idn",                                       \
-                           "Support for internationalized domain names", \
-                           priority,                                    \
-                           "libidn2.so.0")
-
-#define DLOPEN_IDN(log_level, priority)                                 \
-        ({                                                              \
-                IDN_NOTE(priority);                                     \
-                dlopen_idn(log_level);                                  \
-        })
-#else
-#define DLOPEN_IDN(log_level, priority) dlopen_idn(log_level)
 #endif
 
 int dlopen_idn(int log_level);
+
+#define DLOPEN_IDN(log_level, priority)                                 \
+        ({                                                              \
+                LIBIDN2_NOTE(priority);                                 \
+                dlopen_idn(log_level);                                  \
+        })

--- a/src/shared/libarchive-util.c
+++ b/src/shared/libarchive-util.c
@@ -2,8 +2,6 @@
 
 #include <syslog.h>
 
-#include "sd-dlopen.h"
-
 #include "libarchive-util.h"
 #include "log.h"                        /* IWYU pragma: keep */
 #include "user-util.h"                  /* IWYU pragma: keep */
@@ -80,7 +78,7 @@ int dlopen_libarchive(int log_level) {
         static void *libarchive_dl = NULL;
         int r;
 
-        LIBARCHIVE_NOTE(SD_ELF_NOTE_DLOPEN_PRIORITY_SUGGESTED);
+        LIBARCHIVE_NOTE(suggested);
 
         r = dlopen_many_sym_or_warn(
                         &libarchive_dl,

--- a/src/shared/libarchive-util.h
+++ b/src/shared/libarchive-util.h
@@ -85,7 +85,7 @@ DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_RENAME(struct archive*, sym_archive_write_free,
 DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_RENAME(struct archive*, sym_archive_read_free, archive_read_freep, NULL);
 #endif
 
-int dlopen_libarchive(int log_level);
+int dlopen_libarchive(int log_level) _dlopen_loader_;
 
 #define DLOPEN_LIBARCHIVE(log_level, priority)                          \
         ({                                                              \

--- a/src/shared/libarchive-util.h
+++ b/src/shared/libarchive-util.h
@@ -1,8 +1,7 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 #pragma once
 
-#include "sd-dlopen.h"
-
+#include "dlopen-note.h"
 #include "shared-forward.h"
 
 #if HAVE_LIBARCHIVE
@@ -84,21 +83,12 @@ extern DLSYM_PROTOTYPE(archive_write_set_format_pax);
 DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_RENAME(struct archive_entry*, sym_archive_entry_free, archive_entry_freep, NULL);
 DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_RENAME(struct archive*, sym_archive_write_free, archive_write_freep, NULL);
 DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_RENAME(struct archive*, sym_archive_read_free, archive_read_freep, NULL);
+#endif
 
-#define LIBARCHIVE_NOTE(priority)                                       \
-        SD_ELF_NOTE_DLOPEN("archive",                                   \
-                           "Support for decompressing archive files",   \
-                           priority,                                    \
-                           "libarchive.so.13")
+int dlopen_libarchive(int log_level);
 
 #define DLOPEN_LIBARCHIVE(log_level, priority)                          \
         ({                                                              \
                 LIBARCHIVE_NOTE(priority);                              \
                 dlopen_libarchive(log_level);                           \
         })
-
-#else
-#define DLOPEN_LIBARCHIVE(log_level, priority) dlopen_libarchive(log_level)
-#endif
-
-int dlopen_libarchive(int log_level);

--- a/src/shared/libaudit-util.c
+++ b/src/shared/libaudit-util.c
@@ -4,8 +4,7 @@
 #include <linux/netlink.h>
 #include <sys/socket.h>
 
-#include "sd-dlopen.h"
-
+#include "dlopen-note.h"
 #include "errno-util.h"
 #include "fd-util.h"
 #include "iovec-util.h"
@@ -25,11 +24,7 @@ int dlopen_libaudit(int log_level) {
 #if HAVE_AUDIT
         static void *libaudit_dl = NULL;
 
-        SD_ELF_NOTE_DLOPEN(
-                        "audit",
-                        "Support for Audit logging",
-                        SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED,
-                        "libaudit.so.1");
+        LIBAUDIT_NOTE(recommended);
 
         return dlopen_many_sym_or_warn(
                         &libaudit_dl,

--- a/src/shared/libaudit-util.c
+++ b/src/shared/libaudit-util.c
@@ -4,7 +4,6 @@
 #include <linux/netlink.h>
 #include <sys/socket.h>
 
-#include "dlopen-note.h"
 #include "errno-util.h"
 #include "fd-util.h"
 #include "iovec-util.h"

--- a/src/shared/libaudit-util.h
+++ b/src/shared/libaudit-util.h
@@ -1,9 +1,10 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 #pragma once
 
+#include "dlopen-note.h"
 #include "shared-forward.h"
 
-int dlopen_libaudit(int log_level);
+int dlopen_libaudit(int log_level) _dlopen_loader_;
 
 #if HAVE_AUDIT
 #  ifndef SYSTEMD_CFLAGS_MARKER_LIBAUDIT

--- a/src/shared/libcrypt-util.c
+++ b/src/shared/libcrypt-util.c
@@ -7,10 +7,9 @@
 #  include <crypt.h>
 #endif
 
-#include "sd-dlopen.h"
-
 #include "alloc-util.h"
 #include "dlfcn-util.h"
+#include "dlopen-note.h"
 #include "errno-util.h"
 #include "libcrypt-util.h"
 #include "log.h"
@@ -144,15 +143,11 @@ int dlopen_libcrypt(int log_level) {
         if (cached < 0)
                 return cached; /* Already tried, and failed. */
 
+        LIBCRYPT_NOTE(recommended);
+
         /* Several distributions like Debian/Ubuntu and OpenSUSE provide libxcrypt as libcrypt.so.1
          * (libcrypt.so.1.1 on some architectures), while others like Fedora/CentOS and Arch provide it as
          * libcrypt.so.2. */
-        SD_ELF_NOTE_DLOPEN(
-                        "crypt",
-                        "Support for hashing passwords",
-                        SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED,
-                        "libcrypt.so.2", "libcrypt.so.1", "libcrypt.so.1.1");
-
         FOREACH_STRING(soname, "libcrypt.so.2", "libcrypt.so.1", "libcrypt.so.1.1") {
                 r = dlopen_many_sym_or_warn(
                                 &libcrypt_dl, soname, LOG_DEBUG,

--- a/src/shared/libcrypt-util.c
+++ b/src/shared/libcrypt-util.c
@@ -9,7 +9,6 @@
 
 #include "alloc-util.h"
 #include "dlfcn-util.h"
-#include "dlopen-note.h"
 #include "errno-util.h"
 #include "libcrypt-util.h"
 #include "log.h"

--- a/src/shared/libcrypt-util.h
+++ b/src/shared/libcrypt-util.h
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 #pragma once
 
+#include "dlopen-note.h"
 #include "shared-forward.h"
 
 #if HAVE_LIBCRYPT
@@ -16,6 +17,6 @@ static inline int hash_password(const char *password, char **ret) {
 }
 #endif
 
-int dlopen_libcrypt(int log_level);
+int dlopen_libcrypt(int log_level) _dlopen_loader_;
 
 bool looks_like_hashed_password(const char *s);

--- a/src/shared/libfido2-util.c
+++ b/src/shared/libfido2-util.c
@@ -1,6 +1,5 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
-#include "dlopen-note.h"
 #include "libfido2-util.h"
 #include "log.h"
 

--- a/src/shared/libfido2-util.c
+++ b/src/shared/libfido2-util.c
@@ -1,7 +1,6 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
-#include "sd-dlopen.h"
-
+#include "dlopen-note.h"
 #include "libfido2-util.h"
 #include "log.h"
 
@@ -86,11 +85,7 @@ int dlopen_libfido2(int log_level) {
         static void *libfido2_dl = NULL;
         int r;
 
-        SD_ELF_NOTE_DLOPEN(
-                        "fido2",
-                        "Support fido2 for encryption and authentication",
-                        SD_ELF_NOTE_DLOPEN_PRIORITY_SUGGESTED,
-                        "libfido2.so.1");
+        LIBFIDO2_NOTE(suggested);
 
         r = dlopen_many_sym_or_warn(
                         &libfido2_dl, "libfido2.so.1", log_level,

--- a/src/shared/libfido2-util.h
+++ b/src/shared/libfido2-util.h
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 #pragma once
 
+#include "dlopen-note.h"
 #include "shared-forward.h"
 
 #define FIDO2_SALT_SIZE 32U
@@ -16,7 +17,7 @@ typedef enum Fido2EnrollFlags {
         _FIDO2ENROLL_TYPE_INVALID = -EINVAL,
 } Fido2EnrollFlags;
 
-int dlopen_libfido2(int log_level);
+int dlopen_libfido2(int log_level) _dlopen_loader_;
 
 #if HAVE_LIBFIDO2
 #ifndef SYSTEMD_CFLAGS_MARKER_LIBFIDO2

--- a/src/shared/libmount-util.c
+++ b/src/shared/libmount-util.c
@@ -7,8 +7,6 @@
 
 #include <stdio.h>
 
-#include "sd-dlopen.h"
-
 #include "fstab-util.h"
 
 DLSYM_PROTOTYPE(mnt_free_iter) = NULL;
@@ -120,7 +118,7 @@ int dlopen_libmount(int log_level) {
 #if HAVE_LIBMOUNT
         static void *libmount_dl = NULL;
 
-        LIBMOUNT_NOTE(SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+        LIBMOUNT_NOTE(recommended);
 
         return dlopen_many_sym_or_warn(
                         &libmount_dl,

--- a/src/shared/libmount-util.h
+++ b/src/shared/libmount-util.h
@@ -88,7 +88,7 @@ static inline void* sym_mnt_unref_monitor(struct libmnt_monitor *p) {
 
 #endif
 
-int dlopen_libmount(int log_level);
+int dlopen_libmount(int log_level) _dlopen_loader_;
 
 #define DLOPEN_LIBMOUNT(log_level, priority)                            \
         ({                                                              \

--- a/src/shared/libmount-util.h
+++ b/src/shared/libmount-util.h
@@ -1,8 +1,7 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 #pragma once
 
-#include "sd-dlopen.h"
-
+#include "dlopen-note.h"
 #include "shared-forward.h"
 
 #if HAVE_LIBMOUNT
@@ -78,28 +77,21 @@ int libmount_is_leaf(
                 struct libmnt_table *table,
                 struct libmnt_fs *fs);
 
-#define LIBMOUNT_NOTE(priority)                                         \
-        SD_ELF_NOTE_DLOPEN("mount",                                     \
-                           "Support for mount enumeration",             \
-                           priority,                                    \
-                           "libmount.so.1")
-
-#define DLOPEN_LIBMOUNT(log_level, priority)                            \
-        ({                                                              \
-                LIBMOUNT_NOTE(priority);                                \
-                dlopen_libmount(log_level);                             \
-        })
 #else
 
 struct libmnt_monitor;
-
 
 static inline void* sym_mnt_unref_monitor(struct libmnt_monitor *p) {
         assert(p == NULL);
         return NULL;
 }
 
-#define DLOPEN_LIBMOUNT(log_level, priority) dlopen_libmount(log_level)
 #endif
 
 int dlopen_libmount(int log_level);
+
+#define DLOPEN_LIBMOUNT(log_level, priority)                            \
+        ({                                                              \
+                LIBMOUNT_NOTE(priority);                                \
+                dlopen_libmount(log_level);                             \
+        })

--- a/src/shared/microhttpd-util.c
+++ b/src/shared/microhttpd-util.c
@@ -2,8 +2,6 @@
 
 #include <stdio.h>
 
-#include "sd-dlopen.h"
-
 #include "alloc-util.h"
 #include "gnutls-util.h"
 #include "log.h"
@@ -36,7 +34,7 @@ int dlopen_microhttpd(int log_level) {
 #if HAVE_MICROHTTPD
         static void *microhttpd_dl = NULL;
 
-        MICROHTTPD_NOTE(SD_ELF_NOTE_DLOPEN_PRIORITY_SUGGESTED);
+        LIBMICROHTTPD_NOTE(suggested);
 
         return dlopen_many_sym_or_warn(
                         &microhttpd_dl,

--- a/src/shared/microhttpd-util.h
+++ b/src/shared/microhttpd-util.h
@@ -1,28 +1,13 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 #pragma once
 
-#include "sd-dlopen.h"
-
+#include "dlopen-note.h"
 #include "shared-forward.h"
-
-int dlopen_microhttpd(int log_level);
 
 #if HAVE_MICROHTTPD
 #ifndef SYSTEMD_CFLAGS_MARKER_LIBMICROHTTPD
 #  error "missing libmicrohttpd_cflags in meson dependency."
 #endif
-
-#define MICROHTTPD_NOTE(priority)                                       \
-        SD_ELF_NOTE_DLOPEN("microhttpd",                                \
-                           "Support for embedded HTTP server via libmicrohttpd", \
-                           priority,                                    \
-                           "libmicrohttpd.so.12")
-
-#define DLOPEN_MICROHTTPD(log_level, priority)                          \
-        ({                                                              \
-                MICROHTTPD_NOTE(priority);                              \
-                dlopen_microhttpd(log_level);                           \
-        })
 
 #include <microhttpd.h>
 
@@ -150,7 +135,12 @@ int setup_gnutls_logger(char **categories);
 
 DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_RENAME(struct MHD_Daemon*, sym_MHD_stop_daemon, MHD_stop_daemonp, NULL);
 DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_RENAME(struct MHD_Response*, sym_MHD_destroy_response, MHD_destroy_responsep, NULL);
-
-#else
-#define DLOPEN_MICROHTTPD(log_level, priority) dlopen_microhttpd(log_level)
 #endif
+
+int dlopen_microhttpd(int log_level);
+
+#define DLOPEN_MICROHTTPD(log_level, priority)                          \
+        ({                                                              \
+                LIBMICROHTTPD_NOTE(priority);                           \
+                dlopen_microhttpd(log_level);                           \
+        })

--- a/src/shared/microhttpd-util.h
+++ b/src/shared/microhttpd-util.h
@@ -137,7 +137,7 @@ DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_RENAME(struct MHD_Daemon*, sym_MHD_stop_daemon,
 DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_RENAME(struct MHD_Response*, sym_MHD_destroy_response, MHD_destroy_responsep, NULL);
 #endif
 
-int dlopen_microhttpd(int log_level);
+int dlopen_microhttpd(int log_level) _dlopen_loader_;
 
 #define DLOPEN_MICROHTTPD(log_level, priority)                          \
         ({                                                              \

--- a/src/shared/module-util.c
+++ b/src/shared/module-util.c
@@ -2,8 +2,6 @@
 
 #include <syslog.h>
 
-#include "sd-dlopen.h"
-
 #include "log.h"
 #include "module-util.h"
 #include "proc-cmdline.h"
@@ -173,7 +171,7 @@ int dlopen_libkmod(int log_level) {
 #if HAVE_KMOD
         static void *libkmod_dl = NULL;
 
-        LIBKMOD_NOTE(SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+        LIBKMOD_NOTE(recommended);
 
         return dlopen_many_sym_or_warn(
                         &libkmod_dl,

--- a/src/shared/module-util.h
+++ b/src/shared/module-util.h
@@ -53,7 +53,7 @@ static inline int module_load_and_warn(struct kmod_ctx *ctx, const char *module,
 
 #endif
 
-int dlopen_libkmod(int log_level);
+int dlopen_libkmod(int log_level) _dlopen_loader_;
 
 #define DLOPEN_LIBKMOD(log_level, priority)                             \
         ({                                                              \

--- a/src/shared/module-util.h
+++ b/src/shared/module-util.h
@@ -1,8 +1,7 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 #pragma once
 
-#include "sd-dlopen.h"
-
+#include "dlopen-note.h"
 #include "shared-forward.h"
 
 #if HAVE_KMOD
@@ -40,21 +39,9 @@ DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_RENAME(struct kmod_list*, sym_kmod_module_unref
 int module_load_and_warn(struct kmod_ctx *ctx, const char *module, bool verbose);
 int module_setup_context(struct kmod_ctx **ret);
 
-#define LIBKMOD_NOTE(priority)                                          \
-        SD_ELF_NOTE_DLOPEN("kmod",                                      \
-                           "Support for loading kernel modules",        \
-                           priority,                                    \
-                           "libkmod.so.2")
-
-#define DLOPEN_LIBKMOD(log_level, priority)                             \
-        ({                                                              \
-                LIBKMOD_NOTE(priority);                                 \
-                dlopen_libkmod(log_level);                              \
-        })
 #else
 
 struct kmod_ctx;
-
 
 static inline int module_setup_context(struct kmod_ctx **ret) {
         return -EOPNOTSUPP;
@@ -64,7 +51,12 @@ static inline int module_load_and_warn(struct kmod_ctx *ctx, const char *module,
         return -EOPNOTSUPP;
 }
 
-#define DLOPEN_LIBKMOD(log_level, priority) dlopen_libkmod(log_level)
 #endif
 
 int dlopen_libkmod(int log_level);
+
+#define DLOPEN_LIBKMOD(log_level, priority)                             \
+        ({                                                              \
+                LIBKMOD_NOTE(priority);                                 \
+                dlopen_libkmod(log_level);                              \
+        })

--- a/src/shared/pam-util.c
+++ b/src/shared/pam-util.c
@@ -9,7 +9,6 @@
 #include <syslog.h>
 
 #include "sd-bus.h"
-#include "sd-dlopen.h"
 
 #include "alloc-util.h"
 #include "bus-internal.h"
@@ -383,7 +382,7 @@ int dlopen_libpam(int log_level) {
 #if HAVE_PAM
         static void *libpam_dl = NULL;
 
-        LIBPAM_NOTE(SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+        LIBPAM_NOTE(recommended);
 
         return dlopen_many_sym_or_warn(
                         &libpam_dl,

--- a/src/shared/pam-util.h
+++ b/src/shared/pam-util.h
@@ -110,7 +110,7 @@ int pam_prompt_graceful(pam_handle_t *pamh, int style, char **ret_response, cons
 int pam_putenv_assign(pam_handle_t *pamh, const char *name, const char *value);
 #endif
 
-int dlopen_libpam(int log_level);
+int dlopen_libpam(int log_level) _dlopen_loader_;
 
 #define DLOPEN_LIBPAM(log_level, priority)                              \
         ({                                                              \

--- a/src/shared/pam-util.h
+++ b/src/shared/pam-util.h
@@ -1,8 +1,7 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 #pragma once
 
-#include "sd-dlopen.h"
-
+#include "dlopen-note.h"
 #include "shared-forward.h"
 
 #if HAVE_PAM
@@ -109,20 +108,12 @@ int pam_prompt_graceful(pam_handle_t *pamh, int style, char **ret_response, cons
 /* Equivalent of pam_misc_setenv(pamh, name, value, 0), without the libpam_misc dep — builds "name=value"
  * and hands it to sym_pam_putenv(), then erases the buffer before freeing in case it carried a secret. */
 int pam_putenv_assign(pam_handle_t *pamh, const char *name, const char *value);
+#endif
 
-#define LIBPAM_NOTE(priority)                                           \
-        SD_ELF_NOTE_DLOPEN("pam",                                       \
-                           "Support for LinuxPAM",                      \
-                           priority,                                    \
-                           "libpam.so.0")
+int dlopen_libpam(int log_level);
 
 #define DLOPEN_LIBPAM(log_level, priority)                              \
         ({                                                              \
                 LIBPAM_NOTE(priority);                                  \
                 dlopen_libpam(log_level);                               \
         })
-#else
-#define DLOPEN_LIBPAM(log_level, priority) dlopen_libpam(log_level)
-#endif
-
-int dlopen_libpam(int log_level);

--- a/src/shared/password-quality-util-passwdqc.c
+++ b/src/shared/password-quality-util-passwdqc.c
@@ -1,6 +1,5 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
-#include "dlopen-note.h"
 #include "errno-util.h"          /* IWYU pragma: keep */
 #include "log.h"                 /* IWYU pragma: keep */
 #include "password-quality-util-passwdqc.h"

--- a/src/shared/password-quality-util-passwdqc.c
+++ b/src/shared/password-quality-util-passwdqc.c
@@ -1,9 +1,9 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
-#include "password-quality-util-passwdqc.h"
-
+#include "dlopen-note.h"
 #include "errno-util.h"          /* IWYU pragma: keep */
 #include "log.h"                 /* IWYU pragma: keep */
+#include "password-quality-util-passwdqc.h"
 
 #if HAVE_PASSWDQC
 #ifndef SYSTEMD_CFLAGS_MARKER_LIBPWQUALITY
@@ -11,8 +11,6 @@
 #endif
 
 #include <passwdqc.h>
-
-#include "sd-dlopen.h"
 
 #include "alloc-util.h"
 #include "dlfcn-util.h"
@@ -143,11 +141,7 @@ int dlopen_passwdqc(int log_level) {
 #if HAVE_PASSWDQC
         static void *passwdqc_dl = NULL;
 
-        SD_ELF_NOTE_DLOPEN(
-                        "passwdqc",
-                        "Support for password quality checks",
-                        SD_ELF_NOTE_DLOPEN_PRIORITY_SUGGESTED,
-                        "libpasswdqc.so.1");
+        LIBPASSWDQC_NOTE(suggested);
 
         return dlopen_many_sym_or_warn(
                         &passwdqc_dl, "libpasswdqc.so.1", log_level,

--- a/src/shared/password-quality-util-passwdqc.h
+++ b/src/shared/password-quality-util-passwdqc.h
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 #pragma once
 
+#include "dlopen-note.h"
 #include "shared-forward.h"
 
 #if HAVE_PASSWDQC
@@ -8,4 +9,4 @@ int suggest_passwords(void);
 int check_password_quality(const char *password, const char *old, const char *username, char **ret_error);
 #endif
 
-int dlopen_passwdqc(int log_level);
+int dlopen_passwdqc(int log_level) _dlopen_loader_;

--- a/src/shared/password-quality-util-pwquality.c
+++ b/src/shared/password-quality-util-pwquality.c
@@ -1,6 +1,5 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
-#include "dlopen-note.h"
 #include "errno-util.h"
 #include "log.h"
 #include "password-quality-util-pwquality.h"

--- a/src/shared/password-quality-util-pwquality.c
+++ b/src/shared/password-quality-util-pwquality.c
@@ -1,9 +1,9 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
-#include "password-quality-util-pwquality.h"
-
+#include "dlopen-note.h"
 #include "errno-util.h"
 #include "log.h"
+#include "password-quality-util-pwquality.h"
 
 #if HAVE_PWQUALITY
 #ifndef SYSTEMD_CFLAGS_MARKER_LIBPWQUALITY
@@ -13,8 +13,6 @@
 #include <pwquality.h>
 #include <stdio.h>
 #include <unistd.h>
-
-#include "sd-dlopen.h"
 
 #include "alloc-util.h"
 #include "dlfcn-util.h"
@@ -159,11 +157,7 @@ int dlopen_pwquality(int log_level) {
 #if HAVE_PWQUALITY
         static void *pwquality_dl = NULL;
 
-        SD_ELF_NOTE_DLOPEN(
-                        "pwquality",
-                        "Support for password quality checks",
-                        SD_ELF_NOTE_DLOPEN_PRIORITY_SUGGESTED,
-                        "libpwquality.so.1");
+        LIBPWQUALITY_NOTE(suggested);
 
         return dlopen_many_sym_or_warn(
                         &pwquality_dl, "libpwquality.so.1", log_level,

--- a/src/shared/password-quality-util-pwquality.h
+++ b/src/shared/password-quality-util-pwquality.h
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 #pragma once
 
+#include "dlopen-note.h"
 #include "shared-forward.h"
 
 #if HAVE_PWQUALITY
@@ -8,4 +9,4 @@ int suggest_passwords(void);
 int check_password_quality(const char *password, const char *old, const char *username, char **ret_error);
 #endif
 
-int dlopen_pwquality(int log_level);
+int dlopen_pwquality(int log_level) _dlopen_loader_;

--- a/src/shared/pcre2-util.c
+++ b/src/shared/pcre2-util.c
@@ -1,7 +1,6 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
 #include "dlfcn-util.h"
-#include "dlopen-note.h"
 #include "hash-funcs.h"
 #include "log.h"
 #include "pcre2-util.h"

--- a/src/shared/pcre2-util.c
+++ b/src/shared/pcre2-util.c
@@ -1,8 +1,7 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
-#include "sd-dlopen.h"
-
 #include "dlfcn-util.h"
+#include "dlopen-note.h"
 #include "hash-funcs.h"
 #include "log.h"
 #include "pcre2-util.h"
@@ -30,11 +29,7 @@ int dlopen_pcre2(int log_level) {
 #if HAVE_PCRE2
         static void *pcre2_dl = NULL;
 
-        SD_ELF_NOTE_DLOPEN(
-                        "pcre2",
-                        "Support for regular expressions",
-                        SD_ELF_NOTE_DLOPEN_PRIORITY_SUGGESTED,
-                        "libpcre2-8.so.0");
+        LIBPCRE2_NOTE(suggested);
 
         /* So here's something weird: PCRE2 actually renames the symbols exported by the library via C
          * macros, so that the exported symbols carry a suffix "_8" but when used from C the suffix is

--- a/src/shared/pcre2-util.h
+++ b/src/shared/pcre2-util.h
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 #pragma once
 
+#include "dlopen-note.h"
 #include "shared-forward.h"
 
 #if HAVE_PCRE2
@@ -47,4 +48,4 @@ typedef enum PatternCompileCase {
 int pattern_compile_and_log(const char *pattern, PatternCompileCase case_, pcre2_code **ret);
 int pattern_matches_and_log(pcre2_code *compiled_pattern, const char *message, size_t size, size_t *ret_ovec);
 
-int dlopen_pcre2(int log_level);
+int dlopen_pcre2(int log_level) _dlopen_loader_;

--- a/src/shared/pkcs11-util.c
+++ b/src/shared/pkcs11-util.c
@@ -1,11 +1,10 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
-#include "sd-dlopen.h"
-
 #include "alloc-util.h"
 #include "ask-password-api.h"
 #include "crypto-util.h"
 #include "dlfcn-util.h"
+#include "dlopen-note.h"
 #include "env-util.h"
 #include "escape.h"
 #include "format-table.h"
@@ -1963,11 +1962,7 @@ int dlopen_p11kit(int log_level) {
 #if HAVE_P11KIT
         static void *p11kit_dl = NULL;
 
-        SD_ELF_NOTE_DLOPEN(
-                        "p11-kit",
-                        "Support for PKCS11 hardware tokens",
-                        SD_ELF_NOTE_DLOPEN_PRIORITY_SUGGESTED,
-                        "libp11-kit.so.0");
+        LIBP11KIT_NOTE(suggested);
 
         return dlopen_many_sym_or_warn(
                         &p11kit_dl,

--- a/src/shared/pkcs11-util.c
+++ b/src/shared/pkcs11-util.c
@@ -4,7 +4,6 @@
 #include "ask-password-api.h"
 #include "crypto-util.h"
 #include "dlfcn-util.h"
-#include "dlopen-note.h"
 #include "env-util.h"
 #include "escape.h"
 #include "format-table.h"

--- a/src/shared/pkcs11-util.h
+++ b/src/shared/pkcs11-util.h
@@ -11,6 +11,7 @@
 
 #include "ask-password-api.h"
 #include "dlfcn-util.h"
+#include "dlopen-note.h"
 #include "pkcs11-padding.h"
 #include "shared-forward.h"
 
@@ -107,7 +108,7 @@ int pkcs11_crypt_device_callback(
 
 #endif
 
-int dlopen_p11kit(int log_level);
+int dlopen_p11kit(int log_level) _dlopen_loader_;
 
 typedef struct {
         const char *friendly_name;

--- a/src/shared/qrcode-util.c
+++ b/src/shared/qrcode-util.c
@@ -12,7 +12,6 @@
 
 #include "ansi-color.h"
 #include "dlfcn-util.h"
-#include "dlopen-note.h"
 #include "locale-util.h"
 #include "log.h"
 #include "strv.h"

--- a/src/shared/qrcode-util.c
+++ b/src/shared/qrcode-util.c
@@ -10,10 +10,9 @@
 #endif
 #include <stdio.h>
 
-#include "sd-dlopen.h"
-
 #include "ansi-color.h"
 #include "dlfcn-util.h"
+#include "dlopen-note.h"
 #include "locale-util.h"
 #include "log.h"
 #include "strv.h"
@@ -34,11 +33,7 @@ int dlopen_qrencode(int log_level) {
         static void *qrcode_dl = NULL;
         int r;
 
-        SD_ELF_NOTE_DLOPEN(
-                        "qrencode",
-                        "Support for generating QR codes",
-                        SD_ELF_NOTE_DLOPEN_PRIORITY_SUGGESTED,
-                        "libqrencode.so.4", "libqrencode.so.3");
+        LIBQRENCODE_NOTE(suggested);
 
         FOREACH_STRING(s, "libqrencode.so.4", "libqrencode.so.3") {
                 r = dlopen_many_sym_or_warn(

--- a/src/shared/qrcode-util.h
+++ b/src/shared/qrcode-util.h
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 #pragma once
 
+#include "dlopen-note.h"
 #include "shared-forward.h"
 
 int print_qrcode_full(
@@ -13,7 +14,7 @@ int print_qrcode_full(
                 unsigned tty_height,
                 bool check_tty);
 
-int dlopen_qrencode(int log_level);
+int dlopen_qrencode(int log_level) _dlopen_loader_;
 
 static inline int print_qrcode(FILE *out, const char *header, const char *string) {
         return print_qrcode_full(out, header, string, UINT_MAX, UINT_MAX, UINT_MAX, UINT_MAX, true);

--- a/src/shared/seccomp-util.c
+++ b/src/shared/seccomp-util.c
@@ -16,8 +16,6 @@
 #include <asm/sgidefs.h>
 #endif
 
-#include "sd-dlopen.h"
-
 #include "af-list.h"
 #include "alloc-util.h"
 #include "env-util.h"
@@ -2604,7 +2602,7 @@ int dlopen_libseccomp(int log_level) {
 #if HAVE_SECCOMP
         static void *libseccomp_dl = NULL;
 
-        LIBSECCOMP_NOTE(SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+        LIBSECCOMP_NOTE(recommended);
 
         return dlopen_many_sym_or_warn(
                         &libseccomp_dl,

--- a/src/shared/seccomp-util.h
+++ b/src/shared/seccomp-util.h
@@ -169,7 +169,7 @@ static inline bool is_seccomp_available(void) {
 
 #endif
 
-int dlopen_libseccomp(int log_level);
+int dlopen_libseccomp(int log_level) _dlopen_loader_;
 
 #define DLOPEN_LIBSECCOMP(log_level, priority)                          \
         ({                                                              \

--- a/src/shared/seccomp-util.h
+++ b/src/shared/seccomp-util.h
@@ -1,8 +1,7 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 #pragma once
 
-#include "sd-dlopen.h"
-
+#include "dlopen-note.h"
 #include "errno-util.h"
 #include "shared-forward.h"
 
@@ -161,17 +160,6 @@ int parse_syscall_and_errno(const char *in, char **name, int *error);
 
 int seccomp_suppress_sync(void);
 
-#define LIBSECCOMP_NOTE(priority)                                       \
-        SD_ELF_NOTE_DLOPEN("seccomp",                                   \
-                           "Support for Seccomp Sandboxes",             \
-                           priority,                                    \
-                           "libseccomp.so.2")
-
-#define DLOPEN_LIBSECCOMP(log_level, priority)                          \
-        ({                                                              \
-                LIBSECCOMP_NOTE(priority);                              \
-                dlopen_libseccomp(log_level);                           \
-        })
 #else
 
 static inline bool is_seccomp_available(void) {
@@ -179,10 +167,15 @@ static inline bool is_seccomp_available(void) {
 }
 
 
-#define DLOPEN_LIBSECCOMP(log_level, priority) dlopen_libseccomp(log_level)
 #endif
 
 int dlopen_libseccomp(int log_level);
+
+#define DLOPEN_LIBSECCOMP(log_level, priority)                          \
+        ({                                                              \
+                LIBSECCOMP_NOTE(priority);                              \
+                dlopen_libseccomp(log_level);                           \
+        })
 
 /* This is a special value to be used where syscall filters otherwise expect errno numbers, will be
    replaced with real seccomp action. */

--- a/src/shared/selinux-util.c
+++ b/src/shared/selinux-util.c
@@ -17,8 +17,6 @@
 #include <selinux/label.h>
 #include <selinux/selinux.h>
 
-#include "sd-dlopen.h"
-
 #include "alloc-util.h"
 #include "fd-util.h"
 #include "path-util.h"
@@ -94,7 +92,7 @@ int dlopen_libselinux(int log_level) {
 #if HAVE_SELINUX
         static void *libselinux_dl = NULL;
 
-        LIBSELINUX_NOTE(SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+        LIBSELINUX_NOTE(recommended);
 
         return dlopen_many_sym_or_warn(
                         &libselinux_dl,

--- a/src/shared/selinux-util.h
+++ b/src/shared/selinux-util.h
@@ -3,8 +3,7 @@
 
 #include <sys/socket.h>
 
-#include "sd-dlopen.h"
-
+#include "dlopen-note.h"
 #include "shared-forward.h"
 
 #if HAVE_SELINUX
@@ -56,28 +55,21 @@ extern DLSYM_PROTOTYPE(string_to_security_class);
 
 DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_RENAME(char*, sym_freecon, freeconp, NULL);
 
-#define LIBSELINUX_NOTE(priority)                                       \
-        SD_ELF_NOTE_DLOPEN("selinux",                                   \
-                           "Support for SELinux",                       \
-                           priority,                                    \
-                           "libselinux.so.1")
+#else
+
+static inline void freeconp(char **p) {
+        assert(*p == NULL);
+}
+
+#endif
+
+int dlopen_libselinux(int log_level);
 
 #define DLOPEN_LIBSELINUX(log_level, priority)                          \
         ({                                                              \
                 LIBSELINUX_NOTE(priority);                              \
                 dlopen_libselinux(log_level);                           \
         })
-#else
-
-
-static inline void freeconp(char **p) {
-        assert(*p == NULL);
-}
-
-#define DLOPEN_LIBSELINUX(log_level, priority) dlopen_libselinux(log_level)
-#endif
-
-int dlopen_libselinux(int log_level);
 
 #define _cleanup_freecon_ _cleanup_(freeconp)
 

--- a/src/shared/selinux-util.h
+++ b/src/shared/selinux-util.h
@@ -63,7 +63,7 @@ static inline void freeconp(char **p) {
 
 #endif
 
-int dlopen_libselinux(int log_level);
+int dlopen_libselinux(int log_level) _dlopen_loader_;
 
 #define DLOPEN_LIBSELINUX(log_level, priority)                          \
         ({                                                              \

--- a/src/shared/ssl-util.c
+++ b/src/shared/ssl-util.c
@@ -1,7 +1,5 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
-#include "sd-dlopen.h"
-
 #include "log.h"                /* IWYU pragma: keep */
 #include "ssl-util.h"
 #include "strv.h"
@@ -38,7 +36,7 @@ int dlopen_libssl(int log_level) {
         static void *libssl_dl = NULL;
         int r;
 
-        LIBSSL_NOTE(SD_ELF_NOTE_DLOPEN_PRIORITY_SUGGESTED);
+        LIBSSL_NOTE(suggested);
 
         FOREACH_STRING(soname, "libssl.so.4", "libssl.so.3") {
                 r = dlopen_many_sym_or_warn(

--- a/src/shared/ssl-util.h
+++ b/src/shared/ssl-util.h
@@ -1,28 +1,13 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 #pragma once
 
-#include "sd-dlopen.h"
-
+#include "dlopen-note.h"
 #include "shared-forward.h"
-
-int dlopen_libssl(int log_level);
 
 #if HAVE_OPENSSL
 #ifndef SYSTEMD_CFLAGS_MARKER_LIBOPENSSL
 #  error "missing libopenssl_cflags in meson dependency."
 #endif
-
-#define LIBSSL_NOTE(priority)                                           \
-        SD_ELF_NOTE_DLOPEN("libssl",                                    \
-                           "Support for TLS",                           \
-                           priority,                                    \
-                           "libssl.so.4", "libssl.so.3")
-
-#define DLOPEN_LIBSSL(log_level, priority)                              \
-        ({                                                              \
-                LIBSSL_NOTE(priority);                                  \
-                dlopen_libssl(log_level);                               \
-        })
 
 #  include <openssl/ssl.h>              /* IWYU pragma: export */
 
@@ -60,7 +45,12 @@ extern DLSYM_PROTOTYPE(TLS_client_method);
 
 DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_RENAME(SSL*, sym_SSL_free, SSL_freep, NULL);
 DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_RENAME(SSL_CTX*, sym_SSL_CTX_free, SSL_CTX_freep, NULL);
-
-#else
-#define DLOPEN_LIBSSL(log_level, priority) dlopen_libssl(log_level)
 #endif
+
+int dlopen_libssl(int log_level);
+
+#define DLOPEN_LIBSSL(log_level, priority)                              \
+        ({                                                              \
+                LIBSSL_NOTE(priority);                                  \
+                dlopen_libssl(log_level);                               \
+        })

--- a/src/shared/ssl-util.h
+++ b/src/shared/ssl-util.h
@@ -47,7 +47,7 @@ DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_RENAME(SSL*, sym_SSL_free, SSL_freep, NULL);
 DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_RENAME(SSL_CTX*, sym_SSL_CTX_free, SSL_CTX_freep, NULL);
 #endif
 
-int dlopen_libssl(int log_level);
+int dlopen_libssl(int log_level) _dlopen_loader_;
 
 #define DLOPEN_LIBSSL(log_level, priority)                              \
         ({                                                              \

--- a/src/shared/tpm2-util.c
+++ b/src/shared/tpm2-util.c
@@ -4,7 +4,6 @@
 #include <unistd.h>
 
 #include "sd-device.h"
-#include "sd-dlopen.h"
 
 #include "alloc-util.h"
 #include "ansi-color.h"
@@ -171,7 +170,7 @@ static int dlopen_tpm2_esys(int log_level) {
         static void *libtss2_esys_dl = NULL;
         int r;
 
-        TPM2_ESYS_NOTE(SD_ELF_NOTE_DLOPEN_PRIORITY_SUGGESTED);
+        LIBTSS2_ESYS_NOTE(suggested);
 
         r = dlopen_many_sym_or_warn(
                         &libtss2_esys_dl, "libtss2-esys.so.0", log_level,
@@ -233,7 +232,7 @@ static int dlopen_tpm2_esys(int log_level) {
 static int dlopen_tpm2_rc(int log_level) {
         static void *libtss2_rc_dl = NULL;
 
-        TPM2_RC_NOTE(SD_ELF_NOTE_DLOPEN_PRIORITY_SUGGESTED);
+        LIBTSS2_RC_NOTE(suggested);
 
         return dlopen_many_sym_or_warn(
                         &libtss2_rc_dl, "libtss2-rc.so.0", log_level,
@@ -243,7 +242,7 @@ static int dlopen_tpm2_rc(int log_level) {
 static int dlopen_tpm2_mu(int log_level) {
         static void *libtss2_mu_dl = NULL;
 
-        TPM2_MU_NOTE(SD_ELF_NOTE_DLOPEN_PRIORITY_SUGGESTED);
+        LIBTSS2_MU_NOTE(suggested);
 
         return dlopen_many_sym_or_warn(
                         &libtss2_mu_dl, "libtss2-mu.so.0", log_level,
@@ -275,7 +274,7 @@ static int dlopen_tpm2_tcti_device(int log_level) {
         /* The "device" TCTI is the most relevant one, let's also load it explicitly on dlopen_tpm2(), even
          * if we don't resolve any symbols here. */
 
-        TPM2_TCTI_DEVICE_NOTE(SD_ELF_NOTE_DLOPEN_PRIORITY_SUGGESTED);
+        LIBTSS2_TCTI_DEVICE_NOTE(suggested);
 
         return dlopen_verbose(
                         &libtss2_tcti_device_dl,

--- a/src/shared/tpm2-util.c
+++ b/src/shared/tpm2-util.c
@@ -166,6 +166,7 @@ static DLSYM_PROTOTYPE(Tss2_MU_UINT32_Marshal) = NULL;
 
 static DLSYM_PROTOTYPE(Tss2_RC_Decode) = NULL;
 
+_dlopen_loader_
 static int dlopen_tpm2_esys(int log_level) {
         static void *libtss2_esys_dl = NULL;
         int r;
@@ -229,6 +230,7 @@ static int dlopen_tpm2_esys(int log_level) {
         return 0;
 }
 
+_dlopen_loader_
 static int dlopen_tpm2_rc(int log_level) {
         static void *libtss2_rc_dl = NULL;
 
@@ -239,6 +241,7 @@ static int dlopen_tpm2_rc(int log_level) {
                         DLSYM_ARG(Tss2_RC_Decode));
 }
 
+_dlopen_loader_
 static int dlopen_tpm2_mu(int log_level) {
         static void *libtss2_mu_dl = NULL;
 
@@ -268,6 +271,7 @@ static int dlopen_tpm2_mu(int log_level) {
                         DLSYM_ARG(Tss2_MU_UINT32_Marshal));
 }
 
+_dlopen_loader_
 static int dlopen_tpm2_tcti_device(int log_level) {
         static void *libtss2_tcti_device_dl = NULL;
 

--- a/src/shared/tpm2-util.h
+++ b/src/shared/tpm2-util.h
@@ -46,7 +46,7 @@ static inline bool TPM2_PCR_MASK_VALID(uint32_t pcr_mask) {
 
 #define TPM2_N_HASH_ALGORITHMS 4U
 
-int dlopen_tpm2(int log_level);
+int dlopen_tpm2(int log_level) _dlopen_loader_;
 
 /* tpm2_unseal() returns a bunch of different errors for various flavours of PCR issues, let's group them.
  * Kept outside the HAVE_TPM2 guard as callers switch on these errnos even in builds without TPM2. */

--- a/src/shared/tpm2-util.h
+++ b/src/shared/tpm2-util.h
@@ -1,9 +1,8 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 #pragma once
 
-#include "sd-dlopen.h"
-
 #include "bitfield.h"
+#include "dlopen-note.h"
 #include "iovec-util.h"
 #include "shared-forward.h"
 #include "sha256.h"
@@ -58,33 +57,16 @@ int dlopen_tpm2(int log_level);
  * other tokens. */
 #define ERRNO_IS_NEG_TPM2_TOKEN_MISMATCH(r) IN_SET(r, -EREMCHG, -ENOANO, -EPERM, -ENOSTR, -EREMOTE, -EADDRNOTAVAIL)
 
-#if HAVE_TPM2
-#ifndef SYSTEMD_CFLAGS_MARKER_TPM2
-#  error "missing tpm2_cflags in meson dependency."
-#endif
-
-#define TPM2_ESYS_NOTE(priority) \
-        SD_ELF_NOTE_DLOPEN("tpm", "Support for TPM", priority, "libtss2-esys.so.0")
-#define TPM2_RC_NOTE(priority) \
-        SD_ELF_NOTE_DLOPEN("tpm", "Support for TPM", priority, "libtss2-rc.so.0")
-#define TPM2_MU_NOTE(priority) \
-        SD_ELF_NOTE_DLOPEN("tpm", "Support for TPM", priority, "libtss2-mu.so.0")
-#define TPM2_TCTI_DEVICE_NOTE(priority) \
-        SD_ELF_NOTE_DLOPEN("tpm", "Support for TPM", priority, "libtss2-tcti-device.so.0")
-
-#define TPM2_NOTE(priority)                                             \
-        ({                                                              \
-                TPM2_ESYS_NOTE(priority);                               \
-                TPM2_RC_NOTE(priority);                                 \
-                TPM2_MU_NOTE(priority);                                 \
-                TPM2_TCTI_DEVICE_NOTE(priority);                        \
-        })
-
 #define DLOPEN_TPM2(log_level, priority)                                \
         ({                                                              \
                 TPM2_NOTE(priority);                                    \
                 dlopen_tpm2(log_level);                                 \
         })
+
+#if HAVE_TPM2
+#ifndef SYSTEMD_CFLAGS_MARKER_TPM2
+#  error "missing tpm2_cflags in meson dependency."
+#endif
 
 #include <tss2/tss2_esys.h>     /* IWYU pragma: export */
 #include <tss2/tss2_mu.h>       /* IWYU pragma: export */
@@ -483,8 +465,6 @@ typedef struct Tpm2PCRValue {} Tpm2PCRValue;
 static inline int tpm2_pcrlock_search_file(const char *path, FILE **ret_file, char **ret_path) {
         return -ENOENT;
 }
-
-#define DLOPEN_TPM2(log_level, priority) dlopen_tpm2(log_level)
 #endif /* HAVE_TPM2 */
 
 int tpm2_list_devices(bool legend, bool quiet);

--- a/src/shutdown/detach-swap.c
+++ b/src/shutdown/detach-swap.c
@@ -36,7 +36,7 @@ int swap_list_get(const char *swaps, SwapDevice **head) {
 
         assert(head);
 
-        r = DLOPEN_LIBMOUNT(LOG_ERR, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+        r = DLOPEN_LIBMOUNT(LOG_ERR, recommended);
         if (r < 0)
                 return r;
 

--- a/src/shutdown/meson.build
+++ b/src/shutdown/meson.build
@@ -19,17 +19,7 @@ executables += [
                         'shutdown.c',
                 ) + shutdown_detach_sources,
                 'dependencies' : libmount_cflags,
-        },
-        libexec_template + {
-                'name' : 'systemd-shutdown.standalone',
-                'import' : ['systemd-shutdown'],
-                'link_with' : [
-                        libc_wrapper_static,
-                        libbasic_static,
-                        libshared_static,
-                        libsystemd_static,
-                ],
-                'dependencies' : libmount_cflags,
+                'install' : have_standalone_binaries ? 'both' : 'yes',
         },
         test_template + {
                 'sources' : files('test-umount.c') +

--- a/src/shutdown/shutdown.c
+++ b/src/shutdown/shutdown.c
@@ -24,6 +24,7 @@
 #include "detach-loopback.h"
 #include "detach-md.h"
 #include "detach-swap.h"
+#include "dlopen-note.h"
 #include "errno-util.h"
 #include "exec-util.h"
 #include "fd-util.h"
@@ -377,6 +378,8 @@ int main(int argc, char *argv[]) {
         dual_timestamp shutdown_late_start;
         size_t n_luo_fds = 0;
         int cmd, r;
+
+        LIBSELINUX_NOTE(recommended);
 
         /* LUO will preserve these across kexec */
         dual_timestamp_now(&shutdown_late_start);

--- a/src/socket-activate/socket-activate.c
+++ b/src/socket-activate/socket-activate.c
@@ -9,6 +9,7 @@
 #include "alloc-util.h"
 #include "build.h"
 #include "daemon-util.h"
+#include "dlopen-note.h"
 #include "env-util.h"
 #include "errno-util.h"
 #include "escape.h"
@@ -467,6 +468,8 @@ static int run(int argc, char **argv) {
         _cleanup_close_ int epoll_fd = -EBADF;
         _cleanup_strv_free_ char **exec_argv = NULL;
         int r, n;
+
+        LIBSELINUX_NOTE(recommended);
 
         log_setup();
 

--- a/src/ssh-generator/ssh-generator.c
+++ b/src/ssh-generator/ssh-generator.c
@@ -4,6 +4,7 @@
 
 #include "alloc-util.h"
 #include "creds-util.h"
+#include "dlopen-note.h"
 #include "errno-util.h"
 #include "fd-util.h"
 #include "fileio.h"
@@ -449,6 +450,9 @@ static int run(const char *dest, const char *dest_early, const char *dest_late) 
         int r;
 
         assert(dest);
+
+        LIBCRYPTO_NOTE(suggested);
+        TPM2_NOTE(suggested);
 
         r = proc_cmdline_parse(parse_proc_cmdline_item, /* userdata= */ NULL, /* flags= */ 0);
         if (r < 0)

--- a/src/sysext/sysext.c
+++ b/src/sysext/sysext.c
@@ -1828,7 +1828,7 @@ static int unmerge(
         bool need_to_reload;
         int r;
 
-        (void) DLOPEN_LIBMOUNT(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_REQUIRED);
+        (void) DLOPEN_LIBMOUNT(LOG_DEBUG, required);
 
         r = get_extension_release_metadata(image_class, hierarchies, no_reload, &need_to_reload, &units_to_restart, &units_to_reload_or_restart);
         if (r < 0)
@@ -2413,9 +2413,9 @@ static int merge(ImageClass image_class,
 
         int r;
 
-        (void) DLOPEN_CRYPTSETUP(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
-        (void) DLOPEN_LIBBLKID(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_REQUIRED);
-        (void) DLOPEN_LIBMOUNT(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_REQUIRED);
+        (void) DLOPEN_CRYPTSETUP(LOG_DEBUG, recommended);
+        (void) DLOPEN_LIBBLKID(LOG_DEBUG, required);
+        (void) DLOPEN_LIBMOUNT(LOG_DEBUG, required);
 
         _cleanup_(pidref_done) PidRef pidref = PIDREF_NULL;
         r = pidref_safe_fork("(sd-merge)", FORK_DEATHSIG_SIGTERM|FORK_LOG|FORK_NEW_MOUNTNS, &pidref);

--- a/src/sysext/sysext.c
+++ b/src/sysext/sysext.c
@@ -28,6 +28,7 @@
 #include "devnum-util.h"
 #include "discover-image.h"
 #include "dissect-image.h"
+#include "dlopen-note.h"
 #include "env-util.h"
 #include "errno-util.h"
 #include "escape.h"
@@ -3174,6 +3175,9 @@ static int parse_argv(int argc, char *argv[], char ***ret_args) {
 static int run(int argc, char *argv[]) {
         char **args = NULL;
         int r;
+
+        LIBCRYPTO_NOTE(suggested);
+        LIBSELINUX_NOTE(recommended);
 
         log_setup();
 

--- a/src/sysinstall/sysinstall.c
+++ b/src/sysinstall/sysinstall.c
@@ -15,6 +15,7 @@
 #include "chase.h"
 #include "conf-files.h"
 #include "constants.h"
+#include "dlopen-note.h"
 #include "efi-loader.h"
 #include "efivars.h"
 #include "env-file.h"
@@ -2067,6 +2068,11 @@ static void end_marker(void) {
 
 static int run(int argc, char *argv[]) {
         int r;
+
+        LIBBLKID_NOTE(recommended);
+        LIBCRYPTO_NOTE(suggested);
+        LIBCRYPTSETUP_NOTE(suggested);
+        LIBMOUNT_NOTE(recommended);
 
         setlocale(LC_ALL, "");
 

--- a/src/systemctl/meson.build
+++ b/src/systemctl/meson.build
@@ -40,31 +40,23 @@ systemctl_export_sources = files(
         'systemctl.c',
 )
 
-if get_option('link-systemctl-shared')
-        systemctl_link_with = [libshared]
-else
-        systemctl_link_with = [libsystemd_static,
-                               libshared_static]
-endif
-
 executables += [
         executable_template + {
                 'name' : 'systemctl',
                 'public' : true,
                 'sources' : systemctl_sources,
                 'export' : systemctl_export_sources,
-                'link_with' : systemctl_link_with,
                 'dependencies' : [
                         liblz4_cflags,
                         libxz_cflags,
                         libzstd_cflags,
                 ],
+                'install' : get_option('link-systemctl-shared') ? 'yes' : 'static',
                 'install_tag' : 'systemctl',
         },
         fuzz_template + {
                 'sources' : files('fuzz-systemctl-parse-argv.c'),
                 'import' : ['systemctl'],
-                'link_with' : systemctl_link_with,
                 'dependencies' : [
                         libselinux_cflags,
                 ],

--- a/src/systemctl/systemctl-main.c
+++ b/src/systemctl/systemctl-main.c
@@ -3,6 +3,7 @@
 #include <locale.h>
 
 #include "dissect-image.h"
+#include "dlopen-note.h"
 #include "glyph-util.h"
 #include "log.h"
 #include "logs-show.h"
@@ -22,6 +23,13 @@ static int run(int argc, char *argv[]) {
         _cleanup_(umount_and_freep) char *mounted_dir = NULL;
         char **args = STRV_EMPTY;
         int r;
+
+        COMPRESS_DEFAULT_NOTE;
+        LIBBLKID_NOTE(recommended);
+        LIBCRYPTO_NOTE(suggested);
+        LIBCRYPTSETUP_NOTE(suggested);
+        LIBMOUNT_NOTE(recommended);
+        LIBSELINUX_NOTE(recommended);
 
         setlocale(LC_ALL, "");
         log_setup();

--- a/src/systemd/sd-dlopen.h
+++ b/src/systemd/sd-dlopen.h
@@ -23,6 +23,8 @@
 
 #include <stdint.h>
 
+#include "_sd-common.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -94,6 +96,69 @@ extern "C" {
                 ".popsection\n"                                                                                                 \
                 ".endif\n")
 
+/*
+ * SD_ELF_NOTE_DLOPEN_ANCHORED() emits a .note.dlopen ELF note that is "anchored" to a dummy symbol via the
+ * SHF_LINK_ORDER ('o') section flag, in addition to SHF_GROUP ('G') for folding identical notes together.
+ *
+ * Unlike the plain SD_ELF_NOTE_DLOPEN() macro, this variant ties the note's lifetime to a dummy symbol named
+ * with the specified tag: if the linker's --gc-sections removes the function that calls the macro (e.g.
+ * because the function is never referenced), the associated .note.dlopen entry is garbage-collected along
+ * with it.
+ *
+ * USAGE NOTE:
+ * - The 'tag' argument must be a unique symbol name to characterize the dlopen note (e.g. generated from
+ *   feature and its priority).
+ *
+ *   Example:
+ *       void dlopen_libfoo(int log_level) {
+ *               SD_ELF_NOTE_DLOPEN_ANCHORED(foo_suggested, "foo", "description of foo", "suggested", "libfoo.so.0");
+ *               ...
+ *       }
+ *
+ * TOOLCHAIN REQUIREMENTS:
+ * - GNU as (binutils) >= 2.35: this is when support for specifying the SHF_LINK_ORDER ('o') associated
+ *   symbol as a direct argument to .section/.pushsection was added.
+ * - LLVM (clang -integrated-as) >= 18: matching support for the 'o' flag argument combined with 'G'
+ *   (SHF_GROUP) landed around LLVM 18.
+ * - Do NOT add 'R' (SHF_GNU_RETAIN) to these flags: combined with SHF_LINK_ORDER, it would prevent the
+ *   linker from ever garbage-collecting the note, defeating the whole purpose of anchoring it to a symbol in
+ *   the first place.
+ */
+#define _SD_ELF_NOTE_DLOPEN_ANCHORED(tag, uniq_var, json)                                                                       \
+        _Pragma("GCC diagnostic push")                                                                                          \
+        _Pragma("GCC diagnostic ignored \"-Wnested-externs\"")                                                                  \
+        __attribute__((visibility("hidden")))                                                                                   \
+        extern volatile const char uniq_var __asm__("__sd_dlopen_anchor_" #tag);                                                \
+        _Pragma("GCC diagnostic pop")                                                                                           \
+        __asm__ (                                                                                                               \
+                ".ifndef \"sd_dlopen:emitted:" #tag "\"\n"                                                                      \
+                _SD_ELF_NOTE_DLOPEN_GUARD " \"sd_dlopen:emitted:" #tag "\", 1\n"                                                \
+                ".pushsection .data.sd_dlopen_dummy." #tag ", \"awG\", %progbits, sd_dlopen_group_" #tag ", comdat\n"           \
+                ".weak __sd_dlopen_anchor_" #tag "\n"                                                                           \
+                ".hidden __sd_dlopen_anchor_" #tag "\n"                                                                         \
+                ".type __sd_dlopen_anchor_" #tag ", %object\n"                                                                  \
+                ".balign 8\n"                                                                                                   \
+                "__sd_dlopen_anchor_" #tag ":\n"                                                                                \
+                ".byte 0\n"                                                                                                     \
+                ".popsection\n"                                                                                                 \
+                ".pushsection .note.dlopen, \"aGo\", %note, __sd_dlopen_anchor_" #tag ", sd_dlopen_group_" #tag ", comdat\n"    \
+                ".balign 4\n"                                                                                                   \
+                ".long 884f - 883f\n"                                                                                           \
+                ".long 882f - 881f\n"                                                                                           \
+                ".long 0x407c0c0a\n"                                                                                            \
+                "883:\n"                                                                                                        \
+                ".asciz \"" SD_ELF_NOTE_DLOPEN_VENDOR "\"\n"                                                                    \
+                "884:\n"                                                                                                        \
+                ".balign 4\n"                                                                                                   \
+                "881:\n"                                                                                                        \
+                ".asciz \"" json "\"\n"                                                                                         \
+                "882:\n"                                                                                                        \
+                ".balign 4\n"                                                                                                   \
+                ".popsection\n"                                                                                                 \
+                ".endif\n"                                                                                                      \
+        );                                                                                                                      \
+        __asm__ volatile ("" : : "r" (&uniq_var))
+
 #define _SD_SONAME_ARRAY1(a) "[\\\"" a "\\\"]"
 #define _SD_SONAME_ARRAY2(a, b) "[\\\"" a "\\\",\\\"" b "\\\"]"
 #define _SD_SONAME_ARRAY3(a, b, c) "[\\\"" a "\\\",\\\"" b "\\\",\\\"" c "\\\"]"
@@ -102,8 +167,28 @@ extern "C" {
 #define _SD_SONAME_ARRAY_GET(_1,_2,_3,_4,_5,NAME,...) NAME
 #define _SD_SONAME_ARRAY(...) _SD_SONAME_ARRAY_GET(__VA_ARGS__, _SD_SONAME_ARRAY5, _SD_SONAME_ARRAY4, _SD_SONAME_ARRAY3, _SD_SONAME_ARRAY2, _SD_SONAME_ARRAY1)(__VA_ARGS__)
 
+#define _SD_DLOPEN_UNIQ_VAR(tag)                                \
+        _SD_CONCATENATE(_SD_CONCATENATE(__sd_dlopen_anchor_, tag), _SD_CONCATENATE(_, _SD_UNIQ))
+
+#define _SD_DLOPEN_JSON(feature, description, priority, ...)    \
+        "[{"                                                    \
+        "\\\"feature\\\":\\\"" feature "\\\","                  \
+        "\\\"description\\\":\\\"" description "\\\","          \
+        "\\\"priority\\\":\\\"" priority "\\\","                \
+        "\\\"soname\\\":" _SD_SONAME_ARRAY(__VA_ARGS__)         \
+        "}]"
+
 #define SD_ELF_NOTE_DLOPEN(feature, description, priority, ...) \
-        _SD_ELF_NOTE_DLOPEN("[{\\\"feature\\\":\\\"" feature "\\\",\\\"description\\\":\\\"" description "\\\",\\\"priority\\\":\\\"" priority "\\\",\\\"soname\\\":" _SD_SONAME_ARRAY(__VA_ARGS__) "}]")
+        _SD_ELF_NOTE_DLOPEN(_SD_DLOPEN_JSON(feature, description, priority, __VA_ARGS__))
+
+/* The anchored note requires LLVM >= 18 (see above). Fall back to the non-anchored note on older clang. */
+#if defined(__clang__) && !defined(__apple_build_version__) && __clang_major__ < 18
+#  define SD_ELF_NOTE_DLOPEN_ANCHORED(tag, feature, description, priority, ...) \
+        SD_ELF_NOTE_DLOPEN(feature, description, priority, __VA_ARGS__)
+#else
+#  define SD_ELF_NOTE_DLOPEN_ANCHORED(tag, feature, description, priority, ...) \
+        _SD_ELF_NOTE_DLOPEN_ANCHORED(tag, _SD_DLOPEN_UNIQ_VAR(tag), _SD_DLOPEN_JSON(feature, description, priority, __VA_ARGS__))
+#endif
 
 #ifdef __cplusplus
 }

--- a/src/sysupdate/sysupdate-partition.c
+++ b/src/sysupdate/sysupdate-partition.c
@@ -161,7 +161,7 @@ int find_suitable_partition(
         POINTER_MAY_BE_NULL(partition_type);
         assert(ret);
 
-        r = DLOPEN_FDISK(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+        r = DLOPEN_FDISK(LOG_DEBUG, recommended);
         if (r < 0)
                 return r;
 
@@ -230,7 +230,7 @@ int patch_partition(
         if (change == 0) /* Nothing to do */
                 return 0;
 
-        r = DLOPEN_FDISK(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+        r = DLOPEN_FDISK(LOG_DEBUG, recommended);
         if (r < 0)
                 return r;
 

--- a/src/sysupdate/sysupdate-resource.c
+++ b/src/sysupdate/sysupdate-resource.c
@@ -233,7 +233,7 @@ static int resource_load_from_blockdev(Resource *rr) {
 
         assert(rr);
 
-        r = DLOPEN_FDISK(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+        r = DLOPEN_FDISK(LOG_DEBUG, recommended);
         if (r < 0)
                 return r;
 

--- a/src/sysupdate/sysupdate.c
+++ b/src/sysupdate/sysupdate.c
@@ -14,6 +14,7 @@
 #include "constants.h"
 #include "discover-image.h"
 #include "dissect-image.h"
+#include "dlopen-note.h"
 #include "env-util.h"
 #include "errno-util.h"
 #include "fd-util.h"
@@ -2684,6 +2685,11 @@ static int vl_server(void) {
 
 static int run(int argc, char *argv[]) {
         int r;
+
+        LIBBLKID_NOTE(recommended);
+        LIBCRYPTO_NOTE(suggested);
+        LIBCRYPTSETUP_NOTE(suggested);
+        LIBMOUNT_NOTE(recommended);
 
         log_setup();
 

--- a/src/sysusers/meson.build
+++ b/src/sysusers/meson.build
@@ -10,17 +10,6 @@ executables += [
                 'public' : true,
                 'export' : files('sysusers.c'),
                 'dependencies' : libaudit_cflags,
-        },
-        executable_template + {
-                'name' : 'systemd-sysusers.standalone',
-                'public' : true,
-                'import' : ['systemd-sysusers'],
-                'link_with' : [
-                        libc_wrapper_static,
-                        libbasic_static,
-                        libshared_static,
-                        libsystemd_static,
-                ],
-                'dependencies' : libaudit_cflags,
+                'install' : have_standalone_binaries ? 'both' : 'yes',
         },
 ]

--- a/src/sysusers/sysusers.c
+++ b/src/sysusers/sysusers.c
@@ -11,6 +11,7 @@
 #include "copy.h"
 #include "creds-util.h"
 #include "dissect-image.h"
+#include "dlopen-note.h"
 #include "errno-util.h"
 #include "extract-word.h"
 #include "fd-util.h"
@@ -2268,6 +2269,14 @@ static int run(int argc, char *argv[]) {
 
         Item *i;
         int r;
+
+        LIBAUDIT_NOTE(recommended);
+        LIBBLKID_NOTE(recommended);
+        LIBCRYPT_NOTE(recommended);
+        LIBCRYPTSETUP_NOTE(suggested);
+        LIBCRYPTO_NOTE(suggested);
+        LIBMOUNT_NOTE(recommended);
+        LIBSELINUX_NOTE(recommended);
 
         char **args = NULL;
         r = parse_argv(argc, argv, &args);

--- a/src/test/gcrypt-util.c
+++ b/src/test/gcrypt-util.c
@@ -1,9 +1,5 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
-#include <sys/syslog.h>
-
-#include "sd-dlopen.h"
-
 #include "gcrypt-util.h"
 #include "log.h"                /* IWYU pragma: keep */
 
@@ -45,8 +41,6 @@ DLSYM_PROTOTYPE(gcry_randomize) = NULL;
 int dlopen_gcrypt(int log_level) {
 #if HAVE_GCRYPT
         static void *gcrypt_dl = NULL;
-
-        GCRYPT_NOTE(SD_ELF_NOTE_DLOPEN_PRIORITY_SUGGESTED);
 
         return dlopen_many_sym_or_warn(
                         &gcrypt_dl,

--- a/src/test/gcrypt-util.h
+++ b/src/test/gcrypt-util.h
@@ -2,8 +2,6 @@
 
 #pragma once
 
-#include "sd-dlopen.h"
-
 #include "basic-forward.h"
 
 int dlopen_gcrypt(int log_level);
@@ -14,18 +12,6 @@ int initialize_libgcrypt(bool secmem);
 #ifndef SYSTEMD_CFLAGS_MARKER_LIBGCRYPT
 #  error "missing libgcrypt_cflags in meson dependency."
 #endif
-
-#define GCRYPT_NOTE(priority)                                           \
-        SD_ELF_NOTE_DLOPEN("gcrypt",                                    \
-                           "Support for journald forward-sealing",      \
-                           priority,                                    \
-                           "libgcrypt.so.20")
-
-#define DLOPEN_GCRYPT(log_level, priority)                              \
-        ({                                                              \
-                GCRYPT_NOTE(priority);                                  \
-                dlopen_gcrypt(log_level);                               \
-        })
 
 #include <gcrypt.h> /* IWYU pragma: export */
 
@@ -71,6 +57,4 @@ extern DLSYM_PROTOTYPE(gcry_randomize);
         } while(false)
 
 DEFINE_TRIVIAL_CLEANUP_FUNC_FULL(gcry_md_hd_t, sym_gcry_md_close, NULL);
-#else
-#define DLOPEN_GCRYPT(log_level, priority) dlopen_gcrypt(log_level)
 #endif

--- a/src/test/meson.build
+++ b/src/test/meson.build
@@ -17,6 +17,7 @@ test_env = {
         'SYSTEMD_SLOW_TESTS' : want_slow_tests ? '1' : '0',
         'PYTHONDONTWRITEBYTECODE' : '1',
         'SYSTEMD_LIBC' : get_option('libc'),
+        'SYSTEMD_BUILD_MODE' : get_option('mode'),
 }
 if conf.get('ENABLE_LOCALED') == 1
         test_env += {'SYSTEMD_LANGUAGE_FALLBACK_MAP' : language_fallback_map}
@@ -349,7 +350,7 @@ executables += [
                         libc_wrapper_static,
                         libbasic_static,
                 ],
-                'install' : false,
+                'install' : 'no',
                 'type' : 'manual',
         },
         test_template + {
@@ -721,7 +722,7 @@ if static_libsystemd != 'false'
                         'sources' : [test_libsystemd_sym_c],
                         'link_with' : install_libsystemd_static,
                         'build_by_default' : want_tests != 'false',
-                        'install' : install_tests,
+                        'install' : install_tests ? 'yes' : 'no',
                         'suite' : 'libsystemd',
                 },
         ]
@@ -736,7 +737,7 @@ if static_libudev != 'false'
                         'c_args' : ['-Wno-deprecated-declarations'] + test_cflags,
                         'link_with' : install_libudev_static,
                         'build_by_default' : want_tests != 'false',
-                        'install' : install_tests,
+                        'install' : install_tests ? 'yes' : 'no',
                         'suite' : 'libudev',
                 },
         ]

--- a/src/test/test-bpf-restrict-fsaccess.c
+++ b/src/test/test-bpf-restrict-fsaccess.c
@@ -108,7 +108,7 @@ static int do_attach(void) {
         struct stat st;
         int r;
 
-        r = DLOPEN_BPF(LOG_ERR, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+        r = dlopen_bpf(LOG_ERR);
         if (r < 0)
                 return log_error_errno(r, "Failed to dlopen libbpf: %m");
 

--- a/src/test/test-bpf-token.c
+++ b/src/test/test-bpf-token.c
@@ -11,7 +11,7 @@ static int run(int argc, char *argv[]) {
 #if HAVE_LIBBPF
         int r;
 
-        r = DLOPEN_BPF(LOG_ERR, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+        r = dlopen_bpf(LOG_ERR);
         if (r < 0)
                 return r;
 

--- a/src/test/test-fsprg.c
+++ b/src/test/test-fsprg.c
@@ -501,8 +501,8 @@ TEST(hmac) {
 }
 
 static int intro(void) {
-        if (DLOPEN_GCRYPT(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED) < 0 &&
-            DLOPEN_LIBCRYPTO(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED) < 0)
+        if (dlopen_gcrypt(LOG_DEBUG) < 0 &&
+            dlopen_libcrypto(LOG_DEBUG) < 0)
                 return EXIT_TEST_SKIP;
 
         return EXIT_SUCCESS;

--- a/src/timedate/timedated.c
+++ b/src/timedate/timedated.c
@@ -25,6 +25,7 @@
 #include "conf-files.h"
 #include "constants.h"
 #include "daemon-util.h"
+#include "dlopen-note.h"
 #include "extract-word.h"
 #include "fd-util.h"
 #include "fileio.h"
@@ -1163,6 +1164,8 @@ static int run(int argc, char *argv[]) {
         _cleanup_(sd_event_unrefp) sd_event *event = NULL;
         _cleanup_(sd_bus_flush_close_unrefp) sd_bus *bus = NULL;
         int r;
+
+        LIBSELINUX_NOTE(recommended);
 
         log_setup();
 

--- a/src/timesync/meson.build
+++ b/src/timesync/meson.build
@@ -22,20 +22,13 @@ timesyncd_gperf_c = custom_target(
 generated_sources += timesyncd_gperf_c
 timesyncd_export_sources += timesyncd_gperf_c
 
-if get_option('link-timesyncd-shared')
-        timesyncd_link_with = [libshared]
-else
-        timesyncd_link_with = [libsystemd_static,
-                               libshared_static]
-endif
-
 executables += [
         libexec_template + {
                 'name' : 'systemd-timesyncd',
                 'sources' : timesyncd_sources,
                 'export' : timesyncd_export_sources,
-                'link_with' : timesyncd_link_with,
                 'dependencies' : libm,
+                'install' : get_option('link-timesyncd-shared') ? 'yes' : 'static',
         },
         libexec_template + {
                 'name' : 'systemd-time-wait-sync',

--- a/src/tmpfiles/meson.build
+++ b/src/tmpfiles/meson.build
@@ -16,21 +16,7 @@ executables += [
                         libacl_cflags,
                         libselinux_cflags,
                 ],
-        },
-        executable_template + {
-                'name' : 'systemd-tmpfiles.standalone',
-                'public' : true,
-                'import' : ['systemd-tmpfiles'],
-                'link_with' : [
-                        libc_wrapper_static,
-                        libbasic_static,
-                        libshared_static,
-                        libsystemd_static,
-                ],
-                'dependencies' : [
-                        libacl_cflags,
-                        libselinux_cflags,
-                ],
+                'install' : have_standalone_binaries ? 'both' : 'yes',
         },
         test_template + {
                 'sources' : files('test-offline-passwd.c') +

--- a/src/tmpfiles/tmpfiles.c
+++ b/src/tmpfiles/tmpfiles.c
@@ -25,6 +25,7 @@
 #include "devnum-util.h"
 #include "dirent-util.h"
 #include "dissect-image.h"
+#include "dlopen-note.h"
 #include "env-util.h"
 #include "errno-util.h"
 #include "escape.h"
@@ -4852,6 +4853,12 @@ static int run(int argc, char *argv[]) {
                 _PHASE_MAX
         } phase;
         int r;
+
+        LIBBLKID_NOTE(recommended);
+        LIBCRYPTSETUP_NOTE(suggested);
+        LIBCRYPTO_NOTE(suggested);
+        LIBMOUNT_NOTE(recommended);
+        LIBSELINUX_NOTE(recommended);
 
         char **args = NULL;
         r = parse_argv(argc, argv, &args);

--- a/src/tmpfiles/tmpfiles.c
+++ b/src/tmpfiles/tmpfiles.c
@@ -1270,7 +1270,7 @@ static int parse_acl_cond_exec(
         assert(cond_exec);
         assert(ret);
 
-        r = DLOPEN_LIBACL(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+        r = DLOPEN_LIBACL(LOG_DEBUG, recommended);
         if (r < 0)
                 return r;
 
@@ -1389,7 +1389,7 @@ static int path_set_acl(
 
         assert(c);
 
-        r = DLOPEN_LIBACL(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+        r = DLOPEN_LIBACL(LOG_DEBUG, recommended);
         if (r < 0)
                 return r;
 

--- a/src/tpm2-setup/tpm2-clear.c
+++ b/src/tpm2-setup/tpm2-clear.c
@@ -4,6 +4,7 @@
 
 #include "alloc-util.h"
 #include "build.h"
+#include "dlopen-note.h"
 #include "env-util.h"
 #include "fileio.h"
 #include "format-table.h"
@@ -109,6 +110,10 @@ static int request_tpm2_clear(void) {
 
 static int run(int argc, char *argv[]) {
         int r;
+
+        LIBTSS2_ESYS_NOTE(suggested);
+        LIBTSS2_MU_NOTE(suggested);
+        LIBTSS2_RC_NOTE(suggested);
 
         log_setup();
 

--- a/src/tpm2-setup/tpm2-generator.c
+++ b/src/tpm2-setup/tpm2-generator.c
@@ -2,6 +2,7 @@
 
 #include <unistd.h>
 
+#include "dlopen-note.h"
 #include "dropin.h"
 #include "efivars.h"
 #include "generator.h"
@@ -168,6 +169,10 @@ static int run(const char *dest, const char *dest_early, const char *dest_late) 
         int r;
 
         assert_se(arg_dest = dest);
+
+        LIBTSS2_ESYS_NOTE(suggested);
+        LIBTSS2_MU_NOTE(suggested);
+        LIBTSS2_RC_NOTE(suggested);
 
         r = proc_cmdline_parse(parse_proc_cmdline_item, NULL, PROC_CMDLINE_STRIP_RD_PREFIX);
         if (r < 0)

--- a/src/tpm2-setup/tpm2-setup.c
+++ b/src/tpm2-setup/tpm2-setup.c
@@ -599,11 +599,11 @@ static int run(int argc, char *argv[]) {
                 return EXIT_SUCCESS;
         }
 
-        r = DLOPEN_LIBCRYPTO(LOG_ERR, SD_ELF_NOTE_DLOPEN_PRIORITY_REQUIRED);
+        r = DLOPEN_LIBCRYPTO(LOG_ERR, required);
         if (r < 0)
                 return r;
 
-        r = DLOPEN_TPM2(LOG_ERR, SD_ELF_NOTE_DLOPEN_PRIORITY_REQUIRED);
+        r = DLOPEN_TPM2(LOG_ERR, required);
         if (r < 0)
                 return r;
 

--- a/src/tpm2-setup/tpm2-setup.c
+++ b/src/tpm2-setup/tpm2-setup.c
@@ -10,6 +10,7 @@
 #include "conf-files.h"
 #include "constants.h"
 #include "crypto-util.h"
+#include "dlopen-note.h"
 #include "errno-util.h"
 #include "fd-util.h"
 #include "fileio.h"
@@ -598,6 +599,8 @@ static int run(int argc, char *argv[]) {
                 log_notice("No complete TPM2 support detected, exiting gracefully.");
                 return EXIT_SUCCESS;
         }
+
+        LIBBLKID_NOTE(recommended);
 
         r = DLOPEN_LIBCRYPTO(LOG_ERR, required);
         if (r < 0)

--- a/src/tpm2-setup/tpm2-swtpm.c
+++ b/src/tpm2-setup/tpm2-swtpm.c
@@ -6,6 +6,7 @@
 
 #include "alloc-util.h"
 #include "chase.h"
+#include "dlopen-note.h"
 #include "errno-util.h"
 #include "escape.h"
 #include "fd-util.h"
@@ -144,6 +145,8 @@ static int setup_swtpm(const char *state_dir, int state_fd, const char *secret) 
 
 static int run(int argc, char *argv[]) {
         int r;
+
+        LIBBLKID_NOTE(recommended);
 
         log_setup();
 

--- a/src/tty-ask-password-agent/tty-ask-password-agent.c
+++ b/src/tty-ask-password-agent/tty-ask-password-agent.c
@@ -19,6 +19,7 @@
 #include "daemon-util.h"
 #include "devnum-util.h"
 #include "dirent-util.h"
+#include "dlopen-note.h"
 #include "errno-util.h"
 #include "exit-status.h"
 #include "fd-util.h"
@@ -699,6 +700,8 @@ static int ask_on_consoles(char *argv[]) {
 
 static int run(int argc, char *argv[]) {
         int r;
+
+        LIBSELINUX_NOTE(recommended);
 
         log_setup();
 

--- a/src/udev/meson.build
+++ b/src/udev/meson.build
@@ -106,17 +106,6 @@ generated_sources += link_config_gperf_c
 
 ############################################################
 
-if get_option('link-udev-shared')
-        udev_link_with = [libshared]
-        udev_rpath = pkglibdir
-else
-        udev_link_with = [libshared_static,
-                          libsystemd_static]
-        udev_rpath = ''
-endif
-
-############################################################
-
 udev_dependencies = [
         libacl_cflags,
         libblkid_cflags,
@@ -128,8 +117,7 @@ udev_dependencies = [
 
 udev_plugin_template = executable_template + {
         'public' : true,
-        'link_with' : udev_link_with,
-        'install_rpath' : udev_rpath,
+        'install' : get_option('link-udev-shared') ? 'yes' : 'static',
         'install_dir' : udevlibexecdir,
         'install_tag' : 'udev',
 }
@@ -156,8 +144,7 @@ udev_binaries_dict = [
                         libexec_template['include_directories'],
                 ],
                 'dependencies' : udev_dependencies,
-                'link_with' : udev_link_with,
-                'install_rpath' : udev_rpath,
+                'install' : get_option('link-udev-shared') ? 'yes' : 'static',
                 'install_tag' : 'udev',
         },
         udev_plugin_template + {

--- a/src/udev/net/link-config.c
+++ b/src/udev/net/link-config.c
@@ -320,7 +320,7 @@ int link_load_one(LinkConfigContext *ctx, const char *filename) {
                 return 0;
         }
 
-        if (!condition_test_list(config->conditions, environ, NULL, NULL, NULL)) {
+        if (!condition_test_list_net(config->conditions, environ, NULL, NULL, NULL)) {
                 log_debug("%s: Conditions do not match the system environment, skipping.", filename);
                 return 0;
         }

--- a/src/udev/udev-builtin-blkid.c
+++ b/src/udev/udev-builtin-blkid.c
@@ -520,7 +520,7 @@ static int builtin_blkid(UdevEvent *event, int argc, char *argv[]) {
         int64_t offset = 0;
         int r;
 
-        r = DLOPEN_LIBBLKID(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_REQUIRED);
+        r = DLOPEN_LIBBLKID(LOG_DEBUG, required);
         if (r < 0)
                 return log_device_debug_errno(dev, r, "blkid not available: %m");
 

--- a/src/udev/udevadm.c
+++ b/src/udev/udevadm.c
@@ -3,6 +3,7 @@
 #include <stdio.h>
 
 #include "argv-util.h"
+#include "dlopen-note.h"
 #include "format-table.h"
 #include "help-util.h"
 #include "label-util.h"
@@ -100,6 +101,10 @@ int print_version(void) {
 static int run(int argc, char *argv[]) {
         char **args = NULL;
         int r;
+
+        LIBAPPARMOR_NOTE(recommended);
+        LIBAUDIT_NOTE(recommended);
+        LIBSELINUX_NOTE(recommended);
 
         if (invoked_as(argv, "udevd"))
                 return run_udevd(argc, argv);

--- a/src/udev/udevadm.c
+++ b/src/udev/udevadm.c
@@ -102,8 +102,6 @@ static int run(int argc, char *argv[]) {
         char **args = NULL;
         int r;
 
-        LIBAPPARMOR_NOTE(recommended);
-        LIBAUDIT_NOTE(recommended);
         LIBSELINUX_NOTE(recommended);
 
         if (invoked_as(argv, "udevd"))

--- a/src/udev/udevd.c
+++ b/src/udev/udevd.c
@@ -58,11 +58,11 @@ int run_udevd(int argc, char *argv[]) {
                 return log_error_errno(r, "Failed to create /run/udev: %m");
 
         /* Load some shared libraries before we fork any workers */
-        (void) DLOPEN_LIBACL(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
-        (void) DLOPEN_LIBBLKID(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
-        (void) DLOPEN_LIBKMOD(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
-        (void) DLOPEN_LIBMOUNT(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
-        (void) DLOPEN_TPM2(LOG_DEBUG, SD_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED);
+        (void) DLOPEN_LIBACL(LOG_DEBUG, recommended);
+        (void) DLOPEN_LIBBLKID(LOG_DEBUG, recommended);
+        (void) DLOPEN_LIBKMOD(LOG_DEBUG, recommended);
+        (void) DLOPEN_LIBMOUNT(LOG_DEBUG, recommended);
+        (void) DLOPEN_TPM2(LOG_DEBUG, recommended);
 
         if (arg_daemonize) {
                 pid_t pid;

--- a/src/update-done/update-done.c
+++ b/src/update-done/update-done.c
@@ -5,6 +5,7 @@
 #include "alloc-util.h"
 #include "build.h"
 #include "chase.h"
+#include "dlopen-note.h"
 #include "errno-util.h"
 #include "fd-util.h"
 #include "fileio.h"
@@ -123,6 +124,8 @@ static int parse_argv(int argc, char *argv[]) {
 static int run(int argc, char *argv[]) {
         struct stat st;
         int r;
+
+        LIBSELINUX_NOTE(recommended);
 
         r = parse_argv(argc, argv);
         if (r <= 0)

--- a/src/update-utmp/update-utmp.c
+++ b/src/update-utmp/update-utmp.c
@@ -7,6 +7,7 @@
 #include "bus-error.h"
 #include "bus-locator.h"
 #include "bus-util.h"
+#include "dlopen-note.h"
 #include "libaudit-util.h"
 #include "log.h"
 #include "main-func.h"
@@ -108,6 +109,8 @@ static int run(int argc, char *argv[]) {
         _cleanup_(context_clear) Context c = {
                 .audit_fd = -EBADF,
         };
+
+        LIBAUDIT_NOTE(recommended);
 
         log_setup();
 

--- a/src/user-sessions/user-sessions.c
+++ b/src/user-sessions/user-sessions.c
@@ -2,6 +2,7 @@
 
 #include <sys/stat.h>
 
+#include "dlopen-note.h"
 #include "fs-util.h"
 #include "label-util.h"
 #include "log.h"
@@ -11,6 +12,8 @@
 
 static int run(int argc, char *argv[]) {
         int r;
+
+        LIBSELINUX_NOTE(recommended);
 
         if (argc != 2)
                 return log_error_errno(SYNTHETIC_ERRNO(EINVAL),

--- a/src/userdb/userdbctl.c
+++ b/src/userdb/userdbctl.c
@@ -10,6 +10,7 @@
 #include "copy.h"
 #include "creds-util.h"
 #include "dirent-util.h"
+#include "dlopen-note.h"
 #include "errno-list.h"
 #include "errno-util.h"
 #include "escape.h"
@@ -1852,6 +1853,8 @@ static int parse_argv(int argc, char *argv[], char ***remaining_args) {
 static int run(int argc, char *argv[]) {
         _cleanup_strv_free_ char **args = NULL;
         int r;
+
+        LIBSELINUX_NOTE(recommended);
 
         log_setup();
 

--- a/src/validatefs/validatefs.c
+++ b/src/validatefs/validatefs.c
@@ -290,7 +290,7 @@ static int validate_gpt_metadata_one(sd_device *d, const char *path, const Valid
         assert(d);
         assert(f);
 
-        r = DLOPEN_LIBBLKID(LOG_ERR, SD_ELF_NOTE_DLOPEN_PRIORITY_REQUIRED);
+        r = DLOPEN_LIBBLKID(LOG_ERR, required);
         if (r < 0)
                 return r;
 

--- a/src/veritysetup/veritysetup.c
+++ b/src/veritysetup/veritysetup.c
@@ -8,6 +8,7 @@
 #include "alloc-util.h"
 #include "argv-util.h"
 #include "cryptsetup-util.h"
+#include "dlopen-note.h"
 #include "extract-word.h"
 #include "fileio.h"
 #include "format-table.h"
@@ -492,6 +493,8 @@ static int run(int argc, char *argv[]) {
                 return help();
 
         log_setup();
+
+        LIBCRYPTO_NOTE(suggested);
 
         r = DLOPEN_CRYPTSETUP(LOG_ERR, required);
         if (r < 0)

--- a/src/veritysetup/veritysetup.c
+++ b/src/veritysetup/veritysetup.c
@@ -493,7 +493,7 @@ static int run(int argc, char *argv[]) {
 
         log_setup();
 
-        r = DLOPEN_CRYPTSETUP(LOG_ERR, SD_ELF_NOTE_DLOPEN_PRIORITY_REQUIRED);
+        r = DLOPEN_CRYPTSETUP(LOG_ERR, required);
         if (r < 0)
                 return r;
 

--- a/src/vmspawn/vmspawn.c
+++ b/src/vmspawn/vmspawn.c
@@ -29,6 +29,7 @@
 #include "copy.h"
 #include "discover-image.h"
 #include "dissect-image.h"
+#include "dlopen-note.h"
 #include "escape.h"
 #include "ether-addr-util.h"
 #include "event-util.h"
@@ -4285,6 +4286,9 @@ static int verify_arguments(void) {
 static int run(int argc, char *argv[]) {
         int r, kvm_device_fd = -EBADF, vhost_device_fd = -EBADF;
         _cleanup_strv_free_ char **names = NULL;
+
+        LIBBLKID_NOTE(recommended);
+        LIBSELINUX_NOTE(recommended);
 
         log_setup();
 

--- a/src/volatile-root/volatile-root.c
+++ b/src/volatile-root/volatile-root.c
@@ -7,6 +7,7 @@
 #include "blockdev-util.h"
 #include "chase.h"
 #include "devnum-util.h"
+#include "dlopen-note.h"
 #include "escape.h"
 #include "log.h"
 #include "main-func.h"
@@ -121,6 +122,8 @@ static int run(int argc, char *argv[]) {
         const char *path;
         dev_t devt;
         int r;
+
+        LIBMOUNT_NOTE(recommended);
 
         log_setup();
 

--- a/test/meson.build
+++ b/test/meson.build
@@ -279,6 +279,60 @@ endif
 
 ############################################################
 
+if want_tests != 'false' and pyelftools.found()
+        test_dlopen_note_py = files('test-dlopen-note.py')
+
+        foreach name, exe : executables_by_name
+                if name.endswith('.static') or name.endswith('.shared')
+                        continue
+                endif
+
+                name_static = name + '.static'
+                if name + '.standalone' in executables_by_name
+                        exe_shared = exe
+                        exe_static = executables_by_name.get(name + '.standalone')
+                elif name + '.shared' in executables_by_name
+                        exe_shared = executables_by_name.get(name + '.shared')
+                        exe_static = exe
+                else
+                        continue
+                endif
+
+                test(name,
+                     test_dlopen_note_py,
+                     env : test_env,
+                     args : ['--shared', exe_shared.full_path(), '--static', exe_static.full_path()],
+                     depends : [exe_shared, exe_static],
+                     suite : 'dlopen')
+        endforeach
+
+        foreach name, lib : modules_by_name
+                if name.endswith('.standalone')
+                        continue
+                endif
+
+                lib_static = modules_by_name.get(name + '.standalone', lib)
+
+                test('lib' + lib.name(),
+                     test_dlopen_note_py,
+                     env : test_env,
+                     args : ['--shared', lib.full_path(), '--static', lib_static.full_path()],
+                     depends : [lib, lib_static],
+                     suite : 'dlopen')
+        endforeach
+
+        foreach lib : [libshared, libsystemd, libudev]
+                test('lib' + lib.name(),
+                     test_dlopen_note_py,
+                     env : test_env,
+                     args : ['--shared', lib.full_path(), '--static', lib.full_path()],
+                     depends : [lib],
+                     suite : 'dlopen')
+        endforeach
+endif
+
+############################################################
+
 if want_tests != 'false'
         subdir('integration-tests')
 endif

--- a/test/test-dlopen-note.py
+++ b/test/test-dlopen-note.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""
+Compare statically linked dlopen symbols against shared library ELF notes.
+
+This script extracts surviving dlopen_* symbols from a statically linked
+executable (representing the true minimal set of dynamically loaded features
+actually invoked by the code after linker optimizations like --gc-sections)
+and compares them against the embedded FDO .note.dlopen metadata inside a
+shared library or dynamic executable.
+
+It highlights missing metadata, over-included (dead) metadata, and detects
+any unmapped symbols that require script updates.
+"""
+
+import argparse
+import enum
+import json
+import os
+import re
+import sys
+from functools import total_ordering
+from pathlib import Path
+from typing import Any
+
+try:
+    from elftools.elf.elffile import ELFFile
+    from elftools.elf.sections import NoteSection, SymbolTableSection
+except ImportError:
+    print("Error: 'elftools' python module not found.", file=sys.stderr)
+    sys.exit(1)
+
+
+# Function filter: Maps wrapper/sentinel symbols to real symbols or an empty list (ignore).
+FUNCTION_FILTER = {
+    # Filtered out (internal helpers, verbose loggers, sentinels)
+    'dlopen_safe': [],
+    'dlopen_verbose': [],
+    'dlopen_many_sym_or_warn_sentinel': [],
+    'dlopen_dw_has_dwfl_set_sysroot': [],
+    # Mapped to multiple functions (expands generic wrappers into specific sub-layers)
+    'dlopen_tpm2': [
+        'dlopen_tpm2_esys',
+        'dlopen_tpm2_mu',
+        'dlopen_tpm2_rc',
+        'dlopen_tpm2_tcti_device',
+    ],
+}
+
+
+# Direct mapping from clean symbol name to expected FDO dlopen feature name.
+FUNCTION_TO_FEATURE = {
+    'dlopen_bpf': 'bpf',
+    'dlopen_bzip2': 'bzip2',
+    'dlopen_cryptsetup': 'cryptsetup',
+    'dlopen_curl': 'curl',
+    'dlopen_dw': 'dw',
+    'dlopen_elf': 'elf',
+    'dlopen_fdisk': 'fdisk',
+    'dlopen_gnutls': 'gnutls',
+    'dlopen_idn': 'idn',
+    'dlopen_libacl': 'acl',
+    'dlopen_libapparmor': 'apparmor',
+    'dlopen_libarchive': 'archive',
+    'dlopen_libaudit': 'audit',
+    'dlopen_libblkid': 'blkid',
+    'dlopen_libcrypt': 'crypt',
+    'dlopen_libcrypto': 'libcrypto',
+    'dlopen_libfido2': 'fido2',
+    'dlopen_libkmod': 'kmod',
+    'dlopen_libmount': 'mount',
+    'dlopen_libpam': 'pam',
+    'dlopen_libseccomp': 'seccomp',
+    'dlopen_libselinux': 'selinux',
+    'dlopen_libssl': 'libssl',
+    'dlopen_lz4': 'lz4',
+    'dlopen_microhttpd': 'microhttpd',
+    'dlopen_p11kit': 'p11-kit',
+    'dlopen_passwdqc': 'passwdqc',
+    'dlopen_pcre2': 'pcre2',
+    'dlopen_pwquality': 'pwquality',
+    'dlopen_qrencode': 'qrencode',
+    'dlopen_tpm2_esys': 'tpm (esys)',
+    'dlopen_tpm2_mu': 'tpm (mu)',
+    'dlopen_tpm2_rc': 'tpm (rc)',
+    'dlopen_tpm2_tcti_device': 'tpm (tcti-device)',
+    'dlopen_xkbcommon': 'xkbcommon',
+    'dlopen_xz': 'lzma',
+    'dlopen_zlib': 'zlib',
+    'dlopen_zstd': 'zstd',
+}
+
+
+def dlopen_function_append(name: str, function_names: set[str]) -> None:
+    """Add a symbol to the set, expanding or dropping based on FUNCTION_FILTER."""
+    function_names.update(FUNCTION_FILTER.get(name, [name]))
+
+
+def dlopen_functions_parse(path: Path) -> set[str]:
+    """Parse ELF symbol tables and extract surviving dlopen_* function names."""
+    function_names: set[str] = set()
+
+    try:
+        with path.open('rb') as f:
+            elffile = ELFFile(f)
+            for section in elffile.iter_sections():
+                if not isinstance(section, SymbolTableSection):
+                    continue
+                for symbol in section.iter_symbols():
+                    # Ignore undefined (externally referenced) or non-function symbols
+                    if symbol['st_info']['type'] != 'STT_FUNC' or symbol['st_shndx'] == 'SHN_UNDEF':
+                        continue
+
+                    if m := re.match(r'^(?:sym_)?(dlopen_[a-zA-Z0-9_]+)$', symbol.name):
+                        dlopen_function_append(m.group(1), function_names)
+
+    except Exception as e:
+        print(f"Failed to read '{path}': {e}", file=sys.stderr)
+        sys.exit(1)
+
+    return function_names
+
+
+def dlopen_note_get_feature(item: dict[str, Any]) -> str:
+    if 'feature' not in item:
+        return None
+
+    feature = item['feature']
+    if feature != 'tpm':
+        return feature
+
+    # TPM features are collapsed into "tpm" in the ELF note. We iterate over
+    # sonames to correctly map them back to detailed granular layers.
+    for soname in item.get('soname', []):
+        if 'esys' in soname:
+            return 'tpm (esys)'
+        if 'mu' in soname:
+            return 'tpm (mu)'
+        if 'rc' in soname:
+            return 'tpm (rc)'
+        if 'tcti-device' in soname:
+            return 'tpm (tcti-device)'
+    else:
+        return feature  # If not found, let's return 'tpm' as is, and warn later.
+
+
+@total_ordering
+class Priority(enum.Enum):
+    suggested = 1
+    recommended = 2
+    required = 3
+
+    def __lt__(self, other):
+        return self.value < other.value
+
+    def __str__(self):
+        return self.name
+
+
+def dlopen_note_append(item: dict[str, Any], entries: dict[str, dict[str, Any]]) -> None:
+    """Store the parsed note item into the dictionary."""
+
+    feat = dlopen_note_get_feature(item)
+    prio = Priority[item.get('priority', 'recommended')]
+
+    if feat in entries and Priority[entries[feat].get('priority', 'recommended')] >= prio:
+        return
+
+    entries[feat] = item
+
+
+def dlopen_note_merge(
+    a: dict[str, dict[str, Any]],
+    b: dict[str, dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    c = a
+
+    for item in b.values():
+        dlopen_note_append(item, c)
+
+    return c
+
+
+def dlopen_note_parse(path: Path) -> dict[str, dict[str, Any]]:
+    """Parse .note.dlopen ELF section and extract embedded JSON metadata."""
+    entries: dict[str, dict[str, Any]] = {}
+
+    try:
+        with path.open('rb') as f:
+            elffile = ELFFile(f)
+            for section in elffile.iter_sections():
+                # Verify section name and type safely
+                if section.name != '.note.dlopen' or not isinstance(section, NoteSection):
+                    continue
+
+                for note in section.iter_notes():
+                    desc = note['n_desc']
+                    # Handle raw bytes or string payloads, stripping null-terminator bytes (\x00)
+                    desc_str = (
+                        desc.decode('utf-8', errors='ignore').rstrip('\x00')
+                        if isinstance(desc, bytes)
+                        else str(desc).rstrip('\x00')
+                    )
+
+                    try:
+                        data = json.loads(desc_str)
+                        # According to FDO specs, payload can be a JSON array or a single dict
+                        items = data if isinstance(data, list) else [data]
+                        for item in items:
+                            if isinstance(item, dict):
+                                dlopen_note_append(item, entries)
+                    except json.JSONDecodeError:
+                        continue
+
+    except Exception as e:
+        print(f"Failed to read '{path}': {e}", file=sys.stderr)
+        sys.exit(1)
+
+    return entries
+
+
+def dlopen_note_dump(entries: dict[str, dict[str, Any]], path: str) -> None:
+    print(f'=== Embedded .note.dlopen Metadata in: {path} ===')
+    if not entries:
+        print('  (No .note.dlopen metadata found)')
+    else:
+        for feat, item in sorted(entries.items()):
+            p = item.get('priority', 'recommended')
+            print(f"  - {feat.ljust(20)} : {p.ljust(15)} : {' '.join(item.get('soname', []))}")
+    print()
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Compare dlopen symbols vs metadata notes.')
+    parser.add_argument('--static', required=True, help='Path to statically linked binary')
+    parser.add_argument('--shared', required=True, help='Path to shared library or dynamic binary')
+    args = parser.parse_args()
+
+    unknown_functions = set()
+    features_by_func = set()
+    if check_function_symbol := os.getenv('SYSTEMD_BUILD_MODE') == 'developer':
+        for name in dlopen_functions_parse(Path(args.static)):
+            if name not in FUNCTION_TO_FEATURE:
+                unknown_functions.add(name)
+            else:
+                features_by_func.add(FUNCTION_TO_FEATURE[name])
+
+    note_static = dlopen_note_parse(Path(args.static))
+    note_shared = dlopen_note_parse(Path(args.shared))
+    note_merged = dlopen_note_merge(note_static, note_shared)
+
+    dlopen_note_dump(note_static, args.static)
+    dlopen_note_dump(note_shared, args.shared)
+
+    print('=== [DIFF] Analysis & Verification ===')
+
+    rc = 0
+
+    for feat, item in sorted(note_merged.items()):
+        if feat not in note_shared:
+            print(f'  ❌ {feat} is missing.')
+            rc = 1
+            continue
+
+        p = Priority[item.get('priority', 'recommended')]
+        q = Priority[note_shared[feat].get('priority', 'recommended')]
+        if q < p:
+            print(f'  ⚠️ {feat} has weaker priority ({q} < {p}).')
+            rc = 1
+            continue
+
+        if check_function_symbol and feat not in features_by_func:
+            print(f'  💥 {feat} is set, but corresponding dlopen() is not called.')
+            rc = 1
+            continue
+
+        if feat not in note_static:
+            print(f'  👀 {feat} is missing in {args.static}.')
+            rc = 1
+
+    if unknown_functions:
+        print('  💀  [UNKNOWN DLOPEN FUNCTIONS] Found unknown dlopen functions, please update tables:')
+        for f in sorted(unknown_functions):
+            print(f"     * Function '{f}'")
+            rc = 1
+
+    if rc == 0:
+        print('  🎉 PERFECT MATCH! Exactly required dlopen notes are embedded.')
+
+    sys.exit(rc)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This PR optimizes the handling of `dlopen` ELF notes and reduces binary footprints across the tree. 

By enabling compiler section-splitting (`-ffunction-sections`/`-fdata-sections`), the linker can now accurately garbage-collect unused code and data. To align with this, `SD_ELF_NOTE_DLOPEN_ANCHORED()` macro is introduced, which ties `dlopen` notes to their calling functions so that unused notes are automatically removed by `--gc-sections`. 

Additionally, this explicitly embeds required `dlopen` notes into individual executables to fix a visibility issue where package managers missed runtime dependencies invoked indirectly through `libsystemd-shared.so`.