### PR TITLE
hwdb: mark Adesso wireless keyboard trackball as trackball

### DIFF
--- a/hwdb.d/70-mouse.hwdb
+++ b/hwdb.d/70-mouse.hwdb
@@ -183,6 +183,14 @@ mouse:bluetooth:v256fpc63a:name:*
  ID_INPUT_3D_MOUSE=1
 
 ##########################################
+# Adesso
+##########################################
+
+# Adesso Wireless keyboard with integrated trackball (MosArt 062a:4101)
+mouse:usb:v062ap4101:*
+ ID_INPUT_TRACKBALL=1
+
+##########################################
 # Apple
 ##########################################
 


### PR DESCRIPTION
The Adesso wireless keyboard with an integrated trackball (MosArt
062a:4101) is identified as a regular mouse, so trackball-style
scrolling does not work out of the box. Add a hwdb entry in
`70-mouse.hwdb` setting `ID_INPUT_TRACKBALL=1` so libinput and other
clients treat the device as a trackball.

Fixes #29609
