### PR TITLE
string-util: don't miss ANSI sequence at the very end in previous_ansi_sequence()

### DIFF
--- a/src/basic/string-util.c
+++ b/src/basic/string-util.c
@@ -293,13 +293,15 @@ static size_t previous_ansi_sequence(const char *s, size_t length, const char **
                 return 0;
         }
 
-        for (size_t i = length - 2; i > 0; i--) {  /* -2 because at least two bytes are needed */
-                size_t slen = ansi_sequence_length(s + (i - 1), length - (i - 1));
-                if (slen == 0)
-                        continue;
+        for (size_t i = length - 2;; i--) {  /* -2 because at least two bytes are needed */
+                size_t slen = ansi_sequence_length(s + i, length - i);
+                if (slen > 0) {
+                        *ret_where = s + i;
+                        return slen;
+                }
 
-                *ret_where = s + (i - 1);
-                return slen;
+                if (i == 0)
+                        break;
         }
 
         *ret_where = NULL;

--- a/src/test/test-ellipsize.c
+++ b/src/test/test-ellipsize.c
@@ -162,6 +162,21 @@ TEST(ellipsize_ansi_cats) {
         ASSERT_STREQ(h, "🐱…" ANSI_NORMAL "🐱" ANSI_NORMAL);
 }
 
+TEST(ellipsize_ansi_two_byte) {
+        _cleanup_free_ char *e = NULL, *f = NULL;
+
+        /* Fe escape sequences are just two bytes long (ESC followed by 0x40…0x5F). Make sure they are
+         * skipped over like the longer CSI sequences are, in particular when one terminates the string. */
+
+        e = ellipsize("🐱🐱" "\x1bM" "🐱🐱" "\x1bM", 5, 0);
+        puts(e);
+        ASSERT_STREQ(e, "…" "\x1bM" "🐱🐱" "\x1bM");
+
+        f = ellipsize("ab" "\x1bM" "cd" "\x1bM", 4, 90);
+        puts(f);
+        ASSERT_STREQ(f, "ab" "\x1bM" "cd" "\x1bM");
+}
+
 TEST(ellipsize_esc_infinite_loop) {
         /* Make sure we don't infinite loop on an ESC in the first half */
         static const char s[] = { 'A', 'B', 0x1B, ' ', 'D', '\0' };


### PR DESCRIPTION
`previous_ansi_sequence()` scans backwards for the closest preceding ANSI escape sequence, but the loop counter and the position it actually reads are off by one relative to each other:

```c
for (size_t i = length - 2; i > 0; i--)          /* counts down from length-2 ... */
        ansi_sequence_length(s + (i - 1), ...);   /* ... but reads at offset i-1 */
```

so only start offsets `length-3` through `0` are ever examined. Offset `length-2`, the last position at which a sequence can begin, is skipped.

CSI sequences are at least three bytes long, so one ending at the end of the examined slice starts at offset `length-3` or lower and is still found. Two byte Fe sequences (ESC followed by 0x40…0x5F, such as `ESC M`) start at exactly `length-2` in that case, and are missed.

That is the case the only caller cares about: `ellipsize_mem()` uses the result to check whether a sequence ends exactly at the position it is currently looking at, so that it can be skipped instead of being counted towards the visible width. When it is missed, the ESC and its final byte are treated as two ordinary characters, counted as two cells, and copied through as text, so the string ends up ellipsized more aggressively than requested:

```
ellipsize("🐱🐱\x1bM🐱🐱\x1bM", 5, 0)
  before: …\x1bM🐱\x1bM      (3 cells, one character dropped for no reason)
  after:  …\x1bM🐱🐱\x1bM    (5 cells, as requested)
```

This is a display issue only. The allocation for the ANSI case is `old_length + 3 + 1`, which bounds the output either way, so nothing is written out of bounds.

The fix iterates over the offset directly rather than over an index that is then adjusted, which also makes the loop match the intent stated in the comment. The `length < 2` guard added in f66144cf2a keeps `length - 2` from underflowing.

Test added to `test-ellipsize`, covering both a case where the string is ellipsized and one where it is short enough to be returned unchanged. It fails before the change and passes after.