### PR TITLE
sysctl: introduce the varlink interface for writing sysctl

### DIFF
--- a/src/basic/sysctl-util.c
+++ b/src/basic/sysctl-util.c
@@ -114,6 +114,43 @@ int sysctl_writef(const char *property, const char *format, ...) {
         return sysctl_write(property, v);
 }
 
+int sysctl_write_verify(const char *property, const char *value) {
+        int r;
+
+        assert(property);
+        assert(value);
+
+        /* Some sysctl settings accept invalid values on write, but refuses on read. E.g. coredump pattern,
+         * be1e0283021ec73c2eb92839db9a471a068709d9 (v6.17) and 7d7c1fb85cba5627bbe741fb7539c709435e3848
+         * (v6.16.8), which is fixed by a779e27f24aeb679969ddd1fdd7f636e22ddbc1e (v6.18) and
+         * 304aa560385720baf3660fe8500f6dd425b63ea9 (v6.17.5). Let's first save the original value, and
+         * restore to the saved value if the new value is refused. */
+
+        _cleanup_free_ char *original = NULL;
+        r = sysctl_read(property, &original);
+        if (r >= 0 && streq(original, value))
+                return 0; /* Already set. */
+
+        r = sysctl_write(property, value);
+        if (r >= 0) {
+                _cleanup_free_ char *current = NULL;
+                r = sysctl_read(property, &current);
+                if (r >= 0) {
+                        if (streq(current, value))
+                                return 0; /* Yay! */
+
+                        /* At least for coredump pattern, this does not happen, but let's handle this as the
+                         * same as we wrote something invalid. */
+                        r = -EINVAL;
+                }
+        }
+
+        if (original)
+                (void) sysctl_write(property, original);
+
+        return r;
+}
+
 static const char* af_to_sysctl_dir(int af) {
         if (af == AF_MPLS)
                 return "mpls";

--- a/src/basic/sysctl-util.h
+++ b/src/basic/sysctl-util.h
@@ -12,6 +12,7 @@ int sysctl_writef(const char *property, const char *format, ...) _printf_(2, 3);
 static inline int sysctl_write(const char *property, const char *value) {
         return sysctl_write_full(property, value, NULL);
 }
+int sysctl_write_verify(const char *property, const char *value);
 
 int sysctl_read_ip_property(int af, const char *ifname, const char *property, char **ret);
 int sysctl_read_ip_property_int(int af, const char *ifname, const char *property, int *ret);

--- a/src/libsystemd/sd-varlink/test-varlink-idl.c
+++ b/src/libsystemd/sd-varlink/test-varlink-idl.c
@@ -55,6 +55,7 @@
 #include "varlink-io.systemd.SysInstall.h"
 #include "varlink-io.systemd.SysUpdate.h"
 #include "varlink-io.systemd.SysUpdate.Notify.h"
+#include "varlink-io.systemd.Sysctl.h"
 #include "varlink-io.systemd.Udev.h"
 #include "varlink-io.systemd.Unit.h"
 #include "varlink-io.systemd.UserDatabase.h"
@@ -235,6 +236,7 @@ TEST(parse_format) {
                 &vl_interface_io_systemd_SysInstall,
                 &vl_interface_io_systemd_SysUpdate,
                 &vl_interface_io_systemd_SysUpdate_Notify,
+                &vl_interface_io_systemd_Sysctl,
                 &vl_interface_io_systemd_Udev,
                 &vl_interface_io_systemd_Unit,
                 &vl_interface_io_systemd_UserDatabase,

--- a/src/shared/meson.build
+++ b/src/shared/meson.build
@@ -259,6 +259,7 @@ shared_sources = files(
         'varlink-io.systemd.SysInstall.c',
         'varlink-io.systemd.SysUpdate.c',
         'varlink-io.systemd.SysUpdate.Notify.c',
+        'varlink-io.systemd.Sysctl.c',
         'varlink-io.systemd.Udev.c',
         'varlink-io.systemd.Unit.c',
         'varlink-io.systemd.UserDatabase.c',

--- a/src/shared/varlink-io.systemd.Sysctl.c
+++ b/src/shared/varlink-io.systemd.Sysctl.c
@@ -1,0 +1,28 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include "varlink-io.systemd.Sysctl.h"
+
+static SD_VARLINK_DEFINE_STRUCT_TYPE(
+                SysctlSetting,
+                SD_VARLINK_FIELD_COMMENT("A sysctl key. This can take a glob pattern."),
+                SD_VARLINK_DEFINE_FIELD(key, SD_VARLINK_STRING, 0),
+                SD_VARLINK_FIELD_COMMENT("A sysctl value to be written. When this is unspecified, the setting is handled as an exclude entry of other glob patterns."),
+                SD_VARLINK_DEFINE_FIELD(value, SD_VARLINK_STRING, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("Ignore errors in writing sysctl value."),
+                SD_VARLINK_DEFINE_FIELD(ignoreFailure, SD_VARLINK_BOOL, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("Verify sysctl value after write."),
+                SD_VARLINK_DEFINE_FIELD(verify, SD_VARLINK_BOOL, SD_VARLINK_NULLABLE));
+
+static SD_VARLINK_DEFINE_METHOD(
+                Apply,
+                SD_VARLINK_FIELD_COMMENT("settings"),
+                SD_VARLINK_DEFINE_INPUT_BY_TYPE(settings, SysctlSetting, SD_VARLINK_ARRAY));
+
+SD_VARLINK_DEFINE_INTERFACE(
+                io_systemd_Sysctl,
+                "io.systemd.Sysctl",
+                SD_VARLINK_INTERFACE_COMMENT("Sysctl APIs."),
+                SD_VARLINK_SYMBOL_COMMENT("A structure encapsulating sysctl setting."),
+                &vl_type_SysctlSetting,
+                SD_VARLINK_SYMBOL_COMMENT("Apply settings."),
+                &vl_method_Apply);

--- a/src/shared/varlink-io.systemd.Sysctl.h
+++ b/src/shared/varlink-io.systemd.Sysctl.h
@@ -1,0 +1,6 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#pragma once
+
+#include "sd-varlink-idl.h"
+
+extern const sd_varlink_interface vl_interface_io_systemd_Sysctl;

--- a/src/sysctl/sysctl.c
+++ b/src/sysctl/sysctl.c
@@ -425,18 +425,18 @@ static int parse_argv(int argc, char *argv[], char ***remaining_args) {
 }
 
 static int run(int argc, char *argv[]) {
-        _cleanup_ordered_hashmap_free_ OrderedHashmap *sysctl_options = NULL;
         int r;
+
+        log_setup();
 
         char **args = NULL;
         r = parse_argv(argc, argv, &args);
         if (r <= 0)
                 return r;
 
-        log_setup();
-
         umask(0022);
 
+        _cleanup_ordered_hashmap_free_ OrderedHashmap *sysctl_options = NULL;
         if (!strv_isempty(args)) {
                 unsigned pos = 0;
 

--- a/src/sysctl/sysctl.c
+++ b/src/sysctl/sysctl.c
@@ -12,6 +12,7 @@
 #include "format-table.h"
 #include "glob-util.h"
 #include "hashmap.h"
+#include "json-util.h"
 #include "log.h"
 #include "main-func.h"
 #include "options.h"
@@ -21,11 +22,14 @@
 #include "string-util.h"
 #include "strv.h"
 #include "sysctl-util.h"
+#include "varlink-io.systemd.Sysctl.h"
+#include "varlink-util.h"
 
 static char **arg_prefixes = NULL;
 static CatFlags arg_cat_flags = CAT_CONFIG_OFF;
 static bool arg_strict = false;
 static bool arg_inline = false;
+static bool arg_varlink = false;
 static PagerFlags arg_pager_flags = 0;
 
 STATIC_DESTRUCTOR_REGISTER(arg_prefixes, strv_freep);
@@ -321,6 +325,111 @@ static int read_credential_lines(OrderedHashmap **sysctl_options) {
         return parse_file(sysctl_options, j, /* ignore_enoent= */ true);
 }
 
+static int dispatch_setting(const char *name, sd_json_variant *variant, sd_json_dispatch_flags_t flags, void *userdata) {
+        OrderedHashmap **sysctl_options = ASSERT_PTR(userdata);
+        int r;
+
+        _cleanup_(sysctl_option_freep) SysctlOption *option = new0(SysctlOption, 1);
+        if (!option)
+                return log_oom();
+
+        static const sd_json_dispatch_field dispatch_table[] = {
+                { "key",           SD_JSON_VARIANT_STRING,  sd_json_dispatch_string,  offsetof(SysctlOption, key),            SD_JSON_MANDATORY },
+                { "value",         SD_JSON_VARIANT_STRING,  sd_json_dispatch_string,  offsetof(SysctlOption, value),          0                 },
+                { "ignoreFailure", SD_JSON_VARIANT_BOOLEAN, sd_json_dispatch_stdbool, offsetof(SysctlOption, ignore_failure), 0                 },
+                { "verify",        SD_JSON_VARIANT_BOOLEAN, sd_json_dispatch_stdbool, offsetof(SysctlOption, verify),         0                 },
+                {},
+        };
+
+        r = sd_json_dispatch(variant, dispatch_table, flags, option);
+        if (r < 0)
+                return r;
+
+        sysctl_normalize(option->key);
+
+        SysctlOption *existing = ordered_hashmap_get(*sysctl_options, option->key);
+        if (existing) {
+                if (streq_ptr(option->value, existing->value)) {
+                        existing->ignore_failure = existing->ignore_failure || option->ignore_failure;
+                        return 0;
+                }
+
+                log_debug("Overwriting earlier assignment of '%s'.", option->key);
+                sysctl_option_free(ordered_hashmap_remove(*sysctl_options, option->key));
+        }
+
+        r = ordered_hashmap_ensure_put(sysctl_options, &sysctl_option_hash_ops, option->key, option);
+        if (r < 0)
+                return log_error_errno(r, "Failed to add sysctl variable '%s' to hashmap: %m", option->key);
+
+        TAKE_PTR(option);
+        return 0;
+}
+
+static int dispatch_settings(const char *name, sd_json_variant *variant, sd_json_dispatch_flags_t flags, void *userdata) {
+        int r;
+
+        sd_json_variant *v;
+        JSON_VARIANT_ARRAY_FOREACH(v, variant) {
+                r = dispatch_setting(name, v, flags, userdata);
+                if (r < 0)
+                        return r;
+        }
+
+        return 0;
+}
+
+static int vl_method_apply(sd_varlink *link, sd_json_variant *parameters, sd_varlink_method_flags_t flags, void *userdata) {
+        int r;
+
+        assert(link);
+
+        static const sd_json_dispatch_field dispatch_table[] = {
+                { "settings", SD_JSON_VARIANT_ARRAY, dispatch_settings, 0, SD_JSON_MANDATORY},
+                {}
+        };
+
+        _cleanup_ordered_hashmap_free_ OrderedHashmap *sysctl_options = NULL;
+        r = sd_varlink_dispatch(link, parameters, dispatch_table, &sysctl_options);
+        if (r != 0)
+                return r;
+
+        return apply_all(sysctl_options);
+}
+
+static int vl_server(void) {
+        int r;
+
+        /* Invocation as Varlink service */
+
+        _cleanup_(sd_varlink_server_unrefp) sd_varlink_server *varlink_server = NULL;
+        r = varlink_server_new(
+                        &varlink_server,
+                        SD_VARLINK_SERVER_ROOT_ONLY |
+                        SD_VARLINK_SERVER_MYSELF_ONLY,
+                        /* userdata= */ NULL);
+        if (r < 0)
+                return log_error_errno(r, "Failed to allocate Varlink server: %m");
+
+        r = sd_varlink_server_add_interface_many(
+                        varlink_server,
+                        &vl_interface_io_systemd_Sysctl);
+        if (r < 0)
+                return log_error_errno(r, "Failed to add Varlink interfaces: %m");
+
+        r = sd_varlink_server_bind_method_many(
+                        varlink_server,
+                        "io.systemd.Sysctl.Apply", vl_method_apply);
+        if (r < 0)
+                return log_error_errno(r, "Failed to bind Varlink methods: %m");
+
+        r = sd_varlink_server_loop_auto(varlink_server);
+        if (r < 0)
+                return log_error_errno(r, "Failed to run Varlink event loop: %m");
+
+        return 0;
+}
+
 static int cat_config(char **files) {
         pager_open(arg_pager_flags);
 
@@ -370,6 +479,8 @@ static int help(void) {
 }
 
 static int parse_argv(int argc, char *argv[], char ***remaining_args) {
+        int r;
+
         assert(argc >= 0);
         assert(argv);
         assert(remaining_args);
@@ -435,6 +546,26 @@ static int parse_argv(int argc, char *argv[], char ***remaining_args) {
                 return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
                                        "Positional arguments are not allowed with --cat-config/--tldr.");
 
+        r = sd_varlink_invocation(SD_VARLINK_ALLOW_ACCEPT);
+        if (r < 0)
+                return log_error_errno(r, "Failed to check if invoked in Varlink mode: %m");
+        if (r > 0) {
+                if (arg_cat_flags != CAT_CONFIG_OFF)
+                        return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
+                                               "--cat-config/--tldr cannot be used on Varlink mode.");
+                if (!strv_isempty(arg_prefixes))
+                        return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
+                                               "--prefix= cannot be used on Varlink mode.");
+                if (arg_inline)
+                        return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
+                                               "--inline cannot be used on Varlink mode.");
+                if (!strv_isempty(*remaining_args))
+                        return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
+                                               "Positional arguments are not allowed on Varlink mode.");
+
+                arg_varlink = true;
+        }
+
         return 1;
 }
 
@@ -449,6 +580,9 @@ static int run(int argc, char *argv[]) {
                 return r;
 
         umask(0022);
+
+        if (arg_varlink)
+                return vl_server();
 
         _cleanup_ordered_hashmap_free_ OrderedHashmap *sysctl_options = NULL;
         if (!strv_isempty(args)) {

--- a/src/sysctl/sysctl.c
+++ b/src/sysctl/sysctl.c
@@ -86,24 +86,26 @@ static SysctlOption* sysctl_option_new(
         return TAKE_PTR(o);
 }
 
-static int sysctl_write_or_warn(const char *key, const char *value, bool ignore_failure, bool ignore_enoent) {
+static int sysctl_write_or_warn(const SysctlOption *option, bool ignore_enoent) {
         int r;
 
-        r = sysctl_write(key, value);
+        assert(option);
+
+        r = sysctl_write(option->key, option->value);
         if (r < 0) {
                 /* Proceed without failing if ignore_failure is true.
                  * If the sysctl is not available in the kernel or we are running with reduced privileges and
                  * cannot write it, then log about the issue, and proceed without failing. Unless strict mode
-                 * (arg_strict = true) is enabled, in which case we should fail. (EROFS is treated as a
+                 * is enabled (ignore_enoent == false), in which case we should fail. (EROFS is treated as a
                  * permission problem here, since that's how container managers usually protected their
                  * sysctls.)
                  * In all other cases log an error and make the tool fail. */
-                if (ignore_failure || (!arg_strict && ERRNO_IS_NEG_FS_WRITE_REFUSED(r)))
-                        log_debug_errno(r, "Couldn't write '%s' to '%s', ignoring: %m", value, key);
+                if (option->ignore_failure || (ignore_enoent && ERRNO_IS_NEG_FS_WRITE_REFUSED(r)))
+                        log_debug_errno(r, "Couldn't write '%s' to '%s', ignoring: %m", option->value, option->key);
                 else if (ignore_enoent && r == -ENOENT)
-                        log_warning_errno(r, "Couldn't write '%s' to '%s', ignoring: %m", value, key);
+                        log_warning_errno(r, "Couldn't write '%s' to '%s', ignoring: %m", option->value, option->key);
                 else
-                        return log_error_errno(r, "Couldn't write '%s' to '%s': %m", value, key);
+                        return log_error_errno(r, "Couldn't write '%s' to '%s': %m", option->value, option->key);
         }
 
         return 0;
@@ -138,9 +140,13 @@ static int apply_glob_option_with_prefix(OrderedHashmap *sysctl_options, SysctlO
                                 return 0;
                         }
 
-                        return sysctl_write_or_warn(key, option->value,
-                                                    /* ignore_failure= */ option->ignore_failure,
-                                                    /* ignore_enoent= */ true);
+                        return sysctl_write_or_warn(
+                                        &(const SysctlOption) {
+                                                .key = key,
+                                                .value = option->value,
+                                                .ignore_failure = option->ignore_failure,
+                                        },
+                                        /* ignore_enoent= */ true);
                 }
 
                 pattern = path_join("/proc/sys", key);
@@ -172,9 +178,13 @@ static int apply_glob_option_with_prefix(OrderedHashmap *sysctl_options, SysctlO
                 }
 
                 RET_GATHER(r,
-                           sysctl_write_or_warn(key, option->value,
-                                                /* ignore_failure= */ option->ignore_failure,
-                                                /* ignore_enoent= */ !arg_strict));
+                           sysctl_write_or_warn(
+                                        &(const SysctlOption) {
+                                                .key = (char*) key,
+                                                .value = option->value,
+                                                .ignore_failure = option->ignore_failure,
+                                        },
+                                        /* ignore_enoent= */ !arg_strict));
         }
 
         return r;
@@ -205,9 +215,7 @@ static int apply_all(OrderedHashmap *sysctl_options) {
                 if (string_is_glob(option->key))
                         k = apply_glob_option(sysctl_options, option);
                 else
-                        k = sysctl_write_or_warn(option->key, option->value,
-                                                 /* ignore_failure= */ option->ignore_failure,
-                                                 /* ignore_enoent= */ !arg_strict);
+                        k = sysctl_write_or_warn(option, /* ignore_enoent= */ !arg_strict);
                 RET_GATHER(r, k);
         }
 

--- a/src/sysctl/sysctl.c
+++ b/src/sysctl/sysctl.c
@@ -34,6 +34,7 @@ typedef struct SysctlOption {
         char *key;
         char *value;
         bool ignore_failure;
+        bool verify;
 } SysctlOption;
 
 static SysctlOption* sysctl_option_free(SysctlOption *o) {
@@ -91,7 +92,10 @@ static int sysctl_write_or_warn(const SysctlOption *option, bool ignore_enoent) 
 
         assert(option);
 
-        r = sysctl_write(option->key, option->value);
+        if (option->verify)
+                r = sysctl_write_verify(option->key, option->value);
+        else
+                r = sysctl_write(option->key, option->value);
         if (r < 0) {
                 /* Proceed without failing if ignore_failure is true.
                  * If the sysctl is not available in the kernel or we are running with reduced privileges and
@@ -145,6 +149,7 @@ static int apply_glob_option_with_prefix(OrderedHashmap *sysctl_options, SysctlO
                                                 .key = key,
                                                 .value = option->value,
                                                 .ignore_failure = option->ignore_failure,
+                                                .verify = option->verify,
                                         },
                                         /* ignore_enoent= */ true);
                 }
@@ -183,6 +188,7 @@ static int apply_glob_option_with_prefix(OrderedHashmap *sysctl_options, SysctlO
                                                 .key = (char*) key,
                                                 .value = option->value,
                                                 .ignore_failure = option->ignore_failure,
+                                                .verify = option->verify,
                                         },
                                         /* ignore_enoent= */ !arg_strict));
         }

--- a/test/units/TEST-87-AUX-UTILS-VM.sysctl.sh
+++ b/test/units/TEST-87-AUX-UTILS-VM.sysctl.sh
@@ -78,3 +78,11 @@ EOF
 assert_eq "$(cat /proc/sys/net/ipv4/conf/hoge/drop_gratuitous_arp)" "1"
 assert_eq "$(cat /proc/sys/net/ipv4/conf/hoge/bootp_relay)" "1"
 assert_eq "$(cat /proc/sys/net/ipv4/conf/hoge/disable_policy)" "0"
+
+echo 0 >/proc/sys/net/ipv4/conf/hoge/drop_gratuitous_arp
+
+varlinkctl call /run/systemd/io.systemd.Sysctl io.systemd.Sysctl.Apply '{"settings":[{"key":"net.ipv4.conf.hoge.drop_gratuitous_arp","value":"1","verify":true}]}'
+assert_eq "$(cat /proc/sys/net/ipv4/conf/hoge/drop_gratuitous_arp)" "1"
+
+(! varlinkctl call /run/systemd/io.systemd.Sysctl io.systemd.Sysctl.Apply '{"settings":[{"key":"net.ipv4.conf.hoge.should_not_exist_xxx","value":"1"}]}')
+varlinkctl call /run/systemd/io.systemd.Sysctl io.systemd.Sysctl.Apply '{"settings":[{"key":"net.ipv4.conf.hoge.should_not_exist_xxx","value":"1","ignoreFailure":true}]}'

--- a/units/meson.build
+++ b/units/meson.build
@@ -829,6 +829,11 @@ units = [
           'symlinks' : ['sysinit.target.wants/'],
         },
         {
+          'file' : 'systemd-sysctl.socket',
+          'symlinks' : ['sockets.target.wants/'],
+        },
+        { 'file' : 'systemd-sysctl@.service.in' },
+        {
           'file' : 'systemd-sysext.service',
           'conditions' : ['ENABLE_SYSEXT'],
         },

--- a/units/systemd-sysctl.socket
+++ b/units/systemd-sysctl.socket
@@ -1,0 +1,28 @@
+#  SPDX-License-Identifier: LGPL-2.1-or-later
+#
+#  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+
+[Unit]
+Description=Socket for Applying Kernel Variables
+Documentation=man:systemd-sysctl.service(8) man:sysctl.d(5)
+DefaultDependencies=no
+After=systemd-modules-load.service
+Before=sockets.target shutdown.target
+Conflicts=shutdown.target
+ConditionPathIsReadWrite=/proc/sys/net/
+
+[Socket]
+ListenStream=/run/systemd/io.systemd.Sysctl
+Symlinks=/run/varlink/registry/io.systemd.Sysctl
+FileDescriptorName=varlink
+SocketMode=0600
+Accept=yes
+MaxConnectionsPerSource=16
+XAttrEntryPoint=user.varlink=entrypoint
+XAttrListen=user.varlink=listen
+XAttrAccept=user.varlink=server

--- a/units/systemd-sysctl@.service.in
+++ b/units/systemd-sysctl@.service.in
@@ -1,0 +1,20 @@
+#  SPDX-License-Identifier: LGPL-2.1-or-later
+#
+#  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+
+[Unit]
+Description=Apply Kernel Variables
+Documentation=man:systemd-sysctl.service(8) man:sysctl.d(5)
+DefaultDependencies=no
+Conflicts=shutdown.target
+After=systemd-modules-load.service
+Before=sysinit.target shutdown.target
+ConditionPathIsReadWrite=/proc/sys/net/
+
+[Service]
+ExecStart={{LIBEXECDIR}}/systemd-sysctl


### PR DESCRIPTION
This may be useful, for example, when changing the coredump pattern from a non-default mount namespace, where the kernel refuses direct writes to the coredump pattern.