### PR TITLE
rules: classify PlayStation audio controllers as controller form-factor

### DIFF
--- a/hwdb.d/70-sound-card.hwdb
+++ b/hwdb.d/70-sound-card.hwdb
@@ -52,6 +52,19 @@ usb:v045Ep091E*
  SOUND_FORM_FACTOR=headset
 
 ###########################################################
+# Sony
+###########################################################
+# DualSense (PS5)
+usb:v054Cp0CE6*
+# DualSense Edge (PS5)
+usb:v054Cp0DF2*
+# DualShock 4 [CUH-ZCT1x]
+usb:v054Cp05C4*
+# DualShock 4 [CUH-ZCT2x]
+usb:v054Cp09CC*
+ SOUND_FORM_FACTOR=controller
+
+###########################################################
 # Steelseries
 ###########################################################
 # Arctis Headsets

--- a/hwdb.d/parse_hwdb.py
+++ b/hwdb.d/parse_hwdb.py
@@ -230,7 +230,18 @@ def property_grammar():
         ('ID_CAMERA_DIRECTION', Or(('front', 'rear'))),
         (
             'SOUND_FORM_FACTOR',
-            Or(('internal', 'webcam', 'speaker', 'headphone', 'headset', 'handset', 'microphone')),
+            Or(
+                (
+                    'internal',
+                    'webcam',
+                    'speaker',
+                    'headphone',
+                    'headset',
+                    'handset',
+                    'microphone',
+                    'controller',
+                )
+            ),
         ),
         ('ID_SYS_VENDOR_IS_RUBBISH', zero_one),
         ('ID_PRODUCT_NAME_IS_RUBBISH', zero_one),


### PR DESCRIPTION
Add Sony PlayStation controller entries to 70-sound-card.hwdb so that their ALSA sound devices are tagged with SOUND_FORM_FACTOR=controller:
 - DualSense (054c:0ce6)
 - DualSense Edge (054c:0df2)
 - DualShock 4 CUH-ZCT1x (054c:05c4)
 - DualShock 4 CUH-ZCT2x (054c:09cc)

These controllers expose USB audio but are neither headsets nor speakers. Pinning them in the hwdb ensures they are identified correctly before any fallback matching occurs.