### PR TITLE
iovec-util: enclose macro arg in ()

### DIFF
--- a/src/basic/iovec-util.h
+++ b/src/basic/iovec-util.h
@@ -29,7 +29,7 @@ struct iovec* iovec_make_string(struct iovec *iovec, const char *s);
 
 #define IOVEC_MAKE_BYTE(c)                                      \
         (const struct iovec) {                                  \
-                .iov_base = (char*) ((const char[]) { c }),     \
+                .iov_base = (char*) ((const char[]) { (c) }),   \
                 .iov_len = 1,                                   \
         }
 


### PR DESCRIPTION
Follow-up for 56f3ae9292742fff1cac6dbe4883a1715e56e874