### PR TITLE
tmpfiles: add hardening in glob_item_recursively

### DIFF
--- a/src/tmpfiles/tmpfiles.c
+++ b/src/tmpfiles/tmpfiles.c
@@ -2897,10 +2897,9 @@ static int glob_item_recursively(
                 /* Make sure we won't trigger/follow file object (such as device nodes, automounts, ...)
                  * pointed out by 'fn' with O_PATH. Note, when O_PATH is used, flags other than
                  * O_CLOEXEC, O_DIRECTORY, and O_NOFOLLOW are ignored. */
-
-                fd = open(*fn, O_CLOEXEC|O_NOFOLLOW|O_PATH);
+                fd = path_open_safe(*fn);
                 if (fd < 0) {
-                        RET_GATHER(r, log_error_errno(errno, "Failed to open '%s': %m", *fn));
+                        RET_GATHER(r, fd);
                         continue;
                 }
 


### PR DESCRIPTION
Hardening for https://github.com/systemd/systemd-bugs/blob/main/findings/glob_item_recursively_chase_safe_bypass/FINDING.md

This detects a TOCTOU vulnerability when glob_item_recursively() re-opens each glob-expanded path with a bare open(O_NOFOLLOW), which only guards the final component. A local attacker owning an intermediate directory can swap it for a symlink between safe_glob_full()'s string-vector return and the open() call, redirecting the resulting fd to an arbitrary inode. RECURSIVE_* item types are affected (chmod, chown, SELinux relabel, xattr, etc).
Replace the bare open() with path_open_safe(), which calls chase(CHASE_SAFE|CHASE_WARN|CHASE_NOFOLLOW) and rejects any path traversal where a non-root-owned component leads to a different-UID target.