### PR TITLE
ssh-generator,vmspawn: add .ssh/authorized_keys2 to AuthorizedKeysFile=

### DIFF
--- a/man/systemd-ssh-generator.xml
+++ b/man/systemd-ssh-generator.xml
@@ -71,6 +71,15 @@
     <para>The generator will use a packaged <filename>sshd@.service</filename> service template file if one
     exists, and otherwise generate a suitable service template file.</para>
 
+    <para>Note that the generated service template file overrides the
+    <varname>AuthorizedKeysFile</varname> setting of
+    <citerefentry project='man-pages'><refentrytitle>sshd_config</refentrytitle><manvolnum>5</manvolnum></citerefentry>,
+    in order to pick up the key provided via the
+    <varname>ssh.ephemeral-authorized_keys-all</varname> credential. It lists that key file first, followed
+    by <filename>.ssh/authorized_keys</filename> and <filename>.ssh/authorized_keys2</filename>, i.e. the two
+    paths <command>sshd</command> looks at by default. Any other paths configured locally are not
+    considered, as <command>sshd</command> provides no way to append to the setting.</para>
+
     <para><command>systemd-ssh-generator</command> implements
     <citerefentry><refentrytitle>systemd.generator</refentrytitle><manvolnum>7</manvolnum></citerefentry>.</para>
   </refsect1>

--- a/man/systemd-ssh-generator.xml
+++ b/man/systemd-ssh-generator.xml
@@ -73,7 +73,7 @@
 
     <para>Note that the generated service template file overrides the
     <varname>AuthorizedKeysFile</varname> setting of
-    <citerefentry project='man-pages'><refentrytitle>sshd_config</refentrytitle><manvolnum>5</manvolnum></citerefentry>,
+    <citerefentry project="man-pages"><refentrytitle>sshd_config</refentrytitle><manvolnum>5</manvolnum></citerefentry>,
     in order to pick up the key provided via the
     <varname>ssh.ephemeral-authorized_keys-all</varname> credential. It lists that key file first, followed
     by <filename>.ssh/authorized_keys</filename> and <filename>.ssh/authorized_keys2</filename>, i.e. the two

--- a/src/ssh-generator/ssh-generator.c
+++ b/src/ssh-generator/ssh-generator.c
@@ -120,7 +120,7 @@ static int make_sshd_template_unit(
                         "\n"
                         "[Service]\n"
                         "ExecStartPre=systemd-tmpfiles --create --inline 'f^ /run/sshd-generated-%%i/authorized_keys 0444 root root - ssh.ephemeral-authorized_keys-all'\n"
-                        "ExecStart=-%s -i -o \"AuthorizedKeysFile /run/sshd-generated-%%i/authorized_keys .ssh/authorized_keys\"\n"
+                        "ExecStart=-%s -i -o \"AuthorizedKeysFile /run/sshd-generated-%%i/authorized_keys .ssh/authorized_keys .ssh/authorized_keys2\"\n"
                         "StandardInput=socket\n"
                         "ImportCredential=ssh.ephemeral-authorized_keys-all\n"
                         "RuntimeDirectory=sshd-generated-%%i\n",

--- a/src/vmspawn/vmspawn.c
+++ b/src/vmspawn/vmspawn.c
@@ -3618,7 +3618,7 @@ static int run_virtual_machine(int kvm_device_fd, int vhost_device_fd) {
                                 "[Service]\n"
                                 "ExecStartPre=systemd-tmpfiles --create --inline 'f^ /run/sshd-vsock-%i/authorized_keys 0444 root root - ssh.ephemeral-authorized_keys-all'\n"
                                 "ExecStart=\n"
-                                "ExecStart=-sshd -i -o 'AuthorizedKeysFile=/run/sshd-vsock-%i/authorized_keys .ssh/authorized_keys'\n"
+                                "ExecStart=-sshd -i -o 'AuthorizedKeysFile=/run/sshd-vsock-%i/authorized_keys .ssh/authorized_keys .ssh/authorized_keys2'\n"
                                 "ImportCredential=ssh.ephemeral-authorized_keys-all\n"
                                 "RuntimeDirectory=sshd-vsock-%i\n",
                                 SIZE_MAX);


### PR DESCRIPTION
The `sshd-generated@.service` unit written by `systemd-ssh-generator`, and the `sshd-vsock@.service` drop-in written by `systemd-vmspawn`, override sshd's `AuthorizedKeysFile=` setting, so that the key from the `ssh.ephemeral-authorized_keys-all` credential is accepted. Since sshd offers no way to *append* to the setting, we have to list the paths we want explicitly.

Both listed `.ssh/authorized_keys`, but not `.ssh/authorized_keys2`, i.e. dropped one of the two paths sshd looks at by default:

```
$ sshd -f /dev/null -G | grep authorizedkeysfile
authorizedkeysfile .ssh/authorized_keys .ssh/authorized_keys2
```

Let's list it too, so that we stop discarding a path sshd would have used on its own.

A missing file in the list is not a problem: sshd walks the listed files and skips the ones it cannot open. That is necessarily the case, given that the stock default lists `.ssh/authorized_keys2` while hardly any system actually has it. This also raises no requirement on the installed sshd, as listing multiple whitespace-separated paths is something the existing code already relies on.

Note that this does *not* address locally configured paths, e.g. the `.ssh/authorized_keys.d/ignition` that Ignition configures on Fedora CoreOS, which is what #43092 is about. Those still get discarded. Determining the effective setting is not something a generator can do, as it may run before sshd's configuration is even visible; the proper fix for that is support for additive drop-ins in sshd itself.

See #43092 for context.
