### PR TITLE
hostname-util: strip all trailing separators in hostname_cleanup()

### DIFF
--- a/src/basic/hostname-util.c
+++ b/src/basic/hostname-util.c
@@ -130,7 +130,7 @@ char* hostname_cleanup(char *s) {
                         hyphen = false;
                 }
 
-        if (d > s && IN_SET(d[-1], '-', '.'))
+        while (d > s && IN_SET(d[-1], '-', '.'))
                 /* The dot can occur at most once, but we might have multiple
                  * hyphens, hence the loop */
                 d--;

--- a/src/test/test-hostname-util.c
+++ b/src/test/test-hostname-util.c
@@ -85,6 +85,14 @@ TEST(hostname_cleanup) {
         ASSERT_STREQ(hostname_cleanup(s), "foo.bar");
         s = strdupa_safe("foo.bar..");
         ASSERT_STREQ(hostname_cleanup(s), "foo.bar");
+        s = strdupa_safe("foobar--");
+        ASSERT_STREQ(hostname_cleanup(s), "foobar");
+        s = strdupa_safe("foobar-.");
+        ASSERT_STREQ(hostname_cleanup(s), "foobar");
+        s = strdupa_safe("foobar.-");
+        ASSERT_STREQ(hostname_cleanup(s), "foobar");
+        s = strdupa_safe("foobar-.-");
+        ASSERT_STREQ(hostname_cleanup(s), "foobar");
         s = strdupa_safe("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");
         ASSERT_STREQ(hostname_cleanup(s), "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");
         s = strdupa_safe("xxxx........xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");


### PR DESCRIPTION
## hostname-util: strip all trailing separators in `hostname_cleanup()`

`hostname_cleanup()` removed only a *single* trailing `'-'` or `'.'`. When the cleaned-up string ended in more than one separator, the extra one was left in place, so the function could return an invalid hostname ending in `'-'`.

For example:

| input       | before      | after     |
|-------------|-------------|-----------|
| `foobar--`  | `foobar-`   | `foobar`  |
| `foobar-.`  | `foobar-`   | `foobar`  |
| `foobar.-`  | `foobar.`   | `foobar`  |

The code already documented the intended behaviour: the trailing-separator removal carries the comment *"The dot can occur at most once, but we might have multiple hyphens, hence the loop"*; but it was implemented as a single `if`, not a loop. This changes it to a `while` so all trailing `'-'`/`'.'` characters are stripped, matching the comment.

### Changes

- `src/basic/hostname-util.c`: `if` -> `while` for trailing separator removal.
- `src/test/test-hostname-util.c`: add regression cases covering multiple and mixed trailing separators (`foobar--`, `foobar-.`, `foobar.-`, `foobar-.-`).

Existing test cases are unaffected: cases such as `foo-bar-.-com-.` still yield `foo-bar--com`, because there only a single separator ever reaches the tail; the new loop only changes behaviour when two or more trailing separators are present.

Fixes: https://github.com/systemd/systemd/issues/43054