### PR TITLE
ci: check 'update-man-rules' to ensure it is not forgotten

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -87,3 +87,8 @@ jobs:
 
       - name: Run coccinelle checks
         run: mkosi box -- meson test -C build --suite=coccinelle --print-errorlogs --no-stdsplit
+
+      - name: Run man-rules checks
+        run: |
+          mkosi box -- ninja -C build update-man-rules
+          git diff --exit-code -- man/rules/meson.build


### PR DESCRIPTION
We often forget to run this command when updating manpages, and notice only much later. Add a step in the CI to flag it, as we already do for the D-Bus docs.