### PR TITLE
boot: Group entries in sub-menus

### DIFF
--- a/man/systemd-boot.xml
+++ b/man/systemd-boot.xml
@@ -140,9 +140,18 @@
       <varlistentry>
         <term><keycap>↵</keycap> (Enter)</term>
         <term><keycap>→</keycap> (Right)</term>
-        <listitem><para>Boot selected entry</para>
+        <listitem><para>Boot the selected entry, or enter the selected submenu</para>
 
         <xi:include href="version-info.xml" xpointer="v239"/></listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term><keycap>←</keycap> (Left)</term>
+        <term><keycap>Del</keycap></term>
+        <term><keycap>Esc</keycap></term>
+        <listitem><para>Go back to the entry list from a submenu</para>
+
+        <xi:include href="version-info.xml" xpointer="v262"/></listitem>
       </varlistentry>
 
       <varlistentry>
@@ -230,7 +239,8 @@
 
         <para>For compatibility with the keybindings of several firmware implementations this operation
         may also be reached with <keycap>F2</keycap>, <keycap>F10</keycap>, <keycap>Del</keycap> and
-        <keycap>Esc</keycap>.</para>
+        <keycap>Esc</keycap>. Note that <keycap>Del</keycap> and <keycap>Esc</keycap> only do this in the
+        entry list: while a submenu is open they leave the submenu instead.</para>
 
         <xi:include href="version-info.xml" xpointer="v250"/></listitem>
       </varlistentry>

--- a/src/boot/boot.c
+++ b/src/boot/boot.c
@@ -134,6 +134,7 @@ typedef struct BootEntry {
         char16_t *current_name;
         char16_t *next_name;
         unsigned profile;
+        bool grouped;
 } BootEntry;
 
 typedef struct {
@@ -202,8 +203,8 @@ enum {
 };
 
 
-static size_t entry_lookup_key(Config *config, size_t start, char16_t key) {
-        assert(config);
+static size_t entry_lookup_key(BootEntry **entries, size_t n_entries, size_t start, char16_t key) {
+        assert(entries);
 
         if (key == 0)
                 return IDX_INVALID;
@@ -211,18 +212,29 @@ static size_t entry_lookup_key(Config *config, size_t start, char16_t key) {
         /* select entry by number key */
         if (key >= '1' && key <= '9') {
                 size_t i = key - '0';
-                if (i > config->n_entries)
-                        i = config->n_entries;
+                if (i > n_entries)
+                        i = n_entries;
                 return i-1;
         }
 
         /* find matching key in boot entries */
-        for (size_t i = start; i < config->n_entries; i++)
-                if (config->entries[i]->key == key)
+        for (size_t i = start; i < n_entries; i++)
+                if (entries[i]->key == key)
                         return i;
 
         for (size_t i = 0; i < start; i++)
-                if (config->entries[i]->key == key)
+                if (entries[i]->key == key)
+                        return i;
+
+        return IDX_INVALID;
+}
+
+static size_t config_entry_index_by_id(const Config *config, const char16_t *id) {
+        assert(config);
+        assert(id);
+
+        for (size_t i = 0; i < config->n_entries; i++)
+                if (strcmp16(config->entries[i]->id, id) == 0)
                         return i;
 
         return IDX_INVALID;
@@ -490,6 +502,173 @@ static EFI_STATUS call_reboot_into_firmware(const BootEntry *entry, EFI_FILE *ro
         return call_reboot_system(entry, root_dir, parent_image);
 }
 
+static BootEntry* boot_entry_free(BootEntry *entry);
+
+static void config_reset_grouped_entries(BootEntry **entries, size_t n_entries) {
+        for (size_t i = 0; i < n_entries; i++) {
+                if (entries[i]->grouped)
+                        boot_entry_free(entries[i]);
+                entries[i] = NULL;
+        }
+}
+
+/* Append the config entry at index src to the output list, recording its output position if it is the
+ * (efivar or config) default. */
+static void config_add_menu_entry(
+                Config *config,
+                BootEntry **entries,
+                size_t *n_entries,
+                size_t src,
+                size_t *ret_idx_default,
+                size_t *ret_idx_default_efivar) {
+
+        assert(config);
+        assert(entries);
+        assert(n_entries);
+        assert(ret_idx_default_efivar);
+        assert(src < config->n_entries);
+
+        if (config->idx_default_efivar == src)
+                *ret_idx_default_efivar = *n_entries;
+        if (ret_idx_default && config->idx_default == src)
+                *ret_idx_default = *n_entries;
+        entries[(*n_entries)++] = config->entries[src];
+}
+
+/* Whether the entry at the given index exists and carries the given sort key. Safe to call with
+ * IDX_INVALID, hence usable on the possibly unset default indexes. */
+static bool entry_has_sort_key(Config *config, size_t idx, const char16_t *sort_key) {
+        assert(config);
+        assert(sort_key);
+
+        return idx < config->n_entries && streq16(config->entries[idx]->sort_key, sort_key);
+}
+
+/* Build the top level menu, collapsing each group of three or more entries sharing a sort key behind a
+ * single representative entry plus a "More >" submenu placeholder, which is always placed directly below
+ * its representative.
+ *
+ * Note that entries sharing a sort key are not necessarily adjacent: boot_entry_compare() orders entries
+ * with no tries left to the very end of the list, before it ever looks at the sort key. A sort key used by
+ * both healthy and exhausted entries is thus split in two runs, which we still want to treat as one
+ * group. Hence group members are looked up by sort key across the whole list. */
+static void config_calculate_top_entries(
+                Config *config,
+                BootEntry **entries,
+                size_t *n_entries,
+                size_t *ret_idx_default,
+                size_t *ret_idx_default_efivar) {
+
+        assert(config);
+        assert(config->entries);
+        assert(entries);
+        assert(n_entries);
+        assert(ret_idx_default_efivar);
+
+        config_reset_grouped_entries(entries, *n_entries);
+        *n_entries = 0;
+        *ret_idx_default_efivar = IDX_INVALID;
+        if (ret_idx_default)
+                *ret_idx_default = IDX_INVALID;
+
+        for (size_t i = 0; i < config->n_entries; i++) {
+                char16_t *sort_key = config->entries[i]->sort_key;
+                size_t n_group = 0, first = IDX_INVALID;
+
+                /* Count the entries sharing this sort key, remembering the first of them. Only whether we
+                 * reach three matters, so stop counting there. Entries without a sort key are never
+                 * grouped, and hence never counted. */
+                if (sort_key)
+                        for (size_t j = 0; j < config->n_entries && n_group < 3; j++)
+                                if (entry_has_sort_key(config, j, sort_key)) {
+                                        if (n_group == 0)
+                                                first = j;
+                                        n_group++;
+                                }
+
+                /* One or two entries are not worth a submenu, show them as they are */
+                if (n_group < 3) {
+                        config_add_menu_entry(config, entries, n_entries, i, ret_idx_default, ret_idx_default_efivar);
+                        continue;
+                }
+
+                /* Already collapsed into the group emitted for its first member */
+                if (first != i)
+                        continue;
+
+                /* Prefer the efivar default as the representative, so that a preference set inside the
+                 * submenu stays visible (and marked) in the top menu; otherwise fall back to the config
+                 * default, then to the first (newest) entry. At a fresh boot the two indexes coincide, so
+                 * this does not change what boots on timeout. */
+                bool default_in_group = entry_has_sort_key(config, config->idx_default, sort_key);
+
+                size_t rep;
+                if (entry_has_sort_key(config, config->idx_default_efivar, sort_key))
+                        rep = config->idx_default_efivar;
+                else if (default_in_group)
+                        rep = config->idx_default;
+                else
+                        rep = first;
+
+                size_t rep_pos = *n_entries;
+                config_add_menu_entry(config, entries, n_entries, rep, ret_idx_default, ret_idx_default_efivar);
+
+                /* The representative stands in for every entry collapsed into it, hence highlight it if the
+                 * config default is one of them. The efivar default needs no such fixup: whenever it is part
+                 * of the group it is also the representative. */
+                if (ret_idx_default && default_in_group)
+                        *ret_idx_default = rep_pos;
+
+                /* Allocate the submenu placeholder; freed by config_reset_grouped_entries() */
+                BootEntry *entry = xnew(BootEntry, 1);
+                *entry = (BootEntry) {
+                        .title_show = xstrdup16(u"More >"),
+                        .sort_key = xstrdup16(sort_key),
+                        .grouped = true,
+                };
+                entries[(*n_entries)++] = entry;
+        }
+}
+
+/* Fill the entry list with the contents of one submenu, i.e. every entry carrying the given sort key. */
+static void submenu_for_sort_key(
+                char16_t *sort_key,
+                Config *config,
+                BootEntry **entries,
+                size_t *n_entries,
+                size_t *ret_idx_default_efivar) {
+
+        assert(sort_key);
+        assert(config);
+        assert(entries);
+        assert(n_entries);
+        assert(ret_idx_default_efivar);
+
+        config_reset_grouped_entries(entries, *n_entries);
+        *n_entries = 0;
+        *ret_idx_default_efivar = IDX_INVALID;
+
+        for (size_t i = 0; i < config->n_entries; i++)
+                if (entry_has_sort_key(config, i, sort_key))
+                        config_add_menu_entry(config, entries, n_entries, i,
+                                     /* ret_idx_default= */ NULL, ret_idx_default_efivar);
+}
+
+/* Return the status line to show for a firmware-setup request, and report via ret_enter_setup whether the
+ * firmware actually supports booting into its setup UI. */
+static char16_t* firmware_setup_prompt(bool *ret_enter_setup) {
+        assert(ret_enter_setup);
+
+        if (FLAGS_SET(get_os_indications_supported(), EFI_OS_INDICATIONS_BOOT_TO_FW_UI)) {
+                *ret_enter_setup = true;
+                /* Let's make sure the user really wants to do this. */
+                return xstrdup16(u"Press Enter to reboot into firmware interface.");
+        }
+
+        *ret_enter_setup = false;
+        return xstrdup16(u"Reboot into firmware interface not supported.");
+}
+
 static bool menu_run(
                 Config *config,
                 BootEntry **chosen_entry,
@@ -511,6 +690,15 @@ static bool menu_run(
                 timeout_remain = config->timeout_sec == TIMEOUT_MENU_FORCE ? 0 : config->timeout_sec;
         int64_t console_mode_initial = ST->ConOut->Mode->Mode, console_mode_efivar_saved = config->console_mode_efivar;
         size_t default_efivar_saved = config->idx_default_efivar;
+        _cleanup_free_ BootEntry** entries = NULL;
+        size_t n_entries = 0;
+        size_t idx_default_efivar = IDX_INVALID;
+        /* Position of the "More >" placeholder in the top-level menu whose submenu we are currently in,
+         * IDX_INVALID while we are in the top level menu itself. Rebuilding the entry list never moves a
+         * group's placeholder, since that depends only on which config entries are group-firsts, not on
+         * which one is currently picked as the representative, so this stays valid across rebuilds. */
+        size_t submenu_top_idx = IDX_INVALID;
+        bool enter_setup;
 
         enum {
                 ACTION_CONTINUE,        /* Continue with loop over user input */
@@ -536,6 +724,9 @@ static bool menu_run(
                 log_error_status(err, "Error switching console mode: %m");
         }
 
+        entries = xnew(BootEntry *, config->n_entries);
+        config_calculate_top_entries(config, entries, &n_entries, &idx_highlight, &idx_default_efivar);
+
         size_t line_width = 0, entry_padding = 3;
         while (IN_SET(action, ACTION_CONTINUE, ACTION_FIRMWARE_SETUP)) {
                 uint64_t key;
@@ -550,39 +741,39 @@ static bool menu_run(
                         * sure that idx_highlight is centered, but not if we are close to the
                         * beginning/end of the entry list. Otherwise we would have a half-empty
                         * screen. */
-                        if (config->n_entries <= visible_max || idx_highlight <= visible_max / 2)
+                        if (n_entries <= visible_max || idx_highlight <= visible_max / 2)
                                 idx_first = 0;
-                        else if (idx_highlight >= config->n_entries - (visible_max / 2))
-                                idx_first = config->n_entries - visible_max;
+                        else if (idx_highlight >= n_entries - (visible_max / 2))
+                                idx_first = n_entries - visible_max;
                         else
                                 idx_first = idx_highlight - (visible_max / 2);
                         idx_last = idx_first + visible_max - 1;
 
                         /* length of the longest entry */
                         line_width = 0;
-                        for (size_t i = 0; i < config->n_entries; i++)
-                                line_width = MAX(line_width, strlen16(config->entries[i]->title_show));
+                        for (size_t i = 0; i < n_entries; i++)
+                                line_width = MAX(line_width, strlen16(entries[i]->title_show));
                         line_width = MIN(line_width + 2 * entry_padding, x_max);
 
                         /* offsets to center the entries on the screen */
                         x_start = (x_max - (line_width)) / 2;
-                        if (config->n_entries < visible_max)
-                                y_start = ((visible_max - config->n_entries) / 2) + 1;
+                        if (n_entries < visible_max)
+                                y_start = ((visible_max - n_entries) / 2) + 1;
                         else
                                 y_start = 0;
 
                         /* Put status line after the entry list, but give it some breathing room. */
-                        y_status = MIN(y_start + MIN(visible_max, config->n_entries) + 1, y_max - 1);
+                        y_status = MIN(y_start + MIN(visible_max, n_entries) + 1, y_max - 1);
 
                         lines = strv_free(lines);
                         clearline = mfree(clearline);
                         separator = mfree(separator);
 
                         /* menu entries title lines */
-                        lines = xnew(char16_t *, config->n_entries + 1);
+                        lines = xnew(char16_t *, n_entries + 1);
 
-                        for (size_t i = 0; i < config->n_entries; i++) {
-                                size_t width = line_width - MIN(strlen16(config->entries[i]->title_show), line_width);
+                        for (size_t i = 0; i < n_entries; i++) {
+                                size_t width = line_width - MIN(strlen16(entries[i]->title_show), line_width);
                                 size_t padding = width / 2;
                                 bool odd = width % 2;
 
@@ -590,7 +781,7 @@ static bool menu_run(
                                 padding = MAX((size_t) 2, padding);
 
                                 size_t print_width = MIN(
-                                                strlen16(config->entries[i]->title_show),
+                                                strlen16(entries[i]->title_show),
                                                 line_width - padding * 2);
 
                                 assert((padding + 1) <= INT_MAX);
@@ -599,10 +790,10 @@ static bool menu_run(
                                 lines[i] = xasprintf(
                                                 "%*ls%.*ls%*ls",
                                                 (int) padding, u"",
-                                                (int) print_width, config->entries[i]->title_show,
+                                                (int) print_width, entries[i]->title_show,
                                                 odd ? (int) (padding + 1) : (int) padding, u"");
                         }
-                        lines[config->n_entries] = NULL;
+                        lines[n_entries] = NULL;
 
                         clearline = xnew(char16_t, x_max + 1);
                         separator = xnew(char16_t, x_max + 1);
@@ -624,11 +815,11 @@ static bool menu_run(
                 }
 
                 if (refresh) {
-                        for (size_t i = idx_first; i <= idx_last && i < config->n_entries; i++) {
+                        for (size_t i = idx_first; i <= idx_last && i < n_entries; i++) {
                                 print_at(x_start, y_start + i - idx_first,
                                          i == idx_highlight ? COLOR_HIGHLIGHT : COLOR_ENTRY,
                                          lines[i]);
-                                if (i == config->idx_default_efivar)
+                                if (i == idx_default_efivar)
                                         print_at(x_start,
                                                  y_start + i - idx_first,
                                                  i == idx_highlight ? COLOR_HIGHLIGHT : COLOR_ENTRY,
@@ -638,12 +829,12 @@ static bool menu_run(
                 } else if (highlight) {
                         print_at(x_start, y_start + idx_highlight_prev - idx_first, COLOR_ENTRY, lines[idx_highlight_prev]);
                         print_at(x_start, y_start + idx_highlight - idx_first, COLOR_HIGHLIGHT, lines[idx_highlight]);
-                        if (idx_highlight_prev == config->idx_default_efivar)
+                        if (idx_highlight_prev == idx_default_efivar)
                                 print_at(x_start,
                                          y_start + idx_highlight_prev - idx_first,
                                          COLOR_ENTRY,
                                          unicode_supported() ? u" ►" : u"=>");
-                        if (idx_highlight == config->idx_default_efivar)
+                        if (idx_highlight == idx_default_efivar)
                                 print_at(x_start,
                                          y_start + idx_highlight - idx_first,
                                          COLOR_HIGHLIGHT,
@@ -731,7 +922,7 @@ static bool menu_run(
                 case KEYPRESS(0, SCAN_VOLUME_DOWN, 0):
                 case KEYPRESS(0, 0, 'j'):
                 case KEYPRESS(0, 0, 'J'):
-                        if (idx_highlight < config->n_entries-1)
+                        if (idx_highlight < n_entries-1)
                                 idx_highlight++;
                         break;
 
@@ -745,9 +936,9 @@ static bool menu_run(
 
                 case KEYPRESS(0, SCAN_END, 0):
                 case KEYPRESS(EFI_ALT_PRESSED, 0, '>'):
-                        if (idx_highlight < config->n_entries-1) {
+                        if (idx_highlight < n_entries-1) {
                                 refresh = true;
-                                idx_highlight = config->n_entries-1;
+                                idx_highlight = n_entries-1;
                         }
                         break;
 
@@ -760,8 +951,8 @@ static bool menu_run(
 
                 case KEYPRESS(0, SCAN_PAGE_DOWN, 0):
                         idx_highlight += visible_max;
-                        if (idx_highlight > config->n_entries-1)
-                                idx_highlight = config->n_entries-1;
+                        if (idx_highlight > n_entries-1)
+                                idx_highlight = n_entries-1;
                         break;
 
                 case KEYPRESS(0, 0, '\n'):
@@ -770,7 +961,23 @@ static bool menu_run(
                 case KEYPRESS(0, SCAN_F3, '\r'):   /* Teclast X98+ II firmware sends malformed events */
                 case KEYPRESS(0, SCAN_RIGHT, 0):
                 case KEYPRESS(0, SCAN_SUSPEND, 0): /* Handle phones/tablets with only a power key + volume up/down rocker (and otherwise just touchscreen input) */
-                        action = ACTION_RUN;
+                        if (entries[idx_highlight]->grouped) {
+                                /* Take the sort key from the representative right above the placeholder,
+                                 * rather than from the placeholder itself: the former is a real config
+                                 * entry, the latter is freed as soon as we rebuild the entry list. */
+                                assert(idx_highlight > 0);
+                                submenu_top_idx = idx_highlight;
+
+                                submenu_for_sort_key(
+                                                entries[idx_highlight - 1]->sort_key,
+                                                config,
+                                                entries,
+                                                &n_entries,
+                                                &idx_default_efivar);
+                                idx_highlight = idx_default_efivar == IDX_INVALID ? 0 : idx_default_efivar;
+                                new_mode = true;
+                        } else
+                                action = ACTION_RUN;
                         break;
 
                 case KEYPRESS(0, SCAN_F1, 0):
@@ -789,14 +996,19 @@ static bool menu_run(
 
                 /* Set/unset the preferred entry */
                 case KEYPRESS(0, 0, 'd'):
-                        if (config->idx_default_efivar != idx_highlight) {
+                        if (entries[idx_highlight]->grouped)
+                                break;
+
+                        if (idx_default_efivar != idx_highlight) {
                                 free(config->entry_preferred_efivar);
-                                config->entry_preferred_efivar = xstrdup16(config->entries[idx_highlight]->id);
-                                config->idx_default_efivar = idx_highlight;
+                                config->entry_preferred_efivar = xstrdup16(entries[idx_highlight]->id);
+                                config->idx_default_efivar = config_entry_index_by_id(config, entries[idx_highlight]->id);
+                                idx_default_efivar = idx_highlight;
                                 status = xstrdup16(u"Preferred boot entry selected.");
                         } else {
                                 config->entry_preferred_efivar = mfree(config->entry_preferred_efivar);
                                 config->idx_default_efivar = IDX_INVALID;
+                                idx_default_efivar = IDX_INVALID;
                                 status = xstrdup16(u"Preferred boot entry cleared.");
                         }
                         config->entry_default_efivar = mfree(config->entry_default_efivar);
@@ -807,14 +1019,19 @@ static bool menu_run(
 
                 /* Set/unset the default entry */
                 case KEYPRESS(0, 0, 'D'):
-                        if (config->idx_default_efivar != idx_highlight) {
+                        if (entries[idx_highlight]->grouped)
+                                break;
+
+                        if (idx_default_efivar != idx_highlight) {
                                 free(config->entry_default_efivar);
-                                config->entry_default_efivar = xstrdup16(config->entries[idx_highlight]->id);
-                                config->idx_default_efivar = idx_highlight;
+                                config->entry_default_efivar = xstrdup16(entries[idx_highlight]->id);
+                                config->idx_default_efivar = config_entry_index_by_id(config, entries[idx_highlight]->id);
+                                idx_default_efivar = idx_highlight;
                                 status = xstrdup16(u"Default boot entry selected.");
                         } else {
                                 config->entry_default_efivar = mfree(config->entry_default_efivar);
                                 config->idx_default_efivar = IDX_INVALID;
+                                idx_default_efivar = IDX_INVALID;
                                 status = xstrdup16(u"Default boot entry cleared.");
                         }
                         config->entry_preferred_efivar = mfree(config->entry_preferred_efivar);
@@ -837,7 +1054,8 @@ static bool menu_run(
                 case KEYPRESS(0, 0, 'E'):
                         /* only the options of configured entries can be edited */
                         if (!config->editor ||
-                            !LOADER_TYPE_ALLOW_EDITOR(config->entries[idx_highlight]->type)) {
+                            !LOADER_TYPE_ALLOW_EDITOR(entries[idx_highlight]->type) ||
+                            entries[idx_highlight]->grouped) {
                                 status = xstrdup16(u"Entry does not support editing the command line.");
                                 break;
                         }
@@ -845,9 +1063,9 @@ static bool menu_run(
                         /* Unified kernels that are signed as a whole will not accept command line options
                          * when secure boot is enabled unless there is none embedded in the image. Do not try
                          * to pretend we can edit it to only have it be ignored. */
-                        if (!LOADER_TYPE_ALLOW_EDITOR_IN_SB(config->entries[idx_highlight]->type) &&
+                        if (!LOADER_TYPE_ALLOW_EDITOR_IN_SB(entries[idx_highlight]->type) &&
                             secure_boot_enabled() &&
-                            config->entries[idx_highlight]->options) {
+                            entries[idx_highlight]->options) {
                                 status = xstrdup16(u"Entry not editable in SecureBoot mode.");
                                 break;
                         }
@@ -858,13 +1076,13 @@ static bool menu_run(
                          * Since we cannot paint the last character of the edit line, we simply start
                          * at x-offset 1 for symmetry. */
                         print_at(1, y_status, COLOR_EDIT, clearline + 2);
-                        if (line_edit(&config->entries[idx_highlight]->options, x_max - 2, y_status))
+                        if (line_edit(&entries[idx_highlight]->options, x_max - 2, y_status))
                                 action = ACTION_RUN;
                         print_at(1, y_status, COLOR_NORMAL, clearline + 2);
 
                         /* The options string was now edited, hence we have to pass it to the invoked
                          * binary. */
-                        config->entries[idx_highlight]->options_implied = false;
+                        entries[idx_highlight]->options_implied = false;
                         break;
 
                 case KEYPRESS(0, 0, 'v'):
@@ -922,14 +1140,28 @@ static bool menu_run(
                 case KEYPRESS(0, 0, 'F'):
                 case KEYPRESS(0, SCAN_F2, 0):     /* Most vendors. */
                 case KEYPRESS(0, SCAN_F10, 0):    /* HP and Lenovo. */
+                        status = firmware_setup_prompt(&enter_setup);
+                        if (enter_setup)
+                                action = ACTION_FIRMWARE_SETUP;
+                        break;
+
                 case KEYPRESS(0, SCAN_DELETE, 0): /* Same as F2. */
                 case KEYPRESS(0, SCAN_ESC, 0):    /* HP. */
-                        if (FLAGS_SET(get_os_indications_supported(), EFI_OS_INDICATIONS_BOOT_TO_FW_UI)) {
-                                action = ACTION_FIRMWARE_SETUP;
-                                /* Let's make sure the user really wants to do this. */
-                                status = xstrdup16(u"Press Enter to reboot into firmware interface.");
-                        } else
-                                status = xstrdup16(u"Reboot into firmware interface not supported.");
+                        if (submenu_top_idx == IDX_INVALID) {
+                                status = firmware_setup_prompt(&enter_setup);
+                                if (enter_setup)
+                                        action = ACTION_FIRMWARE_SETUP;
+                        }
+                        _fallthrough_;
+
+                case KEYPRESS(0, SCAN_LEFT, 0):
+                        if (submenu_top_idx != IDX_INVALID) {
+                                config_calculate_top_entries(
+                                                config, entries, &n_entries, NULL, &idx_default_efivar);
+                                idx_highlight = submenu_top_idx;
+                                submenu_top_idx = IDX_INVALID;
+                                new_mode = true;
+                        }
                         break;
 
                 case KEYPRESS(0, 0, 'O'): /* Only uppercase, so that it can't be hit so easily fat-fingered,
@@ -943,7 +1175,7 @@ static bool menu_run(
 
                 default:
                         /* jump with a hotkey directly to a matching entry */
-                        idx = entry_lookup_key(config, idx_highlight+1, KEYCHAR(key));
+                        idx = entry_lookup_key(entries, n_entries, idx_highlight+1, KEYCHAR(key));
                         if (idx == IDX_INVALID)
                                 break;
                         idx_highlight = idx;
@@ -1019,7 +1251,15 @@ static bool menu_run(
                 break;
         }
 
-        *chosen_entry = config->entries[idx_highlight];
+        /* A grouped "More >" placeholder must never be booted, but it can still be the highlighted row when
+         * we bail out on a console read error. Boot the group's representative instead, i.e. the real entry
+         * right above the placeholder, which is what the group shows itself as. */
+        if (entries[idx_highlight]->grouped) {
+                assert(idx_highlight > 0);
+                *chosen_entry = entries[idx_highlight - 1];
+        } else
+                *chosen_entry = entries[idx_highlight];
+        config_reset_grouped_entries(entries, n_entries);
         clear_screen(COLOR_NORMAL);
         return action == ACTION_RUN;
 }
@@ -3477,7 +3717,7 @@ static EFI_STATUS run(EFI_HANDLE image) {
                 err = console_key_read(&key, 100 * 1000);
                 if (err == EFI_SUCCESS) {
                         /* find matching key in boot entries */
-                        size_t idx = entry_lookup_key(&config, config.idx_default, KEYCHAR(key));
+                        size_t idx = entry_lookup_key(config.entries, config.n_entries, config.idx_default, KEYCHAR(key));
                         if (idx != IDX_INVALID)
                                 config.idx_default = idx;
                         else


### PR DESCRIPTION
If there are 3 or more boot entries that share a sort-key, group them in a submenu. When grouping them, put the newest / latest entry first, or the default efi entry if belongs to the same group. Add an entry "More >" to enter the submenu and implement the needed keybindings to enter and exit the submenu.

Reimplement #28084.