### PR TITLE
nspawn-oci: match the spec-correct "swappiness" memory field key

### DIFF
--- a/src/nspawn/nspawn-oci.c
+++ b/src/nspawn/nspawn-oci.c
@@ -56,7 +56,6 @@
  * /bin/mount regarding NFS and FUSE required?
  * what does terminal=false mean?
  * sysctl inside or outside? allow-listing?
- * swapiness typo -> swappiness
  *
  * Unsupported:
  *
@@ -1124,7 +1123,8 @@ static int oci_cgroup_memory(const char *name, sd_json_variant *v, sd_json_dispa
                 { "swap",             SD_JSON_VARIANT_NUMBER,  oci_cgroup_memory_limit, offsetof(struct memory_data, swap),        0                  },
                 { "kernel",           SD_JSON_VARIANT_NUMBER,  oci_unsupported,         0,                                         SD_JSON_PERMISSIVE },
                 { "kernelTCP",        SD_JSON_VARIANT_NUMBER,  oci_unsupported,         0,                                         SD_JSON_PERMISSIVE },
-                { "swapiness",        SD_JSON_VARIANT_NUMBER,  oci_unsupported,         0,                                         SD_JSON_PERMISSIVE },
+                { "swapiness",        SD_JSON_VARIANT_NUMBER,  oci_unsupported,         0,                                         SD_JSON_PERMISSIVE }, /* compat name, misspelt */
+                { "swappiness",       SD_JSON_VARIANT_NUMBER,  oci_unsupported,         0,                                         SD_JSON_PERMISSIVE }, /* spec-correct name */
                 { "disableOOMKiller", SD_JSON_VARIANT_BOOLEAN, oci_unsupported,         0,                                         SD_JSON_PERMISSIVE },
                 {}
         };


### PR DESCRIPTION
The OCI runtime specification names the memory swappiness knob 'swappiness' (memory.swappiness), but the dispatch table in oci_cgroup_memory() registered it as 'swapiness'.

Since sd_json_dispatch_full() matches object keys by exact string comparison, a spec-correct config carrying 'swappiness' never hit the intended oci_unsupported() handler and was instead routed to the bad-field callback oci_unexpected(), which returns -EINVAL and fails the whole memory cgroup section.

Register the correctly key so real OCI bundles parse, and drop the now-resolved reminder from the file header TODO list.