### PR TITLE
man: document that ExitType=cgroup is rejected for Type=oneshot

### DIFF
--- a/man/systemd.service.xml
+++ b/man/systemd.service.xml
@@ -305,11 +305,11 @@
           <itemizedlist>
             <listitem><para>If set to <option>main</option> (the default), the service manager
             will consider the unit stopped when the main process, which is determined according to the
-            <varname>Type=</varname>, exits. Consequently, it cannot be used with
-            <varname>Type=</varname><option>oneshot</option>.</para></listitem>
+            <varname>Type=</varname>, exits.</para></listitem>
 
             <listitem><para>If set to <option>cgroup</option>, the service will be considered running as long as at
-            least one process in the cgroup has not exited.</para></listitem>
+            least one process in the cgroup has not exited. This option cannot be used with
+            <varname>Type=</varname><option>oneshot</option>.</para></listitem>
           </itemizedlist>
 
           <para>It is generally recommended to use <varname>ExitType=</varname><option>main</option> when a service has


### PR DESCRIPTION
The `ExitType=` documentation in `systemd.service(5)` stated that `ExitType=main` "cannot be used with `Type=oneshot`", which is incorrect: `ExitType=main` is the default and works perfectly fine with `Type=oneshot`. The restriction actually enforced by the code is that `ExitType=cgroup` is refused for `Type=oneshot` services (see `service_verify()` in `src/core/service.c`):

```c
if (s->type == SERVICE_ONESHOT && s->exit_type == SERVICE_EXIT_CGROUP)
    return log_unit_error_errno(..., "Service has ExitType=cgroup set, which isn't allowed for Type=oneshot services. Refusing.");
```

This moves the "cannot be used with `Type=oneshot`" note from the `ExitType=main` bullet to the `ExitType=cgroup` bullet where it belongs.

Fixes #42327

---

Supersedes #42434, which attempted the same fix but (1) incorrectly stated that `ExitType=main` also cannot be used with `Type=oneshot`, (2) later removed the restriction note entirely instead of relocating it, and (3) had a commit message that did not match the diff.
