### PR TITLE
systemd-imds-import: run before systemd-tmpfiles-setup

### DIFF
--- a/units/systemd-imds-import.service.in
+++ b/units/systemd-imds-import.service.in
@@ -14,7 +14,7 @@ Documentation=man:systemd.system-credentials(7)
 DefaultDependencies=no
 Wants=systemd-imdsd.socket network-online.target
 After=systemd-imdsd.socket network-online.target
-Before=sysinit.target systemd-firstboot.service
+Before=sysinit.target systemd-firstboot.service systemd-tmpfiles-setup.service
 Conflicts=shutdown.target
 Before=shutdown.target
 


### PR DESCRIPTION
provision.conf sets up /root/.ssh/authorized_keys based on the ssh.authorized_keys.root credential that  
systemd-imds-import provisions. However for that means that the provisioning of the credential should happen before systemd-tmpfiles runs.