### PR TITLE
homed: fix verification of local identity file

### DIFF
--- a/src/home/homed-home.c
+++ b/src/home/homed-home.c
@@ -1109,10 +1109,21 @@ static void home_authenticating_finish(Home *h, int ret, UserRecord *hr) {
         }
 
         if (hr) {
+                bool signed_locally = false, signed_locally_needs_update = false;
+
+                r = home_verify_user_record(h, hr, &signed_locally, /* ret_error= */ NULL);
+                if (r < 0)
+                        hr = h->record;
+                else
+                        signed_locally_needs_update = true;
+
                 r = home_set_record(h, hr);
                 if (r < 0)
                         log_warning_errno(r, "Failed to update home record, ignoring: %m");
                 else {
+                        if (signed_locally_needs_update)
+                                h->signed_locally = signed_locally;
+
                         r = user_record_good_authentication(h->record);
                         if (r < 0)
                                 log_warning_errno(r, "Failed to increase good authentication counter, ignoring: %m");

--- a/test/units/TEST-46-HOMED.sh
+++ b/test/units/TEST-46-HOMED.sh
@@ -1109,4 +1109,22 @@ testcase_deactivate_busy() {
     homectl remove busytest
 }
 
+testcase_identity_groups() {
+    NEWPASSWORD=foobar homectl create idgrouptest --enforce-password-policy=no
+    PASSWORD=foobar homectl activate idgrouptest
+
+    machinectl shell idgrouptest@ /usr/bin/bash -euxo pipefail -c "jq '.memberOf = ((.memberOf // []) + [\"systemd-journal\"] | unique) | .lastChangeUSec = ((.lastChangeUSec // 0) + 3600000000)' /home/idgrouptest/.identity > /home/idgrouptest/.identity.new && mv -f /home/idgrouptest/.identity.new /home/idgrouptest/.identity"
+    jq -e '.memberOf | index("systemd-journal") != null' /home/idgrouptest/.identity
+
+    PASSWORD=foobar homectl authenticate idgrouptest
+
+    local groups
+    groups="$(machinectl shell idgrouptest@ /usr/bin/groups)"
+    (! grep -q systemd-journal <<<"$groups")
+
+    homectl deactivate idgrouptest ||:
+    wait_for_state idgrouptest inactive
+    homectl remove idgrouptest
+}
+
 run_testcases


### PR DESCRIPTION
Follow-up for 70a5db5822c8056b53d9a4a9273ad12cb5f87a92