### PR TITLE
man: clarify enqueue-marked uses try-restart semantics

### DIFF
--- a/man/systemctl.xml
+++ b/man/systemctl.xml
@@ -514,6 +514,12 @@ Jan 12 10:46:45 example.com bluetoothd[8900]: gatt-time-server: Input/output err
           <literal>needs-*</literal> markers set. When a unit marked for reload does not support reload,
           restart will be queued. Those properties can be set using <command>set-property Markers=…</command>.</para>
 
+          <para>Note that <literal>needs-restart</literal> and <literal>needs-reload</literal> use
+          <command>try-restart</command>/<literal>try-reload</literal> semantics: inactive units are not started.
+          This differs from <command>reload-or-restart</command> without <option>--marked</option>, which
+          starts units that are not yet running. Markers such as <literal>needs-start</literal> still
+          enqueue an unconditional start job.</para>
+
           <para>Unless <option>--no-block</option> is used, <command>systemctl</command> will wait for the
           queued jobs to finish.</para>
 


### PR DESCRIPTION
## Summary
- Document that `enqueue-marked` (and deprecated `reload-or-restart --marked`) applies `try-restart` semantics for `needs-restart` / `needs-reload`, so inactive units are not started.
- Call out that this differs from plain `reload-or-restart`, which starts units that are not running.
- Matches `EnqueueMarkedJobs()` in `src/core/dbus-manager.c`, which queues `JOB_TRY_RESTART` for those markers.

Fixes #40483

## Test plan
- [ ] Review the updated `enqueue-marked` and `reload-or-restart` paragraphs in `man/systemctl.xml`
- [ ] Optional: build man pages and skim `systemctl(1)` for the new wording