### PR TITLE
env-file: cleanups for write_env_file_label()

### DIFF
--- a/src/basic/env-file.c
+++ b/src/basic/env-file.c
@@ -666,29 +666,32 @@ static void write_env_var(FILE *f, const char *v) {
 }
 
 int write_env_file_label(int dir_fd, const char *fname, char **headers, char **l, WriteEnvFileFlags flags, LabelContext *label_context) {
-        _cleanup_fclose_ FILE *f = NULL;
-        _cleanup_free_ char *p = NULL;
         int r;
 
         assert(dir_fd >= 0 || dir_fd == AT_FDCWD);
         assert(fname);
 
-        bool call_label_ops_post = false;
         if (FLAGS_SET(flags, WRITE_ENV_FILE_LABEL)) {
                 r = label_ops_pre(dir_fd, fname, S_IFREG, label_context);
                 if (r < 0)
                         return r;
-
-                call_label_ops_post = true;
         }
 
+        _cleanup_fclose_ FILE *f = NULL;
+        _cleanup_free_ char *p = NULL;
         r = fopen_tmpfile_linkable_at(dir_fd, fname, O_WRONLY|O_CLOEXEC, &p, &f);
-        int k = call_label_ops_post ? label_ops_post(f ? fileno(f) : dir_fd, f ? NULL : fname, /* created= */ !!f, label_context) : 0;
-        if (r < 0)
+        if (r < 0) {
+                if (FLAGS_SET(flags, WRITE_ENV_FILE_LABEL))
+                        (void) label_ops_post(dir_fd, fname, /* created= */ false, label_context);
                 return r;
+        }
         CLEANUP_TMPFILE_AT(dir_fd, p);
-        if (k < 0)
-                return k;
+
+        if (FLAGS_SET(flags, WRITE_ENV_FILE_LABEL)) {
+                r = label_ops_post(fileno(f), /* path= */ NULL, /* created= */ true, label_context);
+                if (r < 0)
+                        return r;
+        }
 
         r = fchmod_umask(fileno(f), 0644);
         if (r < 0)


### PR DESCRIPTION
Explicitly call label_ops_post() where necessary with specific arguments. Previously, regardless if fopen_tmpfile_linkable_at() success, label_ops_post() was called but its argument was heavily conditionalized. Let's call it both on failure and success cases with specific arguments. This should be easy to read.

This also
- moves variable declarations where used,
- drops unnecessary boolean flag call_label_ops_post.

No functional change. Just reafactoring.

Hopefully silence CID#1664328, though it is false-positive.