### PR TITLE
resolved: return NXDOMAIN for .onion domains

### DIFF
--- a/src/resolve/test-dns-synthesize.c
+++ b/src/resolve/test-dns-synthesize.c
@@ -302,4 +302,27 @@ TEST(dns_synthesize_answer_address_local_dns_proxy) {
         ASSERT_TRUE(dns_answer_contains(answer, rr));
 }
 
+TEST(dns_synthesize_answer_onion) {
+        Manager manager = {};
+        _cleanup_(dns_question_unrefp) DnsQuestion *question = NULL;
+        _cleanup_(dns_resource_key_unrefp) DnsResourceKey *key_a = NULL;
+        _cleanup_(dns_resource_key_unrefp) DnsResourceKey *key_txt = NULL;
+        _cleanup_(dns_answer_unrefp) DnsAnswer *answer = NULL;
+
+        question = dns_question_new(2);
+        ASSERT_NOT_NULL(question);
+
+        key_a = dns_resource_key_new(DNS_CLASS_IN, DNS_TYPE_A, "mysecret.onion");
+        ASSERT_NOT_NULL(key_a);
+        ASSERT_OK(dns_question_add(question, key_a, 0));
+
+        key_txt = dns_resource_key_new(DNS_CLASS_IN, DNS_TYPE_TXT, "mysecret.onion");
+        ASSERT_NOT_NULL(key_txt);
+        ASSERT_OK(dns_question_add(question, key_txt, 0));
+
+        /* Verify RFC 7686: .onion leak prevention must return ENXIO to trigger NXDOMAIN */
+        ASSERT_ERROR(dns_synthesize_answer(&manager, question, 0, &answer), ENXIO);
+        ASSERT_NULL(answer);
+}
+
 DEFINE_TEST_MAIN(LOG_DEBUG);

--- a/src/shared/dns-domain.c
+++ b/src/shared/dns-domain.c
@@ -1372,5 +1372,9 @@ bool dns_name_dont_resolve(const char *name) {
         if (dns_name_endswith(name, "alt") > 0)
                 return true;
 
+        /* Never respond to the domains listed in RFC7686 */
+        if (dns_name_endswith(name, "onion") > 0)
+                return true;
+
         return false;
 }


### PR DESCRIPTION
RFC 7686 mandates that name resolution APIs MUST respond to .onion names with NXDOMAIN to prevent leaks to the resolving name server. This intercepts .onion queries and synthesizes an NXDOMAIN response locally.

Fixes #42980 