### PR TITLE
man: clarify that --fido2-with-user-presence=n may not be supported

### DIFF
--- a/man/systemd-cryptenroll.xml
+++ b/man/systemd-cryptenroll.xml
@@ -538,9 +538,9 @@
 
         <listitem><para>When enrolling a FIDO2 security token, controls whether to require the user to enter
         a PIN when unlocking the volume (the FIDO2 <literal>clientPin</literal> feature). Defaults to
-        <literal>yes</literal>. (Note: this setting is without effect if the security token does not support
-        the <literal>clientPin</literal> feature at all, or does not allow enabling or disabling
-        it.)</para>
+        <literal>yes</literal>. Note that this setting has no effect if the security token does not
+        support the <literal>clientPin</literal> feature, or does not allow the client PIN requirement
+        to be enabled or disabled for the requested operation.</para>
 
         <xi:include href="version-info.xml" xpointer="v249"/></listitem>
       </varlistentry>
@@ -550,9 +550,9 @@
 
         <listitem><para>When enrolling a FIDO2 security token, controls whether to require the user to
         verify presence (tap the token, the FIDO2 <literal>up</literal> feature) when unlocking the volume.
-        Defaults to <literal>yes</literal>. (Note: this setting is without effect if the security token does not support
-        the <literal>up</literal> feature at all, or does not allow enabling or disabling it.)
-        </para>
+        Defaults to <literal>yes</literal>. Note that this setting has no effect if the security token does not
+        support the <literal>up</literal> feature, or does not allow the user presence requirement to be
+        enabled or disabled for the requested operation.</para>
 
         <xi:include href="version-info.xml" xpointer="v249"/></listitem>
       </varlistentry>
@@ -562,8 +562,9 @@
 
         <listitem><para>When enrolling a FIDO2 security token, controls whether to require user verification
         when unlocking the volume (the FIDO2 <literal>uv</literal> feature). Defaults to
-        <literal>no</literal>. (Note: this setting is without effect if the security token does not support
-        the <literal>uv</literal> feature at all, or does not allow enabling or disabling it.)</para>
+        <literal>no</literal>. Note that this setting has no effect if the security token does not
+        support the <literal>uv</literal> feature, or does not allow the user verification requirement
+        to be enabled or disabled for the requested operation.</para>
 
         <xi:include href="version-info.xml" xpointer="v249"/></listitem>
       </varlistentry>


### PR DESCRIPTION
FIDO2 enrollment in systemd-cryptenroll uses the `hmac-secret` extension, which per the CTAP2 specification requires user presence (the `up` feature). Setting `--fido2-with-user-presence=no` will therefore typically not be supported by the security token, even on tokens that allow disabling user presence for other use cases.

Document this explicitly in the man page to save users from confusion when the option is silently ignored or rejected.

Fixes #23632
