### PR TITLE
network: do not use assert() on a call with side effects

### DIFF
--- a/src/network/networkd-ndisc.c
+++ b/src/network/networkd-ndisc.c
@@ -2052,7 +2052,7 @@ static int ndisc_router_process_captive_portal(Link *link, sd_ndisc_router *rt, 
                                 target = c;
 
                 assert(target);
-                assert(set_remove(link->ndisc_captive_portals, target) == target);
+                assert_se(set_remove(link->ndisc_captive_portals, target) == target);
                 ndisc_captive_portal_free(target);
         }
 


### PR DESCRIPTION
Fixes bf943a9d49941801b45e4631f010359619173d12.