### PR TITLE
discover-image: don't ignore symlinks to raw images

### DIFF
--- a/src/shared/discover-image.c
+++ b/src/shared/discover-image.c
@@ -618,7 +618,7 @@ static int image_make(
                 (*ret)->foreign_uid_owned = uid_is_foreign(st->st_uid);
                 return 0;
 
-        } else if (S_ISREG(st->st_mode) && endswith(path, ".raw")) {
+        } else if (S_ISREG(st->st_mode) && (endswith(path, ".raw") || pretty)) {
                 usec_t crtime = 0;
 
                 /* It's a RAW disk image */

--- a/test/units/TEST-13-NSPAWN.machined.sh
+++ b/test/units/TEST-13-NSPAWN.machined.sh
@@ -229,6 +229,16 @@ machinectl import-fs /var/tmp/container.dir container-dir
 machinectl start container-dir
 rm -fr /var/tmp/container.dir
 
+# Check if machinectl can properly work with symlinks to raw images
+touch /var/lib/machines/linked.squashfs
+ln -svrf /var/lib/machines/linked.squashfs /var/lib/machines/linked.raw
+ls -la /var/lib/machines/
+machinectl list-images | tee /tmp/out.log
+grep -E "linked\s+raw" /tmp/out.log
+(! grep -E "squashfs" /tmp/out.log)
+[[ "$(machinectl show-image --property=Type --value linked)" == "raw" ]]
+rm -f /var/lib/machines/linked.{squashfs,raw} /tmp/out.log
+
 timeout 30 bash -c "until machinectl clean --all; do sleep .5; done"
 
 NSPAWN_FRAGMENT="machinectl-test-$RANDOM.nspawn"


### PR DESCRIPTION
Since 5c6bb289990ba53898cbc62db6e732ecb9dc87ac image_discover() uses chaseat() to chase the path to the image. This however breaks the raw image check in image_make() as "path" is now not the symlink itself, but the symlink target.

So with:
```
$ ls -l /var/lib/machines
total 872104
lrwxrwxrwx. 1 root root         12 Jul 14 06:10 foo.raw -> foo.squashfs
-rw-r--r--. 1 root root 5368709120 Jul 13 02:07 foo.squashfs
```
The endswith(path, ".raw") check is now performed on "/.../foo.squashfs" instead of "/.../foo.raw", making it false and thus ignoring the image symlink completely.

Address this by also checking if the pretty name is set - if so, and the path is a regular file, the caller must've been image_find() or image_discover() which already checked if the original path ends in .raw and is a regular file.

Follow-up for 5c6bb289990ba53898cbc62db6e732ecb9dc87ac.

Resolves: #41656