### PR TITLE
hwdb: fix Lenovo B570e touchpad ABS ranges for edge scrolling

### DIFF
--- a/hwdb.d/60-evdev.hwdb
+++ b/hwdb.d/60-evdev.hwdb
@@ -566,6 +566,16 @@ evdev:name:SYNA3602:00 093A:35ED Touchpad:dmi:*svnInfinix:*pnY3Max**
 # Lenovo
 #########################################
 
+# Lenovo B570e
+# Fixes wrong touchpad edge-scroll area: without this override the
+# kernel reports wider ABS ranges, making edge scrolling trigger across the
+# right half of the touchpad.
+evdev:name:ETPS/2 Elantech Touchpad:dmi:*svnLENOVO*:pvrLenovoB570e:*
+ EVDEV_ABS_00=0:2934:29
+ EVDEV_ABS_01=-652:652:26
+ EVDEV_ABS_35=0:2934:29
+ EVDEV_ABS_36=-652:652:26
+
 # Lenovo B590
 evdev:name:SynPS/2 Synaptics TouchPad:dmi:*svnLENOVO*:pvrLenovoB590:*
  EVDEV_ABS_00=1243:5759:48


### PR DESCRIPTION
The Lenovo B570e touchpad (ETPS/2 Elantech) reports ABS ranges that
are too wide by default, which makes edge scrolling trigger across
roughly the right half of the touchpad instead of only at the right
edge. Add an evdev hwdb entry in `60-evdev.hwdb` that overrides the
ABS_X/ABS_Y (and the matching MT position) ranges with the calibrated
values, following the same pattern already used for the Lenovo B590
and L430 entries.

The DMI match is simplified to `dmi:*svnLENOVO*:pvrLenovoB570e:*`
(matching the convention of the neighbouring B590 entry) so it is not
tied to a specific BIOS version.

Fixes #29666
