### PR TITLE
timesyncd: add maximum clock step policy

### DIFF
--- a/man/timesyncd.conf.xml
+++ b/man/timesyncd.conf.xml
@@ -133,6 +133,21 @@
         <xi:include href="version-info.xml" xpointer="v250"/></listitem>
       </varlistentry>
 
+      <varlistentry>
+        <term><varname>MaxClockChangeSec=</varname></term>
+        <listitem><para>Specifies the maximum absolute clock offset that may be corrected based on a single
+        NTP response. If the measured offset exceeds this value, the response is ignored and
+        <command>systemd-timesyncd</command> switches to another server.</para>
+
+        <para>Takes a time span value. The default unit is seconds, but other units may be specified, see
+        <citerefentry><refentrytitle>systemd.time</refentrytitle><manvolnum>7</manvolnum></citerefentry>.
+        Defaults to <literal>infinity</literal>, which permits clock corrections of any size. Systems without
+        a reliable real-time clock may require a large initial correction and should configure this option
+        accordingly.</para>
+
+        <xi:include href="version-info.xml" xpointer="v262"/></listitem>
+      </varlistentry>
+
     </variablelist>
   </refsect1>
 

--- a/src/timesync/test-timesync.c
+++ b/src/timesync/test-timesync.c
@@ -25,4 +25,17 @@ TEST(manager_parse_string) {
         assert_se(manager_parse_server_string(m, SERVER_LINK, "time1.foobar.com time2.foobar.com axrfav.,avf..ra 12345..123") == 0);
 }
 
+TEST(manager_clock_change) {
+        _cleanup_(manager_freep) Manager *m = NULL;
+
+        ASSERT_OK(manager_new(&m));
+        ASSERT_EQ(m->max_clock_change_usec, USEC_INFINITY);
+        ASSERT_FALSE(manager_clock_change_is_too_large(m, 1e9));
+
+        m->max_clock_change_usec = 5 * USEC_PER_SEC;
+        ASSERT_FALSE(manager_clock_change_is_too_large(m, 5.0));
+        ASSERT_TRUE(manager_clock_change_is_too_large(m, 5.001));
+        ASSERT_TRUE(manager_clock_change_is_too_large(m, -5.001));
+}
+
 DEFINE_TEST_MAIN(LOG_DEBUG);

--- a/src/timesync/timesyncd-bus.c
+++ b/src/timesync/timesyncd-bus.c
@@ -215,6 +215,7 @@ static const sd_bus_vtable manager_vtable[] = {
         SD_BUS_PROPERTY("ServerName", "s", property_get_current_server_name, offsetof(Manager, current_server_name), 0),
         SD_BUS_PROPERTY("ServerAddress", "(iay)", property_get_current_server_address, offsetof(Manager, current_server_address), 0),
         SD_BUS_PROPERTY("RootDistanceMaxUSec", "t", bus_property_get_usec, offsetof(Manager, root_distance_max_usec), SD_BUS_VTABLE_PROPERTY_CONST),
+        SD_BUS_PROPERTY("MaxClockChangeUSec", "t", bus_property_get_usec, offsetof(Manager, max_clock_change_usec), SD_BUS_VTABLE_PROPERTY_CONST),
         SD_BUS_PROPERTY("PollIntervalMinUSec", "t", bus_property_get_usec, offsetof(Manager, poll_interval_min_usec), SD_BUS_VTABLE_PROPERTY_CONST),
         SD_BUS_PROPERTY("PollIntervalMaxUSec", "t", bus_property_get_usec, offsetof(Manager, poll_interval_max_usec), SD_BUS_VTABLE_PROPERTY_CONST),
         SD_BUS_PROPERTY("PollIntervalUSec", "t", bus_property_get_usec, offsetof(Manager, poll_interval_usec), 0),

--- a/src/timesync/timesyncd-gperf.gperf
+++ b/src/timesync/timesyncd-gperf.gperf
@@ -29,3 +29,4 @@ Time.PollIntervalMinSec,             config_parse_sec,     0,               offs
 Time.PollIntervalMaxSec,             config_parse_sec,     0,               offsetof(Manager, poll_interval_max_usec)
 Time.ConnectionRetrySec,             config_parse_sec,     0,               offsetof(Manager, connection_retry_usec)
 Time.SaveIntervalSec,                config_parse_sec,     0,               offsetof(Manager, save_time_interval_usec)
+Time.MaxClockChangeSec,              config_parse_sec,     0,               offsetof(Manager, max_clock_change_usec)

--- a/src/timesync/timesyncd-manager.c
+++ b/src/timesync/timesyncd-manager.c
@@ -361,6 +361,12 @@ static bool manager_sample_spike_detection(Manager *m, double offset, double del
         return ABS(offset - m->samples[idx_cur].offset) > 3 * jitter;
 }
 
+bool manager_clock_change_is_too_large(Manager *m, double offset) {
+        assert(m);
+
+        return fabs(offset) > (double) m->max_clock_change_usec / USEC_PER_SEC;
+}
+
 static void manager_adjust_poll(Manager *m, double offset, bool spike) {
         assert(m);
 
@@ -529,6 +535,14 @@ static int manager_receive_response(sd_event_source *source, int fd, uint32_t re
 
         offset = ((receive - origin) + (trans - dest)) / 2;
         delay = (dest - origin) - (trans - receive);
+
+        if (manager_clock_change_is_too_large(m, offset)) {
+                log_warning("Clock offset %+.3f sec from server %s exceeds MaxClockChangeSec=%s. Disconnecting.",
+                            offset,
+                            m->current_server_name->string,
+                            FORMAT_TIMESPAN(m->max_clock_change_usec, USEC_PER_MSEC));
+                return manager_connect(m);
+        }
 
         spike = manager_sample_spike_detection(m, offset, delay);
 
@@ -1115,6 +1129,7 @@ int manager_new(Manager **ret) {
 
         *m = (Manager) {
                 .root_distance_max_usec = NTP_ROOT_DISTANCE_MAX_USEC,
+                .max_clock_change_usec = USEC_INFINITY,
                 .poll_interval_min_usec = NTP_POLL_INTERVAL_MIN_USEC,
                 .poll_interval_max_usec = NTP_POLL_INTERVAL_MAX_USEC,
 

--- a/src/timesync/timesyncd-manager.h
+++ b/src/timesync/timesyncd-manager.h
@@ -76,6 +76,7 @@ typedef struct Manager {
         unsigned samples_idx;
         double samples_jitter;
         usec_t root_distance_max_usec;
+        usec_t max_clock_change_usec;
 
         /* last change */
         bool jumped;
@@ -116,6 +117,8 @@ void manager_set_server_name(Manager *m, ServerName *n);
 void manager_set_server_address(Manager *m, ServerAddress *a);
 void manager_flush_server_names(Manager *m, ServerType t);
 void manager_flush_runtime_servers(Manager *m);
+
+bool manager_clock_change_is_too_large(Manager *m, double offset);
 
 int manager_connect(Manager *m);
 void manager_disconnect(Manager *m);

--- a/src/timesync/timesyncd.conf.in
+++ b/src/timesync/timesyncd.conf.in
@@ -24,3 +24,4 @@
 #PollIntervalMaxSec=2048
 #ConnectionRetrySec=30
 #SaveIntervalSec=60
+#MaxClockChangeSec=infinity


### PR DESCRIPTION
## Summary

- add an opt-in `MaxClockStepSec=` limit for the absolute offset accepted from one NTP response;
- ignore responses beyond the configured limit and continue with another server;
- expose the configured limit over D-Bus and document the RTC-less first-boot tradeoff; and
- preserve the existing behavior by defaulting to `infinity`.

This implements the policy control requested in #17782. A finite default is intentionally not proposed: systems without a reliable RTC may legitimately require a large initial correction. Administrators that have a trustworthy starting clock can now select an appropriate ceiling.

## Testing

Tested from current `main` at `765dc9691be793e03b6b13b16bb834c0aa216c9e` on a Debian testing ARM64 host:

```text
ninja -C build test-timesync systemd-timesyncd
meson test -C build --print-errorlogs test-timesync

1/1 timesync - systemd:test-timesync OK
```

The unit coverage checks the unlimited default, the exact configured boundary, and positive and negative offsets beyond it. `git diff --check` and XML well-formedness checks also pass.

Closes #17782.
