### PR TITLE
network: invalidate cached driver when an interface is renamed

### DIFF
--- a/src/network/networkd-link.c
+++ b/src/network/networkd-link.c
@@ -2680,6 +2680,13 @@ static int link_update_name(Link *link, sd_netlink_message *message) {
 
         log_link_info(link, "Interface name change detected, renamed to %s.", ifname);
 
+        /* The legacy ethtool API uses interface names instead of ifindexes, which is racy.
+         * Invalidate the driver cache so it can be re-read later.
+         * TODO: Switch to the new Netlink-based API that accepts ifindex directly. */
+        link->ethtool_driver_read = false;
+        link->driver = mfree(link->driver);
+        link->dsa_master_ifindex = 0;
+
         hashmap_remove_value(link->manager->links_by_name, link->ifname, link);
 
         r = free_and_strdup(&link->ifname, ifname);


### PR DESCRIPTION
During early boot, interfaces may be renamed frequently, which can lead to caching the driver name of a different interface. Invalidate the cached driver whenever an interface rename is detected so it can be re-read using the new name.

Follow-up for #42545.
Fixes #43099.