### PR TITLE
core/dbus: do not flush a user manager's bus that is not RUNNING

### DIFF
--- a/src/core/dbus.c
+++ b/src/core/dbus.c
@@ -1095,9 +1095,14 @@ static void destroy_bus(Manager *m, sd_bus **bus) {
         if (m->pending_reload_message_dbus && sd_bus_message_get_bus(m->pending_reload_message_dbus) == *bus)
                 m->pending_reload_message_dbus = sd_bus_message_unref(m->pending_reload_message_dbus);
 
-        /* Possibly flush unwritten data, but only if we are
-         * unprivileged, since we don't want to sync here */
-        if (!MANAGER_IS_SYSTEM(m))
+        /* Possibly flush unwritten data, but only if we are unprivileged, since we don't want to sync
+         * here, and only if the connection is currently RUNNING: sd_bus_flush() first drives the
+         * connection to completion via bus_ensure_running(), which blocks us synchronously for up to
+         * BUS_AUTH_TIMEOUT if the peer accepted the connection but never answers authentication (e.g. a
+         * socket-activated D-Bus service that is hung or already gone during session teardown).
+         * sd_bus_flush() only touches the write queue once that step succeeds, so anything queued on a
+         * connection that does not reach RUNNING is discarded either way - not worth blocking for. */
+        if (!MANAGER_IS_SYSTEM(m) && sd_bus_is_ready(*bus) > 0)
                 sd_bus_flush(*bus);
 
         /* And destroy the object */


### PR DESCRIPTION
## Summary

Skip the flush in `destroy_bus()` unless the connection reached `RUNNING` — removing the block traced in #16471 (2020, v245), where a user manager whose bus connection was stuck in `AUTHENTICATING` froze for 90 s mid-shutdown.

The mechanism: `destroy_bus()` flushes unwritten data for unprivileged managers, and when the connection being destroyed is not `RUNNING`, `sd_bus_flush()` first drives it to completion via `bus_ensure_running()` — blocking the manager synchronously, event loop not running, for up to `BUS_AUTH_TIMEOUT` (= `DEFAULT_TIMEOUT_USEC`, 90 s by default) against a peer that may never answer. `sd_bus_flush()` only touches the write queue once the connection is up, so anything queued on a connection that does not reach `RUNNING` is discarded either way — there is nothing worth blocking for.

## Problem

During session teardown, `dbus.socket` can be — or re-enter — the listening state while the D-Bus service behind it is hung or already gone (see the socket-state analysis in #16471). The manager's bus connection then sits in `AUTHENTICATING`: `connect()` succeeded against the socket backlog, but nothing is there to answer. `destroy_bus()` is reached from four places — the disconnect handler, `manager_recheck_dbus()`, the failed-setup path in `api_bus_instance_id_reply()`, and `bus_done()` during normal shutdown or reexec (via `manager_free()`) — and in any of them, the flush freezes the user manager mid-shutdown (or mid-reexec) for 90 s, with every remaining unit stop, or the reexec itself, gated behind it.

The reporter of #16471 traced exactly this in 2020: their strace shows the manager hanging in a single-fd `ppoll` with an ~89 s timeout right after SIGTERM — `bus_ensure_running()` driving an `AUTHENTICATING` reconnection — and their summary attributes it to the flush: *"Then user-systemd will try to flush, which starts authenticating to the dbus.service (which already was terminated), causing a hang of 90 seconds."*

1166f4472d ("core/dbus: do not block the manager on GetId during bus (re-)connection") recently removed the connect-time instance of the same class of block — code from 2025. This removes the teardown-time instance, which is twelve years older: it dates back to the libsystemd-bus conversion (718db96199, 2013).

## Solution

Flush only when `sd_bus_is_ready(*bus) > 0`. This does not change what gets delivered in the failure case being fixed. A non-RUNNING connection's write queue can hold more than auth/Hello traffic — a per-unit or per-job `sd_bus_track` can attach to `m->api_bus` without a readiness check, so a subscriber signal can in principle be enqueued before `RUNNING`. But `sd_bus_flush()` calls `bus_ensure_running()` *before* it ever looks at the write queue, so on a connection that never reaches `RUNNING` (exactly the case here) that data was already being silently dropped on close by the old code too; the only change is that it no longer blocks for up to 90 s first. `bus_foreach_bus()` already applies the same "not ready yet" principle in the other direction, skipping enqueue for connections that "haven't started yet" via the same `sd_bus_is_ready()` check.

The one real narrowing: a connection that *would* complete authentication within the timeout window previously got its queued traffic delivered after the block; now it does not. Every `destroy_bus()` call site above is reached only once the manager has already decided the connection is being torn down — disconnected, recognized as down, or the process itself exiting or reexecuting — so this does not trade a working delivery for a broken one.

Alternatives from the #16471 thread, and why not:

- The reporter's tested sd-bus-level patch (a SIGTERM-set flag breaking `bus_ensure_running()`'s wait) was functionally on target, but was met with *"a work-around once things are already bad, but we shouldn't even get in that state"*. The same reply stated the expectation this PR implements — the manager *"should normally protect itself … and not issue dbus messages when the dbus service isn't fully up"* — and the `sd_bus_is_ready()` guard is that protection at the teardown call site, covering all four `destroy_bus()` paths without changing library semantics.
- The socket-side hardening suggested there (not re-entering the listening state while a stop job is queued) would narrow one enabling window, but is a behavior change for all socket units and does not cover other ways the accepting-but-dead window arises. It remains a reasonable complementary change; this PR does not depend on it.

Known residual, deliberately out of scope: a bus that reached `RUNNING` whose peer then stopped reading can still hang the flush (its write loop waits unboundedly). That is pre-existing behavior for delivered-but-stuck connections, distinct from the never-authenticated case this fixes.

## Verification

- Minimal demonstrator (sd-bus client against a Unix socket that listens but never accepts, mirroring the accepting-socket/dead-service state): unguarded `sd_bus_flush()` on the `AUTHENTICATING` connection blocks for the full auth timeout (measured 90.0 s, returning `-ENOTCONN`); with the `sd_bus_is_ready()` guard it returns immediately. This demonstrates the blocking primitive; the production-scenario evidence is the 2020 trace in #16471. (Program in the details block below.)
- Full build of systemd with this patch applied; no functional test exists for this path — the demonstrator above stands in for it.

<details><summary>flush-block.c</summary>

```c
/* Minimal demonstrator for the destroy_bus() flush block (systemd#16471):
 * sd_bus_flush() on a connection whose peer accepted but never answers
 * authentication blocks synchronously in bus_ensure_running() until
 * BUS_AUTH_TIMEOUT.
 *
 * Build: cc flush-block.c -o flush-block $(pkg-config --cflags --libs libsystemd)
 * Peer (listens, never accepts - the accepting-socket/dead-service state):
 *   python3 -c 'import socket,time; s=socket.socket(socket.AF_UNIX);
 *               s.bind("/tmp/silent.sock"); s.listen(1); time.sleep(3600)' &
 * Run:   ./flush-block /tmp/silent.sock         # unguarded: blocks ~90 s
 *        ./flush-block /tmp/silent.sock guard   # guarded: returns at once
 */
#include <stdio.h>
#include <time.h>
#include <systemd/sd-bus.h>

int main(int argc, char **argv) {
        sd_bus *bus = NULL;
        struct timespec a, b;
        char addr[256];
        int r, ready, guard = argc > 2;
        double dt;

        if (argc < 2) {
                fprintf(stderr, "usage: flush-block <socket-path> [guard]\n");
                return 1;
        }

        snprintf(addr, sizeof(addr), "unix:path=%s", argv[1]);
        sd_bus_new(&bus);
        sd_bus_set_address(bus, addr);
        r = sd_bus_start(bus);
        if (r < 0) {
                fprintf(stderr, "start: %d\n", r);
                return 1;
        }
        sd_bus_process(bus, NULL);
        ready = sd_bus_is_ready(bus);

        clock_gettime(CLOCK_MONOTONIC, &a);
        r = 0;                          /* 0 = flush skipped by the guard */
        if (!guard || ready > 0)
                r = sd_bus_flush(bus);
        clock_gettime(CLOCK_MONOTONIC, &b);
        dt = (b.tv_sec - a.tv_sec) + (b.tv_nsec - a.tv_nsec) / 1e9;

        printf("%s: is_ready=%d flush_r=%d blocked=%.1fs\n",
               guard ? "guarded" : "unguarded", ready, r, dt);
        sd_bus_close_unref(bus);
        return 0;
}
```

</details>

Fixes #16471
