### PR TITLE
claude-review: downgrade effort from xhigh to high

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -448,7 +448,7 @@ jobs:
 
           claude \
             --model us.anthropic.claude-opus-4-8 \
-            --effort xhigh \
+            --effort high \
             --max-turns 200 \
             --setting-sources user \
             --output-format stream-json \


### PR DESCRIPTION
Claude reviews keep failing due to hitting 60m timeouts, as they take too long. Lower effort from xhigh to high to try and speed them up.