### PR TITLE
dlopen-note: drop unnecessary header

### DIFF
--- a/src/basic/dlopen-note.h
+++ b/src/basic/dlopen-note.h
@@ -4,7 +4,6 @@
 #include "sd-dlopen.h"
 
 #include "forward.h"
-#include "strv.h"
 
 /* Prevent dlopen helper functions (e.g., dlopen_libfoo()) from being inlined or cloned by the compiler/LTO.
  * This ensures that their specific symbols remain intact in the final executable, allowing the developer


### PR DESCRIPTION
It unexpectedly snuck in there.

Follow-up for a74b3e1778ec00a21f5d1f10947daef2c02c6ffe.