### PR TITLE
resolved: share one mDNS querier between subscribers of the same browse question

### DIFF
--- a/src/resolve/resolved-dns-browse-services.c
+++ b/src/resolve/resolved-dns-browse-services.c
@@ -8,6 +8,7 @@
 #include "event-util.h"
 #include "log.h"
 #include "random-util.h"
+#include "siphash24.h"
 #include "resolved-dns-browse-services.h"
 #include "resolved-dns-cache.h"
 #include "resolved-dns-query.h"
@@ -870,6 +871,97 @@ void dns_browse_services_restart(Manager *m) {
         }
 }
 
+static void dns_service_querier_hash_func(const DnsServiceQuerier *sq, struct siphash *state) {
+        assert(sq);
+
+        dns_resource_key_hash_func(sq->key, state);
+        siphash24_compress_typesafe(sq->ifindex, state);
+        siphash24_compress_typesafe(sq->flags, state);
+}
+
+static int dns_service_querier_compare_func(const DnsServiceQuerier *a, const DnsServiceQuerier *b) {
+        int r;
+
+        assert(a);
+        assert(b);
+
+        r = dns_resource_key_compare_func(a->key, b->key);
+        if (r != 0)
+                return r;
+
+        r = CMP(a->ifindex, b->ifindex);
+        if (r != 0)
+                return r;
+
+        return CMP(a->flags, b->flags);
+}
+
+DEFINE_PRIVATE_HASH_OPS(
+                dns_service_querier_hash_ops,
+                DnsServiceQuerier,
+                dns_service_querier_hash_func,
+                dns_service_querier_compare_func);
+
+/* Bring a subscriber that joined an already-running querier up to speed: synthesize "added" events
+ * for everything discovered so far, mirroring what a first cache-served query would have yielded. */
+static int dns_service_browser_send_snapshot(DnsServiceBrowser *sb) {
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *array = NULL, *vm = NULL;
+        int r;
+
+        assert(sb);
+        assert(sb->querier);
+
+        LIST_FOREACH(dns_services, service, sb->querier->dns_services) {
+                _cleanup_free_ char *name = NULL, *type = NULL, *domain = NULL;
+                _cleanup_(sd_json_variant_unrefp) sd_json_variant *entry = NULL;
+
+                r = dns_service_split(service->rr->ptr.name, &name, &type, &domain);
+                if (r < 0)
+                        return r;
+
+                if (!name) {
+                        type = mfree(type);
+                        domain = mfree(domain);
+                        r = dns_service_split(dns_resource_key_name(service->rr->key), &name, &type, &domain);
+                        if (r < 0)
+                                return r;
+                }
+
+                if (!type)
+                        continue;
+
+                r = sd_json_buildo(
+                                &entry,
+                                SD_JSON_BUILD_PAIR_STRING(
+                                                "updateFlag",
+                                                browse_service_update_event_to_string(
+                                                                BROWSE_SERVICE_UPDATE_ADDED)),
+                                SD_JSON_BUILD_PAIR_INTEGER("family", service->family),
+                                SD_JSON_BUILD_PAIR_CONDITION(
+                                                !isempty(name), "name", SD_JSON_BUILD_STRING(name)),
+                                SD_JSON_BUILD_PAIR_CONDITION(
+                                                !isempty(type), "type", SD_JSON_BUILD_STRING(type)),
+                                SD_JSON_BUILD_PAIR_CONDITION(
+                                                !isempty(domain), "domain", SD_JSON_BUILD_STRING(domain)),
+                                SD_JSON_BUILD_PAIR_INTEGER("ifindex", service->ifindex));
+                if (r < 0)
+                        return r;
+
+                r = sd_json_variant_append_array(&array, entry);
+                if (r < 0)
+                        return r;
+        }
+
+        if (sd_json_variant_is_blank_array(array))
+                return 0;
+
+        r = sd_json_buildo(&vm, SD_JSON_BUILD_PAIR_VARIANT("browserServiceData", array));
+        if (r < 0)
+                return r;
+
+        return sd_varlink_notify(sb->link, vm);
+}
+
 static int dns_service_querier_new(
                 Manager *m,
                 DnsQuestion *question_utf8,
@@ -987,17 +1079,31 @@ int dns_subscribe_browse_service(
         if (r < 0)
                 return log_error_errno(r, "Failed to create DNS question for IDNA version: %m");
 
-        r = dns_service_querier_new(m, question_utf8, question_idna, ifindex, flags, &sq);
-        if (r < 0)
-                return r;
+        /* One querier per browse question: if somebody is asking this already, join them instead of
+         * multicasting the same question a second time. */
+        DnsServiceQuerier *shared = hashmap_get(
+                        m->dns_service_queriers,
+                        &(DnsServiceQuerier) {
+                                .key = dns_question_first_key(question_utf8),
+                                .ifindex = ifindex,
+                                .flags = flags,
+                        });
+        if (shared)
+                sq = dns_service_querier_ref(shared);
+        else {
+                r = dns_service_querier_new(m, question_utf8, question_idna, ifindex, flags, &sq);
+                if (r < 0)
+                        return r;
 
-        r = hashmap_ensure_put(&m->dns_service_queriers, NULL, sq, sq);
-        if (r < 0)
-                return log_error_errno(r, "Failed to add service querier to the hashmap: %m");
+                r = hashmap_ensure_put(&m->dns_service_queriers, &dns_service_querier_hash_ops, sq, sq);
+                if (r < 0)
+                        return log_error_errno(r, "Failed to add service querier to the hashmap: %m");
+        }
 
         sb = new(DnsServiceBrowser, 1);
         if (!sb) {
-                hashmap_remove(m->dns_service_queriers, sq);
+                if (!shared)
+                        hashmap_remove(m->dns_service_queriers, sq);
                 return log_oom();
         }
 
@@ -1012,6 +1118,14 @@ int dns_subscribe_browse_service(
         r = hashmap_ensure_put(&m->dns_service_browsers, NULL, link, sb);
         if (r < 0)
                 return log_error_errno(r, "Failed to add service browser to the hashmap: %m");
+
+        /* A late joiner inherits the querier's current view; hand it over right away. Everything
+         * after this arrives as regular diff events like for any other subscriber. */
+        if (shared) {
+                r = dns_service_browser_send_snapshot(sb);
+                if (r < 0)
+                        log_debug_errno(r, "Failed to send initial browse snapshot, ignoring: %m");
+        }
 
         TAKE_PTR(sb);
 

--- a/src/resolve/resolved-dns-browse-services.c
+++ b/src/resolve/resolved-dns-browse-services.c
@@ -84,46 +84,46 @@ static usec_t mdns_maintenance_jitter(usec_t ttl_usec) {
         return random_u64_range(2 * ttl_usec / 100);
 }
 
-static void mdns_browser_schedule_maintenance(DnsServiceBrowser *sb);
+static void mdns_querier_schedule_maintenance(DnsServiceQuerier *sq);
 
 /* Revisit both families: the ladder is armed against the soonest expiry across both, and the callee
  * logs about failures itself. */
-static void mdns_browser_revisit_cache_both(DnsServiceBrowser *sb) {
+static void mdns_querier_revisit_cache_both(DnsServiceQuerier *sq) {
         int af;
 
-        assert(sb);
+        assert(sq);
 
         FOREACH_ARGUMENT(af, AF_INET, AF_INET6)
-                (void) mdns_browser_revisit_cache(sb, af);
+                (void) mdns_querier_revisit_cache(sq, af);
 }
 
 static void mdns_maintenance_query_complete(DnsQuery *q) {
-        _cleanup_(dns_service_browser_unrefp) DnsServiceBrowser *sb = NULL;
+        _cleanup_(dns_service_querier_unrefp) DnsServiceQuerier *sq = NULL;
         _cleanup_(dns_query_freep) DnsQuery *query = q;
 
         assert(query);
         assert(query->manager);
 
-        sb = dns_service_browser_ref(query->service_browser_request);
-        if (!sb)
+        sq = dns_service_querier_ref(query->service_querier_request);
+        if (!sq)
                 return;
 
         if (query->state != DNS_TRANSACTION_SUCCESS)
                 return;
 
-        mdns_browser_revisit_cache_both(sb);
+        mdns_querier_revisit_cache_both(sq);
 }
 
-/* A maintenance query in flight pins the browser via its reference; abort it when the browser's
- * subscription ends, so the browser can be released. (Freeing the query clears the tracking field,
+/* A maintenance query in flight pins the querier via its reference; abort it when the last
+ * subscriber is gone, so the querier can be released. (Freeing the query clears the tracking field,
  * whichever way the query goes away — see dns_query_free().) */
-static void mdns_browser_abort_maintenance_query(DnsServiceBrowser *sb) {
-        assert(sb);
+static void mdns_querier_abort_maintenance_query(DnsServiceQuerier *sq) {
+        assert(sq);
 
-        if (!sb->maintenance_query)
+        if (!sq->maintenance_query)
                 return;
 
-        dns_query_complete(sb->maintenance_query, DNS_TRANSACTION_ABORTED);
+        dns_query_complete(sq->maintenance_query, DNS_TRANSACTION_ABORTED);
 }
 
 /* One re-confirmation ladder per browser: the maintenance query re-issues the
@@ -133,81 +133,81 @@ static void mdns_browser_abort_maintenance_query(DnsServiceBrowser *sb) {
  * multicasting the same question N*M times when N clients browse a type with M
  * instances, while preserving loss-resilient re-confirmation and prompt
  * removal-at-expiry. */
-int mdns_browser_maintenance(sd_event_source *s, uint64_t usec, void *userdata) {
-        _cleanup_(dns_service_browser_unrefp) DnsServiceBrowser *sb = NULL;
+int mdns_querier_maintenance(sd_event_source *s, uint64_t usec, void *userdata) {
+        _cleanup_(dns_service_querier_unrefp) DnsServiceQuerier *sq = NULL;
         _cleanup_(dns_query_freep) DnsQuery *q = NULL;
         int r;
 
         /* Hold a ref for the duration of the handler, as mdns_next_query_schedule() does. */
-        sb = dns_service_browser_ref(ASSERT_PTR(userdata));
+        sq = dns_service_querier_ref(ASSERT_PTR(userdata));
 
         /* Terminal: the soonest expiry has elapsed. Reconcile the cache (this prunes expired records
          * and emits "removed") and reschedule against what remains — the revisit frees services,
-         * never the browser that owns this timer. */
-        if (sb->rr_ttl_state == DNS_RECORD_TTL_STATE_100_PERCENT) {
-                sb->rr_ttl_state = DNS_RECORD_TTL_STATE_80_PERCENT;
-                mdns_browser_revisit_cache_both(sb);
-                mdns_browser_schedule_maintenance(sb);
+         * never the querier that owns this timer. */
+        if (sq->rr_ttl_state == DNS_RECORD_TTL_STATE_100_PERCENT) {
+                sq->rr_ttl_state = DNS_RECORD_TTL_STATE_80_PERCENT;
+                mdns_querier_revisit_cache_both(sq);
+                mdns_querier_schedule_maintenance(sq);
                 return 0;
         }
 
         /* Advance the ladder and re-issue the browse question to re-confirm the RRset. Errors are
          * logged and swallowed: a negative return would make sd-event disable the source over the
          * re-arm, leaving the ladder dead for good. */
-        sb->rr_ttl_state++;
+        sq->rr_ttl_state++;
 
-        mdns_browser_schedule_maintenance(sb);
+        mdns_querier_schedule_maintenance(sq);
 
-        /* At most one maintenance query in flight per browser: a rung's query that has not completed
+        /* At most one maintenance query in flight per querier: a rung's query that has not completed
          * by the next rung is superseded. */
-        mdns_browser_abort_maintenance_query(sb);
+        mdns_querier_abort_maintenance_query(sq);
 
         r = dns_query_new(
-                        sb->manager,
+                        sq->manager,
                         &q,
-                        sb->question_utf8,
-                        sb->question_idna,
+                        sq->question_utf8,
+                        sq->question_idna,
                         /* question_bypass= */ NULL,
-                        sb->ifindex,
-                        sb->flags);
+                        sq->ifindex,
+                        sq->flags | SD_RESOLVED_QUERY_CONTINUOUS | SD_RESOLVED_NO_CACHE);
         if (r < 0) {
                 log_warning_errno(r, "Failed to create mDNS query for maintenance, ignoring: %m");
                 return 0;
         }
 
         q->complete = mdns_maintenance_query_complete;
-        q->service_browser_request = dns_service_browser_ref(sb);
+        q->service_querier_request = dns_service_querier_ref(sq);
 
         /* Track the query before starting it: dns_query_go() completes a query synchronously when no
          * scope matches the question or the cache answers it, and the completion handler then frees
          * the query and clears this field again. A pointer stored only afterwards would dangle. */
-        sb->maintenance_query = TAKE_PTR(q);
+        sq->maintenance_query = TAKE_PTR(q);
 
-        r = dns_query_go(sb->maintenance_query);
+        r = dns_query_go(sq->maintenance_query);
         if (r < 0) {
                 log_warning_errno(r, "Failed to send mDNS maintenance query, ignoring: %m");
-                sb->maintenance_query = dns_query_free(sb->maintenance_query);
+                sq->maintenance_query = dns_query_free(sq->maintenance_query);
                 return 0;
         }
 
         return 0;
 }
 
-/* (Re)arm the browser's single maintenance ladder against the soonest-expiring
+/* (Re)arm the querier's single maintenance ladder against the soonest-expiring
  * discovered service. Disables the timer when no services remain. */
-static void mdns_browser_schedule_maintenance(DnsServiceBrowser *sb) {
+static void mdns_querier_schedule_maintenance(DnsServiceQuerier *sq) {
         DnssdDiscoveredService *soonest = NULL;
         usec_t next_time = 0;
         int r;
 
-        assert(sb);
+        assert(sq);
 
-        LIST_FOREACH(dns_services, s, sb->dns_services)
+        LIST_FOREACH(dns_services, s, sq->dns_services)
                 if (!soonest || s->until < soonest->until)
                         soonest = s;
 
         if (!soonest) {
-                sb->maintenance_event = sd_event_source_disable_unref(sb->maintenance_event);
+                sq->maintenance_event = sd_event_source_disable_unref(sq->maintenance_event);
                 return;
         }
 
@@ -215,47 +215,47 @@ static void mdns_browser_schedule_maintenance(DnsServiceBrowser *sb) {
 
         /* Skip ladder increments whose scheduled time already elapsed (e.g. a
          * service discovered late in its lifetime, or a lingering expired one). */
-        while (sb->rr_ttl_state >= DNS_RECORD_TTL_STATE_80_PERCENT &&
-               sb->rr_ttl_state < _DNS_RECORD_TTL_STATE_MAX) {
-                next_time = mdns_maintenance_next_time(soonest->until, ttl_usec, sb->rr_ttl_state);
+        while (sq->rr_ttl_state >= DNS_RECORD_TTL_STATE_80_PERCENT &&
+               sq->rr_ttl_state < _DNS_RECORD_TTL_STATE_MAX) {
+                next_time = mdns_maintenance_next_time(soonest->until, ttl_usec, sq->rr_ttl_state);
                 if (next_time >= usec)
                         break;
 
-                sb->rr_ttl_state++;
+                sq->rr_ttl_state++;
         }
 
         if (next_time < usec) {
                 /* Already at/past expiry: re-check shortly so the terminal branch
                  * prunes the record from cache and emits the removal. */
                 next_time = usec_add(usec, USEC_PER_SEC);
-                sb->rr_ttl_state = DNS_RECORD_TTL_STATE_100_PERCENT;
+                sq->rr_ttl_state = DNS_RECORD_TTL_STATE_100_PERCENT;
         }
 
         /* The 2% jitter desynchronizes the §5.2 re-confirmation queries across queriers; the terminal
          * rung is our own expiry check, not a query — arming it past the record's actual expiry would
          * only delay the removal this ladder exists to guarantee. */
-        usec_t jitter = sb->rr_ttl_state == DNS_RECORD_TTL_STATE_100_PERCENT ?
+        usec_t jitter = sq->rr_ttl_state == DNS_RECORD_TTL_STATE_100_PERCENT ?
                 0 : mdns_maintenance_jitter(ttl_usec);
 
         r = event_reset_time(
-                        sb->manager->event,
-                        &sb->maintenance_event,
+                        sq->manager->event,
+                        &sq->maintenance_event,
                         CLOCK_BOOTTIME,
                         usec_add(next_time, jitter),
                         /* accuracy= */ 0,
-                        mdns_browser_maintenance,
-                        sb,
+                        mdns_querier_maintenance,
+                        sq,
                         /* priority= */ 0,
-                        "mdns-browser-maintenance",
+                        "mdns-querier-maintenance",
                         /* force_reset= */ true);
         if (r < 0)
                 log_warning_errno(r, "Failed to schedule mDNS maintenance query, ignoring: %m");
 }
 
-int dns_add_new_service(DnsServiceBrowser *sb, DnsResourceRecord *rr, int owner_family, int ifindex, usec_t until) {
+int dns_add_new_service(DnsServiceQuerier *sq, DnsResourceRecord *rr, int owner_family, int ifindex, usec_t until) {
         _cleanup_(dnssd_discovered_service_freep) DnssdDiscoveredService *s = NULL;
 
-        assert(sb);
+        assert(sq);
         assert(rr);
 
         s = new(DnssdDiscoveredService, 1);
@@ -271,23 +271,23 @@ int dns_add_new_service(DnsServiceBrowser *sb, DnsResourceRecord *rr, int owner_
         if (!s->rr)
                 return log_oom();
 
-        LIST_PREPEND(dns_services, sb->dns_services, s);
+        LIST_PREPEND(dns_services, sq->dns_services, s);
         TAKE_PTR(s);
 
         /* The list changed: wind the ladder back (see rr_ttl_state). */
-        sb->rr_ttl_state = DNS_RECORD_TTL_STATE_80_PERCENT;
+        sq->rr_ttl_state = DNS_RECORD_TTL_STATE_80_PERCENT;
         return 0;
 }
 
-void dns_remove_service(DnsServiceBrowser *sb, DnssdDiscoveredService *service) {
-        assert(sb);
+void dns_remove_service(DnsServiceQuerier *sq, DnssdDiscoveredService *service) {
+        assert(sq);
         assert(service);
 
-        LIST_REMOVE(dns_services, sb->dns_services, service);
+        LIST_REMOVE(dns_services, sq->dns_services, service);
         dnssd_discovered_service_free(service);
 
         /* The list changed: wind the ladder back (see rr_ttl_state). */
-        sb->rr_ttl_state = DNS_RECORD_TTL_STATE_80_PERCENT;
+        sq->rr_ttl_state = DNS_RECORD_TTL_STATE_80_PERCENT;
 }
 
 DnssdDiscoveredService *dnssd_discovered_service_free(DnssdDiscoveredService *service) {
@@ -307,11 +307,11 @@ static void mdns_service_update(DnssdDiscoveredService *service, DnsResourceReco
         service->rr->ttl = rr->ttl;
 }
 
-static int mdns_answer_item_ifindex(DnsServiceBrowser *sb, DnsAnswerItem *item) {
-        assert(sb);
+static int mdns_answer_item_ifindex(DnsServiceQuerier *sq, DnsAnswerItem *item) {
+        assert(sq);
         assert(item);
 
-        return item->ifindex > 0 ? item->ifindex : sb->ifindex;
+        return item->ifindex > 0 ? item->ifindex : sq->ifindex;
 }
 
 static int dns_service_matches(
@@ -365,14 +365,14 @@ int dns_service_match_and_update(
 }
 
 int mdns_answer_contains_service(
-                DnsServiceBrowser *sb,
+                DnsServiceQuerier *sq,
                 DnsAnswer *answer,
                 DnssdDiscoveredService *service) {
 
         DnsAnswerItem *item;
         int r;
 
-        assert(sb);
+        assert(sq);
         assert(service);
 
         DNS_ANSWER_FOREACH_ITEM(item, answer) {
@@ -380,7 +380,7 @@ int mdns_answer_contains_service(
                                 service,
                                 item->rr,
                                 service->family,
-                                mdns_answer_item_ifindex(sb, item));
+                                mdns_answer_item_ifindex(sq, item));
                 if (r < 0)
                         return r;
                 if (r > 0)
@@ -398,47 +398,47 @@ void dns_browse_services_purge(Manager *m, int family) {
         if (!m)
                 return;
 
-        DnsServiceBrowser *sb;
-        HASHMAP_FOREACH(sb, m->dns_service_browsers) {
-                r = sd_event_source_set_enabled(sb->schedule_event, SD_EVENT_OFF);
+        DnsServiceQuerier *sq;
+        HASHMAP_FOREACH(sq, m->dns_service_queriers) {
+                r = sd_event_source_set_enabled(sq->schedule_event, SD_EVENT_OFF);
                 if (r < 0)
-                        log_error_errno(r, "Failed to disable event source for service browser, ignoring: %m");
+                        log_error_errno(r, "Failed to disable event source for service querier, ignoring: %m");
 
                 if (IN_SET(family, AF_INET, AF_UNSPEC)) {
-                     r = mdns_browser_revisit_cache(sb, AF_INET);
+                        r = mdns_querier_revisit_cache(sq, AF_INET);
                         if (r < 0)
                                 log_error_errno(r, "Failed to revisit cache for IPv4, ignoring: %m");
                 }
 
                 if (IN_SET(family, AF_INET6, AF_UNSPEC)) {
-                        r = mdns_browser_revisit_cache(sb, AF_INET6);
+                        r = mdns_querier_revisit_cache(sq, AF_INET6);
                         if (r < 0)
                                 log_error_errno(r, "Failed to revisit cache for IPv6, ignoring: %m");
                 }
         }
 }
 
-int mdns_manage_services_answer(DnsServiceBrowser *sb, DnsAnswer *answer, int owner_family) {
+int mdns_manage_services_answer(DnsServiceQuerier *sq, DnsAnswer *answer, int owner_family) {
         DnsAnswerItem *item;
         _cleanup_(sd_json_variant_unrefp) sd_json_variant *array = NULL;
         int r;
 
-        assert(sb);
+        assert(sq);
 
         /* Check for new service added */
         DNS_ANSWER_FOREACH_ITEM(item, answer) {
                 _cleanup_free_ char *name = NULL, *type = NULL, *domain = NULL;
                 _cleanup_(sd_json_variant_unrefp) sd_json_variant *entry = NULL;
-                int ifindex = mdns_answer_item_ifindex(sb, item);
+                int ifindex = mdns_answer_item_ifindex(sq, item);
 
-                r = dns_service_match_and_update(sb->dns_services, item->rr, owner_family, ifindex, item->until);
+                r = dns_service_match_and_update(sq->dns_services, item->rr, owner_family, ifindex, item->until);
                 if (r < 0) {
                         log_error_errno(r, "Failed to match DNS service: %m");
                         goto finish;
                 }
                 if (r > 0) {
                         /* Seen again: wind the ladder back (see rr_ttl_state). */
-                        sb->rr_ttl_state = DNS_RECORD_TTL_STATE_80_PERCENT;
+                        sq->rr_ttl_state = DNS_RECORD_TTL_STATE_80_PERCENT;
                         continue;
                 }
 
@@ -461,7 +461,7 @@ int mdns_manage_services_answer(DnsServiceBrowser *sb, DnsAnswer *answer, int ow
                 if (!type)
                         continue;
 
-                r = dns_add_new_service(sb, item->rr, owner_family, ifindex, item->until);
+                r = dns_add_new_service(sq, item->rr, owner_family, ifindex, item->until);
                 if (r < 0) {
                         log_error_errno(r, "Failed to add new DNS service: %m");
                         goto finish;
@@ -501,7 +501,7 @@ int mdns_manage_services_answer(DnsServiceBrowser *sb, DnsAnswer *answer, int ow
         }
 
         /* Check for services removed */
-        LIST_FOREACH(dns_services, service, sb->dns_services) {
+        LIST_FOREACH(dns_services, service, sq->dns_services) {
                 _cleanup_free_ char *name = NULL, *type = NULL, *domain = NULL;
                 _cleanup_(sd_json_variant_unrefp) sd_json_variant *entry = NULL;
                 int ifindex;
@@ -509,7 +509,7 @@ int mdns_manage_services_answer(DnsServiceBrowser *sb, DnsAnswer *answer, int ow
                 if (service->family != owner_family)
                         continue;
 
-                r = mdns_answer_contains_service(sb, answer, service);
+                r = mdns_answer_contains_service(sq, answer, service);
                 if (r < 0) {
                         log_error_errno(r, "Failed to match DNS answer against service list: %m");
                         goto finish;
@@ -537,7 +537,7 @@ int mdns_manage_services_answer(DnsServiceBrowser *sb, DnsAnswer *answer, int ow
                 /* Capture ifindex before removing the service */
                 ifindex = service->ifindex;
 
-                dns_remove_service(sb, service);
+                dns_remove_service(sq, service);
 
                 log_debug("Remove from the list %s, %s, %s, %s, %d",
                           strna(name),
@@ -569,11 +569,11 @@ int mdns_manage_services_answer(DnsServiceBrowser *sb, DnsAnswer *answer, int ow
                 }
         }
 
-        /* (Re-)arm the browser's maintenance ladder once against the reconciled list — doing it per
+        /* (Re-)arm the querier's maintenance ladder once against the reconciled list — doing it per
          * added/removed instance inside the loops above would make reconciling an answer with M
          * instances O(M²), with M driven by untrusted multicast input. This also disables the timer
          * when no discovered service remains. */
-        mdns_browser_schedule_maintenance(sb);
+        mdns_querier_schedule_maintenance(sq);
 
         if (!sd_json_variant_is_blank_array(array)) {
                 _cleanup_(sd_json_variant_unrefp) sd_json_variant *vm = NULL;
@@ -585,25 +585,34 @@ int mdns_manage_services_answer(DnsServiceBrowser *sb, DnsAnswer *answer, int ow
                         goto finish;
                 }
 
-                r = sd_varlink_notify(sb->link, vm);
-                if (r < 0) {
-                        log_error_errno(r, "Failed to notify via varlink: %m");
-                        goto finish;
+                /* Deliver the same update to every subscriber of this querier. A failure to notify
+                 * one of them (e.g. mid-disconnect) must not keep the others from being served. */
+                LIST_FOREACH(subscribers, sb, sq->subscribers) {
+                        r = sd_varlink_notify(sb->link, vm);
+                        if (r < 0)
+                                log_debug_errno(r, "Failed to notify a browse subscriber via varlink, ignoring: %m");
                 }
         }
 
         return 0;
 
 finish:
-        return sd_varlink_error_errno(sb->link, r);
+        /* The events accumulated for this batch are lost with the failure. Terminate every
+         * subscription with an error instead of carrying on silently -- an errored-out client knows
+         * to resubscribe and is then served a fresh snapshot, while a silently dropped batch would
+         * leave its view stale with no signal that anything is missing. */
+        LIST_FOREACH(subscribers, sb, sq->subscribers)
+                (void) sd_varlink_error_errno(sb->link, r);
+
+        return r;
 }
 
-int mdns_browser_revisit_cache(DnsServiceBrowser *sb, int owner_family) {
+int mdns_querier_revisit_cache(DnsServiceQuerier *sq, int owner_family) {
         _cleanup_(dns_answer_unrefp) DnsAnswer *lookup_ret_answer = NULL;
         int r;
 
-        assert(sb);
-        assert(sb->manager);
+        assert(sq);
+        assert(sq->manager);
 
         /* The reconciliation must see real cache expiry times: without SD_RESOLVED_NO_STALE the
          * lookup substitutes the stale-serving clamp for item->until — an absolute timestamp ~30s
@@ -611,21 +620,21 @@ int mdns_browser_revisit_cache(DnsServiceBrowser *sb, int owner_family) {
          * maintenance ladder in its past-expiry one-second re-check for as long as a matching
          * record stays cached. Stale serving is a per-client query feature; the browse
          * bookkeeping always wants the truth, whatever flags the subscriber passed. */
-        uint64_t lookup_flags = sb->flags | SD_RESOLVED_NO_STALE;
+        uint64_t lookup_flags = sq->flags | SD_RESOLVED_NO_STALE;
 
         /* ifindex=0 means "all interfaces". Collect the cached answers from
          * every matching mDNS scope into a single combined answer and reconcile
          * once. Reconciling per-scope would be wrong: mdns_manage_services_answer()
-         * derives removals by diffing the browser's global service list against
+         * derives removals by diffing the querier's global service list against
          * the answer it is handed, so a single scope's answer would spuriously
          * "remove" (and then, on the next scope/pass, re-"add") services that are
          * still present on other interfaces — resulting in a continuous
          * added/removed event flap for services seen on more than the current
          * scope. */
-        if (sb->ifindex == 0) {
+        if (sq->ifindex == 0) {
                 _cleanup_(dns_answer_unrefp) DnsAnswer *combined = NULL;
 
-                LIST_FOREACH(scopes, scope, sb->manager->dns_scopes) {
+                LIST_FOREACH(scopes, scope, sq->manager->dns_scopes) {
                         _cleanup_(dns_answer_unrefp) DnsAnswer *answer = NULL;
                         DnsAnswerItem *item;
 
@@ -639,7 +648,7 @@ int mdns_browser_revisit_cache(DnsServiceBrowser *sb, int owner_family) {
 
                         r = dns_cache_lookup(
                                         &scope->cache,
-                                        sb->key,
+                                        sq->key,
                                         lookup_flags,
                                         /* ret_rcode= */ NULL,
                                         &answer,
@@ -664,7 +673,7 @@ int mdns_browser_revisit_cache(DnsServiceBrowser *sb, int owner_family) {
                         }
                 }
 
-                r = mdns_manage_services_answer(sb, combined, owner_family);
+                r = mdns_manage_services_answer(sq, combined, owner_family);
                 if (r < 0)
                         return log_error_errno(r, "Failed to manage mDNS services after cache lookup for all interfaces: %m");
 
@@ -672,13 +681,13 @@ int mdns_browser_revisit_cache(DnsServiceBrowser *sb, int owner_family) {
         }
 
         /* Single scope for specifically requested interface */
-        DnsScope *scope = manager_find_scope_from_protocol(sb->manager, sb->ifindex, DNS_PROTOCOL_MDNS, owner_family);
+        DnsScope *scope = manager_find_scope_from_protocol(sq->manager, sq->ifindex, DNS_PROTOCOL_MDNS, owner_family);
         if (!scope) {
                 /* No scope to reconcile against — mDNS is off on the link, or the link is gone. Treat
                  * it like the all-interfaces path with no matching scope and reconcile against an
                  * empty answer: lingering instances get their removed events and the ladder winds
                  * down, instead of re-checking a list nothing can update once per second. */
-                r = mdns_manage_services_answer(sb, NULL, owner_family);
+                r = mdns_manage_services_answer(sq, NULL, owner_family);
                 if (r < 0)
                         return log_error_errno(r, "Failed to manage mDNS services without a scope: %m");
 
@@ -689,7 +698,7 @@ int mdns_browser_revisit_cache(DnsServiceBrowser *sb, int owner_family) {
 
         r = dns_cache_lookup(
                         &scope->cache,
-                        sb->key,
+                        sq->key,
                         lookup_flags,
                         /* ret_rcode= */ NULL,
                         &lookup_ret_answer,
@@ -699,7 +708,7 @@ int mdns_browser_revisit_cache(DnsServiceBrowser *sb, int owner_family) {
         if (r < 0)
                 return log_error_errno(r, "Failed to look up DNS cache for service browser key: %m");
 
-        r = mdns_manage_services_answer(sb, lookup_ret_answer, owner_family);
+        r = mdns_manage_services_answer(sq, lookup_ret_answer, owner_family);
         if (r < 0)
                 return log_error_errno(r, "Failed to manage mDNS services after cache lookup: %m");
 
@@ -707,18 +716,18 @@ int mdns_browser_revisit_cache(DnsServiceBrowser *sb, int owner_family) {
 }
 
 int mdns_notify_browsers_goodbye(DnsScope *scope) {
-        DnsServiceBrowser *sb;
+        DnsServiceQuerier *sq;
         int r;
 
         if (!scope)
                 return 0;
 
-        HASHMAP_FOREACH(sb, scope->manager->dns_service_browsers) {
-                r = mdns_browser_revisit_cache(sb, scope->family);
+        HASHMAP_FOREACH(sq, scope->manager->dns_service_queriers) {
+                r = mdns_querier_revisit_cache(sq, scope->family);
                 if (r < 0)
                         return log_error_errno(
                                         r,
-                                        "Failed to revisit cache for service browser with family %d: %m",
+                                        "Failed to revisit cache for service querier with family %d: %m",
                                         scope->family);
         }
 
@@ -726,7 +735,7 @@ int mdns_notify_browsers_goodbye(DnsScope *scope) {
 }
 
 int mdns_notify_browsers_unsolicited_updates(Manager *m, DnsAnswer *answer, int owner_family) {
-        DnsServiceBrowser *sb;
+        DnsServiceQuerier *sq;
         int r;
 
         assert(m);
@@ -734,26 +743,26 @@ int mdns_notify_browsers_unsolicited_updates(Manager *m, DnsAnswer *answer, int 
         if (!answer)
                 return 0;
 
-        HASHMAP_FOREACH(sb, m->dns_service_browsers) {
+        HASHMAP_FOREACH(sq, m->dns_service_queriers) {
 
-                r = dns_answer_match_key(answer, sb->key, NULL);
+                r = dns_answer_match_key(answer, sq->key, NULL);
                 if (r < 0)
                         return log_error_errno(
                                         r,
-                                        "Failed to match answer key with service browser's key: %m");
+                                        "Failed to match answer key with service querier's key: %m");
                 if (r == 0)
                         continue;
 
-                r = mdns_browser_revisit_cache(sb, owner_family);
+                r = mdns_querier_revisit_cache(sq, owner_family);
                 if (r < 0)
-                        return log_error_errno(r, "Failed to revisit cache for service browser: %m");
+                        return log_error_errno(r, "Failed to revisit cache for service querier: %m");
         }
 
         return 0;
 }
 
 static void mdns_browse_service_query_complete(DnsQuery *q) {
-        _cleanup_(dns_service_browser_unrefp) DnsServiceBrowser *sb = NULL;
+        _cleanup_(dns_service_querier_unrefp) DnsServiceQuerier *sq = NULL;
         _cleanup_(dns_query_freep) DnsQuery *query = q;
         int r;
 
@@ -763,70 +772,64 @@ static void mdns_browse_service_query_complete(DnsQuery *q) {
         if (query->state != DNS_TRANSACTION_SUCCESS)
                 return;
 
-        sb = dns_service_browser_ref(query->service_browser_request);
-        if (!sb)
+        sq = dns_service_querier_ref(query->service_querier_request);
+        if (!sq)
                 return;
 
-        r = mdns_browser_revisit_cache(sb, query->answer_family);
+        r = mdns_querier_revisit_cache(sq, query->answer_family);
         if (r < 0)
-                return (void) log_error_errno(r, "Failed to revisit cache for service browser: %m");
+                return (void) log_error_errno(r, "Failed to revisit cache for service querier: %m");
 
         /* When the query is answered from cache, we only get answers for one
          * answer_family i.e. either ipv4 or ipv6. We need to perform another
          * cache lookup for the other answer_family */
         if (query->answer_query_flags == SD_RESOLVED_FROM_CACHE) {
-                r = mdns_browser_revisit_cache(sb, query->answer_family == AF_INET ? AF_INET6 : AF_INET);
+                r = mdns_querier_revisit_cache(sq, query->answer_family == AF_INET ? AF_INET6 : AF_INET);
                 if (r < 0)
-                        return (void) log_error_errno(r, "Failed to revisit cache for service browser: %m");
+                        return (void) log_error_errno(r, "Failed to revisit cache for service querier: %m");
         }
 }
 
 static int mdns_next_query_schedule(sd_event_source *s, uint64_t usec, void *userdata) {
-        _cleanup_(dns_service_browser_unrefp) DnsServiceBrowser *sb = NULL;
+        _cleanup_(dns_service_querier_unrefp) DnsServiceQuerier *sq = NULL;
         _cleanup_(dns_query_freep) DnsQuery *q = NULL;
+        uint64_t flags;
         int r;
 
         assert(userdata);
-        assert_se(sb = dns_service_browser_ref(userdata));
+        assert_se(sq = dns_service_querier_ref(userdata));
 
-        /* If the varlink connection has a userdata, then that means the previous query has not been finished. */
-        if (!sd_varlink_get_userdata(sb->link)) {
+        /* RFC 6762 Section 5.2 outlines timing requirements for continuous queries. Only the very
+         * first query may be served from the cache; every later one exists to poke the network.
+         * sq->flags itself stays untouched: it is part of the querier's identity. */
+        flags = sq->flags | SD_RESOLVED_QUERY_CONTINUOUS;
+        if (sq->delay != 0)
+                flags |= SD_RESOLVED_NO_CACHE;
 
-                /* Enable the answer from the cache for the very first query */
-                if (sb->delay == 0)
-                        SET_FLAG(sb->flags, SD_RESOLVED_NO_CACHE, false);
+        r = dns_query_new(sq->manager, &q, sq->question_utf8, sq->question_idna, NULL, sq->ifindex, flags);
+        if (r < 0)
+                return log_error_errno(r, "Failed to create new DNS query: %m");
 
-                /* Set the flag indicating that the query is continuous.
-                 * RFC 6762 Section 5.2 outlines timing requirements for continuous queries. */
-                sb->flags |= SD_RESOLVED_QUERY_CONTINUOUS;
+        /* Continuous queries are not tracked individually: each one pins the querier through its own
+         * reference, so one firing before the previous one completed is harmless. */
+        q->complete = mdns_browse_service_query_complete;
+        q->service_querier_request = dns_service_querier_ref(sq);
 
-                r = dns_query_new(sb->manager, &q, sb->question_utf8, sb->question_idna, NULL, sb->ifindex, sb->flags);
-                if (r < 0)
-                        return log_error_errno(r, "Failed to create new DNS query: %m");
-
-                q->complete = mdns_browse_service_query_complete;
-                q->service_browser_request = dns_service_browser_ref(sb);
-                q->varlink_request = sd_varlink_ref(sb->link);
-                sd_varlink_set_userdata(sb->link, q);
-
-                r = dns_query_go(q);
-                if (r < 0)
-                        return log_error_errno(r, "Failed to send DNS query: %m");
-        }
+        r = dns_query_go(q);
+        if (r < 0)
+                return log_error_errno(r, "Failed to send DNS query: %m");
 
         /* Calculate the next query delay */
-        sb->delay = mdns_calculate_next_query_delay(sb->delay);
-
-        SET_FLAG(sb->flags, SD_RESOLVED_NO_CACHE, true);
+        sq->delay = mdns_calculate_next_query_delay(sq->delay);
 
         r = event_reset_time_relative(
-                        sb->manager->event,
-                        &sb->schedule_event,
+                        sq->manager->event,
+                        &sq->schedule_event,
                         CLOCK_BOOTTIME,
-                        sb->delay,
+                        sq->delay,
                         /* accuracy= */ 0,
                         mdns_next_query_schedule,
-                        sb,
+                        sq,
                         /* priority= */ 0,
                         "mdns-next-query-schedule",
                         /* force_reset= */ true);
@@ -841,36 +844,104 @@ static int mdns_next_query_schedule(sd_event_source *s, uint64_t usec, void *use
 void dns_browse_services_restart(Manager *m) {
         int r;
 
-        if (!(m && m->dns_service_browsers))
+        if (!(m && m->dns_service_queriers))
                 return;
 
-        DnsServiceBrowser *sb;
+        DnsServiceQuerier *sq;
 
-        HASHMAP_FOREACH(sb, m->dns_service_browsers) {
-                sb->delay = 0;
+        HASHMAP_FOREACH(sq, m->dns_service_queriers) {
+                sq->delay = 0;
 
                 r = event_reset_time_relative(
-                                sb->manager->event,
-                                &sb->schedule_event,
+                                sq->manager->event,
+                                &sq->schedule_event,
                                 CLOCK_BOOTTIME,
-                                (sb->delay * USEC_PER_SEC),
+                                (sq->delay * USEC_PER_SEC),
                                 /* accuracy= */ 0,
                                 mdns_next_query_schedule,
-                                sb,
+                                sq,
                                 /* priority= */ 0,
                                 "mdns-next-query-schedule",
                                 /* force_reset= */ true);
 
                 if (r < 0)
                         log_error_errno(r,
-                                        "Failed to reset mDNS service subscriber event for service browser: %m");
+                                        "Failed to reset mDNS service subscriber event for service querier: %m");
         }
+}
+
+static int dns_service_querier_new(
+                Manager *m,
+                DnsQuestion *question_utf8,
+                DnsQuestion *question_idna,
+                int ifindex,
+                uint64_t flags,
+                DnsServiceQuerier **ret) {
+
+        _cleanup_(dns_service_querier_unrefp) DnsServiceQuerier *sq = NULL;
+        int r;
+
+        assert(m);
+        assert(question_utf8);
+        assert(question_idna);
+        assert(ret);
+
+        sq = new(DnsServiceQuerier, 1);
+        if (!sq)
+                return log_oom();
+
+        *sq = (DnsServiceQuerier) {
+                .n_ref = 1,
+                .manager = m,
+                .question_utf8 = dns_question_ref(question_utf8),
+                .question_idna = dns_question_ref(question_idna),
+                .key = dns_resource_key_ref(dns_question_first_key(question_utf8)),
+                .ifindex = ifindex,
+                .flags = flags,
+                .delay = 0,
+        };
+
+        r = sd_event_add_time_relative(
+                        m->event,
+                        &sq->schedule_event,
+                        CLOCK_BOOTTIME,
+                        sq->delay,
+                        /* accuracy= */ 0,
+                        mdns_next_query_schedule,
+                        sq);
+        if (r < 0)
+                return r;
+
+        *ret = TAKE_PTR(sq);
+        return 0;
+}
+
+/* Detach a subscriber. The last one takes the querier off the air: it is dropped from the manager's
+ * registry and its timers are disabled right away, so no further queries hit the wire while in-flight
+ * completions (which hold their own reference) wind down against an empty subscriber list. */
+static void dns_service_querier_detach(DnsServiceQuerier *sq, DnsServiceBrowser *sb) {
+        assert(sq);
+        assert(sb);
+
+        LIST_REMOVE(subscribers, sq->subscribers, sb);
+
+        if (sq->subscribers)
+                return;
+
+        hashmap_remove(sq->manager->dns_service_queriers, sq);
+        sq->schedule_event = sd_event_source_disable_unref(sq->schedule_event);
+        sq->maintenance_event = sd_event_source_disable_unref(sq->maintenance_event);
+
+        /* An in-flight maintenance query holds a reference that would keep the orphaned querier
+         * alive until the query completed on its own. */
+        mdns_querier_abort_maintenance_query(sq);
 }
 
 int dns_subscribe_browse_service(
                 Manager *m, sd_varlink *link, const char *domain, const char *type, int ifindex, uint64_t flags) {
 
-        _cleanup_(dns_service_browser_unrefp) DnsServiceBrowser *sb = NULL;
+        _cleanup_(dns_service_querier_unrefp) DnsServiceQuerier *sq = NULL;
+        _cleanup_(dns_service_browser_freep) DnsServiceBrowser *sb = NULL;
         _cleanup_(dns_question_unrefp) DnsQuestion *question_idna = NULL, *question_utf8 = NULL;
         int r;
 
@@ -902,6 +973,10 @@ int dns_subscribe_browse_service(
                         return sd_varlink_error_invalid_parameter_name(link, "domain");
         }
 
+        /* Only mDNS continuous querying is currently supported. See RFC 6762 */
+        if (!FLAGS_SET(flags, SD_RESOLVED_MDNS))
+                return -EINVAL;
+
         r = dns_question_new_service_pointer(
                         &question_utf8, type, domain, /* convert_idna= */ false);
         if (r < 0)
@@ -912,36 +987,27 @@ int dns_subscribe_browse_service(
         if (r < 0)
                 return log_error_errno(r, "Failed to create DNS question for IDNA version: %m");
 
-        sb = new(DnsServiceBrowser, 1);
-        if (!sb)
-                return log_oom();
-
-        *sb = (DnsServiceBrowser) {
-                .n_ref = 1,
-                .manager = m,
-                .link = sd_varlink_ref(link),
-                .question_utf8 = dns_question_ref(question_utf8),
-                .question_idna = dns_question_ref(question_idna),
-                .key = dns_question_first_key(question_utf8),
-                .ifindex = ifindex,
-                .flags = flags,
-                .delay = 0,
-        };
-
-        /* Only mDNS continuous querying is currently supported. See RFC 6762 */
-        if (!FLAGS_SET(flags, SD_RESOLVED_MDNS))
-                return -EINVAL;
-
-        r = sd_event_add_time_relative(
-                        m->event,
-                        &sb->schedule_event,
-                        CLOCK_BOOTTIME,
-                        sb->delay,
-                        /* accuracy= */ 0,
-                        mdns_next_query_schedule,
-                        sb);
+        r = dns_service_querier_new(m, question_utf8, question_idna, ifindex, flags, &sq);
         if (r < 0)
                 return r;
+
+        r = hashmap_ensure_put(&m->dns_service_queriers, NULL, sq, sq);
+        if (r < 0)
+                return log_error_errno(r, "Failed to add service querier to the hashmap: %m");
+
+        sb = new(DnsServiceBrowser, 1);
+        if (!sb) {
+                hashmap_remove(m->dns_service_queriers, sq);
+                return log_oom();
+        }
+
+        *sb = (DnsServiceBrowser) {
+                .manager = m,
+                .link = sd_varlink_ref(link),
+                .querier = dns_service_querier_ref(sq),
+        };
+
+        LIST_PREPEND(subscribers, sq->subscribers, sb);
 
         r = hashmap_ensure_put(&m->dns_service_browsers, NULL, link, sb);
         if (r < 0)
@@ -952,55 +1018,47 @@ int dns_subscribe_browse_service(
         return 0;
 }
 
-/* Disarm the timers and abort the continuous browse query (anchored in the link's userdata): what has
- * to stop once the subscription is gone, whether or not the browser itself lives on for a while. */
-static void dns_service_browser_stop(DnsServiceBrowser *sb) {
-        DnsQuery *q;
-
-        assert(sb);
-
-        sb->schedule_event = sd_event_source_disable_unref(sb->schedule_event);
-        sb->maintenance_event = sd_event_source_disable_unref(sb->maintenance_event);
-
-        q = sd_varlink_get_userdata(sb->link);
-        if (q && DNS_TRANSACTION_IS_LIVE(q->state))
-                dns_query_complete(q, DNS_TRANSACTION_ABORTED);
-}
-
 /* The counterpart of dns_subscribe_browse_service(): drop the browser registered for a varlink
- * connection. A query in flight holds a reference that keeps the browser alive past this call, so the
- * subscription's machinery is stopped right here rather than left to the final free: the timers, the
- * continuous browse query, and the maintenance query — which would otherwise keep the orphaned
- * browser and its armed ladder alive until it completed. */
+ * connection. Freeing it detaches it from its querier, which is torn down — a maintenance query still
+ * in flight included — once its last subscriber is gone. */
 void dns_unsubscribe_browse_service(Manager *m, sd_varlink *link) {
-        _cleanup_(dns_service_browser_unrefp) DnsServiceBrowser *sb = NULL;
-
         assert(m);
         assert(link);
 
-        sb = hashmap_remove(m->dns_service_browsers, link);
-        if (!sb)
-                return;
-
-        dns_service_browser_stop(sb);
-        mdns_browser_abort_maintenance_query(sb);
+        dns_service_browser_free(hashmap_remove(m->dns_service_browsers, link));
 }
 
 DnsServiceBrowser *dns_service_browser_free(DnsServiceBrowser *sb) {
         if (!sb)
                 return NULL;
 
-        while (sb->dns_services)
-                dns_remove_service(sb, sb->dns_services);
-
-        dns_service_browser_stop(sb);
-
-        sb->question_idna = dns_question_unref(sb->question_idna);
-        sb->question_utf8 = dns_question_unref(sb->question_utf8);
+        if (sb->querier) {
+                dns_service_querier_detach(sb->querier, sb);
+                sb->querier = dns_service_querier_unref(sb->querier);
+        }
 
         sb->link = sd_varlink_unref(sb->link);
 
         return mfree(sb);
 }
 
-DEFINE_TRIVIAL_REF_UNREF_FUNC(DnsServiceBrowser, dns_service_browser, dns_service_browser_free);
+DnsServiceQuerier *dns_service_querier_free(DnsServiceQuerier *sq) {
+        if (!sq)
+                return NULL;
+
+        assert(!sq->subscribers);
+
+        while (sq->dns_services)
+                dns_remove_service(sq, sq->dns_services);
+
+        sq->schedule_event = sd_event_source_disable_unref(sq->schedule_event);
+        sq->maintenance_event = sd_event_source_disable_unref(sq->maintenance_event);
+
+        sq->question_idna = dns_question_unref(sq->question_idna);
+        sq->question_utf8 = dns_question_unref(sq->question_utf8);
+        sq->key = dns_resource_key_unref(sq->key);
+
+        return mfree(sq);
+}
+
+DEFINE_TRIVIAL_REF_UNREF_FUNC(DnsServiceQuerier, dns_service_querier, dns_service_querier_free);

--- a/src/resolve/resolved-dns-browse-services.c
+++ b/src/resolve/resolved-dns-browse-services.c
@@ -60,7 +60,7 @@ static inline int DNS_RECORD_TTL_STATE_TO_PERCENT(DnsRecordTTLState ttl_state) {
         return ttl_percent_table[ttl_state];
 }
 
-static usec_t mdns_maintenance_next_time(usec_t until, uint32_t ttl, DnsRecordTTLState ttl_state) {
+static usec_t mdns_maintenance_next_time(usec_t until, usec_t ttl_usec, DnsRecordTTLState ttl_state) {
         assert(ttl_state >= DNS_RECORD_TTL_STATE_80_PERCENT);
         assert(ttl_state < _DNS_RECORD_TTL_STATE_MAX);
 
@@ -68,14 +68,20 @@ static usec_t mdns_maintenance_next_time(usec_t until, uint32_t ttl, DnsRecordTT
         assert(percent > 0);
         assert(percent <= 100);
 
-        return usec_sub_unsigned(until, (100 - percent) * ttl * USEC_PER_SEC / 100);
+        return usec_sub_unsigned(until, (100 - percent) * ttl_usec / 100);
 }
 
 /* RFC 6762 section 5.2
  * A random variation of 2% of the record TTL should
  * be added to maintenance queries. */
-static usec_t mdns_maintenance_jitter(uint32_t ttl) {
-        return random_u64_range(2 * ttl * USEC_PER_SEC / 100);
+static usec_t mdns_maintenance_jitter(usec_t ttl_usec) {
+        /* A zero TTL (as seen on the wire for goodbyes, or substituted for out-of-range TTLs per RFC
+         * 2181) must yield zero jitter: random_u64_range() treats 0 as "the full 64-bit range", which
+         * would saturate the maintenance timer to never-fire. */
+        if (ttl_usec == 0)
+                return 0;
+
+        return random_u64_range(2 * ttl_usec / 100);
 }
 
 static void mdns_maintenance_query_complete(DnsQuery *q) {
@@ -130,7 +136,8 @@ static int mdns_maintenance_query(sd_event_source *s, uint64_t usec, void *userd
         q->dnsservice_request = dnssd_discovered_service_ref(service);
 
         /* Schedule the next maintenance query based on the TTL */
-        usec_t next_time = mdns_maintenance_next_time(service->until, service->rr->ttl, service->rr_ttl_state);
+        usec_t next_time = mdns_maintenance_next_time(
+                        service->until, service->rr->ttl * USEC_PER_SEC, service->rr_ttl_state);
 
         r = event_reset_time(
                         service->service_browser->manager->event,
@@ -186,10 +193,10 @@ int dns_add_new_service(DnsServiceBrowser *sb, DnsResourceRecord *rr, int owner_
          * TTL. RFC 6762 section 5.2. If service is being added after 80% of the
          * TTL has already elapsed, schedule the next query at the next 5%
          * increment. */
-        usec_t next_time = 0;
+        usec_t ttl_usec = s->rr->ttl * USEC_PER_SEC, next_time = 0;
         while (s->rr_ttl_state >= DNS_RECORD_TTL_STATE_80_PERCENT &&
                s->rr_ttl_state < _DNS_RECORD_TTL_STATE_MAX) {
-                next_time = mdns_maintenance_next_time(s->until, s->rr->ttl, s->rr_ttl_state);
+                next_time = mdns_maintenance_next_time(s->until, ttl_usec, s->rr_ttl_state);
                 if (next_time >= usec)
                         break;
 
@@ -204,7 +211,7 @@ int dns_add_new_service(DnsServiceBrowser *sb, DnsResourceRecord *rr, int owner_
                 s->rr_ttl_state = DNS_RECORD_TTL_STATE_100_PERCENT;
         }
 
-        usec_t jitter = mdns_maintenance_jitter(rr->ttl);
+        usec_t jitter = mdns_maintenance_jitter(ttl_usec);
 
         r = sd_event_add_time(
                         sb->manager->event,
@@ -259,9 +266,10 @@ int mdns_service_update(DnssdDiscoveredService *service, DnsResourceRecord *rr, 
         /* Update the 80% TTL maintenance event based on new record received
          * from the network. RFC 6762 section 5.2  */
         if (service->schedule_event) {
+                usec_t ttl_usec = service->rr->ttl * USEC_PER_SEC;
                 usec_t next_time = mdns_maintenance_next_time(
-                        service->until, service->rr->ttl, DNS_RECORD_TTL_STATE_80_PERCENT);
-                usec_t jitter = mdns_maintenance_jitter(service->rr->ttl);
+                                service->until, ttl_usec, DNS_RECORD_TTL_STATE_80_PERCENT);
+                usec_t jitter = mdns_maintenance_jitter(ttl_usec);
 
                 return sd_event_source_set_time(service->schedule_event, usec_add(next_time, jitter));
         }

--- a/src/resolve/resolved-dns-browse-services.c
+++ b/src/resolve/resolved-dns-browse-services.c
@@ -127,6 +127,45 @@ static void mdns_querier_abort_maintenance_query(DnsServiceQuerier *sq) {
         dns_query_complete(sq->maintenance_query, DNS_TRANSACTION_ABORTED);
 }
 
+/* Fire the querier's browse question on the wire once; the answers flow back through the regular
+ * completion revisit. At most one such query in flight per querier: one that has not completed by
+ * the time the next is due is superseded. */
+static int mdns_querier_send_question(DnsServiceQuerier *sq) {
+        _cleanup_(dns_query_freep) DnsQuery *q = NULL;
+        int r;
+
+        assert(sq);
+
+        mdns_querier_abort_maintenance_query(sq);
+
+        r = dns_query_new(
+                        sq->manager,
+                        &q,
+                        sq->question_utf8,
+                        sq->question_idna,
+                        /* question_bypass= */ NULL,
+                        sq->ifindex,
+                        sq->flags | SD_RESOLVED_QUERY_CONTINUOUS | SD_RESOLVED_NO_CACHE);
+        if (r < 0)
+                return r;
+
+        q->complete = mdns_maintenance_query_complete;
+        q->service_querier_request = dns_service_querier_ref(sq);
+
+        /* Track the query before starting it: dns_query_go() completes a query synchronously when no
+         * scope matches the question or the cache answers it, and the completion handler then frees
+         * the query and clears this field again. A pointer stored only afterwards would dangle. */
+        sq->maintenance_query = TAKE_PTR(q);
+
+        r = dns_query_go(sq->maintenance_query);
+        if (r < 0) {
+                sq->maintenance_query = dns_query_free(sq->maintenance_query);
+                return r;
+        }
+
+        return 0;
+}
+
 /* One re-confirmation ladder per browser: the maintenance query re-issues the
  * browse PTR question, and a single PTR response refreshes the entire browsed
  * RRset (all discovered instances). Running the RFC 6762 §5.2 80/85/90/95/100%
@@ -136,7 +175,6 @@ static void mdns_querier_abort_maintenance_query(DnsServiceQuerier *sq) {
  * removal-at-expiry. */
 int mdns_querier_maintenance(sd_event_source *s, uint64_t usec, void *userdata) {
         _cleanup_(dns_service_querier_unrefp) DnsServiceQuerier *sq = NULL;
-        _cleanup_(dns_query_freep) DnsQuery *q = NULL;
         int r;
 
         /* Hold a ref for the duration of the handler, as mdns_next_query_schedule() does. */
@@ -159,37 +197,9 @@ int mdns_querier_maintenance(sd_event_source *s, uint64_t usec, void *userdata) 
 
         mdns_querier_schedule_maintenance(sq);
 
-        /* At most one maintenance query in flight per querier: a rung's query that has not completed
-         * by the next rung is superseded. */
-        mdns_querier_abort_maintenance_query(sq);
-
-        r = dns_query_new(
-                        sq->manager,
-                        &q,
-                        sq->question_utf8,
-                        sq->question_idna,
-                        /* question_bypass= */ NULL,
-                        sq->ifindex,
-                        sq->flags | SD_RESOLVED_QUERY_CONTINUOUS | SD_RESOLVED_NO_CACHE);
-        if (r < 0) {
-                log_warning_errno(r, "Failed to create mDNS query for maintenance, ignoring: %m");
-                return 0;
-        }
-
-        q->complete = mdns_maintenance_query_complete;
-        q->service_querier_request = dns_service_querier_ref(sq);
-
-        /* Track the query before starting it: dns_query_go() completes a query synchronously when no
-         * scope matches the question or the cache answers it, and the completion handler then frees
-         * the query and clears this field again. A pointer stored only afterwards would dangle. */
-        sq->maintenance_query = TAKE_PTR(q);
-
-        r = dns_query_go(sq->maintenance_query);
-        if (r < 0) {
+        r = mdns_querier_send_question(sq);
+        if (r < 0)
                 log_warning_errno(r, "Failed to send mDNS maintenance query, ignoring: %m");
-                sq->maintenance_query = dns_query_free(sq->maintenance_query);
-                return 0;
-        }
 
         return 0;
 }
@@ -733,6 +743,61 @@ int mdns_notify_browsers_goodbye(DnsScope *scope) {
         }
 
         return 0;
+}
+
+/* RFC 6762 §10.1 defers acting on a goodbye by one second so that other
+ * publishers of the same records can rescue them. resolved keeps a single
+ * cache entry per record, whatever machine announced it, so without a nudge
+ * that rescue only happens by luck: a surviving publisher of the same
+ * instance re-announces on its own schedule, and the browse question's §5.2
+ * backoff can be a full hour away — until then the subscriber sees a spurious
+ * 'removed' for a service that never went away. Re-issue the browse question
+ * as soon as a goodbye matches it: a surviving publisher's answer then
+ * refreshes the record inside the one-second grace and no removal is ever
+ * reported. If nobody answers, the goodbye takes effect exactly as before. */
+void mdns_queriers_rescue_query_goodbye(DnsScope *scope, DnsAnswer *answer) {
+        DnsServiceQuerier *sq;
+        DnsResourceRecord *rr;
+        usec_t t;
+        int r;
+
+        assert(scope);
+        assert(scope->manager);
+
+        t = now(CLOCK_BOOTTIME);
+
+        HASHMAP_FOREACH(sq, scope->manager->dns_service_queriers) {
+                bool match = false;
+
+                if (sq->ifindex != 0 && sq->ifindex != dns_scope_ifindex(scope))
+                        continue;
+
+                /* Half the §10.1 grace: covers goodbye repetitions at their
+                 * usual one-second spacing, and bounds the query rate should
+                 * someone flood us with goodbyes. */
+                if (sq->last_goodbye_rescue_usec > 0 &&
+                    t < usec_add(sq->last_goodbye_rescue_usec, USEC_PER_SEC / 2))
+                        continue;
+
+                DNS_ANSWER_FOREACH(rr, answer) {
+                        /* Goodbyes arrive here with their TTL already rewritten to 1. */
+                        if (rr->ttl > 1)
+                                continue;
+
+                        if (dns_resource_key_equal(rr->key, sq->key) > 0) {
+                                match = true;
+                                break;
+                        }
+                }
+                if (!match)
+                        continue;
+
+                sq->last_goodbye_rescue_usec = t;
+
+                r = mdns_querier_send_question(sq);
+                if (r < 0)
+                        log_warning_errno(r, "Failed to send mDNS rescue query for a goodbye, ignoring: %m");
+        }
 }
 
 int mdns_notify_browsers_unsolicited_updates(Manager *m, DnsAnswer *answer, int owner_family) {

--- a/src/resolve/resolved-dns-browse-services.c
+++ b/src/resolve/resolved-dns-browse-services.c
@@ -84,87 +84,176 @@ static usec_t mdns_maintenance_jitter(usec_t ttl_usec) {
         return random_u64_range(2 * ttl_usec / 100);
 }
 
+static void mdns_browser_schedule_maintenance(DnsServiceBrowser *sb);
+
+/* Revisit both families: the ladder is armed against the soonest expiry across both, and the callee
+ * logs about failures itself. */
+static void mdns_browser_revisit_cache_both(DnsServiceBrowser *sb) {
+        int af;
+
+        assert(sb);
+
+        FOREACH_ARGUMENT(af, AF_INET, AF_INET6)
+                (void) mdns_browser_revisit_cache(sb, af);
+}
+
 static void mdns_maintenance_query_complete(DnsQuery *q) {
         _cleanup_(dns_service_browser_unrefp) DnsServiceBrowser *sb = NULL;
         _cleanup_(dns_query_freep) DnsQuery *query = q;
-        DnssdDiscoveredService *service = NULL;
-        int r;
 
         assert(query);
         assert(query->manager);
 
-        if (query->state != DNS_TRANSACTION_SUCCESS)
-                return;
-
-        service = dnssd_discovered_service_ref(query->dnsservice_request);
-        if (!service)
-                return;
-
-        sb = dns_service_browser_ref(service->service_browser);
+        sb = dns_service_browser_ref(query->service_browser_request);
         if (!sb)
                 return;
 
-        r = mdns_browser_revisit_cache(sb, query->answer_family);
-        if (r < 0)
-                return (void) log_error_errno(r, "Failed to revisit cache for family %s: %m", af_to_name(query->answer_family));
+        if (query->state != DNS_TRANSACTION_SUCCESS)
+                return;
+
+        mdns_browser_revisit_cache_both(sb);
 }
 
-static int mdns_maintenance_query(sd_event_source *s, uint64_t usec, void *userdata) {
-        DnssdDiscoveredService *service = ASSERT_PTR(userdata);
+/* A maintenance query in flight pins the browser via its reference; abort it when the browser's
+ * subscription ends, so the browser can be released. (Freeing the query clears the tracking field,
+ * whichever way the query goes away — see dns_query_free().) */
+static void mdns_browser_abort_maintenance_query(DnsServiceBrowser *sb) {
+        assert(sb);
+
+        if (!sb->maintenance_query)
+                return;
+
+        dns_query_complete(sb->maintenance_query, DNS_TRANSACTION_ABORTED);
+}
+
+/* One re-confirmation ladder per browser: the maintenance query re-issues the
+ * browse PTR question, and a single PTR response refreshes the entire browsed
+ * RRset (all discovered instances). Running the RFC 6762 §5.2 80/85/90/95/100%
+ * ladder once per browser — instead of once per discovered service — avoids
+ * multicasting the same question N*M times when N clients browse a type with M
+ * instances, while preserving loss-resilient re-confirmation and prompt
+ * removal-at-expiry. */
+int mdns_browser_maintenance(sd_event_source *s, uint64_t usec, void *userdata) {
+        _cleanup_(dns_service_browser_unrefp) DnsServiceBrowser *sb = NULL;
         _cleanup_(dns_query_freep) DnsQuery *q = NULL;
         int r;
 
-        /* Check if the TTL state has reached the maximum value, then revisit
-         * cache */
-        if (service->rr_ttl_state++ == DNS_RECORD_TTL_STATE_100_PERCENT)
-                return mdns_browser_revisit_cache(service->service_browser, service->family);
+        /* Hold a ref for the duration of the handler, as mdns_next_query_schedule() does. */
+        sb = dns_service_browser_ref(ASSERT_PTR(userdata));
 
-        /* Create a new DNS query */
+        /* Terminal: the soonest expiry has elapsed. Reconcile the cache (this prunes expired records
+         * and emits "removed") and reschedule against what remains — the revisit frees services,
+         * never the browser that owns this timer. */
+        if (sb->rr_ttl_state == DNS_RECORD_TTL_STATE_100_PERCENT) {
+                sb->rr_ttl_state = DNS_RECORD_TTL_STATE_80_PERCENT;
+                mdns_browser_revisit_cache_both(sb);
+                mdns_browser_schedule_maintenance(sb);
+                return 0;
+        }
+
+        /* Advance the ladder and re-issue the browse question to re-confirm the RRset. Errors are
+         * logged and swallowed: a negative return would make sd-event disable the source over the
+         * re-arm, leaving the ladder dead for good. */
+        sb->rr_ttl_state++;
+
+        mdns_browser_schedule_maintenance(sb);
+
+        /* At most one maintenance query in flight per browser: a rung's query that has not completed
+         * by the next rung is superseded. */
+        mdns_browser_abort_maintenance_query(sb);
+
         r = dns_query_new(
-                        service->service_browser->manager,
+                        sb->manager,
                         &q,
-                        service->service_browser->question_utf8,
-                        service->service_browser->question_idna,
+                        sb->question_utf8,
+                        sb->question_idna,
                         /* question_bypass= */ NULL,
-                        service->ifindex,
-                        service->service_browser->flags);
-        if (r < 0)
-                return log_error_errno(r, "Failed to create mDNS query for maintenance: %m");
+                        sb->ifindex,
+                        sb->flags);
+        if (r < 0) {
+                log_warning_errno(r, "Failed to create mDNS query for maintenance, ignoring: %m");
+                return 0;
+        }
 
         q->complete = mdns_maintenance_query_complete;
-        q->service_browser_request = dns_service_browser_ref(service->service_browser);
-        q->dnsservice_request = dnssd_discovered_service_ref(service);
+        q->service_browser_request = dns_service_browser_ref(sb);
 
-        /* Schedule the next maintenance query based on the TTL */
-        usec_t next_time = mdns_maintenance_next_time(
-                        service->until, service->rr->ttl * USEC_PER_SEC, service->rr_ttl_state);
+        /* Track the query before starting it: dns_query_go() completes a query synchronously when no
+         * scope matches the question or the cache answers it, and the completion handler then frees
+         * the query and clears this field again. A pointer stored only afterwards would dangle. */
+        sb->maintenance_query = TAKE_PTR(q);
 
-        r = event_reset_time(
-                        service->service_browser->manager->event,
-                        &service->schedule_event,
-                        CLOCK_BOOTTIME,
-                        next_time,
-                        /* accuracy= */ 0,
-                        mdns_maintenance_query,
-                        service,
-                        /* priority= */ 0,
-                        "mdns-next-query-schedule",
-                        /* force_reset= */ true);
-        if (r < 0)
-                return log_error_errno(r, "Failed to schedule next mDNS maintenance query: %m");
+        r = dns_query_go(sb->maintenance_query);
+        if (r < 0) {
+                log_warning_errno(r, "Failed to send mDNS maintenance query, ignoring: %m");
+                sb->maintenance_query = dns_query_free(sb->maintenance_query);
+                return 0;
+        }
 
-        /* Perform the query */
-        r = dns_query_go(q);
-        if (r < 0)
-                return log_error_errno(r, "Failed to send mDNS maintenance query: %m");
-
-        TAKE_PTR(q);
         return 0;
 }
 
-int dns_add_new_service(DnsServiceBrowser *sb, DnsResourceRecord *rr, int owner_family, int ifindex, usec_t until) {
-        _cleanup_(dnssd_discovered_service_unrefp) DnssdDiscoveredService *s = NULL;
+/* (Re)arm the browser's single maintenance ladder against the soonest-expiring
+ * discovered service. Disables the timer when no services remain. */
+static void mdns_browser_schedule_maintenance(DnsServiceBrowser *sb) {
+        DnssdDiscoveredService *soonest = NULL;
+        usec_t next_time = 0;
         int r;
+
+        assert(sb);
+
+        LIST_FOREACH(dns_services, s, sb->dns_services)
+                if (!soonest || s->until < soonest->until)
+                        soonest = s;
+
+        if (!soonest) {
+                sb->maintenance_event = sd_event_source_disable_unref(sb->maintenance_event);
+                return;
+        }
+
+        usec_t usec = now(CLOCK_BOOTTIME), ttl_usec = soonest->rr->ttl * USEC_PER_SEC;
+
+        /* Skip ladder increments whose scheduled time already elapsed (e.g. a
+         * service discovered late in its lifetime, or a lingering expired one). */
+        while (sb->rr_ttl_state >= DNS_RECORD_TTL_STATE_80_PERCENT &&
+               sb->rr_ttl_state < _DNS_RECORD_TTL_STATE_MAX) {
+                next_time = mdns_maintenance_next_time(soonest->until, ttl_usec, sb->rr_ttl_state);
+                if (next_time >= usec)
+                        break;
+
+                sb->rr_ttl_state++;
+        }
+
+        if (next_time < usec) {
+                /* Already at/past expiry: re-check shortly so the terminal branch
+                 * prunes the record from cache and emits the removal. */
+                next_time = usec_add(usec, USEC_PER_SEC);
+                sb->rr_ttl_state = DNS_RECORD_TTL_STATE_100_PERCENT;
+        }
+
+        /* The 2% jitter desynchronizes the §5.2 re-confirmation queries across queriers; the terminal
+         * rung is our own expiry check, not a query — arming it past the record's actual expiry would
+         * only delay the removal this ladder exists to guarantee. */
+        usec_t jitter = sb->rr_ttl_state == DNS_RECORD_TTL_STATE_100_PERCENT ?
+                0 : mdns_maintenance_jitter(ttl_usec);
+
+        r = event_reset_time(
+                        sb->manager->event,
+                        &sb->maintenance_event,
+                        CLOCK_BOOTTIME,
+                        usec_add(next_time, jitter),
+                        /* accuracy= */ 0,
+                        mdns_browser_maintenance,
+                        sb,
+                        /* priority= */ 0,
+                        "mdns-browser-maintenance",
+                        /* force_reset= */ true);
+        if (r < 0)
+                log_warning_errno(r, "Failed to schedule mDNS maintenance query, ignoring: %m");
+}
+
+int dns_add_new_service(DnsServiceBrowser *sb, DnsResourceRecord *rr, int owner_family, int ifindex, usec_t until) {
+        _cleanup_(dnssd_discovered_service_freep) DnssdDiscoveredService *s = NULL;
 
         assert(sb);
         assert(rr);
@@ -173,62 +262,20 @@ int dns_add_new_service(DnsServiceBrowser *sb, DnsResourceRecord *rr, int owner_
         if (!s)
                 return log_oom();
 
-        usec_t usec = now(CLOCK_BOOTTIME);
-
         *s = (DnssdDiscoveredService) {
-                .n_ref = 1,
-                .service_browser = sb,
                 .rr = dns_resource_record_copy(rr),
                 .family = owner_family,
                 .ifindex = ifindex,
                 .until = until,
-                .query = NULL,
-                .rr_ttl_state = DNS_RECORD_TTL_STATE_80_PERCENT,
         };
         if (!s->rr)
                 return log_oom();
 
-        /* Schedule the first cache maintenance query at 80% of the record's
-         * TTL. Subsequent queries issued at 5% increments until 100% of the
-         * TTL. RFC 6762 section 5.2. If service is being added after 80% of the
-         * TTL has already elapsed, schedule the next query at the next 5%
-         * increment. */
-        usec_t ttl_usec = s->rr->ttl * USEC_PER_SEC, next_time = 0;
-        while (s->rr_ttl_state >= DNS_RECORD_TTL_STATE_80_PERCENT &&
-               s->rr_ttl_state < _DNS_RECORD_TTL_STATE_MAX) {
-                next_time = mdns_maintenance_next_time(s->until, ttl_usec, s->rr_ttl_state);
-                if (next_time >= usec)
-                        break;
-
-                s->rr_ttl_state++;
-        }
-
-        if (next_time < usec) {
-                /* If next_time is still in the past, the service is being added
-                 * after it has already expired. Just schedule a 100%
-                 * maintenance query. */
-                next_time = usec_add(usec, USEC_PER_SEC);
-                s->rr_ttl_state = DNS_RECORD_TTL_STATE_100_PERCENT;
-        }
-
-        usec_t jitter = mdns_maintenance_jitter(ttl_usec);
-
-        r = sd_event_add_time(
-                        sb->manager->event,
-                        &s->schedule_event,
-                        CLOCK_BOOTTIME,
-                        usec_add(next_time, jitter),
-                        /* accuracy= */ 0,
-                        mdns_maintenance_query,
-                        s);
-        if (r < 0)
-                return log_error_errno(
-                                r,
-                                "Failed to schedule mDNS maintenance query for DNS service: %m");
-
         LIST_PREPEND(dns_services, sb->dns_services, s);
-
         TAKE_PTR(s);
+
+        /* The list changed: wind the ladder back (see rr_ttl_state). */
+        sb->rr_ttl_state = DNS_RECORD_TTL_STATE_80_PERCENT;
         return 0;
 }
 
@@ -237,44 +284,27 @@ void dns_remove_service(DnsServiceBrowser *sb, DnssdDiscoveredService *service) 
         assert(service);
 
         LIST_REMOVE(dns_services, sb->dns_services, service);
-        dnssd_discovered_service_unref(service);
+        dnssd_discovered_service_free(service);
+
+        /* The list changed: wind the ladder back (see rr_ttl_state). */
+        sb->rr_ttl_state = DNS_RECORD_TTL_STATE_80_PERCENT;
 }
 
-DnssdDiscoveredService *dns_service_free(DnssdDiscoveredService *service) {
+DnssdDiscoveredService *dnssd_discovered_service_free(DnssdDiscoveredService *service) {
         if (!service)
                 return NULL;
-
-        service->schedule_event = sd_event_source_disable_unref(service->schedule_event);
-
-        if (service->query && DNS_TRANSACTION_IS_LIVE(service->query->state))
-                dns_query_complete(service->query, DNS_TRANSACTION_ABORTED);
 
         service->rr = dns_resource_record_unref(service->rr);
 
         return mfree(service);
 }
 
-DEFINE_TRIVIAL_REF_UNREF_FUNC(DnssdDiscoveredService, dnssd_discovered_service, dns_service_free);
-
-int mdns_service_update(DnssdDiscoveredService *service, DnsResourceRecord *rr, usec_t t, usec_t until) {
+static void mdns_service_update(DnssdDiscoveredService *service, DnsResourceRecord *rr, usec_t until) {
         assert(service);
         assert(rr);
 
         service->until = until;
         service->rr->ttl = rr->ttl;
-
-        /* Update the 80% TTL maintenance event based on new record received
-         * from the network. RFC 6762 section 5.2  */
-        if (service->schedule_event) {
-                usec_t ttl_usec = service->rr->ttl * USEC_PER_SEC;
-                usec_t next_time = mdns_maintenance_next_time(
-                                service->until, ttl_usec, DNS_RECORD_TTL_STATE_80_PERCENT);
-                usec_t jitter = mdns_maintenance_jitter(ttl_usec);
-
-                return sd_event_source_set_time(service->schedule_event, usec_add(next_time, jitter));
-        }
-
-        return 0;
 }
 
 static int mdns_answer_item_ifindex(DnsServiceBrowser *sb, DnsAnswerItem *item) {
@@ -309,7 +339,6 @@ int dns_service_match_and_update(
                 int ifindex,
                 usec_t until) {
 
-        usec_t t = now(CLOCK_BOOTTIME);
         int r;
 
         /* Check if a discovered service matching the given resource record, owner family, and ifindex exists
@@ -327,7 +356,7 @@ int dns_service_match_and_update(
                         return 1;
 
                 if (service->until < until)
-                        mdns_service_update(service, rr, t, until);
+                        mdns_service_update(service, rr, until);
 
                 return 1;
         }
@@ -407,8 +436,11 @@ int mdns_manage_services_answer(DnsServiceBrowser *sb, DnsAnswer *answer, int ow
                         log_error_errno(r, "Failed to match DNS service: %m");
                         goto finish;
                 }
-                if (r > 0)
+                if (r > 0) {
+                        /* Seen again: wind the ladder back (see rr_ttl_state). */
+                        sb->rr_ttl_state = DNS_RECORD_TTL_STATE_80_PERCENT;
                         continue;
+                }
 
                 r = dns_service_split(item->rr->ptr.name, &name, &type, &domain);
                 if (r < 0) {
@@ -537,6 +569,12 @@ int mdns_manage_services_answer(DnsServiceBrowser *sb, DnsAnswer *answer, int ow
                 }
         }
 
+        /* (Re-)arm the browser's maintenance ladder once against the reconciled list — doing it per
+         * added/removed instance inside the loops above would make reconciling an answer with M
+         * instances O(M²), with M driven by untrusted multicast input. This also disables the timer
+         * when no discovered service remains. */
+        mdns_browser_schedule_maintenance(sb);
+
         if (!sd_json_variant_is_blank_array(array)) {
                 _cleanup_(sd_json_variant_unrefp) sd_json_variant *vm = NULL;
 
@@ -567,6 +605,14 @@ int mdns_browser_revisit_cache(DnsServiceBrowser *sb, int owner_family) {
         assert(sb);
         assert(sb->manager);
 
+        /* The reconciliation must see real cache expiry times: without SD_RESOLVED_NO_STALE the
+         * lookup substitutes the stale-serving clamp for item->until — an absolute timestamp ~30s
+         * after boot, i.e. long in the past on any running system — which would wedge the
+         * maintenance ladder in its past-expiry one-second re-check for as long as a matching
+         * record stays cached. Stale serving is a per-client query feature; the browse
+         * bookkeeping always wants the truth, whatever flags the subscriber passed. */
+        uint64_t lookup_flags = sb->flags | SD_RESOLVED_NO_STALE;
+
         /* ifindex=0 means "all interfaces". Collect the cached answers from
          * every matching mDNS scope into a single combined answer and reconcile
          * once. Reconciling per-scope would be wrong: mdns_manage_services_answer()
@@ -594,7 +640,7 @@ int mdns_browser_revisit_cache(DnsServiceBrowser *sb, int owner_family) {
                         r = dns_cache_lookup(
                                         &scope->cache,
                                         sb->key,
-                                        sb->flags,
+                                        lookup_flags,
                                         /* ret_rcode= */ NULL,
                                         &answer,
                                         /* ret_full_packet= */ NULL,
@@ -627,15 +673,24 @@ int mdns_browser_revisit_cache(DnsServiceBrowser *sb, int owner_family) {
 
         /* Single scope for specifically requested interface */
         DnsScope *scope = manager_find_scope_from_protocol(sb->manager, sb->ifindex, DNS_PROTOCOL_MDNS, owner_family);
-        if (!scope)
+        if (!scope) {
+                /* No scope to reconcile against — mDNS is off on the link, or the link is gone. Treat
+                 * it like the all-interfaces path with no matching scope and reconcile against an
+                 * empty answer: lingering instances get their removed events and the ladder winds
+                 * down, instead of re-checking a list nothing can update once per second. */
+                r = mdns_manage_services_answer(sb, NULL, owner_family);
+                if (r < 0)
+                        return log_error_errno(r, "Failed to manage mDNS services without a scope: %m");
+
                 return 0;
+        }
 
         dns_cache_prune(&scope->cache);
 
         r = dns_cache_lookup(
                         &scope->cache,
                         sb->key,
-                        sb->flags,
+                        lookup_flags,
                         /* ret_rcode= */ NULL,
                         &lookup_ret_answer,
                         /* ret_full_packet= */ NULL,
@@ -897,20 +952,48 @@ int dns_subscribe_browse_service(
         return 0;
 }
 
-DnsServiceBrowser *dns_service_browser_free(DnsServiceBrowser *sb) {
+/* Disarm the timers and abort the continuous browse query (anchored in the link's userdata): what has
+ * to stop once the subscription is gone, whether or not the browser itself lives on for a while. */
+static void dns_service_browser_stop(DnsServiceBrowser *sb) {
         DnsQuery *q;
 
+        assert(sb);
+
+        sb->schedule_event = sd_event_source_disable_unref(sb->schedule_event);
+        sb->maintenance_event = sd_event_source_disable_unref(sb->maintenance_event);
+
+        q = sd_varlink_get_userdata(sb->link);
+        if (q && DNS_TRANSACTION_IS_LIVE(q->state))
+                dns_query_complete(q, DNS_TRANSACTION_ABORTED);
+}
+
+/* The counterpart of dns_subscribe_browse_service(): drop the browser registered for a varlink
+ * connection. A query in flight holds a reference that keeps the browser alive past this call, so the
+ * subscription's machinery is stopped right here rather than left to the final free: the timers, the
+ * continuous browse query, and the maintenance query — which would otherwise keep the orphaned
+ * browser and its armed ladder alive until it completed. */
+void dns_unsubscribe_browse_service(Manager *m, sd_varlink *link) {
+        _cleanup_(dns_service_browser_unrefp) DnsServiceBrowser *sb = NULL;
+
+        assert(m);
+        assert(link);
+
+        sb = hashmap_remove(m->dns_service_browsers, link);
+        if (!sb)
+                return;
+
+        dns_service_browser_stop(sb);
+        mdns_browser_abort_maintenance_query(sb);
+}
+
+DnsServiceBrowser *dns_service_browser_free(DnsServiceBrowser *sb) {
         if (!sb)
                 return NULL;
 
         while (sb->dns_services)
                 dns_remove_service(sb, sb->dns_services);
 
-        sb->schedule_event = sd_event_source_disable_unref(sb->schedule_event);
-
-        q = sd_varlink_get_userdata(sb->link);
-        if (q && DNS_TRANSACTION_IS_LIVE(q->state))
-                dns_query_complete(q, DNS_TRANSACTION_ABORTED);
+        dns_service_browser_stop(sb);
 
         sb->question_idna = dns_question_unref(sb->question_idna);
         sb->question_utf8 = dns_question_unref(sb->question_utf8);

--- a/src/resolve/resolved-dns-browse-services.h
+++ b/src/resolve/resolved-dns-browse-services.h
@@ -8,6 +8,7 @@
 #include "dns-rr.h"
 
 typedef struct DnsServiceBrowser DnsServiceBrowser;
+typedef struct DnsServiceQuerier DnsServiceQuerier;
 typedef struct DnssdDiscoveredService DnssdDiscoveredService;
 typedef struct DnsQuery DnsQuery;
 typedef struct DnsScope DnsScope;
@@ -32,38 +33,52 @@ struct DnssdDiscoveredService {
         LIST_FIELDS(DnssdDiscoveredService, dns_services);
 };
 
-struct DnsServiceBrowser {
+/* The shared browse engine: everything needed to keep one browse question answered — the continuous
+ * query, the TTL re-confirmation ladder and the discovered-service list — exists once per
+ * (question, ifindex, flags), no matter how many clients subscribed to it. */
+struct DnsServiceQuerier {
         unsigned n_ref;
         Manager *manager;
-        sd_varlink *link;
         DnsQuestion *question_idna;
         DnsQuestion *question_utf8;
+        DnsResourceKey *key;
         uint64_t flags;
+        int ifindex;
+        usec_t delay;
         sd_event_source *schedule_event;      /* continuous browse query (RFC 6762 §5.2 backoff) */
         sd_event_source *maintenance_event;   /* single TTL re-confirmation ladder for the whole RRset */
         DnsQuery *maintenance_query;          /* in-flight ladder query; cleared by dns_query_free() */
         DnsRecordTTLState rr_ttl_state;       /* the ladder's rung: wound back to 80% whenever the list
                                                  changes or an instance is seen again, advanced only by
-                                                 mdns_browser_maintenance(), re-armed once per
+                                                 mdns_querier_maintenance(), re-armed once per
                                                  reconciliation (re-arming skips the rungs already
                                                  behind us, so a wind-back only takes effect once an
                                                  expiry moved) */
-        usec_t delay;
-        DnsResourceKey *key;
-        int ifindex;
         LIST_HEAD(DnssdDiscoveredService, dns_services);
+        LIST_HEAD(DnsServiceBrowser, subscribers);
+};
+
+/* One per varlink BrowseServices subscription; just the client's connection plus its seat on the
+ * shared querier. */
+struct DnsServiceBrowser {
+        Manager *manager;
+        sd_varlink *link;
+        DnsServiceQuerier *querier;
+        LIST_FIELDS(DnsServiceBrowser, subscribers);
 };
 
 DnsServiceBrowser *dns_service_browser_free(DnsServiceBrowser *sb);
-void dns_remove_service(DnsServiceBrowser *sb, DnssdDiscoveredService *service);
+DnsServiceQuerier *dns_service_querier_free(DnsServiceQuerier *sq);
+void dns_remove_service(DnsServiceQuerier *sq, DnssdDiscoveredService *service);
 DnssdDiscoveredService *dnssd_discovered_service_free(DnssdDiscoveredService *service);
 
-DECLARE_TRIVIAL_REF_UNREF_FUNC(DnsServiceBrowser, dns_service_browser);
+DECLARE_TRIVIAL_REF_UNREF_FUNC(DnsServiceQuerier, dns_service_querier);
 
 void dns_browse_services_purge(Manager *m, int family);
 void dns_browse_services_restart(Manager *m);
 
-DEFINE_TRIVIAL_CLEANUP_FUNC(DnsServiceBrowser *, dns_service_browser_unref);
+DEFINE_TRIVIAL_CLEANUP_FUNC(DnsServiceBrowser *, dns_service_browser_free);
+DEFINE_TRIVIAL_CLEANUP_FUNC(DnsServiceQuerier *, dns_service_querier_unref);
 DEFINE_TRIVIAL_CLEANUP_FUNC(DnssdDiscoveredService *, dnssd_discovered_service_free);
 
 int dns_service_match_and_update(
@@ -73,13 +88,13 @@ int dns_service_match_and_update(
                 int ifindex,
                 usec_t until);
 int mdns_answer_contains_service(
-                DnsServiceBrowser *sb,
+                DnsServiceQuerier *sq,
                 DnsAnswer *answer,
                 DnssdDiscoveredService *service);
-int mdns_manage_services_answer(DnsServiceBrowser *sb, DnsAnswer *answer, int owner_family);
-int dns_add_new_service(DnsServiceBrowser *sb, DnsResourceRecord *rr, int owner_family, int ifindex, usec_t until);
-int mdns_browser_revisit_cache(DnsServiceBrowser *sb, int owner_family);
-int mdns_browser_maintenance(sd_event_source *s, uint64_t usec, void *userdata);
+int mdns_manage_services_answer(DnsServiceQuerier *sq, DnsAnswer *answer, int owner_family);
+int dns_add_new_service(DnsServiceQuerier *sq, DnsResourceRecord *rr, int owner_family, int ifindex, usec_t until);
+int mdns_querier_revisit_cache(DnsServiceQuerier *sq, int owner_family);
+int mdns_querier_maintenance(sd_event_source *s, uint64_t usec, void *userdata);
 int dns_subscribe_browse_service(
                 Manager *m,
                 sd_varlink *link,

--- a/src/resolve/resolved-dns-browse-services.h
+++ b/src/resolve/resolved-dns-browse-services.h
@@ -54,6 +54,7 @@ struct DnsServiceQuerier {
                                                  reconciliation (re-arming skips the rungs already
                                                  behind us, so a wind-back only takes effect once an
                                                  expiry moved) */
+        usec_t last_goodbye_rescue_usec;      /* rate limit for the §10.1 goodbye rescue query */
         LIST_HEAD(DnssdDiscoveredService, dns_services);
         LIST_HEAD(DnsServiceBrowser, subscribers);
 };
@@ -105,3 +106,4 @@ int dns_subscribe_browse_service(
 void dns_unsubscribe_browse_service(Manager *m, sd_varlink *link);
 int mdns_notify_browsers_unsolicited_updates(Manager *m, DnsAnswer *answer, int owner_family);
 int mdns_notify_browsers_goodbye(DnsScope *scope);
+void mdns_queriers_rescue_query_goodbye(DnsScope *scope, DnsAnswer *answer);

--- a/src/resolve/resolved-dns-browse-services.h
+++ b/src/resolve/resolved-dns-browse-services.h
@@ -51,7 +51,6 @@ struct DnsServiceBrowser {
         usec_t delay;
         DnsResourceKey *key;
         int ifindex;
-        uint64_t token;
         LIST_HEAD(DnssdDiscoveredService, dns_services);
 };
 

--- a/src/resolve/resolved-dns-browse-services.h
+++ b/src/resolve/resolved-dns-browse-services.h
@@ -25,15 +25,10 @@ enum DnsRecordTTLState {
 };
 
 struct DnssdDiscoveredService {
-        unsigned n_ref;
-        DnsServiceBrowser *service_browser;
-        sd_event_source *schedule_event;
         DnsResourceRecord *rr;
         int family;
         int ifindex;
         usec_t until;
-        DnsRecordTTLState rr_ttl_state;
-        DnsQuery *query;
         LIST_FIELDS(DnssdDiscoveredService, dns_services);
 };
 
@@ -44,7 +39,15 @@ struct DnsServiceBrowser {
         DnsQuestion *question_idna;
         DnsQuestion *question_utf8;
         uint64_t flags;
-        sd_event_source *schedule_event;
+        sd_event_source *schedule_event;      /* continuous browse query (RFC 6762 §5.2 backoff) */
+        sd_event_source *maintenance_event;   /* single TTL re-confirmation ladder for the whole RRset */
+        DnsQuery *maintenance_query;          /* in-flight ladder query; cleared by dns_query_free() */
+        DnsRecordTTLState rr_ttl_state;       /* the ladder's rung: wound back to 80% whenever the list
+                                                 changes or an instance is seen again, advanced only by
+                                                 mdns_browser_maintenance(), re-armed once per
+                                                 reconciliation (re-arming skips the rungs already
+                                                 behind us, so a wind-back only takes effect once an
+                                                 expiry moved) */
         usec_t delay;
         DnsResourceKey *key;
         int ifindex;
@@ -54,16 +57,15 @@ struct DnsServiceBrowser {
 
 DnsServiceBrowser *dns_service_browser_free(DnsServiceBrowser *sb);
 void dns_remove_service(DnsServiceBrowser *sb, DnssdDiscoveredService *service);
-DnssdDiscoveredService *dns_service_free(DnssdDiscoveredService *service);
+DnssdDiscoveredService *dnssd_discovered_service_free(DnssdDiscoveredService *service);
 
 DECLARE_TRIVIAL_REF_UNREF_FUNC(DnsServiceBrowser, dns_service_browser);
-DECLARE_TRIVIAL_REF_UNREF_FUNC(DnssdDiscoveredService, dnssd_discovered_service);
 
 void dns_browse_services_purge(Manager *m, int family);
 void dns_browse_services_restart(Manager *m);
 
 DEFINE_TRIVIAL_CLEANUP_FUNC(DnsServiceBrowser *, dns_service_browser_unref);
-DEFINE_TRIVIAL_CLEANUP_FUNC(DnssdDiscoveredService *, dnssd_discovered_service_unref);
+DEFINE_TRIVIAL_CLEANUP_FUNC(DnssdDiscoveredService *, dnssd_discovered_service_free);
 
 int dns_service_match_and_update(
                 DnssdDiscoveredService *services,
@@ -77,8 +79,8 @@ int mdns_answer_contains_service(
                 DnssdDiscoveredService *service);
 int mdns_manage_services_answer(DnsServiceBrowser *sb, DnsAnswer *answer, int owner_family);
 int dns_add_new_service(DnsServiceBrowser *sb, DnsResourceRecord *rr, int owner_family, int ifindex, usec_t until);
-int mdns_service_update(DnssdDiscoveredService *service, DnsResourceRecord *rr, usec_t t, usec_t until);
 int mdns_browser_revisit_cache(DnsServiceBrowser *sb, int owner_family);
+int mdns_browser_maintenance(sd_event_source *s, uint64_t usec, void *userdata);
 int dns_subscribe_browse_service(
                 Manager *m,
                 sd_varlink *link,
@@ -86,5 +88,6 @@ int dns_subscribe_browse_service(
                 const char *type,
                 int ifindex,
                 uint64_t flags);
+void dns_unsubscribe_browse_service(Manager *m, sd_varlink *link);
 int mdns_notify_browsers_unsolicited_updates(Manager *m, DnsAnswer *answer, int owner_family);
 int mdns_notify_browsers_goodbye(DnsScope *scope);

--- a/src/resolve/resolved-dns-query.c
+++ b/src/resolve/resolved-dns-query.c
@@ -522,9 +522,13 @@ DnsQuery *dns_query_free(DnsQuery *q) {
 
         free(q->request_address_string);
 
-        dnssd_discovered_service_unref(q->dnsservice_request);
-
-        dns_service_browser_unref(q->service_browser_request);
+        if (q->service_browser_request) {
+                /* As with the varlink userdata above: clear the browser's tracking pointer whichever way
+                 * the query goes away, so that it never dangles. */
+                if (q->service_browser_request->maintenance_query == q)
+                        q->service_browser_request->maintenance_query = NULL;
+                dns_service_browser_unref(q->service_browser_request);
+        }
 
         hook_query_free(q->hook_query);
 

--- a/src/resolve/resolved-dns-query.c
+++ b/src/resolve/resolved-dns-query.c
@@ -522,12 +522,12 @@ DnsQuery *dns_query_free(DnsQuery *q) {
 
         free(q->request_address_string);
 
-        if (q->service_browser_request) {
-                /* As with the varlink userdata above: clear the browser's tracking pointer whichever way
+        if (q->service_querier_request) {
+                /* As with the varlink userdata above: clear the querier's tracking pointer whichever way
                  * the query goes away, so that it never dangles. */
-                if (q->service_browser_request->maintenance_query == q)
-                        q->service_browser_request->maintenance_query = NULL;
-                dns_service_browser_unref(q->service_browser_request);
+                if (q->service_querier_request->maintenance_query == q)
+                        q->service_querier_request->maintenance_query = NULL;
+                dns_service_querier_unref(q->service_querier_request);
         }
 
         hook_query_free(q->hook_query);

--- a/src/resolve/resolved-dns-query.h
+++ b/src/resolve/resolved-dns-query.h
@@ -106,8 +106,7 @@ typedef struct DnsQuery {
         DnsAnswer *reply_additional;
         DnsStubListenerExtra *stub_listener_extra;
 
-        /* Browser Service and Dnssd Discovered Service Information */
-        DnssdDiscoveredService *dnsservice_request;
+        /* Service browser this (browse or maintenance) query belongs to */
         DnsServiceBrowser *service_browser_request;
 
         /* Pending query to any installed hooks */

--- a/src/resolve/resolved-dns-query.h
+++ b/src/resolve/resolved-dns-query.h
@@ -106,8 +106,8 @@ typedef struct DnsQuery {
         DnsAnswer *reply_additional;
         DnsStubListenerExtra *stub_listener_extra;
 
-        /* Service browser this (browse or maintenance) query belongs to */
-        DnsServiceBrowser *service_browser_request;
+        /* Shared service querier this (browse or maintenance) query belongs to */
+        DnsServiceQuerier *service_querier_request;
 
         /* Pending query to any installed hooks */
         HookQuery *hook_query;

--- a/src/resolve/resolved-manager.c
+++ b/src/resolve/resolved-manager.c
@@ -926,6 +926,7 @@ Manager* manager_free(Manager *m) {
         while ((sb = hashmap_first(m->dns_service_browsers)))
                 dns_unsubscribe_browse_service(m, sb->link);
         hashmap_free(m->dns_service_browsers);
+        hashmap_free(m->dns_service_queriers);
 
         hashmap_free(m->hooks);
 

--- a/src/resolve/resolved-manager.c
+++ b/src/resolve/resolved-manager.c
@@ -924,7 +924,7 @@ Manager* manager_free(Manager *m) {
         manager_static_records_flush(m);
 
         while ((sb = hashmap_first(m->dns_service_browsers)))
-                dns_service_browser_free(sb);
+                dns_unsubscribe_browse_service(m, sb->link);
         hashmap_free(m->dns_service_browsers);
 
         hashmap_free(m->hooks);

--- a/src/resolve/resolved-manager.h
+++ b/src/resolve/resolved-manager.h
@@ -166,6 +166,7 @@ typedef struct Manager {
 
         /* Map varlink links to DnsServiceBrowser instances. */
         Hashmap *dns_service_browsers;
+        Hashmap *dns_service_queriers;
 
         Hashmap *hooks;
         struct stat hook_stat;

--- a/src/resolve/resolved-mdns.c
+++ b/src/resolve/resolved-mdns.c
@@ -429,6 +429,7 @@ static int on_mdns_packet(sd_event_source *s, int fd, uint32_t revents, void *us
 
         if (dns_packet_validate_reply(p) > 0) {
                 DnsResourceRecord *rr;
+                bool saw_goodbye = false;
 
                 /* RFC 6762 section 6:
                  * The source UDP port in all Multicast DNS responses MUST be 5353 (the well-known port
@@ -475,6 +476,7 @@ static int on_mdns_packet(sd_event_source *s, int fd, uint32_t revents, void *us
                                 log_debug("Got a goodbye packet");
                                 /* See the section 10.1 of RFC6762 */
                                 rr->ttl = 1;
+                                saw_goodbye = true;
 
                                 /* Look at the cache 1 second later and remove stale entries.
                                  * This is particularly useful to keep service browsers updated on service removal,
@@ -536,6 +538,12 @@ static int on_mdns_packet(sd_event_source *s, int fd, uint32_t revents, void *us
                 /* Check if incoming packet key matches with active browse clients. If yes, update the same */
                 if (unsolicited_packet)
                         mdns_notify_browsers_unsolicited_updates(m, p->answer, p->family);
+
+                /* A goodbye for a record a querier browses: give surviving publishers of the
+                 * same records their RFC 6762 §10.1 chance to rescue them before the one-second
+                 * grace above expires and a removal is reported. */
+                if (saw_goodbye)
+                        mdns_queriers_rescue_query_goodbye(scope, p->answer);
         } else if (dns_packet_validate_query(p) > 0)  {
                 log_debug("Got mDNS query packet for id %u", DNS_PACKET_ID(p));
 

--- a/src/resolve/resolved-varlink.c
+++ b/src/resolve/resolved-varlink.c
@@ -167,8 +167,7 @@ static void vl_on_disconnect(sd_varlink_server *s, sd_varlink *link, void *userd
         if (!m)
                 return;
 
-        DnsServiceBrowser *sb = hashmap_remove(m->dns_service_browsers, link);
-        dns_service_browser_unref(sb);
+        dns_unsubscribe_browse_service(m, link);
 
         q = sd_varlink_get_userdata(link);
         if (!q)

--- a/src/resolve/test-dns-browse-services.c
+++ b/src/resolve/test-dns-browse-services.c
@@ -3,10 +3,15 @@
 #include <string.h>
 #include <sys/socket.h>
 
+#include "sd-event.h"
+
 #include "dns-answer.h"
+#include "dns-question.h"
 #include "dns-rr.h"
 #include "resolved-dns-browse-services.h"
+#include "resolved-manager.h"
 #include "tests.h"
+#include "time-util.h"
 
 static DnsResourceRecord *new_test_service_rr(uint32_t ttl) {
         DnsResourceRecord *rr;
@@ -145,6 +150,117 @@ TEST(mdns_answer_contains_service_ifindex) {
 
         sb_scoped.ifindex = 3;
         ASSERT_OK_ZERO(mdns_answer_contains_service(&sb_scoped, answer2, &service));
+}
+
+/* dns_query_go() completes a query synchronously when no scope matches its question, and the
+ * completion handler then frees the query. The ladder tracks its maintenance query by pointer, so the
+ * pointer has to be stored before the query is started and be gone again once the handler returns — a
+ * manager without any scope makes the completion synchronous. */
+TEST(mdns_browser_maintenance_query_completing_synchronously) {
+        _cleanup_(dns_question_unrefp) DnsQuestion *question = NULL;
+        _cleanup_(dns_resource_key_unrefp) DnsResourceKey *key = NULL;
+        Manager manager = {};
+
+        ASSERT_NOT_NULL(key = dns_resource_key_new(DNS_CLASS_IN, DNS_TYPE_PTR, "_http._tcp.local"));
+        ASSERT_NOT_NULL(question = dns_question_new(1));
+        ASSERT_OK(dns_question_add(question, key, /* flags= */ 0));
+
+        DnsServiceBrowser sb = {
+                .n_ref = 1,
+                .manager = &manager,
+                .question_idna = question,
+                .question_utf8 = question,
+                .rr_ttl_state = DNS_RECORD_TTL_STATE_80_PERCENT,
+        };
+
+        ASSERT_OK(mdns_browser_maintenance(/* s= */ NULL, /* usec= */ 0, &sb));
+
+        /* The rung advanced, the query was issued and is gone again, and nothing leaked. */
+        ASSERT_EQ(sb.rr_ttl_state, DNS_RECORD_TTL_STATE_85_PERCENT);
+        ASSERT_NULL(sb.maintenance_query);
+        ASSERT_EQ(sb.n_ref, 1u);
+        ASSERT_EQ(manager.n_dns_queries, 0u);
+}
+
+/* The terminal rung used to be a one-shot that returned without rescheduling; now it reconciles the
+ * cache and starts the ladder over. With no scope and no discovered service there is nothing to remove
+ * and nothing to re-arm against, but the rung must still be reset, no query issued, and the handler
+ * must return success so that sd-event keeps the source. */
+TEST(mdns_browser_maintenance_terminal_rung_resets_ladder) {
+        Manager manager = {};
+        DnsServiceBrowser sb = {
+                .n_ref = 1,
+                .manager = &manager,
+                .rr_ttl_state = DNS_RECORD_TTL_STATE_100_PERCENT,
+        };
+
+        ASSERT_OK(mdns_browser_maintenance(/* s= */ NULL, /* usec= */ 0, &sb));
+
+        ASSERT_EQ(sb.rr_ttl_state, DNS_RECORD_TTL_STATE_80_PERCENT);
+        ASSERT_NULL(sb.maintenance_query);
+        ASSERT_NULL(sb.maintenance_event);
+        ASSERT_EQ(sb.n_ref, 1u);
+        ASSERT_EQ(manager.n_dns_queries, 0u);
+}
+
+/* Every change to the discovered-service list winds the ladder back to 80%, so that a live RRset never
+ * ratchets towards the terminal rung and a surviving instance does not inherit the rung the just-removed
+ * soonest one had climbed to. */
+TEST(mdns_browser_ladder_winds_back_on_add_and_remove) {
+        _cleanup_(dns_resource_record_unrefp) DnsResourceRecord *rr = NULL;
+        DnsServiceBrowser sb = {
+                .rr_ttl_state = DNS_RECORD_TTL_STATE_95_PERCENT,
+        };
+
+        ASSERT_NOT_NULL(rr = new_test_service_rr(120));
+
+        ASSERT_OK(dns_add_new_service(&sb, rr, AF_INET, /* ifindex= */ 2, /* until= */ 100));
+        ASSERT_NOT_NULL(sb.dns_services);
+        ASSERT_EQ(sb.rr_ttl_state, DNS_RECORD_TTL_STATE_80_PERCENT);
+
+        sb.rr_ttl_state = DNS_RECORD_TTL_STATE_95_PERCENT;
+        dns_remove_service(&sb, sb.dns_services);
+        ASSERT_NULL(sb.dns_services);
+        ASSERT_EQ(sb.rr_ttl_state, DNS_RECORD_TTL_STATE_80_PERCENT);
+}
+
+/* ...and so does an answer that merely re-confirms a known instance, refreshing its expiry — which is
+ * what every answered maintenance query produces. Nothing is added or removed, so no client
+ * notification is attempted; the list stays as it was and the ladder is armed against it. */
+TEST(mdns_browser_ladder_winds_back_on_refresh) {
+        _cleanup_(sd_event_unrefp) sd_event *event = NULL;
+        _cleanup_(dns_answer_unrefp) DnsAnswer *answer = NULL;
+        _cleanup_(dns_resource_record_unrefp) DnsResourceRecord *rr = NULL;
+        usec_t t = now(CLOCK_BOOTTIME);
+
+        ASSERT_OK(sd_event_new(&event));
+
+        Manager manager = {
+                .event = event,
+        };
+        DnsServiceBrowser sb = {
+                .n_ref = 1,
+                .manager = &manager,
+                .ifindex = 2,
+        };
+
+        ASSERT_NOT_NULL(rr = new_test_service_rr(120));
+        ASSERT_OK(dns_add_new_service(&sb, rr, AF_INET, /* ifindex= */ 2, usec_add(t, 60 * USEC_PER_SEC)));
+        sb.rr_ttl_state = DNS_RECORD_TTL_STATE_95_PERCENT;
+
+        ASSERT_OK(dns_answer_add_extend_full(
+                          &answer, rr, /* ifindex= */ 2, DNS_ANSWER_CACHEABLE, /* rrsig= */ NULL,
+                          usec_add(t, 120 * USEC_PER_SEC)));
+        ASSERT_OK(mdns_manage_services_answer(&sb, answer, AF_INET));
+
+        ASSERT_EQ(sb.rr_ttl_state, DNS_RECORD_TTL_STATE_80_PERCENT);
+        ASSERT_NOT_NULL(sb.dns_services);
+        ASSERT_NULL(sb.dns_services->dns_services_next);
+        ASSERT_EQ(sb.dns_services->until, usec_add(t, 120 * USEC_PER_SEC));
+        ASSERT_NOT_NULL(sb.maintenance_event);
+
+        sb.maintenance_event = sd_event_source_disable_unref(sb.maintenance_event);
+        dns_remove_service(&sb, sb.dns_services);
 }
 
 DEFINE_TEST_MAIN(LOG_DEBUG);

--- a/src/resolve/test-dns-browse-services.c
+++ b/src/resolve/test-dns-browse-services.c
@@ -124,10 +124,10 @@ TEST(mdns_answer_contains_service_ifindex) {
         ASSERT_NOT_NULL(answer3 = dns_answer_new(0));
         ASSERT_NOT_NULL(rr = new_test_service_rr(120));
 
-        DnsServiceBrowser sb_all = {
+        DnsServiceQuerier sq_all = {
                 .ifindex = 0,
         };
-        DnsServiceBrowser sb_scoped = {
+        DnsServiceQuerier sq_scoped = {
                 .ifindex = 2,
         };
         DnssdDiscoveredService service = {
@@ -137,26 +137,26 @@ TEST(mdns_answer_contains_service_ifindex) {
         };
 
         ASSERT_OK_POSITIVE(dns_answer_add(answer, rr, 3, DNS_ANSWER_CACHEABLE, /* rrsig= */ NULL));
-        ASSERT_OK_ZERO(mdns_answer_contains_service(&sb_all, answer, &service));
+        ASSERT_OK_ZERO(mdns_answer_contains_service(&sq_all, answer, &service));
 
         ASSERT_OK_POSITIVE(dns_answer_add(answer, rr, 2, DNS_ANSWER_CACHEABLE, /* rrsig= */ NULL));
-        ASSERT_OK_POSITIVE(mdns_answer_contains_service(&sb_all, answer, &service));
+        ASSERT_OK_POSITIVE(mdns_answer_contains_service(&sq_all, answer, &service));
 
         ASSERT_OK_POSITIVE(dns_answer_add(answer2, rr, 0, DNS_ANSWER_CACHEABLE, /* rrsig= */ NULL));
-        ASSERT_OK_POSITIVE(mdns_answer_contains_service(&sb_scoped, answer2, &service));
+        ASSERT_OK_POSITIVE(mdns_answer_contains_service(&sq_scoped, answer2, &service));
 
         ASSERT_OK_POSITIVE(dns_answer_add(answer3, rr, 3, DNS_ANSWER_CACHEABLE, /* rrsig= */ NULL));
-        ASSERT_OK_ZERO(mdns_answer_contains_service(&sb_scoped, answer3, &service));
+        ASSERT_OK_ZERO(mdns_answer_contains_service(&sq_scoped, answer3, &service));
 
-        sb_scoped.ifindex = 3;
-        ASSERT_OK_ZERO(mdns_answer_contains_service(&sb_scoped, answer2, &service));
+        sq_scoped.ifindex = 3;
+        ASSERT_OK_ZERO(mdns_answer_contains_service(&sq_scoped, answer2, &service));
 }
 
 /* dns_query_go() completes a query synchronously when no scope matches its question, and the
  * completion handler then frees the query. The ladder tracks its maintenance query by pointer, so the
  * pointer has to be stored before the query is started and be gone again once the handler returns — a
  * manager without any scope makes the completion synchronous. */
-TEST(mdns_browser_maintenance_query_completing_synchronously) {
+TEST(mdns_querier_maintenance_query_completing_synchronously) {
         _cleanup_(dns_question_unrefp) DnsQuestion *question = NULL;
         _cleanup_(dns_resource_key_unrefp) DnsResourceKey *key = NULL;
         Manager manager = {};
@@ -165,7 +165,7 @@ TEST(mdns_browser_maintenance_query_completing_synchronously) {
         ASSERT_NOT_NULL(question = dns_question_new(1));
         ASSERT_OK(dns_question_add(question, key, /* flags= */ 0));
 
-        DnsServiceBrowser sb = {
+        DnsServiceQuerier sq = {
                 .n_ref = 1,
                 .manager = &manager,
                 .question_idna = question,
@@ -173,12 +173,12 @@ TEST(mdns_browser_maintenance_query_completing_synchronously) {
                 .rr_ttl_state = DNS_RECORD_TTL_STATE_80_PERCENT,
         };
 
-        ASSERT_OK(mdns_browser_maintenance(/* s= */ NULL, /* usec= */ 0, &sb));
+        ASSERT_OK(mdns_querier_maintenance(/* s= */ NULL, /* usec= */ 0, &sq));
 
         /* The rung advanced, the query was issued and is gone again, and nothing leaked. */
-        ASSERT_EQ(sb.rr_ttl_state, DNS_RECORD_TTL_STATE_85_PERCENT);
-        ASSERT_NULL(sb.maintenance_query);
-        ASSERT_EQ(sb.n_ref, 1u);
+        ASSERT_EQ(sq.rr_ttl_state, DNS_RECORD_TTL_STATE_85_PERCENT);
+        ASSERT_NULL(sq.maintenance_query);
+        ASSERT_EQ(sq.n_ref, 1u);
         ASSERT_EQ(manager.n_dns_queries, 0u);
 }
 
@@ -186,48 +186,48 @@ TEST(mdns_browser_maintenance_query_completing_synchronously) {
  * cache and starts the ladder over. With no scope and no discovered service there is nothing to remove
  * and nothing to re-arm against, but the rung must still be reset, no query issued, and the handler
  * must return success so that sd-event keeps the source. */
-TEST(mdns_browser_maintenance_terminal_rung_resets_ladder) {
+TEST(mdns_querier_maintenance_terminal_rung_resets_ladder) {
         Manager manager = {};
-        DnsServiceBrowser sb = {
+        DnsServiceQuerier sq = {
                 .n_ref = 1,
                 .manager = &manager,
                 .rr_ttl_state = DNS_RECORD_TTL_STATE_100_PERCENT,
         };
 
-        ASSERT_OK(mdns_browser_maintenance(/* s= */ NULL, /* usec= */ 0, &sb));
+        ASSERT_OK(mdns_querier_maintenance(/* s= */ NULL, /* usec= */ 0, &sq));
 
-        ASSERT_EQ(sb.rr_ttl_state, DNS_RECORD_TTL_STATE_80_PERCENT);
-        ASSERT_NULL(sb.maintenance_query);
-        ASSERT_NULL(sb.maintenance_event);
-        ASSERT_EQ(sb.n_ref, 1u);
+        ASSERT_EQ(sq.rr_ttl_state, DNS_RECORD_TTL_STATE_80_PERCENT);
+        ASSERT_NULL(sq.maintenance_query);
+        ASSERT_NULL(sq.maintenance_event);
+        ASSERT_EQ(sq.n_ref, 1u);
         ASSERT_EQ(manager.n_dns_queries, 0u);
 }
 
 /* Every change to the discovered-service list winds the ladder back to 80%, so that a live RRset never
  * ratchets towards the terminal rung and a surviving instance does not inherit the rung the just-removed
  * soonest one had climbed to. */
-TEST(mdns_browser_ladder_winds_back_on_add_and_remove) {
+TEST(mdns_querier_ladder_winds_back_on_add_and_remove) {
         _cleanup_(dns_resource_record_unrefp) DnsResourceRecord *rr = NULL;
-        DnsServiceBrowser sb = {
+        DnsServiceQuerier sq = {
                 .rr_ttl_state = DNS_RECORD_TTL_STATE_95_PERCENT,
         };
 
         ASSERT_NOT_NULL(rr = new_test_service_rr(120));
 
-        ASSERT_OK(dns_add_new_service(&sb, rr, AF_INET, /* ifindex= */ 2, /* until= */ 100));
-        ASSERT_NOT_NULL(sb.dns_services);
-        ASSERT_EQ(sb.rr_ttl_state, DNS_RECORD_TTL_STATE_80_PERCENT);
+        ASSERT_OK(dns_add_new_service(&sq, rr, AF_INET, /* ifindex= */ 2, /* until= */ 100));
+        ASSERT_NOT_NULL(sq.dns_services);
+        ASSERT_EQ(sq.rr_ttl_state, DNS_RECORD_TTL_STATE_80_PERCENT);
 
-        sb.rr_ttl_state = DNS_RECORD_TTL_STATE_95_PERCENT;
-        dns_remove_service(&sb, sb.dns_services);
-        ASSERT_NULL(sb.dns_services);
-        ASSERT_EQ(sb.rr_ttl_state, DNS_RECORD_TTL_STATE_80_PERCENT);
+        sq.rr_ttl_state = DNS_RECORD_TTL_STATE_95_PERCENT;
+        dns_remove_service(&sq, sq.dns_services);
+        ASSERT_NULL(sq.dns_services);
+        ASSERT_EQ(sq.rr_ttl_state, DNS_RECORD_TTL_STATE_80_PERCENT);
 }
 
 /* ...and so does an answer that merely re-confirms a known instance, refreshing its expiry — which is
  * what every answered maintenance query produces. Nothing is added or removed, so no client
  * notification is attempted; the list stays as it was and the ladder is armed against it. */
-TEST(mdns_browser_ladder_winds_back_on_refresh) {
+TEST(mdns_querier_ladder_winds_back_on_refresh) {
         _cleanup_(sd_event_unrefp) sd_event *event = NULL;
         _cleanup_(dns_answer_unrefp) DnsAnswer *answer = NULL;
         _cleanup_(dns_resource_record_unrefp) DnsResourceRecord *rr = NULL;
@@ -238,29 +238,29 @@ TEST(mdns_browser_ladder_winds_back_on_refresh) {
         Manager manager = {
                 .event = event,
         };
-        DnsServiceBrowser sb = {
+        DnsServiceQuerier sq = {
                 .n_ref = 1,
                 .manager = &manager,
                 .ifindex = 2,
         };
 
         ASSERT_NOT_NULL(rr = new_test_service_rr(120));
-        ASSERT_OK(dns_add_new_service(&sb, rr, AF_INET, /* ifindex= */ 2, usec_add(t, 60 * USEC_PER_SEC)));
-        sb.rr_ttl_state = DNS_RECORD_TTL_STATE_95_PERCENT;
+        ASSERT_OK(dns_add_new_service(&sq, rr, AF_INET, /* ifindex= */ 2, usec_add(t, 60 * USEC_PER_SEC)));
+        sq.rr_ttl_state = DNS_RECORD_TTL_STATE_95_PERCENT;
 
         ASSERT_OK(dns_answer_add_extend_full(
                           &answer, rr, /* ifindex= */ 2, DNS_ANSWER_CACHEABLE, /* rrsig= */ NULL,
                           usec_add(t, 120 * USEC_PER_SEC)));
-        ASSERT_OK(mdns_manage_services_answer(&sb, answer, AF_INET));
+        ASSERT_OK(mdns_manage_services_answer(&sq, answer, AF_INET));
 
-        ASSERT_EQ(sb.rr_ttl_state, DNS_RECORD_TTL_STATE_80_PERCENT);
-        ASSERT_NOT_NULL(sb.dns_services);
-        ASSERT_NULL(sb.dns_services->dns_services_next);
-        ASSERT_EQ(sb.dns_services->until, usec_add(t, 120 * USEC_PER_SEC));
-        ASSERT_NOT_NULL(sb.maintenance_event);
+        ASSERT_EQ(sq.rr_ttl_state, DNS_RECORD_TTL_STATE_80_PERCENT);
+        ASSERT_NOT_NULL(sq.dns_services);
+        ASSERT_NULL(sq.dns_services->dns_services_next);
+        ASSERT_EQ(sq.dns_services->until, usec_add(t, 120 * USEC_PER_SEC));
+        ASSERT_NOT_NULL(sq.maintenance_event);
 
-        sb.maintenance_event = sd_event_source_disable_unref(sb.maintenance_event);
-        dns_remove_service(&sb, sb.dns_services);
+        sq.maintenance_event = sd_event_source_disable_unref(sq.maintenance_event);
+        dns_remove_service(&sq, sq.dns_services);
 }
 
 DEFINE_TEST_MAIN(LOG_DEBUG);

--- a/test/units/TEST-89-RESOLVED-MDNS.sh
+++ b/test/units/TEST-89-RESOLVED-MDNS.sh
@@ -333,6 +333,110 @@ testcase_second_unreachable() {
     done
 }
 
+testcase_mdns_remove_on_expiry() {
+    : "A service that vanishes without a goodbye must be removed when its records expire"
+
+    local out_file error_file unit_name service_type
+    out_file="$(mktemp)"
+    error_file="$(mktemp)"
+    unit_name="varlinkctl-expiry-$SRANDOM.service"
+    service_type="_testExpiry._udp"
+
+    # An EXIT trap, not RETURN: set -e aborts skip RETURN traps, and this subshell's EXIT trap
+    # fires however the testcase ends — the infinity browse unit must never outlive it. Armed
+    # before anything can fail, so an early abort cleans up the files too.
+    # shellcheck disable=SC2064
+    trap "systemctl stop $unit_name 2>/dev/null || :; rm -f $out_file $error_file" EXIT
+
+    # Publish a canary service type from the second container ONLY. A type that
+    # both containers publish cannot discriminate a broken maintenance ladder:
+    # the surviving publisher keeps answering the browser's continuous PTR
+    # query, and each successful completion of that query also revisits the
+    # cache -- pruning expired records and emitting the very 'removed' event
+    # this test is about, ladder or no ladder. With no surviving publisher, no
+    # transaction completes successfully once the container is gone, so the
+    # removal below is reachable only through the ladder's terminal fire.
+    systemd-run -M "$CONTAINER_2" --wait --pipe -- tee /etc/systemd/dnssd/expiry-canary.dnssd <<EOF
+[Service]
+Name=Expiry Canary on %H
+Type=$service_type
+Port=8010
+TxtText=DC=Device PN=123456 SN=1234567890
+EOF
+    # Reload rather than restart: it re-runs dnssd_load() to pick up the new
+    # file while leaving the runtime per-link mDNS switches from setup intact.
+    systemd-run -M "$CONTAINER_2" --wait --pipe -- systemctl reload systemd-resolved.service
+
+    resolvectl flush-caches
+
+    # Note: --timeout=infinity, because this subscription must outlive the 120s record
+    # TTL: varlinkctl's default 45s method-call timeout would sever the connection --
+    # and with it the server-side browser and its maintenance ladder -- long before
+    # the expiry-driven removal that this test is about could be observed.
+    systemd-run --unit="$unit_name" --service-type=exec -p StandardOutput="file:$out_file" -p StandardError="file:$error_file" \
+        varlinkctl call --more --timeout=infinity /run/systemd/resolve/io.systemd.Resolve io.systemd.Resolve.BrowseServices \
+        "{ \"domain\": \"$service_type.local\", \"type\": \"\", \"ifindex\": ${BRIDGE_INDEX:?}, \"flags\": 16785432 }"
+
+    # Wait until the canary has been discovered.
+    local ok=0
+    for _ in {0..14}; do
+        if grep "on $CONTAINER_2" >/dev/null "$out_file"; then
+            ok=1
+            break
+        fi
+        sleep 2
+    done
+    if [[ "$ok" -ne 1 ]]; then
+        echo >&2 "Never discovered the expiry canary on $CONTAINER_2"
+        cat "$out_file" "$error_file" >&2
+        return 1
+    fi
+
+    # Checkpoint the output: only 'removed' events produced AFTER the container
+    # goes away count, so a match is provably expiry-driven rather than some
+    # earlier transient churn.
+    local off
+    off="$(wc -c <"$out_file")"
+
+    # Yank the second container off the network *abruptly* (no goodbye). We do
+    # NOT flush caches here: with the canary's only publisher gone, removal must
+    # be driven purely by the browser's TTL-maintenance ladder re-confirming
+    # and then, at TTL expiry, pruning the now-unanswered records and emitting
+    # 'removed'.
+    systemd-run -M "$CONTAINER_2" --wait --pipe -- networkctl down host0
+
+    # Records use MDNS_DEFAULT_TTL (120s); the terminal fire lands at ~down+120s
+    # plus ladder jitter and event-loop slop, so poll generously (~200s).
+    local removed=0
+    for _ in {0..99}; do
+        if tail -c "+$((off + 1))" "$out_file" | { grep -oE '"updateFlag":"removed"[^}]*"name":"[^"]*"' || :; } | grep "on $CONTAINER_2" >/dev/null; then
+            removed=1
+            break
+        fi
+        sleep 2
+    done
+
+    if [[ "$removed" -ne 1 ]]; then
+        echo >&2 "$CONTAINER_2 services were not removed after their records expired"
+        cat "$out_file" "$error_file" >&2
+        systemd-run -M "$CONTAINER_2" --wait --pipe -- networkctl up host0 || :
+        return 1
+    fi
+
+    # Restore the second container for the remaining testcases and withdraw the
+    # canary again. Best-effort: the removal this testcase is about has already
+    # been asserted above, and the next testcase re-downs host0 and brings it
+    # back up with its own wait -- a transient hiccup here (say, wait-online
+    # hitting its cap on a loaded runner) must not fail a passed testcase.
+    systemd-run -M "$CONTAINER_2" --wait --pipe -- networkctl up host0 || :
+    systemd-run -M "$CONTAINER_2" --wait --pipe -- \
+        /usr/lib/systemd/systemd-networkd-wait-online --ipv4 --ipv6 --interface=host0 --operational-state=degraded --timeout=30 || :
+    systemd-run -M "$CONTAINER_2" --wait --pipe -- rm /etc/systemd/dnssd/expiry-canary.dnssd || :
+    systemd-run -M "$CONTAINER_2" --wait --pipe -- systemctl reload systemd-resolved.service || :
+
+    echo testcase_end
+}
+
 : "Setup host & containers"
 # Note: create the drop-in intentionally under /run/ and copy it manually into the containers
 mkdir -p /run/systemd/resolved.conf.d/

--- a/test/units/TEST-89-RESOLVED-MDNS.sh
+++ b/test/units/TEST-89-RESOLVED-MDNS.sh
@@ -315,6 +315,131 @@ testcase_browse_ifindex_zero_no_flap() {
     echo testcase_end
 }
 
+testcase_browse_shared_querier() {
+    : "Concurrent subscribers of one service type share a querier and each receives updates"
+    resolvectl flush-caches
+
+    local out1 out2 out3 unit1 unit2 unit3 service_type params n1 n2 n3
+    service_type="_testService8._udp"
+    params="{ \"domain\": \"$service_type.local\", \"type\": \"\", \"ifindex\": ${BRIDGE_INDEX:?}, \"flags\": 16785432 }"
+    out1="$(mktemp)"; out2="$(mktemp)"; out3="$(mktemp)"
+    unit1="varlinkctl-shared1-$SRANDOM.service"
+    unit2="varlinkctl-shared2-$SRANDOM.service"
+    unit3="varlinkctl-shared3-$SRANDOM.service"
+
+    # An EXIT trap, not RETURN: set -e aborts skip RETURN traps, and this subshell's EXIT trap
+    # fires however the testcase ends — the infinity browse units must never outlive it. Armed
+    # before anything can fail, so an early abort cleans up the files too.
+    # shellcheck disable=SC2064
+    trap "systemctl stop $unit1 $unit2 $unit3 2>/dev/null || :; rm -f $out1 $out2 $out3" EXIT
+
+    # Two concurrent subscriptions to the same question from the start. --timeout=infinity: both
+    # must survive the ~120s TTL expiry phase below despite going idle in between.
+    systemd-run --unit="$unit1" --service-type=exec -p StandardOutput="file:$out1" \
+        varlinkctl call --more --timeout=infinity /run/systemd/resolve/io.systemd.Resolve io.systemd.Resolve.BrowseServices "$params"
+    systemd-run --unit="$unit2" --service-type=exec -p StandardOutput="file:$out2" \
+        varlinkctl call --more --timeout=infinity /run/systemd/resolve/io.systemd.Resolve io.systemd.Resolve.BrowseServices "$params"
+
+    # Both subscribers must see all 40 services (20 per container, both families collapse onto
+    # family-tagged entries; count 'added' occurrences like the other testcases). The raw >=40
+    # count alone could be satisfied by a single container's 20 services on two families, so
+    # also require that BOTH containers appear in each stream -- the expiry phase below yanks
+    # CONTAINER_2 and would be doomed from the start if it was never discovered.
+    local both=0
+    for _ in {0..14}; do
+        n1="$( { grep -o '"updateFlag":"added"' "$out1" || :; } | wc -l)"
+        n2="$( { grep -o '"updateFlag":"added"' "$out2" || :; } | wc -l)"
+        if [[ "$n1" -ge 40 && "$n2" -ge 40 ]] &&
+           grep "on $CONTAINER_1" "$out1" >/dev/null && grep "on $CONTAINER_2" "$out1" >/dev/null &&
+           grep "on $CONTAINER_1" "$out2" >/dev/null && grep "on $CONTAINER_2" "$out2" >/dev/null; then
+            both=1
+            break
+        fi
+        sleep 2
+    done
+    if [[ "$both" -ne 1 ]]; then
+        echo >&2 "Concurrent subscribers did not both discover both containers' services (n1=${n1:-0} n2=${n2:-0})"
+        cat "$out1" "$out2" >&2
+        return 1
+    fi
+
+    # A late joiner of the same question is served a snapshot of the querier state and must not
+    # need to wait for any wire traffic -- poll briefly only to absorb event-loop scheduling.
+    systemd-run --unit="$unit3" --service-type=exec -p StandardOutput="file:$out3" \
+        varlinkctl call --more --timeout=infinity /run/systemd/resolve/io.systemd.Resolve io.systemd.Resolve.BrowseServices "$params"
+    local snap=0
+    for _ in {0..9}; do
+        n3="$( { grep -o '"updateFlag":"added"' "$out3" || :; } | wc -l)"
+        if [[ "$n3" -ge 40 ]] &&
+           grep "on $CONTAINER_1" "$out3" >/dev/null && grep "on $CONTAINER_2" "$out3" >/dev/null; then
+            snap=1
+            break
+        fi
+        sleep 1
+    done
+    if [[ "$snap" -ne 1 ]]; then
+        echo >&2 "Late joiner did not receive the full initial snapshot (n3=${n3:-0})"
+        cat "$out3" >&2
+        return 1
+    fi
+
+    # Detaching one subscriber must not affect the others: checkpoint the survivors' streams
+    # BEFORE the stop, hold a quiet window spanning several continuous-query revisits (as the
+    # no-flap testcase does), and assert no 'removed' reached them. All publishers are still up,
+    # so any hit here is detach-induced flap -- which would otherwise be indistinguishable from
+    # the expiry-driven removals asserted below.
+    local off1 off3
+    off1="$(wc -c <"$out1")"
+    off3="$(wc -c <"$out3")"
+
+    systemctl stop "$unit2"
+    sleep 12
+
+    if tail -c "+$((off1 + 1))" "$out1" | grep '"updateFlag":"removed"' >/dev/null; then
+        echo >&2 "Detaching a subscriber caused spurious 'removed' events for a surviving subscriber:"
+        tail -c "+$((off1 + 1))" "$out1" >&2
+        return 1
+    fi
+    if tail -c "+$((off3 + 1))" "$out3" | grep '"updateFlag":"removed"' >/dev/null; then
+        echo >&2 "Detaching a subscriber caused spurious 'removed' events for the late joiner:"
+        tail -c "+$((off3 + 1))" "$out3" >&2
+        return 1
+    fi
+
+    # Take the second container off the network abruptly. The assertion here is the fan-out:
+    # however the expired records get pruned (for a type the surviving publisher still answers,
+    # its refreshes can drive the pruning just as well as the querier's TTL-maintenance ladder
+    # -- testcase_mdns_remove_on_expiry is what pins down the ladder mechanism), every remaining
+    # subscriber must receive the resulting 'removed' events, late joiner included.
+    systemd-run -M "$CONTAINER_2" --wait --pipe -- networkctl down host0
+
+    local removed1=0 removed3=0
+    for _ in {0..99}; do
+        if [[ "$removed1" -eq 0 ]] && tail -c "+$((off1 + 1))" "$out1" | { grep -oE '"updateFlag":"removed"[^}]*"name":"[^"]*"' || :; } | grep "on $CONTAINER_2" >/dev/null; then
+            removed1=1
+        fi
+        if [[ "$removed3" -eq 0 ]] && tail -c "+$((off3 + 1))" "$out3" | { grep -oE '"updateFlag":"removed"[^}]*"name":"[^"]*"' || :; } | grep "on $CONTAINER_2" >/dev/null; then
+            removed3=1
+        fi
+        [[ "$removed1" -eq 1 && "$removed3" -eq 1 ]] && break
+        sleep 2
+    done
+
+    if [[ "$removed1" -ne 1 || "$removed3" -ne 1 ]]; then
+        echo >&2 "Expiry removals were not fanned out to all subscribers (removed1=$removed1 removed3=$removed3)"
+        cat "$out1" "$out3" >&2
+        systemd-run -M "$CONTAINER_2" --wait --pipe -- networkctl up host0 || :
+        return 1
+    fi
+
+    # Restore the second container for the remaining testcases.
+    systemd-run -M "$CONTAINER_2" --wait --pipe -- networkctl up host0
+    systemd-run -M "$CONTAINER_2" --wait --pipe -- \
+        /usr/lib/systemd/systemd-networkd-wait-online --ipv4 --ipv6 --interface=host0 --operational-state=degraded --timeout=30
+
+    echo testcase_end
+}
+
 testcase_second_unreachable() {
     : "Test each service type while the second container is unreachable"
     systemd-run -M "$CONTAINER_2" --wait --pipe -- networkctl down host0


### PR DESCRIPTION
**Stacked on #42984** — the first three commits are that PR, under review there; the five commits on top are what this PR adds. It will be rebased to drop the base commits as soon as #42984 merges (draft until then).

Currently every BrowseServices subscriber runs its own full browse engine: its own continuous PTR queries and its own re-confirmation ladder, for the identical question. Wire traffic scales with the number of local subscribers, which the mDNS browser has carried as a TODO since its introduction (8458b7fb91: duplicate question suppression, RFC 6762 §7.3).

This splits the browse engine out of the per-client `DnsServiceBrowser` into a `DnsServiceQuerier` shared between all subscribers of the same (question key, ifindex, flags), with event fan-out to every subscriber and a snapshot of already-discovered services for late joiners — one question on the wire, no matter how many local clients.

Measured effects:
- tcpdump over 70s on a dedicated bridge: 12 vs 14 PTR queries for 1 vs 3 concurrent browsers (traffic no longer scales with subscriber count).
- With a scripted mDNS peer counting queries in a 12s window while a second subscriber joins an established browse: 4 queries on current main (the new subscriber's fresh query schedule) vs 1 with this change.

The TEST-89 addition asserts that concurrent browsers share a querier and that each still receives its own complete event stream (including the late-joiner snapshot).

The last commit makes the querier give RFC 6762 §10.1's one-second goodbye grace its intended effect: identical records from different machines share one cache entry, so one publisher's goodbye used to yield a spurious `removed` for an instance another machine still answers for (reported in [libcups#81](https://github.com/OpenPrinting/libcups/issues/81#issuecomment-5303811269)). When a goodbye matches an active browse question, the querier now re-issues that question immediately, so a surviving publisher's answer refreshes the records inside the grace second and no removal is reported; with no survivor the goodbye takes effect exactly as before.

Note: the TEST-89 conformance scorecard proposed in #43220 tracks these defects as the `duplicate_question_suppression` and `goodbye_shared_instance` known failures; whichever PR lands second drops those table entries.

