### PR TITLE
udev: require exact builtin command matches

### DIFF
--- a/src/udev/udev-builtin.c
+++ b/src/udev/udev-builtin.c
@@ -105,7 +105,9 @@ UdevBuiltinCommand udev_builtin_lookup(const char *command) {
         command += strspn(command, WHITESPACE);
         n = strcspn(command, WHITESPACE);
         for (UdevBuiltinCommand i = 0; i < _UDEV_BUILTIN_MAX; i++)
-                if (builtins[i] && strneq(builtins[i]->name, command, n))
+                if (builtins[i] &&
+                    strlen(builtins[i]->name) == n &&
+                    strneq(builtins[i]->name, command, n))
                         return i;
 
         return _UDEV_BUILTIN_INVALID;

--- a/test/units/TEST-17-UDEV.sanity-check.sh
+++ b/test/units/TEST-17-UDEV.sanity-check.sh
@@ -177,6 +177,8 @@ udevadm test -h
 
 # Builtins
 (! udevadm test-builtin aaaaa /dev/null)
+(! udevadm test-builtin k /dev/null)
+(! udevadm test-builtin key /dev/null)
 udevadm test-builtin blkid "$loopdev"
 (! udevadm test-builtin "btrfs" "$loopdev")
 (! udevadm test-builtin "btrfs aaaaa" "$loopdev")


### PR DESCRIPTION
Commit 9b917abe025 (udev-builtin: simplify code a bit) seems to have modified the behavior of the original code. A simple fix has been made for this.
Before:
```
$ udevadm test-builtin k /dev/null
null: Running in test mode, skipping execution of 'keyboard' builtin command.
$ echo $?
0
```

After:
```
$ udevadm test-builtin k /dev/null
Unknown command 'k'
$ echo $?
1

Full name still works:

$ udevadm test-builtin keyboard /dev/null
null: Running in test mode, skipping execution of 'keyboard' builtin command.
$ echo $?
0
```