### PR TITLE
test-ndisc-send: correct add_link_layer_address argument order

### DIFF
--- a/src/libsystemd-network/test-ndisc-send.c
+++ b/src/libsystemd-network/test-ndisc-send.c
@@ -280,13 +280,13 @@ static int send_icmp6(int fd, const struct icmp6_hdr *hdr) {
         assert(hdr);
 
         if (arg_set_source_mac) {
-                r = ndisc_option_add_link_layer_address(&options, 0, SD_NDISC_OPTION_SOURCE_LL_ADDRESS, &arg_source_mac);
+                r = ndisc_option_add_link_layer_address(&options, SD_NDISC_OPTION_SOURCE_LL_ADDRESS, 0, &arg_source_mac);
                 if (r < 0)
                         return r;
         }
 
         if (arg_set_target_mac) {
-                r = ndisc_option_add_link_layer_address(&options, 0, SD_NDISC_OPTION_TARGET_LL_ADDRESS, &arg_target_mac);
+                r = ndisc_option_add_link_layer_address(&options, SD_NDISC_OPTION_TARGET_LL_ADDRESS, 0, &arg_target_mac);
                 if (r < 0)
                         return r;
         }


### PR DESCRIPTION
Found by inspection while working on networkd.