### PR TITLE
machined: Allow user ids in open_shell for machine-dbus

### DIFF
--- a/src/machine/machine-dbus.c
+++ b/src/machine/machine-dbus.c
@@ -391,7 +391,7 @@ int bus_machine_method_open_shell(sd_bus_message *message, void *userdata, sd_bu
                 return r;
         user = isempty(user) ? "root" : user;
 
-        if (!valid_user_group_name(user, VALID_USER_RELAX))
+        if (!valid_user_group_name(user, VALID_USER_RELAX | VALID_USER_ALLOW_NUMERIC))
                 return sd_bus_error_setf(error, SD_BUS_ERROR_INVALID_ARGS, "Invalid user name '%s'", user);
 
         /* Ensure only root can shell into the root namespace. This is to avoid unprivileged users registering


### PR DESCRIPTION
Previously `machinectl shell --uid=1000 <machine>` resulted in a sucessful drop into a shell in the respective target machine. After commit a9e9288288567beae57337ae903dd3b6c774001c this is no longer the case.

This fixes the above breaking change brought in commit a9e9288288567beae57337ae903dd3b6c774001c