### PR TITLE
repart: pass FileSystemSectorSize= to mkfs.erofs

### DIFF
--- a/src/shared/mkfs-util.c
+++ b/src/shared/mkfs-util.c
@@ -6,6 +6,7 @@
 
 #include "escape.h"
 #include "log.h"
+#include "memory-util.h"
 #include "mkfs-util.h"
 #include "mount-util.h"
 #include "mountpoint-util.h"
@@ -619,6 +620,12 @@ int make_filesystem(
                         if (strv_extend(&argv, c) < 0)
                                 return log_oom();
                 }
+
+                /* mkfs.erofs defaults to the page size and rejects block sizes larger than
+                 * that, so only pass an explicit block size when it is actually smaller. */
+                if (sector_size > 0 && sector_size < (uint64_t) page_size() &&
+                    strv_extendf(&argv, "-b%"PRIu64, sector_size) < 0)
+                        return log_oom();
 
                 if (strv_extend_many(&argv, node, root) < 0)
                         return log_oom();


### PR DESCRIPTION
The erofs branch in `make_filesystem()` never passed the sector size to `mkfs.erofs`, so `FileSystemSectorSize=` was silently ignored for erofs partitions. `mkfs.erofs` defaults to the page size (e.g. 16K on aarch64), which is too large for some use cases such as UFS with 4K blocks.

Pass `-b <sector_size>` to `mkfs.erofs`, matching how the other supported filesystems (xfs, ext4, btrfs, f2fs, vfat) already handle `sector_size`.

Fixes #43238
