### PR TITLE
creds: allow normal users to use `--with-key=null`

### DIFF
--- a/src/creds/creds.c
+++ b/src/creds/creds.c
@@ -602,7 +602,7 @@ static int verb_encrypt(int argc, char *argv[], uintptr_t _data, void *userdata)
         if (arg_not_after != USEC_INFINITY && arg_not_after < timestamp)
                 return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "Credential is invalidated before it is valid.");
 
-        if (geteuid() != 0) {
+        if (geteuid() != 0 && !sd_id128_equal(arg_with_key, CRED_AES256_GCM_BY_NULL)) {
                 (void) polkit_agent_open_if_enabled(BUS_TRANSPORT_LOCAL, arg_ask_password);
 
                 r = ipc_encrypt_credential(


### PR DESCRIPTION
When encrypting with the `--with-key=null` option systemd-creds
is currently doing the encryption via IPC. This is not needed
for the null key, no privs are required so we can just do the
in-process operation. So instead simply check for the null-key and
if its requested use the in-process path.

---

Doing the equivalent for decrypt is possible but a tiny bit more owrk as we would havae to look at the credential header first, not a lot of work but not free (like the encryption part which is essentially free).