### PR TITLE
ukify.py doesn't honor --tools option when using systemd-keyutil

### DIFF
--- a/src/ukify/ukify.py
+++ b/src/ukify/ukify.py
@@ -1374,7 +1374,7 @@ def make_uki(opts: UkifyConfig) -> None:
 
     pcrpkey: Union[bytes, Path, None] = opts.pcrpkey
     if pcrpkey is None:
-        keyutil_tool = find_tool('systemd-keyutil', '/usr/lib/systemd/systemd-keyutil')
+        keyutil_tool = find_tool('systemd-keyutil', '/usr/lib/systemd/systemd-keyutil', opts=opts)
         cmd = [keyutil_tool, 'extract-public']
 
         if opts.pcr_public_keys and len(opts.pcr_public_keys) == 1:


### PR DESCRIPTION
### Problem
`ukify build` has a `--tools` option that lets users specify directories where helper binaries are searched for. This worked for all tools except `systemd-keyutil` — when extracting a PCR public key from a private key, `find_tool()` was called without `opts=opts`, so it ignored `--tools` and fell through to the hardcoded fallback path.

This issue appeared when I built `systemd` in a different build root, and when asking `ukify.py` to read the PCR segment of a UKI image, the python script failed to find the built `systemd-keyutil` in the custom root dir.

### Root Cause
In `make_uki()`, the `find_tool()` call for `systemd-keyutil` was missing the `opts=` parameter:

```python
# Before (broken) ukify.py L1377
keyutil_tool = find_tool('systemd-keyutil', '/usr/lib/systemd/systemd-keyutil')

# After (fixed) ukify.py L1377
keyutil_tool = find_tool('systemd-keyutil', '/usr/lib/systemd/systemd-keyutil', opts=opts)
```

All other tools in the same function already pass `opts=opts` — e.g. `systemd-measure` at line 774:

```python
measure_tool = find_tool(
    'systemd-measure',
    '/usr/lib/systemd/systemd-measure',
    opts=opts,
)
```

So I am highly confident this is most likely a careless typo in the code.

### Fix
Add `opts=opts` to the `find_tool()` call in `src/ukify/ukify.py:1377`.
