### PR TITLE
install: accept DT_UNKNOWN entries in find_symlinks()

### DIFF
--- a/src/shared/install.c
+++ b/src/shared/install.c
@@ -982,7 +982,11 @@ static int find_symlinks(
                 _cleanup_free_ const char *path = NULL;
                 _cleanup_closedir_ DIR *d = NULL;
 
-                if (de->d_type != DT_DIR)
+                /* Some filesystems (e.g. overlayfs, certain network filesystems)
+                 * report DT_UNKNOWN for all entries. opendir() below follows
+                 * symlinks and fails gracefully for non-directory entries, so
+                 * accept DT_UNKNOWN here and let opendir() decide. */
+                if (!IN_SET(de->d_type, DT_DIR, DT_UNKNOWN))
                         continue;
 
                 suffix = strrchr(de->d_name, '.');


### PR DESCRIPTION
Some filesystems (e.g. overlayfs, certain network filesystems) report `DT_UNKNOWN` for all directory entries instead of `DT_DIR`. The `find_symlinks()` function in `src/shared/install.c` filtered entries with `if (de->d_type != DT_DIR) continue;`, which caused such `.wants`/`.requires`/`.upholds` suffix directories to be skipped entirely. As a result, units enabled via those suffix directories were not detected, and `systemctl is-enabled` reported them as `disabled` even though they were enabled.

Accept `DT_UNKNOWN` in addition to `DT_DIR` and let the subsequent `opendir()` follow symlinks and fail gracefully for non-directory entries.

Per maintainer feedback in #42571, symlinked `.wants`/`.requires`/`.upholds` directories themselves are intentionally not supported — only the `DT_UNKNOWN` case is addressed here.

Fixes #42571.
