### PR TITLE
mkosi: update fedora commit reference to 45c16dd369c961b70664e473552d…

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -51,7 +51,7 @@ jobs:
   trigger: pull_request
   fmf_url: https://src.fedoraproject.org/rpms/systemd
   # This is automatically updated by tools/fetch-distro.py --update fedora
-  fmf_ref: 9cb09470c9c5a437f8e9c1e0e449b87de83733eb
+  fmf_ref: 45c16dd369c961b70664e473552def34d5469664
   targets:
   - fedora-rawhide-x86_64
   # testing-farm in the Fedora repository is explicitly configured to use testing-farm bare metal runners as

--- a/mkosi/mkosi.pkgenv/mkosi.conf.d/centos-fedora.conf
+++ b/mkosi/mkosi.pkgenv/mkosi.conf.d/centos-fedora.conf
@@ -9,5 +9,5 @@ Profiles=!hyperscale
 Environment=
         GIT_URL=https://src.fedoraproject.org/rpms/systemd.git
         GIT_BRANCH=rawhide
-        GIT_COMMIT=9cb09470c9c5a437f8e9c1e0e449b87de83733eb
+        GIT_COMMIT=45c16dd369c961b70664e473552def34d5469664
         PKG_SUBDIR=fedora


### PR DESCRIPTION
…ef34d5469664

* 45c16dd369 Use uniform format for %rhel conditionals
* 034fa693f2 Print the build status also in %build
* 3cc7e03365 Restore definitions of helper macros
* 2382c910b7 Disable the standalone report yet again
* 2d6fd95c70 Restore explicit requires for Centos Stream 9 and 10
* 521ab0fb09 test: skip the integration test suite on Fedora ELN (for now)
* 453447b79b rpminspect: ignore test-coredump-stacktrace in annocheck
* 9d4edaa576 test: work around a kernel bug in virtio/vsock
* c53b2fb307 test: cap the number of parallel tests
* 9bd26bb71f Fix ntpvendor for ELN
* de7b685908 Disable reqs for dlopen'ed libraries on CentOS
* 4830641844 Move portabled to systemd-container subpackage
* 893fcd9978 Add missing conditionalization and more debugging
* c783e74791 split-files: improve error message
* ee2dff42d6 Add systemd-report-standalone
* 9c87a3f8ad Load libssl.so.4 rather than libssl.so.3
* 714b0799d2 Version 261.1
* 054158500a Update to load openssl-4 rather than openssl-3
* 5a3e750ef8 Version 261
* 4faee7ab7d Version 261~rc4
* 8ff635a921 Rebuilt for openssl 4.0
* 0064f73d97 Rebuilt for openssl 4.0
* 14a9aac87e Use dlopen notes again
* 720fa8259a Do not check ownership of /var/lib/systemd/timesync/ in rpm -V
* 06bd9926f2 Version 261~rc3
* 6ddbd499e8 Drop unused tree build dependency
* bd81a14bfc Version 261~rc2