### PR TITLE
rm-rf: downgrade root check log when directory doesn't exist

### DIFF
--- a/src/shared/rm-rf.c
+++ b/src/shared/rm-rf.c
@@ -449,7 +449,11 @@ int rm_rf_at(int dir_fd, const char *path, RemoveFlags flags) {
         if (FLAGS_SET(flags, REMOVE_MISSING_OK) && r == -ENOENT)
                 return 0;
         if (r < 0)
-                return log_error_errno(r, "Failed to determine whether '%s' is the root file system: %m", path);
+                return log_full_errno(
+                                r == -ENOENT ? LOG_DEBUG : LOG_ERR,
+                                r,
+                                "Failed to determine whether '%s' is the root file system: %m",
+                                path);
         if (r > 0)
                 return log_error_errno(SYNTHETIC_ERRNO(EPERM),
                                        "Attempted to remove entire root file system, and we can't allow that.");


### PR DESCRIPTION
When a unit is stopped we try to destroy the credential mount point, which might not exist. This logs at error level, which is noisy and pointless. Downgrade to debug level on ENOENT.

systemd[1]: Failed to determine whether '/run/credentials/run-p119516-i119816.service' is the root file system: No such file or directory

Follow-up for 9dd2dab37e91ab4b000802d98aa7c4713836d53a