### PR TITLE
sd-dhcp-relay: reject option changes while running

### DIFF
--- a/src/libsystemd-network/sd-dhcp-relay.c
+++ b/src/libsystemd-network/sd-dhcp-relay.c
@@ -119,12 +119,14 @@ int sd_dhcp_relay_set_server_port(sd_dhcp_relay *relay, uint16_t port) {
 
 int sd_dhcp_relay_set_remote_id(sd_dhcp_relay *relay, const struct iovec *iov) {
         assert_return(relay, -EINVAL);
+        assert_return(!sd_dhcp_relay_is_running(relay), -EBUSY);
 
         return iovec_done_and_memdup(&relay->remote_id, iov);
 }
 
 int sd_dhcp_relay_set_server_identifier_override(sd_dhcp_relay *relay, int b) {
         assert_return(relay, -EINVAL);
+        assert_return(!sd_dhcp_relay_is_running(relay), -EBUSY);
 
         relay->server_identifier_override = !!b;
         return 0;
@@ -132,6 +134,7 @@ int sd_dhcp_relay_set_server_identifier_override(sd_dhcp_relay *relay, int b) {
 
 int dhcp_relay_set_extra_options(sd_dhcp_relay *relay, TLV *options) {
         assert(relay);
+        assert(!sd_dhcp_relay_is_running(relay));
 
         return unref_and_replace_new_ref(relay->extra_options, options, tlv_ref, tlv_unref);
 }

--- a/src/libsystemd-network/test-dhcp-relay.c
+++ b/src/libsystemd-network/test-dhcp-relay.c
@@ -281,6 +281,9 @@ TEST(forwarding) {
         downstream->socket_fd = TAKE_FD(downstream_fd[0]);
         ASSERT_OK(sd_dhcp_relay_interface_start(downstream));
 
+        ASSERT_RETURN_EXPECTED(ASSERT_ERROR(sd_dhcp_relay_set_remote_id(relay, &IOVEC_MAKE_STRING("changed")), EBUSY));
+        ASSERT_RETURN_EXPECTED(ASSERT_ERROR(sd_dhcp_relay_set_server_identifier_override(relay, false), EBUSY));
+
         /* IO event source for the client side. */
         _cleanup_(sd_event_source_unrefp) sd_event_source *fake_client = NULL;
         ASSERT_OK(sd_event_add_io(e, &fake_client, downstream_fd[1], EPOLLIN, fake_client_handler, relay));


### PR DESCRIPTION
If the original support for hot modification does not require tightening, please let me know.