### PR TITLE
ci: fix /etc and /usr ownership

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -47,6 +47,9 @@ jobs:
     env:
       CROSS_ARCH: ${{ matrix.cross_arch || '' }}
     steps:
+      # FIXME: revert this once https://github.com/actions/runner-images/issues/14477 is resolved
+      - name: Fix /etc and /usr ownership
+        run: sudo chown -v root:root /etc /usr
       - name: Repository checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:


### PR DESCRIPTION
Recent Ubuntu 24.04 GHA images have /etc and /usr owned by runner instead of root, which breaks some of our tests. This has been filed to GH as https://github.com/actions/runner-images/issues/14477, so let's work around this in our jobs until it's fixed.