### PR TITLE
hwdb: add numlock mapping for PATEN/Labtec USB Numpad

### DIFF
--- a/hwdb.d/60-keyboard.hwdb
+++ b/hwdb.d/60-keyboard.hwdb
@@ -2437,6 +2437,14 @@ evdev:name:AT Translated Set 2 keyboard:dmi:bvn*bvr*:svnMultilaserIndustrial:pn*
  KEYBOARD_KEY_76=touchpad_toggle                        # Fn+f2 toggle touchpad
 
 ###########################################################
+# PATEN/Labtec
+###########################################################
+# Labtec USB Number Pad for Notebooks (y-UE70)
+evdev:input:b0003v00001020p00000501*
+ KEYBOARD_KEY_c004f=numlock                             # Numlock key
+ KEYBOARD_LED_NUMLOCK=0
+
+###########################################################
 # Other
 ###########################################################
 


### PR DESCRIPTION
**Disclaimer:** I don't really know what I am doing, but I fixed the issue locally for my device and I thought I'd share the fix to the community.

In short (more details below), I couldn't get my external numpad to type numbers (which was the whole point buying it) on Ubuntu 26.04. Turns out the Numlock is mapped to event code 240 (`KEY_UNKNOWN`) instead of code 69 (~nice~`KEY_NUMLOCK`), so I fixed the mapping. Also, the device has no numlock LED, so I added that to the commit but I'm not sure whether this is useful.


The device is an external Number Pad from Labtec, the label on the back reads:
* Model Number: Y-UE70
* Product Number: 867578-0000
* PID: PN830KA

In `/dev/input/event*` it shows up as three inputs:
```
/dev/input/eventX:	PATEN USB Keyboard
/dev/input/eventY:	PATEN USB Keyboard Consumer Control
/dev/input/eventZ:	PATEN USB Keyboard System Control
```

Here is the result of `evtest` before the fix when typing on the numlock key:
```
Input driver version is 1.0.1
Input device ID: bus 0x3 vendor 0x1020 product 0x501 version 0x110
Input device name: "PATEN USB Keyboard Consumer Control"
Supported events:
  Event type 0 (EV_SYN)
  Event type 1 (EV_KEY)
    Event code 113 (KEY_MUTE)
    Event code 114 (KEY_VOLUMEDOWN)
    Event code 115 (KEY_VOLUMEUP)
    Event code 128 (KEY_STOP)
    Event code 140 (KEY_CALC)
    Event code 144 (KEY_FILE)
    Event code 155 (KEY_MAIL)
    Event code 156 (KEY_BOOKMARKS)
    Event code 158 (KEY_BACK)
    Event code 159 (KEY_FORWARD)
    Event code 163 (KEY_NEXTSONG)
    Event code 164 (KEY_PLAYPAUSE)
    Event code 165 (KEY_PREVIOUSSONG)
    Event code 166 (KEY_STOPCD)
    Event code 171 (KEY_CONFIG)
    Event code 172 (KEY_HOMEPAGE)
    Event code 173 (KEY_REFRESH)
    Event code 217 (KEY_SEARCH)
    Event code 240 (KEY_UNKNOWN)
  Event type 4 (EV_MSC)
    Event code 4 (MSC_SCAN)
Properties:
Testing ... (interrupt to exit)
Event: time 1784802370.781508, type 4 (EV_MSC), code 4 (MSC_SCAN), value c004f
Event: time 1784802370.781508, type 1 (EV_KEY), code 240 (KEY_UNKNOWN), value 1
Event: time 1784802370.781508, -------------- SYN_REPORT ------------
Event: time 1784802370.893585, type 4 (EV_MSC), code 4 (MSC_SCAN), value c004f
Event: time 1784802370.893585, type 1 (EV_KEY), code 240 (KEY_UNKNOWN), value 0
Event: time 1784802370.893585, -------------- SYN_REPORT ------------
```

Here is the full identifier for this specific input:
```
$ cat /sys/class/input/eventY/device/modalias
input:b0003v1020p0501e0110-e0,1,4,k71,72,73,80,8C,90,9B,9C,9E,9F,A3,A4,A5,A6,AB,AC,AD,D9,F0,ram4,lsfw
```

So I did the following:
```
$ echo 'evdev:input:b0003v1020p0501*
 KEYBOARD_KEY_c004f=numlock' | sudo tee /etc/udev/hwdb.d/90-paten-numlock.hwdb
$ sudo systemd-hwdb update
$ sudo udevadm trigger --sysname-match="event*"
```
Then I unplugged and plugged the device again.

And then (supported events unchanged):
```
Testing ... (interrupt to exit)
Event: time 1784802729.086699, type 4 (EV_MSC), code 4 (MSC_SCAN), value c004f
Event: time 1784802729.086699, type 1 (EV_KEY), code 69 (KEY_NUMLOCK), value 1
Event: time 1784802729.086699, -------------- SYN_REPORT ------------
Event: time 1784802729.238700, type 4 (EV_MSC), code 4 (MSC_SCAN), value c004f
Event: time 1784802729.238700, type 1 (EV_KEY), code 69 (KEY_NUMLOCK), value 0
Event: time 1784802729.238700, -------------- SYN_REPORT ------------
```

And more importantly, I can finally type numbers.

