### PR TITLE
Parse multiple FDO package metadata notes

### DIFF
--- a/man/systemd-analyze.xml
+++ b/man/systemd-analyze.xml
@@ -911,6 +911,15 @@ alias.service:7: Unknown key name 'MysteryKey' in section 'Service', ignoring.
       <ulink url="https://systemd.io/PACKAGE_METADATA_FOR_EXECUTABLE_FILES/">
       Package Metadata for Executable Files</ulink> document for more information.</para>
 
+      <para>An ELF object (or a module within a core file) may carry more than one packaging metadata note,
+      for example when statically linked or vendored dependencies each embed their own. The first note is
+      treated as the module's main package and its fields are reported directly on the module object, next to
+      the build-id, exactly as when only a single note is present. Any further notes describe additional
+      packages contained in the same module and are reported as an array under the
+      <literal>contains</literal> key, which is only present when there is more than one note. In the table
+      output the additional packages are printed as separate paragraphs. The <literal>contains</literal>
+      terminology is borrowed from the SPDX <literal>CONTAINS</literal> relationship type.</para>
+
       <example>
         <title>Print information about a core file as JSON</title>
 
@@ -930,6 +939,30 @@ alias.service:7: Unknown key name 'MysteryKey' in section 'Service', ignoring.
                 "name" : "fsverity-utils",
                 "version" : "1.3-1",
                 "buildId" : "b5e428254abf14237b0ae70ed85fffbb98a78f88"
+        }
+}
+</programlisting>
+      </example>
+
+      <example>
+        <title>A binary bundling a statically linked dependency, as JSON</title>
+
+        <programlisting>$ systemd-analyze inspect-elf --json=pretty /usr/bin/foo
+{
+        "elfType" : "executable",
+        "elfArchitecture" : "AMD x86-64",
+        "/usr/bin/foo" : {
+                "type" : "deb",
+                "name" : "foo",
+                "version" : "1.2-3",
+                "buildId" : "a3d6de4507a72d75b99611a44341face68794f7c",
+                "contains" : [
+                        {
+                                "type" : "deb",
+                                "name" : "libbar",
+                                "version" : "0.9-1"
+                        }
+                ]
         }
 }
 </programlisting>

--- a/src/analyze/analyze-inspect-elf.c
+++ b/src/analyze/analyze-inspect-elf.c
@@ -55,7 +55,7 @@ static int analyze_elf(char **filenames, sd_json_format_flags_t json_flags) {
 
                         JSON_VARIANT_OBJECT_FOREACH(module_name, module_json, package_metadata) {
                                 const char *field_name;
-                                sd_json_variant *field;
+                                sd_json_variant *field, *contains, *component;
 
                                 /* The ELF type and architecture are added as top-level objects,
                                  * since they are only parsed for the file itself, but the packaging
@@ -94,6 +94,9 @@ static int analyze_elf(char **filenames, sd_json_format_flags_t json_flags) {
                                                 return table_log_add_error(r);
                                 }
 
+                                /* The module object holds the "main" package's fields (and the build-id)
+                                 * directly. Print them; the "contains" array (additional packages) is not a
+                                 * string, so it is skipped here and handled separately below. */
                                 JSON_VARIANT_OBJECT_FOREACH(field_name, field, module_json)
                                         if (sd_json_variant_is_string(field)) {
                                                 r = table_add_many(
@@ -103,6 +106,24 @@ static int analyze_elf(char **filenames, sd_json_format_flags_t json_flags) {
                                                 if (r < 0)
                                                         return table_log_add_error(r);
                                         }
+
+                                /* Then print each additional contained package as its own paragraph. */
+                                contains = sd_json_variant_by_key(module_json, "contains");
+                                JSON_VARIANT_ARRAY_FOREACH(component, contains) {
+                                        r = table_add_many(t, TABLE_EMPTY, TABLE_EMPTY);
+                                        if (r < 0)
+                                                return table_log_add_error(r);
+
+                                        JSON_VARIANT_OBJECT_FOREACH(field_name, field, component)
+                                                if (sd_json_variant_is_string(field)) {
+                                                        r = table_add_many(
+                                                                        t,
+                                                                        TABLE_FIELD, field_name,
+                                                                        TABLE_STRING, sd_json_variant_string(field));
+                                                        if (r < 0)
+                                                                return table_log_add_error(r);
+                                                }
+                                }
                         }
                 }
 

--- a/src/coredump/coredump-submit.c
+++ b/src/coredump/coredump-submit.c
@@ -753,6 +753,8 @@ int coredump_submit(const CoredumpConfig *config, CoredumpContext *context) {
                         if (!path_equal_filename(module_name, context->exe))
                                 continue;
 
+                        /* The module object holds the "main" package's fields directly (additional packages,
+                         * if any, live in the "contains" array), so read name/version straight from it. */
                         t = sd_json_variant_by_key(module_json, "name");
                         if (t)
                                 (void) iovw_put_string_field(&context->iovw, "COREDUMP_PACKAGE_NAME=", sd_json_variant_string(t));

--- a/src/coredump/coredumpctl.c
+++ b/src/coredump/coredumpctl.c
@@ -869,6 +869,7 @@ static int print_info(FILE *file, sd_journal *j, bool need_space) {
                         if (!path_equal_filename(module_name, f.fields[COREDUMP_FIELD_EXE]))
                                 continue;
 
+                        /* The build-id sits right on the module object, next to the main package's fields. */
                         build_id = sd_json_variant_by_key(module_json, "buildId");
                         if (build_id)
                                 fprintf(file, "      build-id: %s\n", sd_json_variant_string(build_id));

--- a/src/shared/elf-util.c
+++ b/src/shared/elf-util.c
@@ -331,7 +331,9 @@ static char* build_package_reference(
                        strempty(arch));
 }
 
-static void report_module_metadata(StackContext *c, const char *name, sd_json_variant *metadata) {
+static void report_module_metadata(StackContext *c, const char *name, sd_json_variant *metadata, sd_json_variant *id_json) {
+        const char *package = NULL, *version = NULL;
+
         assert(c);
         assert(name);
 
@@ -342,11 +344,10 @@ static void report_module_metadata(StackContext *c, const char *name, sd_json_va
 
         if (metadata) {
                 const char
-                        *build_id = sd_json_variant_string(sd_json_variant_by_key(metadata, "buildId")),
                         *type = sd_json_variant_string(sd_json_variant_by_key(metadata, "type")),
-                        *package = sd_json_variant_string(sd_json_variant_by_key(metadata, "name")),
-                        *version = sd_json_variant_string(sd_json_variant_by_key(metadata, "version")),
                         *arch = sd_json_variant_string(sd_json_variant_by_key(metadata, "architecture"));
+                package = sd_json_variant_string(sd_json_variant_by_key(metadata, "name"));
+                version = sd_json_variant_string(sd_json_variant_by_key(metadata, "version"));
 
                 if (package) {
                         /* Version/architecture is only meaningful with a package name.
@@ -354,10 +355,13 @@ static void report_module_metadata(StackContext *c, const char *name, sd_json_va
                         _cleanup_free_ char *id = build_package_reference(type, package, version, arch);
                         fprintf(c->m.f, " from %s", strnull(id));
                 }
-
-                if (build_id && !(package && version))
-                        fprintf(c->m.f, ", build-id=%s", build_id);
         }
+
+        /* The build-id is a per-module property (there's exactly one), so it's kept separately from the
+         * package notes; read it from the build-id object rather than from a note. */
+        const char *build_id = sd_json_variant_string(sd_json_variant_by_key(id_json, "buildId"));
+        if (build_id && !(package && version))
+                fprintf(c->m.f, ", build-id=%s", build_id);
 
         fputs("\n", c->m.f);
 }
@@ -410,7 +414,7 @@ static int parse_metadata(const char *name, sd_json_variant *id_json, Elf *elf, 
                      note_offset < data->d_size &&
                      (note_offset = sym_gelf_getnote(data, note_offset, &note_header, &name_offset, &desc_offset)) > 0;) {
 
-                        _cleanup_(sd_json_variant_unrefp) sd_json_variant *v = NULL, *w = NULL;
+                        _cleanup_(sd_json_variant_unrefp) sd_json_variant *v = NULL;
                         const char *payload = (const char *)data->d_buf + desc_offset;
 
                         if (note_header.n_namesz == 0 || note_header.n_descsz == 0)
@@ -441,28 +445,49 @@ static int parse_metadata(const char *name, sd_json_variant *id_json, Elf *elf, 
                         }
 
                         if (note_header.n_type == ELF_PACKAGE_METADATA_ID) {
-                                /* If we have a build-id, merge it in the same JSON object so that it appears all
-                                 * nicely together in the logs/metadata. */
-                                if (id_json) {
-                                        r = sd_json_variant_merge_object(&v, id_json);
-                                        if (r < 0)
-                                                return log_error_errno(r, "sd_json_variant_merge of package meta with buildId failed: %m");
-                                }
-
                                 /* Pretty-print to the buffer, so that the metadata goes as plaintext in the
                                  * journal. */
-                                report_module_metadata(c, name, v);
+                                report_module_metadata(c, name, v, id_json);
 
-                                /* Then we build a new object using the module name as the key, and merge it
-                                 * with the previous parses, so that in the end it all fits together in a single
-                                 * JSON blob. */
-                                r = sd_json_buildo(&w, SD_JSON_BUILD_PAIR_VARIANT(name, v));
-                                if (r < 0)
-                                        return log_error_errno(r, "Failed to build JSON object: %m");
+                                /* An ELF object (or a module within a core file) may carry more than one
+                                 * .note.package note, e.g. when statically linked or vendored dependencies each
+                                 * embed their own metadata. We don't stop at the first note anymore, but keep
+                                 * scanning all program headers so that no note is lost. */
+                                sd_json_variant *module = sd_json_variant_by_key(*c->package_metadata, name);
+                                if (!module) {
+                                        /* The first note describes the module's "main" package. For backwards
+                                         * compatibility it is stored flat in the module object, together with
+                                         * the module's build-id, exactly as a single note has always been. */
+                                        if (id_json) {
+                                                r = sd_json_variant_merge_object(&v, id_json);
+                                                if (r < 0)
+                                                        return log_error_errno(r, "Failed to merge build-id into package metadata: %m");
+                                        }
 
-                                r = sd_json_variant_merge_object(c->package_metadata, w);
-                                if (r < 0)
-                                        return log_error_errno(r, "sd_json_variant_merge of package meta with buildId failed: %m");
+                                        r = sd_json_variant_set_field(c->package_metadata, name, v);
+                                        if (r < 0)
+                                                return log_error_errno(r, "Failed to add package metadata to JSON object: %m");
+                                } else {
+                                        /* Any further notes describe additional packages contained in the same
+                                         * module. Append them to the module's "contains" array, without
+                                         * duplicating the module-level build-id into them. The "contains" name
+                                         * is borrowed from the SPDX CONTAINS relationship type. */
+                                        _cleanup_(sd_json_variant_unrefp) sd_json_variant *contains =
+                                                sd_json_variant_ref(sd_json_variant_by_key(module, "contains"));
+
+                                        r = sd_json_variant_append_array(&contains, v);
+                                        if (r < 0)
+                                                return log_error_errno(r, "Failed to append package metadata to contains array: %m");
+
+                                        _cleanup_(sd_json_variant_unrefp) sd_json_variant *w = sd_json_variant_ref(module);
+                                        r = sd_json_variant_set_field(&w, "contains", contains);
+                                        if (r < 0)
+                                                return log_error_errno(r, "Failed to build module metadata object: %m");
+
+                                        r = sd_json_variant_set_field(c->package_metadata, name, w);
+                                        if (r < 0)
+                                                return log_error_errno(r, "Failed to update package metadata object: %m");
+                                }
 
                                 package_metadata_found = true;
                         } else if (c->dlopen_metadata) {
@@ -479,13 +504,6 @@ static int parse_metadata(const char *name, sd_json_variant *id_json, Elf *elf, 
                         r = set_put_strdup(c->modules, name);
                         if (r < 0)
                                 return log_error_errno(r, "set_put_strdup failed: %m");
-
-                        if (!c->dlopen_metadata) {
-                                if (ret_interpreter_found)
-                                        *ret_interpreter_found = interpreter_found;
-
-                                return 1;
-                        }
                 }
         }
 
@@ -577,7 +595,7 @@ static int module_callback(Dwfl_Module *mod, void **userdata, const char *name, 
         if (r < 0) {
                 log_warning("Could not parse number of program headers from core file: %s",
                             sym_elf_errmsg(-1)); /* -1 retrieves the most recent error */
-                report_module_metadata(c, name, id_json);
+                report_module_metadata(c, name, /* metadata= */ NULL, id_json);
 
                 return DWARF_CB_OK;
         }

--- a/test/meson.build
+++ b/test/meson.build
@@ -109,6 +109,17 @@ endif
 if install_tests
         install_data(test_compare_versions_sh,
                      install_dir : unittestsdir)
+
+        # A shared library carrying two .note.package (FDO_PACKAGING_METADATA) notes, used by
+        # TEST-65-ANALYZE to exercise "systemd-analyze inspect-elf". Built as a shared object (not an
+        # executable) so that no C runtime startup objects are linked in: some distributions ship those with
+        # their own .note.package note (e.g. Ubuntu's crt1.o/Scrt1.o), which would otherwise shadow ours.
+        shared_library(
+                'test-inspect-elf-helper',
+                'test-inspect-elf-helper.c',
+                name_prefix : '',
+                install : true,
+                install_dir : testdata_dir)
 endif
 
 ############################################################

--- a/test/meson.build
+++ b/test/meson.build
@@ -110,13 +110,22 @@ if install_tests
         install_data(test_compare_versions_sh,
                      install_dir : unittestsdir)
 
-        # A shared library carrying two .note.package (FDO_PACKAGING_METADATA) notes, used by
-        # TEST-65-ANALYZE to exercise "systemd-analyze inspect-elf". Built as a shared object (not an
-        # executable) so that no C runtime startup objects are linked in: some distributions ship those with
-        # their own .note.package note (e.g. Ubuntu's crt1.o/Scrt1.o), which would otherwise shadow ours.
+        # Shared libraries carrying .note.package (FDO_PACKAGING_METADATA) notes, used by TEST-65-ANALYZE to
+        # exercise "systemd-analyze inspect-elf". Built as shared objects (not executables) so that no C
+        # runtime startup objects are linked in: some distributions ship those with their own .note.package
+        # note (e.g. Ubuntu's crt1.o/Scrt1.o), which would otherwise shadow ours. Two variants are built: one
+        # with a single note (backwards-compatible flat output) and one that adds a second note (reported
+        # under the "contains" array).
         shared_library(
                 'test-inspect-elf-helper',
                 'test-inspect-elf-helper.c',
+                name_prefix : '',
+                install : true,
+                install_dir : testdata_dir)
+        shared_library(
+                'test-inspect-elf-helper-contains',
+                'test-inspect-elf-helper.c',
+                c_args : '-DTEST_INSPECT_ELF_CONTAINS',
                 name_prefix : '',
                 install : true,
                 install_dir : testdata_dir)

--- a/test/test-inspect-elf-helper.c
+++ b/test/test-inspect-elf-helper.c
@@ -1,0 +1,44 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+/* Test fixture for "systemd-analyze inspect-elf". This translation unit is built into a shared library
+ * (test-inspect-elf-helper.so) rather than an executable on purpose: shared objects do not pull in the C
+ * runtime startup objects (crt1.o/Scrt1.o), some of which ship their own .note.package note on certain
+ * distributions (e.g. Ubuntu's glibc). Building a .so therefore leaves the binary with exactly the two
+ * FDO_PACKAGING_METADATA notes embedded below and nothing else, which keeps the test output deterministic
+ * across build hosts.
+ *
+ * The note layout (owner "FDO", type NT_FDO_PACKAGING_METADATA == 0xcafe1a7e, description = JSON) follows
+ * https://uapi-group.org/specifications/specs/package_metadata_for_executable_files/ and is written by hand
+ * as a plain struct so that no special assembler or linker support is required. Two stanzas are embedded to
+ * model a binary that carries metadata for both the application and a vendored dependency; note that
+ * inspect-elf reports the first note found for a plain ELF object, so assertions should target the first
+ * (systemd) stanza. */
+
+#if defined(__ELF__)
+
+/* Emit one .note.package note carrying the given JSON payload. Each note is a separately-aligned variable so
+ * that consecutive notes stay 4-byte aligned as the ELF note format requires. The "used"/"retain" attributes
+ * keep the note even when the linker runs with --gc-sections (retain needs binutils >= 2.36). */
+#define PACKAGE_METADATA_NOTE(varname, json)                                    \
+        __attribute__((used, retain, section(".note.package"), aligned(4)))     \
+        static const struct {                                                   \
+                unsigned int namesz;                                            \
+                unsigned int descsz;                                            \
+                unsigned int type;                                              \
+                char name[4];                                                   \
+                char desc[sizeof(json)];                                        \
+        } varname = {                                                           \
+                sizeof("FDO"),                                                  \
+                sizeof(json),                                                   \
+                0xcafe1a7e,                                                     \
+                "FDO",                                                          \
+                json,                                                           \
+        }
+
+PACKAGE_METADATA_NOTE(package_note_systemd,
+        "{\"type\":\"test-type\",\"os\":\"test-os\",\"name\":\"test-systemd\"}");
+
+PACKAGE_METADATA_NOTE(package_note_glibc,
+        "{\"type\":\"test-type\",\"os\":\"test-os\",\"name\":\"test-glibc\"}");
+
+#endif

--- a/test/test-inspect-elf-helper.c
+++ b/test/test-inspect-elf-helper.c
@@ -1,18 +1,19 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
-/* Test fixture for "systemd-analyze inspect-elf". This translation unit is built into a shared library
- * (test-inspect-elf-helper.so) rather than an executable on purpose: shared objects do not pull in the C
- * runtime startup objects (crt1.o/Scrt1.o), some of which ship their own .note.package note on certain
- * distributions (e.g. Ubuntu's glibc). Building a .so therefore leaves the binary with exactly the two
- * FDO_PACKAGING_METADATA notes embedded below and nothing else, which keeps the test output deterministic
- * across build hosts.
+/* Test fixture for "systemd-analyze inspect-elf". This translation unit is built into shared libraries
+ * rather than executables on purpose: shared objects do not pull in the C runtime startup objects
+ * (crt1.o/Scrt1.o), some of which ship their own .note.package note on certain distributions (e.g. Ubuntu's
+ * glibc). Building a .so therefore leaves the binary with exactly the FDO_PACKAGING_METADATA notes embedded
+ * below and nothing else, which keeps the test output deterministic across build hosts.
  *
  * The note layout (owner "FDO", type NT_FDO_PACKAGING_METADATA == 0xcafe1a7e, description = JSON) follows
  * https://uapi-group.org/specifications/specs/package_metadata_for_executable_files/ and is written by hand
- * as a plain struct so that no special assembler or linker support is required. Two stanzas are embedded to
- * model a binary that carries metadata for both the application and a vendored dependency; note that
- * inspect-elf reports the first note found for a plain ELF object, so assertions should target the first
- * (systemd) stanza. */
+ * as a plain struct so that no special assembler or linker support is required.
+ *
+ * Two variants are built from this file (see test/meson.build):
+ *   - the default carries a single note, exercising the backwards-compatible flat JSON output;
+ *   - when TEST_INSPECT_ELF_CONTAINS is defined a second note is added, modelling a binary that also bundles
+ *     a vendored dependency, exercising inspect-elf's reporting of additional packages under "contains". */
 
 #if defined(__ELF__)
 
@@ -38,7 +39,9 @@
 PACKAGE_METADATA_NOTE(package_note_systemd,
         "{\"type\":\"test-type\",\"os\":\"test-os\",\"name\":\"test-systemd\"}");
 
+#if defined(TEST_INSPECT_ELF_CONTAINS)
 PACKAGE_METADATA_NOTE(package_note_glibc,
         "{\"type\":\"test-type\",\"os\":\"test-os\",\"name\":\"test-glibc\"}");
+#endif
 
 #endif

--- a/test/units/TEST-65-ANALYZE.sh
+++ b/test/units/TEST-65-ANALYZE.sh
@@ -1013,6 +1013,21 @@ if systemd-analyze --version | grep -F "+ELFUTILS" >/dev/null; then
     systemd-analyze inspect-elf /lib/systemd/systemd
     systemd-analyze inspect-elf --json=short /lib/systemd/systemd | grep -F '"elfType":"executable"' >/dev/null
 
+    # Inspect a purpose-built helper carrying an FDO_PACKAGING_METADATA (.note.package) note. It is shipped
+    # as a shared library so that no C runtime startup objects are linked in: on some distributions those
+    # carry their own .note.package note that would otherwise be reported instead of ours. inspect-elf reports
+    # the first note found, so we assert on the first (systemd) stanza embedded in the helper.
+    elf_helper="/usr/lib/systemd/tests/testdata/test-inspect-elf-helper.so"
+    systemd-analyze inspect-elf "$elf_helper"
+    elf_json="$(systemd-analyze inspect-elf --json=short "$elf_helper")"
+    assert_eq "$(echo "$elf_json" | jq -r '.elfType')" 'library'
+    # The package metadata is keyed by the module path, so pick the sole object-valued entry.
+    elf_pkg="$(echo "$elf_json" | jq '[to_entries[] | select(.value | type == "object")][0].value')"
+    assert_eq "$(echo "$elf_pkg" | jq -r '.type')" 'test-type'
+    assert_eq "$(echo "$elf_pkg" | jq -r '.os')" 'test-os'
+    assert_eq "$(echo "$elf_pkg" | jq -r '.name')" 'test-systemd'
+    assert_eq "$(echo "$elf_pkg" | jq -r '.buildId | type')" 'string'
+
     # For some unknown reason the .note.dlopen sections are removed when building with sanitizers, so only
     # run this test if we're not running under sanitizers.
     # Also the linker removes them on CentOS 9 as binutils < 2.36 does not support the SHF_GNU_RETAIN flag

--- a/test/units/TEST-65-ANALYZE.sh
+++ b/test/units/TEST-65-ANALYZE.sh
@@ -1013,20 +1013,37 @@ if systemd-analyze --version | grep -F "+ELFUTILS" >/dev/null; then
     systemd-analyze inspect-elf /lib/systemd/systemd
     systemd-analyze inspect-elf --json=short /lib/systemd/systemd | grep -F '"elfType":"executable"' >/dev/null
 
-    # Inspect a purpose-built helper carrying an FDO_PACKAGING_METADATA (.note.package) note. It is shipped
-    # as a shared library so that no C runtime startup objects are linked in: on some distributions those
-    # carry their own .note.package note that would otherwise be reported instead of ours. inspect-elf reports
-    # the first note found, so we assert on the first (systemd) stanza embedded in the helper.
+    # Inspect purpose-built helpers carrying FDO_PACKAGING_METADATA (.note.package) notes. They are shipped as
+    # shared libraries so that no C runtime startup objects are linked in: on some distributions those carry
+    # their own .note.package note that would otherwise show up too.
+
+    # 1) A single note: the metadata must be reported flat on the module object (next to the build-id), with
+    #    no "contains" key, i.e. byte-identical to the historical format.
     elf_helper="/usr/lib/systemd/tests/testdata/test-inspect-elf-helper.so"
     systemd-analyze inspect-elf "$elf_helper"
     elf_json="$(systemd-analyze inspect-elf --json=short "$elf_helper")"
     assert_eq "$(echo "$elf_json" | jq -r '.elfType')" 'library'
-    # The package metadata is keyed by the module path, so pick the sole object-valued entry.
-    elf_pkg="$(echo "$elf_json" | jq '[to_entries[] | select(.value | type == "object")][0].value')"
-    assert_eq "$(echo "$elf_pkg" | jq -r '.type')" 'test-type'
-    assert_eq "$(echo "$elf_pkg" | jq -r '.os')" 'test-os'
-    assert_eq "$(echo "$elf_pkg" | jq -r '.name')" 'test-systemd'
-    assert_eq "$(echo "$elf_pkg" | jq -r '.buildId | type')" 'string'
+    elf_mod="$(echo "$elf_json" | jq '[to_entries[] | select(.value | type == "object")][0].value')"
+    assert_eq "$(echo "$elf_mod" | jq -r '.type')" 'test-type'
+    assert_eq "$(echo "$elf_mod" | jq -r '.os')" 'test-os'
+    assert_eq "$(echo "$elf_mod" | jq -r '.name')" 'test-systemd'
+    assert_eq "$(echo "$elf_mod" | jq -r '.buildId | type')" 'string'
+    # No "contains" key when there is only a single note (backwards compatibility).
+    assert_eq "$(echo "$elf_mod" | jq 'has("contains")')" 'false'
+
+    # 2) A main note plus an additional one: the main package stays flat on the module object exactly as
+    #    above, and the additional package is reported under "contains" (without a duplicated build-id).
+    elf_helper="/usr/lib/systemd/tests/testdata/test-inspect-elf-helper-contains.so"
+    systemd-analyze inspect-elf "$elf_helper"
+    elf_json="$(systemd-analyze inspect-elf --json=short "$elf_helper")"
+    elf_mod="$(echo "$elf_json" | jq '[to_entries[] | select(.value | type == "object")][0].value')"
+    # Main package unchanged from the single-note case.
+    assert_eq "$(echo "$elf_mod" | jq -r '.name')" 'test-systemd'
+    assert_eq "$(echo "$elf_mod" | jq -r '.buildId | type')" 'string'
+    # Additional package reported under "contains".
+    assert_eq "$(echo "$elf_mod" | jq '.contains | length')" '1'
+    assert_eq "$(echo "$elf_mod" | jq -r '.contains[0].name')" 'test-glibc'
+    assert_eq "$(echo "$elf_mod" | jq '.contains[0] | (.type == "test-type" and .os == "test-os" and (has("buildId") | not))')" 'true'
 
     # For some unknown reason the .note.dlopen sections are removed when building with sanitizers, so only
     # run this test if we're not running under sanitizers.


### PR DESCRIPTION
Related:
- https://github.com/uapi-group/specifications/pull/222

- **test: exercise systemd-analyze inspect-elf against FDO package metadata**
  TEST-65-ANALYZE only ran inspect-elf against the installed systemd
  binary, checking little beyond that the command succeeds and reports
  elfType. Add a purpose-built fixture carrying FDO_PACKAGING_METADATA
  (.note.package) notes so we can assert on the parsed package metadata.
  
  The fixture is built as a shared library rather than an executable on
  purpose: on some distributions the C runtime startup objects
  (crt1.o/Scrt1.o) ship their own .note.package note, which would be
  reported instead of ours. Shared objects do not link those startup
  objects, so the library carries exactly the notes we embed and the test
  output stays deterministic across build hosts. inspect-elf reports the
  first note found for a plain ELF object, so the assertions target the
  first stanza.
  

- **analyze,coredump: parse and report additional .note.package notes**

  An ELF object (or a module within a core file) may legitimately carry
more than one FDO_PACKAGING_METADATA (.note.package) note, for example
when statically linked or vendored dependencies each embed their own
packaging metadata. Until now parse_metadata() stopped at the first note
found for a given module and only ever reported that one, silently
dropping the rest.

  Keep scanning all program headers and report every note, while staying
strictly backwards compatible: the first note is treated as the module's
"main" package and its fields are stored flat on the module object next
to the build-id, exactly as a single note has always been. Any further
notes are appended to a "contains" array on the same module object:

```
  "<module>" : {
      "type" : "…", "name" : "…", "version" : "…",   # main package (as before)
      "buildId" : "…",
      "contains" : [ { … }, … ]                       # additional packages
  }
```

  The "contains" key is only present when there is more than one note, so
single-note and build-id-only output is byte-identical to before and
existing consumers (module.name/version/buildId) keep working unchanged.
As a side effect scanning all headers also makes PT_INTERP detection
reliable even when it follows the note segment.

  inspect-elf prints the additional packages as extra paragraphs in the
table output and includes the "contains" array in the JSON output. The
coredump consumers are unaffected as they only read the main package's
fields and the build-id.

  Build the inspect-elf test fixture in two variants and assert both
cases: a single-note object still produces the flat, historical JSON
with no "contains" key, and a two-note object reports the main package
flat plus the additional one under "contains" (without a duplicated
build-id). Document the format.