### PR TITLE
varlink: clean up failed connection setup

### DIFF
--- a/src/libsystemd/sd-varlink/sd-varlink.c
+++ b/src/libsystemd/sd-varlink/sd-varlink.c
@@ -3433,9 +3433,16 @@ _public_ int sd_varlink_server_add_connection_pair(
         v->server = sd_varlink_server_ref(server);
         sd_varlink_ref(v);
 
+        if (ucred_acquired)
+                json_stream_set_peer_ucred(&v->stream, &ucred);
+
         r = json_stream_attach_fds(&v->stream, input_fd, output_fd);
-        if (r < 0)
+        if (r < 0) {
+                TAKE_FD(v->stream.input_fd);
+                TAKE_FD(v->stream.output_fd);
+                sd_varlink_close(v);
                 return r;
+        }
 
         if (server->flags & SD_VARLINK_SERVER_INHERIT_USERDATA)
                 v->userdata = server->userdata;
@@ -3444,9 +3451,6 @@ _public_ int sd_varlink_server_add_connection_pair(
          * byte-bounded reads so we don't accidentally consume post-upgrade bytes. */
         if (FLAGS_SET(server->flags, SD_VARLINK_SERVER_UPGRADABLE))
                 json_stream_set_flags(&v->stream, JSON_STREAM_BOUNDED_READS, true);
-
-        if (ucred_acquired)
-                json_stream_set_peer_ucred(&v->stream, &ucred);
 
         _cleanup_free_ char *desc = NULL;
         if (asprintf(&desc, "%s-%i-%i", varlink_server_description(server), input_fd, output_fd) >= 0)

--- a/src/libsystemd/sd-varlink/test-varlink.c
+++ b/src/libsystemd/sd-varlink/test-varlink.c
@@ -346,6 +346,32 @@ static int block_fd_handler(sd_event_source *s, int fd, uint32_t revents, void *
         return 0;
 }
 
+TEST(add_connection_failure_cleanup) {
+        _cleanup_(sd_varlink_server_unrefp) sd_varlink_server *s = NULL;
+        _cleanup_(sd_varlink_unrefp) sd_varlink *v = NULL;
+        _cleanup_close_pair_ int fds[2] = EBADF_PAIR;
+        const struct ucred ucred = {
+                .pid = getpid(),
+                .uid = getuid(),
+                .gid = getgid(),
+        };
+
+        ASSERT_OK(sd_varlink_server_new(&s, SD_VARLINK_SERVER_ACCOUNT_UID));
+        ASSERT_OK(sd_varlink_server_set_connections_per_uid_max(s, 1));
+        ASSERT_OK_ERRNO(socketpair(AF_UNIX, SOCK_STREAM|SOCK_CLOEXEC, 0, fds));
+
+        int bad_fd = ASSERT_OK(memfd_new("closed-fd"));
+        ASSERT_OK_ERRNO(close(bad_fd));
+
+        ASSERT_ERROR(sd_varlink_server_add_connection_pair(s, fds[0], bad_fd, &ucred, /* ret= */ NULL), EBADF);
+        ASSERT_EQ(sd_varlink_server_current_connections(s), 0U);
+
+        ASSERT_OK(sd_varlink_server_add_connection(s, TAKE_FD(fds[0]), &v));
+        v = sd_varlink_ref(v);
+        sd_varlink_close(v);
+        ASSERT_EQ(sd_varlink_server_current_connections(s), 0U);
+}
+
 TEST(chat) {
         _cleanup_(sd_event_source_unrefp) sd_event_source *block_event = NULL;
         _cleanup_(sd_varlink_server_unrefp) sd_varlink_server *s = NULL;


### PR DESCRIPTION
Fixes failed `sd_varlink_server_add_connection_pair()` setup retaining server-side accounting and references.

FD validation now completes before caching credentials, counting the connection, or linking it to the server. On an earlier failure, the caller retains the descriptors and no disconnect callback is invoked.

Adds an ACCOUNT_UID regression test that uses a closed output FD, verifies the connection count, and confirms a subsequent connection from the same UID can be accepted.
