### PR TITLE
meson: disable dlopen tests by default, enable in gcc github workflow

### DIFF
--- a/.github/workflows/unit-tests.sh
+++ b/.github/workflows/unit-tests.sh
@@ -51,6 +51,9 @@ MESON_ARGS=()
 if [ "$(uname -m)" = "aarch64" ] || [ "$(uname -m)" = "x86_64" ]; then
     ADDITIONAL_DEPS+=(python3-pefile)
     ADDITIONAL_DEPS+=(systemd-boot-efi)
+    HAVE_AMDARM64=true
+else
+    HAVE_AMDARM64=
 fi
 
 if [[ -n "$CROSS_ARCH" ]]; then
@@ -121,10 +124,21 @@ for phase in "${PHASES[@]}"; do
                 fi
             fi
 
-            # On ppc64le the workers are slower and some slow tests time out
             MESON_TEST_ARGS=()
-            if [[ "$(uname -m)" != "x86_64" ]] && [[ "$(uname -m)" != "aarch64" ]]; then
+
+            # On ppc64le the workers are slower and some slow tests time out
+            if [ -z "${HAVE_AMDARM64}" ]; then
                 MESON_TEST_ARGS+=(--timeout-multiplier=3)
+            fi
+
+            if [ -n "${HAVE_AMDARM64}" ] && [ -z "${CROSS_ARCH}" ] && [[ "$phase" == "RUN_GCC" ]]; then
+                # The dlopen tests require linking all .standalone binaries,
+                # which is fairly slow and uses up a lot of disk space. Enable
+                # those tests for one compiler and two fast native architectures.
+                #
+                # Note: linker garbage collection for unused symbols appears to
+                # be broken on ppc64le (both GCC and CLANG) or s390x (GCC).
+                MESON_ARGS+=(-Ddlopen-tests=true)
             fi
 
             MESON_ARGS+=(--fatal-meson-warnings)
@@ -132,12 +146,6 @@ for phase in "${PHASES[@]}"; do
             ninja -C build -v
             # Ensure setting a timezone (like the reproducible build tests do) does not break time/date unit tests
             TZ=GMT+12 meson test "${MESON_TEST_ARGS[@]}" -C build --print-errorlogs --no-stdsplit --quiet
-
-            # Linker garbage collection for unused symbols appears to be broken on ppc64le (both GCC and CLANG) or s390x (GCC).
-            # Skip the dlopen note verification test in those specific configurations.
-            if ! [[ "$(uname -m)" == "ppc64le" || ( "$(uname -m)" == "s390x" && "$phase" == "RUN_GCC" ) ]]; then
-                meson test -C build --suite=dlopen --print-errorlogs --no-stdsplit --quiet
-            fi
             ;;
         RUN_ASAN_UBSAN|RUN_GCC_ASAN_UBSAN|RUN_CLANG_ASAN_UBSAN|RUN_CLANG_ASAN_UBSAN_NO_DEPS)
             # TODO: drop after we switch to ubuntu 26.04

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -94,11 +94,9 @@ jobs:
                   -Dslow-tests=true \
                   -Dfuzz-tests=true \
                   -Dlibc=musl \
+                  -Ddlopen-tests=true \
                   build
           mkosi box -- ninja -v -C build
 
       - name: Test
         run: mkosi box -- meson test -C build --print-errorlogs --no-stdsplit --quiet
-
-      - name: Test (dlopen)
-        run: mkosi box -- meson test -C build --print-errorlogs --no-stdsplit --quiet --suite=dlopen

--- a/meson.build
+++ b/meson.build
@@ -15,7 +15,7 @@ project('systemd', 'c',
 
 add_test_setup(
         'default',
-        exclude_suites : ['clang-tidy', 'coccinelle', 'dlopen', 'unused-symbols', 'integration-tests'],
+        exclude_suites : ['clang-tidy', 'coccinelle', 'unused-symbols', 'integration-tests'],
         exe_wrapper : find_program('tools/test-crash-trace.sh'),
         is_default : true,
 )
@@ -347,6 +347,7 @@ userspace_c_ld_args = []
 userspace_sources = []
 
 want_tests = get_option('tests')
+want_dlopen_tests = want_tests != 'false' and get_option('dlopen-tests')
 want_slow_tests = want_tests != 'false' and get_option('slow-tests')
 want_fuzz_tests = want_tests != 'false' and get_option('fuzz-tests')
 install_tests = want_tests != 'false' and get_option('install-tests')
@@ -1743,9 +1744,11 @@ efi_arch = {
         'x86'         : 'ia32',
 }.get(host_machine.cpu_family(), '')
 
-pyelftools = pymod.find_installation('python3',
-                                     required : get_option('bootloader'),
-                                     modules : ['elftools'])
+pyelftools = pymod.find_installation(
+        'python3',
+        required : get_option('bootloader').enabled() or want_dlopen_tests,
+        modules : ['elftools'],
+)
 
 have = get_option('bootloader').require(
         pyelftools.found() and get_option('efi') and efi_arch != '',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -538,6 +538,8 @@ option('zshcompletiondir', type : 'string',
 
 option('tests', type : 'combo', choices : ['true', 'unsafe', 'false'],
        description : 'enable extra tests with =unsafe')
+option('dlopen-tests', type : 'boolean', value : false,
+       description : 'run the dlopen tests by default (requires linking all .standalone binaries)')
 option('slow-tests', type : 'boolean', value : false,
        description : 'run the slow tests by default')
 option('fuzz-tests', type : 'boolean', value : true,

--- a/test/meson.build
+++ b/test/meson.build
@@ -279,9 +279,9 @@ endif
 
 ############################################################
 
-if want_tests != 'false' and pyelftools.found()
-        test_dlopen_note_py = files('test-dlopen-note.py')
+test_dlopen_note_py = files('test-dlopen-note.py')
 
+if want_dlopen_tests
         foreach name, exe : executables_by_name
                 if name.endswith('.static') or name.endswith('.shared')
                         continue


### PR DESCRIPTION
Alternative to #43045.