### PR TITLE
core: allow PrivateIPC= without POSIX mqueue support

### DIFF
--- a/src/core/namespace.c
+++ b/src/core/namespace.c
@@ -1643,6 +1643,8 @@ static int mount_mqueuefs(const MountEntry *m) {
         (void) umount_recursive(entry_path, 0);
 
         r = mount_nofollow_verbose(LOG_DEBUG, "mqueue", entry_path, "mqueue", m->flags, mount_entry_options(m));
+        if (r == -ENODEV) /* POSIX message queues may be disabled in the kernel. */
+                return 0;
         if (r < 0)
                 return r;
 

--- a/test/units/TEST-07-PID1.mqueue-ownership.sh
+++ b/test/units/TEST-07-PID1.mqueue-ownership.sh
@@ -3,6 +3,17 @@
 set -eux
 set -o pipefail
 
+# Verify PrivateIPC= works and creates a separate IPC namespace even if POSIX
+# message queues are not supported.
+host_ipcns=$(readlink /proc/self/ns/ipc)
+private_ipcns=$(systemd-run --quiet --wait --pipe -p PrivateIPC=yes readlink /proc/self/ns/ipc)
+[[ "$private_ipcns" != "$host_ipcns" ]]
+
+if [[ ! -d /proc/sys/fs/mqueue ]]; then
+    echo "POSIX message queues are not supported, skipping ownership checks"
+    exit 0
+fi
+
 # Verify ownership attributes are applied to message queues
 
 # Select arbitrary non-default attributes to apply to the queue.


### PR DESCRIPTION
When `CONFIG_POSIX_MQUEUE` is disabled, services using `PrivateIPC=yes`
fail during namespace setup because mounting the mqueue filesystem returns
`ENODEV`.

Treat only `ENODEV` as indicating that this optional kernel feature is
unavailable. The private IPC namespace is still created, while other mqueue
mount errors remain fatal.

Fixes #42582

## Testing

Tested on a kernel built without `CONFIG_POSIX_MQUEUE`:

```console
$ grep -w mqueue /proc/filesystems
# no output

$ systemctl is-active test-private-ipc-long.service
active

$ readlink /proc/1/ns/ipc
ipc:[4026531839]

$ readlink /proc/$(systemctl show -P MainPID test-private-ipc-long.service)/ns/ipc
ipc:[4026532657]

This confirms that the service starts and receives a separate IPC namespace
while the mqueue filesystem is unavailable.

The updated integration test also passes:

$ sudo bash test/units/TEST-07-PID1.mqueue-ownership.sh
...
+ host_ipcns='ipc:[4026531839]'
+ private_ipcns='ipc:[4026532659]'
+ [[ ipc:[4026532659] != ipc:[4026531839] ]]
+ [[ -d /proc/sys/fs/mqueue ]]
+ exit 0

Also built successfully with:

$ meson compile -C build systemd-executor