### PR TITLE
core/varlink: add io.systemd.Unit.SubscribeJobs (JobNew/JobRemoved equivalent)

### DIFF
--- a/src/core/manager.h
+++ b/src/core/manager.h
@@ -493,7 +493,7 @@ typedef struct Manager {
         unsigned notifygen;
 
         sd_varlink_server *varlink_server;
-        Set *varlink_job_subscribers; /* SubscribeJobs streams, one entry per subscribed link */
+        Hashmap *varlink_job_subscribers; /* sd_varlink* => VARLINK_JOB_SUBSCRIBER_* */
         /* When we're a system manager, this object manages the subscription from systemd-oomd to PID1 that's
          * used to report changes in ManagedOOM settings (systemd server - oomd client). When
          * we're a user manager, this object manages the client connection from the user manager to

--- a/src/core/manager.h
+++ b/src/core/manager.h
@@ -493,6 +493,7 @@ typedef struct Manager {
         unsigned notifygen;
 
         sd_varlink_server *varlink_server;
+        Set *varlink_job_subscribers; /* SubscribeJobs streams, one entry per subscribed link */
         /* When we're a system manager, this object manages the subscription from systemd-oomd to PID1 that's
          * used to report changes in ManagedOOM settings (systemd server - oomd client). When
          * we're a user manager, this object manages the client connection from the user manager to

--- a/src/core/unit.c
+++ b/src/core/unit.c
@@ -788,6 +788,20 @@ Unit* unit_free(Unit *u) {
 
         bus_unit_send_removed_signal(u);
 
+        /* Uninstall jobs before unit_done() tears down the unit's runtime state, since job observers
+         * (e.g. SubscribeJobs withRuntime subscribers) snapshot it from job_uninstall(). */
+        if (u->job) {
+                Job *j = u->job;
+                job_uninstall(j);
+                job_free(j);
+        }
+
+        if (u->nop_job) {
+                Job *j = u->nop_job;
+                job_uninstall(j);
+                job_free(j);
+        }
+
         unit_done(u);
 
         u->match_bus_slot = sd_bus_slot_unref(u->match_bus_slot);
@@ -805,18 +819,6 @@ Unit* unit_free(Unit *u) {
 
         if (!sd_id128_is_null(u->invocation_id))
                 hashmap_remove_value(u->manager->units_by_invocation_id, &u->invocation_id, u);
-
-        if (u->job) {
-                Job *j = u->job;
-                job_uninstall(j);
-                job_free(j);
-        }
-
-        if (u->nop_job) {
-                Job *j = u->nop_job;
-                job_uninstall(j);
-                job_free(j);
-        }
 
         /* A unit is being dropped from the tree, make sure our family is realized properly. Do this after we
          * detach the unit from slice tree in order to eliminate its effect on controller masks. */

--- a/src/core/varlink-job.c
+++ b/src/core/varlink-job.c
@@ -41,6 +41,12 @@ static int activation_details_build_json(sd_json_variant **ret, const char *name
 int job_build_json(sd_json_variant **ret, const char *name, void *userdata) {
         Job *j = ASSERT_PTR(userdata);
 
+        /* A job removed without ever completing (e.g. its unit got unloaded) has no result;
+         * report it as canceled so a finished notification always carries one. */
+        JobResult result = j->result;
+        if (j->state == JOB_FINISHED && result < 0)
+                result = JOB_CANCELED;
+
         /* "Unit" is omitted in StartTransient streaming notifications where the caller already knows the unit. */
         return sd_json_buildo(
                         ASSERT_PTR(ret),
@@ -48,7 +54,7 @@ int job_build_json(sd_json_variant **ret, const char *name, void *userdata) {
                         JSON_BUILD_PAIR_STRING_NON_EMPTY("Unit", j->unit ? j->unit->id : NULL),
                         JSON_BUILD_PAIR_ENUM("JobType", job_type_to_string(j->type)),
                         JSON_BUILD_PAIR_ENUM("State", job_state_to_string(j->state)),
-                        JSON_BUILD_PAIR_ENUM_NON_EMPTY("Result", job_result_to_string(j->result)),
+                        JSON_BUILD_PAIR_ENUM_NON_EMPTY("Result", job_result_to_string(result)),
                         JSON_BUILD_PAIR_CALLBACK_NON_NULL("ActivationDetails", activation_details_build_json, j));
 }
 

--- a/src/core/varlink-unit.c
+++ b/src/core/varlink-unit.c
@@ -623,8 +623,101 @@ void varlink_unit_send_change_signal(Unit *u) {
                         SD_JSON_BUILD_PAIR_CALLBACK("runtime", unit_runtime_build_json, u));
 }
 
+/* Notify SubscribeJobs subscribers of a job state change. */
+static void varlink_job_broadcast_change(Job *j) {
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *v = NULL;
+        _cleanup_free_ sd_varlink **dead = NULL;
+        size_t n_dead = 0;
+        Manager *m;
+        sd_varlink *link;
+        int r;
+
+        assert(j);
+        m = ASSERT_PTR(j->manager);
+
+        SET_FOREACH(link, m->varlink_job_subscribers) {
+                if (mac_selinux_unit_access_check_varlink(j->unit, link, "status") < 0)
+                        continue; /* silently skip jobs the subscriber may not see */
+
+                /* Built at most once per event and shared by all subscribers. */
+                if (!v) {
+                        r = sd_json_buildo(&v, SD_JSON_BUILD_PAIR_CALLBACK("job", job_build_json, j));
+                        if (r < 0) {
+                                log_debug_errno(r, "Failed to build job notification, ignoring: %m");
+                                continue;
+                        }
+                }
+
+                r = sd_varlink_notify(link, v);
+                if (r < 0) {
+                        /* Overflowed (ENOBUFS) or broken subscriber: drop it rather than
+                         * keep buffering for a client that cannot receive. */
+                        log_debug_errno(r, "Failed to notify job subscriber, disconnecting: %m");
+                        if (GREEDY_REALLOC(dead, n_dead + 1))
+                                dead[n_dead++] = link;
+                        else {
+                                /* Cannot defer the disconnect — drop the subscriber inline (removing
+                                 * the current entry during iteration is safe). */
+                                if (set_remove(m->varlink_job_subscribers, link))
+                                        sd_varlink_unref(link);
+                                sd_varlink_close(link);
+                        }
+                }
+        }
+
+        /* Deregister before closing so vl_disconnect() cannot unref a second time. */
+        FOREACH_ARRAY(d, dead, n_dead) {
+                if (set_remove(m->varlink_job_subscribers, *d))
+                        sd_varlink_unref(*d);
+                sd_varlink_close(*d);
+        }
+}
+
+int vl_method_subscribe_jobs(sd_varlink *link, sd_json_variant *parameters, sd_varlink_method_flags_t flags, void *userdata) {
+        Manager *m = ASSERT_PTR(userdata);
+        Job *j;
+        int r;
+
+        assert(link);
+        assert(parameters);
+
+        /* SD_VARLINK_REQUIRES_MORE in the IDL rejects non-streaming callers before we get here */
+        assert(FLAGS_SET(flags, SD_VARLINK_METHOD_MORE));
+
+        r = sd_varlink_dispatch(link, parameters, /* dispatch_table= */ NULL, /* userdata= */ NULL);
+        if (r != 0)
+                return r;
+
+        /* Snapshot current jobs before registering, so that subscribing before enqueuing
+         * cannot miss a transition. */
+        HASHMAP_FOREACH(j, m->jobs) {
+                if (mac_selinux_unit_access_check_varlink(j->unit, link, "status") < 0)
+                        continue;
+
+                r = sd_varlink_notifybo(link, SD_JSON_BUILD_PAIR_CALLBACK("job", job_build_json, j));
+                if (r < 0)
+                        return r;
+        }
+
+        /* The ready ack concludes the snapshot. Registration below happens in the same
+         * dispatch, before any other connection's message is processed, so a client that
+         * has seen it cannot race a subsequently enqueued job. */
+        r = sd_varlink_notifybo(link, SD_JSON_BUILD_PAIR_BOOLEAN("ready", true));
+        if (r < 0)
+                return r;
+
+        r = set_ensure_put(&m->varlink_job_subscribers, NULL, link);
+        if (r < 0)
+                return r;
+
+        sd_varlink_ref(link);
+        return 1;
+}
+
 void varlink_job_send_change_signal(Job *j) {
         assert(j);
+
+        varlink_job_broadcast_change(j);
 
         if (!j->varlink || !j->varlink_notify_job_changes)
                 return;
@@ -636,6 +729,8 @@ void varlink_job_send_change_signal(Job *j) {
 
 void varlink_job_send_removed_signal(Job *j) {
         assert(j);
+
+        varlink_job_broadcast_change(j);
 
         if (!j->varlink)
                 return;

--- a/src/core/varlink-unit.c
+++ b/src/core/varlink-unit.c
@@ -623,32 +623,50 @@ void varlink_unit_send_change_signal(Unit *u) {
                         SD_JSON_BUILD_PAIR_CALLBACK("runtime", unit_runtime_build_json, u));
 }
 
-/* Notify SubscribeJobs subscribers of a job state change. */
-static void varlink_job_broadcast_change(Job *j) {
-        _cleanup_(sd_json_variant_unrefp) sd_json_variant *v = NULL;
+static int job_notification_build(Job *j, bool with_runtime, sd_json_variant **ret) {
+        assert(j);
+        assert(ret);
+
+        if (with_runtime)
+                return sd_json_buildo(
+                                ret,
+                                SD_JSON_BUILD_PAIR_CALLBACK("job", job_build_json, j),
+                                SD_JSON_BUILD_PAIR_CALLBACK("runtime", unit_runtime_build_json, j->unit));
+
+        return sd_json_buildo(ret, SD_JSON_BUILD_PAIR_CALLBACK("job", job_build_json, j));
+}
+
+/* Notify SubscribeJobs subscribers of a job state change. Subscribers that opted into
+ * withRuntime (hashmap value 2) get a unit runtime snapshot on finished notifications. */
+static void varlink_job_broadcast_change(Job *j, bool finished) {
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *plain = NULL, *enriched = NULL;
         _cleanup_free_ sd_varlink **dead = NULL;
         size_t n_dead = 0;
         Manager *m;
         sd_varlink *link;
+        void *value;
         int r;
 
         assert(j);
         m = ASSERT_PTR(j->manager);
 
-        SET_FOREACH(link, m->varlink_job_subscribers) {
+        HASHMAP_FOREACH_KEY(value, link, m->varlink_job_subscribers) {
                 if (mac_selinux_unit_access_check_varlink(j->unit, link, "status") < 0)
                         continue; /* silently skip jobs the subscriber may not see */
 
-                /* Built at most once per event and shared by all subscribers. */
-                if (!v) {
-                        r = sd_json_buildo(&v, SD_JSON_BUILD_PAIR_CALLBACK("job", job_build_json, j));
+                /* Built at most once per event and shared by all subscribers: the runtime
+                 * build reads cgroupfs/BPF accounting, too costly to redo per subscriber. */
+                bool with_runtime = finished && PTR_TO_UINT(value) == VARLINK_JOB_SUBSCRIBER_WITH_RUNTIME;
+                sd_json_variant **v = with_runtime ? &enriched : &plain;
+                if (!*v) {
+                        r = job_notification_build(j, with_runtime, v);
                         if (r < 0) {
                                 log_debug_errno(r, "Failed to build job notification, ignoring: %m");
                                 continue;
                         }
                 }
 
-                r = sd_varlink_notify(link, v);
+                r = sd_varlink_notify(link, *v);
                 if (r < 0) {
                         /* Overflowed (ENOBUFS) or broken subscriber: drop it rather than
                          * keep buffering for a client that cannot receive. */
@@ -658,7 +676,7 @@ static void varlink_job_broadcast_change(Job *j) {
                         else {
                                 /* Cannot defer the disconnect — drop the subscriber inline (removing
                                  * the current entry during iteration is safe). */
-                                if (set_remove(m->varlink_job_subscribers, link))
+                                if (hashmap_remove(m->varlink_job_subscribers, link))
                                         sd_varlink_unref(link);
                                 sd_varlink_close(link);
                         }
@@ -667,14 +685,20 @@ static void varlink_job_broadcast_change(Job *j) {
 
         /* Deregister before closing so vl_disconnect() cannot unref a second time. */
         FOREACH_ARRAY(d, dead, n_dead) {
-                if (set_remove(m->varlink_job_subscribers, *d))
+                if (hashmap_remove(m->varlink_job_subscribers, *d))
                         sd_varlink_unref(*d);
                 sd_varlink_close(*d);
         }
 }
 
 int vl_method_subscribe_jobs(sd_varlink *link, sd_json_variant *parameters, sd_varlink_method_flags_t flags, void *userdata) {
+        static const sd_json_dispatch_field dispatch_table[] = {
+                { "withRuntime", SD_JSON_VARIANT_BOOLEAN, sd_json_dispatch_tristate, 0, SD_JSON_NULLABLE },
+                {}
+        };
+
         Manager *m = ASSERT_PTR(userdata);
+        int with_runtime = -1;
         Job *j;
         int r;
 
@@ -684,7 +708,7 @@ int vl_method_subscribe_jobs(sd_varlink *link, sd_json_variant *parameters, sd_v
         /* SD_VARLINK_REQUIRES_MORE in the IDL rejects non-streaming callers before we get here */
         assert(FLAGS_SET(flags, SD_VARLINK_METHOD_MORE));
 
-        r = sd_varlink_dispatch(link, parameters, /* dispatch_table= */ NULL, /* userdata= */ NULL);
+        r = sd_varlink_dispatch(link, parameters, dispatch_table, &with_runtime);
         if (r != 0)
                 return r;
 
@@ -706,7 +730,9 @@ int vl_method_subscribe_jobs(sd_varlink *link, sd_json_variant *parameters, sd_v
         if (r < 0)
                 return r;
 
-        r = set_ensure_put(&m->varlink_job_subscribers, NULL, link);
+        VarlinkJobSubscriberKind kind =
+                with_runtime > 0 ? VARLINK_JOB_SUBSCRIBER_WITH_RUNTIME : VARLINK_JOB_SUBSCRIBER_PLAIN;
+        r = hashmap_ensure_put(&m->varlink_job_subscribers, NULL, link, UINT_TO_PTR(kind));
         if (r < 0)
                 return r;
 
@@ -717,7 +743,7 @@ int vl_method_subscribe_jobs(sd_varlink *link, sd_json_variant *parameters, sd_v
 void varlink_job_send_change_signal(Job *j) {
         assert(j);
 
-        varlink_job_broadcast_change(j);
+        varlink_job_broadcast_change(j, /* finished= */ false);
 
         if (!j->varlink || !j->varlink_notify_job_changes)
                 return;
@@ -730,7 +756,7 @@ void varlink_job_send_change_signal(Job *j) {
 void varlink_job_send_removed_signal(Job *j) {
         assert(j);
 
-        varlink_job_broadcast_change(j);
+        varlink_job_broadcast_change(j, /* finished= */ true);
 
         if (!j->varlink)
                 return;

--- a/src/core/varlink-unit.h
+++ b/src/core/varlink-unit.h
@@ -24,6 +24,7 @@ int varlink_unit_queue_job_one(
 int vl_method_set_unit_properties(sd_varlink *link, sd_json_variant *parameters, sd_varlink_method_flags_t flags, void *userdata);
 
 int vl_method_start_transient_unit(sd_varlink *link, sd_json_variant *parameters, sd_varlink_method_flags_t flags, void *userdata);
+int vl_method_subscribe_jobs(sd_varlink *link, sd_json_variant *parameters, sd_varlink_method_flags_t flags, void *userdata);
 
 void varlink_unit_send_change_signal(Unit *u);
 void varlink_job_send_change_signal(Job *j);

--- a/src/core/varlink-unit.h
+++ b/src/core/varlink-unit.h
@@ -26,6 +26,12 @@ int vl_method_set_unit_properties(sd_varlink *link, sd_json_variant *parameters,
 int vl_method_start_transient_unit(sd_varlink *link, sd_json_variant *parameters, sd_varlink_method_flags_t flags, void *userdata);
 int vl_method_subscribe_jobs(sd_varlink *link, sd_json_variant *parameters, sd_varlink_method_flags_t flags, void *userdata);
 
+/* Values in Manager.varlink_job_subscribers; nonzero so hashmap lookups can distinguish absence. */
+typedef enum VarlinkJobSubscriberKind {
+        VARLINK_JOB_SUBSCRIBER_PLAIN = 1,
+        VARLINK_JOB_SUBSCRIBER_WITH_RUNTIME,
+} VarlinkJobSubscriberKind;
+
 void varlink_unit_send_change_signal(Unit *u);
 void varlink_job_send_change_signal(Job *j);
 void varlink_job_send_removed_signal(Job *j);

--- a/src/core/varlink.c
+++ b/src/core/varlink.c
@@ -11,6 +11,7 @@
 #include "metrics.h"
 #include "path-util.h"
 #include "pidref.h"
+#include "set.h"
 #include "stdio-util.h"
 #include "string-util.h"
 #include "strv.h"
@@ -393,6 +394,9 @@ static void vl_disconnect(sd_varlink_server *s, sd_varlink *link, void *userdata
                         u->varlink_unit_change = sd_varlink_unref(u->varlink_unit_change);
                         break;
                 }
+
+        if (set_remove(m->varlink_job_subscribers, link))
+                sd_varlink_unref(link);
 }
 
 int manager_setup_varlink_server(Manager *m) {
@@ -442,6 +446,7 @@ int manager_setup_varlink_server(Manager *m) {
                         "io.systemd.Unit.List", vl_method_list_units,
                         "io.systemd.Unit.SetProperties", vl_method_set_unit_properties,
                         "io.systemd.Unit.StartTransient", vl_method_start_transient_unit,
+                        "io.systemd.Unit.SubscribeJobs", vl_method_subscribe_jobs,
                         "io.systemd.service.Ping", varlink_method_ping,
                         "io.systemd.service.GetEnvironment", varlink_method_get_environment);
         if (r < 0)
@@ -632,6 +637,16 @@ void manager_varlink_done(Manager *m) {
         sd_varlink_close_unref(TAKE_PTR(m->managed_oom_varlink));
 
         m->pending_reload_message_vl = sd_varlink_unref(m->pending_reload_message_vl);
+
+        /* Job subscribers hold a ref taken in vl_method_subscribe_jobs(); take each out of
+         * the set before unreffing so vl_disconnect() cannot unref a second time. */
+        for (;;) {
+                sd_varlink *link = set_steal_first(m->varlink_job_subscribers);
+                if (!link)
+                        break;
+                sd_varlink_unref(link);
+        }
+        m->varlink_job_subscribers = set_free(m->varlink_job_subscribers);
 
         m->varlink_server = sd_varlink_server_unref(m->varlink_server);
         m->managed_oom_varlink = sd_varlink_close_unref(m->managed_oom_varlink);

--- a/src/core/varlink.c
+++ b/src/core/varlink.c
@@ -11,7 +11,6 @@
 #include "metrics.h"
 #include "path-util.h"
 #include "pidref.h"
-#include "set.h"
 #include "stdio-util.h"
 #include "string-util.h"
 #include "strv.h"
@@ -395,7 +394,8 @@ static void vl_disconnect(sd_varlink_server *s, sd_varlink *link, void *userdata
                         break;
                 }
 
-        if (set_remove(m->varlink_job_subscribers, link))
+        /* Values are nonzero (VARLINK_JOB_SUBSCRIBER_*), so remove() disambiguates membership. */
+        if (hashmap_remove(m->varlink_job_subscribers, link))
                 sd_varlink_unref(link);
 }
 
@@ -639,14 +639,15 @@ void manager_varlink_done(Manager *m) {
         m->pending_reload_message_vl = sd_varlink_unref(m->pending_reload_message_vl);
 
         /* Job subscribers hold a ref taken in vl_method_subscribe_jobs(); take each out of
-         * the set before unreffing so vl_disconnect() cannot unref a second time. */
+         * the map before unreffing so vl_disconnect() cannot unref a second time. */
         for (;;) {
-                sd_varlink *link = set_steal_first(m->varlink_job_subscribers);
-                if (!link)
+                sd_varlink *link;
+                void *value = hashmap_steal_first_key_and_value(m->varlink_job_subscribers, (void**) &link);
+                if (!value)
                         break;
                 sd_varlink_unref(link);
         }
-        m->varlink_job_subscribers = set_free(m->varlink_job_subscribers);
+        m->varlink_job_subscribers = hashmap_free(m->varlink_job_subscribers);
 
         m->varlink_server = sd_varlink_server_unref(m->varlink_server);
         m->managed_oom_varlink = sd_varlink_close_unref(m->managed_oom_varlink);

--- a/src/shared/varlink-io.systemd.Unit.c
+++ b/src/shared/varlink-io.systemd.Unit.c
@@ -1978,10 +1978,14 @@ static SD_VARLINK_DEFINE_METHOD_FULL(
 static SD_VARLINK_DEFINE_METHOD_FULL(
                 SubscribeJobs,
                 SD_VARLINK_REQUIRES_MORE,
+                SD_VARLINK_FIELD_COMMENT("If true, include the unit's runtime state in finished-job notifications. Defaults to false."),
+                SD_VARLINK_DEFINE_INPUT(withRuntime, SD_VARLINK_BOOL, SD_VARLINK_NULLABLE),
                 SD_VARLINK_FIELD_COMMENT("Set once, on the notification concluding the initial snapshot: the subscription is registered and job state changes from before this notification cannot be observed anymore."),
                 SD_VARLINK_DEFINE_OUTPUT(ready, SD_VARLINK_BOOL, SD_VARLINK_NULLABLE),
                 SD_VARLINK_FIELD_COMMENT("The job this notification is about; unset on the ready notification. On subscription one notification per currently queued job is sent, then job state changes stream as they happen. A notification with State=finished and Result set is the last one for a job. A short-lived job may be observed as a single, already finished notification: unlike the D-Bus JobNew/JobRemoved pair, no preceding notification is guaranteed, and the finished notification is self-contained."),
-                SD_VARLINK_DEFINE_OUTPUT_BY_TYPE(job, Job, SD_VARLINK_NULLABLE));
+                SD_VARLINK_DEFINE_OUTPUT_BY_TYPE(job, Job, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("Unit runtime snapshot, taken when the job finished. Set on finished-job notifications when withRuntime was true."),
+                SD_VARLINK_DEFINE_OUTPUT_BY_TYPE(runtime, UnitRuntime, SD_VARLINK_NULLABLE));
 
 static SD_VARLINK_DEFINE_METHOD(
                 SetProperties,

--- a/src/shared/varlink-io.systemd.Unit.c
+++ b/src/shared/varlink-io.systemd.Unit.c
@@ -1975,6 +1975,14 @@ static SD_VARLINK_DEFINE_METHOD_FULL(
                 SD_VARLINK_FIELD_COMMENT("The job that was enqueued. Always set in the final streaming reply; also included in intermediate streaming notifications when notifyJobChanges is true."),
                 SD_VARLINK_DEFINE_OUTPUT_BY_TYPE(job, Job, SD_VARLINK_NULLABLE));
 
+static SD_VARLINK_DEFINE_METHOD_FULL(
+                SubscribeJobs,
+                SD_VARLINK_REQUIRES_MORE,
+                SD_VARLINK_FIELD_COMMENT("Set once, on the notification concluding the initial snapshot: the subscription is registered and job state changes from before this notification cannot be observed anymore."),
+                SD_VARLINK_DEFINE_OUTPUT(ready, SD_VARLINK_BOOL, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("The job this notification is about; unset on the ready notification. On subscription one notification per currently queued job is sent, then job state changes stream as they happen. A notification with State=finished and Result set is the last one for a job. A short-lived job may be observed as a single, already finished notification: unlike the D-Bus JobNew/JobRemoved pair, no preceding notification is guaranteed, and the finished notification is self-contained."),
+                SD_VARLINK_DEFINE_OUTPUT_BY_TYPE(job, Job, SD_VARLINK_NULLABLE));
+
 static SD_VARLINK_DEFINE_METHOD(
                 SetProperties,
                 SD_VARLINK_FIELD_COMMENT("The name of the unit to operate on."),
@@ -1993,6 +2001,8 @@ SD_VARLINK_DEFINE_INTERFACE(
                 &vl_method_SetProperties,
                 SD_VARLINK_SYMBOL_COMMENT("Create a transient unit and start it"),
                 &vl_method_StartTransient,
+                SD_VARLINK_SYMBOL_COMMENT("Subscribe to job state changes"),
+                &vl_method_SubscribeJobs,
                 &vl_type_RateLimit,
                 SD_VARLINK_SYMBOL_COMMENT("An object to represent a unit's conditions"),
                 &vl_type_Condition,

--- a/test/units/TEST-74-AUX-UTILS.varlinkctl-unit.sh
+++ b/test/units/TEST-74-AUX-UTILS.varlinkctl-unit.sh
@@ -389,5 +389,18 @@ kill "$SUBJOBS_PID" 2>/dev/null || true
 wait "$SUBJOBS_PID" 2>/dev/null || true
 rm -f "$SUBJOBS_OUT"
 
+# withRuntime: finished-job notifications carry a unit runtime snapshot
+SUBJOBS_RT_OUT="$(mktemp)"
+varlinkctl call --more "$MANAGER_SOCKET" io.systemd.Unit.SubscribeJobs '{"withRuntime":true}' >"$SUBJOBS_RT_OUT" &
+SUBJOBS_RT_PID=$!
+timeout 10 bash -c "until jq --seq --slurp -e 'any(.[]; .ready == true)' \"$SUBJOBS_RT_OUT\" >/dev/null 2>&1; do sleep 0.2; done"
+defer_transient_cleanup varlink-subjobs-rt-test.service
+varlinkctl call "$MANAGER_SOCKET" io.systemd.Unit.StartTransient \
+    '{"context":{"ID":"varlink-subjobs-rt-test.service","Service":{"Type":"oneshot","ExecStart":[{"path":"/bin/true"}]}}}'
+timeout 30 bash -c "until jq --seq --slurp -e 'any(.[]; .job.Unit == \"varlink-subjobs-rt-test.service\" and .job.State == \"finished\" and .runtime.Service.ExecMain.Status == 0)' \"$SUBJOBS_RT_OUT\" >/dev/null 2>&1; do sleep 0.5; done"
+kill "$SUBJOBS_RT_PID" 2>/dev/null || true
+wait "$SUBJOBS_RT_PID" 2>/dev/null || true
+rm -f "$SUBJOBS_RT_OUT"
+
 transient_cleanup
 trap - EXIT

--- a/test/units/TEST-74-AUX-UTILS.varlinkctl-unit.sh
+++ b/test/units/TEST-74-AUX-UTILS.varlinkctl-unit.sh
@@ -368,5 +368,26 @@ echo "$unsupported_service" | grep "io.systemd.Unit.PropertyNotSupported"
 echo "$unsupported_service" | grep "Service.Restart"
 set -o pipefail
 
+# Test io.systemd.Unit.SubscribeJobs
+# Requires 'more'
+(! varlinkctl call "$MANAGER_SOCKET" io.systemd.Unit.SubscribeJobs '{}')
+
+# Subscribe in the background; the stream never terminates on its own.
+SUBJOBS_OUT="$(mktemp)"
+varlinkctl call --more "$MANAGER_SOCKET" io.systemd.Unit.SubscribeJobs '{}' >"$SUBJOBS_OUT" &
+SUBJOBS_PID=$!
+# The ready ack concludes the snapshot and proves the subscription is registered
+timeout 10 bash -c "until jq --seq --slurp -e 'any(.[]; .ready == true)' \"$SUBJOBS_OUT\" >/dev/null 2>&1; do sleep 0.2; done"
+
+# A transient unit started after the ack must produce a finished-job notification
+defer_transient_cleanup varlink-subjobs-test.service
+varlinkctl call "$MANAGER_SOCKET" io.systemd.Unit.StartTransient \
+    '{"context":{"ID":"varlink-subjobs-test.service","Service":{"Type":"oneshot","ExecStart":[{"path":"/bin/true"}]}}}'
+timeout 30 bash -c "until jq --seq --slurp -e 'any(.[]; .job.Unit == \"varlink-subjobs-test.service\" and .job.State == \"finished\" and .job.Result == \"done\")' \"$SUBJOBS_OUT\" >/dev/null 2>&1; do sleep 0.5; done"
+
+kill "$SUBJOBS_PID" 2>/dev/null || true
+wait "$SUBJOBS_PID" 2>/dev/null || true
+rm -f "$SUBJOBS_OUT"
+
 transient_cleanup
 trap - EXIT


### PR DESCRIPTION
Implements #43175.

Adds `io.systemd.Unit.SubscribeJobs`, a manager-wide job state change subscription — the Varlink equivalent of the D-Bus `Subscribe()` + `JobNew`/`JobRemoved` signal pair. Today the only way to observe job completion over Varlink is `StartTransient`'s own streaming reply, which covers only the caller's job and pins a connection for the job's lifetime, so observing n jobs costs n connections against the per-UID connection limit (128). `systemd-run --wait`-style supervision of many units is currently impossible over Varlink; over D-Bus it is what `bus-wait-for-jobs.c` is built on.

Two commits, independently mergeable:

1. **Parity**: `SubscribeJobs` following the `io.systemd.Resolve.Monitor` subscription pattern (`SD_VARLINK_REQUIRES_MORE`, the `more` call is the subscription, disconnect unsubscribes). On subscribe, one notification per currently queued job (snapshot), concluded by a `ready` ack sent in the same dispatch that registers the link — a client that has seen it cannot miss a subsequent transition. `State=finished` + `Result` set is the last notification for a job (the `JobRemoved` equivalent). Per-unit SELinux access checks as in `List`; notification payload built once per state change and shared across subscribers; a subscriber whose stream cannot accept a notification (output queue overflow) is disconnected rather than buffering indefinitely in PID1.

2. **`withRuntime`**: subscribers may opt in to receive the unit's `UnitRuntime` (ExecMain status, service result, resource accounting) in finished-job notifications, snapshotted at job finish while the unit is guaranteed to still exist. Rationale: bare `JobRemoved` parity is not sufficient to learn how a service ended — over D-Bus every real client (e.g. `run.c`) builds `AddRef=` + `PropertiesChanged` + property re-reads on top, and that pattern doesn't transfer to Varlink: without `ResetFailed()`, transient units need `CollectMode=inactive-or-failed`, and a post-notification query then races GC (`NoSuchUnit`). The runtime build reads cgroupfs/BPF accounting, so it is opt-in, finished-notifications-only, and built at most once per state change regardless of subscriber count.

Integration tests added to `TEST-74-AUX-UTILS.varlinkctl-unit.sh` for both commits (requires-more rejection, ready ack ordering, finished notification for a transient unit, `runtime.Service.ExecMain.Status` presence with `withRuntime`).

Validated out of tree in PatOS (image-based OS built on systemd): a test agent supervising all workloads over a single subscription, including 150 concurrent transient units in flight simultaneously — past the per-UID connection cap that bounds the connection-per-job approach — with exit status and service result taken from the finished notifications.
