### PR TITLE
man/network: fix default value for RequiredFamilyForOnline=

### DIFF
--- a/man/systemd.network.xml
+++ b/man/systemd.network.xml
@@ -347,7 +347,7 @@
           required when determining whether the link is online (including when running
           <command>systemd-networkd-wait-online</command>). Takes one of <literal>ipv4</literal>,
           <literal>ipv6</literal>, <literal>both</literal>, or <literal>any</literal>. Defaults to
-          <literal>no</literal>. Note that this option has no effect if
+          <literal>any</literal>. Note that this option has no effect if
           <literal>RequiredForOnline=no</literal>.</para>
 
           <xi:include href="version-info.xml" xpointer="v249"/>


### PR DESCRIPTION
It was unexpectedly changed by c89efaf9e5b0d8820dff51edfa7a0e576ed8b3b2.

Fixes #43074.