### PR TITLE
test: add coverage for systemctl preset in test-systemctl-enable.sh

### DIFF
--- a/test/test-systemctl-enable.sh
+++ b/test/test-systemctl-enable.sh
@@ -713,7 +713,37 @@ test ! -h "$root/etc/systemd/system/another-target@.target.wants/some-some-link7
 test ! -h "$root/etc/systemd/system/target2@some-some-link7.target.requires/some-some-link7.socket"
 test ! -h "$root/etc/systemd/system/another-target2@.target.requires/some-some-link7.socket"
 
-# TODO: repeat the tests above for presets
+: '-------specifiers in presets------------------------------------'
+# Repeat the check above, but via 'systemctl preset' instead
+# of calling enable/disable directly. We reuse the same unit file, which is
+# currently disabled (no symlinks) from the block above.
+
+mkdir -p "$root/etc/systemd/system-preset"
+cat >"$root/etc/systemd/system-preset/99-test.preset" <<EOF
+enable some-some-link7.socket
+EOF
+
+"$systemctl" --root="$root" preset 'some-some-link7.socket'
+islink "$root/etc/systemd/system/target@some-some-link7.target.wants/some-some-link7.socket" "/etc/systemd/system/some-some-link7.socket"
+islink "$root/etc/systemd/system/another-target@.target.wants/some-some-link7.socket" "/etc/systemd/system/some-some-link7.socket"
+islink "$root/etc/systemd/system/target2@some-some-link7.target.requires/some-some-link7.socket" "/etc/systemd/system/some-some-link7.socket"
+islink "$root/etc/systemd/system/another-target2@.target.requires/some-some-link7.socket" "/etc/systemd/system/some-some-link7.socket"
+
+cat >"$root/etc/systemd/system-preset/99-test.preset" <<EOF
+disable some-some-link7.socket
+EOF
+
+"$systemctl" --root="$root" preset 'some-some-link7.socket'
+test ! -h "$root/etc/systemd/system/target@some-some-link7.target.wants/some-some-link7.socket"
+test ! -h "$root/etc/systemd/system/another-target@.target.wants/some-some-link7.socket"
+test ! -h "$root/etc/systemd/system/target2@some-some-link7.target.requires/some-some-link7.socket"
+test ! -h "$root/etc/systemd/system/another-target2@.target.requires/some-some-link7.socket"
+
+# Not testing preset-all here: $root has leftover units from earlier
+# sections that are deliberately invalid, and preset-all trips on those.
+
+# Clean up so later tests aren't affected by this preset file.
+rm -f "$root/etc/systemd/system-preset/99-test.preset"
 
 : '-------SYSTEMD_OS_RELEASE relative to root---------------------'
 # check that os-release overwriting works as expected with root


### PR DESCRIPTION
Closes the `# TODO: repeat the tests above for presets` in
test/test-systemctl-enable.sh, right after the existing
"specifiers in WantedBy" enable/disable check.

This adds an equivalent check using `systemctl preset` (enable then
disable via a .preset file), reusing the same unit and asserting the
same symlinks.

`preset-all` is intentionally not exercised here: by this point in the
script, `$root` has accumulated unit files from earlier sections that
are deliberately invalid (masked units, bad aliases, unresolvable
specifiers), and `preset-all` walks the whole unit directory, so it
fails on units unrelated to this test.