### PR TITLE
emacs: Fix warning when opening shell scripts

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -20,7 +20,7 @@
  (nxml-mode . ((nxml-child-indent . 2)
                (fill-column . 109)))
  (meson-mode . ((meson-indent-basic . 8)))
- (sh-mode . ((sh-indentation . 4)))
+ (sh-mode . ((sh-basic-offset . 4)))
  (awk-mode . ((c-basic-offset . 8)))
  (python-mode . ((indent-tabs-mode . nil)
                  (tab-width . 4)


### PR DESCRIPTION
Opening a shell script, Emacs notified me in the echo area:

sh-indentation is obsolete (since 26.1); use ‘sh-basic-offset’ instead

Commit 0c40aef7ef14 ("emacs: drop obsolete emacs property") got it backwards, keeping sh-indentation rather than sh-basic-offset.  The latter is an obsolete alias for the former.