### PR TITLE
udev: probe_superblocks: return a real negative errno on failure

### DIFF
--- a/src/udev/udev-builtin-blkid.c
+++ b/src/udev/udev-builtin-blkid.c
@@ -321,8 +321,6 @@ static int probe_superblocks(blkid_probe pr) {
         struct stat st;
         int rc;
 
-        /* TODO: Return negative errno. */
-
         if (fstat(sym_blkid_probe_get_fd(pr), &st))
                 return -errno;
 
@@ -337,9 +335,10 @@ static int probe_superblocks(blkid_probe pr) {
                  */
                 sym_blkid_probe_enable_superblocks(pr, 0);
 
+                errno = 0;
                 rc = sym_blkid_do_fullprobe(pr);
                 if (rc < 0)
-                        return rc;        /* -1 = error, 1 = nothing, 0 = success */
+                        return errno_or_else(EIO);
 
                 if (sym_blkid_probe_lookup_value(pr, "PTTYPE", NULL, NULL) == 0)
                         return 0;        /* partition table detected */
@@ -348,7 +347,12 @@ static int probe_superblocks(blkid_probe pr) {
         sym_blkid_probe_set_partitions_flags(pr, BLKID_PARTS_ENTRY_DETAILS);
         sym_blkid_probe_enable_superblocks(pr, 1);
 
-        return sym_blkid_do_safeprobe(pr);
+        errno = 0;
+        rc = sym_blkid_do_safeprobe(pr);
+        if (rc < 0)
+                return errno_or_else(EIO);
+
+        return rc; /* 0 = success, 1 = nothing found */
 }
 
 static int read_loopback_backing_inode(


### PR DESCRIPTION
Previously, probe_superblocks() forwarded blkid_do_fullprobe()'s and blkid_do_safeprobe()'s raw return code on error, which is just -1 with no errno attached. The caller passes this value straight to log_device_debug_errno() with %m, so a generic probing failure always printed strerror(-1) regardless of what actually went wrong.

Convert the -1 error case to a proper negative errno via errno_or_else(), matching the pattern used elsewhere in this file. The 'nothing found' (1) and success (0) return values are unchanged.