### PR TITLE
creds: add new "edit" verb for interactively editing encrypted credentials

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -56,6 +56,16 @@ CHANGES WITH 262:
           IPv4ProxyARP=yes but has no effect if IPv4ProxyARP= has been set to
           false. This mirrors the behavior of IPv6ProxyNDPAddress=.
 
+        Changes in systemd-creds:
+
+        * The new "systemd-creds edit" verb may be used to interactively edit
+          an encrypted credential file: the credential is decrypted, opened in
+          the editor configured via $SYSTEMD_EDITOR/$EDITOR/$VISUAL, and
+          re-encrypted once the editor exits. The plaintext is only ever
+          stored in a private directory backed by a RAM file system excluded
+          from swap. If the specified file does not exist yet it is created,
+          making this an easy way to create new encrypted credentials.
+
 CHANGES WITH 261:
 
         Announcements of Future Feature Removals and Incompatible Changes:

--- a/man/systemd-creds.xml
+++ b/man/systemd-creds.xml
@@ -177,6 +177,38 @@
         <xi:include href="version-info.xml" xpointer="v250"/></listitem>
       </varlistentry>
 
+      <varlistentry>
+        <term><command>edit</command> <replaceable>file</replaceable></term>
+
+        <listitem><para>Interactively edit an encrypted credential file: the specified credential file is
+        loaded and decrypted (see the <command>decrypt</command> command above), the plaintext is opened in
+        a text editor, and once the editor exits the (possibly modified) plaintext is encrypted again and
+        used to atomically replace the specified file (see the <command>encrypt</command> command above). If
+        the specified file does not exist yet, it is created, starting from empty plaintext. If the
+        plaintext is unmodified when the editor exits, or if it is saved as a completely empty file, the
+        credential file is not updated.</para>
+
+        <para>The file name part of the specified path is used as the credential name to validate against
+        the name embedded in the credential and to embed when re-encrypting, unless overridden with the
+        <option>--name=</option> switch. The encryption key to use may be configured with the
+        <option>--with-key=</option> switch, and defaults to <literal>auto</literal>, independently of which
+        key the existing credential was encrypted with.</para>
+
+        <para>The plaintext is edited in a scratch file located in a private directory backed by
+        unswappable memory (if supported), the same way service credential directories are set up, ensuring
+        the plaintext credential data does not touch persistent storage. When invoked without the
+        privileges to set up such a directory, the scratch file is placed in a private directory below the
+        user's runtime directory (<varname>$XDG_RUNTIME_DIR</varname>) instead, which is required to reside
+        on a RAM-backed file system, too. Note that the configured editor might maintain temporary or backup copies of the edited
+        data in other, less secure locations, this tool has no control over. Configure your editor
+        accordingly.</para>
+
+        <para>The editor to use is selected via the <varname>$SYSTEMD_EDITOR</varname>,
+        <varname>$EDITOR</varname> and <varname>$VISUAL</varname> environment variables, see below.</para>
+
+        <xi:include href="version-info.xml" xpointer="v262"/></listitem>
+      </varlistentry>
+
       <xi:include href="standard-options.xml" xpointer="no-ask-password" />
       <xi:include href="standard-options.xml" xpointer="help" />
       <xi:include href="standard-options.xml" xpointer="version" />
@@ -202,8 +234,8 @@
       <varlistentry>
         <term><option>--user</option></term>
 
-        <listitem><para>When specified with the <command>encrypt</command> and <command>decrypt</command>
-        commands encrypts a user-scoped (rather than a system-scoped) credential. Use <option>--uid=</option>
+        <listitem><para>When specified with the <command>encrypt</command>, <command>decrypt</command> and
+        <command>edit</command> commands encrypts a user-scoped (rather than a system-scoped) credential. Use <option>--uid=</option>
         to select which user the credential is from. Such credentials may only be decrypted from the
         specified user's context, except if privileges can be acquired. Generally, when an encrypted
         credential shall be used in the per-user service manager it should be encrypted with this option set,
@@ -284,6 +316,11 @@
         was used when encrypted) the specified name has no effect as no credential name validation is
         done.</para>
 
+        <para>When specified with the <command>edit</command> command the name is used both ways, i.e. to
+        validate the name embedded in the existing encrypted credential and to embed in the updated
+        encrypted credential. If not specified, the name is chosen automatically from the filename component
+        of the specified path.</para>
+
         <para>Embedding the credential name in the encrypted credential is done in order to protect against
         reuse of credentials for purposes they were not originally intended for, under the assumption the
         credential name is chosen carefully to encode its intended purpose.</para>
@@ -303,14 +340,18 @@
         validate the "not-after" timestamp that was configured with <option>--not-after=</option> during
         encryption. If not specified, defaults to the current system time.</para>
 
+        <para>When specified with the <command>edit</command> command the timestamp is used both ways, i.e.
+        for validation of the existing encrypted credential and for embedding in the updated encrypted
+        credential.</para>
+
         <xi:include href="version-info.xml" xpointer="v250"/></listitem>
       </varlistentry>
 
       <varlistentry>
         <term><option>--not-after=<replaceable>timestamp</replaceable></option></term>
 
-        <listitem><para>When specified with the <command>encrypt</command> command controls the time when the
-        credential shall not be used anymore. This embeds the specified timestamp in the encrypted
+        <listitem><para>When specified with the <command>encrypt</command> and <command>edit</command>
+        commands controls the time when the credential shall not be used anymore. This embeds the specified timestamp in the encrypted
         credential. During decryption the timestamp is checked against the current system clock, and if the
         timestamp is in the past the decryption will fail. By default, no such timestamp is set. Takes a
         timestamp specification in the format described in
@@ -324,8 +365,8 @@
         <term><option>-H</option></term>
         <term><option>-T</option></term>
 
-        <listitem><para>When specified with the <command>encrypt</command> command controls the
-        encryption/signature key to use. Takes one of <literal>host</literal>, <literal>tpm2</literal>,
+        <listitem><para>When specified with the <command>encrypt</command> and <command>edit</command>
+        commands controls the encryption/signature key to use. Takes one of <literal>host</literal>, <literal>tpm2</literal>,
         <literal>host+tpm2</literal>, <literal>null</literal>, <literal>auto</literal>,
         <literal>auto-initrd</literal>. See above for details on the key types. If set to
         <literal>auto</literal> (which is the default) the TPM2 key is used if a TPM2 device is found and not
@@ -464,6 +505,29 @@
     <title>Exit status</title>
 
     <para>On success, 0 is returned.</para>
+  </refsect1>
+
+  <refsect1>
+    <title>Environment</title>
+
+    <variablelist class='environment-variables'>
+      <varlistentry>
+        <term><varname>$SYSTEMD_EDITOR</varname></term>
+
+        <listitem><para>Editor to use when editing credentials; overrides <varname>$EDITOR</varname> and
+        <varname>$VISUAL</varname>. If neither <varname>$SYSTEMD_EDITOR</varname> nor
+        <varname>$EDITOR</varname> nor <varname>$VISUAL</varname> are present or if it is set to an empty
+        string or if their execution failed, systemd-creds will try to execute well known editors in this
+        order:
+        <citerefentry project='die-net'><refentrytitle>editor</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
+        <citerefentry project='die-net'><refentrytitle>nano</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
+        <citerefentry project='die-net'><refentrytitle>vim</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
+        <citerefentry project='die-net'><refentrytitle>vi</refentrytitle><manvolnum>1</manvolnum></citerefentry>.
+        </para>
+
+        <xi:include href="version-info.xml" xpointer="v262"/></listitem>
+      </varlistentry>
+    </variablelist>
   </refsect1>
 
   <refsect1>

--- a/shell-completion/bash/systemd-creds
+++ b/shell-completion/bash/systemd-creds
@@ -64,6 +64,7 @@ _systemd_creds() {
         [CAT]='cat'
         [ENCRYPT]='encrypt'
         [DECRYPT]='decrypt'
+        [EDIT]='edit'
     )
 
     local -A OPTS_FOR_VERB=(
@@ -105,6 +106,24 @@ _systemd_creds() {
                    --name
                    --timestamp
                    --allow-null'
+        [EDIT]='--help
+                --version
+                --no-pager
+                --no-legend
+                --no-ask-password
+                --uid
+                --with-key
+                -H
+                -T
+                --tpm2-device
+                --tpm2-pcrs
+                --tpm2-public-key
+                --tpm2-public-key-pcrs
+                --tpm2-signature
+                --not-after
+                --name
+                --timestamp
+                --allow-null'
     )
 
     _init_completion || return
@@ -173,6 +192,13 @@ _systemd_creds() {
     elif __contains_word "$verb" ${VERBS[DECRYPT]}; then
         if [[ $cur = -* ]]; then
             comps=${OPTS_FOR_VERB[DECRYPT]}
+        else
+            comps=$( compgen -A file -- "$cur" )
+            compopt -o filenames
+        fi
+    elif __contains_word "$verb" ${VERBS[EDIT]}; then
+        if [[ $cur = -* ]]; then
+            comps=${OPTS_FOR_VERB[EDIT]}
         else
             comps=$( compgen -A file -- "$cur" )
             compopt -o filenames

--- a/src/creds/creds.c
+++ b/src/creds/creds.c
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
 #include <linux/magic.h>
+#include <sys/mount.h>                  /* IWYU pragma: keep */
 #include <unistd.h>
 
 #include "sd-json.h"
@@ -13,29 +14,40 @@
 #include "creds-util.h"
 #include "dirent-util.h"
 #include "dlopen-note.h"
+#include "edit-util.h"
 #include "errno-util.h"
 #include "escape.h"
+#include "fd-util.h"
 #include "fileio.h"
 #include "format-table.h"
 #include "hashmap.h"
 #include "hexdecoct.h"
+#include "io-util.h"
+#include "iovec-util.h"
 #include "json-util.h"
 #include "libmount-util.h"
 #include "log.h"
 #include "main-func.h"
 #include "memory-util.h"
+#include "mkdir.h"
+#include "mount-util.h"
+#include "namespace-util.h"
 #include "options.h"
 #include "pager.h"
 #include "parse-argument.h"
 #include "parse-util.h"
+#include "path-lookup.h"
+#include "path-util.h"
 #include "polkit-agent.h"
 #include "pretty-print.h"
+#include "rm-rf.h"
 #include "stat-util.h"
 #include "string-table.h"
 #include "string-util.h"
 #include "strv.h"
 #include "terminal-util.h"
 #include "time-util.h"
+#include "tmpfile-util.h"
 #include "tpm2-pcr.h"
 #include "tpm2-util.h"
 #include "user-util.h"
@@ -746,6 +758,279 @@ static int verb_decrypt(int argc, char *argv[], uintptr_t _data, void *userdata)
         if (r < 0)
                 return r;
 
+        return EXIT_SUCCESS;
+}
+
+typedef struct EditScratchDir {
+        char *path;
+        bool mounted;
+} EditScratchDir;
+
+static void edit_scratch_dir_done(EditScratchDir *d) {
+        assert(d);
+
+        if (!d->path)
+                return;
+
+        /* Get rid of the plaintext scratch area again. If we mounted a file system, detaching it releases
+         * the RAM backing it. Otherwise the directory resides on some other RAM-backed file system (we
+         * refuse to operate on anything else), whose backing memory is released on file deletion. */
+
+        if (d->mounted)
+                (void) umount_verbose(LOG_DEBUG, d->path, MNT_DETACH|UMOUNT_NOFOLLOW);
+
+        (void) rm_rf(d->path, REMOVE_ROOT);
+        d->path = mfree(d->path);
+}
+
+static int edit_scratch_dir_acquire(EditScratchDir *ret) {
+        _cleanup_free_ char *base = NULL, *template = NULL;
+        _cleanup_(rm_rf_physical_and_freep) char *d = NULL;
+        int r;
+
+        assert(ret);
+
+        /* Sets up a private scratch directory for editing plaintext credential data, backed by a RAM file
+         * system excluded from swap if we can have it, so that the plaintext never touches persistent
+         * storage. */
+
+        r = runtime_directory_generic(geteuid() == 0 ? RUNTIME_SCOPE_SYSTEM : RUNTIME_SCOPE_USER, "systemd", &base);
+        if (r == -ENXIO)
+                return log_error_errno(r, "$XDG_RUNTIME_DIR is not set, refusing to edit plaintext credential data without a RAM-backed scratch directory.");
+        if (r < 0)
+                return log_error_errno(r, "Failed to determine runtime directory: %m");
+
+        r = mkdir_p(base, 0755);
+        if (r < 0)
+                return log_error_errno(r, "Failed to create directory '%s': %m", base);
+
+        template = path_join(base, "creds-edit.XXXXXX");
+        if (!template)
+                return log_oom();
+
+        r = mkdtemp_malloc(template, &d);
+        if (r < 0)
+                return log_error_errno(r, "Failed to create scratch directory below '%s': %m", base);
+
+        /* Try to mount a tmpfs with swapping disabled (or ramfs) over the directory, the same way PID 1
+         * sets up service credential directories. Do so in a detached mount namespace: that keeps the
+         * plaintext invisible to other processes, and, more importantly, ensures the kernel releases the
+         * mount (and thus the memory backing the plaintext) when we die, even if we are killed by a signal
+         * before our cleanup handler runs. If that's not possible (for lack of privileges, a kernel
+         * without namespace support, or suchlike), fall back to the plain directory, but insist on a
+         * RAM-backed file system in that case, too. */
+        r = detach_mount_namespace();
+        if (r >= 0) {
+                r = mount_credentials_fs(d);
+                if (r < 0)
+                        return log_error_errno(r, "Failed to mount credentials file system over '%s': %m", d);
+
+                *ret = (EditScratchDir) {
+                        .path = TAKE_PTR(d),
+                        .mounted = true,
+                };
+                return 0;
+        }
+        log_debug_errno(r, "Cannot detach mount namespace, using plain scratch directory '%s': %m", d);
+
+        _cleanup_close_ int dfd = open(d, O_DIRECTORY|O_CLOEXEC);
+        if (dfd < 0)
+                return log_error_errno(errno, "Failed to open scratch directory '%s': %m", d);
+
+        struct statfs sfs;
+        if (fstatfs(dfd, &sfs) < 0)
+                return log_error_errno(errno, "Failed to determine file system of scratch directory '%s': %m", d);
+
+        if (is_fs_type(&sfs, TMPFS_MAGIC)) {
+                struct stat st;
+
+                if (fstat(dfd, &st) < 0)
+                        return log_error_errno(errno, "Failed to stat scratch directory '%s': %m", d);
+
+                r = is_tmpfs_with_noswap(st.st_dev);
+                if (r < 0)
+                        log_debug_errno(r, "Failed to determine if file system of '%s' has 'noswap' enabled, assuming not: %m", d);
+                if (r <= 0)
+                        log_warning("Scratch directory '%s' is backed by tmpfs without the 'noswap' option, "
+                                    "plaintext credential data may be paged out to swap while editing.", d);
+        } else if (!is_fs_type(&sfs, RAMFS_MAGIC))
+                return log_error_errno(SYNTHETIC_ERRNO(EMEDIUMTYPE),
+                                       "Scratch directory '%s' is not located on a RAM-backed file system, refusing to edit plaintext credential data there.", d);
+
+        *ret = (EditScratchDir) {
+                .path = TAKE_PTR(d),
+                .mounted = false,
+        };
+        return 0;
+}
+
+VERB(verb_edit, "edit", "FILE", 2, 2, 0,
+     "Edit encrypted credential file interactively");
+static int verb_edit(int argc, char *argv[], uintptr_t _data, void *userdata) {
+        _cleanup_(iovec_done_erase) struct iovec plaintext = {}, new_plaintext = {}, output = {};
+        _cleanup_(iovec_done) struct iovec input = {};
+        _cleanup_(edit_scratch_dir_done) EditScratchDir scratch = {};
+        _cleanup_free_ char *fname = NULL, *scratch_file = NULL, *base64_buf = NULL;
+        const char *target, *name;
+        ssize_t base64_size;
+        usec_t timestamp;
+        int r;
+
+        assert(argc == 2);
+
+        if (!on_tty())
+                return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "Cannot edit credentials if not on a tty.");
+
+        target = argv[1];
+        if (empty_or_dash(target))
+                return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "Editing standard input/output is not supported, please specify a path to a credential file.");
+
+        if (arg_name_any)
+                name = NULL;
+        else if (arg_name)
+                name = arg_name;
+        else {
+                r = path_extract_filename(target, &fname);
+                if (r < 0)
+                        return log_error_errno(r, "Failed to extract filename from '%s': %m", target);
+                if (r == O_DIRECTORY)
+                        return log_error_errno(SYNTHETIC_ERRNO(EISDIR), "Path '%s' refers to directory, refusing.", target);
+
+                name = fname;
+        }
+
+        /* Validate the name before the interactive editing session, so that we don't throw away the
+         * freshly entered plaintext when encryption then refuses the name. */
+        if (name && !credential_name_valid(name))
+                return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "Invalid credential name: %s", name);
+
+        timestamp = arg_timestamp != USEC_INFINITY ? arg_timestamp : now(CLOCK_REALTIME);
+
+        if (arg_not_after != USEC_INFINITY && arg_not_after < timestamp)
+                return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "Credential is invalidated before it is valid.");
+
+        /* Load and decrypt the existing credential, if there is one. Otherwise, we start with empty
+         * plaintext, i.e. the credential file is created from scratch. */
+        r = read_full_file_full(AT_FDCWD, target, UINT64_MAX, CREDENTIAL_ENCRYPTED_SIZE_MAX, READ_FULL_FILE_UNBASE64|READ_FULL_FILE_FAIL_WHEN_LARGER, NULL, (char**) &input.iov_base, &input.iov_len);
+        if (r == -E2BIG)
+                return log_error_errno(r, "Data too long for encrypted credential (allowed size: %zu).", (size_t) CREDENTIAL_ENCRYPTED_SIZE_MAX);
+        if (r == -ENOENT)
+                log_info("Credential file '%s' does not exist yet, will create it.", target);
+        else if (r < 0)
+                return log_error_errno(r, "Failed to read encrypted credential data: %m");
+
+        bool existing = r >= 0 && input.iov_len > 0;
+
+        if (existing) {
+                if (geteuid() != 0) {
+                        (void) polkit_agent_open_if_enabled(BUS_TRANSPORT_LOCAL, arg_ask_password);
+
+                        r = ipc_decrypt_credential(
+                                        name,
+                                        timestamp,
+                                        arg_uid,
+                                        &input,
+                                        arg_credential_flags,
+                                        &plaintext);
+                } else
+                        r = decrypt_credential_and_warn(
+                                        name,
+                                        timestamp,
+                                        arg_tpm2_device,
+                                        arg_tpm2_signature,
+                                        arg_uid,
+                                        &input,
+                                        arg_credential_flags,
+                                        &plaintext);
+                if (r < 0)
+                        return r;
+        }
+
+        r = edit_scratch_dir_acquire(&scratch);
+        if (r < 0)
+                return r;
+
+        scratch_file = path_join(scratch.path, name ?: "credential");
+        if (!scratch_file)
+                return log_oom();
+
+        _cleanup_close_ int fd = open(scratch_file, O_WRONLY|O_CREAT|O_EXCL|O_NOFOLLOW|O_CLOEXEC, 0600);
+        if (fd < 0)
+                return log_error_errno(errno, "Failed to create scratch file '%s': %m", scratch_file);
+
+        r = loop_write(fd, plaintext.iov_base, plaintext.iov_len);
+        if (r < 0)
+                return log_error_errno(r, "Failed to write plaintext credential data to scratch file '%s': %m", scratch_file);
+
+        fd = safe_close(fd);
+
+        r = run_editor(STRV_MAKE(scratch_file), /* first_line= */ 1);
+        if (r < 0)
+                return r;
+
+        r = read_full_file_full(AT_FDCWD, scratch_file, UINT64_MAX, CREDENTIAL_SIZE_MAX, READ_FULL_FILE_SECURE|READ_FULL_FILE_FAIL_WHEN_LARGER, NULL, (char**) &new_plaintext.iov_base, &new_plaintext.iov_len);
+        if (r == -E2BIG)
+                return log_error_errno(r, "Plaintext too long for credential (allowed size: %zu).", (size_t) CREDENTIAL_SIZE_MAX);
+        if (r < 0)
+                return log_error_errno(r, "Failed to read back edited credential data: %m");
+
+        if (existing && iovec_equal(&plaintext, &new_plaintext)) {
+                log_info("Credential data unchanged, not updating '%s'.", target);
+                return EXIT_SUCCESS;
+        }
+
+        if (new_plaintext.iov_len == 0) {
+                log_notice("Edited credential data is empty, not updating '%s'.", target);
+                return EXIT_SUCCESS;
+        }
+
+        /* Take a fresh timestamp for encryption: the new credential comes into existence now, and the IPC
+         * service only waives interactive authentication for fresh timestamps, which matters if the editing
+         * session took a while. */
+        if (arg_timestamp == USEC_INFINITY) {
+                timestamp = now(CLOCK_REALTIME);
+
+                if (arg_not_after != USEC_INFINITY && arg_not_after < timestamp)
+                        return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "Credential is invalidated before it is valid.");
+        }
+
+        if (geteuid() != 0 && !sd_id128_equal(arg_with_key, CRED_AES256_GCM_BY_NULL)) {
+                (void) polkit_agent_open_if_enabled(BUS_TRANSPORT_LOCAL, arg_ask_password);
+
+                r = ipc_encrypt_credential(
+                                name,
+                                timestamp,
+                                arg_not_after,
+                                arg_uid,
+                                &new_plaintext,
+                                arg_credential_flags,
+                                &output);
+        } else
+                r = encrypt_credential_and_warn(
+                                arg_with_key,
+                                name,
+                                timestamp,
+                                arg_not_after,
+                                arg_tpm2_device,
+                                arg_tpm2_pcr_mask,
+                                arg_tpm2_public_key,
+                                arg_tpm2_public_key_pcr_mask,
+                                arg_uid,
+                                &new_plaintext,
+                                arg_credential_flags,
+                                &output);
+        if (r < 0)
+                return r;
+
+        base64_size = base64mem_full(output.iov_base, output.iov_len, 79, &base64_buf);
+        if (base64_size < 0)
+                return base64_size;
+
+        r = write_string_file(target, base64_buf, WRITE_STRING_FILE_ATOMIC|WRITE_STRING_FILE_CREATE);
+        if (r < 0)
+                return log_error_errno(r, "Failed to write '%s': %m", target);
+
+        log_info("Successfully updated encrypted credential file '%s'.", target);
         return EXIT_SUCCESS;
 }
 

--- a/src/shared/edit-util.c
+++ b/src/shared/edit-util.c
@@ -239,12 +239,11 @@ static int create_edit_temp_file(EditFile *e, const char *contents, size_t conte
         return 0;
 }
 
-static int run_editor_child(const EditFileContext *context) {
+static int run_editor_child(char * const *paths, unsigned first_line) {
         _cleanup_strv_free_ char **args = NULL, **editor = NULL;
         int r;
 
-        assert(context);
-        assert(context->n_files >= 1);
+        assert(!strv_isempty(paths));
 
         /* SYSTEMD_EDITOR takes precedence over EDITOR which takes precedence over VISUAL.
          * If neither SYSTEMD_EDITOR nor EDITOR nor VISUAL are present, we try to execute
@@ -260,18 +259,16 @@ static int run_editor_child(const EditFileContext *context) {
                 }
         }
 
-        if (context->n_files == 1 && context->files[0].line > 1) {
+        if (strv_length(paths) == 1 && first_line > 1) {
                 /* If editing a single file only, use the +LINE syntax to put cursor on the right line */
-                r = strv_extendf(&args, "+%u", context->files[0].line);
+                r = strv_extendf(&args, "+%u", first_line);
                 if (r < 0)
                         return log_oom();
         }
 
-        FOREACH_ARRAY(i, context->files, context->n_files) {
-                r = strv_extend(&args, i->temp);
-                if (r < 0)
-                        return log_oom();
-        }
+        r = strv_extend_strv(&args, paths, /* filter_duplicates= */ false);
+        if (r < 0)
+                return log_oom();
 
         size_t editor_n = strv_length(editor);
         if (editor_n > 0) {
@@ -314,10 +311,10 @@ static int run_editor_child(const EditFileContext *context) {
                                "Cannot edit files, no editor available. Please set either $SYSTEMD_EDITOR, $EDITOR or $VISUAL.");
 }
 
-static int run_editor(const EditFileContext *context) {
+int run_editor(char * const *paths, unsigned first_line) {
         int r;
 
-        assert(context);
+        assert(!strv_isempty(paths));
 
         r = pidref_safe_fork(
                         "(editor)",
@@ -326,7 +323,7 @@ static int run_editor(const EditFileContext *context) {
         if (r < 0)
                 return r;
         if (r == 0) { /* Child */
-                r = run_editor_child(context);
+                r = run_editor_child(paths, first_line);
                 _exit(r < 0 ? EXIT_FAILURE : EXIT_SUCCESS);
         }
 
@@ -483,13 +480,19 @@ int do_edit_files_and_install(EditFileContext *context) {
                 if (r < 0)
                         return log_error_errno(r, "Failed to read stdin: %m");
         } else {
+                _cleanup_strv_free_ char **paths = NULL;
+
                 FOREACH_ARRAY(editfile, context->files, context->n_files) {
                         r = create_edit_temp_file(editfile, /* contents= */ NULL, /* contents_size= */ 0);
                         if (r < 0)
                                 return r;
+
+                        r = strv_extend(&paths, editfile->temp);
+                        if (r < 0)
+                                return log_oom();
                 }
 
-                r = run_editor(context);
+                r = run_editor(paths, /* first_line= */ context->n_files == 1 ? context->files[0].line : 1);
                 if (r < 0)
                         return r;
         }

--- a/src/shared/edit-util.h
+++ b/src/shared/edit-util.h
@@ -29,3 +29,5 @@ int edit_files_add(
                 char * const *comment_paths);
 
 int do_edit_files_and_install(EditFileContext *context);
+
+int run_editor(char * const *paths, unsigned first_line);

--- a/test/units/TEST-54-CREDS.sh
+++ b/test/units/TEST-54-CREDS.sh
@@ -168,6 +168,44 @@ systemd-creds decrypt /tmp/cred.enc /tmp/cred.dec
 diff /tmp/cred.orig /tmp/cred.dec
 rm -f /tmp/cred.{enc,dec}
 
+# verb: edit
+echo -n "secret data" >/tmp/edit.orig
+systemd-creds encrypt /tmp/edit.orig /tmp/edit.cred
+cp /tmp/edit.cred /tmp/edit.cred.copy
+# Unmodified plaintext -> the credential file must not be rewritten
+EDITOR='true' script -ec 'systemd-creds edit /tmp/edit.cred' /dev/null
+cmp /tmp/edit.cred /tmp/edit.cred.copy
+# Not on a TTY -> refuse
+(! systemd-creds edit /tmp/edit.cred </dev/null >/dev/null)
+# The plaintext must be decrypted into the scratch file, which must reside in a
+# private directory on a RAM-backed file system, and edits must be re-encrypted
+cat >/tmp/test-54-editor.sh <<'EOF'
+#!/usr/bin/env bash
+set -eux
+[[ "$(stat -f -c %T "$1")" =~ ^(tmpfs|ramfs)$ ]]
+[[ "$(stat -c %a "$(dirname "$1")")" == 700 ]]
+grep "secret data" "$1"
+echo -n "edited data" >"$1"
+EOF
+chmod +x /tmp/test-54-editor.sh
+EDITOR=/tmp/test-54-editor.sh script -ec 'systemd-creds edit /tmp/edit.cred' /dev/null
+systemd-creds decrypt /tmp/edit.cred | grep "edited data"
+# Scratch directories must not be left behind
+(! ls -d /run/systemd/creds-edit.*)
+# The embedded credential name must be validated, same as for decrypt
+cp /tmp/edit.cred /tmp/renamed.cred
+(! EDITOR='true' script -ec 'systemd-creds edit /tmp/renamed.cred' /dev/null)
+EDITOR='true' script -ec 'systemd-creds --name=edit.cred edit /tmp/renamed.cred' /dev/null
+# Creating a new credential from scratch
+rm -f /tmp/new.cred
+EDITOR='cp /tmp/edit.orig' script -ec 'systemd-creds edit /tmp/new.cred' /dev/null
+systemd-creds decrypt /tmp/new.cred | cmp /tmp/edit.orig
+# Saving empty plaintext -> no credential file is created
+rm -f /tmp/empty.cred
+EDITOR='truncate -s 0' script -ec 'systemd-creds edit /tmp/empty.cred' /dev/null
+test ! -e /tmp/empty.cred
+rm -f /tmp/edit.orig /tmp/edit.cred /tmp/edit.cred.copy /tmp/renamed.cred /tmp/new.cred /tmp/test-54-editor.sh
+
 # Null-key credentials and the systemd.credentials_boot_policy= setting.
 #
 # A null-key credential ("--with-key=null") is wrapped in the normal systemd-creds
@@ -595,6 +633,17 @@ dd if=/dev/urandom of=/tmp/brummbaer.data bs=4096 count=1
 run0 -u testuser --pipe mkdir -p /home/testuser/.config/credstore.encrypted
 run0 -u testuser --pipe systemd-creds encrypt --user --name=brummbaer - /home/testuser/.config/credstore.encrypted/brummbaer < /tmp/brummbaer.data
 run0 -u testuser --pipe systemd-run --user --pipe -p ImportCredential=brummbaer systemd-creds cat brummbaer | cmp /tmp/brummbaer.data
+
+# Fully unpriv interactive editing (uses the encryption/decryption IPC service
+# and the plain scratch directory fallback in $XDG_RUNTIME_DIR). Drop privileges
+# via setpriv rather than run0, since nesting a pseudoterminal inside a run0
+# session is prone to hangs here, and no logind session is needed. Suppress the
+# polkit TTY agent, which would keep the pty open after exit and hang script(1);
+# own-scope operations need no authentication anyway.
+run0 -u testuser --pipe bash -xec 'echo -n "brummbaer ist muede" | systemd-creds encrypt --user - /tmp/useredit.cred'
+EDITOR='sed -i s/muede/wach/' script -ec "setpriv --reuid=testuser --regid=testuser --init-groups env XDG_RUNTIME_DIR=/run/user/$(id -u testuser) systemd-creds edit --user --no-ask-password /tmp/useredit.cred" /dev/null
+run0 -u testuser --pipe systemd-creds decrypt --user /tmp/useredit.cred - | grep "brummbaer ist wach"
+rm -f /tmp/useredit.cred
 
 # https://github.com/systemd/systemd/pull/40108
 run0 -u testuser --pipe systemd-run --user --wait -p ImportCredential=brummbaer -p ExecStartPre='ls -l $CREDENTIALS_DIRECTORY' bash -c 'systemd-creds cat brummbaer | cmp /tmp/brummbaer.data'


### PR DESCRIPTION
Add `systemd-creds edit FILE`: decrypt a credential file, open the plaintext in `$SYSTEMD_EDITOR`/`$EDITOR`/`$VISUAL`, re-encrypt and atomically replace the file when the editor exits. Also works for creating credential files that do not exist yet. The plaintext is confined to a private RAM-backed scratch directory so it never touches persistent storage.

Note that re-encryption selects the key via `--with-key=` (default `auto`) rather than preserving the original key class, since the decryption APIs do not currently report which key a credential was encrypted with. That could be a follow-up.

Fixes https://github.com/systemd/systemd/issues/37397