### PR TITLE
tree-wide: fix some double word errors like "the the"

### DIFF
--- a/man/homectl.xml
+++ b/man/homectl.xml
@@ -239,7 +239,7 @@
 
         <listitem><para>Takes a boolean argument. By default the interactive user creation via
         <command>firstboot --prompt-new-user</command> screen will show reverse color "chrome" bars at the
-        top and and the bottom of the terminal screen, which may be disabled by setting this option to
+        top and the bottom of the terminal screen, which may be disabled by setting this option to
         false.</para>
 
         <xi:include href="version-info.xml" xpointer="v259"/></listitem>

--- a/man/kernel-command-line.xml
+++ b/man/kernel-command-line.xml
@@ -833,7 +833,7 @@
       <varlistentry>
         <term><varname>systemd.factory_reset=</varname></term>
 
-        <listitem><para>Controls whether to to boot into factory reset mode, implemented by
+        <listitem><para>Controls whether to boot into factory reset mode, implemented by
         <citerefentry><refentrytitle>systemd-factory-reset-generator</refentrytitle><manvolnum>8</manvolnum></citerefentry>,
         <citerefentry><refentrytitle>systemd-repart</refentrytitle><manvolnum>8</manvolnum></citerefentry>,
         and other tools.</para>

--- a/man/systemd-firstboot.xml
+++ b/man/systemd-firstboot.xml
@@ -382,7 +382,7 @@
         <term><option>--chrome=</option></term>
 
         <listitem><para>Takes a boolean argument. By default the initial setup screen will show reverse color
-        "chrome" bars at the top and and the bottom of the terminal screen, which may be disabled by setting
+        "chrome" bars at the top and the bottom of the terminal screen, which may be disabled by setting
         this option to false.</para>
 
         <xi:include href="version-info.xml" xpointer="v259"/></listitem>

--- a/man/systemd-fstab-generator.xml
+++ b/man/systemd-fstab-generator.xml
@@ -149,7 +149,7 @@
 
         <listitem><para>Takes the <filename>/usr/</filename> filesystem to be mounted by the initrd. If
         <varname>mount.usrfstype=</varname> or <varname>mount.usrflags=</varname> is set, then the mount
-        configured via <varname>mount.usr=</varname> will default to the the same value set in
+        configured via <varname>mount.usr=</varname> will default to the same value set in
         <varname>root=</varname>.</para>
 
         <para>Set to <literal>dissect</literal> to explicitly request automatic <filename>/usr/</filename>

--- a/man/systemd-network-generator.service.xml
+++ b/man/systemd-network-generator.service.xml
@@ -108,7 +108,7 @@
           as a special placeholder rather than a real interface name. Then, in combination with the MAC address provided
           by <varname>BOOTIF=</varname>, this is translated into a
           <citerefentry><refentrytitle>systemd.network</refentrytitle><manvolnum>5</manvolnum></citerefentry> file
-          which matches on the the provided MAC address. When <varname>rd.bootif=0</varname> is passed, this functionality
+          which matches on the provided MAC address. When <varname>rd.bootif=0</varname> is passed, this functionality
           is disabled, and the <varname>BOOTIF=</varname> option is ignored.</para>
 
           <para>See <citerefentry project='man-pages'><refentrytitle>dracut.cmdline</refentrytitle><manvolnum>7</manvolnum></citerefentry>

--- a/man/systemd.netdev.xml
+++ b/man/systemd.netdev.xml
@@ -1060,7 +1060,7 @@ Ports=eth2</programlisting>
           <literal>prp</literal>. Defaults to <literal>hsr</literal>.</para>
 
           <para>Both protocols work by sending two copies of every outgoing frame, one for each of the two
-          ports. The destination node receives the two frames and and keeps only the first one. If a link
+          ports. The destination node receives the two frames and keeps only the first one. If a link
           fails, only one of the two frames is received. HSR uses a ring topology where the two outgoing
           frames are sent in opposite directions in the ring. PRP doesn't need a specific topology, but it
           requires two completely redundant networks attached to the two ports.</para>

--- a/man/varlinkctl.xml
+++ b/man/varlinkctl.xml
@@ -424,7 +424,7 @@
           functionality may be used to consume replies that come with associated file descriptors in a
           reasonable way.</para>
 
-          <para>Now that if <option>--exec</option> is specified the the third parameter to
+          <para>Now that if <option>--exec</option> is specified the third parameter to
           <command>call</command> is not optional (i.e. the method call parameters).</para>
 
           <xi:include href="version-info.xml" xpointer="v258"/>

--- a/src/core/namespace.c
+++ b/src/core/namespace.c
@@ -2628,7 +2628,7 @@ int setup_namespace(const NamespaceParameters *p, char **reterr_path) {
                                 root_mount_fd = _root_mount_fd;
                         }
 
-                        /* Try to to clone the directory mount if we have privs to, so that we can apply the
+                        /* Try to clone the directory mount if we have privs to, so that we can apply the
                          * MS_SLAVE propagation settings right-away. */
                         if (root_mount_fd < 0) {
                                 _root_mount_fd = open_tree_attr_with_fallback(

--- a/src/fundamental/uki.h
+++ b/src/fundamental/uki.h
@@ -15,7 +15,7 @@ typedef enum UnifiedSection {
         UNIFIED_SECTION_DTB,
         UNIFIED_SECTION_UNAME,
         UNIFIED_SECTION_SBAT,
-        UNIFIED_SECTION_PCRSIG,   /* This is is not measured actually */
+        UNIFIED_SECTION_PCRSIG,   /* This is not measured actually */
         UNIFIED_SECTION_PCRPKEY,
         UNIFIED_SECTION_PROFILE,
         UNIFIED_SECTION_DTBAUTO,

--- a/src/resolve/resolved-hook.c
+++ b/src/resolve/resolved-hook.c
@@ -23,7 +23,7 @@
  * of resolution requests we keep multiple connections open thus, but not too many. */
 #define HOOK_IDLE_CONNECTIONS_MAX 4U
 
-/* Encapsulates a specific hook, i.e. bound socket in in the /run/systemd/resolve.hook/ directory */
+/* Encapsulates a specific hook, i.e. bound socket in the /run/systemd/resolve.hook/ directory */
 typedef struct Hook {
         unsigned n_ref;
 

--- a/src/shared/mstack.c
+++ b/src/shared/mstack.c
@@ -456,7 +456,7 @@ static int mstack_load_now(MStack *mstack, const char *dir, int dir_fd, MStackFl
         if (dir_fd < 0) {
                 _dir_fd = openat(AT_FDCWD, isempty(dir) ? "." : dir, O_DIRECTORY|O_CLOEXEC);
                 if (_dir_fd < 0)
-                        return log_debug_errno(errno, "Failed to to open '%s': %m", dir);
+                        return log_debug_errno(errno, "Failed to open '%s': %m", dir);
 
                 dir_fd = _dir_fd;
         } else {

--- a/src/shared/varlink-io.systemd.Login.c
+++ b/src/shared/varlink-io.systemd.Login.c
@@ -26,7 +26,7 @@ SD_VARLINK_DEFINE_ENUM_TYPE(
                 SD_VARLINK_DEFINE_ENUM_VALUE(user_early_light),
                 SD_VARLINK_FIELD_COMMENT("Display manager greeter screen used for login"),
                 SD_VARLINK_DEFINE_ENUM_VALUE(greeter),
-                SD_VARLINK_FIELD_COMMENT("Similar, but a a lock screen"),
+                SD_VARLINK_FIELD_COMMENT("Similar, but a lock screen"),
                 SD_VARLINK_DEFINE_ENUM_VALUE(lock_screen),
                 SD_VARLINK_FIELD_COMMENT("Background session (that has no TTY, VT, Seat)"),
                 SD_VARLINK_DEFINE_ENUM_VALUE(background),

--- a/src/shared/varlink-io.systemd.Resolve.Hook.c
+++ b/src/shared/varlink-io.systemd.Resolve.Hook.c
@@ -39,7 +39,7 @@ static SD_VARLINK_DEFINE_METHOD(
                 ResolveRecord,
                 SD_VARLINK_FIELD_COMMENT("The question being looked up, i.e. a combination of resource record keys. Note that unlike DNS "
                                          "queries on the wire these lookups can carry multiple key requests, albeit closely related ones. "
-                                         "Specifically, lookups for A+AAAA for the the same hostname are submitted as one question, as "
+                                         "Specifically, lookups for A+AAAA for the same hostname are submitted as one question, as "
                                          "are lookups for TXT+SRV when doing DNS-SD resolution. Moreover, when looking up resources with "
                                          "non-ASCII characters, they are placed together in a single question, once with labels encoded in "
                                          "UTF-8, and once in IDNA. Hook implementations must be able to deal with these and other similar "

--- a/src/udev/udev-builtin-blkid.c
+++ b/src/udev/udev-builtin-blkid.c
@@ -187,7 +187,7 @@ static int find_gpt_root(UdevEvent *event, blkid_probe pr, const char *loop_back
                          * hence no need to bother with searching for ESP/XBOOTLDR */
                         need_esp_or_xbootldr = false;
                 } else
-                        /* We now know the the ESP/xbootldr UUID, but we cannot be sure yet it's on this block
+                        /* We now know the ESP/xbootldr UUID, but we cannot be sure yet it's on this block
                          * device, hence look for it among partitions now */
                         need_esp_or_xbootldr = true;
         } else {


### PR DESCRIPTION
By chance (because I had this mistake in my own commit) I noticed that there are a bunch of duplicated works like "the the" in the code and man-pages.

This commit fixes them and some similar issues with "and and" etc.