### PR TITLE
docs: fix typo in man/sd-device.xml

### DIFF
--- a/man/sd-device.xml
+++ b/man/sd-device.xml
@@ -37,7 +37,7 @@
     <para><filename>sd-device.h</filename> is part of
     <citerefentry><refentrytitle>libsystemd</refentrytitle><manvolnum>3</manvolnum></citerefentry> and
     provides an API to introspect and enumerate devices on the local system. It provides a programmatic
-    interface to the database of devices and their properties mananaged by
+    interface to the database of devices and their properties managed by
     <citerefentry><refentrytitle>systemd-udevd.service</refentrytitle><manvolnum>8</manvolnum></citerefentry>.
     This API is a replacement for
     <citerefentry><refentrytitle>libudev</refentrytitle><manvolnum>3</manvolnum></citerefentry> and


### PR DESCRIPTION
Fix spelling of "managed" in man/sd-device.xml.