### PR TITLE
namespace: Initialize flags variable before use

### DIFF
--- a/src/core/namespace.c
+++ b/src/core/namespace.c
@@ -719,7 +719,7 @@ static int append_tmpfs_mounts(MountList *ml, const TemporaryFileSystem *tmpfs, 
 
         FOREACH_ARRAY(t, tmpfs, n) {
                 _cleanup_free_ char *o = NULL, *str = NULL;
-                unsigned long flags;
+                unsigned long flags = 0;
                 bool ro = false;
                 int r;
 


### PR DESCRIPTION
Currently, the flags variable in append_tmpfs_mount() is passed to mount_option_mangle() before it gets initialized, which is not good code hygiene.