### PR TITLE
sd-device: allow non-safe characters in uevent files

### DIFF
--- a/src/libsystemd/sd-device/sd-device.c
+++ b/src/libsystemd/sd-device/sd-device.c
@@ -837,7 +837,7 @@ int device_read_uevent_file(sd_device *device) {
         device->uevent_loaded = true;
 
         const char *uevent;
-        r = device_get_sysattr_safe_string(device, "uevent", &uevent);
+        r = sd_device_get_sysattr_value(device, "uevent", &uevent);
         if (ERRNO_IS_NEG_PRIVILEGE(r) || ERRNO_IS_NEG_DEVICE_ABSENT(r))
                 /* The uevent files may be write-only, the device may be already removed, or the device
                  * may not have the uevent file. */
@@ -854,25 +854,30 @@ int device_read_uevent_file(sd_device *device) {
         STRV_FOREACH(s, v) {
                 char *eq = strchr(*s, '=');
                 if (!eq) {
-                        log_device_debug(device, "sd-device: Invalid uevent line, ignoring: %s", *s);
+                        _cleanup_free_ char *escaped = cescape(*s);
+                        log_device_debug(device, "sd-device: Invalid uevent line, ignoring: %s", strnull(escaped));
                         continue;
                 }
 
                 *eq = '\0';
 
                 r = handle_uevent_line(device, *s, eq + 1, &major, &minor);
-                if (r < 0)
+                if (r < 0) {
+                        _cleanup_free_ char *escaped_key = cescape(*s), *escaped_value = cescape(eq + 1);
                         log_device_debug_errno(device, r,
                                                "sd-device: Failed to handle uevent entry '%s=%s', ignoring: %m",
-                                               *s, eq + 1);
+                                               strnull(escaped_key), strnull(escaped_value));
+                }
         }
 
         if (major) {
                 r = device_set_devnum(device, major, minor);
-                if (r < 0)
+                if (r < 0) {
+                        _cleanup_free_ char *escaped_major = cescape(major), *escaped_minor = minor ? cescape(minor) : NULL;
                         log_device_debug_errno(device, r,
                                                "sd-device: Failed to set 'MAJOR=%s' and/or 'MINOR=%s' from uevent, ignoring: %m",
-                                               major, strna(minor));
+                                               strnull(escaped_major), minor ? strnull(escaped_minor) : "n/a");
+                }
         }
 
         r = device_in_subsystem(device, "drivers");


### PR DESCRIPTION
This partially reverts 13ce62caba10e0dfa715dfa5c3ab551dedb02095.

Sometimes, the kernel passes non-safe characters in uevent files, such as the UNIQ= property for USB serial devices.

Instead of rejecting the entire uevent file, let's only ignore the specific key-value pairs that contain non-safe characters.

Fixes #43008.