### PR TITLE
boot: add devicetree-overlay BLS key support

### DIFF
--- a/.github/workflows/build-test.sh
+++ b/.github/workflows/build-test.sh
@@ -54,6 +54,7 @@ DEVEL_PACKAGES=(
     libbpf-dev
     libcurl4-gnutls-dev
     libfdisk-dev
+    libfdt-dev
     libfido2-dev
     libgpg-error-dev
     liblz4-dev

--- a/NEWS
+++ b/NEWS
@@ -51,6 +51,12 @@ CHANGES WITH 262:
           rather, the symlink is maintained to ensure the socket is bound under
           the same conditions as before.
 
+        * DeviceTree overlay support in systemd-boot/stub now requires libfdt,
+          and is disabled when not provided. Note that the normal userspace static
+          library as already provided by all major distributions is enough, no
+          EFI-specific build is needed, and it will be autodiscovered at build
+          time like any other dependency.
+
         Changes in the system and service manager:
 
         * The manager now embeds a basic set of unit files (basic.target,

--- a/docs/BOOT_LOADER_INTERFACE.md
+++ b/docs/BOOT_LOADER_INTERFACE.md
@@ -147,6 +147,8 @@ Variables will be listed below using the Linux efivarfs naming,
                 EFI variable `LoaderKeyboardLayout-4a67b082-0a4c-41cf-b6c7-440b29bb8c4f`.
   * `1 << 21` → The boot loader measures SMBIOS information into a TPM2 PCR and reports the PCR index in the
                 EFI variable `LoaderPcrSMBIOS-4a67b082-0a4c-41cf-b6c7-440b29bb8c4f`.
+  * `1 << 22` → The boot loader supports the `devicetree-overlay` field defined by the
+                [Boot Loader Specification](https://uapi-group.org/specifications/specs/boot_loader_specification).
 
 * The EFI variable `LoaderSystemToken-4a67b082-0a4c-41cf-b6c7-440b29bb8c4f`
   contains binary random data,

--- a/meson.build
+++ b/meson.build
@@ -1762,13 +1762,38 @@ have = get_option('bootloader').require(
 conf.set10('ENABLE_BOOTLOADER', have)
 conf.set_quoted('EFI_MACHINE_TYPE_NAME', have ? efi_arch : '')
 
+libfdt = dependency('libfdt', static : true, required : false)
+if not libfdt.found()
+        # Older versions (not built with meson) do not ship a pkg-config file.
+        libfdt = cc.find_library('fdt', static : true, required : false)
+endif
+have_libfdt = libfdt.found()
+conf.set10('HAVE_LIBFDT', have_libfdt)
+
 efi_arch_alt = ''
 efi_cpu_family_alt = ''
-if have and efi_arch == 'x64' and cc.links('''
+have_efi_arch_alt = have and efi_arch == 'x64' and cc.links('''
                 #include <limits.h>
                 int main(int argc, char *argv[]) {
                         return __builtin_popcount(argc - CHAR_MAX);
-                }''', args : ['-m32', '-march=i686'], name : '32bit build possible')
+                }''',
+                args : ['-m32', '-march=i686'],
+                name : '32bit build possible')
+if have_efi_arch_alt and have_libfdt
+        have_efi_arch_alt_fdt = cc.links('''
+                        #include <libfdt.h>
+                        int main(int argc, char *argv[]) {
+                                return fdt_check_header(argv);
+                        }''',
+                        args : ['-m32', '-march=i686'],
+                        dependencies : libfdt,
+                        name : '32bit build possible with libfdt')
+        if not have_efi_arch_alt_fdt
+                warning('32-bit build is possible but 32-bit libfdt is missing or incompatible. Disabling ia32 EFI build.')
+        endif
+        have_efi_arch_alt = have_efi_arch_alt_fdt
+endif
+if have_efi_arch_alt
         efi_arch_alt = 'ia32'
         efi_cpu_family_alt = 'x86'
 endif
@@ -3065,6 +3090,7 @@ foreach tuple : [
         ['libcurl'],
         ['libfdisk'],
         ['libfido2'],
+        ['libfdt'],
         ['libidn2'],
         ['microhttpd'],
         ['openssl'],

--- a/mkosi/mkosi.conf.d/arch/mkosi.conf
+++ b/mkosi/mkosi.conf.d/arch/mkosi.conf
@@ -22,6 +22,7 @@ Packages=
         dbus-broker
         dbus-broker-units
         dhcp
+        dtc
         elfutils
         erofs-utils
         gnutls

--- a/mkosi/mkosi.conf.d/centos-fedora/mkosi.conf
+++ b/mkosi/mkosi.conf.d/centos-fedora/mkosi.conf
@@ -43,6 +43,8 @@ Packages=
         kernel-core
         knot
         libcap-ng-utils
+        libfdt-devel
+        libfdt-static
         libmicrohttpd
         liburing
         man-db

--- a/mkosi/mkosi.conf.d/debian-ubuntu/mkosi.conf
+++ b/mkosi/mkosi.conf.d/debian-ubuntu/mkosi.conf
@@ -53,6 +53,7 @@ Packages=
         libcap-ng-utils
         libdw-dev
         libdw1
+        libfdt-dev
         liburing2
         locales
         login

--- a/mkosi/mkosi.conf.d/opensuse/mkosi.conf
+++ b/mkosi/mkosi.conf.d/opensuse/mkosi.conf
@@ -57,6 +57,7 @@ Packages=
         libcap-progs
         libdw-devel
         libdw1
+        libfdt-devel
         libmicrohttpd12
         libtss2-tcti-device0
         liburing2

--- a/mkosi/mkosi.tools.conf/mkosi.conf.d/arch.conf
+++ b/mkosi/mkosi.tools.conf/mkosi.conf.d/arch.conf
@@ -8,6 +8,7 @@ PrepareScripts=%D/mkosi/mkosi.images/build/mkosi.conf.d/arch/mkosi.prepare
 Packages=
         base
         clang-tools-extra
+        dtc
         github-cli
         lcov
         liburing

--- a/mkosi/mkosi.tools.conf/mkosi.conf.d/centos-fedora.conf
+++ b/mkosi/mkosi.tools.conf/mkosi.conf.d/centos-fedora.conf
@@ -14,3 +14,5 @@ Packages=
         libubsan
         liburing-devel
         compiler-rt
+        libfdt-devel
+        libfdt-static

--- a/mkosi/mkosi.tools.conf/mkosi.conf.d/debian-ubuntu.conf
+++ b/mkosi/mkosi.tools.conf/mkosi.conf.d/debian-ubuntu.conf
@@ -10,6 +10,7 @@ Packages=
         clang-tidy
         coccinelle
         lcov
+        libfdt-dev
         liburing-dev
         mypy
         shellcheck

--- a/mkosi/mkosi.tools.conf/mkosi.conf.d/opensuse.conf
+++ b/mkosi/mkosi.tools.conf/mkosi.conf.d/opensuse.conf
@@ -10,6 +10,7 @@ Packages=
         coccinelle
         gh
         lcov
+        libfdt-devel
         libtss2-tcti-device0
         liburing-devel
         mypy

--- a/src/boot/boot.c
+++ b/src/boot/boot.c
@@ -122,6 +122,7 @@ typedef struct BootEntry {
         char16_t *loader;
         char16_t *url;
         char16_t *devicetree;
+        char16_t **devicetree_overlay;
         char16_t *options;
         bool options_implied; /* If true, these options are implied if we invoke the PE binary without any parameters (as in: UKI). If false we must specify these options explicitly. */
         char16_t **initrd;
@@ -434,6 +435,8 @@ static void print_status(Config *config, char16_t *loaded_image_path) {
                         printf("         extra: %ls\n", *extra);
                 if (entry->devicetree)
                         printf("    devicetree: %ls\n", entry->devicetree);
+                STRV_FOREACH(dtbo, entry->devicetree_overlay)
+                        printf("    dt-overlay: %ls\n", *dtbo);
                 if (entry->options)
                         printf("       options: %ls\n", entry->options);
                 if (entry->profile > 0)
@@ -1053,6 +1056,7 @@ static BootEntry* boot_entry_free(BootEntry *entry) {
         free(entry->loader);
         free(entry->url);
         free(entry->devicetree);
+        strv_free(entry->devicetree_overlay);
         free(entry->options);
         strv_free(entry->initrd);
         strv_free(entry->extras);
@@ -1384,6 +1388,9 @@ static void boot_entry_add_type1(
         _cleanup_(boot_entry_freep) BootEntry *entry = NULL;
         char *line;
         size_t pos = 0, n_initrd = 0, n_extras = 0;
+#if HAVE_LIBFDT
+        size_t n_dt_overlay = 0;
+#endif
         char *key, *value;
         EFI_STATUS err;
 
@@ -1504,7 +1511,19 @@ static void boot_entry_add_type1(
                         free(entry->devicetree);
                         entry->devicetree = xstr8_to_path(value);
 
-                } else if (streq8(key, "initrd")) {
+                }
+#if HAVE_LIBFDT
+                else if (streq8(key, "devicetree-overlay")) {
+                        entry->devicetree_overlay = xrealloc(
+                                entry->devicetree_overlay,
+                                n_dt_overlay == 0 ? 0 : (n_dt_overlay + 1) * sizeof(uint16_t *),
+                                (n_dt_overlay + 2) * sizeof(uint16_t *));
+                        entry->devicetree_overlay[n_dt_overlay++] = xstr8_to_path(value);
+                        entry->devicetree_overlay[n_dt_overlay] = NULL;
+
+                }
+#endif
+                else if (streq8(key, "initrd")) {
                         entry->initrd = xrealloc(
                                 entry->initrd,
                                 n_initrd == 0 ? 0 : (n_initrd + 1) * sizeof(uint16_t *),
@@ -3029,10 +3048,18 @@ static EFI_STATUS call_image_start(
                 /* DTBs are loaded by the kernel before ExitBootServices(), and they can be used to map and
                  * assign arbitrary memory ranges, so skip them when secure boot is enabled as the DTB here
                  * is unverified. */
-                if (entry->devicetree && !secure_boot_enabled()) {
-                        err = devicetree_load(&dtstate, image_root, entry->devicetree);
-                        if (err != EFI_SUCCESS)
-                                return log_error_status(err, "Error loading %ls: %m", entry->devicetree);
+                if (!secure_boot_enabled()) {
+                        if (entry->devicetree) {
+                                err = devicetree_load(&dtstate, image_root, entry->devicetree);
+                                if (err != EFI_SUCCESS)
+                                        return log_error_status(err, "Error loading %ls: %m", entry->devicetree);
+                        }
+
+                        STRV_FOREACH(dtbo, entry->devicetree_overlay) {
+                                err = devicetree_apply_overlay(&dtstate, image_root, *dtbo);
+                                if (err != EFI_SUCCESS)
+                                        return log_error_status(err, "Error applying devicetree overlay %ls: %m", *dtbo);
+                        }
 
                         err = devicetree_install(&dtstate);
                         if (err != EFI_SUCCESS)
@@ -3288,6 +3315,9 @@ static void export_loader_variables(
                 EFI_LOADER_FEATURE_TPM2_ACTIVE_PCR_BANKS |
                 EFI_LOADER_FEATURE_KEYBOARD_LAYOUT |
                 EFI_LOADER_FEATURE_SMBIOS_MEASURED |
+#if HAVE_LIBFDT
+                EFI_LOADER_FEATURE_DEVICETREE_OVERLAY |
+#endif
                 0;
 
         assert(loaded_image);

--- a/src/boot/boot.c
+++ b/src/boot/boot.c
@@ -3030,9 +3030,13 @@ static EFI_STATUS call_image_start(
                  * assign arbitrary memory ranges, so skip them when secure boot is enabled as the DTB here
                  * is unverified. */
                 if (entry->devicetree && !secure_boot_enabled()) {
-                        err = devicetree_install(&dtstate, image_root, entry->devicetree);
+                        err = devicetree_load(&dtstate, image_root, entry->devicetree);
                         if (err != EFI_SUCCESS)
                                 return log_error_status(err, "Error loading %ls: %m", entry->devicetree);
+
+                        err = devicetree_install(&dtstate);
+                        if (err != EFI_SUCCESS)
+                                return log_error_status(err, "Error installing devicetree: %m");
                 }
 
                 switch (entry->type) {

--- a/src/boot/devicetree.c
+++ b/src/boot/devicetree.c
@@ -224,6 +224,118 @@ EFI_STATUS devicetree_install_from_memory(
                         MAKE_GUID_PTR(EFI_DTB_TABLE), PHYSICAL_ADDRESS_TO_POINTER(state->addr));
 }
 
+EFI_STATUS devicetree_apply_overlay(
+                struct devicetree_state *state,
+                EFI_FILE *root_dir,
+                char16_t *name) {
+
+#if HAVE_LIBFDT
+        _cleanup_free_ char *overlay = NULL;
+        size_t overlay_len;
+        EFI_STATUS err;
+        int fdterr;
+
+        assert(state);
+        assert(root_dir);
+        assert(name);
+
+        /* If no base devicetree has been installed yet, use the firmware-provided one */
+        if (!state->pages) {
+                void *fw_dtb = find_configuration_table(MAKE_GUID_PTR(EFI_DTB_TABLE));
+                if (!fw_dtb)
+                        return log_error_status(EFI_NOT_FOUND,
+                                        "No base devicetree available for overlay %ls", name);
+
+                if ((uintptr_t) fw_dtb % alignof(struct fdt_header) != 0 || fdt_check_header(fw_dtb) < 0)
+                        return log_error_status(EFI_LOAD_ERROR,
+                                        "Firmware devicetree has invalid header for overlay %ls", name);
+
+                size_t fw_size = fdt_totalsize(fw_dtb);
+
+                state->orig = fw_dtb;
+
+                err = devicetree_allocate(state, fw_size + EFI_PAGE_SIZE);
+                if (err != EFI_SUCCESS)
+                        return err;
+
+                memcpy(PHYSICAL_ADDRESS_TO_POINTER(state->addr), fw_dtb, fw_size);
+
+                fdterr = fdt_open_into(PHYSICAL_ADDRESS_TO_POINTER(state->addr),
+                                       PHYSICAL_ADDRESS_TO_POINTER(state->addr),
+                                       devicetree_allocated(state));
+                if (fdterr < 0)
+                        return log_error_status(EFI_LOAD_ERROR,
+                                        "Failed to open firmware devicetree for overlay: fdt error %d", fdterr);
+        }
+
+        err = file_read(root_dir, name, 0, 1 * 1024 * 1024, &overlay, &overlay_len);
+        if (err != EFI_SUCCESS)
+                return err;
+        if (overlay_len < FDT_V1_SIZE)
+                return EFI_INVALID_PARAMETER;
+        if (overlay_len >= 1 * 1024 * 1024)
+                return log_error_status(EFI_LOAD_ERROR,
+                                "Devicetree overlay %ls too large (possibly truncated)", name);
+        if (fdt_check_full(overlay, overlay_len) < 0)
+                return log_error_status(EFI_LOAD_ERROR,
+                                "Devicetree overlay %ls has invalid structure", name);
+
+        /* Ensure the base DTB has enough space for the overlay.
+         * We need to potentially reallocate with more headroom. */
+        void *base = PHYSICAL_ADDRESS_TO_POINTER(state->addr);
+        size_t allocated = devicetree_allocated(state);
+
+        if (fdt_check_header(base) < 0)
+                return log_error_status(EFI_LOAD_ERROR,
+                                "Base devicetree has invalid header");
+
+        size_t current_size = fdt_totalsize(base);
+        if (current_size > allocated)
+                return log_error_status(EFI_LOAD_ERROR,
+                                "Base devicetree totalsize %zu exceeds allocation %zu",
+                                current_size, allocated);
+
+        size_t needed = current_size + overlay_len + 4 * EFI_PAGE_SIZE;
+
+        if (needed > allocated) {
+                EFI_PHYSICAL_ADDRESS oldaddr = state->addr;
+                size_t oldpages = state->pages;
+
+                err = devicetree_allocate(state, needed);
+                if (err != EFI_SUCCESS)
+                        return err;
+
+                memcpy(PHYSICAL_ADDRESS_TO_POINTER(state->addr),
+                       PHYSICAL_ADDRESS_TO_POINTER(oldaddr), current_size);
+                err = BS->FreePages(oldaddr, oldpages);
+                if (err != EFI_SUCCESS)
+                        return err;
+
+                base = PHYSICAL_ADDRESS_TO_POINTER(state->addr);
+        }
+
+        fdterr = fdt_open_into(base, base, devicetree_allocated(state));
+        if (fdterr < 0)
+                return log_error_status(EFI_LOAD_ERROR,
+                                "Failed to prepare devicetree for overlay: fdt error %d", fdterr);
+
+        fdterr = fdt_overlay_apply(base, overlay);
+        if (fdterr < 0)
+                return log_error_status(EFI_LOAD_ERROR,
+                                "Failed to apply devicetree overlay %ls: fdt error %d", name, fdterr);
+
+        fdterr = fdt_pack(base);
+        if (fdterr < 0)
+                return log_error_status(EFI_LOAD_ERROR,
+                                "Failed to pack devicetree after overlay: fdt error %d", fdterr);
+
+        state->size = fdt_totalsize(base);
+        return EFI_SUCCESS;
+#else
+        return EFI_UNSUPPORTED;
+#endif
+}
+
 EFI_STATUS devicetree_install(struct devicetree_state *state) {
         assert(state);
 

--- a/src/boot/devicetree.c
+++ b/src/boot/devicetree.c
@@ -62,7 +62,7 @@ static EFI_STATUS devicetree_fixup(struct devicetree_state *state, size_t len) {
         return err;
 }
 
-EFI_STATUS devicetree_install(struct devicetree_state *state, EFI_FILE *root_dir, char16_t *name) {
+EFI_STATUS devicetree_load(struct devicetree_state *state, EFI_FILE *root_dir, char16_t *name) {
         _cleanup_file_close_ EFI_FILE *handle = NULL;
         _cleanup_free_ EFI_FILE_INFO *info = NULL;
         size_t len;
@@ -98,12 +98,8 @@ EFI_STATUS devicetree_install(struct devicetree_state *state, EFI_FILE *root_dir
         if (err != EFI_SUCCESS)
                 return err;
 
-        err = devicetree_fixup(state, len);
-        if (err != EFI_SUCCESS)
-                return err;
-
-        return BS->InstallConfigurationTable(
-                        MAKE_GUID_PTR(EFI_DTB_TABLE), PHYSICAL_ADDRESS_TO_POINTER(state->addr));
+        state->size = len;
+        return EFI_SUCCESS;
 }
 
 static const char* devicetree_get_compatible(const void *dtb) {
@@ -250,6 +246,21 @@ EFI_STATUS devicetree_install_from_memory(
         memcpy(PHYSICAL_ADDRESS_TO_POINTER(state->addr), dtb_buffer, dtb_length);
 
         err = devicetree_fixup(state, dtb_length);
+        if (err != EFI_SUCCESS)
+                return err;
+
+        return BS->InstallConfigurationTable(
+                        MAKE_GUID_PTR(EFI_DTB_TABLE), PHYSICAL_ADDRESS_TO_POINTER(state->addr));
+}
+
+EFI_STATUS devicetree_install(struct devicetree_state *state) {
+        assert(state);
+
+        /*there is no devicetree, so no-op*/
+        if (!state->pages)
+                return EFI_SUCCESS;
+
+        EFI_STATUS err = devicetree_fixup(state, state->size);
         if (err != EFI_SUCCESS)
                 return err;
 

--- a/src/boot/devicetree.c
+++ b/src/boot/devicetree.c
@@ -1,10 +1,27 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
+#if HAVE_LIBFDT
+#  include <libfdt.h>
+#  include "efi-log.h"
+#endif
+
 #include "devicetree.h"
 #include "proto/dt-fixup.h"
 #include "util.h"
 
-#define FDT_V1_SIZE (7*4)
+/* For the libfdt-less builds, which doesn't support overlays, but has minimal DTB support (loading) */
+#if !HAVE_LIBFDT
+struct fdt_header {
+        uint32_t magic;
+        uint32_t totalsize;
+        uint32_t off_dt_struct;
+        uint32_t off_dt_strings;
+        uint32_t off_mem_rsvmap;
+        uint32_t version;
+        uint32_t last_comp_version;
+};
+#define FDT_V1_SIZE sizeof(struct fdt_header)
+#endif
 
 static EFI_STATUS devicetree_allocate(struct devicetree_state *state, size_t size) {
         size_t pages = DIV_ROUND_UP(size, EFI_PAGE_SIZE);
@@ -102,74 +119,26 @@ EFI_STATUS devicetree_load(struct devicetree_state *state, EFI_FILE *root_dir, c
         return EFI_SUCCESS;
 }
 
-static const char* devicetree_get_compatible(const void *dtb) {
-        if ((uintptr_t) dtb % alignof(FdtHeader) != 0)
+#if HAVE_LIBFDT
+static const char* devicetree_get_compatible(const void *dtb, size_t dtb_size) {
+        const char *compatible;
+        int len;
+
+        assert(dtb);
+
+        if ((uintptr_t) dtb % alignof(struct fdt_header) != 0)
                 return NULL;
 
-        const FdtHeader *dt_header = ASSERT_PTR(dtb);
-
-        if (be32toh(dt_header->magic) != UINT32_C(0xd00dfeed))
+        if (fdt_check_full(dtb, dtb_size) < 0)
                 return NULL;
 
-        uint32_t dt_size = be32toh(dt_header->total_size);
-        uint32_t struct_off = be32toh(dt_header->off_dt_struct);
-        uint32_t struct_size = be32toh(dt_header->size_dt_struct);
-        uint32_t strings_off = be32toh(dt_header->off_dt_strings);
-        uint32_t strings_size = be32toh(dt_header->size_dt_strings);
-        uint32_t end;
-
-        if (PTR_TO_SIZE(dtb) > SIZE_MAX - dt_size)
+        compatible = fdt_getprop(dtb, /* nodeoffset= */ 0, "compatible", &len);
+        if (!compatible || len <= 0 || compatible[len - 1] != '\0')
                 return NULL;
 
-        if (!ADD_SAFE(&end, strings_off, strings_size) || end > dt_size)
-                return NULL;
-        const char *strings_block = (const char *) ((const uint8_t *) dt_header + strings_off);
-
-        if (struct_off % sizeof(uint32_t) != 0)
-                return NULL;
-
-        if (struct_size % sizeof(uint32_t) != 0 ||
-            !ADD_SAFE(&end, struct_off, struct_size) ||
-            end > strings_off)
-                return NULL;
-        const uint32_t *cursor = (const uint32_t *) ((const uint8_t *) dt_header + struct_off);
-
-        size_t size_words = struct_size / sizeof(uint32_t);
-        size_t len, name_off, len_words, s;
-
-        for (size_t i = 0; i < size_words; i++) {
-                switch (be32toh(cursor[i])) {
-                case FDT_BEGIN_NODE:
-                        if (i + 1 >= size_words || cursor[++i] != 0)
-                                return NULL;
-                        break;
-                case FDT_NOP:
-                        break;
-                case FDT_PROP:
-                        /* At least 3 words should present: len, name_off, c (nul-terminated string always has non-zero length) */
-                        if (i + 3 >= size_words)
-                                return NULL;
-                        len = be32toh(cursor[++i]);
-                        name_off = be32toh(cursor[++i]);
-                        len_words = DIV_ROUND_UP(len, sizeof(uint32_t));
-
-                        if (ADD_SAFE(&s, name_off, STRLEN("compatible")) &&
-                            s < strings_size && streq8(strings_block + name_off, "compatible")) {
-                                const char *c = (const char *) &cursor[++i];
-                                if (len == 0 || i + len_words > size_words || c[len - 1] != '\0')
-                                        c = NULL;
-
-                                return c;
-                        }
-                        i += len_words;
-                        break;
-                default:
-                        return NULL;
-                }
-        }
-
-        return NULL;
+        return compatible;
 }
+#endif
 
 bool firmware_devicetree_exists(void) {
         return !!find_configuration_table(MAKE_GUID_PTR(EFI_DTB_TABLE));
@@ -194,36 +163,38 @@ bool firmware_devicetree_exists(void) {
  * Other entries might refer to SoC and therefore can't be used for matching
  */
 EFI_STATUS devicetree_match(const void *uki_dtb, size_t uki_dtb_length) {
+#if HAVE_LIBFDT
         const void *fw_dtb = find_configuration_table(MAKE_GUID_PTR(EFI_DTB_TABLE));
         if (!fw_dtb)
                 return EFI_UNSUPPORTED;
 
-        const char *fw_compat = devicetree_get_compatible(fw_dtb);
+        if ((uintptr_t) fw_dtb % alignof(struct fdt_header) != 0 || fdt_check_header(fw_dtb) < 0)
+                return EFI_UNSUPPORTED;
+
+        const char *fw_compat = devicetree_get_compatible(fw_dtb, fdt_totalsize(fw_dtb));
         if (!fw_compat)
                 return EFI_UNSUPPORTED;
 
         return devicetree_match_by_compatible(uki_dtb, uki_dtb_length, fw_compat);
+#else
+        return EFI_UNSUPPORTED;
+#endif
 }
 
 EFI_STATUS devicetree_match_by_compatible(const void *uki_dtb, size_t uki_dtb_length, const char *compat) {
-        if ((uintptr_t) uki_dtb % alignof(FdtHeader) != 0)
-                return EFI_INVALID_PARAMETER;
-
-        const FdtHeader *dt_header = ASSERT_PTR(uki_dtb);
-
-        if (uki_dtb_length < sizeof(FdtHeader) ||
-            uki_dtb_length < be32toh(dt_header->total_size))
-                return EFI_INVALID_PARAMETER;
-
+#if HAVE_LIBFDT
         if (!compat)
                 return EFI_INVALID_PARAMETER;
 
-        const char *dt_compat = devicetree_get_compatible(uki_dtb);
+        const char *dt_compat = devicetree_get_compatible(uki_dtb, uki_dtb_length);
         if (!dt_compat)
                 return EFI_INVALID_PARAMETER;
 
         /* Only matches the first compatible string from each DT */
         return streq8(dt_compat, compat) ? EFI_SUCCESS : EFI_NOT_FOUND;
+#else
+        return EFI_UNSUPPORTED;
+#endif
 }
 
 EFI_STATUS devicetree_install_from_memory(

--- a/src/boot/devicetree.h
+++ b/src/boot/devicetree.h
@@ -10,27 +10,6 @@ struct devicetree_state {
         void *orig;
 };
 
-enum {
-        FDT_BEGIN_NODE = 1,
-        FDT_END_NODE   = 2,
-        FDT_PROP       = 3,
-        FDT_NOP        = 4,
-        FDT_END        = 9,
-};
-
-typedef struct FdtHeader {
-        uint32_t magic;
-        uint32_t total_size;
-        uint32_t off_dt_struct;
-        uint32_t off_dt_strings;
-        uint32_t off_mem_rsv_map;
-        uint32_t version;
-        uint32_t last_comp_version;
-        uint32_t boot_cpuid_phys;
-        uint32_t size_dt_strings;
-        uint32_t size_dt_struct;
-} FdtHeader;
-
 bool firmware_devicetree_exists(void);
 EFI_STATUS devicetree_match(const void *uki_dtb, size_t uki_dtb_length);
 EFI_STATUS devicetree_match_by_compatible(const void *uki_dtb, size_t uki_dtb_length, const char *compat);

--- a/src/boot/devicetree.h
+++ b/src/boot/devicetree.h
@@ -14,6 +14,7 @@ bool firmware_devicetree_exists(void);
 EFI_STATUS devicetree_match(const void *uki_dtb, size_t uki_dtb_length);
 EFI_STATUS devicetree_match_by_compatible(const void *uki_dtb, size_t uki_dtb_length, const char *compat);
 EFI_STATUS devicetree_load(struct devicetree_state *state, EFI_FILE *root_dir, char16_t *name);
+EFI_STATUS devicetree_apply_overlay(struct devicetree_state *state, EFI_FILE *root_dir, char16_t *name);
 EFI_STATUS devicetree_install(struct devicetree_state *state);
 EFI_STATUS devicetree_install_from_memory(
                 struct devicetree_state *state, const void *dtb_buffer, size_t dtb_length);

--- a/src/boot/devicetree.h
+++ b/src/boot/devicetree.h
@@ -6,6 +6,7 @@
 struct devicetree_state {
         EFI_PHYSICAL_ADDRESS addr;
         size_t pages;
+        size_t size;  /* actual content size in bytes */
         void *orig;
 };
 
@@ -33,7 +34,8 @@ typedef struct FdtHeader {
 bool firmware_devicetree_exists(void);
 EFI_STATUS devicetree_match(const void *uki_dtb, size_t uki_dtb_length);
 EFI_STATUS devicetree_match_by_compatible(const void *uki_dtb, size_t uki_dtb_length, const char *compat);
-EFI_STATUS devicetree_install(struct devicetree_state *state, EFI_FILE *root_dir, char16_t *name);
+EFI_STATUS devicetree_load(struct devicetree_state *state, EFI_FILE *root_dir, char16_t *name);
+EFI_STATUS devicetree_install(struct devicetree_state *state);
 EFI_STATUS devicetree_install_from_memory(
                 struct devicetree_state *state, const void *dtb_buffer, size_t dtb_length);
 void devicetree_cleanup(struct devicetree_state *state);

--- a/src/boot/efi-string.c
+++ b/src/boot/efi-string.c
@@ -118,6 +118,86 @@ DEFINE_STRCPY(char16_t, strcpy16);
                 return c ? NULL : (type *) s;      \
         }
 
+#define DEFINE_STRRCHR(type, name)                 \
+        type *name(const type *s, type c) {        \
+                if (!s)                            \
+                        return NULL;               \
+                                                   \
+                const type *last = NULL;           \
+                while (*s != '\0') {               \
+                        if (*s == c)               \
+                                last = s;          \
+                        s++;                       \
+                }                                  \
+                if (c == '\0')                     \
+                        return (type *) s;          \
+                return (type *) last;               \
+        }
+
+DEFINE_STRRCHR(char, strrchr8);
+DEFINE_STRRCHR(char16_t, strrchr16);
+
+#define DEFINE_STRTOUL(type, name)                                              \
+        unsigned long name(const type *nptr, type **endptr, int base) {         \
+                assert(nptr);                                                   \
+                assert(base == 0 || (base >= 2 && base <= 16));                 \
+                                                                                \
+                const type *p = nptr;                                           \
+                unsigned long result = 0;                                       \
+                int any = 0;                                                    \
+                                                                                \
+                while (*p == ' ' || *p == '\t' || *p == '\n' || *p == '\r') {   \
+                        p++;                                                    \
+                }                                                               \
+                                                                                \
+                if ((base == 0 || base == 16) &&                                \
+                    *p == '0' && (*(p + 1) == 'x' || *(p + 1) == 'X')) {        \
+                        base = 16;                                              \
+                        p += 2;                                                 \
+                } else if (base == 0) {                                         \
+                        base = (*p == '0') ? 8 : 10;                            \
+                }                                                               \
+                                                                                \
+                unsigned long max_val = ~0UL;                                   \
+                unsigned long cutoff = max_val / base;                          \
+                unsigned long cutlim = max_val % base;                          \
+                                                                                \
+                for (;; p++) {                                                  \
+                        unsigned long digit;                                    \
+                        if (*p >= '0' && *p <= '9')                             \
+                                digit = *p - '0';                               \
+                        else if (*p >= 'a' && *p <= 'f')                        \
+                                digit = *p - 'a' + 10;                          \
+                        else if (*p >= 'A' && *p <= 'F')                        \
+                                digit = *p - 'A' + 10;                          \
+                        else                                                    \
+                                break;                                          \
+                                                                                \
+                        if (digit >= (unsigned long)base)                       \
+                                break;                                          \
+                                                                                \
+                        if (any < 0 || result > cutoff ||                       \
+                           (result == cutoff && digit > cutlim)) {              \
+                                any = -1;                                       \
+                        } else {                                                \
+                                any = 1;                                        \
+                                result = result * base + digit;                 \
+                        }                                                       \
+                }                                                               \
+                                                                                \
+                if (any < 0) {                                                  \
+                        result = max_val;                                       \
+                }                                                               \
+                                                                                \
+                if (endptr)                                                     \
+                        *endptr = (type *)(any ? p : nptr);                     \
+                                                                                \
+                return result;                                                  \
+        }
+
+DEFINE_STRTOUL(char, strtoul8);
+DEFINE_STRTOUL(char16_t, strtoul16);
+
 DEFINE_STRCHR(char, strchr8);
 DEFINE_STRCHR(char16_t, strchr16);
 
@@ -1051,11 +1131,13 @@ char16_t *xvasprintf_status(EFI_STATUS status, const char *format, va_list ap) {
 #  undef memchr
 #  undef memcmp
 #  undef memcpy
+#  undef memmove
 #  undef memset
 // NOLINTBEGIN(misc-use-internal-linkage)
 _used_ void *memchr(const void *p, int c, size_t n);
 _used_ int memcmp(const void *p1, const void *p2, size_t n);
 _used_ void *memcpy(void * restrict dest, const void * restrict src, size_t n);
+_used_ void *memmove(void *dest, const void *src, size_t n);
 _used_ void *memset(void *p, int c, size_t n);
 // NOLINTEND(misc-use-internal-linkage)
 #else
@@ -1064,6 +1146,7 @@ _used_ void *memset(void *p, int c, size_t n);
 #  define memchr efi_memchr
 #  define memcmp efi_memcmp
 #  define memcpy efi_memcpy
+#  define memmove efi_memmove
 #  define memset efi_memset
 #endif
 
@@ -1124,6 +1207,12 @@ void *memcpy(void * restrict dest, const void * restrict src, size_t n) {
         }
 
         return dest;
+}
+
+void *memmove(void *dest, const void *src, size_t n) {
+        /* Our memcpy delegates to the firmware's CopyMem, which the UEFI spec
+         * guarantees handles overlapping regions correctly. */
+        return memcpy(dest, src, n);
 }
 
 void *memset(void *p, int c, size_t n) {

--- a/src/boot/efi-string.c
+++ b/src/boot/efi-string.c
@@ -1133,7 +1133,15 @@ char16_t *xvasprintf_status(EFI_STATUS status, const char *format, va_list ap) {
 #  undef memcpy
 #  undef memmove
 #  undef memset
+#  undef strlen
 // NOLINTBEGIN(misc-use-internal-linkage)
+_used_ char *strchr(const char *s, int c);
+_used_ char *strrchr(const char *s, int c);
+_used_ size_t strlen(const char *s);
+_used_ size_t strnlen(const char *s, size_t n);
+_used_ unsigned long strtoul(const char * restrict nptr, char ** restrict endptr, int base);
+/* needed to link with static libfdt.a */
+_used_ unsigned long __isoc23_strtoul(const char * restrict nptr, char ** restrict endptr, int base);
 _used_ void *memchr(const void *p, int c, size_t n);
 _used_ int memcmp(const void *p1, const void *p2, size_t n);
 _used_ void *memcpy(void * restrict dest, const void * restrict src, size_t n);
@@ -1236,6 +1244,32 @@ void *memset(void *p, int c, size_t n) {
 
         return p;
 }
+
+#if SD_BOOT
+char *strchr(const char *s, int c) {
+        return strchr8(s, c);
+}
+
+char *strrchr(const char *s, int c) {
+        return strrchr8(s, c);
+}
+
+size_t strlen(const char *s) {
+        return strlen8(s);
+}
+
+size_t strnlen(const char *s, size_t n) {
+        return strnlen8(s, n);
+}
+
+unsigned long strtoul(const char * restrict nptr, char ** restrict endptr, int base) {
+        return strtoul8(nptr, endptr, base);
+}
+
+unsigned long __isoc23_strtoul(const char * restrict nptr, char ** restrict endptr, int base) {
+        return strtoul(nptr, endptr, base);
+}
+#endif
 
 size_t strspn16(const char16_t *p, const char16_t *good) {
         assert(p);

--- a/src/boot/efi-string.h
+++ b/src/boot/efi-string.h
@@ -15,11 +15,11 @@ static inline size_t strlen16(const char16_t *s) {
 }
 
 static inline size_t strsize8(const char *s) {
-        return s ? (strlen8(s) + 1) * sizeof(*s) : 0;
+        return s ? (strlen8(s) + 1) * sizeof(char) : 0;
 }
 
 static inline size_t strsize16(const char16_t *s) {
-        return s ? (strlen16(s) + 1) * sizeof(*s) : 0;
+        return s ? (strlen16(s) + 1) * sizeof(char16_t) : 0;
 }
 
 char* strtolower8(char *s);
@@ -83,6 +83,12 @@ char16_t *strcpy16(char16_t * restrict dest, const char16_t * restrict src);
 
 char* strchr8(const char *s, char c);
 char16_t *strchr16(const char16_t *s, char16_t c);
+
+char* strrchr8(const char *s, char c);
+char16_t *strrchr16(const char16_t *s, char16_t c);
+
+unsigned long strtoul8(const char *nptr, char **endptr, int base);
+unsigned long strtoul16(const char16_t *nptr, char16_t **endptr, int base);
 
 char* xstrndup8(const char *s, size_t n);
 char16_t *xstrndup16(const char16_t *s, size_t n);
@@ -169,6 +175,7 @@ _gnu_printf_(2, 0) _warn_unused_result_ char16_t *xvasprintf_status(EFI_STATUS s
 #  define memchr __builtin_memchr
 #  define memcmp __builtin_memcmp
 #  define memcpy __builtin_memcpy
+#  define memmove __builtin_memmove
 #  define memset __builtin_memset
 
 static inline void *mempcpy(void * restrict dest, const void * restrict src, size_t n) {
@@ -183,5 +190,6 @@ static inline void *mempcpy(void * restrict dest, const void * restrict src, siz
 void *efi_memchr(const void *p, int c, size_t n);
 int efi_memcmp(const void *p1, const void *p2, size_t n);
 void *efi_memcpy(void * restrict dest, const void * restrict src, size_t n);
+void *efi_memmove(void *dest, const void *src, size_t n);
 void *efi_memset(void *p, int c, size_t n);
 #endif

--- a/src/boot/libfdt_env.h
+++ b/src/boot/libfdt_env.h
@@ -1,0 +1,25 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#pragma once
+
+/* libfdt requires reimplementing the libfdt_env.h header locally that the vendor's libfdt.h includes,
+ * customizing it for the local environment and providing some utility functions that libfdt's public
+ * headers require. */
+
+#include "util.h"
+
+#define strchr strchr8
+#define strlen strlen8
+#define strnlen strnlen8
+#define strrchr strrchr8
+#define strtoul strtoul8
+
+typedef uint16_t fdt16_t;
+typedef uint32_t fdt32_t;
+typedef uint64_t fdt64_t;
+
+#define fdt16_to_cpu(x) be16toh(x)
+#define fdt32_to_cpu(x) be32toh(x)
+#define fdt64_to_cpu(x) be64toh(x)
+#define cpu_to_fdt16(x) htobe16(x)
+#define cpu_to_fdt32(x) htobe32(x)
+#define cpu_to_fdt64(x) htobe64(x)

--- a/src/boot/meson.build
+++ b/src/boot/meson.build
@@ -81,7 +81,8 @@ efi_conf = configuration_data()
 
 # import several configs from userspace
 foreach name : ['HAVE_WARNING_ZERO_LENGTH_BOUNDS',
-                'HAVE_WARNING_ZERO_AS_NULL_POINTER_CONSTANT']
+                'HAVE_WARNING_ZERO_AS_NULL_POINTER_CONSTANT',
+                'HAVE_LIBFDT']
         efi_conf.set(name, conf.get(name))
 endforeach
 
@@ -163,11 +164,19 @@ configure_file(
 
 ############################################################
 
+efi_include = include_directories('.')
 efi_includes = [
-        include_directories('.'),
+        efi_include,
         fundamental_include,
         version_include,
 ]
+
+libfdt_efi = []
+if have_libfdt
+        libfdt_efi = declare_dependency(
+                dependencies : libfdt,
+                include_directories : efi_include)
+endif
 
 efi_c_args = [
         '-DSD_BOOT=1',
@@ -414,6 +423,7 @@ foreach archspec : efi_archspecs
                 include_directories : efi_includes,
                 implicit_include_directories : false,
                 c_args : archspec['c_args'],
+                dependencies : libfdt_efi,
                 gnu_symbol_visibility : 'hidden',
                 override_options : efi_override_options,
                 pic : true)
@@ -422,6 +432,7 @@ foreach archspec : efi_archspecs
                 'include_directories' : efi_includes,
                 'implicit_include_directories' : false,
                 'c_args' : archspec['c_args'],
+                'dependencies' : libfdt_efi,
                 'link_args' : archspec['link_args'],
                 'gnu_symbol_visibility' : 'hidden',
                 'override_options' : efi_override_options,

--- a/src/boot/test-efi-string.c
+++ b/src/boot/test-efi-string.c
@@ -249,6 +249,86 @@ TEST(strchr16) {
         ASSERT_PTR_EQ(strchr16(str, 0), str + strlen16(str));
 }
 
+TEST(strrchr8) {
+        ASSERT_NULL(strrchr8(NULL, 'a'));
+        ASSERT_NULL(strrchr8("", 'a'));
+        ASSERT_NULL(strrchr8("123", 'a'));
+
+        const char str[] = "abcaBc";
+        ASSERT_PTR_EQ(strrchr8(str, 'a'), &str[3]);
+        ASSERT_PTR_EQ(strrchr8(str, 'c'), &str[5]);
+        ASSERT_PTR_EQ(strrchr8(str, 'B'), &str[4]);
+
+        ASSERT_PTR_EQ(strrchr8(str, 0), str + strlen8(str));
+}
+
+TEST(strrchr16) {
+        ASSERT_NULL(strrchr16(NULL, 'a'));
+        ASSERT_NULL(strrchr16(u"", 'a'));
+        ASSERT_NULL(strrchr16(u"123", 'a'));
+
+        const char16_t str[] = u"abcaBc";
+        ASSERT_PTR_EQ(strrchr16(str, 'a'), &str[3]);
+        ASSERT_PTR_EQ(strrchr16(str, 'c'), &str[5]);
+        ASSERT_PTR_EQ(strrchr16(str, 'B'), &str[4]);
+
+        ASSERT_PTR_EQ(strrchr16(str, 0), str + strlen16(str));
+}
+
+TEST(strtoul8) {
+        char *end = NULL;
+
+        /* Basic decimal (base 10) */
+        ASSERT_EQ(strtoul8("0", &end, 10), 0UL);
+        ASSERT_EQ(*end, '\0');
+        ASSERT_EQ(strtoul8("123", &end, 10), 123UL);
+        ASSERT_EQ(*end, '\0');
+        ASSERT_EQ(strtoul8("456xyz", &end, 10), 456UL);
+        ASSERT_EQ(*end, 'x');
+
+        /* Hex (base 16) */
+        ASSERT_EQ(strtoul8("ff", &end, 16), 255UL);
+        ASSERT_EQ(*end, '\0');
+        ASSERT_EQ(strtoul8("0xFF", &end, 16), 255UL);
+        ASSERT_EQ(*end, '\0');
+        ASSERT_EQ(strtoul8("0XAB", &end, 16), 171UL);
+        ASSERT_EQ(*end, '\0');
+        ASSERT_EQ(strtoul8("1a2b", &end, 16), 0x1a2bUL);
+        ASSERT_EQ(*end, '\0');
+
+        /* Auto-detect (base 0) */
+        ASSERT_EQ(strtoul8("123", &end, 0), 123UL);
+        ASSERT_EQ(*end, '\0');
+        ASSERT_EQ(strtoul8("0xff", &end, 0), 255UL);
+        ASSERT_EQ(*end, '\0');
+        ASSERT_EQ(strtoul8("010", &end, 0), 8UL);
+        ASSERT_EQ(*end, '\0');
+        ASSERT_EQ(strtoul8("0", &end, 0), 0UL);
+        ASSERT_EQ(*end, '\0');
+
+        /* No valid digits */
+        ASSERT_EQ(strtoul8("abc", &end, 10), 0UL);
+        ASSERT_EQ(*end, 'a');
+
+        /* NULL endptr */
+        ASSERT_EQ(strtoul8("42", NULL, 10), 42UL);
+}
+
+TEST(strtoul16) {
+        char16_t *end = NULL;
+
+        ASSERT_EQ(strtoul16(u"0", &end, 10), 0UL);
+        ASSERT_EQ(*end, u'\0');
+        ASSERT_EQ(strtoul16(u"123", &end, 10), 123UL);
+        ASSERT_EQ(*end, u'\0');
+        ASSERT_EQ(strtoul16(u"0xff", &end, 16), 255UL);
+        ASSERT_EQ(*end, u'\0');
+        ASSERT_EQ(strtoul16(u"0xff", &end, 0), 255UL);
+        ASSERT_EQ(*end, u'\0');
+        ASSERT_EQ(strtoul16(u"010", &end, 0), 8UL);
+        ASSERT_EQ(*end, u'\0');
+}
+
 TEST(xstrndup8) {
         char *s = NULL;
 

--- a/src/boot/util.h
+++ b/src/boot/util.h
@@ -142,6 +142,7 @@ EFI_STATUS load_file_from_simple_filesystem(const EFI_DEVICE_PATH *device_path, 
 EFI_STATUS file_handle_read(EFI_FILE *handle, uint64_t offset, size_t size, char **ret, size_t *ret_size);
 
 static inline void file_closep(EFI_FILE **handle) {
+        assert(handle);
         if (!*handle)
                 return;
 
@@ -151,6 +152,7 @@ static inline void file_closep(EFI_FILE **handle) {
 #define _cleanup_file_close_ _cleanup_(file_closep)
 
 static inline void unload_imagep(EFI_HANDLE *image) {
+        assert(image);
         if (*image)
                 (void) BS->UnloadImage(*image);
 }

--- a/src/boot/util.h
+++ b/src/boot/util.h
@@ -248,8 +248,12 @@ char16_t *get_extra_dir(const EFI_DEVICE_PATH *file_path);
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 #  define be16toh(x) __builtin_bswap16(x)
 #  define be32toh(x) __builtin_bswap32(x)
+#  define be64toh(x) __builtin_bswap64(x)
 #  define le16toh(x) (x)
 #  define le32toh(x) (x)
+#  define htobe16(x) __builtin_bswap16(x)
+#  define htobe32(x) __builtin_bswap32(x)
+#  define htobe64(x) __builtin_bswap64(x)
 #else
 #  error "Unexpected byte order in EFI mode?"
 #endif

--- a/src/bootctl/bootctl-status.c
+++ b/src/bootctl/bootctl-status.c
@@ -411,6 +411,7 @@ int verb_status(int argc, char *argv[], uintptr_t _data, void *userdata) {
                         { EFI_LOADER_FEATURE_TPM2_ACTIVE_PCR_BANKS,   "Loader reports active TPM2 PCR banks"    },
                         { EFI_LOADER_FEATURE_KEYBOARD_LAYOUT,         "Loader reports firmware keyboard layout" },
                         { EFI_LOADER_FEATURE_SMBIOS_MEASURED,         "Loader measures SMBIOS information"      },
+                        { EFI_LOADER_FEATURE_DEVICETREE_OVERLAY,      "Support Type #1 devicetree-overlay field"},
                 };
                 static const struct {
                         uint64_t flag;

--- a/src/fundamental/efivars.h
+++ b/src/fundamental/efivars.h
@@ -31,6 +31,7 @@
 #define EFI_LOADER_FEATURE_ENTRY_PREFERRED         (UINT64_C(1) << 19)
 #define EFI_LOADER_FEATURE_KEYBOARD_LAYOUT         (UINT64_C(1) << 20)
 #define EFI_LOADER_FEATURE_SMBIOS_MEASURED         (UINT64_C(1) << 21)
+#define EFI_LOADER_FEATURE_DEVICETREE_OVERLAY      (UINT64_C(1) << 22)
 
 /* Features of the stub, i.e. systemd-stub */
 #define EFI_STUB_FEATURE_REPORT_BOOT_PARTITION     (UINT64_C(1) << 0)

--- a/src/shared/bootspec.c
+++ b/src/shared/bootspec.c
@@ -234,36 +234,6 @@ static int parse_path_strv(
         return strv_consume(s, c);
 }
 
-static int parse_path_many(
-                const char *fname,
-                unsigned line,
-                const char *field,
-                char ***s,
-                const char *p) {
-
-        _cleanup_strv_free_ char **l = NULL, **f = NULL;
-        int r;
-
-        l = strv_split(p, NULL);
-        if (!l)
-                return -ENOMEM;
-
-        STRV_FOREACH(i, l) {
-                char *c;
-
-                r = mangle_path(fname, line, field, *i, &c);
-                if (r < 0)
-                        return r;
-                if (r == 0)
-                        continue;
-
-                r = strv_consume(&f, c);
-                if (r < 0)
-                        return r;
-        }
-
-        return strv_extend_strv_consume(s, TAKE_PTR(f), /* filter_duplicates= */ false);
-}
 
 static int parse_extra(
                 const char *fname,
@@ -519,7 +489,7 @@ static int boot_entry_load_type1(
                 else if (streq(field, "devicetree"))
                         r = parse_path_one(tmp.path, line, field, &tmp.device_tree, p);
                 else if (streq(field, "devicetree-overlay"))
-                        r = parse_path_many(tmp.path, line, field, &tmp.device_tree_overlay, p);
+                        r = parse_path_strv(tmp.path, line, field, &tmp.device_tree_overlay, p);
                 else if (streq(field, "extra"))
                         r = parse_extra(tmp.path, line, field, &tmp.local_extras, p);
                 else {


### PR DESCRIPTION
This allows applying Device Tree overlays (.dtbo) at boot time before
passing the final flattened device tree to the OS.

Fixes: #21742 