### PR TITLE
core: fix TimerSlackNSec= applying garbage timer slack on 32-bit ABIs

### DIFF
--- a/src/core/exec-invoke.c
+++ b/src/core/exec-invoke.c
@@ -5659,7 +5659,10 @@ int exec_invoke(
                 }
 
         if (context->timer_slack_nsec != NSEC_INFINITY)
-                if (prctl(PR_SET_TIMERSLACK, context->timer_slack_nsec) < 0) {
+                /* prctl() is variadic, hence the value must be passed as unsigned long, not as uint64_t:
+                 * on 32-bit ABIs that align 64-bit varargs to register pairs (e.g. ARM AAPCS) the kernel
+                 * would otherwise receive an unrelated register's contents as the timer slack. */
+                if (prctl(PR_SET_TIMERSLACK, (unsigned long) MIN(context->timer_slack_nsec, (nsec_t) ULONG_MAX)) < 0) {
                         *exit_status = EXIT_TIMERSLACK;
                         return log_error_errno(errno, "Failed to set up timer slack: %m");
                 }

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -2795,7 +2795,8 @@ static int initialize_runtime(
                 log_warning_errno(r, "Failed to reset ambient capability set, ignoring: %m");
 
         if (arg_timer_slack_nsec != NSEC_INFINITY)
-                if (prctl(PR_SET_TIMERSLACK, arg_timer_slack_nsec) < 0)
+                /* prctl() is variadic, hence pass the value as unsigned long, not as uint64_t (see exec-invoke.c). */
+                if (prctl(PR_SET_TIMERSLACK, (unsigned long) MIN(arg_timer_slack_nsec, (nsec_t) ULONG_MAX)) < 0)
                         log_warning_errno(errno, "Failed to adjust timer slack, ignoring: %m");
 
         if (arg_syscall_archs) {


### PR DESCRIPTION
## Summary

`TimerSlackNSec=` (both the unit setting and the PID 1 `system.conf` option) silently applies an arbitrary garbage value instead of the configured one on 32-bit ARM.

`prctl()` is variadic and the kernel reads its optional arguments as `unsigned long`. Both call sites pass `nsec_t` (`uint64_t`) directly, so on 32-bit ARM (AAPCS) the compiler aligns the 64-bit vararg to the r2/r3 register pair, skipping r1. The libc `prctl()` wrapper forwards r1 — dead register contents, typically a leftover heap pointer — as arg2, so the kernel applies a garbage slack while the configured value arrives in the (ignored) arg3. The call returns 0, so nothing is logged.

## Reproduction (armv7, glibc, systemd 250; code unchanged on main)

```
# systemd-run -q -p TimerSlackNSec=500000 --wait --pipe sh -c 'cat /proc/self/timerslack_ns'
7011152
# systemd-run -q -p TimerSlackNSec=123456 --wait --pipe sh -c 'cat /proc/self/timerslack_ns'
7011152
# systemd-run -q -p TimerSlackNSec=1000000 --wait --pipe sh -c 'cat /proc/self/timerslack_ns'
7011152
# systemd-run -q --wait --pipe sh -c 'cat /proc/self/timerslack_ns'   # no option: correct inherit
50000
```

The result is independent of the configured value but stable per call site (a service started at boot got 6034080; PID 1 applying `system.conf`'s `TimerSlackNSec=500000` set itself to 56789, inherited by every service).

Disassembly of the shipped binary at the exec_child call site shows the mechanism (value in r2/r3, `r1` never written):

```
ldrd    r2, r3, [r2, #232]    ; context->timer_slack_nsec
cmp.w   r3, #0xffffffff       ; != NSEC_INFINITY check
cmpeq.w r2, #0xffffffff
beq.n   <skip>
movs    r0, #29               ; PR_SET_TIMERSLACK
blx     <prctl@plt>           ; r1 = stale pointer -> kernel arg2
```

## Fix

Cast to `unsigned long` at both call sites, saturating at `ULONG_MAX` so out-of-range values (> ~4.29 s on 32-bit) degrade to the largest expressible slack instead of truncating.

With the fix, arm32 codegen loads the value's low word into r1 (with the saturation guard), and the configured value reaches the kernel; 64-bit platforms are unaffected (single-register value), as is i386 (stack varargs put the little-endian low word in the right slot) — which is why this went unnoticed.

Same bug class as #4575 (`RestrictAddressFamilies=` broken on 32-bit).
