### PR TITLE
rules: install 60-persistent-media-controller.rules

### DIFF
--- a/rules.d/meson.build
+++ b/rules.d/meson.build
@@ -18,6 +18,7 @@ rules = [
                '60-persistent-alsa.rules',
                '60-persistent-hidraw.rules',
                '60-persistent-input.rules',
+               '60-persistent-media-controller.rules',
                '60-persistent-storage-mtd.rules',
                '60-persistent-storage-tape.rules',
                '60-persistent-v4l.rules',


### PR DESCRIPTION
 The rule file was added in 04f19d673587 and the feature was announced in the v256 NEWS ("systemd-udevd now creates persistent /dev/media/by-path/ symlinks for media controllers"), but the file was never registered in rules.d/meson.build, so it has never been installed by any build. Easy to verify: ls /usr/lib/udev/rules.d/ | grep media-controller is empty on any distro shipping v256+. Found while relying on those symlinks on an embedded board where /dev/mediaN numbering shuffles across boots.