### PR TITLE
udev: derive path ID for PNP devices from ACPI firmware node

### DIFF
--- a/src/udev/udev-builtin-path_id.c
+++ b/src/udev/udev-builtin-path_id.c
@@ -677,6 +677,30 @@ static void add_id_tag(UdevEvent *event, const char *path) {
         (void) udev_builtin_add_property(event, "ID_PATH_TAG", tag);
 }
 
+static int handle_pnp(sd_device *parent, char **path) {
+        _cleanup_(sd_device_unrefp) sd_device *firmware_node = NULL;
+        const char *sysname;
+        int r;
+
+        assert(parent);
+        assert(path);
+
+        r = sd_device_new_child(&firmware_node, parent, "firmware_node");
+        if (r < 0)
+                return r;
+
+        if (device_in_subsystem(firmware_node, "acpi") <= 0)
+                return -ENODEV;
+
+        r = sd_device_get_sysname(firmware_node, &sysname);
+        if (r < 0)
+                return r;
+
+        path_prepend(path, "acpi-%s", sysname);
+
+        return 0;
+}
+
 static int builtin_path_id(UdevEvent *event, int argc, char *argv[]) {
         sd_device *dev = ASSERT_PTR(ASSERT_PTR(event)->dev);
         _cleanup_(sd_device_unrefp) sd_device *dev_other_branch = NULL;
@@ -749,6 +773,10 @@ static int builtin_path_id(UdevEvent *event, int argc, char *argv[]) {
                                 path_prepend(&compat_path, "acpi-%s", sysname);
                         parent = skip_subsystem(parent, "acpi");
                         supported_parent = true;
+                } else if (device_in_subsystem(parent, "pnp") > 0) {
+                        if (handle_pnp(parent, &path) >= 0)
+                                supported_parent = true;
+                        parent = skip_subsystem(parent, "pnp");
                 } else if (device_in_subsystem(parent, "xen") > 0) {
                         path_prepend(&path, "xen-%s", sysname);
                         if (compat_path)

--- a/test/sys-script.py
+++ b/test/sys-script.py
@@ -10584,6 +10584,7 @@ f('sys/devices/pnp0/00:07/rtc/rtc0/name', 0o644, b'rtc_cmos\n')
 f('sys/devices/pnp0/00:07/rtc/rtc0/time', 0o644, b'02:30:51\n')
 f('sys/devices/pnp0/00:07/rtc/rtc0/uevent', 0o644, b'''MAJOR=253
 MINOR=0
+DEVNAME=rtc0
 ''')
 d('sys/devices/pnp0/00:07/rtc/rtc0/power', 0o755)
 f('sys/devices/pnp0/00:07/rtc/rtc0/power/wakeup', 0o644, b'\n')

--- a/test/test-udev.py
+++ b/test/test-udev.py
@@ -2072,6 +2072,17 @@ SUBSYSTEMS=="scsi", PROGRAM=="/bin/bash -c \"printf %%s 'foo1 foo2' | grep 'foo1
         ''',
     ),
     Rules.new(
+        'builtin path_id for PNP device with ACPI firmware node',
+        Device(
+            '/devices/pnp0/00:07/rtc/rtc0',
+            exp_links=['rtc/by-path/acpi-PNP0B00:00'],
+        ),
+        rules=r'''
+        KERNEL=="rtc0", IMPORT{builtin}="path_id"
+        KERNEL=="rtc0", ENV{ID_PATH}=="?*", SYMLINK+="rtc/by-path/$env{ID_PATH}"
+        ''',
+    ),
+    Rules.new(
         'add and match tag',
         Device(
             '/devices/pci0000:00/0000:00:1f.2/host0/target0:0:0/0:0:0:0/block/sda',


### PR DESCRIPTION
Hello everyone,

On 2018-2020 Apple T2 MacBooks and iMacs, the display brightness setting is lost across
reboots. The system starts with the default brightness currently left in the GMUX
hardware instead of restoring the value saved during the previous session.

The GMUX backlight is exposed below a PNP device. Since `path_id` cannot derive
an ID for that topology, the udev rule responsible for starting
`systemd-backlight` does not complete. No state file is created for
`gmux_backlight`, and the brightness is therefore neither saved at shutdown nor
restored during boot.

The PNP device exposes a stable ACPI `firmware_node`, which can be used to
identify the backlight.

```
ID_PATH=acpi-APP000B:00
ID_PATH_TAG=acpi-APP000B_00
SYSTEMD_WANTS=systemd-backlight@backlight:gmux_backlight.service
```

The included regression test passes with

`1 passed, 166 deselected`

Thanks for your time and work,
André
