### PR TITLE
ask-password: refuse agent requests with unsafe characters in prompt fields

### DIFF
--- a/src/shared/ask-password-api.c
+++ b/src/shared/ask-password-api.c
@@ -828,6 +828,21 @@ static int create_socket(const char *askpwdir, char **ret) {
         return TAKE_FD(fd);
 }
 
+bool ask_password_agent_prompt_fields_are_safe(const AskPasswordRequest *req) {
+        /* These fields end up in single-line "Key=value" assignments in the agent request file, hence a
+         * newline (or any other control character) in them would let the caller add further assignments to
+         * the [Ask] section, which agents then happily honour. Only the characters string_is_safe() rejects
+         * by default matter here, the rest is fine to appear in a prompt. */
+        const StringSafeFlags flags = STRING_ALLOW_EMPTY | STRING_ALLOW_BACKSLASHES |
+                                      STRING_ALLOW_QUOTES | STRING_ALLOW_GLOBS;
+
+        assert(req);
+
+        return (!req->message || string_is_safe(req->message, flags)) &&
+               (!req->icon || string_is_safe(req->icon, flags)) &&
+               (!req->id || string_is_safe(req->id, flags));
+}
+
 int ask_password_agent(
                 const AskPasswordRequest *req,
                 AskPasswordFlags flags,
@@ -849,6 +864,10 @@ int ask_password_agent(
         /* We don't support the flag file concept for now when querying via the agent logic */
         if (req->flag_file)
                 return -EOPNOTSUPP;
+
+        if (!ask_password_agent_prompt_fields_are_safe(req))
+                return log_debug_errno(SYNTHETIC_ERRNO(EINVAL),
+                                       "Password request contains unsafe characters, refusing.");
 
         _cleanup_free_ char *askpwdir = NULL;
         r = get_ask_password_directory_for_flags(flags, &askpwdir);

--- a/src/shared/ask-password-api.h
+++ b/src/shared/ask-password-api.h
@@ -32,6 +32,7 @@ typedef struct AskPasswordRequest {
 
 int ask_password_tty(const AskPasswordRequest *req, AskPasswordFlags flags, char ***ret);
 int ask_password_plymouth(const AskPasswordRequest *req, AskPasswordFlags flags, char ***ret);
+bool ask_password_agent_prompt_fields_are_safe(const AskPasswordRequest *req) _pure_;
 int ask_password_agent(const AskPasswordRequest *req, AskPasswordFlags flags, char ***ret);
 int ask_password_auto(const AskPasswordRequest *req, AskPasswordFlags flags, char ***ret);
 

--- a/src/test/meson.build
+++ b/src/test/meson.build
@@ -60,6 +60,7 @@ simple_tests += files(
         'test-architecture.c',
         'test-argv-util.c',
         'test-arphrd-util.c',
+        'test-ask-password-agent.c',
         'test-audit-util.c',
         'test-barrier.c',
         'test-binfmt-util.c',

--- a/src/test/test-ask-password-agent.c
+++ b/src/test/test-ask-password-agent.c
@@ -1,0 +1,35 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include "ask-password-api.h"
+#include "tests.h"
+
+TEST(prompt_fields_are_safe) {
+        AskPasswordRequest req = {
+                .message = "Password for /dev/disk/by-label/über?",
+                .icon = "drive-harddisk",
+                .id = "cryptsetup:/dev/disk\\by-label/'data'[*]",
+                .tty_fd = -EBADF,
+                .hup_fd = -EBADF,
+        };
+
+        ASSERT_TRUE(ask_password_agent_prompt_fields_are_safe(&req));
+
+        req.message = "";
+        ASSERT_TRUE(ask_password_agent_prompt_fields_are_safe(&req));
+
+        req.message = "first line\nSocket=/tmp/injected";
+        ASSERT_FALSE(ask_password_agent_prompt_fields_are_safe(&req));
+
+        req.message = "Password:";
+        req.icon = "drive\rIcon";
+        ASSERT_FALSE(ask_password_agent_prompt_fields_are_safe(&req));
+
+        req.icon = "drive-harddisk";
+        req.id = "cryptsetup:\x01/dev/sda";
+        ASSERT_FALSE(ask_password_agent_prompt_fields_are_safe(&req));
+
+        req.id = "cryptsetup:\xff/dev/sda";
+        ASSERT_FALSE(ask_password_agent_prompt_fields_are_safe(&req));
+}
+
+DEFINE_TEST_MAIN(LOG_INFO);


### PR DESCRIPTION
`ask_password_agent()` writes the caller-supplied `message`, `icon` and `id` strings verbatim into single-line assignments of the `[Ask]` section of the request file it drops in `/run/systemd/ask-password/`:

```c
if (req->message)
    fprintf(f, "Message=%s\n", req->message);
```

A newline in any of those fields therefore terminates the assignment early and lets the rest of the string become further `Key=value` lines in the same section. Agents parse that file with the normal config parser, where a later assignment simply overrides an earlier one, so an injected line can replace `Socket=` with an arbitrary path. `systemd-tty-ask-password-agent` then sends the collected password to that path:

```c
{ "Ask", "Socket", config_parse_string, CONFIG_PARSE_STRING_SAFE, &socket_name },
...
r = send_passwords(socket_name, passwords);
```

`CONFIG_PARSE_STRING_SAFE` on the reader side does not help here: the injected line is perfectly well-formed, there is just no way for the agent to tell that it was not written by the requesting process.

These strings are not always fully under the requesting program's control. `systemd-ask-password` passes `--message=`/`--id=` straight through, and `systemd-cryptsetup` builds the prompt from `friendly_disk_name()`, which mixes in a udev device description and the mount point.

Reject the request with `-EINVAL` instead of writing a request file that says something other than what the caller asked for. `string_is_safe()` already implements exactly the check we need (no control characters, valid UTF-8); the remaining characters it is strict about by default (backslashes, quotes, globs) are fine in a password prompt and are allowed explicitly. Note that `systemd-cryptsetup` already `cescape()`s the `id` it passes, so backslashes must keep working.

The check is placed after the existing `flag_file` check so that the error codes of the existing early returns are unaffected.