### PR TITLE
oci-util: Don't fall back to default registry for explicit registries

### DIFF
--- a/src/import/oci-util.c
+++ b/src/import/oci-util.c
@@ -216,7 +216,7 @@ int oci_ref_normalize(char **protocol, char **registry, char **image, char **tag
         _cleanup_fclose_ FILE *f = NULL;
         _cleanup_free_ char *path = NULL;
         r = search_and_fopen_nulstr(fn, "re", /* root= */ NULL, CONF_PATHS_NULSTR("systemd/oci-registry"), &f, &path);
-        if (r == -ENOENT)
+        if (r == -ENOENT && isempty(*registry))
                 r = search_and_fopen_nulstr("default.oci-registry", "re", /* root= */ NULL, CONF_PATHS_NULSTR("systemd/oci-registry"), &f, &path);
         if (r < 0 && r != -ENOENT)
                 return log_debug_errno(r, "Failed to find suitable OCI registry file: %m");


### PR DESCRIPTION
When a reference specifies a registry like ghcr.io or quay.io for which we don't have a registry config file, the fallback forced the default registry which is wrong.

Only use the default as fallback when there is no explicit registry.