### PR TITLE
test-nss-users: quote empty member lists

### DIFF
--- a/src/test/test-nss-users.c
+++ b/src/test/test-nss-users.c
@@ -7,6 +7,7 @@
 #include "alloc-util.h"
 #include "dlfcn-util.h"
 #include "errno-list.h"
+#include "escape.h"
 #include "format-util.h"
 #include "log.h"
 #include "main-func.h"
@@ -30,30 +31,30 @@ static void print_struct_passwd(const struct passwd *pwd) {
 }
 
 static void print_struct_group(const struct group *gr) {
-        _cleanup_free_ char *members = NULL;
+        _cleanup_free_ char *members = NULL, *quoted = NULL;
 
         log_info("        \"%s\" / "GID_FMT,
                  gr->gr_name, gr->gr_gid);
         log_info("        passwd=\"%s\"", gr->gr_passwd);
 
         assert_se(members = strv_join(ASSERT_PTR(gr->gr_mem), ", "));
-        // FIXME: use shell_maybe_quote(SHELL_ESCAPE_EMPTY) when it becomes available
-        log_info("        members=%s", members);
+        quoted = ASSERT_NOT_NULL(shell_maybe_quote(members, SHELL_ESCAPE_EMPTY));
+        log_info("        members=%s", quoted);
 }
 
 static void print_struct_sgrp(const struct sgrp *sg) {
-        _cleanup_free_ char *administrators = NULL, *members = NULL;
+        _cleanup_free_ char *administrators = NULL, *members = NULL, *quoted_administrators = NULL, *quoted_members = NULL;
 
         log_info("        \"%s\"", sg->sg_namp);
         log_info("        passwd=\"%s\"", sg->sg_passwd);
 
         assert_se(administrators = strv_join(ASSERT_PTR(sg->sg_adm), ", "));
-        // FIXME: use shell_maybe_quote(SHELL_ESCAPE_EMPTY) when it becomes available
-        log_info("        administrators=%s", administrators);
+        quoted_administrators = ASSERT_NOT_NULL(shell_maybe_quote(administrators, SHELL_ESCAPE_EMPTY));
+        log_info("        administrators=%s", quoted_administrators);
 
         assert_se(members = strv_join(ASSERT_PTR(sg->sg_mem), ", "));
-        // FIXME: use shell_maybe_quote(SHELL_ESCAPE_EMPTY) when it becomes available
-        log_info("        members=%s", members);
+        quoted_members = ASSERT_NOT_NULL(shell_maybe_quote(members, SHELL_ESCAPE_EMPTY));
+        log_info("        members=%s", quoted_members);
 }
 
 static void test_getpwnam_r(void *handle, const char *module, const char *name) {


### PR DESCRIPTION
Use shell_maybe_quote() with SHELL_ESCAPE_EMPTY when logging joined group and shadow group member vectors, so empty vectors are rendered explicitly as "".

Follow-up for: f0d1266821771724b09a00764f4e20478c77f0a2
Follow-up for: 2eaca3ea5f0de702382d388d3bbc753c000ada4b