### PR TITLE
update-utmp: let libaudit determine comm on boot/shutdown

### DIFF
--- a/src/update-utmp/update-utmp.c
+++ b/src/update-utmp/update-utmp.c
@@ -63,7 +63,7 @@ static int verb_on_reboot(int argc, char *argv[], uintptr_t _data, void *userdat
 
 #if HAVE_AUDIT
         if (c->audit_fd >= 0)
-                if (sym_audit_log_user_comm_message(c->audit_fd, AUDIT_SYSTEM_BOOT, "", "systemd-update-utmp", NULL, NULL, NULL, 1) < 0 &&
+                if (sym_audit_log_user_comm_message(c->audit_fd, AUDIT_SYSTEM_BOOT, "", "update-utmp", NULL, NULL, NULL, 1) < 0 &&
                     errno != EPERM)
                         q = log_error_errno(errno, "Failed to send audit message: %m");
 #endif
@@ -93,7 +93,7 @@ static int verb_on_shutdown(int argc, char *argv[], uintptr_t _data, void *userd
         Context *c = ASSERT_PTR(userdata);
 
         if (c->audit_fd >= 0)
-                if (sym_audit_log_user_comm_message(c->audit_fd, AUDIT_SYSTEM_SHUTDOWN, "", "systemd-update-utmp", NULL, NULL, NULL, 1) < 0 &&
+                if (sym_audit_log_user_comm_message(c->audit_fd, AUDIT_SYSTEM_SHUTDOWN, "", "update-utmp", NULL, NULL, NULL, 1) < 0 &&
                     errno != EPERM)
                         q = log_error_errno(errno, "Failed to send audit message: %m");
 #endif


### PR DESCRIPTION
audit_log_user_comm_message from libaudit 4.2 rejects comm arguments that exceed the kernel's comm limit of 15 characters with EINVAL. The hard-coded "systemd-update-utmp" exceeds this by 4 characters.

Pass NULL as comm and let audit_log_user_comm_message determine comm using procfs instead. In practice, the AUDIT_SYSTEM_BOOT/SHUTDOWN audit records will have their comm set to "systemd-update-u".

Fixes: #43143 