### PR TITLE
gpt: allow "-v" and "-vsig" as shorthands for the verity suffixes

### DIFF
--- a/man/repart.d.xml
+++ b/man/repart.d.xml
@@ -141,12 +141,12 @@
               </row>
 
               <row>
-                <entry><constant>root-verity</constant></entry>
+                <entry><constant>root-verity</constant>, <constant>root-vty</constant></entry>
                 <entry>Verity data for the root file system partition for the local architecture</entry>
               </row>
 
               <row>
-                <entry><constant>root-verity-sig</constant></entry>
+                <entry><constant>root-verity-sig</constant>, <constant>root-sig</constant></entry>
                 <entry>Verity signature data for the root file system partition for the local architecture</entry>
               </row>
 
@@ -156,12 +156,12 @@
               </row>
 
               <row>
-                <entry><constant>root-secondary-verity</constant></entry>
+                <entry><constant>root-secondary-verity</constant>, <constant>root-secondary-vty</constant></entry>
                 <entry>Verity data for the root file system partition of the secondary architecture</entry>
               </row>
 
               <row>
-                <entry><constant>root-secondary-verity-sig</constant></entry>
+                <entry><constant>root-secondary-verity-sig</constant>, <constant>root-secondary-sig</constant></entry>
                 <entry>Verity signature data for the root file system partition of the secondary architecture</entry>
               </row>
 
@@ -171,12 +171,12 @@
               </row>
 
               <row>
-                <entry><constant>root-{arch}-verity</constant></entry>
+                <entry><constant>root-{arch}-verity</constant>, <constant>root-{arch}-vty</constant></entry>
                 <entry>Verity data for the root file system partition of the given architecture</entry>
               </row>
 
               <row>
-                <entry><constant>root-{arch}-verity-sig</constant></entry>
+                <entry><constant>root-{arch}-verity-sig</constant>, <constant>root-{arch}-sig</constant></entry>
                 <entry>Verity signature data for the root file system partition of the given architecture</entry>
               </row>
 
@@ -186,12 +186,12 @@
               </row>
 
               <row>
-                <entry><constant>usr-verity</constant></entry>
+                <entry><constant>usr-verity</constant>, <constant>usr-vty</constant></entry>
                 <entry>Verity data for the <filename>/usr/</filename> file system partition for the local architecture</entry>
               </row>
 
               <row>
-                <entry><constant>usr-verity-sig</constant></entry>
+                <entry><constant>usr-verity-sig</constant>, <constant>usr-sig</constant></entry>
                 <entry>Verity signature data for the <filename>/usr/</filename> file system partition for the local architecture</entry>
               </row>
 
@@ -201,12 +201,12 @@
               </row>
 
               <row>
-                <entry><constant>usr-secondary-verity</constant></entry>
+                <entry><constant>usr-secondary-verity</constant>, <constant>usr-secondary-vty</constant></entry>
                 <entry>Verity data for the <filename>/usr/</filename> file system partition of the secondary architecture</entry>
               </row>
 
               <row>
-                <entry><constant>usr-secondary-verity-sig</constant></entry>
+                <entry><constant>usr-secondary-verity-sig</constant>, <constant>usr-secondary-sig</constant></entry>
                 <entry>Verity signature data for the <filename>/usr/</filename> file system partition of the secondary architecture</entry>
               </row>
 
@@ -216,12 +216,12 @@
               </row>
 
               <row>
-                <entry><constant>usr-{arch}-verity</constant></entry>
+                <entry><constant>usr-{arch}-verity</constant>, <constant>usr-{arch}-vty</constant></entry>
                 <entry>Verity data for the <filename>/usr/</filename> file system partition of the given architecture</entry>
               </row>
 
               <row>
-                <entry><constant>usr-{arch}-verity-sig</constant></entry>
+                <entry><constant>usr-{arch}-verity-sig</constant>, <constant>usr-{arch}-sig</constant></entry>
                 <entry>Verity signature data for the <filename>/usr/</filename> file system partition of the given architecture</entry>
               </row>
             </tbody>
@@ -237,6 +237,21 @@
         <constant>s390</constant>, <constant>s390x</constant>, <constant>tilegx</constant>,
         <constant>x86</constant> (32-bit, aka i386) and <constant>x86-64</constant> (64-bit, aka amd64).</para>
 
+        <para>As shown in the table above, the <constant>-verity</constant> and
+        <constant>-verity-sig</constant> suffixes may always be abbreviated as <constant>-vty</constant> and
+        <constant>-sig</constant> respectively. Both spellings refer to the same partition type UUID and are
+        accepted everywhere a partition type identifier is expected.</para>
+
+        <para>GPT limits partition labels to 36 characters. The abbreviated identifier is hence the one used
+        for the label automatically derived from the partition type when <varname>Label=</varname> is not
+        specified, i.e. a <constant>usr-x86-64-verity-sig</constant> partition is labelled
+        <literal>usr-x86-64-sig</literal>. It is equally useful when assembling labels manually, for
+        example when a version string has to fit next to the partition type identifier. The canonical (long)
+        spelling remains what is shown when a partition type itself is displayed, for example in the type
+        column of
+        <citerefentry><refentrytitle>systemd-repart</refentrytitle><manvolnum>8</manvolnum></citerefentry>
+        output.</para>
+
         <para>Most of the partition type UUIDs listed above are defined in the <ulink
         url="https://uapi-group.org/specifications/specs/discoverable_partitions_specification">UAPI.2 Discoverable Partitions
         Specification</ulink>.</para>
@@ -251,7 +266,8 @@
         setting is not used for matching. It is also not used when a label is already set for an existing
         partition. It is thus only used when a partition is newly created or when an existing one had a no
         label set (that is: an empty label). If not specified, a label derived from the partition type is
-        automatically used. Simple specifier expansion is supported, see below.</para>
+        automatically used, using the abbreviated form of the type identifier, see
+        <varname>Type=</varname> above. Simple specifier expansion is supported, see below.</para>
 
         <xi:include href="version-info.xml" xpointer="v245"/></listitem>
       </varlistentry>

--- a/src/repart/repart.c
+++ b/src/repart/repart.c
@@ -4269,7 +4269,7 @@ static int format_size_change(uint64_t from, uint64_t to, char **ret) {
         return 1;
 }
 
-static const char *partition_label(const Partition *p) {
+static const char *partition_label(const Partition *p, char buffer[static GPT_PARTITION_TYPE_NAME_MAX]) {
         assert(p);
 
         if (p->new_label)
@@ -4278,8 +4278,10 @@ static const char *partition_label(const Partition *p) {
         if (p->current_label)
                 return p->current_label;
 
-        return gpt_partition_type_uuid_to_string(p->type.uuid);
+        return gpt_partition_type_uuid_to_short_string(p->type.uuid, buffer);
 }
+
+#define PARTITION_LABEL(p) partition_label((p), (char[GPT_PARTITION_TYPE_NAME_MAX]) {})
 
 static int volume_label(const Partition *p, char **ret) {
         assert(p);
@@ -4288,7 +4290,7 @@ static int volume_label(const Partition *p, char **ret) {
         if (p->new_volume_label)
                 return strdup_to(ret, p->new_volume_label);
 
-        const char *e = partition_label(p);
+        const char *e = PARTITION_LABEL(p);
         if (!e)
                 return -ENODATA;
 
@@ -4385,7 +4387,7 @@ static int context_dump_partitions(Context *context) {
                 else if (p->current_size != p->new_size)
                         activity = "resize";
 
-                label = partition_label(p);
+                label = PARTITION_LABEL(p);
                 partname = p->partno != UINT64_MAX ? sym_fdisk_partname(context->node, p->partno+1) : NULL;
 
                 r = format_size_change(p->current_size, p->new_size, &size_change);
@@ -4546,7 +4548,7 @@ static int partition_hint(const Partition *p, const char *node, char **ret) {
         if (p->definition_path)
                 return path_extract_filename(p->definition_path, ret);
 
-        label = partition_label(p);
+        label = PARTITION_LABEL(p);
         if (!isempty(label)) {
                 buf = strdup(label);
                 goto done;
@@ -7740,7 +7742,7 @@ static int partition_acquire_label(Context *context, Partition *p, char **ret) {
         assert(p);
         assert(ret);
 
-        prefix = gpt_partition_type_uuid_to_string(p->type.uuid);
+        prefix = GPT_PARTITION_TYPE_UUID_TO_SHORT_STRING(p->type.uuid);
         if (!prefix)
                 prefix = "linux";
 

--- a/src/shared/gpt.c
+++ b/src/shared/gpt.c
@@ -244,11 +244,74 @@ const char* gpt_partition_type_uuid_to_string_harder(
         return sd_id128_to_uuid_string(id, buffer);
 }
 
+/* Shorthands for the verity suffixes, accepted for any partition type that carries them, i.e. "root-vty" is
+ * equivalent to "root-verity" and "usr-x86-64-sig" to "usr-x86-64-verity-sig". */
+static const struct {
+        const char *shorthand;
+        const char *suffix;
+} gpt_verity_shorthand_table[] = {
+        { "-vty", "-verity"     },
+        { "-sig", "-verity-sig" },
+};
+
+const char* gpt_partition_type_uuid_to_short_string(
+                sd_id128_t id,
+                char buffer[static GPT_PARTITION_TYPE_NAME_MAX]) {
+
+        const char *s;
+
+        assert(buffer);
+
+        /* Like gpt_partition_type_uuid_to_string(), but abbreviates the verity suffixes. Use this where the
+         * identifier ends up in a GPT partition label, which may not be longer than GPT_LABEL_MAX. */
+
+        s = gpt_partition_type_uuid_to_string(id);
+        if (!s)
+                return NULL;
+
+        FOREACH_ELEMENT(i, gpt_verity_shorthand_table) {
+                const char *e;
+
+                e = endswith(s, i->suffix);
+                if (!e)
+                        continue;
+
+                size_t n = e - s;
+                assert(n + strlen(i->shorthand) < GPT_PARTITION_TYPE_NAME_MAX);
+
+                memcpy(buffer, s, n);
+                strcpy(buffer + n, i->shorthand);
+                return buffer;
+        }
+
+        return s;
+}
+
 int gpt_partition_type_from_string(const char *s, GptPartitionType *ret) {
+        _cleanup_free_ char *expanded = NULL;
         sd_id128_t id = SD_ID128_NULL;
         int r;
 
         assert(s);
+
+        FOREACH_ELEMENT(i, gpt_verity_shorthand_table) {
+                const char *e;
+
+                /* The canonical "-verity-sig" suffix ends in the "-sig" shorthand itself, so leave a name
+                 * that is already spelled out alone. */
+                if (endswith(s, i->suffix))
+                        break;
+
+                e = endswith(s, i->shorthand);
+                if (!e)
+                        continue;
+
+                if (!strextendn(&expanded, s, e - s) || !strextend(&expanded, i->suffix))
+                        return -ENOMEM;
+
+                s = expanded;
+                break;
+        }
 
         FOREACH_ARRAY(t, gpt_partition_type_table, ELEMENTSOF(gpt_partition_type_table) - 1)
                 if (streq(s, t->name)) {

--- a/src/shared/gpt.h
+++ b/src/shared/gpt.h
@@ -11,6 +11,10 @@
 /* maximum length of gpt label */
 #define GPT_LABEL_MAX 36
 
+/* maximum length of a partition type identifier, including the NUL byte. The longest one we know is
+ * "root-loongarch64-verity-sig", i.e. 28 bytes, so this leaves plenty of room. */
+#define GPT_PARTITION_TYPE_NAME_MAX 64
+
 typedef enum PartitionDesignator {
         PARTITION_ROOT, /* Primary architecture */
         PARTITION_USR,
@@ -60,6 +64,13 @@ const char* gpt_partition_type_uuid_to_string_harder(
 
 #define GPT_PARTITION_TYPE_UUID_TO_STRING_HARDER(id) \
         gpt_partition_type_uuid_to_string_harder((id), (char[SD_ID128_UUID_STRING_MAX]) {})
+
+const char* gpt_partition_type_uuid_to_short_string(
+                sd_id128_t id,
+                char buffer[static GPT_PARTITION_TYPE_NAME_MAX]);
+
+#define GPT_PARTITION_TYPE_UUID_TO_SHORT_STRING(id) \
+        gpt_partition_type_uuid_to_short_string((id), (char[GPT_PARTITION_TYPE_NAME_MAX]) {})
 
 Architecture gpt_partition_type_uuid_to_arch(sd_id128_t id) _const_;
 

--- a/src/test/test-gpt.c
+++ b/src/test/test-gpt.c
@@ -87,6 +87,52 @@ TEST(type_alias_same) {
         }
 }
 
+TEST(verity_shorthands) {
+        FOREACH_STRING(prefix, "root", "usr", "root-x86-64", "usr-arm64", "root-secondary", "usr-aarch64")
+                FOREACH_STRING(suffix, "-verity", "-verity-sig") {
+                        _cleanup_free_ char *canonical = NULL, *shorthand = NULL;
+                        GptPartitionType x, y;
+
+                        ASSERT_NOT_NULL(canonical = strjoin(prefix, suffix));
+                        ASSERT_NOT_NULL(shorthand = strjoin(prefix, streq(suffix, "-verity") ? "-vty" : "-sig"));
+
+                        if (gpt_partition_type_from_string(canonical, &x) < 0)
+                                continue;
+
+                        ASSERT_OK(gpt_partition_type_from_string(shorthand, &y));
+                        ASSERT_EQ_ID128(x.uuid, y.uuid);
+                        ASSERT_EQ(x.arch, y.arch);
+                        ASSERT_EQ(x.designator, y.designator);
+                        ASSERT_STREQ(x.name, y.name);
+
+                        /* The abbreviated identifier must be shorter than the canonical one, and must
+                         * resolve back to the same type. */
+                        const char *abbreviated = GPT_PARTITION_TYPE_UUID_TO_SHORT_STRING(x.uuid);
+                        ASSERT_NOT_NULL(abbreviated);
+                        ASSERT_TRUE(strlen(abbreviated) < strlen(x.name));
+
+                        GptPartitionType z;
+                        ASSERT_OK(gpt_partition_type_from_string(abbreviated, &z));
+                        ASSERT_EQ_ID128(x.uuid, z.uuid);
+                }
+
+        ASSERT_ERROR(gpt_partition_type_from_string("esp-vty", NULL), EINVAL);
+        ASSERT_ERROR(gpt_partition_type_from_string("-sig", NULL), EINVAL);
+
+        /* The canonical "-verity-sig" suffix ends in the "-sig" shorthand, make sure it is not expanded a
+         * second time. */
+        GptPartitionType t;
+        ASSERT_OK(gpt_partition_type_from_string("root-x86-64-verity-sig", &t));
+        ASSERT_EQ_ID128(t.uuid, SD_GPT_ROOT_X86_64_VERITY_SIG);
+
+        ASSERT_STREQ(GPT_PARTITION_TYPE_UUID_TO_SHORT_STRING(SD_GPT_ROOT_X86_64_VERITY), "root-x86-64-vty");
+        ASSERT_STREQ(GPT_PARTITION_TYPE_UUID_TO_SHORT_STRING(SD_GPT_USR_X86_64_VERITY_SIG), "usr-x86-64-sig");
+
+        /* Types without a verity suffix are returned as-is, unknown ones not at all. */
+        ASSERT_STREQ(GPT_PARTITION_TYPE_UUID_TO_SHORT_STRING(SD_GPT_ESP), "esp");
+        ASSERT_NULL(GPT_PARTITION_TYPE_UUID_TO_SHORT_STRING(SD_ID128_NULL));
+}
+
 TEST(override_architecture) {
         GptPartitionType x, y;
 


### PR DESCRIPTION
GPT limits partition labels to 36 characters, which is tight when the label
is derived from a partition type identifier: "usr-x86-64-verity-sig" alone
takes up 21 of them, leaving little room for a version suffix or any other
decoration.

Accept "-v" and "-vsig" as aliases for the "-verity" and "-verity-sig"
suffixes, saving 6 characters for signature partitions and 5 for hash
partitions. The shorthand is expanded before the partition type table is
searched, so it applies to every type carrying a verity suffix, including
the architecture specific and secondary ones, and any architecture added
later gets it for free. Types are still resolved by UUID afterwards, so the
canonical long name remains what we report back to the user.

test-gpt gains a test asserting that both spellings resolve to the same
type, and that a shorthand on a type without verity variants is still
rejected.
