### PR TITLE
hwdb: add MSI Claw 8 EX AI+ CG3EM to keyboard hwdb list

### DIFF
--- a/hwdb.d/60-keyboard.hwdb
+++ b/hwdb.d/60-keyboard.hwdb
@@ -1686,6 +1686,12 @@ evdev:name:AT Translated Set 2 keyboard:dmi:*:rvnMicro-StarInternationalCo.,Ltd.
  KEYBOARD_KEY_b9=f15                                   # Right Face Button
  KEYBOARD_KEY_ba=f16                                   # Left Face Button
 
+# MSI Claw 8 EX AI+ CG3EM
+# Face-button scancodes are swapped compared to the older Claw models
+evdev:name:AT Translated Set 2 keyboard:dmi:*:rvnMicro-StarInternationalCo.,Ltd.:rnMS-1T91:*
+ KEYBOARD_KEY_db=f15                                   # Left Face Button
+ KEYBOARD_KEY_b9=f16                                   # Right Face Button
+
 # MSI Katana GF66 12UD toggles touchpad using Fn+F4 where the keyboard key is 76
 evdev:atkbd:dmi:*svnMicro-Star*:pnKatanaGF6612UD:*
  KEYBOARD_KEY_76=touchpad_toggle                       # Toggle touchpad


### PR DESCRIPTION
Adds support for the new Panther Lake model of the MSI Claw, the MSI Claw 8 EX AI+ CG3EM

/cc @pastaq 