### PR TITLE
hwdb: Fix Brazilian ABNT2 KEY_RO scancode for HP ProBook x360 435 G7

### DIFF
--- a/hwdb.d/60-keyboard.hwdb
+++ b/hwdb.d/60-keyboard.hwdb
@@ -899,6 +899,10 @@ evdev:atkbd:dmi:bvn*:bvr*:bd*:svnHP*:pnHPProBook11G2*:pvr*
  KEYBOARD_KEY_d8=!touchpad_off                          # Fn+F2: touchpad off
  KEYBOARD_KEY_d9=!touchpad_on                           # Fn+F2: touchpad on
 
+# HP ProBook x360 435 G7 - Brazilian ABNT2 keyboard
+evdev:atkbd:dmi:bvnHP*:bvr*:bd*:svnHP*:pnHPProBookx360435G7*:pvr*
+ KEYBOARD_KEY_4e=ro                                     # slash/question key
+
 # HP mt44 Mobile Thin Client
 evdev:atkbd:dmi:bvn*:bvr*:svnHP*:pnHP*mt44*Mobile*Thin*Client*:*
  KEYBOARD_KEY_64=calendar                               # Calendar icon (Fn + F12)


### PR DESCRIPTION
The physical key between right Shift and right Ctrl (Brazilian ABNT2 ["/ ? deg"]) emits scancode 0x4e (KEY_KPPLUS) at boot, switching to KEY_RO after evtest is oppened.
    
Remap the observed 0x4e keycode to KEY_RO so it produces the expected characters with the Brazilian ABNT2 XKB layout.
    
---

This is a Debian system, running Niri (wayland).
For some reason I dont yet know, this does not happen in Gnome or KDE (both with wayland). 
It does not happen in the TTY either.
I've been using the "xremap" tool to remap this for months, and finally decided to try to fix this permanently.


<details>
  <summary>Click to expand my locale settings:</summary>
  These are my relevant locale settings:

cat /etc/vconsole.conf

```
XKBMODEL="pc105"
XKBLAYOUT="br"
XKBVARIANT=""
BACKSPACE="guess"
XKBOPTIONS=""
```

and localectl output:

```
localectl
System Locale: LANG=en_US.UTF-8
               LC_NUMERIC=pt_BR.UTF-8
               LC_TIME=pt_BR.UTF-8
               LC_MONETARY=pt_BR.UTF-8
               LC_PAPER=pt_BR.UTF-8
               LC_NAME=pt_BR.UTF-8
               LC_ADDRESS=pt_BR.UTF-8
               LC_TELEPHONE=pt_BR.UTF-8
               LC_MEASUREMENT=pt_BR.UTF-8
               LC_IDENTIFICATION=pt_BR.UTF-8
    VC Keymap: (unset)
   X11 Layout: br
    X11 Model: pc105
```

</details>

First, there was no dmesg logs related to this.
I added a patch to my Kernel, with some logs in the `atkbd_set_keycode_table` (init path) and a log message in `atkbd_pre_receive_byte` (typing path).
I will leave the patch collapsed at the end of the comment, if you want to look at it.

After booting:

sudo dmesg -w | rg "AY"
```
[    0.570265] AY atkbd_set_keycode_table set1=0x0c set2=0x4e make=12 break=0
[    0.570293] AY atkbd_set_keycode_table set1=0x34 set2=0x49 make=52 break=0
[    0.570308] AY atkbd_set_keycode_table set1=0x49 set2=0x7d make=73 break=104
[    0.570322] AY atkbd_set_keycode_table set1=0x4e set2=0x79 make=78 break=118
[    0.570337] AY atkbd_set_keycode_table final: 0x49->73 0x4e->78
...
# --- boot finished
```

below are two log sequences from when I hit the "[/ ?]" key (resulting in +):

```
[   52.089930] atkbd serio0: AY Received 4e flags 00
[   52.089949] AY atkbd_receive_byte raw=0x4e code=0x04e keycode=78 press
+[   52.175409] atkbd serio0: AY Received ce flags 00
[   52.175428] AY atkbd_receive_byte raw=0xce code=0x04e keycode=78 release

+[   53.629807] atkbd serio0: AY Received 4e flags 00
[   53.629825] AY atkbd_receive_byte raw=0x4e code=0x04e keycode=78 press
[   53.699167] atkbd serio0: AY Received ce flags 00
[   53.699186] AY atkbd_receive_byte raw=0xce code=0x04e keycode=78 release
```
In another window, I ran the "wev" wayland tool. The kernel logs looked the same as the ones above.
wev Output:
```
[        16:     wl_keyboard] key: serial: 240; time: 84825; key: 86; state: 1 (pressed)
                      sym: KP_Add       (65451), utf8: '+'
[        16:     wl_keyboard] key: serial: 241; time: 84878; key: 86; state: 0 (released)
                      sym: KP_Add       (65451), utf8: ''
```

Now, if I run the evtest tool, the output is immediately different:
evtest:
```
Event: time 1785187415.437241, type 4 (EV_MSC), code 4 (MSC_SCAN), value 73
Event: time 1785187415.437241, type 1 (EV_KEY), code 89 (KEY_RO), value 1
Event: time 1785187415.437241, -------------- SYN_REPORT ------------
```

wev output after evtest:
```
[        16:     wl_keyboard] key: serial: 4591; time: 308566; key: 97; state: 1 (pressed)
                      sym: slash        (47), utf8: '/'
[        16:     wl_keyboard] key: serial: 4592; time: 308645; key: 97; state: 0 (released)
                      sym: slash        (47), utf8: ''
```

And the kernel logs are also different:
dmesg after evtest:
```
[  169.492983] AY atkbd_receive_byte raw=0x73 code=0x073 keycode=89 press
[  169.576776] AY atkbd_receive_byte raw=0xf3 code=0x073 keycode=89 release
[  173.609779] AY atkbd_receive_byte raw=0x73 code=0x073 keycode=89 press
[  173.683972] AY atkbd_receive_byte raw=0xf3 code=0x073 keycode=89 release
```

<details>
  <summary>Click to expand my debug patch</summary>
  
My debug patch:
"AY" is just a prefix I use to easily filter dmesg ;P

```diff
diff --git i/drivers/input/keyboard/atkbd.c w/drivers/input/keyboard/atkbd.c
index 8cb4dc6fb1658..02b63599c769b 100644
--- i/drivers/input/keyboard/atkbd.c
+++ w/drivers/input/keyboard/atkbd.c
@@ -423,7 +423,10 @@ static enum ps2_disposition atkbd_pre_receive_byte(struct ps2dev *ps2dev,
 {
 	struct serio *serio = ps2dev->serio;
 
-	dev_dbg(&serio->dev, "Received %02x flags %02x\n", data, flags);
+	if ((data & 0x7f) == 0x49 || (data & 0x7f) == 0x4e)
+		dev_info(&serio->dev, "AY Received %02x flags %02x\n", data, flags);
+	else
+		dev_dbg(&serio->dev, "Received %02x flags %02x\n", data, flags);
 
 #if !defined(__i386__) && !defined(__x86_64__)
 	if (atkbd_handle_frame_error(ps2dev, data, flags))
@@ -497,6 +500,11 @@ static void atkbd_receive_byte(struct ps2dev *ps2dev, u8 data)
 
 	keycode = atkbd->keycode[code];
 
+	if ((data & 0x7f) == 0x49 || (data & 0x7f) == 0x4e || keycode == KEY_RO)
+		pr_info("AY %s raw=0x%02x code=0x%03x keycode=%u %s\n",
+			__func__, data, code, keycode,
+			atkbd->release ? "release" : "press");
+
 	if (!(atkbd->release && test_bit(code, atkbd->force_release_mask)))
 		if (keycode != ATKBD_KEY_NULL)
 			input_event(dev, EV_MSC, MSC_SCAN, code);
@@ -1127,6 +1135,10 @@ static void atkbd_set_keycode_table(struct atkbd *atkbd)
 				for (j = 0; j < ARRAY_SIZE(atkbd_scroll_keys); j++)
 					if ((scancode | 0x80) == atkbd_scroll_keys[j].set2)
 						atkbd->keycode[i | 0x80] = atkbd_scroll_keys[j].keycode;
+			if (i == 0x49 || i == 0x4e || scancode == 0x49 || scancode == 0x4e)
+				pr_warn("AY %s set1=0x%02x set2=0x%02x make=%u break=%u\n",
+					__func__, i, scancode,
+					atkbd->keycode[i], atkbd->keycode[i | 0x80]);
 		}
 	} else if (atkbd->set == 3) {
 		memcpy(atkbd->keycode, atkbd_set3_keycode, sizeof(atkbd->keycode));
@@ -1157,6 +1169,11 @@ static void atkbd_set_keycode_table(struct atkbd *atkbd)
  */
 	if (atkbd_platform_fixup)
 		atkbd_platform_fixup(atkbd, atkbd_platform_fixup_data);
+
+	if (atkbd->translated)
+		pr_info("AY %s final: 0x49->%u 0x4e->%u\n",
+			__func__,
+			atkbd->keycode[0x49], atkbd->keycode[0x4e]);
 }
 
 /*


```

</details>