### PR TITLE
test-bpf-restrict-fs: skip if manager startup fails due to lack of privileges

### DIFF
--- a/src/test/test-bpf-restrict-fs.c
+++ b/src/test/test-bpf-restrict-fs.c
@@ -86,8 +86,15 @@ int main(int argc, char *argv[]) {
         ASSERT_OK(setenv_unit_path(unit_dir));
         ASSERT_NOT_NULL((runtime_dir = setup_fake_runtime_dir()));
 
-        ASSERT_OK(manager_new(RUNTIME_SCOPE_SYSTEM, MANAGER_TEST_RUN_BASIC, &m));
-        ASSERT_OK(manager_startup(m, NULL, NULL, NULL, NULL));
+        r = manager_new(RUNTIME_SCOPE_SYSTEM, MANAGER_TEST_RUN_BASIC, &m);
+        if (manager_errno_skip_test(r))
+                return log_tests_skipped_errno(r, "manager_new");
+        ASSERT_OK(r);
+
+        r = manager_startup(m, NULL, NULL, NULL, NULL);
+        if (manager_errno_skip_test(r))
+                return log_tests_skipped_errno(r, "manager_startup");
+        ASSERT_OK(r);
 
         /* bpf_restrict_fs_supported() above only checks that the BPF LSM hook is enabled in the kernel; it
          * doesn't verify that the LSM BPF program managed to actually attach (e.g. some architectures/older


### PR DESCRIPTION
## What

Follow-up to #43177, which broke the OBS build:

```
1145/1954 core - systemd:test-bpf-restrict-fs                                      FAIL              0.02s   killed by signal 6 SIGABRT
...
src/test/test-bpf-restrict-fs.c:90: Assertion failed: Expected "manager_startup(m, NULL, NULL, NULL, NULL)" to succeed, but got error: -13/EACCES
```

`test-bpf-restrict-fs.c` creates a `Manager` with `RUNTIME_SCOPE_SYSTEM`, which tries to set up the real system runtime directory hierarchy (e.g. create `/run/systemd/`), and that requires privileges the test process may not have (e.g. unprivileged sandboxed builders such as OBS).

Previously this was masked because `bpf_restrict_fs_supported()` did a trial open/load/attach of the BPF program itself, which also requires elevated privileges and so failed first, causing the test to skip before ever reaching `manager_new()`/`manager_startup()`. Since #43177 removed that trial load from the probe, the test now reaches `manager_new()`/`manager_startup()` in these unprivileged environments and hard-fails instead of skipping.

## Fix

Use the same `manager_errno_skip_test()` pattern already used by other tests (`test-engine.c`, `test-execute.c`, `test-path.c`, ...) to skip gracefully when `manager_new()` or `manager_startup()` fail due to missing privileges, instead of asserting.