### PR TITLE
strv: don't read past end of string on invalid UTF-8 in strv_rebreak_lines()

### DIFF
--- a/src/basic/strv.c
+++ b/src/basic/strv.c
@@ -8,7 +8,6 @@
 #include "escape.h"
 #include "extract-word.h"
 #include "fileio.h"
-#include "gunicode.h"
 #include "hashmap.h"
 #include "log.h"
 #include "memory-util.h"
@@ -1241,7 +1240,7 @@ int strv_rebreak_lines(char **l, size_t width, char ***ret) {
                 bool in_prefix = true; /* still in the whitespace in the beginning of the line? */
                 size_t w = 0;
 
-                for (const char *p = start; *p != 0; p = utf8_next_char(p)) {
+                for (const char *p = start; *p != 0; ) {
                         if (strchr(NEWLINE, *p)) {
                                 in_prefix = true;
                                 whitespace_begin = whitespace_end = NULL;
@@ -1258,11 +1257,13 @@ int strv_rebreak_lines(char **l, size_t width, char ***ret) {
                                 in_prefix = false;
                         }
 
-                        int cw = utf8_char_console_width(p);
-                        if (cw < 0) {
-                                log_debug_errno(cw, "Comment to line break contains invalid UTF-8, ignoring.");
-                                cw = 1;
-                        }
+                        char32_t c;
+                        int n = utf8_encoded_to_unichar(p, &c);
+                        if (n < 0)
+                                return log_debug_errno(n, "Line to break contains invalid UTF-8, refusing: %m");
+
+                        int cw = unichar_console_width(c);
+                        assert(cw >= 0);
 
                         w += cw;
 
@@ -1277,10 +1278,16 @@ int strv_rebreak_lines(char **l, size_t width, char ***ret) {
                                 if (r < 0)
                                         return r;
 
+                                /* Continue with the next line, starting at the first character after the
+                                 * whitespace we broke at. Note, that character has not been measured for
+                                 * the new line yet, hence reset the width and reprocess it. */
                                 p = start = whitespace_end;
                                 whitespace_begin = whitespace_end = NULL;
-                                w = cw;
+                                w = 0;
+                                continue;
                         }
+
+                        p += n;
                 }
 
                 /* Process rest of the line */

--- a/src/test/test-strv.c
+++ b/src/test/test-strv.c
@@ -1267,6 +1267,20 @@ TEST(strv_rebreak_lines) {
 
                 assert_se(strv_equal(a, b));
         }
+
+        /* Invalid UTF-8 is refused rather than measured. Previously a truncated multibyte lead byte at the
+         * end of a line was blind-skipped by its expected length, stepping over the NUL and reading past
+         * the end of the string. */
+        ASSERT_ERROR(strv_rebreak_lines(STRV_MAKE("foo\xF0"), 10, &l), EINVAL);
+        ASSERT_NULL(l);
+
+        ASSERT_ERROR(strv_rebreak_lines(STRV_MAKE("bar\xFC"), 10, &l), EINVAL);
+        ASSERT_NULL(l);
+
+        /* Same, but reached after a line break, i.e. with the scan restarted at the character following
+         * the whitespace we broke at. */
+        ASSERT_ERROR(strv_rebreak_lines(STRV_MAKE("a \xF0" "b"), 3, &l), EINVAL);
+        ASSERT_NULL(l);
 }
 
 TEST(strv_find_closest) {


### PR DESCRIPTION
## strv: don't read past end of string on invalid UTF-8 in `strv_rebreak_lines()`

`strv_rebreak_lines()` iterates each line with

```c
for (const char *p = start; *p != 0; p = utf8_next_char(p)) {
        ...
        int cw = utf8_char_console_width(p);
        if (cw < 0) {
                log_debug_errno(cw, "Comment to line break contains invalid UTF-8, ignoring.");
                cw = 1;
        }
        ...
}
```

`utf8_next_char()` is a blind advance by `utf8_skip_data[lead byte]` (up to 6), so it trusts the lead byte to actually be followed by that many continuation bytes. When the current character is invalid/truncated, `cw < 0` is only logged (and `cw` reset to 1) - the loop then advances by the full skip width anyway.

A line ending in a truncated multi-byte sequence therefore steps clean over the `NUL`. For the one-byte payload `"\xF0"` (stored as `F0 00`), `utf8_skip_data[0xF0] == 4` moves `p` four bytes forward, and the next `*p != 0` test reads past the end of the allocation. A `0xFC` lead advances six.

This is an out-of-bounds *read* only (the value is only tested against zero, never emitted), and I could not find a way to reach it from untrusted input on current `main` - the only non-test caller, `varlink_idl_format_comment()`, runs its input through `utf8_is_valid_n()` first. But `strv_rebreak_lines()` is a general helper in `src/basic/`, it is reachable via the exported `sd_varlink_idl_dump()`, and nothing documents a "must be valid UTF-8" precondition on the comment strings it receives - so the loop shouldn't depend on one.

### Fix

Advance by exactly one byte when the current character is not valid UTF-8, reusing the `cw < 0` result that is already computed. This mirrors the two sibling loops that already handle this correctly: `utf8_console_width()` (`src/basic/utf8.c`) bails out on `cw < 0`, and `src/shared/format-table.c` bounds its scan and does a plain `p++` on an invalid character.

### Changes

- `src/basic/strv.c`: move the loop advance to the end of the body and step by one byte on invalid UTF-8 (`p = cw < 0 ? p + 1 : utf8_next_char(p);`). The valid-UTF-8 path is unchanged.
- `src/test/test-strv.c`: add regression cases for inputs ending in a truncated lead byte (`"foo\xF0"`, `"bar\xFC"`); these read out of bounds under ASan/valgrind before the fix.
