### PR TITLE
bootctl: Fix prepend when installing systemd-boot for the first time

### DIFF
--- a/src/bootctl/bootctl-install.c
+++ b/src/bootctl/bootctl-install.c
@@ -1339,7 +1339,7 @@ static int insert_into_order(InstallContext *c, uint16_t slot, uint16_t after_sl
         order = t;
 
         /* add us to the top or end of the list */
-        if (c->operation != INSTALL_NEW) {
+        if (c->operation == INSTALL_NEW) {
                 memmove(order + 1, order, n * sizeof(uint16_t));
                 order[0] = slot;
         } else


### PR DESCRIPTION
In commit 38433a6d06ef ("bootctl: rework bootctl-install.c in preparation of varlinkification"), the `first` argument of install_boot_option() was reworked to use the new InstallContext struct/InstallOperation. `first` was intended to indicate if we were on the install path, so the check should be == INSTALL_NEW, not != INSTALL_NEW.

Fixes: 38433a6d06ef ("bootctl: rework bootctl-install.c in preparation of varlinkification")