### PR TITLE
modules-load: downgrade kmod to recommends

### DIFF
--- a/src/modules-load/modules-load.c
+++ b/src/modules-load/modules-load.c
@@ -391,7 +391,7 @@ static int run(int argc, char *argv[]) {
         char *module;
         int ret = 0, r;
 
-        LIBKMOD_NOTE(required);
+        LIBKMOD_NOTE(recommended);
 
         char **args = NULL;
         r = parse_argv(argc, argv, &args);


### PR DESCRIPTION
While this binary needs libkmod, it makes little sense to split into a separate package, and in many cases using it to load kernel modules will not be necessarily needed in all setups.
Downgrade from depends to recommends, so that libkmod is pulled in by default, so normal setups have it, but it can also be excluded explicitly when building a minimal image, without requiring a separate package.

Follow-up for 4c0d8d967300fde858f83ec4b361db19e3e257c8