### PR TITLE
fixups for systemd-osc-context

### DIFF
--- a/profile.d/80-systemd-osc-context.sh
+++ b/profile.d/80-systemd-osc-context.sh
@@ -63,7 +63,7 @@ __systemd_osc_context_precmdline() {
         if [ "$systemd_exitstatus" -gt 128 ] && systemd_signal=$(kill -l "$systemd_exitstatus" 2>&-); then
             printf "\033]3008;end=%.64s;exit=failure;status=%d;signal=SIG%s\033\\" "$systemd_osc_context_cmd_id" "$systemd_exitstatus" "$systemd_signal"
         elif [ "$systemd_exitstatus" -ne 0 ]; then
-            printf "\033]3008;end=%.64s;exit=failure;status=%d\033\\" "$systemd_osc_context_cmd_id" $((systemd_exitstatus))
+            printf "\033]3008;end=%.64s;exit=failure;status=%d\033\\" "$systemd_osc_context_cmd_id" "$systemd_exitstatus"
         else
             printf "\033]3008;end=%.64s;exit=success\033\\" "$systemd_osc_context_cmd_id"
         fi

--- a/profile.d/80-systemd-osc-context.sh
+++ b/profile.d/80-systemd-osc-context.sh
@@ -53,6 +53,7 @@ __systemd_osc_context_common() {
         printf ";machineid=%.36s" "$(</etc/machine-id)"
     fi
     printf ";user=%.255s;hostname=%.255s;bootid=%.36s;pid=%.20s" "$USER" "$HOSTNAME" "$(</proc/sys/kernel/random/boot_id)" "$$"
+    printf ";cwd=%.255s" "$(__systemd_osc_context_escape "$PWD")"
 }
 
 __systemd_osc_context_precmdline() {
@@ -75,7 +76,7 @@ __systemd_osc_context_precmdline() {
     fi
 
     # Create or update the shell session
-    printf "\033]3008;start=%.64s;type=shell%s;cwd=%.255s\033\\" "$systemd_osc_context_shell_id" "$(__systemd_osc_context_common)" "$(__systemd_osc_context_escape "$PWD")"
+    printf "\033]3008;start=%.64s;type=shell%s\033\\" "$systemd_osc_context_shell_id" "$(__systemd_osc_context_common)"
 
     # Prepare cmd id for next command
     read -r systemd_osc_context_cmd_id </proc/sys/kernel/random/uuid
@@ -85,7 +86,7 @@ __systemd_osc_context_ps0() {
     # Skip if PROMPT_COMMAND= is cleared manually or by other profiles.
     [ -n "${systemd_osc_context_cmd_id:-}" ] || return
 
-    printf "\033]3008;start=%.64s;type=command%s;cwd=%.255s\033\\" "$systemd_osc_context_cmd_id" "$(__systemd_osc_context_common)" "$(__systemd_osc_context_escape "$PWD")"
+    printf "\033]3008;start=%.64s;type=command%s\033\\" "$systemd_osc_context_cmd_id" "$(__systemd_osc_context_common)"
 }
 
 if [ -n "${BASH_VERSION:-}" ]; then

--- a/profile.d/80-systemd-osc-context.sh
+++ b/profile.d/80-systemd-osc-context.sh
@@ -52,7 +52,7 @@ __systemd_osc_context_common() {
     if [ -f /etc/machine-id ]; then
         printf ";machineid=%.36s" "$(</etc/machine-id)"
     fi
-    printf ";user=%.255s;hostname=%.255s;bootid=%.36s;pid=%.20d" "$USER" "$HOSTNAME" "$(</proc/sys/kernel/random/boot_id)" "$$"
+    printf ";user=%.255s;hostname=%.255s;bootid=%.36s;pid=%.20s" "$USER" "$HOSTNAME" "$(</proc/sys/kernel/random/boot_id)" "$$"
 }
 
 __systemd_osc_context_precmdline() {

--- a/profile.d/80-systemd-osc-context.sh
+++ b/profile.d/80-systemd-osc-context.sh
@@ -35,25 +35,27 @@
 shopt -q promptvars || return 0
 
 __systemd_osc_context_escape() {
-    # Escape according to the OSC 3008 spec. We'll only do it where it's
-    # strictly necessary, and skip it when processing strings we are pretty
-    # sure we won't need it for, such as uuids, id128, hostnames, usernames,
-    # since they all come with syntax requirements that exclude \ and ;
-    # anyway. This hence primarily is about escaping the current working
-    # directory.
-    local systemd_value="$1"
+    # Escape according to the OSC 3008 spec. We'll skip it when processing
+    # strings we are pretty sure we won't need it for, such as uuids
+    # (originating from /proc/sys/kernel/ or /etc/machine-id) and special shell
+    # variables such as $$ and $? that always expand to decimal numbers.
+    local systemd_format="$1"
+    local systemd_value="$2"
     systemd_value="${systemd_value//\\/\\x5c}"
     systemd_value="${systemd_value//;/\\x3b}"
     systemd_value="${systemd_value//[[:cntrl:]]/⍰}"
-    printf "%s" "$systemd_value"
+    # shellcheck disable=SC2059 # always called with fixed format strings with a single string specifier
+    printf "$systemd_format" "$systemd_value"
 }
 
 __systemd_osc_context_common() {
     if [ -f /etc/machine-id ]; then
         printf ";machineid=%.36s" "$(</etc/machine-id)"
     fi
-    printf ";user=%.255s;hostname=%.255s;bootid=%.36s;pid=%.20s" "$USER" "$HOSTNAME" "$(</proc/sys/kernel/random/boot_id)" "$$"
-    printf ";cwd=%.255s" "$(__systemd_osc_context_escape "$PWD")"
+    __systemd_osc_context_escape ";user=%.255s" "$USER"
+    __systemd_osc_context_escape ";hostname=%.255s" "$HOSTNAME"
+    printf ";bootid=%.36s;pid=%.20s" "$(</proc/sys/kernel/random/boot_id)" "$$"
+    __systemd_osc_context_escape ";cwd=%.255s" "$PWD"
 }
 
 __systemd_osc_context_precmdline() {

--- a/profile.d/80-systemd-osc-context.sh
+++ b/profile.d/80-systemd-osc-context.sh
@@ -75,7 +75,7 @@ __systemd_osc_context_precmdline() {
     fi
 
     # Create or update the shell session
-    printf "\033]3008;start=%.64s%s;type=shell;cwd=%.255s\033\\" "$systemd_osc_context_shell_id" "$(__systemd_osc_context_common)" "$(__systemd_osc_context_escape "$PWD")"
+    printf "\033]3008;start=%.64s;type=shell%s;cwd=%.255s\033\\" "$systemd_osc_context_shell_id" "$(__systemd_osc_context_common)" "$(__systemd_osc_context_escape "$PWD")"
 
     # Prepare cmd id for next command
     read -r systemd_osc_context_cmd_id </proc/sys/kernel/random/uuid
@@ -85,7 +85,7 @@ __systemd_osc_context_ps0() {
     # Skip if PROMPT_COMMAND= is cleared manually or by other profiles.
     [ -n "${systemd_osc_context_cmd_id:-}" ] || return
 
-    printf "\033]3008;start=%.64s%s;type=command;cwd=%.255s\033\\" "$systemd_osc_context_cmd_id" "$(__systemd_osc_context_common)" "$(__systemd_osc_context_escape "$PWD")"
+    printf "\033]3008;start=%.64s;type=command%s;cwd=%.255s\033\\" "$systemd_osc_context_cmd_id" "$(__systemd_osc_context_common)" "$(__systemd_osc_context_escape "$PWD")"
 }
 
 if [ -n "${BASH_VERSION:-}" ]; then

--- a/profile.d/80-systemd-osc-context.sh
+++ b/profile.d/80-systemd-osc-context.sh
@@ -35,13 +35,17 @@
 shopt -q promptvars || return 0
 
 __systemd_osc_context_escape() {
-    # Escape according to the OSC 3008 spec. Since this requires shelling out
-    # to 'sed' we'll only do it where it's strictly necessary, and skip it when
-    # processing strings we are pretty sure we won't need it for, such as
-    # uuids, id128, hostnames, usernames, since they all come with syntax
-    # requirements that exclude \ and ; anyway. This hence primarily is about
-    # escaping the current working directory.
-    echo "$1" | sed -e 's/\\/\\x5c/g' -e 's/;/\\x3b/g' -e 's/[[:cntrl:]]/⍰/g'
+    # Escape according to the OSC 3008 spec. We'll only do it where it's
+    # strictly necessary, and skip it when processing strings we are pretty
+    # sure we won't need it for, such as uuids, id128, hostnames, usernames,
+    # since they all come with syntax requirements that exclude \ and ;
+    # anyway. This hence primarily is about escaping the current working
+    # directory.
+    local systemd_value="$1"
+    systemd_value="${systemd_value//\\/\\x5c}"
+    systemd_value="${systemd_value//;/\\x3b}"
+    systemd_value="${systemd_value//[[:cntrl:]]/⍰}"
+    printf "%s" "$systemd_value"
 }
 
 __systemd_osc_context_common() {


### PR DESCRIPTION
I noticed that the use of sed in the `80-systemd-osc-context.sh` was unnecessary, and upon writing a replacement in pure bash and testing it, actually buggy. While in there, I also spotted some other minor things that might be worth doing.

Getting rid of fork+exec for doing sed is probably the biggest win, but there are still quite a few subshell invocations (that only do fork, not exec). I haven't measured the overhead of those, but it seems that we could get rid of those as well if we want.

Another thing I wonder about is whether we should emit an end= marker on shell exit. There's no guaranteed way of doing it. Just as everything else, we could get killed before getting a chance to do it. But also, unlike PROMPT_COMMANDS, there's no "at_exit" array to hook into. Still, we could ask if there is a 'trap exit' hook installed, and if not, install one ourselves; if the user's bashrc subsequently overrides that, so be it (though .bash_logout would be more appropriate).