### PR TITLE
Fix typo in 'website' in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ System and Service Manager
 
 ## Details
 
-Most documentation is available on [systemd's web site](https://systemd.io/).
+Most documentation is available on [systemd's website](https://systemd.io/).
 
 Assorted, older, general information about systemd can be found in the [systemd Wiki](https://www.freedesktop.org/wiki/Software/systemd).
 


### PR DESCRIPTION
Fixed a typo in the README from "web site" to "website."