### PR TITLE
core/bpf-restrict-fsaccess: avoid loading the LSM BPF program twice at boot

### DIFF
--- a/src/core/bpf-restrict-fsaccess.c
+++ b/src/core/bpf-restrict-fsaccess.c
@@ -39,7 +39,6 @@ const char* const restrict_fsaccess_link_names[_RESTRICT_FILESYSTEM_ACCESS_LINK_
 
 #if BPF_FRAMEWORK && HAVE_LSM_INTEGRITY_TYPE
 #include "bpf-util.h"
-#include "bpf-link.h"
 #include "restrict-fsaccess-skel.h"
 
 static struct restrict_fsaccess_bpf *restrict_fsaccess_bpf_free(struct restrict_fsaccess_bpf *obj) {
@@ -165,7 +164,6 @@ int bpf_restrict_fsaccess_prepare(struct restrict_fsaccess_bpf **ret) {
 }
 
 bool bpf_restrict_fsaccess_supported(void) {
-        _cleanup_(restrict_fsaccess_bpf_freep) struct restrict_fsaccess_bpf *obj = NULL;
         static int supported = -1;
         int r;
 
@@ -188,15 +186,13 @@ bool bpf_restrict_fsaccess_supported(void) {
                 return (supported = false);
         }
 
-        r = bpf_restrict_fsaccess_prepare(&obj);
-        if (r < 0)
-                return (supported = false);
-
-        if (!bpf_can_link_lsm_program(obj->progs.restrict_fsaccess_bprm_check)) {
-                log_warning("bpf-restrict-fsaccess: Failed to link program; assuming BPF LSM is not available.");
-                return (supported = false);
-        }
-
+        /* We don't try to open/load/attach the BPF program here: that's the expensive part (a real kernel
+         * verifier pass plus, on the real attach in bpf_restrict_fsaccess_setup(), an LSM link), and doing
+         * it twice (once here just to throw the result away, once for real in
+         * bpf_restrict_fsaccess_setup()) means paying that cost twice on every boot for no benefit. If
+         * BPF_LSM_MAC attach isn't actually usable (e.g. no BPF trampoline support on this
+         * architecture/kernel), bpf_restrict_fsaccess_setup()'s own attach will fail when it is later
+         * called, and that failure is already logged and handled gracefully by its caller. */
         return (supported = true);
 }
 


### PR DESCRIPTION
## What

`bpf_restrict_fsaccess_setup()` is always called right after a successful
`bpf_restrict_fsaccess_supported()` probe (see `manager_setup()` in
`manager.c`), gated on `RestrictFileSystemAccess=` being enabled. Both
independently called `bpf_restrict_fsaccess_prepare()` (open + size +
kernel-verifier-load the BPF object), and the probe additionally did a
trial LSM attach/detach (`bpf_can_link_lsm_program()`) before throwing
the object away — so the `restrict_fsaccess` BPF program was opened,
sized and verified by the kernel **twice** on every boot of systems that
opt into `RestrictFileSystemAccess=` (e.g. dm-verity/hardened images).

This is the exact same double-load pattern already fixed for the
neighboring `bpf-restrict-fs.c` in #43177 ("core/bpf-restrict-fs: avoid
loading the LSM BPF program twice at boot"), just not applied to this
sibling file.

## Fix

Drop the trial open/load/attach from `bpf_restrict_fsaccess_supported()`
— it now only checks `lsm_supported("bpf")`. If `BPF_LSM_MAC` attach
ever isn't actually usable, `bpf_restrict_fsaccess_setup()`'s own
`restrict_fsaccess_bpf__attach()` call will fail, which is already
logged and handled gracefully by its caller. So the program only needs
to be opened/loaded once, in `bpf_restrict_fsaccess_setup()`, instead of
once per function.

## Testing

Built and booted a Fedora 44 `mkosi` VM (aarch64 KVM) with
`BPF_FRAMEWORK` compiled in, both with and without this patch, and
compared the `restrict_fsaccess` helper's `check` command (which calls
`bpf_restrict_fsaccess_supported()`) under `strace -c -e trace=bpf`:

Before:
```
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ----------------
100.00    0.004494         136        33         1 bpf
------ ----------- ----------- --------- --------- ----------------
100.00    0.004494         136        33         1 total
```

After:
```
(no bpf() syscalls at all)
```

So the redundant kernel verifier pass (33 `bpf()` syscalls, ~4.5ms) is
eliminated from the probe entirely — that cost is now paid exactly once,
in `bpf_restrict_fsaccess_setup()`, instead of twice per boot.

Also verified in the same VM:
- `test-bpf-restrict-fs` still passes (unrelated sibling BPF program,
  unaffected by this change).
- `test-bpf-restrict-fsaccess check` still correctly reports BPF LSM as
  supported and correctly fails when `dm-verity.require_signatures` is
  not enabled (unaffected code path).
- `systemctl is-system-running` reports `running` with 0 failed units
  after boot.
