### PR TITLE
escape: reject UTF-16 surrogates in \u escapes in cunescape_one()

### DIFF
--- a/src/basic/escape.c
+++ b/src/basic/escape.c
@@ -202,6 +202,13 @@ int cunescape_one(const char *p, size_t length, char32_t *ret, bool *eight_bit, 
                 if (c == 0 && !accept_nul)
                         return -EINVAL;
 
+                /* Don't allow UTF-16 surrogates, they cannot be encoded as valid UTF-8. Note we
+                 * deliberately do *not* use unichar_is_valid() here (unlike the \U case below):
+                 * it also rejects noncharacters such as U+FFFE, which callers legitimately round-trip
+                 * through \u (e.g. systemd.mount-extra= parsing, see test-fstab-generator). */
+                if (utf16_is_surrogate(c))
+                        return -EINVAL;
+
                 *ret = c;
                 r = 5;
                 break;

--- a/src/test/test-escape.c
+++ b/src/test/test-escape.c
@@ -102,6 +102,21 @@ TEST(cunescape) {
         ASSERT_STREQ(unescaped, "ßßΠA");
         unescaped = mfree(unescaped);
 
+        /* UTF-16 surrogates cannot be encoded as valid UTF-8 and must be rejected */
+        ASSERT_ERROR(cunescape("\\ud800", 0, &unescaped), EINVAL);
+        ASSERT_ERROR(cunescape("\\udfff", 0, &unescaped), EINVAL);
+
+        /* The code points immediately outside the surrogate range must still decode */
+        ASSERT_OK(cunescape("\\ud7ff", 0, &unescaped));
+        unescaped = mfree(unescaped);
+        ASSERT_OK(cunescape("\\ue000", 0, &unescaped));
+        unescaped = mfree(unescaped);
+
+        /* Noncharacters (e.g. U+FFFE) are valid scalar values, encode fine as UTF-8, and are
+         * relied upon by callers (systemd.mount-extra=), so unlike \U they stay accepted here */
+        ASSERT_OK(cunescape("\\ufffe", 0, &unescaped));
+        unescaped = mfree(unescaped);
+
         assert_se(cunescape("\\073", 0, &unescaped) >= 0);
         ASSERT_STREQ(unescaped, ";");
         unescaped = mfree(unescaped);


### PR DESCRIPTION
## escape: reject UTF-16 surrogates in `\u` escapes in `cunescape_one()`

A `\u` escape in `cunescape_one()` was accepted for any 16-bit value except NUL. That range `0x0000`-`0xFFFF` includes the UTF-16 surrogates `0xD800`-`0xDFFF`, which are not valid Unicode scalar values and cannot be encoded as valid UTF-8. `\ud800` was therefore decoded into `char32_t 0xD800` and re-encoded downstream into an invalid surrogate ("WTF-8") byte sequence, whereas the equivalent `\U0000d800` is already rejected.

### Fix

Reject surrogates in the `\u` path using `utf16_is_surrogate()`.

Noncharacters (e.g. `U+FFFE`) are deliberately left accepted: they are valid Unicode scalar values, are encodable as UTF-8, and existing callers/tests (e.g. the fstab generator's `systemd.mount-extra=` parsing) rely on them round-tripping. This change is intentionally limited to surrogates.

### Changes

- `src/basic/escape.c`: reject surrogates in the `\u` case of `cunescape_one()`.
- `src/test/test-escape.c`: assert `\ud800`/`\udfff` are rejected and that a noncharacter (`￾`) and a normal `\u` escape still decode.