### PR TITLE
btrfs-util: source root status preserved in snapshots

### DIFF
--- a/src/shared/btrfs-util.c
+++ b/src/shared/btrfs-util.c
@@ -1471,6 +1471,7 @@ int btrfs_subvol_snapshot_at_full(
                                 /* override_uid= */ UID_INVALID,
                                 /* override_gid= */ GID_INVALID,
                                 COPY_MERGE_EMPTY|
+                                COPY_MERGE_APPLY_STAT|
                                 COPY_SAME_MOUNT|
                                 COPY_HARDLINKS|
                                 COPY_ALL_XATTRS|

--- a/src/test/test-btrfs.c
+++ b/src/test/test-btrfs.c
@@ -118,6 +118,38 @@ TEST(fallback_copy) {
         ASSERT_OK_OR(btrfs_subvol_remove_at(dir_fd, "snap", BTRFS_REMOVE_QUOTA), -EPERM);
 }
 
+TEST(fallback_copy_preserve_root_stat) {
+        _cleanup_(rm_rf_subvolume_and_freep) char *dir = NULL;
+        _cleanup_close_ int dir_fd = ASSERT_OK(open_test_subvol(&dir));
+
+        /* On btrfs, snapshotting a plain directory with FALLBACK_COPY creates a fresh subvolume via
+         * btrfs_subvol_make() (owned by the caller, mode 0755) and then copies the source tree into it. */
+        ASSERT_OK_ERRNO(mkdirat(dir_fd, "src", 0755));
+        ASSERT_OK(write_string_file_at(dir_fd, "src/file", "hello", WRITE_STRING_FILE_CREATE));
+        ASSERT_OK_ERRNO(fchmodat(dir_fd, "src", 0700, 0));
+
+        struct stat src_st;
+        ASSERT_OK_ERRNO(fstatat(dir_fd, "src", &src_st, 0));
+
+        ASSERT_OK(btrfs_subvol_snapshot_at(dir_fd, "src", dir_fd, "snap",
+                                           BTRFS_SNAPSHOT_FALLBACK_COPY|BTRFS_SNAPSHOT_FALLBACK_DIRECTORY));
+
+        /* The snapshot root is a real subvolume (fresh-subvolume fallback), not a plain directory. */
+        ASSERT_OK_POSITIVE(btrfs_is_subvol_at(dir_fd, "snap"));
+
+        struct stat snap_st;
+        ASSERT_OK_ERRNO(fstatat(dir_fd, "snap", &snap_st, 0));
+        ASSERT_EQ(snap_st.st_mode & 07777, src_st.st_mode & 07777);
+        ASSERT_EQ(snap_st.st_uid, src_st.st_uid);
+        ASSERT_EQ(snap_st.st_gid, src_st.st_gid);
+
+        _cleanup_free_ char *content = NULL;
+        ASSERT_OK(read_full_file_at(dir_fd, "snap/file", &content, NULL));
+        ASSERT_STREQ(content, "hello\n");
+
+        ASSERT_OK_OR(btrfs_subvol_remove_at(dir_fd, "snap", BTRFS_REMOVE_QUOTA), -EPERM);
+}
+
 TEST(recursive) {
         _cleanup_(rm_rf_subvolume_and_freep) char *dir = NULL;
         _cleanup_close_ int dir_fd = ASSERT_OK(open_test_subvol(&dir));

--- a/src/test/test-copy.c
+++ b/src/test/test-copy.c
@@ -9,6 +9,7 @@
 
 #include "alloc-util.h"
 #include "argv-util.h"
+#include "btrfs-util.h"
 #include "chase.h"
 #include "copy.h"
 #include "errno-util.h"
@@ -856,5 +857,37 @@ TEST(copy_times_clamp) {
         /* No clamp requested: the source's own timestamps. */
         test_copy_times_one(TIMESPEC_PAIR(after, after), USEC_INFINITY, TIMESPEC_PAIR(after, after));
 }
+
+TEST(fallback_directory_preserve_root_stat) {
+        _cleanup_(rm_rf_physical_and_freep) char *dir = NULL;
+        _cleanup_close_ int dir_fd = -EBADF;
+
+        /* Use a plain temp directory (not a btrfs subvolume) so that the fallback copy path is
+         * exercised: btrfs_subvol_make() fails with ENOTSUP and BTRFS_SNAPSHOT_FALLBACK_DIRECTORY
+         * falls back to mkdirat() to create the snapshot root. */
+        dir_fd = ASSERT_OK(mkdtemp_open(NULL, 0, &dir));
+
+        ASSERT_OK_ERRNO(mkdirat(dir_fd, "src", 0755));
+        ASSERT_OK(write_string_file_at(dir_fd, "src/file", "hello", WRITE_STRING_FILE_CREATE));
+        ASSERT_OK_ERRNO(fchmodat(dir_fd, "src", 0700, 0));
+
+        struct stat src_st;
+        ASSERT_OK_ERRNO(fstatat(dir_fd, "src", &src_st, 0));
+
+        ASSERT_OK(btrfs_subvol_snapshot_at(dir_fd, "src", dir_fd, "snap",
+                                           BTRFS_SNAPSHOT_FALLBACK_COPY|BTRFS_SNAPSHOT_FALLBACK_DIRECTORY));
+
+        struct stat snap_st;
+        ASSERT_OK_ERRNO(fstatat(dir_fd, "snap", &snap_st, 0));
+
+        ASSERT_EQ(snap_st.st_mode & 07777, src_st.st_mode & 07777);
+        ASSERT_EQ(snap_st.st_uid, src_st.st_uid);
+        ASSERT_EQ(snap_st.st_gid, src_st.st_gid);
+
+        _cleanup_free_ char *content = NULL;
+        ASSERT_OK(read_full_file_at(dir_fd, "snap/file", &content, NULL));
+        ASSERT_STREQ(content, "hello\n");
+}
+
 
 DEFINE_TEST_MAIN(LOG_DEBUG);


### PR DESCRIPTION
Without COPY_MERGE_APPLY_STAT the directory-based snapshot root keeps the caller's uid/gid and the default 0755 mode instead of the source's.

Issue: #43232