### PR TITLE
hwdb: mark Microsoft Surface Type Cover touchpad as internal

### DIFF
--- a/hwdb.d/70-touchpad.hwdb
+++ b/hwdb.d/70-touchpad.hwdb
@@ -43,3 +43,12 @@
 ###########################################################
 touchpad:bluetooth:v17efp60fa:*
  ID_INPUT_TOUCHPAD_INTEGRATION=internal
+
+###########################################################
+# Microsoft Surface Type Cover
+###########################################################
+# The USB port is reported as removable by firmware, so 65-integration.rules
+# classifies the touchpad as external and libinput skips disable-while-typing.
+# The touchpad is physically integrated; mark it internal to enable DWT.
+touchpad:usb:v045ep09c0:name:Microsoft Surface Type Cover Touchpad:*
+ ID_INPUT_TOUCHPAD_INTEGRATION=internal


### PR DESCRIPTION
The Microsoft Surface Type Cover touchpad (USB 045E:09C0) is attached
through a USB port that firmware reports as removable. Because of that,
`65-integration.rules` sets `ID_INPUT_TOUCHPAD_INTEGRATION=external`, and
libinput skips disable-while-typing (DWT) for the device.

The touchpad is physically integrated into the Type Cover, so add a hwdb
entry in `70-touchpad.hwdb` that overrides
`ID_INPUT_TOUCHPAD_INTEGRATION=internal`, restoring DWT.

Fixes #43256
