### PR TITLE
utf8: split out unichar_console_width() from utf8_char_console_width()

### DIFF
--- a/src/basic/utf8.c
+++ b/src/basic/utf8.c
@@ -179,10 +179,16 @@ int utf8_char_console_width(const char *str) {
         char32_t c;
         int r;
 
+        assert(str);
+
         r = utf8_encoded_to_unichar(str, &c);
         if (r < 0)
                 return r;
 
+        return unichar_console_width(c);
+}
+
+int unichar_console_width(char32_t c) {
         if (c == '\t')
                 return 8; /* Assume a tab width of 8 */
 

--- a/src/basic/utf8.h
+++ b/src/basic/utf8.h
@@ -55,6 +55,7 @@ static inline char32_t utf16_surrogate_pair_to_unichar(char16_t lead, char16_t t
 
 size_t utf8_n_codepoints(const char *str) _pure_;
 int utf8_char_console_width(const char *str) _pure_;
+int unichar_console_width(char32_t c) _pure_;
 size_t utf8_console_width(const char *str) _pure_;
 
 size_t utf8_last_length(const char *s, size_t n) _pure_;


### PR DESCRIPTION
It will be used later.