### PR TITLE
hwdb: sensor: Add Odys Windesk X10 accel mount matrix

### DIFF
--- a/hwdb.d/60-sensor.hwdb
+++ b/hwdb.d/60-sensor.hwdb
@@ -838,6 +838,9 @@ sensor:modalias:acpi:KIOX000A:*:dmi:*:svnTMAX:pnTM101W610L:*    # Solo 10 Draw. 
 sensor:modalias:acpi:BOSC0200:*:dmi:bvnINSYDECorp.:bvrODYS.FUSIONWIN12:*    # Fusion Win 12 2in1
  ACCEL_MOUNT_MATRIX=-1, 0, 0; 0, 1, 0; 0, 0, 1
 
+sensor:modalias:acpi:SMO8500:*:dmi:*:svnAXDIAInternationalGmbH:pnWindeskX10:*    # Windesk X10
+ ACCEL_MOUNT_MATRIX=0, -1, 0; -1, 0, 0; 0, 0, 1
+
 #########################################
 # Onda
 #########################################


### PR DESCRIPTION
Add a mount matrix for the accelerometer on the Odys Windesk X10 tablet to fix auto-rotation.