### PR TITLE
sysupdate: detached PKCS#7 signature support

### DIFF
--- a/man/importctl.xml
+++ b/man/importctl.xml
@@ -126,7 +126,25 @@
         signature of <filename>.sha256</filename> or <filename>SHA256SUMS</filename>.  The public key for
         this verification step needs to be available in
         <filename>/usr/lib/systemd/import-pubring.pgp</filename> or
-        <filename>/etc/systemd/import-pubring.pgp</filename>.</para>
+        <filename>/etc/systemd/import-pubring.pgp</filename>.
+        If no GPG signature is available, <option>--verify=signature</option> can also verify the <filename>SHA256SUMS</filename> manifest with a detached PKCS#7 signature
+        <filename>SHA256SUMS.p7s</filename>. The required X.509 certificates are discovered in accordance with the <ulink url="https://uapi-group.org/specifications/specs/file_hierarchy_for_the_verification_of_os_artifacts/">UAPI.11 File Hierarchy for the Verification of OS Artifacts (VOA)</ulink>.
+        Artifact verifier certificates are read from:
+        <simplelist>
+            <member><filename>/etc/voa/$os/image/$context/x509/*-certificate.pem</filename></member>
+            <member><filename>/run/voa/$os/image/$context/x509/*-certificate.pem</filename></member>
+            <member><filename>/usr/local/lib/voa/$os/image/$context/x509/*-certificate.pem</filename></member>
+            <member><filename>/usr/lib/voa/$os/image/$context/x509/*-certificate.pem</filename></member>
+        </simplelist>
+        Trust anchor certificates are read from:
+        <simplelist>
+            <member><filename>/etc/voa/$os/trust-anchor-image/$context/x509/*-certificate.pem</filename></member>
+            <member><filename>/run/voa/$os/trust-anchor-image/$context/x509/*-certificate.pem</filename></member>
+            <member><filename>/usr/local/lib/voa/$os/trust-anchor-image/$context/x509/*-certificate.pem</filename></member>
+            <member><filename>/usr/lib/voa/$os/trust-anchor-image/$context/x509/*-certificate.pem</filename></member>
+        </simplelist>
+        Here <literal>$os</literal> is the <literal>$ID</literal> field from <filename>/etc/os-release</filename> and <literal>$context</literal> is the selected <option>--class=</option>.
+        </para>
 
         <para>If <option>-keep-download=yes</option> is specified the image will be downloaded and stored in
         a read-only subvolume/directory in the image directory that is named after the specified URL and its

--- a/man/sysupdate.d.xml
+++ b/man/sysupdate.d.xml
@@ -169,14 +169,14 @@
       and then written to the target file or partition. This resource type is only available for sources, not
       for targets. The list of available versions of resources of this type is encoded in
       <filename>SHA256SUMS</filename> manifest files, accompanied by
-      <filename>SHA256SUMS.gpg</filename> detached signatures.</para></listitem>
+      <filename>SHA256SUMS.gpg</filename> or <filename>SHA256SUMS.p7s</filename> detached signatures.</para></listitem>
 
       <listitem><para>The <literal>url-tar</literal> resource type is similar, but the file must be a
       <filename>.tar</filename> archive. When an update takes place, the file is decompressed and unpacked
       into a directory or btrfs subvolume. This resource type is only available for sources, not for
       targets. Just like <literal>url-file</literal>, <literal>url-tar</literal> version enumeration makes
       use of <filename>SHA256SUMS</filename> files, authenticated via
-      <filename>SHA256SUMS.gpg</filename>.</para></listitem>
+      <filename>SHA256SUMS.gpg</filename> or <filename>SHA256SUMS.p7s</filename>.</para></listitem>
 
       <listitem><para>The <literal>regular-file</literal> resource type encapsulates a local regular file on
       disk. During updates the file is uncompressed and written to the target file or partition. This
@@ -502,7 +502,8 @@
         <filename>SHA256SUMS</filename> manifest files, via their detached signature files
         <filename>SHA256SUMS.gpg</filename> in combination with the system keyring
         <filename>/usr/lib/systemd/import-pubring.pgp</filename> or
-        <filename>/etc/systemd/import-pubring.pgp</filename>).</para>
+        <filename>/etc/systemd/import-pubring.pgp</filename>, or detached PKCS#7 signatures
+        <filename>SHA256SUMS.p7s</filename> and X.509 certificates discovered in accordance with <ulink url="https://uapi-group.org/specifications/specs/file_hierarchy_for_the_verification_of_os_artifacts/">UAPI.11 File Hierarchy for the Verification of OS Artifacts (VOA)</ulink>, where <literal>$context</literal> is <literal>default</literal>).</para>
 
         <para>This option is essential to provide integrity guarantees for downloaded resources and thus
         should be left enabled, outside of test environments.</para>
@@ -619,7 +620,8 @@
         <para>If the source type is selected as <constant>url-file</constant> or
         <constant>url-tar</constant> this must be a HTTP/HTTPS URL. The URL is suffixed with
         <filename>/SHA256SUMS</filename> to acquire the manifest file, with
-        <filename>/SHA256SUMS.gpg</filename> to acquire the detached signature file for it, and with the file
+        <filename>/SHA256SUMS.gpg</filename> or <filename>/SHA256SUMS.p7s</filename>
+        to acquire the detached signature file for it, and with the file
         names listed in the manifest file in case an update is executed and a resource shall be
         downloaded.</para>
 
@@ -1030,7 +1032,7 @@ InstancesMax=2</programlisting></para>
 
         <itemizedlist>
           <listitem><para><filename>SHA256SUMS</filename> – The manifest file, containing available files and their SHA256 hashes</para></listitem>
-          <listitem><para><filename>SHA256SUMS.gpg</filename> – The detached cryptographic signature for the manifest file</para></listitem>
+          <listitem><para><filename>SHA256SUMS.gpg</filename> or <filename>SHA256SUMS.p7s</filename> – The detached cryptographic signature for the manifest file</para></listitem>
           <listitem><para><filename>foobarOS_7_8b8186b1-2b4e-4eb6-ad39-8d4d18d2a8fb.verity.xz</filename> – The Verity image for version 7</para></listitem>
           <listitem><para><filename>foobarOS_7_f4d1234f-3ebf-47c4-b31d-4052982f9a2f.root.xz</filename> – The root file system image for version 7</para></listitem>
           <listitem><para><filename>foobarOS_7.efi</filename> – The unified kernel image for version 7</para></listitem>

--- a/src/import/pull-common.c
+++ b/src/import/pull-common.c
@@ -5,11 +5,15 @@
 #include "sd-id128.h"
 
 #include "alloc-util.h"
+#include "assert-util.h"
+#include "conf-files.h"
 #include "copy.h"
+#include "crypto-util.h"
 #include "dirent-util.h"
 #include "escape.h"
 #include "fd-util.h"
 #include "hexdecoct.h"
+#include "import-util.h"
 #include "io-util.h"
 #include "iovec-util.h"
 #include "log.h"
@@ -24,7 +28,9 @@
 #include "siphash24.h"
 #include "string-util.h"
 #include "strv.h"
+#include "time-util.h"
 #include "tmpfile-util.h"
+#include "voa-util.h"
 #include "web-util.h"
 
 #define FILENAME_ESCAPE "/.#\"\'"
@@ -240,6 +246,9 @@ static SignatureStyle signature_style_from_filename(const char *fn) {
         if (streq(fn, "SHA256SUMS.asc"))
                 return SIGNATURE_ASC_PER_DIRECTORY;
 
+        if (streq(fn, "SHA256SUMS.p7s"))
+                return SIGNATURE_PKCS7_PER_DIRECTORY;
+
         if (endswith(fn, ".sha256.gpg"))
                 return SIGNATURE_GPG_PER_FILE;
 
@@ -402,6 +411,187 @@ static int verify_one(PullJob *checksum_job, PullJob *job) {
         return 1;
 }
 
+static int verify_pkcs7(
+                VOAContext voa_context,
+                const struct iovec *payload,
+                const struct iovec *signature) {
+#if HAVE_OPENSSL
+        _cleanup_(sk_X509_free_allp) STACK_OF(X509) *sk = NULL;
+        _cleanup_strv_free_ char **certs = NULL;
+        _cleanup_strv_free_ char **certificate_dirs = NULL;
+        _cleanup_strv_free_ char **trust_anchors = NULL;
+        _cleanup_strv_free_ char **trust_anchor_dirs = NULL;
+        _cleanup_(PKCS7_freep) PKCS7 *p7 = NULL;
+        _cleanup_(BIO_freep) BIO *bio = NULL;
+        _cleanup_(X509_STORE_freep) X509_STORE *store = NULL;
+        const char *voa_root_override;
+        int r;
+
+        assert(iovec_is_valid(payload));
+        assert(iovec_is_set(signature));
+
+        if (payload->iov_len > INT_MAX || signature->iov_len > INT_MAX)
+                return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "Payload or signature length too large.");
+
+        voa_root_override = empty_to_null(secure_getenv("SYSTEMD_VOA_ROOT"));
+        if (!isempty(voa_root_override))
+                log_debug("Using SYSTEMD_VOA_ROOT override: %s", voa_root_override);
+
+        r = dlopen_libcrypto(LOG_DEBUG);
+        if (r < 0)
+                return r;
+
+        const unsigned char *d = signature->iov_base;
+        p7 = sym_d2i_PKCS7(/* val_out= */ NULL, &d, (long) signature->iov_len);
+        if (!p7)
+                return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "Failed to parse PKCS7 DER signature data.");
+        if (d != (const unsigned char*) signature->iov_base + signature->iov_len)
+                return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "Failed to parse PKCS7 DER signature data: Certificate data was not consumed.");
+
+        /* Handle empty payload */
+        if (!iovec_is_set(payload))
+                bio = sym_BIO_new(sym_BIO_s_mem());
+        else
+                bio = sym_BIO_new_mem_buf(payload->iov_base, payload->iov_len);
+        if (!bio)
+                return log_oom();
+
+        r = acquire_voa_trust_anchor_paths(&trust_anchor_dirs, VOA_PURPOSE_IMAGE, voa_context, VOA_TECHNOLOGY_X509, voa_root_override);
+        if (r < 0)
+                return log_error_errno(r, "Failed to acquire VOA trust anchor paths: %m");
+        store = sym_X509_STORE_new();
+        if (!store)
+                return log_oom();
+#  ifdef X509_PURPOSE_CODE_SIGN
+        sym_X509_STORE_set_purpose(store, X509_PURPOSE_CODE_SIGN);
+#  else
+        /* We need to set this for compat as we check the key usage manually */
+        sym_X509_STORE_set_purpose(store, X509_PURPOSE_ANY);
+#  endif
+
+        r = conf_files_list_strv(&trust_anchors, "-certificate.pem", /* root= */ NULL, CONF_FILES_REGULAR|CONF_FILES_FILTER_MASKED, (const char **) trust_anchor_dirs);
+        if (r < 0)
+                return log_error_errno(r, "Failed to enumerate x509 trust anchor certificates: %m");
+        if (strv_isempty(trust_anchors))
+                return log_error_errno(SYNTHETIC_ERRNO(ENODATA), "No trust anchor certificates found to verify PKCS#7 for download.");
+
+        STRV_FOREACH(i, trust_anchors) {
+                _cleanup_(X509_freep) X509 *c = NULL;
+                _cleanup_fclose_ FILE *f = NULL;
+
+                f = fopen(*i, "re");
+                if (!f) {
+                        log_debug_errno(errno, "Failed to open '%s', ignoring: %m", *i);
+                        continue;
+                }
+
+                c = sym_PEM_read_X509(f, /* x= */ NULL, /* pem_password_cb= */ NULL, /* u= */ NULL);
+                if (!c) {
+                        log_debug("Failed to load X509 certificate '%s', ignoring.", *i);
+                        continue;
+                }
+
+                if (!sym_X509_check_ca(c)) {
+                        log_debug("X509 certificate: '%s' is not valid as trust anchor", *i);
+                        continue;
+                }
+
+                if (sym_X509_STORE_add_cert(store, c) == 0)
+                        return log_openssl_errors(LOG_ERR, "Failed to add cert %s to x509 store", *i);
+        }
+
+        r = acquire_voa_certificate_paths(&certificate_dirs, VOA_PURPOSE_IMAGE, voa_context, VOA_TECHNOLOGY_X509, voa_root_override);
+        if (r < 0)
+                return log_error_errno(r, "Failed to acquire VOA certificate paths: %m");
+
+        r = conf_files_list_strv(&certs, "-certificate.pem", /* root= */ NULL, CONF_FILES_REGULAR|CONF_FILES_FILTER_MASKED, (const char**) certificate_dirs);
+        if (r < 0)
+                return log_error_errno(r, "Failed to enumerate PKCS#7 certificates: %m");
+        if (strv_isempty(certs))
+                return log_error_errno(SYNTHETIC_ERRNO(ENODATA), "No certificates found to verify PKCS#7 for download.");
+
+        sk = sym_sk_X509_new_null();
+        if (!sk)
+                return log_oom();
+
+        STRV_FOREACH(i, certs) {
+                _cleanup_(X509_freep) X509 *c = NULL;
+                _cleanup_fclose_ FILE *f = NULL;
+
+                f = fopen(*i, "re");
+                if (!f) {
+                        log_debug_errno(errno, "Failed to open '%s', ignoring: %m", *i);
+                        continue;
+                }
+
+                c = sym_PEM_read_X509(f, /* x= */ NULL, /* pem_password_cb= */ NULL, /* u= */ NULL);
+                if (!c) {
+                        log_debug("Failed to load X509 certificate '%s', ignoring.", *i);
+                        continue;
+                }
+
+                time_t time_now = (time_t) (now(CLOCK_REALTIME) / USEC_PER_SEC);
+                /*
+                        sym_X509_cmp_current_time is deprecated so we use sym_ASN1_TIME_cmp_time_t instead.
+                        See also: https://docs.openssl.org/master/man3/ASN1_TIME_set/#return-values.
+                        -2: error
+                        -1: before
+                         0: equal
+                         1: after
+                */
+                r = sym_ASN1_TIME_cmp_time_t(sym_X509_get0_notBefore(c), time_now);
+                if (r <= -2) {
+                        log_debug("Unable to compare times for %s, ignoring.", *i);
+                        continue;
+                }
+                if (r > 0) {
+                        log_debug("X509 certificate not yet valid: '%s', ignoring.", *i);
+                        continue;
+                }
+
+                r = sym_ASN1_TIME_cmp_time_t(sym_X509_get0_notAfter(c), time_now);
+                if (r <= -2) {
+                        log_debug("Unable to compare times for %s, ignoring.", *i);
+                        continue;
+                }
+                if (r < 0) {
+                        log_debug("X509 certificate expired: '%s', ignoring.", *i);
+                        continue;
+                }
+
+                uint32_t ku = sym_X509_get_key_usage(c);
+                uint32_t eku = sym_X509_get_extended_key_usage(c);
+                if (ku == UINT32_MAX || eku == UINT32_MAX) {
+                        log_debug("X509 certificate '%s' has no key usage extension.", *i);
+                        continue;
+                }
+                if (!(ku & KU_DIGITAL_SIGNATURE) || !(eku & XKU_CODE_SIGN)) {
+                        log_debug("X509 certificate: '%s' is not valid for code signing.", *i);
+                        continue;
+                }
+
+                if (sym_sk_X509_push(sk, c) == 0)
+                        return log_oom();
+
+                TAKE_PTR(c);
+        }
+
+        /* clear the skipped OpenSSL errors */
+        sym_ERR_clear_error();
+        /* We specifically want to verify with a detached signature and with NOINTERN in order to allow signature revocation with masking */
+        r = sym_PKCS7_verify(p7, sk, store, bio, /* out= */ NULL, PKCS7_BINARY|PKCS7_NO_DUAL_CONTENT|PKCS7_NOINTERN);
+        if (r) {
+                log_info("Signature verification succeeded.");
+                return 0;
+        }
+
+        return log_openssl_errors(LOG_ERR, "DOWNLOAD INVALID: PKCS#7 Signature verification failed");
+#else
+        return log_error_errno(SYNTHETIC_ERRNO(EBADMSG),
+                        "Can't verify PKCS#7 signature for download. OpenSSL support disabled.");
+#endif
+}
+
 static int verify_gpg(
                 const struct iovec *payload,
                 const struct iovec *signature) {
@@ -550,6 +740,7 @@ finish:
 }
 
 int pull_verify(ImportVerify verify,
+                VOAContext voa_context,
                 PullJob *main_job,
                 PullJob *checksum_job,
                 PullJob *signature_job,
@@ -559,11 +750,14 @@ int pull_verify(ImportVerify verify,
                 PullJob *verity_job) {
 
         _cleanup_free_ char *fn = NULL;
+        _cleanup_free_ char *sig_fn = NULL;
         PullJob *verify_job;
         int r;
 
         assert(verify == _IMPORT_VERIFY_INVALID || verify < _IMPORT_VERIFY_MAX);
         assert(verify == _IMPORT_VERIFY_INVALID || verify >= 0);
+        assert(voa_context >= 0);
+        assert(voa_context < _VOA_CONTEXT_MAX);
         assert(main_job);
         assert(main_job->state == PULL_JOB_DONE);
 
@@ -609,9 +803,18 @@ int pull_verify(ImportVerify verify,
         assert(signature_job);
         assert(signature_job->state == PULL_JOB_DONE);
 
+        SignatureStyle sig_style = _SIGNATURE_STYLE_INVALID;
+        r = signature_style_from_url(signature_job->url, &sig_style, &sig_fn);
+        if (sig_style < 0)
+                return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
+                                       "Unable to get signature style, cannot verify.");
+
         if (!iovec_is_set(&signature_job->payload))
                 return log_error_errno(SYNTHETIC_ERRNO(EBADMSG),
                                        "Signature is empty, cannot verify.");
+
+        if (sig_style == SIGNATURE_PKCS7_PER_DIRECTORY)
+                return verify_pkcs7(voa_context, &verify_job->payload, &signature_job->payload);
 
         return verify_gpg(&verify_job->payload, &signature_job->payload);
 }
@@ -713,15 +916,35 @@ int pull_job_restart_with_signature(PullJob *j, char **ret) {
 
         switch (style) {
 
-        case SIGNATURE_ASC_PER_DIRECTORY: /* Nothing to do anymore */
+        case SIGNATURE_PKCS7_PER_DIRECTORY:
                 *ret = NULL;
                 return 0;
 
-        case SIGNATURE_ASC_PER_FILE: { /* Try .sha256.gpg next */
-                char *ext;
+        case SIGNATURE_ASC_PER_DIRECTORY: /* Try SHA256SUMS.p7s */
+                log_debug("Got 404 for '%s', now trying to get SHA256SUMS.p7s instead.", j->url);
+                r = import_url_change_last_component(j->url, "SHA256SUMS.p7s", ret);
+                if (r < 0)
+                        return log_error_errno(r, "Failed to replace SHA256SUMS.asc suffix: %m");
+                break;
 
+        case SIGNATURE_GPG_PER_DIRECTORY: /* Try SHA256SUMS.asc next */
+                log_debug("Got 404 for '%s', now trying to get SHA256SUMS.asc instead.", j->url);
+                r = import_url_change_last_component(j->url, "SHA256SUMS.asc", ret);
+                if (r < 0)
+                        return log_error_errno(r, "Failed to replace SHA256SUMS.gpg suffix: %m");
+                break;
+
+        case SIGNATURE_GPG_PER_FILE:  /* Try SHA256SUMS.gpg next */
+                log_debug("Got 404 for '%s', now trying to get SHA256SUMS.gpg instead.", j->url);
+                r = import_url_change_last_component(j->url, "SHA256SUMS.gpg", ret);
+                if (r < 0)
+                        return log_error_errno(r, "Failed to replace SHA256SUMS suffix: %m");
+                break;
+
+        case SIGNATURE_ASC_PER_FILE: { /* Try .sha256.gpg next */
                 log_debug("Got 404 for '%s', now trying to get .sha256.gpg instead.", j->url);
 
+                char *ext;
                 ext = endswith(last, ".asc");
                 assert(ext);
                 strcpy(ext, ".gpg");
@@ -731,20 +954,6 @@ int pull_job_restart_with_signature(PullJob *j, char **ret) {
                         return log_error_errno(r, "Failed to replace .sha256.asc suffix: %m");
                 break;
         }
-
-        case SIGNATURE_GPG_PER_FILE: /* Try SHA256SUMS.gpg next */
-                log_debug("Got 404 for '%s', now trying to get SHA256SUMS.gpg instead.", j->url);
-                r = import_url_change_last_component(j->url, "SHA256SUMS.gpg", ret);
-                if (r < 0)
-                        return log_error_errno(r, "Failed to replace SHA256SUMS suffix: %m");
-                break;
-
-        case SIGNATURE_GPG_PER_DIRECTORY:
-                log_debug("Got 404 for '%s', now trying to get SHA256SUMS.asc instead.", j->url);
-                r = import_url_change_last_component(j->url, "SHA256SUMS.asc", ret);
-                if (r < 0)
-                        return log_error_errno(r, "Failed to replace SHA256SUMS.gpg suffix: %m");
-                break;
 
         default:
                 assert_not_reached();

--- a/src/import/pull-common.h
+++ b/src/import/pull-common.h
@@ -4,6 +4,7 @@
 #include "import-common.h"
 #include "import-util.h"
 #include "pull-forward.h"
+#include "voa-util.h"
 
 int pull_find_old_etags(
                 const char *url,
@@ -42,6 +43,7 @@ int pull_make_verification_jobs(
 
 int pull_verify(
                 ImportVerify verify,
+                VOAContext voa_context,
                 PullJob *main_job,
                 PullJob *checksum_job,
                 PullJob *signature_job,
@@ -60,10 +62,11 @@ typedef enum VerificationStyle {
 int verification_style_from_url(const char *url, VerificationStyle *ret);
 
 typedef enum SignatureStyle {
-        SIGNATURE_GPG_PER_FILE,      /* ".sha256" files with detached .gpg signature */
-        SIGNATURE_ASC_PER_FILE,      /* SUSE-style ".sha256" files with detached .asc signature */
-        SIGNATURE_GPG_PER_DIRECTORY, /* Ubuntu-style SHA256SUM files with detached SHA256SUM.gpg signatures */
-        SIGNATURE_ASC_PER_DIRECTORY, /* SUSE-style SHA256SUM files with detached SHA256SUM.asc signatures */
+        SIGNATURE_GPG_PER_FILE,        /* ".sha256" files with detached .gpg signature */
+        SIGNATURE_ASC_PER_FILE,        /* SUSE-style ".sha256" files with detached .asc signature */
+        SIGNATURE_GPG_PER_DIRECTORY,   /* Ubuntu-style SHA256SUM files with detached SHA256SUM.gpg signatures */
+        SIGNATURE_ASC_PER_DIRECTORY,   /* SUSE-style SHA256SUM files with detached SHA256SUM.asc signatures */
+        SIGNATURE_PKCS7_PER_DIRECTORY, /* OpenSSL detached PKCS7 signature */
         _SIGNATURE_STYLE_MAX,
         _SIGNATURE_STYLE_INVALID = -EINVAL,
 } SignatureStyle;

--- a/src/import/pull-raw.c
+++ b/src/import/pull-raw.c
@@ -22,6 +22,7 @@
 #include "qcow2-util.h"
 #include "string-util.h"
 #include "tmpfile-util.h"
+#include "voa-util.h"
 #include "web-util.h"
 
 typedef enum RawProgress {
@@ -38,6 +39,7 @@ typedef struct RawPull {
 
         ImportFlags flags;
         ImportVerify verify;
+        VOAContext voa_context;
         char *image_root;
 
         uint64_t offset;
@@ -558,6 +560,7 @@ static void raw_pull_job_on_finished(PullJob *j) {
                 raw_pull_report_progress(p, RAW_VERIFYING);
 
                 r = pull_verify(p->verify,
+                                p->voa_context,
                                 p->raw_job,
                                 p->checksum_job,
                                 p->signature_job,
@@ -799,6 +802,7 @@ int raw_pull_start(
                 uint64_t size_max,
                 ImportFlags flags,
                 ImportVerify verify,
+                VOAContext voa_context,
                 const struct iovec *checksum) {
 
         int r;
@@ -808,6 +812,8 @@ int raw_pull_start(
         assert(verify == _IMPORT_VERIFY_INVALID || verify < _IMPORT_VERIFY_MAX);
         assert(verify == _IMPORT_VERIFY_INVALID || verify >= 0);
         assert((verify < 0) || !iovec_is_set(checksum));
+        assert(voa_context >= 0);
+        assert(voa_context < _VOA_CONTEXT_MAX);
         assert(!(flags & ~IMPORT_PULL_FLAGS_MASK_RAW));
         assert(offset == UINT64_MAX || FLAGS_SET(flags, IMPORT_DIRECT));
         assert(!(flags & (IMPORT_PULL_SETTINGS|IMPORT_PULL_ROOTHASH|IMPORT_PULL_ROOTHASH_SIGNATURE|IMPORT_PULL_VERITY)) || !(flags & IMPORT_DIRECT));
@@ -828,6 +834,7 @@ int raw_pull_start(
 
         p->flags = flags;
         p->verify = verify;
+        p->voa_context = voa_context;
 
         /* Queue job for the image itself */
         r = pull_job_new(&p->raw_job, url, p->glue, p);

--- a/src/import/pull-raw.h
+++ b/src/import/pull-raw.h
@@ -4,10 +4,11 @@
 #include "import-common.h"
 #include "import-util.h"
 #include "pull-forward.h"
+#include "voa-util.h"
 
 int raw_pull_new(RawPull **ret, sd_event *event, const char *image_root, RawPullFinished on_finished, void *userdata);
 RawPull* raw_pull_unref(RawPull *p);
 
 DEFINE_TRIVIAL_CLEANUP_FUNC(RawPull*, raw_pull_unref);
 
-int raw_pull_start(RawPull *p, const char *url, const char *local, uint64_t offset, uint64_t size_max, ImportFlags flags, ImportVerify verify, const struct iovec *checksum);
+int raw_pull_start(RawPull *p, const char *url, const char *local, uint64_t offset, uint64_t size_max, ImportFlags flags, ImportVerify verify, VOAContext voa_context, const struct iovec *checksum);

--- a/src/import/pull-tar.c
+++ b/src/import/pull-tar.c
@@ -31,6 +31,7 @@
 #include "time-util.h"
 #include "tmpfile-util.h"
 #include "uid-classification.h"
+#include "voa-util.h"
 #include "web-util.h"
 
 typedef enum TarProgress {
@@ -46,6 +47,7 @@ typedef struct TarPull {
 
         ImportFlags flags;
         ImportVerify verify;
+        VOAContext voa_context;
         char *image_root;
 
         PullJob *tar_job;
@@ -479,6 +481,7 @@ static void tar_pull_job_on_finished(PullJob *j) {
 
                 clear_progress_bar(/* prefix= */ NULL);
                 r = pull_verify(p->verify,
+                                p->voa_context,
                                 p->tar_job,
                                 p->checksum_job,
                                 p->signature_job,
@@ -711,6 +714,7 @@ int tar_pull_start(
                 const char *local,
                 ImportFlags flags,
                 ImportVerify verify,
+                VOAContext voa_context,
                 const struct iovec *checksum) {
 
         int r;
@@ -719,6 +723,8 @@ int tar_pull_start(
         assert(verify == _IMPORT_VERIFY_INVALID || verify < _IMPORT_VERIFY_MAX);
         assert(verify == _IMPORT_VERIFY_INVALID || verify >= 0);
         assert((verify < 0) || !iovec_is_set(checksum));
+        assert(voa_context >= 0);
+        assert(voa_context < _VOA_CONTEXT_MAX);
         assert(!(flags & ~IMPORT_PULL_FLAGS_MASK_TAR));
         assert(!(flags & IMPORT_PULL_SETTINGS) || !(flags & IMPORT_DIRECT));
         assert(!(flags & IMPORT_PULL_SETTINGS) || !iovec_is_set(checksum));
@@ -738,6 +744,7 @@ int tar_pull_start(
 
         p->flags = flags;
         p->verify = verify;
+        p->voa_context = voa_context;
 
         /* Set up download job for TAR file */
         r = pull_job_new(&p->tar_job, url, p->glue, p);

--- a/src/import/pull-tar.h
+++ b/src/import/pull-tar.h
@@ -1,13 +1,15 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 #pragma once
 
+#include "forward.h"
 #include "import-common.h"
 #include "import-util.h"
 #include "pull-forward.h"
+#include "voa-util.h"
 
 int tar_pull_new(TarPull **ret, sd_event *event, const char *image_root, TarPullFinished on_finished, void *userdata);
 TarPull* tar_pull_unref(TarPull *p);
 
 DEFINE_TRIVIAL_CLEANUP_FUNC(TarPull*, tar_pull_unref);
 
-int tar_pull_start(TarPull *p, const char *url, const char *local, ImportFlags flags, ImportVerify verify, const struct iovec *checksum);
+int tar_pull_start(TarPull *p, const char *url, const char *local, ImportFlags flags, ImportVerify verify, VOAContext voa_context, const struct iovec *checksum);

--- a/src/import/pull.c
+++ b/src/import/pull.c
@@ -31,6 +31,7 @@
 #include "signal-util.h"
 #include "string-util.h"
 #include "verbs.h"
+#include "voa-util.h"
 #include "web-util.h"
 
 static char *arg_image_root = NULL;
@@ -39,6 +40,7 @@ static ImportFlags arg_import_flags = IMPORT_PULL_SETTINGS | IMPORT_PULL_ROOTHAS
 static uint64_t arg_offset = UINT64_MAX, arg_size_max = UINT64_MAX;
 static struct iovec arg_checksum = {};
 static ImageClass arg_class = IMAGE_MACHINE;
+static VOAContext arg_voa_context = _VOA_CONTEXT_INVALID;
 static RuntimeScope arg_runtime_scope = _RUNTIME_SCOPE_INVALID;
 
 STATIC_DESTRUCTOR_REGISTER(arg_checksum, iovec_done);
@@ -170,6 +172,7 @@ static int verb_tar(int argc, char *argv[], uintptr_t _data, void *userdata) {
                         normalized,
                         arg_import_flags & IMPORT_PULL_FLAGS_MASK_TAR,
                         arg_verify,
+                        arg_voa_context,
                         &arg_checksum);
         if (r < 0)
                 return log_error_errno(r, "Failed to pull image: %m");
@@ -240,6 +243,7 @@ static int verb_raw(int argc, char *argv[], uintptr_t _data, void *userdata) {
                         arg_size_max,
                         arg_import_flags & IMPORT_PULL_FLAGS_MASK_RAW,
                         arg_verify,
+                        arg_voa_context,
                         &arg_checksum);
         if (r < 0)
                 return log_error_errno(r, "Failed to pull image: %m");
@@ -386,6 +390,13 @@ static int parse_argv(int argc, char *argv[], char ***ret_args) {
                                 return r;
                         break;
 
+                OPTION_LONG("voa-context", "CONTEXT", "Manually override the context in the VOA hierarchy (default, machine, sysext, confext, portable)"): {
+                        VOAContext vc = voa_context_from_string(opts.arg);
+                        if (vc < 0)
+                                return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "Invalid VOA context: %s", opts.arg);
+                        arg_voa_context = vc;
+                        break;
+                }
                 OPTION_LONG("verify", "MODE",
                             "Verify downloaded image, one of: 'no', 'checksum', 'signature' or literal SHA256 hash"): {
                         ImportVerify v;
@@ -576,6 +587,10 @@ static int parse_argv(int argc, char *argv[], char ***ret_args) {
 
         if (arg_runtime_scope == RUNTIME_SCOPE_USER)
                 arg_import_flags |= IMPORT_FOREIGN_UID;
+
+        /* if the context isn't explicitly passed in, we can infer it from the image class */
+        if (arg_voa_context < 0)
+                arg_voa_context = (VOAContext) arg_class;
 
         *ret_args = option_parser_get_args(&opts);
         return 1;

--- a/src/shared/crypto-util.c
+++ b/src/shared/crypto-util.c
@@ -54,6 +54,7 @@ DLSYM_PROTOTYPE(ASN1_STRING_length) = NULL;
 DLSYM_PROTOTYPE(ASN1_STRING_new) = NULL;
 DLSYM_PROTOTYPE(ASN1_STRING_set) = NULL;
 DLSYM_PROTOTYPE(ASN1_STRING_set0) = NULL;
+DLSYM_PROTOTYPE(ASN1_TIME_cmp_time_t) = NULL;
 DLSYM_PROTOTYPE(ASN1_TIME_free) = NULL;
 DLSYM_PROTOTYPE(ASN1_TIME_set) = NULL;
 DLSYM_PROTOTYPE(ASN1_TYPE_new) = NULL;
@@ -287,13 +288,22 @@ DLSYM_PROTOTYPE(X509_ATTRIBUTE_free) = NULL;
 DLSYM_PROTOTYPE(X509_NAME_free) = NULL;
 DLSYM_PROTOTYPE(X509_NAME_oneline) = NULL;
 static DLSYM_PROTOTYPE(X509_NAME_set) = NULL;
+DLSYM_PROTOTYPE(X509_STORE_add_cert) = NULL;
+DLSYM_PROTOTYPE(X509_STORE_free) = NULL;
+DLSYM_PROTOTYPE(X509_STORE_new) = NULL;
+DLSYM_PROTOTYPE(X509_STORE_set_purpose) = NULL;
 DLSYM_PROTOTYPE(X509_VERIFY_PARAM_set1_host) = NULL;
 DLSYM_PROTOTYPE(X509_VERIFY_PARAM_set1_ip) = NULL;
 DLSYM_PROTOTYPE(X509_VERIFY_PARAM_set_hostflags) = NULL;
+DLSYM_PROTOTYPE(X509_check_ca) = NULL;
 DLSYM_PROTOTYPE(X509_free) = NULL;
+DLSYM_PROTOTYPE(X509_get0_notAfter) = NULL;
+DLSYM_PROTOTYPE(X509_get0_notBefore) = NULL;
 DLSYM_PROTOTYPE(X509_get0_pubkey) = NULL;
 static DLSYM_PROTOTYPE(X509_get0_serialNumber) = NULL;
+DLSYM_PROTOTYPE(X509_get_extended_key_usage) = NULL;
 static DLSYM_PROTOTYPE(X509_get_issuer_name) = NULL;
+DLSYM_PROTOTYPE(X509_get_key_usage) = NULL;
 DLSYM_PROTOTYPE(X509_get_pubkey) = NULL;
 static DLSYM_PROTOTYPE(X509_get_signature_info) = NULL;
 DLSYM_PROTOTYPE(X509_get_subject_name) = NULL;
@@ -378,6 +388,7 @@ int dlopen_libcrypto(int log_level) {
                         DLSYM_ARG(ASN1_STRING_new),
                         DLSYM_ARG(ASN1_STRING_set),
                         DLSYM_ARG(ASN1_STRING_set0),
+                        DLSYM_ARG(ASN1_TIME_cmp_time_t),
                         DLSYM_ARG(ASN1_TIME_free),
                         DLSYM_ARG(ASN1_TIME_set),
                         DLSYM_ARG(ASN1_TYPE_new),
@@ -609,13 +620,22 @@ int dlopen_libcrypto(int log_level) {
                         DLSYM_ARG(X509_NAME_free),
                         DLSYM_ARG(X509_NAME_oneline),
                         DLSYM_ARG(X509_NAME_set),
+                        DLSYM_ARG(X509_STORE_add_cert),
+                        DLSYM_ARG(X509_STORE_free),
+                        DLSYM_ARG(X509_STORE_new),
+                        DLSYM_ARG(X509_STORE_set_purpose),
                         DLSYM_ARG(X509_VERIFY_PARAM_set1_host),
                         DLSYM_ARG(X509_VERIFY_PARAM_set1_ip),
                         DLSYM_ARG(X509_VERIFY_PARAM_set_hostflags),
+                        DLSYM_ARG(X509_check_ca),
                         DLSYM_ARG(X509_free),
+                        DLSYM_ARG(X509_get0_notAfter),
+                        DLSYM_ARG(X509_get0_notBefore),
                         DLSYM_ARG(X509_get0_pubkey),
                         DLSYM_ARG(X509_get0_serialNumber),
+                        DLSYM_ARG(X509_get_extended_key_usage),
                         DLSYM_ARG(X509_get_issuer_name),
+                        DLSYM_ARG(X509_get_key_usage),
                         DLSYM_ARG(X509_get_pubkey),
                         DLSYM_ARG(X509_get_signature_info),
                         DLSYM_ARG(X509_get_subject_name),

--- a/src/shared/crypto-util.h
+++ b/src/shared/crypto-util.h
@@ -47,6 +47,8 @@ int parse_openssl_key_source_argument(const char *argument, char **private_key_s
 #  include <openssl/pkcs7.h>            /* IWYU pragma: export */
 #  include <openssl/rsa.h>              /* IWYU pragma: export */
 #  include <openssl/sha.h>              /* IWYU pragma: export */
+#  include <openssl/x509_vfy.h>         /* IWYU pragma: export */
+#  include <openssl/x509v3.h>           /* IWYU pragma: export */
 
 #  include "dlfcn-util.h"
 
@@ -64,6 +66,7 @@ extern DLSYM_PROTOTYPE(ASN1_STRING_length);
 extern DLSYM_PROTOTYPE(ASN1_STRING_new);
 extern DLSYM_PROTOTYPE(ASN1_STRING_set);
 extern DLSYM_PROTOTYPE(ASN1_STRING_set0);
+extern DLSYM_PROTOTYPE(ASN1_TIME_cmp_time_t);
 extern DLSYM_PROTOTYPE(ASN1_TIME_free);
 extern DLSYM_PROTOTYPE(ASN1_TIME_set);
 extern DLSYM_PROTOTYPE(ASN1_TYPE_new);
@@ -249,11 +252,20 @@ extern DLSYM_PROTOTYPE(X509_ALGOR_free);
 extern DLSYM_PROTOTYPE(X509_ATTRIBUTE_free);
 extern DLSYM_PROTOTYPE(X509_NAME_free);
 extern DLSYM_PROTOTYPE(X509_NAME_oneline);
+extern DLSYM_PROTOTYPE(X509_STORE_add_cert);
+extern DLSYM_PROTOTYPE(X509_STORE_free);
+extern DLSYM_PROTOTYPE(X509_STORE_new);
+extern DLSYM_PROTOTYPE(X509_STORE_set_purpose);
 extern DLSYM_PROTOTYPE(X509_VERIFY_PARAM_set1_host);
 extern DLSYM_PROTOTYPE(X509_VERIFY_PARAM_set1_ip);
 extern DLSYM_PROTOTYPE(X509_VERIFY_PARAM_set_hostflags);
+extern DLSYM_PROTOTYPE(X509_check_ca);
 extern DLSYM_PROTOTYPE(X509_free);
+extern DLSYM_PROTOTYPE(X509_get0_notAfter);
+extern DLSYM_PROTOTYPE(X509_get0_notBefore);
 extern DLSYM_PROTOTYPE(X509_get0_pubkey);
+extern DLSYM_PROTOTYPE(X509_get_extended_key_usage);
+extern DLSYM_PROTOTYPE(X509_get_key_usage);
 extern DLSYM_PROTOTYPE(X509_get_pubkey);
 extern DLSYM_PROTOTYPE(X509_get_subject_name);
 extern DLSYM_PROTOTYPE(X509_gmtime_adj);
@@ -307,6 +319,7 @@ DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_RENAME(OSSL_PARAM*, sym_OSSL_PARAM_free, OSSL_P
 DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_RENAME(PKCS7_SIGNER_INFO*, sym_PKCS7_SIGNER_INFO_free, PKCS7_SIGNER_INFO_freep, NULL);
 DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_RENAME(PKCS7*, sym_PKCS7_free, PKCS7_freep, NULL);
 DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_RENAME(X509_NAME*, sym_X509_NAME_free, X509_NAME_freep, NULL);
+DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_RENAME(X509_STORE*, sym_X509_STORE_free, X509_STORE_freep, NULL);
 DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_RENAME(X509*, sym_X509_free, X509_freep, NULL);
 
 /* Stack-of macros that go through the dlopen'd sym_OPENSSL_sk_* variants, mirroring the sk_TYPE_OP() helpers

--- a/src/shared/meson.build
+++ b/src/shared/meson.build
@@ -272,6 +272,7 @@ shared_sources = files(
         'verb-log-control.c',
         'verbs.c',
         'vlan-util.c',
+        'voa-util.c',
         'volatile-util.c',
         'vpick.c',
         'vsock-util.c',

--- a/src/shared/voa-util.c
+++ b/src/shared/voa-util.c
@@ -1,0 +1,93 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include "alloc-util.h"
+#include "constants.h"
+#include "log.h"
+#include "macro.h"
+#include "os-util.h"
+#include "path-util.h"
+#include "string-table.h"
+#include "string-util.h"
+#include "strv.h"
+#include "voa-util.h"
+
+static const char* const voa_context_table[_VOA_CONTEXT_MAX] = {
+        [VOA_CONTEXT_MACHINE]   = "machine",
+        [VOA_CONTEXT_PORTABLE]  = "portable",
+        [VOA_CONTEXT_SYSEXT]    = "sysext",
+        [VOA_CONTEXT_CONFEXT]   = "confext",
+        [VOA_CONTEXT_DEFAULT]   = "default",
+};
+
+DEFINE_STRING_TABLE_LOOKUP(voa_context, VOAContext);
+
+static const char* const voa_purpose_table[_VOA_PURPOSE_MAX] = {
+        [VOA_PURPOSE_IMAGE]   = "image",
+        [VOA_PURPOSE_PACKAGE] = "package",
+};
+
+DEFINE_STRING_TABLE_LOOKUP_TO_STRING(voa_purpose, VOAPurpose);
+
+static const char* const voa_technology_table[_VOA_TECHNOLOGY_MAX] = {
+        [VOA_TECHNOLOGY_X509] = "x509",
+        [VOA_TECHNOLOGY_GPG]  = "gpg",
+        [VOA_TECHNOLOGY_SSH]  = "ssh",
+};
+
+DEFINE_STRING_TABLE_LOOKUP_TO_STRING(voa_technology, VOATechnology);
+
+/* Implementation of: https://uapi-group.org/specifications/specs/file_hierarchy_for_the_verification_of_os_artifacts */
+int acquire_voa_paths_full(char ***ret, VOAPurpose purpose, VOAContext context, VOATechnology technology, bool trust_anchor, const char *conf_root_override) {
+        _cleanup_strv_free_ char **dirs = NULL;
+        _cleanup_strv_free_ char **conf_roots = NULL;
+        _cleanup_free_ char *os_str = NULL;
+        _cleanup_free_ char *purpose_str = NULL;
+        int r;
+
+        assert(purpose >= 0);
+        assert(purpose < _VOA_PURPOSE_MAX);
+        assert(context >= 0);
+        assert(context < _VOA_CONTEXT_MAX);
+        assert(technology >= 0);
+        assert(technology < _VOA_TECHNOLOGY_MAX);
+
+        /* It is possible to expand the '$os' string to include more information from /etc/os-release according to the spec, however, $ID is good enough for our usecase. */
+        r = parse_os_release(/* root= */ NULL, "ID", &os_str);
+        if (r < 0)
+                return log_debug_errno(r, "Failed to read os-release file: %m");
+        if (isempty(os_str) || !filename_is_valid(os_str))
+                return log_debug_errno(SYNTHETIC_ERRNO(ENOENT), "Failed to get ID field from os-release file");
+
+        if (trust_anchor)
+                purpose_str = strjoin("trust-anchor-", voa_purpose_to_string(purpose));
+        else
+                purpose_str = strdup(voa_purpose_to_string(purpose));
+        if (!purpose_str)
+                return -ENOMEM;
+
+        const char *context_str = voa_context_to_string(context);
+        const char *technology_str = voa_technology_to_string(technology);
+
+        if (isempty(conf_root_override))
+                conf_roots = strv_new(CONF_PATHS("voa"));
+        else
+                conf_roots = strv_new(conf_root_override);
+        if (!conf_roots)
+                return -ENOMEM;
+        STRV_FOREACH(dir, conf_roots) {
+                _cleanup_free_ char *full = path_join(*dir,
+                                                os_str,
+                                                purpose_str,
+                                                context_str,
+                                                technology_str);
+                if (!full)
+                        return -ENOMEM;
+
+                r = strv_consume(&dirs, TAKE_PTR(full));
+                if (r < 0)
+                        return r;
+        }
+        *ret = TAKE_PTR(dirs);
+
+        return 0;
+}

--- a/src/shared/voa-util.h
+++ b/src/shared/voa-util.h
@@ -1,0 +1,48 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#pragma once
+
+#include "forward.h"
+#include "os-util.h"
+
+typedef enum VOAContext {
+        /* These are matching with ImageClass src/basic/os-util.h, but there is no reason there can't be more added */
+        VOA_CONTEXT_MACHINE = IMAGE_MACHINE,
+        VOA_CONTEXT_PORTABLE = IMAGE_PORTABLE,
+        VOA_CONTEXT_SYSEXT = IMAGE_SYSEXT,
+        VOA_CONTEXT_CONFEXT = IMAGE_CONFEXT,
+        _VOA_CONTEXT_IS_IMAGE_CLASS_MAX,
+        VOA_CONTEXT_DEFAULT = _VOA_CONTEXT_IS_IMAGE_CLASS_MAX,
+        _VOA_CONTEXT_MAX,
+        _VOA_CONTEXT_INVALID = -EINVAL,
+} VOAContext;
+
+assert_cc((int) _IMAGE_CLASS_MAX == (int) _VOA_CONTEXT_IS_IMAGE_CLASS_MAX);
+
+typedef enum VOAPurpose {
+        VOA_PURPOSE_IMAGE,
+        VOA_PURPOSE_PACKAGE,
+        _VOA_PURPOSE_MAX,
+        _VOA_PURPOSE_INVALID = -EINVAL,
+} VOAPurpose;
+
+typedef enum VOATechnology {
+        VOA_TECHNOLOGY_X509,
+        VOA_TECHNOLOGY_GPG,
+        VOA_TECHNOLOGY_SSH,
+        _VOA_TECHNOLOGY_MAX,
+        _VOA_TECHNOLOGY_INVALID = -EINVAL,
+} VOATechnology;
+
+DECLARE_STRING_TABLE_LOOKUP(voa_context, VOAContext);
+DECLARE_STRING_TABLE_LOOKUP_TO_STRING(voa_purpose, VOAPurpose);
+DECLARE_STRING_TABLE_LOOKUP_TO_STRING(voa_technology, VOATechnology);
+
+int acquire_voa_paths_full(char ***ret, VOAPurpose purpose, VOAContext context, VOATechnology technology, bool trust_anchor, const char *conf_root_override);
+
+static inline int acquire_voa_certificate_paths(char ***ret, VOAPurpose purpose, VOAContext context, VOATechnology technology, const char *conf_root_override) {
+        return acquire_voa_paths_full(ret, purpose, context, technology, false, conf_root_override);
+}
+static inline int acquire_voa_trust_anchor_paths(char ***ret, VOAPurpose purpose, VOAContext context, VOATechnology technology, const char *conf_root_override) {
+        return acquire_voa_paths_full(ret, purpose, context, technology, true, conf_root_override);
+}

--- a/src/sysupdate/sysupdate-resource.c
+++ b/src/sysupdate/sysupdate-resource.c
@@ -405,6 +405,7 @@ static int download_manifest(
                         "raw",
                         "--direct",                        /* just download the specified URL, don't download anything else */
                         "--verify", verify_signature ? "signature" : "no", /* verify the manifest file */
+                        "--voa-context=default",           /* We can't infer context from the class as our image could be anything */
                         suffixed_url,
                         "-",                               /* write to stdout */
                         NULL

--- a/test/units/TEST-72-SYSUPDATE.sh
+++ b/test/units/TEST-72-SYSUPDATE.sh
@@ -1115,7 +1115,7 @@ rm -rf "$CONFIGDIR" "$WORKDIR/blobs"
 rm -f "$WORKDIR/source/notifytest-v1.bin" "$WORKDIR/source/SHA256SUMS" \
       "$WORKDIR/notify-recorder.py" "$NOTIFY_LOG"
 
-test_signature_verification() {
+test_signature_verification_gpg() {
     if ! command -v gpg >/dev/null; then
         echo "gpg not available, skipping signature verification test"
         return 0
@@ -1131,12 +1131,12 @@ test_signature_verification() {
         return 0
     fi
 
-    local sigdir="$WORKDIR/sigtest-source"
-    local defdir="$WORKDIR/sigtest-defs"
-    local gpghome="$WORKDIR/sigtest-gpghome"
-    local other_home="$WORKDIR/sigtest-otherhome"
-    local target="$WORKDIR/sigtest-target"
-    local keyring="$WORKDIR/sigtest-keyring"
+    local sigdir="$WORKDIR/sigtest-gpg-source"
+    local defdir="$WORKDIR/sigtest-gpg-defs"
+    local gpghome="$WORKDIR/sigtest-gpg-gpghome"
+    local other_home="$WORKDIR/sigtest-gpg-otherhome"
+    local target="$WORKDIR/sigtest-gpg-target"
+    local keyring="$WORKDIR/sigtest-gpg-keyring"
     local top_fpr keys
 
     SIGTEST_GPGHOME="$gpghome"
@@ -1214,7 +1214,151 @@ EOF
     cmp "$sigdir/payload-v2.raw" "$target/payload-v2.raw"
 }
 
-test_signature_verification
+test_signature_verification_pkcs7() {
+    if ! command -v openssl >/dev/null; then
+        echo "openssl not available, skipping signature verification test"
+        return 0
+    fi
+
+    local sigdir="$WORKDIR/sigtest-pkcs7-source"
+    local defdir="$WORKDIR/sigtest-pkcs7-defs"
+    local target="$WORKDIR/sigtest-pkcs7-target"
+
+    local os
+    os="$(
+        . /etc/os-release || exit
+        printf '%s' "$ID"
+    )"
+    local voa_root="$WORKDIR/sigtest-pkcs7-voa-root"
+    local voa_signing_dir="$voa_root/$os/image/default/x509"
+    local voa_signing="$voa_signing_dir/signing-certificate.pem"
+    local voa_ca_dir="$voa_root/$os/trust-anchor-image/default/x509"
+    local voa_ca="$voa_ca_dir/ca-certificate.pem"
+
+    ossl_cms_sign_manifest() {
+        openssl cms -sign -binary \
+            -in "$sigdir/SHA256SUMS" \
+            -signer "$voa_signing" \
+            -inkey "$WORKDIR/signer-key.pem" \
+            -outform DER \
+            -out "$sigdir/SHA256SUMS.p7s"
+    }
+    ossl_gen_rsa() {
+        local file="$1"
+        openssl genpkey \
+            -algorithm RSA \
+            -out "$file" \
+            -pkeyopt rsa_keygen_bits:2048
+    }
+
+    mkdir -p "$sigdir" "$defdir" "$target" "$voa_ca_dir" "$voa_signing_dir"
+
+    dd if=/dev/urandom of="$sigdir/payload-v1.raw" bs=1024 count=8 status=none
+    (cd "$sigdir" && sha256sum payload-v1.raw > SHA256SUMS)
+
+    ossl_gen_rsa "$WORKDIR/ca-key.pem"
+    openssl req \
+        -new \
+        -x509 \
+        -days 365 \
+        -key "$WORKDIR/ca-key.pem" \
+        -out "$voa_ca" \
+        -subj "/CN=Testing CA"
+
+    ossl_gen_rsa "$WORKDIR/signer-key.pem"
+    openssl req \
+        -new \
+        -key "$WORKDIR/signer-key.pem" \
+        -out "$WORKDIR/signer.csr" \
+        -subj "/CN=Testing Signer"
+
+    cat > "$WORKDIR/codesign.ext" <<EOF
+basicConstraints=critical,CA:FALSE
+keyUsage=critical,digitalSignature
+extendedKeyUsage=codeSigning
+subjectKeyIdentifier=hash
+authorityKeyIdentifier=keyid
+EOF
+    openssl x509 \
+        -req \
+        -in "$WORKDIR/signer.csr" \
+        -CA "$voa_ca" \
+        -CAkey "$WORKDIR/ca-key.pem" \
+        -set_serial 1 \
+        -days 365 \
+        -extfile "$WORKDIR/codesign.ext" \
+        -out "$voa_signing"
+
+    ossl_cms_sign_manifest
+
+    cat >"$defdir/01-sigtest.transfer" <<EOF
+[Source]
+Type=url-file
+Path=file://$sigdir
+MatchPattern=payload-@v.raw
+
+[Target]
+Type=regular-file
+Path=$target
+MatchPattern=payload-@v.raw
+InstancesMax=3
+EOF
+
+    SYSTEMD_VOA_ROOT="$voa_root" "$SYSUPDATE" --definitions="$defdir" check-new
+    SYSTEMD_VOA_ROOT="$voa_root" "$SYSUPDATE" --definitions="$defdir" update
+    cmp "$sigdir/payload-v1.raw" "$target/payload-v1.raw"
+
+    # Negative test: Sign without code signing purpose
+    dd if=/dev/urandom of="$sigdir/payload-v2.raw" bs=1024 count=8 status=none
+
+    openssl x509 \
+        -req \
+        -in "$WORKDIR/signer.csr" \
+        -CA "$voa_ca" \
+        -CAkey "$WORKDIR/ca-key.pem" \
+        -set_serial 2 \
+        -days 365 \
+        -out "$voa_signing"
+
+    (cd "$sigdir" && sha256sum payload-v1.raw payload-v2.raw > SHA256SUMS)
+    ossl_cms_sign_manifest
+
+    if SYSTEMD_VOA_ROOT="$voa_root" "$SYSUPDATE" --definitions="$defdir" update; then
+        echo "ERROR: accepted an update signed with invalid purpose" >&2
+        exit 1
+    fi
+    if [ -f "$target/payload-v2.raw" ]; then
+        echo "ERROR: payload-v2 should not have been installed" >&2
+        exit 1
+    fi
+
+    # Negative test: Sign with certificate not signed by CA
+    dd if=/dev/urandom of="$sigdir/payload-v3.raw" bs=1024 count=8 status=none
+
+    openssl x509 \
+        -req \
+        -in "$WORKDIR/signer.csr" \
+        -days 365 \
+        -extfile "$WORKDIR/codesign.ext" \
+        -key "$WORKDIR/signer-key.pem" \
+        -out "$voa_signing"
+
+
+    (cd "$sigdir" && sha256sum payload-v1.raw payload-v2.raw payload-v3.raw > SHA256SUMS)
+    ossl_cms_sign_manifest
+
+    if SYSTEMD_VOA_ROOT="$voa_root" "$SYSUPDATE" --definitions="$defdir" update; then
+        echo "ERROR: accepted an update signed with a certificate not signed by a trust anchor" >&2
+        exit 1
+    fi
+    if [ -f "$target/payload-v3.raw" ]; then
+        echo "ERROR: payload-v3 should not have been installed" >&2
+        exit 1
+    fi
+}
+
+test_signature_verification_gpg
+test_signature_verification_pkcs7
 
 # Test '**/' as prefix in MatchPattern= for subpaths in SHA256SUMS
 rm -rf "$CONFIGDIR" "$WORKDIR/blobs" "$WORKDIR/source/sub"


### PR DESCRIPTION
This PR adds basic support for x509 signatures to sign and verify files with `systemd-pull`. Currently I have the CLI such that `systemd-pull --verify x509:path/to/certificate.crt (raw|tar) <URL>` verifies the download with the given certificate using openssl.  x509 seems particularly useful to me as it means you can reuse the keys generated from `mkosi genkey` to sign builds as well, or simply use `mkosi genkey` to generate different signing keys.

Solves: https://github.com/systemd/systemd/issues/38772.