### PR TITLE
vpick: Support matching against the host VERSION_ID

### DIFF
--- a/man/systemd-vpick.xml
+++ b/man/systemd-vpick.xml
@@ -72,7 +72,10 @@
 
         <listitem><para>Explicitly configures the version to select. If specified, a filename with the
         specified version string will be looked for, instead of the newest version
-        available.</para>
+        available. This also disables host version matching for entries whose version is prefixed with
+        <literal>host=</literal>, see
+        <citerefentry><refentrytitle>systemd.v</refentrytitle><manvolnum>7</manvolnum></citerefentry>.
+        The specified version is compared against the version with the prefix removed.</para>
 
         <xi:include href="version-info.xml" xpointer="v256"/></listitem>
       </varlistentry>

--- a/man/systemd.v.xml
+++ b/man/systemd.v.xml
@@ -3,7 +3,7 @@
   "http://www.oasis-open.org/docbook/xml/4.2/docbookx.dtd">
 <!-- SPDX-License-Identifier: LGPL-2.1-or-later -->
 
-<refentry id="systemd.v">
+<refentry id="systemd.v" xmlns:xi="http://www.w3.org/2001/XInclude">
 
   <refentryinfo>
     <title>systemd.v</title>
@@ -106,6 +106,28 @@
       version comparison.</para></listitem>
 
       <listitem><para>The rest of the variable part is the version string.</para></listitem>
+
+      <listitem><para>If the version string is prefixed with the literal <literal>host=</literal>, the file
+      is only considered if the version equals the <varname>VERSION_ID=</varname> field of the
+      <citerefentry><refentrytitle>os-release</refentrytitle><manvolnum>5</manvolnum></citerefentry> file of
+      the OS tree the file is applied to. The prefix is not considered part of the version string for any
+      other purpose. This is useful for resources built for one specific OS version, such as system extension
+      images, where the newest available version is not necessarily the appropriate one for the running OS.
+      For system/configuration extensions applied via
+      <citerefentry><refentrytitle>systemd-sysext</refentrytitle><manvolnum>8</manvolnum></citerefentry> the
+      version is matched against the host (or the tree specified with <option>--root=</option>), for the
+      <varname>ExtensionImages=</varname>/<varname>ExtensionDirectories=</varname> settings of service units
+      against the unit's root file system, and for extension images of portable services against the
+      portable image. For files that are not applied to another OS tree, such as rootfs images, the version
+      is matched against the OS performing the lookup. Note that while files whose host version entry does
+      not match are filtered out, the remaining ones take part in the regular version comparison, hence a
+      file without the host prefix but newer version wins over one with a matching host prefix. Also note
+      that if a version to search for is explicitly specified (e.g., via the <option>-V</option> switch of
+      <citerefentry><refentrytitle>systemd-vpick</refentrytitle><manvolnum>1</manvolnum></citerefentry>),
+      host version matching is disabled, and the specified version is compared against the version string
+      with the prefix removed.</para>
+
+      <xi:include href="version-info.xml" xpointer="v262"/></listitem>
     </itemizedlist>
 
     <para>Or in other words, the files in the <literal>.v/</literal> directories should follow one of these
@@ -119,6 +141,9 @@
       <listitem><para><filename><replaceable>NAME</replaceable>_<replaceable>VERSION</replaceable>_<replaceable>ARCHITECTURE</replaceable>+<replaceable>LEFT</replaceable><replaceable>.SUFFIX</replaceable></filename></para></listitem>
       <listitem><para><filename><replaceable>NAME</replaceable>_<replaceable>VERSION</replaceable>_<replaceable>ARCHITECTURE</replaceable>+<replaceable>LEFT</replaceable>-<replaceable>DONE</replaceable><replaceable>.SUFFIX</replaceable></filename></para></listitem>
     </itemizedlist>
+
+    <para>In each of these structures, <replaceable>VERSION</replaceable> may be prefixed with the literal
+    <literal>host=</literal> to request host version matching, see above.</para>
   </refsect1>
 
   <refsect1>

--- a/src/core/namespace.c
+++ b/src/core/namespace.c
@@ -529,7 +529,8 @@ static int append_extensions(
                 char **hierarchies,
                 const MountImage *mount_images,
                 size_t n_mount_images,
-                char **extension_directories) {
+                char **extension_directories,
+                const char *host_version) {
 
         char ***overlays = NULL;
         size_t n_overlays = 0;
@@ -564,12 +565,15 @@ static int append_extensions(
                 _cleanup_free_ char *mount_point = NULL;
                 const MountImage *m = mount_images + i;
 
+                PickFilter filter = pick_filter_image_raw[0];
+                filter.host_version = host_version;
+
                 r = path_pick(/* root_path= */ NULL,
                               /* root_fd= */ AT_FDCWD,
                               /* dir_fd= */ AT_FDCWD,
                               m->source,
-                              pick_filter_image_raw,
-                              ELEMENTSOF(pick_filter_image_raw),
+                              &filter,
+                              /* n_filters= */ 1,
                               PICK_ARCHITECTURE|PICK_TRIES,
                               &result);
                 if (r == -ENOENT && m->ignore_enoent)
@@ -637,12 +641,15 @@ static int append_extensions(
                 if (startswith(e, "+"))
                         e++;
 
+                PickFilter filter = pick_filter_image_dir[0];
+                filter.host_version = host_version;
+
                 r = path_pick(/* root_path= */ NULL,
                               /* root_fd= */ AT_FDCWD,
                               /* dir_fd= */ AT_FDCWD,
                               e,
-                              pick_filter_image_dir,
-                              ELEMENTSOF(pick_filter_image_dir),
+                              &filter,
+                              /* n_filters= */ 1,
                               PICK_ARCHITECTURE|PICK_TRIES,
                               &result);
                 if (r == -ENOENT && ignore_enoent)
@@ -2587,6 +2594,35 @@ static bool namespace_read_only(const NamespaceParameters *p) {
                 strv_isempty(p->read_write_paths);
 }
 
+static int determine_extension_host_version(const char *root_path, int root_fd, char **ret) {
+        _cleanup_free_ char *v = NULL;
+        int r;
+
+        assert(root_path || root_fd >= 0);
+        assert(ret);
+
+        /* Reads the VERSION_ID of the OS tree the unit's extensions are applied to, so that "host=" vpick
+         * entries are matched against it, like sysext does. If it cannot be determined we return the empty
+         * string, so that "host=" entries never match, rather than falling back to the os-release of the OS
+         * the manager runs on. */
+
+        if (root_fd >= 0)
+                r = parse_os_release_at(root_fd, "VERSION_ID", &v);
+        else
+                r = parse_os_release(root_path, "VERSION_ID", &v);
+        if (r < 0)
+                log_debug_errno(r, "Failed to read os-release data of the unit's root, ignoring: %m");
+
+        if (!v) {
+                v = strdup("");
+                if (!v)
+                        return log_oom_debug();
+        }
+
+        *ret = TAKE_PTR(v);
+        return 0;
+}
+
 int setup_namespace(const NamespaceParameters *p, char **reterr_path) {
 
         _cleanup_(loop_device_unrefp) LoopDevice *loop_device = NULL;
@@ -2847,10 +2883,6 @@ int setup_namespace(const NamespaceParameters *p, char **reterr_path) {
         if (r < 0)
                 return r;
 
-        r = append_extensions(&ml, root, p->private_namespace_dir, hierarchies, p->extension_images, p->n_extension_images, p->extension_directories);
-        if (r < 0)
-                return r;
-
         if (p->private_dev) {
                 MountEntry *me = mount_list_extend(&ml);
                 if (!me)
@@ -3086,13 +3118,6 @@ int setup_namespace(const NamespaceParameters *p, char **reterr_path) {
                 };
         }
 
-        /* Prepend the root directory where that's necessary */
-        r = prefix_where_needed(&ml, root);
-        if (r < 0)
-                return r;
-
-        sort_and_drop_unused_mounts(&ml, root);
-
         /* All above is just preparation, figuring out what to do. Let's now actually start doing something. */
 
         if (unshare(CLONE_NEWNS) < 0) {
@@ -3195,6 +3220,35 @@ int setup_namespace(const NamespaceParameters *p, char **reterr_path) {
         /* Try to set up the new root directory before mounting anything else there. */
         if (pinned_resource_is_set(p->rootfs))
                 (void) base_filesystem_create(root, UID_INVALID, GID_INVALID);
+
+        /* Resolve the extensions only now that the unit's root is mounted, so that its VERSION_ID is
+         * available for "host=" vpick entries */
+        _cleanup_free_ char *extension_host_version = NULL;
+        if (pinned_resource_is_set(p->rootfs) &&
+            (p->n_extension_images > 0 || !strv_isempty(p->extension_directories))) {
+                r = determine_extension_host_version(root, /* root_fd= */ -EBADF, &extension_host_version);
+                if (r < 0)
+                        return r;
+        }
+
+        r = append_extensions(
+                        &ml,
+                        root,
+                        p->private_namespace_dir,
+                        hierarchies,
+                        p->extension_images,
+                        p->n_extension_images,
+                        p->extension_directories,
+                        extension_host_version);
+        if (r < 0)
+                return r;
+
+        /* Prepend the root directory where that's necessary */
+        r = prefix_where_needed(&ml, root);
+        if (r < 0)
+                return r;
+
+        sort_and_drop_unused_mounts(&ml, root);
 
         /* Now make the magic happen */
         r = apply_mounts(&ml, root, p, reterr_path);
@@ -4018,6 +4072,13 @@ int refresh_extensions_in_namespace(
         if (r < 0)
                 return r;
 
+        /* Note that p->rootfs is not populated for this call, but the root fd of the target process refers
+         * to the unit's root in any case */
+        _cleanup_free_ char *host_version = NULL;
+        r = determine_extension_host_version(/* root_path= */ NULL, root_fd, &host_version);
+        if (r < 0)
+                return r;
+
         r = append_extensions(
                         &ml,
                         overlay_prefix,
@@ -4025,7 +4086,8 @@ int refresh_extensions_in_namespace(
                         hierarchies,
                         p->extension_images,
                         p->n_extension_images,
-                        p->extension_directories);
+                        p->extension_directories,
+                        host_version);
         if (r < 0)
                 return r;
 

--- a/src/portable/portable.c
+++ b/src/portable/portable.c
@@ -846,11 +846,39 @@ static int extract_image_and_extensions(
                 name_or_path = result.path;
         }
 
-        r = image_find_harder(scope, IMAGE_PORTABLE, name_or_path, /* root= */ NULL, &image);
+        /* The root image itself is not applied to another OS tree, hence no host version to pass here */
+        r = image_find_harder(scope, IMAGE_PORTABLE, name_or_path, /* root= */ NULL, /* host_version= */ NULL, &image);
+        if (r < 0)
+                return r;
+
+        r = portable_extract_by_path(
+                        scope,
+                        image->path,
+                        /* path_is_extension= */ false,
+                        /* relax_extension_release_check= */ false,
+                        matches,
+                        image_policy,
+                        &os_release,
+                        &unit_files,
+                        &pinned_root_image_policy,
+                        error);
         if (r < 0)
                 return r;
 
         if (!strv_isempty(extension_image_paths)) {
+                /* Read the image's VERSION_ID, so that "host=" vpick entries of the extension images are
+                 * matched against the image they are applied to, rather than the OS we are running on */
+                _cleanup_free_ char *image_version_id = NULL;
+                r = parse_env_file_fd(os_release->fd, os_release->name, "VERSION_ID", &image_version_id);
+                if (r < 0)
+                        log_debug_errno(r, "Failed to read VERSION_ID from os-release of '%s', ignoring: %m",
+                                        image->path);
+
+                PickFilter filters[ELEMENTSOF(pick_filter_image_any)];
+                memcpy(filters, pick_filter_image_any, sizeof(filters));
+                FOREACH_ELEMENT(f, filters)
+                        f->host_version = strempty(image_version_id);
+
                 extension_images = ordered_hashmap_new(&image_hash_ops);
                 if (!extension_images)
                         return -ENOMEM;
@@ -871,8 +899,8 @@ static int extract_image_and_extensions(
                                               /* root_fd= */ AT_FDCWD,
                                               /* dir_fd= */ AT_FDCWD,
                                               *p,
-                                              pick_filter_image_any,
-                                              ELEMENTSOF(pick_filter_image_any),
+                                              filters,
+                                              ELEMENTSOF(filters),
                                               PICK_ARCHITECTURE|PICK_TRIES|PICK_RESOLVE,
                                               &ext_result);
                                 if (r < 0)
@@ -886,7 +914,10 @@ static int extract_image_and_extensions(
                                 path = ext_result.path;
                         }
 
-                        r = image_find_harder(scope, IMAGE_PORTABLE, path, NULL, &new);
+                        /* Extension images given by name are resolved through the image search path, which
+                         * does its own .v handling, hence pass the version on there too */
+                        r = image_find_harder(scope, IMAGE_PORTABLE, path, /* root= */ NULL,
+                                              strempty(image_version_id), &new);
                         if (r < 0)
                                 return r;
 
@@ -896,20 +927,6 @@ static int extract_image_and_extensions(
                         TAKE_PTR(new);
                 }
         }
-
-        r = portable_extract_by_path(
-                        scope,
-                        image->path,
-                        /* path_is_extension= */ false,
-                        /* relax_extension_release_check= */ false,
-                        matches,
-                        image_policy,
-                        &os_release,
-                        &unit_files,
-                        &pinned_root_image_policy,
-                        error);
-        if (r < 0)
-                return r;
 
         /* If we are layering extension images on top of a runtime image, check that the os-release and
          * extension-release metadata match, otherwise reject it immediately as invalid, or it will fail when
@@ -2220,7 +2237,22 @@ static int marker_matches_images(const char *marker, const char *name_or_path, c
                         if (r < 0 && r != -ENOENT)
                                 return r;
 
-                        r = path_extract_image_name(*image_name_or_path, &base_image_name_or_path);
+                        /* A .v directory is named after the base name of its entries, hence derive the
+                         * name from the directory itself. Resolving it again would have to pick the very
+                         * same entry that was picked when attaching, which we cannot rely on: "host="
+                         * entries are matched against the image's VERSION_ID, which is not available
+                         * here, and the images might be gone by now. */
+                        _cleanup_free_ char *without_v = strdup(*image_name_or_path);
+                        if (!without_v)
+                                return -ENOMEM;
+
+                        path_simplify(without_v);
+
+                        char *v = endswith(without_v, ".v");
+                        if (v && v > without_v && !IN_SET(v[-1], '/', '.'))
+                                *v = 0;
+
+                        r = path_extract_image_name(without_v, &base_image_name_or_path);
                         if (r < 0)
                                 return log_debug_errno(r, "Failed to extract image name from %s, ignoring: %m", *image_name_or_path);
 

--- a/src/shared/discover-image.c
+++ b/src/shared/discover-image.c
@@ -854,11 +854,12 @@ static char** make_possible_filenames(ImageClass class, const char *image_name) 
         return TAKE_PTR(l);
 }
 
-int image_find(RuntimeScope scope,
-               ImageClass class,
-               const char *name,
-               const char *root,
-               Image **ret) {
+int image_find_full(RuntimeScope scope,
+                    ImageClass class,
+                    const char *name,
+                    const char *root,
+                    const char *host_version,
+                    Image **ret) {
 
         int r;
 
@@ -952,6 +953,7 @@ int image_find(RuntimeScope scope,
                                         .basename = name,
                                         .architecture = _ARCHITECTURE_INVALID,
                                         .suffix = suffix,
+                                        .host_version = host_version,
                                 };
 
                                 _cleanup_(pick_result_done) PickResult result = PICK_RESULT_NULL;
@@ -1056,15 +1058,25 @@ int image_from_path(const char *path, Image **ret) {
                         ret);
 }
 
+int image_find(RuntimeScope scope,
+               ImageClass class,
+               const char *name,
+               const char *root,
+               Image **ret) {
+
+        return image_find_full(scope, class, name, root, /* host_version= */ NULL, ret);
+}
+
 int image_find_harder(
                 RuntimeScope scope,
                 ImageClass class,
                 const char *name_or_path,
                 const char *root,
+                const char *host_version,
                 Image **ret) {
 
         if (image_name_is_valid(name_or_path))
-                return image_find(scope, class, name_or_path, root, ret);
+                return image_find_full(scope, class, name_or_path, root, host_version, ret);
 
         return image_from_path(name_or_path, ret);
 }

--- a/src/shared/discover-image.h
+++ b/src/shared/discover-image.h
@@ -54,9 +54,12 @@ typedef struct Image {
 DECLARE_TRIVIAL_REF_UNREF_FUNC(Image, image);
 DEFINE_TRIVIAL_CLEANUP_FUNC(Image*, image_unref);
 
+/* host_version is what "host=" vpick entries are matched against, see PickFilter. Leave it NULL unless the
+ * images are applied to another OS tree than the one 'root' refers to. */
+int image_find_full(RuntimeScope scope, ImageClass class, const char *name, const char *root, const char *host_version, Image **ret);
 int image_find(RuntimeScope scope, ImageClass class, const char *name, const char *root, Image **ret);
 int image_from_path(const char *path, Image **ret);
-int image_find_harder(RuntimeScope scope, ImageClass class, const char *name_or_path, const char *root, Image **ret);
+int image_find_harder(RuntimeScope scope, ImageClass class, const char *name_or_path, const char *root, const char *host_version, Image **ret);
 int image_discover(RuntimeScope scope, ImageClass class, const char *root, Hashmap **images);
 
 int image_remove(Image *i, RuntimeScope scope);

--- a/src/shared/mstack.c
+++ b/src/shared/mstack.c
@@ -17,6 +17,7 @@
 #include "macro.h"
 #include "mount-util.h"
 #include "mstack.h"
+#include "os-util.h"
 #include "path-util.h"
 #include "process-util.h"
 #include "recurse-dir.h"
@@ -132,10 +133,19 @@ static int mstack_load_one(MStack *mstack, const char *dir, int dir_fd, const ch
                 if (dotv) {
                         const char *dotrawv = endswith(fname, ".raw.v");
 
+                        /* The layers make up an OS tree rather than being applied to one, hence match
+                         * "host=" entries against the OS we run on. We have to determine it ourselves, as
+                         * the root fd we pass to vpick is the .mstack directory, not an OS tree. */
+                        _cleanup_free_ char *host_version_id = NULL;
+                        r = parse_os_release(/* root= */ NULL, "VERSION_ID", &host_version_id);
+                        if (r < 0)
+                                log_debug_errno(r, "Failed to read VERSION_ID from os-release, ignoring: %m");
+
                         PickFilter filter = {
                                 .type_mask = dotrawv ? (1U << DT_REG) : ((1U << DT_DIR) | (1U << DT_BLK)),
                                 .suffix = dotrawv ? ".raw" : NULL,
                                 .architecture = _ARCHITECTURE_INVALID,
+                                .host_version = strempty(host_version_id),
                         };
 
                         _cleanup_(pick_result_done) PickResult result = PICK_RESULT_NULL;

--- a/src/shared/vpick.c
+++ b/src/shared/vpick.c
@@ -8,11 +8,13 @@
 #include "chase.h"
 #include "fd-util.h"
 #include "log.h"
+#include "os-util.h"
 #include "parse-util.h"
 #include "path-util.h"
 #include "recurse-dir.h"
 #include "stat-util.h"
 #include "string-util.h"
+#include "strv.h"
 #include "vpick.h"
 
 void pick_result_done(PickResult *p) {
@@ -75,6 +77,7 @@ int pick_result_compare(const PickResult *a, const PickResult *b, PickFlags flag
 static int format_fname(
                 const PickFilter *filter,
                 PickFlags flags,
+                bool host_prefix, /* prefix the version with the literal "host=" */
                 char **ret) {
 
         _cleanup_free_ char *fn = NULL;
@@ -84,6 +87,11 @@ static int format_fname(
         assert(ret);
 
         if (FLAGS_SET(flags, PICK_TRIES) || !filter->version) /* Underspecified? */
+                return -ENOEXEC;
+
+        /* Also underspecified: without an architecture to look for, entries with the native or the
+         * secondary architecture are acceptable too, which a single file name cannot express. */
+        if (FLAGS_SET(flags, PICK_ARCHITECTURE) && filter->architecture < 0)
                 return -ENOEXEC;
 
         /* The format for names we match goes like this:
@@ -118,11 +126,22 @@ static int format_fname(
         }
 
         if (filter->version) {
+                _cleanup_free_ char *hv = NULL;
+                const char *v = filter->version;
+
+                if (host_prefix) {
+                        hv = strjoin("host=", filter->version);
+                        if (!hv)
+                                return -ENOMEM;
+
+                        v = hv;
+                }
+
                 if (isempty(fn)) {
-                        r = free_and_strdup(&fn, filter->version);
+                        r = free_and_strdup(&fn, v);
                         if (r < 0)
                                 return r;
-                } else if (!strextend(&fn, "_", filter->version))
+                } else if (!strextend(&fn, "_", v))
                         return -ENOMEM;
         }
 
@@ -339,24 +358,43 @@ static int make_choice(
 
         /* Maybe the filter is fully specified? Then we can generate the file name directly */
         _cleanup_free_ char *j = NULL;
-        r = format_fname(filter, flags, &j);
+        r = format_fname(filter, flags, /* host_prefix= */ false, &j);
         if (r >= 0) {
-                _cleanup_free_ char *object_path = NULL;
+                _cleanup_free_ char *object_path = NULL, *p = NULL;
+                _cleanup_close_ int object_fd = -EBADF;
 
                 /* Yay! This worked! */
-                _cleanup_free_ char *p = path_join(inode_path, j);
-                if (!p)
-                        return log_oom_debug();
 
-                _cleanup_close_ int object_fd = -EBADF;
-                r = chaseat(root_fd, dir_fd, p, /* flags= */ 0, &object_path, &object_fd);
-                if (r == -ENOENT) {
+                /* The version may also be spelled with the "host=" prefix though, which
+                 * is preferred (same as further below). */
+                _cleanup_free_ char *hj = NULL;
+                r = format_fname(filter, flags, /* host_prefix= */ true, &hj);
+                if (r == -ENOMEM)
+                        return log_oom_debug();
+                /* Any other failure means this spelling cannot exist, e.g., because the prefix makes the
+                 * name too long, and since *ret stays NULL it's skipped below. */
+
+                FOREACH_STRING(fname, strempty(hj), j) {
+                        if (isempty(fname)) /* The "host=" spelling could not be formatted, skip it */
+                                continue;
+
+                        _cleanup_free_ char *q = path_join(inode_path, fname);
+                        if (!q)
+                                return log_oom_debug();
+
+                        r = chaseat(root_fd, dir_fd, q, /* flags= */ 0, &object_path, &object_fd);
+                        if (r >= 0) {
+                                free_and_replace(p, q);
+                                break;
+                        }
+                        if (r != -ENOENT) /* Fail but a missing entry means we'll try the other spelling */
+                                return log_debug_errno(r, "Failed to open '%s/%s': %m",
+                                                       empty_to_root(root_path), skip_leading_slash(q));
+                }
+                if (!p) {
                         *ret = PICK_RESULT_NULL;
                         return 0;
                 }
-                if (r < 0)
-                        return log_debug_errno(r, "Failed to open '%s/%s': %m",
-                                               empty_to_root(root_path), skip_leading_slash(p));
 
                 return pin_choice(
                                 root_path,
@@ -388,6 +426,8 @@ static int make_choice(
                                        empty_to_root(root_path), skip_leading_slash(inode_path));
 
         _cleanup_(pick_result_done) PickResult best = PICK_RESULT_NULL;
+        _cleanup_free_ char *host_version_id = NULL;
+        bool host_version_id_read = false;
 
         FOREACH_ARRAY(entry, de->entries, de->n_entries) {
                 unsigned found_tries_done = UINT_MAX, found_tries_left = UINT_MAX;
@@ -447,14 +487,45 @@ static int make_choice(
                                 *underscore = 0;
                 }
 
+                /* If the version is prefixed with the literal "host=" the entry shall only be considered if
+                 * the version equals the VERSION_ID of the OS we operate on. The prefix is not part of the
+                 * version for any other purposes. */
+                char *hv = startswith(e, "host=");
+                if (hv)
+                        e = hv;
+
                 if (!version_is_valid(e, /* flags= */ 0)) {
                         log_debug("Version string '%s' of entry '%s' is invalid, ignoring entry.", e, (*entry)->d_name);
                         continue;
                 }
 
-                if (filter->version && !streq(filter->version, e)) {
-                        log_debug("Found entry with version string '%s', but was looking for '%s', ignoring entry.", e, filter->version);
-                        continue;
+                if (filter->version) {
+                        /* An explicit version filter disables host version matching */
+                        if (!streq(filter->version, e)) {
+                                log_debug("Found entry with version string '%s', but was looking for '%s', ignoring entry.",
+                                          e, filter->version);
+                                continue;
+                        }
+                } else if (hv) {
+                        const char *h = filter->host_version;
+                        if (!h) {
+                                if (!host_version_id_read) {
+                                        r = parse_os_release_at(root_fd, "VERSION_ID", &host_version_id);
+                                        if (r < 0)
+                                                log_debug_errno(r, "Failed to read VERSION_ID from os-release, "
+                                                                "ignoring 'host=' entries: %m");
+                                        host_version_id_read = true;
+                                }
+
+                                h = host_version_id;
+                        }
+
+                        /* An unknown version never matches, rather than falling back to something else */
+                        if (isempty(h) || !streq(e, h)) {
+                                log_debug("Found entry for host version '%s', but the OS tree it is applied to "
+                                          "has VERSION_ID '%s', ignoring entry.", e, strna(h));
+                                continue;
+                        }
                 }
 
                 _cleanup_free_ char *p = path_join(inode_path, (*entry)->d_name);
@@ -643,6 +714,7 @@ static int path_pick_one(
                                 .version = filter->version,
                                 .architecture = filter->architecture,
                                 .suffix = filter_suffix,
+                                .host_version = filter->host_version,
                         },
                         flags,
                         ret);

--- a/src/shared/vpick.h
+++ b/src/shared/vpick.h
@@ -18,6 +18,10 @@ typedef struct PickFilter {
         const char *version;
         Architecture architecture;
         const char *suffix;           /* Can be overridden by search pattern */
+        const char *host_version;     /* Version that "host=" entries are matched against. If NULL, the
+                                       * VERSION_ID of the os-release of the tree 'root_fd' refers to is
+                                       * used, hence set this whenever that is not the tree the picked
+                                       * file is applied to. If empty, "host=" entries never match. */
 } PickFilter;
 
 typedef struct PickResult {

--- a/src/test/test-vpick.c
+++ b/src/test/test-vpick.c
@@ -162,6 +162,75 @@ TEST(path_pick) {
         ASSERT_EQ(result.architecture, ARCHITECTURE_S390);
 }
 
+TEST(path_pick_host_version) {
+        _cleanup_(rm_rf_physical_and_freep) char *p = NULL;
+        _cleanup_close_ int dfd = -EBADF, sub_dfd = -EBADF;
+
+        dfd = ASSERT_OK(mkdtemp_open(NULL, O_DIRECTORY|O_CLOEXEC, &p));
+        sub_dfd = ASSERT_OK(open_mkdir_at(dfd, "foo.v", O_CLOEXEC, 0777));
+
+        ASSERT_OK(write_string_file_at(sub_dfd, "foo_host=38.raw", "38", WRITE_STRING_FILE_CREATE));
+        ASSERT_OK(write_string_file_at(sub_dfd, "foo_host=39.raw", "39", WRITE_STRING_FILE_CREATE));
+        ASSERT_OK(write_string_file_at(sub_dfd, "foo_host=40.raw", "40", WRITE_STRING_FILE_CREATE));
+
+        _cleanup_free_ char *pp = ASSERT_NOT_NULL(path_join(p, "foo.v"));
+
+        PickFilter filter = {
+                .type_mask = UINT32_C(1) << DT_REG,
+                .architecture = _ARCHITECTURE_INVALID,
+                .suffix = ".raw",
+                .host_version = "39",
+        };
+
+        _cleanup_(pick_result_done) PickResult result = PICK_RESULT_NULL;
+
+        /* The entry for the given host version wins, not the newest one */
+        ASSERT_OK_POSITIVE(path_pick(NULL, AT_FDCWD, AT_FDCWD, pp, &filter, /* n_filters= */ 1, PICK_ARCHITECTURE|PICK_TRIES, &result));
+        ASSERT_STREQ(result.version, "39");
+        ASSERT_TRUE(endswith(result.path, "/foo_host=39.raw"));
+        pick_result_done(&result);
+
+        /* An unknown host version never matches */
+        filter.host_version = "";
+        ASSERT_OK_ZERO(path_pick(NULL, AT_FDCWD, AT_FDCWD, pp, &filter, /* n_filters= */ 1, PICK_ARCHITECTURE|PICK_TRIES, &result));
+        ASSERT_NULL(result.path);
+
+        /* Without PICK_TRIES and with an explicit version the fully specified fast path is taken, which has
+         * to find the "host=" spelling as well, and report the version without the prefix */
+        filter.host_version = NULL;
+        filter.version = "40";
+        filter.basename = "foo";
+        ASSERT_OK_POSITIVE(path_pick(NULL, AT_FDCWD, AT_FDCWD, pp, &filter, /* n_filters= */ 1, /* flags= */ 0, &result));
+        ASSERT_STREQ(result.version, "40");
+        ASSERT_TRUE(endswith(result.path, "/foo_host=40.raw"));
+        pick_result_done(&result);
+
+        /* The plain spelling is found by the fast path too */
+        ASSERT_OK(write_string_file_at(sub_dfd, "foo_41.raw", "41", WRITE_STRING_FILE_CREATE));
+        filter.version = "41";
+        ASSERT_OK_POSITIVE(path_pick(NULL, AT_FDCWD, AT_FDCWD, pp, &filter, /* n_filters= */ 1, /* flags= */ 0, &result));
+        ASSERT_STREQ(result.version, "41");
+        ASSERT_TRUE(endswith(result.path, "/foo_41.raw"));
+        pick_result_done(&result);
+
+        /* Neither spelling exists */
+        filter.version = "99";
+        ASSERT_OK_ZERO(path_pick(NULL, AT_FDCWD, AT_FDCWD, pp, &filter, /* n_filters= */ 1, /* flags= */ 0, &result));
+        ASSERT_NULL(result.path);
+
+        /* With PICK_ARCHITECTURE but no architecture to look for the name is not fully specified, hence the
+         * enumeration has to be used, which accepts the native architecture as well */
+        _cleanup_free_ char *native_entry = ASSERT_NOT_NULL(
+                        strjoin("foo_host=42_", architecture_to_string(native_architecture()), ".raw"));
+        ASSERT_OK(write_string_file_at(sub_dfd, native_entry, "42", WRITE_STRING_FILE_CREATE));
+
+        filter.version = "42";
+        ASSERT_OK_POSITIVE(path_pick(NULL, AT_FDCWD, AT_FDCWD, pp, &filter, /* n_filters= */ 1, PICK_ARCHITECTURE, &result));
+        ASSERT_STREQ(result.version, "42");
+        ASSERT_EQ(result.architecture, native_architecture());
+        pick_result_done(&result);
+}
+
 TEST(path_uses_vpick) {
         ASSERT_OK_POSITIVE(path_uses_vpick("foo.v"));
         ASSERT_OK_POSITIVE(path_uses_vpick("path/to/foo.v"));

--- a/test/units/TEST-29-PORTABLE.image.sh
+++ b/test/units/TEST-29-PORTABLE.image.sh
@@ -176,6 +176,31 @@ status="$(portablectl is-attached --extension app1_1.0.raw minimal_1)"
 portablectl detach --now --runtime --extension /tmp/app1.v/ /usr/share/minimal_0.raw app1
 rm -f /tmp/app1.v/app1_1.0.raw
 
+# Ensure "host=" vpick entries of extension images are matched against the VERSION_ID of the portable image
+# they are applied to, and that attaching and detaching such an entry works. Note that the images are built
+# from the same distribution as the host, hence this cannot tell the image's VERSION_ID apart from the
+# host's, but it does cover the pick and the marker comparison on detach.
+IMAGE_VERSION_ID="$(systemd-dissect --copy-from /usr/share/minimal_1.raw /usr/lib/os-release |
+                        sed -n 's/^VERSION_ID=//p' | tr -d '"')"
+
+if [ "$IMAGE_VERSION_ID" != "" ]; then
+    cp /tmp/app1.raw "/tmp/app1.v/app1_host=$IMAGE_VERSION_ID.raw"
+    # A newer entry for a different OS version must not be picked
+    cp /tmp/app1_2.raw /tmp/app1.v/app1_host=99999999-neververtest.raw
+    portablectl "${ARGS[@]}" attach --now --runtime --extension /tmp/app1.v/ /usr/share/minimal_1.raw app1
+
+    systemctl is-active app1.service
+    status="$(portablectl is-attached --extension "app1_host=$IMAGE_VERSION_ID.raw" minimal_1)"
+    [[ "${status}" == "running-runtime" ]]
+    # The drop-in records the resolved path, so this is what tells the entries apart
+    grep -F "app1_host=$IMAGE_VERSION_ID.raw" /run/systemd/system.attached/app1.service.d/20-portable.conf >/dev/null
+
+    # Detaching resolves the .v directory again, which has to still find what was attached
+    portablectl detach --now --runtime --extension /tmp/app1.v/ /usr/share/minimal_1.raw app1
+    (! systemctl is-active app1.service)
+    rm -f "/tmp/app1.v/app1_host=$IMAGE_VERSION_ID.raw" /tmp/app1.v/app1_host=99999999-neververtest.raw
+fi
+
 # Ensure that the combination of read-only images, state directory and dynamic user works, and that
 # state is retained. Check after detaching, as on slow systems (eg: sanitizers) it might take a while
 # after the service is attached before the file appears.

--- a/test/units/TEST-50-DISSECT.dissect.sh
+++ b/test/units/TEST-50-DISSECT.dissect.sh
@@ -666,6 +666,116 @@ rm -rf "$VDIR" "$EMPTY_VDIR"
 systemd-dissect --umount "$IMAGE_DIR/app0"
 systemd-dissect --umount "$IMAGE_DIR/app1"
 
+# Check that "host=" vpick entries in ExtensionDirectories= are matched against the os-release data of the
+# unit's root, not the manager's
+VBASE="vtest$RANDOM"
+VDIR="/tmp/${VBASE}.v"
+FAKE_ROOT="/tmp/${VBASE}-root"
+# os-release is sourced at the top of this file. Note that on distros without VERSION_ID the fallback is
+# just another never-matching entry rather than a decoy for the manager's version.
+HOST_VERSION_ID="${VERSION_ID:-5-decoyvertest}"
+
+# One entry for the fake root's version, one decoy entry for the manager's actual version, and one decoy
+# entry with the highest version that matches no os-release, to also catch a wrong newest-wins pick
+VDIR_RAW="/tmp/${VBASE}.raw.v"
+mkdir "$VDIR" "$VDIR_RAW"
+for v in 1-hostvertest 99999999-neververtest "$HOST_VERSION_ID"; do
+    mkdir -p "$VDIR/${VBASE}_host=$v/usr/lib/extension-release.d"
+    echo "ID=_any" >"$VDIR/${VBASE}_host=$v/usr/lib/extension-release.d/extension-release.${VBASE}_host=$v"
+    echo "$v" >"$VDIR/${VBASE}_host=$v/usr/${VBASE}.marker"
+    # The same set as images, to cover the ExtensionImages= pick as well. Note that the extension name is
+    # derived from the entry, hence the extension-release file has to be renamed along.
+    mkdir -p "/tmp/${VBASE}-img/usr/lib/extension-release.d"
+    echo "ID=_any" >"/tmp/${VBASE}-img/usr/lib/extension-release.d/extension-release.${VBASE}_host=$v"
+    echo "$v" >"/tmp/${VBASE}-img/usr/${VBASE}.marker"
+    mksquashfs "/tmp/${VBASE}-img" "$VDIR_RAW/${VBASE}_host=$v.raw" -noappend
+    rm -rf "/tmp/${VBASE}-img"
+done
+
+# Fake root: bind of /, with /etc overlayed so os-release can be replaced. Unmount it from a subshell trap,
+# so that a failing assertion doesn't leave a second copy of / mounted for the rest of the test run.
+mkdir -p "$FAKE_ROOT" "/tmp/${VBASE}-upper" "/tmp/${VBASE}-work"
+(
+    # Stop the service before unmounting, it runs with the fake root as its root
+    trap 'set +e; systemctl stop testservice-vpick-host.service; rm -f /run/systemd/system/testservice-vpick-host.service; umount "$FAKE_ROOT/etc"; umount "$FAKE_ROOT"' EXIT
+
+    mount --bind / "$FAKE_ROOT"
+    # The bind shares /'s peer group, the overlay mount would propagate back onto the real /etc
+    mount --make-private "$FAKE_ROOT"
+    mount -t overlay overlay -o "lowerdir=/etc,upperdir=/tmp/${VBASE}-upper,workdir=/tmp/${VBASE}-work" "$FAKE_ROOT/etc"
+    rm -f "$FAKE_ROOT/etc/os-release"
+    { grep -v "^VERSION_ID=" /etc/os-release; echo "VERSION_ID=1-hostvertest"; } >"$FAKE_ROOT/etc/os-release"
+
+    # The entry matching the unit root's VERSION_ID is picked, not the manager's, and not the highest one
+    MARKER="$(systemd-run -P \
+                --property RootDirectory="$FAKE_ROOT" \
+                --property MountAPIVFS=yes \
+                --property ExtensionDirectories="$VDIR" \
+                cat "/usr/${VBASE}.marker")"
+    if ! echo "$MARKER" | grep -x 1-hostvertest >/dev/null; then
+        echo >&2 "Wrong extension applied for unit root VERSION_ID=1-hostvertest, marker says: $MARKER"
+        exit 1
+    fi
+
+    # The same for ExtensionImages=, which is a separate pick
+    MARKER="$(systemd-run -P \
+                --property RootDirectory="$FAKE_ROOT" \
+                --property MountAPIVFS=yes \
+                --property ExtensionImages="$VDIR_RAW" \
+                cat "/usr/${VBASE}.marker")"
+    if ! echo "$MARKER" | grep -x 1-hostvertest >/dev/null; then
+        echo >&2 "Wrong extension image applied for unit root VERSION_ID=1-hostvertest, marker says: $MARKER"
+        exit 1
+    fi
+
+    # Reloading has to match against the unit's root as well, see refresh_extensions_in_namespace()
+    mkdir -p /tmp/markers/
+    cat >/run/systemd/system/testservice-vpick-host.service <<EOF
+[Service]
+Type=notify-reload
+EnvironmentFile=-/usr/lib/systemd/systemd-asan-env
+PrivateTmp=disconnected
+RootDirectory=$FAKE_ROOT
+MountAPIVFS=yes
+BindPaths=/tmp/markers/
+ExtensionDirectories=$VDIR
+ExecStart=bash -o pipefail -x -c ' \\
+    trap "{ \\
+        systemd-notify --reloading; \\
+        cat /usr/${VBASE}.marker >/tmp/markers/vpick-host; \\
+        systemd-notify --ready; \\
+    }" SIGHUP; \\
+    systemd-notify --ready; \\
+    while true; do sleep 1; done; \\
+'
+EOF
+    systemctl start testservice-vpick-host.service
+    systemctl is-active testservice-vpick-host.service
+    systemctl reload testservice-vpick-host.service
+    if ! grep -x 1-hostvertest /tmp/markers/vpick-host >/dev/null; then
+        echo >&2 "Wrong extension applied on reload, marker says: $(cat /tmp/markers/vpick-host)"
+        exit 1
+    fi
+    systemctl stop testservice-vpick-host.service
+
+    # No entry matches the unit root's VERSION_ID → nothing is applied, but with the "-" prefix the unit
+    # still starts, which tells a missing extension apart from a unit that cannot start at all
+    { grep -v "^VERSION_ID=" /etc/os-release; echo "VERSION_ID=2-nomatchvertest"; } >"$FAKE_ROOT/etc/os-release"
+    MARKER="$(systemd-run -P \
+                --property RootDirectory="$FAKE_ROOT" \
+                --property MountAPIVFS=yes \
+                --property ExtensionDirectories="-$VDIR" \
+                bash -c "test ! -e /usr/${VBASE}.marker && echo no-marker")"
+    if ! echo "$MARKER" | grep -x no-marker >/dev/null; then
+        echo >&2 "Extension unexpectedly applied for unit root VERSION_ID=2-nomatchvertest, marker says: $MARKER"
+        exit 1
+    fi
+)
+
+# Note: no rm -rf on the former bind mount of /
+rmdir "$FAKE_ROOT"
+rm -rf "$VDIR" "$VDIR_RAW" "/tmp/${VBASE}-upper" "/tmp/${VBASE}-work"
+
 # Check reloading refreshes vpick extensions
 VBASE="vtest$RANDOM"
 VDIR="/tmp/${VBASE}.v"

--- a/test/units/TEST-50-DISSECT.sysext.sh
+++ b/test/units/TEST-50-DISSECT.sysext.sh
@@ -97,6 +97,19 @@ prepare_root() {
     prepend_trap "cleanup_os_release ${root@Q}"
 }
 
+add_version_id() {
+    local root=${1:-}
+    local version_id=${2:?}
+    local f
+
+    # prepare_root() writes no VERSION_ID, which is what "host=" vpick entries are matched against
+    for f in "$root/usr/lib/os-release" "$root/etc/os-release"; do
+        if [[ -f $f ]] && [[ ! -L $f ]]; then
+            echo "VERSION_ID=$version_id" >>"$f"
+        fi
+    done
+}
+
 cleanup_os_release() {
     # shellcheck disable=SC2317 # It is not unreachable, used in a trap couple lines above.
     local root=${1:-}
@@ -1466,6 +1479,75 @@ extension_verify_after_merge "$fake_root" "$hierarchy" -e -h
 run_systemd_sysext "$fake_root" unmerge
 extension_verify_after_unmerge "$fake_root" "$hierarchy" -h
 rm -rf "$fake_root/var/lib/extensions/test-extension.raw.v"
+)
+
+( init_trap
+: "Check if vpick host= entries are matched against the root's VERSION_ID"
+fake_root=${roots_dir:+"$roots_dir/vpick-host-version"}
+hierarchy=/opt
+
+prepare_root "$fake_root" "$hierarchy"
+add_version_id "$fake_root" "1-sysextvertest"
+prepare_extension_image "$fake_root" "$hierarchy"
+mkdir -p "$fake_root/var/lib/extensions/test-extension.v"
+mv -T "$fake_root/var/lib/extensions/test-extension" "$fake_root/var/lib/extensions/test-extension.v/test-extension_host=1-sysextvertest"
+# The newest entry is for a different OS version, hence it must lose against the matching one
+cp -a "$fake_root/var/lib/extensions/test-extension.v/test-extension_host=1-sysextvertest" \
+      "$fake_root/var/lib/extensions/test-extension.v/test-extension_host=99999999-neververtest"
+touch "$fake_root/var/lib/extensions/test-extension.v/test-extension_host=99999999-neververtest$hierarchy/file-from-wrong-extension"
+prepare_read_only_hierarchy "$fake_root" "$hierarchy"
+
+run_systemd_sysext "$fake_root" merge
+extension_verify_after_merge "$fake_root" "$hierarchy" -e -h
+if [[ -e "$fake_root$hierarchy/file-from-wrong-extension" ]]; then
+    echo >&2 "Extension for a different OS version was merged"
+    exit 1
+fi
+
+run_systemd_sysext "$fake_root" unmerge
+extension_verify_after_unmerge "$fake_root" "$hierarchy" -h
+rm -rf "$fake_root/var/lib/extensions/test-extension.v"
+)
+
+( init_trap
+: "Check if vpick host= entries are ignored if the root's VERSION_ID differs"
+fake_root=${roots_dir:+"$roots_dir/vpick-host-version-nomatch"}
+hierarchy=/opt
+
+prepare_root "$fake_root" "$hierarchy"
+add_version_id "$fake_root" "2-nomatchvertest"
+prepare_extension_image "$fake_root" "$hierarchy"
+mkdir -p "$fake_root/var/lib/extensions/test-extension.v"
+mv -T "$fake_root/var/lib/extensions/test-extension" "$fake_root/var/lib/extensions/test-extension.v/test-extension_host=1-sysextvertest"
+prepare_read_only_hierarchy "$fake_root" "$hierarchy"
+
+run_systemd_sysext "$fake_root" merge
+# No entry matches, hence nothing may be merged
+extension_verify_after_merge "$fake_root" "$hierarchy" -h
+
+run_systemd_sysext "$fake_root" unmerge
+extension_verify_after_unmerge "$fake_root" "$hierarchy" -h
+rm -rf "$fake_root/var/lib/extensions/test-extension.v"
+)
+
+( init_trap
+: "Check if vpick host= entries are ignored if the root has no VERSION_ID"
+fake_root=${roots_dir:+"$roots_dir/vpick-host-version-unset"}
+hierarchy=/opt
+
+# Note that prepare_root() writes no VERSION_ID, hence none is added here
+prepare_root "$fake_root" "$hierarchy"
+prepare_extension_image "$fake_root" "$hierarchy"
+mkdir -p "$fake_root/var/lib/extensions/test-extension.v"
+mv -T "$fake_root/var/lib/extensions/test-extension" "$fake_root/var/lib/extensions/test-extension.v/test-extension_host=1-sysextvertest"
+prepare_read_only_hierarchy "$fake_root" "$hierarchy"
+
+run_systemd_sysext "$fake_root" merge
+extension_verify_after_merge "$fake_root" "$hierarchy" -h
+
+run_systemd_sysext "$fake_root" unmerge
+extension_verify_after_unmerge "$fake_root" "$hierarchy" -h
+rm -rf "$fake_root/var/lib/extensions/test-extension.v"
 )
 
 ( init_trap

--- a/test/units/TEST-74-AUX-UTILS.vpick.sh
+++ b/test/units/TEST-74-AUX-UTILS.vpick.sh
@@ -8,6 +8,9 @@ at_exit() {
     rm -rf /var/lib/machines/mymachine.raw.v
     rm -rf /var/lib/machines/mytree.v
     rm -rf /var/lib/machines/testroot.v
+    rm -rf /var/lib/machines/myext.raw.v
+    rm -rf /var/lib/machines/mymstack.mstack
+    rm -f /tmp/vpick-os-release
     umount -l /tmp/dotvroot
     rmdir /tmp/dotvroot
 }
@@ -114,3 +117,70 @@ test "$(systemd-vpick --resolve=yes /var/lib/machines/testroot.v)" = /var/lib/ma
 rm -rf /var/lib/machines/testroot.v/testroot_32
 (! systemd-vpick /var/lib/machines/testroot.v)
 (! systemd-run --wait -p RootDirectory=/var/lib/machines/testroot.v true)
+
+# Test host version matching via the "host=" version prefix
+test_host_version_matching() (
+    mkdir /var/lib/machines/myext.raw.v
+    touch /var/lib/machines/myext.raw.v/myext_host=38.raw
+    touch /var/lib/machines/myext.raw.v/myext_host=39.raw
+    touch /var/lib/machines/myext.raw.v/myext_host=40.raw
+
+    cat >/tmp/vpick-os-release <<EOF
+ID=test
+VERSION_ID=39
+EOF
+
+    export SYSTEMD_OS_RELEASE=/tmp/vpick-os-release
+
+    # The entry matching the host's VERSION_ID wins, not the newest one
+    test "$(systemd-vpick /var/lib/machines/myext.raw.v --suffix=.raw)" = "/var/lib/machines/myext.raw.v/myext_host=39.raw"
+    test "$(systemd-vpick /var/lib/machines/myext.raw.v --suffix=.raw -p version)" = "39"
+
+    # An explicit version filter disables host version matching
+    test "$(systemd-vpick /var/lib/machines/myext.raw.v --suffix=.raw -V 40)" = "/var/lib/machines/myext.raw.v/myext_host=40.raw"
+
+    # Works with architecture identifiers
+    touch /var/lib/machines/myext.raw.v/myext_host=39_x86-64.raw
+    touch /var/lib/machines/myext.raw.v/myext_host=40_x86-64.raw
+    touch /var/lib/machines/myext.raw.v/myext_host=39_arm64.raw
+    test "$(systemd-vpick /var/lib/machines/myext.raw.v --suffix=.raw -A x86-64)" = "/var/lib/machines/myext.raw.v/myext_host=39_x86-64.raw"
+    test "$(systemd-vpick /var/lib/machines/myext.raw.v --suffix=.raw -A x86-64 -p version)" = "39"
+    test "$(systemd-vpick /var/lib/machines/myext.raw.v --suffix=.raw -A arm64)" = "/var/lib/machines/myext.raw.v/myext_host=39_arm64.raw"
+    test "$(systemd-vpick /var/lib/machines/myext.raw.v --suffix=.raw -A x86-64 -V 40)" = "/var/lib/machines/myext.raw.v/myext_host=40_x86-64.raw"
+    test "$(systemd-vpick /var/lib/machines/myext.raw.v --suffix=.raw -A x86-64 -V 40 -p version)" = "40"
+    rm /var/lib/machines/myext.raw.v/myext_host=39_x86-64.raw
+    rm /var/lib/machines/myext.raw.v/myext_host=40_x86-64.raw
+    rm /var/lib/machines/myext.raw.v/myext_host=39_arm64.raw
+
+    # Plain entries compete with matching host= entries by version comparison
+    touch /var/lib/machines/myext.raw.v/myext_100.raw
+    test "$(systemd-vpick /var/lib/machines/myext.raw.v --suffix=.raw)" = "/var/lib/machines/myext.raw.v/myext_100.raw"
+    rm /var/lib/machines/myext.raw.v/myext_100.raw
+
+    # The same matching applies to .v layers of a .mstack directory. Note that vpick gets the .mstack
+    # directory as its root there, hence the host version has to be determined by the caller.
+    mkdir -p "/var/lib/machines/mymstack.mstack/layer@base.v/layer@base_host=39/usr"
+    mkdir -p "/var/lib/machines/mymstack.mstack/layer@base.v/layer@base_host=99999999-neververtest/usr"
+    systemd-mstack --json=short /var/lib/machines/mymstack.mstack | grep "layer@base_host=39" >/dev/null
+
+    # No entry matching the host's VERSION_ID → nothing is picked
+    cat >/tmp/vpick-os-release <<EOF
+ID=test
+VERSION_ID=99
+EOF
+    if systemd-vpick /var/lib/machines/myext.raw.v --suffix=.raw; then
+        echo "Should not find a matching entry" >&2
+        exit 1
+    fi
+
+    # os-release without any VERSION_ID → host= entries never match
+    cat >/tmp/vpick-os-release <<EOF
+ID=test
+EOF
+    if systemd-vpick /var/lib/machines/myext.raw.v --suffix=.raw; then
+        echo "Should not find a matching entry without VERSION_ID" >&2
+        exit 1
+    fi
+
+)
+test_host_version_matching


### PR DESCRIPTION
For OS-version-bound sysexts the CurrentSymlink setting from sysupdate
does not work well because it's not related to the current boot, and
using a .v dir wasn't working either because it always selected the
newest version.
To make .v dirs work for OS-bound sysexts, allow that entries can match
against the host VERSION_ID similar to how they can set the CPU arch
for filtering. Introduce a "host=" prefix in the version part, e.g., it
would look like myext_host=1.0_x86-64.sysext.raw for VERSION_ID=1.0, so
that an entry will not only have to match the host arch but also the
version. This is mainly meant for extensions provided by an image-based
OS through sysupdate when VERSION_ID is advancing for updates and not
only IMAGE_VERSION. Note that "=" is not a valid part of the version
and older systemd releases will reject such entries. For explicit
systemd-vpick -V usage to select a version the "host=" prefix won't do
a host VERSION_ID check.
To support matching against the OS tree the extension is applied to,
for units and portable services we have to look into their root fs first
before we can pick, and we pass the version information to vpick.
Other places where vpick is used without a different OS tree to apply
the picked file to, match against the host OS.
The version is passed through the new host_version field of PickFilter,
which also allows to express that no version could be determined, in
which case "host=" entries never match instead of falling back to the
VERSION_ID of the OS the manager itself runs on. For units this means
that the extension images and directories are only resolved once the
unit's root file system is mounted, which is where its os-release data
becomes readable for RootDirectory=/RootImage=/RootMStack=.