### PR TITLE
run: recognize clock change timer properties

### DIFF
--- a/src/run/run.c
+++ b/src/run/run.c
@@ -607,7 +607,9 @@ static int parse_argv(int argc, char *argv[]) {
                                                "OnStartupSec=",
                                                "OnUnitActiveSec=",
                                                "OnUnitInactiveSec=",
-                                               "OnCalendar=");
+                                               "OnCalendar=",
+                                               "OnClockChange=",
+                                               "OnTimezoneChange=");
                         break;
                 }
 


### PR DESCRIPTION
Treat both properties as timer triggers too, matching the shortcut options and the documented equivalent command line.
It seems that these two options were forgotten to be included.