### PR TITLE
journal-remote: do not create /var/log/journal/remote

### DIFF
--- a/mkosi/mkosi.pkgenv/mkosi.conf.d/arch.conf
+++ b/mkosi/mkosi.pkgenv/mkosi.conf.d/arch.conf
@@ -7,5 +7,5 @@ Distribution=arch
 Environment=
         GIT_URL=https://gitlab.archlinux.org/archlinux/packaging/packages/systemd.git
         GIT_BRANCH=main
-        GIT_COMMIT=15cb472aeb4d93d7fae9c7b7bc2cd6723bc8ec85
+        GIT_COMMIT=f884cb080300eeb273fb7549fd0aa19bb6142c21
         PKG_SUBDIR=arch

--- a/src/journal-remote/meson.build
+++ b/src/journal-remote/meson.build
@@ -95,9 +95,4 @@ endforeach
 if conf.get('ENABLE_REMOTE') == 1 and conf.get('HAVE_MICROHTTPD') == 1
         install_data('browse.html',
                      install_dir : pkgdatadir / 'gatewayd')
-
-        if get_option('create-log-dirs')
-                install_emptydir('/var/log/journal/remote',
-                                 install_mode : 'rwxr-xr-x')
-        endif
 endif


### PR DESCRIPTION
This handling with tmpfiles was dropped in
29444df23bea21c15a3284ad8acfe2f008e5dbae. So let's stop the build system to create that directory. Actually it is create by the service just fine, including correct access mode.