### PR TITLE
password-quality-util-passwdqc: restore password-quality-util.h include

### DIFF
--- a/src/shared/password-quality-util-passwdqc.c
+++ b/src/shared/password-quality-util-passwdqc.c
@@ -14,6 +14,7 @@
 #include "alloc-util.h"
 #include "dlfcn-util.h"
 #include "memory-util.h"
+#include "password-quality-util.h"
 #include "strv.h"
 
 static DLSYM_PROTOTYPE(passwdqc_params_reset) = NULL;


### PR DESCRIPTION
`suggest_passwords()` uses the `N_SUGGESTIONS` macro, defined in
`password-quality-util.h`, but that header is no longer included in the passwdqc
translation unit, so the build fails when the passwdqc backend is enabled:

```
src/shared/password-quality-util-passwdqc.c:71:35: error: 'N_SUGGESTIONS' undeclared (first use in this function)
```

Commit ff33c8f87d ("Extend test-dlopen-so to also cover cases when built without
support") introduced the per-backend split headers. For the pwquality backend it
*added* `password-quality-util-pwquality.h` while keeping
`password-quality-util.h`; for the passwdqc backend it *replaced*
`password-quality-util.h` with `password-quality-util-passwdqc.h` (which only
pulls in `forward.h`/`dlopen-note.h`), so `N_SUGGESTIONS` is no longer visible.

This went unnoticed because the passwdqc backend is not built by the default CI
(pwquality is used instead). Restore the include, matching the pwquality backend.
