### PR TITLE
hashmap: Fix heap-use-after-free in resize_buckets() on thread cancel…

### DIFF
--- a/src/basic/hashmap.c
+++ b/src/basic/hashmap.c
@@ -1167,13 +1167,30 @@ static int resize_buckets(HashmapBase *h, unsigned entries_add) {
                 h->n_direct_entries = 0;
         }
 
+        /*
+         * Save the new storage pointer BEFORE calling get_hash_key().
+         *
+         * get_hash_key() may call random_bytes(), which invokes
+         * getrandom() — or falls back to open("/dev/urandom") — and both
+         * are pthread cancellation points.  If the calling thread is
+         * cancelled there, execution never reaches the assignment below,
+         * and h->indirect.storage would keep pointing to the old storage
+         * buffer that realloc() just freed, causing a heap-use-after-free
+         * when the hashmap is subsequently freed (e.g. from another
+         * thread after pthread_join() returns).
+         *
+         * By updating h->indirect.storage here, the hashmap always holds
+         * a valid pointer to the newly allocated storage, even if the
+         * thread is cancelled inside get_hash_key().
+         */
+        h->indirect.storage = new_storage;
+
         /* Get a new hash key. If we've just upgraded to indirect storage,
          * allow reusing a previously generated key. It's still a different key
          * from the shared one that we used for direct storage. */
         get_hash_key(h->indirect.hash_key, !h->has_indirect);
 
         h->has_indirect = true;
-        h->indirect.storage = new_storage;
         h->indirect.n_buckets = (1U << new_shift) /
                                 (hi->entry_size + sizeof(dib_raw_t));
 


### PR DESCRIPTION
In resize_buckets(), the assignment

    h->indirect.storage = new_storage;

was placed *after* the call to get_hash_key().  However, get_hash_key() may invoke random_bytes(), which calls getrandom() — or falls back to open("/dev/urandom") — and both are pthread cancellation points.

If the calling thread is cancelled inside get_hash_key(), the assignment is never reached and h->indirect.storage keeps pointing to the old storage buffer that realloc() just freed.  When the hashmap is subsequently freed from another thread (e.g. after pthread_join() returns), the stale pointer is dereferenced, resulting in a heap-use-after-free.

This scenario has been observed with multipathd, where the uevent dispatcher thread (T7) is cancelled via pthread_cancel() during exit while it is inside resize_buckets() on an already-indirect hashmap (which forces get_hash_key() to call random_bytes()), and the main thread (T0) later frees the same hashmap through the device/udev object hierarchy, triggering the UAF:

```
  T7: realloc(@X) frees @X, returns @Y
  T7: cancelled in get_hash_key() → random_bytes() → getrandom()
      ⇒ h->indirect.storage is still @X (freed)
  T0: device_free() → ordered_hashmap_free() → hashmap_clear()
      ⇒ bucket_at() computes address from h->indirect.storage (@X)
      ⇒ WRITE to freed memory → UAF
```

Fix this by moving the assignment of h->indirect.storage before get_hash_key(), so the hashmap always holds a valid pointer to the newly allocated storage, even if the thread is cancelled inside get_hash_key().

h->has_indirect is intentionally kept *after* get_hash_key() to preserve the reuse_is_ok = !h->has_indirect optimization, which allows skipping random_bytes() on the first direct→indirect upgrade when a hash key has already been generated.

This change is safe because get_hash_key() does not access h->indirect.storage.  After h->has_indirect = true is set (line after get_hash_key()), storage_ptr(h) and dib_raw_ptr(h) both return the correct new pointer.