### PR TITLE
properties: Peek the variant value type once

### DIFF
--- a/src/login/loginctl.c
+++ b/src/login/loginctl.c
@@ -793,17 +793,18 @@ static int print_seat_status_info(sd_bus *bus, const char *path) {
         return 0;
 }
 
-static int print_property(const char *name, const char *expected_value, sd_bus_message *m, BusPrintPropertyFlags flags) {
-        char type;
-        const char *contents;
+static int print_property(
+                const char *name,
+                const char *expected_value,
+                char type,
+                const char *contents,
+                sd_bus_message *m,
+                BusPrintPropertyFlags flags) {
+
         int r;
 
         assert(name);
         assert(m);
-
-        r = sd_bus_message_peek_type(m, &type, &contents);
-        if (r < 0)
-                return r;
 
         switch (type) {
 

--- a/src/shared/bus-print-properties.c
+++ b/src/shared/bus-print-properties.c
@@ -58,17 +58,18 @@ int bus_print_property_valuef(const char *name, const char *expected_value, BusP
         return bus_print_property_value(name, expected_value, flags, s);
 }
 
-static int bus_print_property(const char *name, const char *expected_value, sd_bus_message *m, BusPrintPropertyFlags flags) {
-        char type;
-        const char *contents;
+static int bus_print_property(
+                const char *name,
+                const char *expected_value,
+                char type,
+                const char *contents,
+                sd_bus_message *m,
+                BusPrintPropertyFlags flags) {
+
         int r;
 
         assert(name);
         assert(m);
-
-        r = sd_bus_message_peek_type(m, &type, &contents);
-        if (r < 0)
-                return r;
 
         switch (type) {
 
@@ -389,10 +390,16 @@ int bus_message_print_all_properties(
                         if (r < 0)
                                 return r;
 
+                        char value_type;
+                        const char *value_contents;
+                        r = sd_bus_message_peek_type(m, &value_type, &value_contents);
+                        if (r < 0)
+                                return r;
+
                         if (func)
-                                r = func(name, expected_value, m, flags);
+                                r = func(name, expected_value, value_type, value_contents, m, flags);
                         if (!func || r == 0)
-                                r = bus_print_property(name, expected_value, m, flags);
+                                r = bus_print_property(name, expected_value, value_type, value_contents, m, flags);
                         if (r < 0)
                                 return r;
                         if (r == 0) {

--- a/src/shared/bus-print-properties.h
+++ b/src/shared/bus-print-properties.h
@@ -8,7 +8,13 @@ typedef enum BusPrintPropertyFlags {
         BUS_PRINT_PROPERTY_SHOW_EMPTY = 1 << 1,  /* e.g. systemctl --all */
 } BusPrintPropertyFlags;
 
-typedef int (*bus_message_print_t) (const char *name, const char *expected_value, sd_bus_message *m, BusPrintPropertyFlags flags);
+typedef int (*bus_message_print_t) (
+                const char *name,
+                const char *expected_value,
+                char type,
+                const char *contents,
+                sd_bus_message *m,
+                BusPrintPropertyFlags flags);
 
 bool bus_property_is_timestamp(const char *name);
 

--- a/src/systemctl/systemctl-show.c
+++ b/src/systemctl/systemctl-show.c
@@ -1169,9 +1169,14 @@ static int map_quota(sd_bus *bus, const char *member, sd_bus_message *m, sd_bus_
         return 0;
 }
 
-static int print_property(const char *name, const char *expected_value, sd_bus_message *m, BusPrintPropertyFlags flags) {
-        char bus_type;
-        const char *contents;
+static int print_property(
+                const char *name,
+                const char *expected_value,
+                char type,
+                const char *contents,
+                sd_bus_message *m,
+                BusPrintPropertyFlags flags) {
+
         int r;
 
         assert(name);
@@ -1179,17 +1184,13 @@ static int print_property(const char *name, const char *expected_value, sd_bus_m
 
         /* This is a low-level property printer, see print_status_info() for the nicer output */
 
-        r = sd_bus_message_peek_type(m, &bus_type, &contents);
-        if (r < 0)
-                return r;
-
-        switch (bus_type) {
+        switch (type) {
 
         case SD_BUS_TYPE_INT32:
                 if (endswith(name, "ActionExitStatus")) {
                         int32_t i;
 
-                        r = sd_bus_message_read_basic(m, bus_type, &i);
+                        r = sd_bus_message_read_basic(m, type, &i);
                         if (r < 0)
                                 return r;
 
@@ -1202,7 +1203,7 @@ static int print_property(const char *name, const char *expected_value, sd_bus_m
                 } else if (streq(name, "NUMAPolicy")) {
                         int32_t i;
 
-                        r = sd_bus_message_read_basic(m, bus_type, &i);
+                        r = sd_bus_message_read_basic(m, type, &i);
                         if (r < 0)
                                 return r;
 
@@ -1216,7 +1217,7 @@ static int print_property(const char *name, const char *expected_value, sd_bus_m
                 if (bus_property_is_timestamp(name)) {
                         uint64_t timestamp;
 
-                        r = sd_bus_message_read_basic(m, bus_type, &timestamp);
+                        r = sd_bus_message_read_basic(m, type, &timestamp);
                         if (r < 0)
                                 return r;
 
@@ -1432,14 +1433,14 @@ static int print_property(const char *name, const char *expected_value, sd_bus_m
                         return 1;
 
                 } else if (contents[0] == SD_BUS_TYPE_STRUCT_BEGIN && streq(name, "Paths")) {
-                        const char *type, *path;
+                        const char *entry_type, *path;
 
                         r = sd_bus_message_enter_container(m, SD_BUS_TYPE_ARRAY, "(ss)");
                         if (r < 0)
                                 return bus_log_parse_error(r);
 
-                        while ((r = sd_bus_message_read(m, "(ss)", &type, &path)) > 0)
-                                bus_print_property_valuef(name, expected_value, flags, "%s (%s)", path, type);
+                        while ((r = sd_bus_message_read(m, "(ss)", &entry_type, &path)) > 0)
+                                bus_print_property_valuef(name, expected_value, flags, "%s (%s)", path, entry_type);
                         if (r < 0)
                                 return bus_log_parse_error(r);
 
@@ -1450,14 +1451,14 @@ static int print_property(const char *name, const char *expected_value, sd_bus_m
                         return 1;
 
                 } else if (contents[0] == SD_BUS_TYPE_STRUCT_BEGIN && streq(name, "Listen")) {
-                        const char *type, *path;
+                        const char *entry_type, *path;
 
                         r = sd_bus_message_enter_container(m, SD_BUS_TYPE_ARRAY, "(ss)");
                         if (r < 0)
                                 return bus_log_parse_error(r);
 
-                        while ((r = sd_bus_message_read(m, "(ss)", &type, &path)) > 0)
-                                bus_print_property_valuef(name, expected_value, flags, "%s (%s)", path, type);
+                        while ((r = sd_bus_message_read(m, "(ss)", &entry_type, &path)) > 0)
+                                bus_print_property_valuef(name, expected_value, flags, "%s (%s)", path, entry_type);
                         if (r < 0)
                                 return bus_log_parse_error(r);
 

--- a/src/timedate/timedatectl.c
+++ b/src/timedate/timedatectl.c
@@ -723,17 +723,18 @@ static int verb_timesync_status(int argc, char *argv[], uintptr_t _data, void *u
         return 0;
 }
 
-static int print_timesync_property(const char *name, const char *expected_value, sd_bus_message *m, BusPrintPropertyFlags flags) {
-        char type;
-        const char *contents;
+static int print_timesync_property(
+                const char *name,
+                const char *expected_value,
+                char type,
+                const char *contents,
+                sd_bus_message *m,
+                BusPrintPropertyFlags flags) {
+
         int r;
 
         assert(name);
         assert(m);
-
-        r = sd_bus_message_peek_type(m, &type, &contents);
-        if (r < 0)
-                return r;
 
         switch (type) {
 


### PR DESCRIPTION
bus_message_print_all_properties() peeks the variant type, but then the print callback and the default bus_print_property() each peek the value type again, so there can be up to two redundant calls per property. Peek it once up front and pass it through.

With this, in my tests `systemctl show` over 160 units decreases in instructions retired from 1167.6M to 1155.7M, so about 1%.