### PR TITLE
basic/strv: propagate invalid UTF-8 from strv_rebreak_lines() instead of walking past it

### DIFF
--- a/src/basic/strv.c
+++ b/src/basic/strv.c
@@ -8,7 +8,6 @@
 #include "escape.h"
 #include "extract-word.h"
 #include "fileio.h"
-#include "gunicode.h"
 #include "hashmap.h"
 #include "log.h"
 #include "memory-util.h"
@@ -1241,7 +1240,10 @@ int strv_rebreak_lines(char **l, size_t width, char ***ret) {
                 bool in_prefix = true; /* still in the whitespace in the beginning of the line? */
                 size_t w = 0;
 
-                for (const char *p = start; *p != 0; p = utf8_next_char(p)) {
+                for (const char *p = start; *p != 0; ) {
+                        char32_t c;
+                        int k;
+
                         if (strchr(NEWLINE, *p)) {
                                 in_prefix = true;
                                 whitespace_begin = whitespace_end = NULL;
@@ -1258,11 +1260,20 @@ int strv_rebreak_lines(char **l, size_t width, char ***ret) {
                                 in_prefix = false;
                         }
 
+                        /* utf8_next_char() blindly indexes utf8_skip_data[] with the lead byte and
+                         * steps that many bytes forward, which on a truncated multi-byte sequence
+                         * advances past the end of the allocation and makes the loop's *p != 0 check
+                         * read out of bounds. Decode the sequence with utf8_encoded_to_unichar()
+                         * instead — it bounds its own continuation-byte scan at the NUL terminator
+                         * and returns the byte length, so we can step by exactly that and propagate
+                         * the error on invalid UTF-8 rather than walking past it. */
+                        k = utf8_encoded_to_unichar(p, &c);
+                        if (k < 0)
+                                return k;
+
                         int cw = utf8_char_console_width(p);
-                        if (cw < 0) {
-                                log_debug_errno(cw, "Comment to line break contains invalid UTF-8, ignoring.");
-                                cw = 1;
-                        }
+                        if (cw < 0)
+                                return cw;
 
                         w += cw;
 
@@ -1279,8 +1290,9 @@ int strv_rebreak_lines(char **l, size_t width, char ***ret) {
 
                                 p = start = whitespace_end;
                                 whitespace_begin = whitespace_end = NULL;
-                                w = cw;
-                        }
+                                w = 0;
+                        } else
+                                p += k;
                 }
 
                 /* Process rest of the line */

--- a/src/test/test-strv.c
+++ b/src/test/test-strv.c
@@ -1267,6 +1267,17 @@ TEST(strv_rebreak_lines) {
 
                 assert_se(strv_equal(a, b));
         }
+
+        /* Entries containing a truncated multi-byte UTF-8 sequence are invalid: strv_rebreak_lines()
+         * must reject them with a negative error code rather than walking past the NUL terminator.
+         * The 0xF0 lead byte would have utf8_skip_data[0xF0] == 4, so the old utf8_next_char() step
+         * advanced 4 bytes from a 2-byte allocation and tripped the *p != 0 check out of bounds.
+         * See https://github.com/systemd/systemd/issues/43052 */
+        for (size_t i = 1; i < 100; i++) {
+                _cleanup_strv_free_ char **a = NULL;
+
+                assert_se(strv_rebreak_lines(STRV_MAKE("foo bar baz qux \xF0", "foo \xF0"), i, &a) == -EINVAL);
+        }
 }
 
 TEST(strv_find_closest) {


### PR DESCRIPTION
## Summary

`strv_rebreak_lines()` walks each entry with `p = utf8_next_char(p)`. `utf8_next_char()` is a blind advance that indexes `utf8_skip_data[]` with the lead byte and steps that many bytes forward, with no validation. When an entry ends in a truncated multi-byte sequence (e.g. a lone `0xF0` lead byte whose three continuation bytes are missing), `utf8_skip_data[0xF0] == 4` makes the walker advance past the end of the allocation; the loop's own `*p != 0` test then reads out of bounds. Under AddressSanitizer this is a heap-buffer-overflow; at a page boundary it can segfault.

## Changes

| File | Change |
|------|--------|
| `src/basic/strv.c` | In the `strv_rebreak_lines()` walk loop, decode each sequence with `utf8_encoded_to_unichar(p, &c)` (which bounds its own continuation-byte scan at the NUL terminator and returns the byte length) and step by that length. Propagate the error on invalid UTF-8 (`if (k < 0) return k;`) rather than trying to step past it. Likewise propagate `utf8_char_console_width()`'s error instead of the old `log_debug_errno()` + `cw = 1` fallback. Drop the now-unused `#include "gunicode.h"`. |
| `src/test/test-strv.c` | Add a `strv_rebreak_lines` test case that line-breaks entries ending in a truncated `0xF0` lead byte; the function must now reject them with `-EINVAL` instead of crashing (without the fix this reproduces the heap-buffer-overflow reported in #43052). |

## Test plan

- [x] `meson test -C build -v test-strv` — passes (includes the new truncated-`0xF0` case asserting `-EINVAL`, and all pre-existing line-break assertions are unchanged)
- [x] `meson test -C build -v test-utf8` — passes (no regressions in UTF-8 handling)
- [x] standalone ASan harness on the exact repro inputs (`"foo bar baz qux \xF0"`, `"foo \xF0"`, NUL-terminated) returns `-EINVAL` with no heap-buffer-overflow

Build config used: `meson setup build -Dmode=developer` with optional features disabled (no gcrypt/gnutls/pam/seccomp/...).

Fixes #43052
