### PR TITLE
meson: add build option for /var/log mode

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -956,6 +956,9 @@ endif
 # Do not use set_quoted() here, so that the value is available as an integer.
 conf.set('TTY_MODE', tty_mode)
 
+var_log_mode = get_option('var-log-mode')
+conf.set_quoted('VAR_LOG_MODE', var_log_mode)
+
 kill_user_processes = get_option('default-kill-user-processes')
 conf.set10('KILL_USER_PROCESSES', kill_user_processes)
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -358,6 +358,10 @@ option('group-render-mode', type : 'string', value : '0666',
        description : 'Access mode for devices owned by render group (e.g. /dev/dri/renderD*, /dev/kfd).')
 option('tty-mode', type : 'string', value : '0600',
        description : 'Access mode for tty/pts device nodes.')
+option('var-log-mode', type : 'combo',
+       description : 'Access mode for /var/log directory.',
+       choices : ['0755', '0775'],
+       value : '0755')
 option('default-kill-user-processes', type : 'boolean',
        description : 'the default value for KillUserProcesses= setting')
 option('gshadow', type : 'boolean',

--- a/tmpfiles.d/var.conf.in
+++ b/tmpfiles.d/var.conf.in
@@ -11,7 +11,7 @@ q /var 0755 - - -
 
 L /var/run - - - - ../run
 
-d /var/log 0755 - - -
+d /var/log {{VAR_LOG_MODE}} - - -
 {% if ENABLE_UTMP %}
 f /var/log/wtmp 0664 root utmp -
 f /var/log/btmp 0660 root utmp -


### PR DESCRIPTION
In Ubuntu, rsyslog is (a) part of the minimal image and (b) does not run as root. To facilitate this, the rsyslog package configures /var/log to be writeable by the syslog group.

There are currently conflicts in the Ubuntu packaging due to the way tmpfiles are handled in package scripts: when systemd-tmpfiles is invoked with both configurations (or for all configurations), things work fine. But if invoked with only var.conf, which is the default case for package upgrades, rsyslog is broken.

One suggestion to approach this was to make rsyslog's tmpfile configuration use ACLs instead of trying to change the owning group and directory mode. This can work, but since the ACL mask is stored in the group permission bits, the effective mask for rsyslog becomes r-x again when var.conf is invoked, because it sees that 0775 != 0755, and chmods the directory.

Hence, for /var/log write permisssions to be extendable with ACLs, the mode must be at least 0775. Rather than change the default, add a build option to configure the /var/log mode.