### PR TITLE
sd-dhcp-relay: fix off-by-one when discarding BOOTREQUEST messages by  hops count

### DIFF
--- a/src/libsystemd-network/dhcp-relay-downstream.c
+++ b/src/libsystemd-network/dhcp-relay-downstream.c
@@ -303,7 +303,7 @@ int downstream_process_message(
 
         /* RFC 1542 section 4.1.1:
          * The relay agent MUST silently discard BOOTREQUEST messages whose 'hops' field exceeds the value 16. */
-        if (message->header.hops >= 16)
+        if (message->header.hops > 16)
                 return 0;
         message->header.hops++;
 

--- a/src/libsystemd-network/test-dhcp-relay.c
+++ b/src/libsystemd-network/test-dhcp-relay.c
@@ -314,7 +314,7 @@ TEST(forwarding) {
 
         /* Invalid message (too large hops). */
         ASSERT_OK(dhcp_message_append_option_u8(m, SD_DHCP_OPTION_MESSAGE_TYPE, 101));
-        m->header.hops = 16;
+        m->header.hops = 17;
         send_message(downstream_fd[1], m);
         dhcp_message_remove_option(m, SD_DHCP_OPTION_MESSAGE_TYPE);
         m->header.hops = 0;


### PR DESCRIPTION
According to RFC specifications
```
RFC 1542 section 4.1.1 states:
The relay agent MUST silently discard BOOTREQUEST messages whose 'hops'
   field exceeds the value 16."
```

"Exceeds the value 16" means hops > 16, i.e. a message that arrives with hops == 16 is still valid and must be relayed (after which its hops field becomes 17). The code used ">= 16", which silently dropped a valid message that had legitimately traversed exactly 16 relay agents, one hop too early.

This matches the wording of the adjacent comment, which already says "exceeds the value 16".