### PR TITLE
Revert "macro: EDG compiler frontends doesn't support enum types"

### DIFF
--- a/src/fundamental/macro.h
+++ b/src/fundamental/macro.h
@@ -519,7 +519,7 @@ assert_cc(STRLEN(__FILE__) > STRLEN(RELATIVE_SOURCE_PATH) + 1);
 #define PROJECT_FILE (&__FILE__[STRLEN(RELATIVE_SOURCE_PATH) + 1])
 
 /* In GCC 14 (C23) we can force enums to have the right types, and not solely rely on language extensions anymore */
-#if (__GNUC__ >= 14 || __STDC_VERSION__ >= 202311L) && !defined(__EDG__)
+#if __GNUC__ >= 14 || __STDC_VERSION__ >= 202311L
 #  define ENUM_TYPE_S64(id) id : int64_t
 #else
 #  define ENUM_TYPE_S64(id) id

--- a/src/systemd/_sd-common.h
+++ b/src/systemd/_sd-common.h
@@ -137,7 +137,7 @@ typedef void (*_sd_destroy_t)(void *userdata);
         _SD_##id##_INT64_MAX = INT64_MAX
 
 /* In GCC 14 (C23) we can force enums to have the right types, and not solely rely on language extensions anymore */
-#if ((__GNUC__ >= 14) || (__STDC_VERSION__ >= 202311L)) && !defined(__cplusplus) && !defined(__EDG__)
+#if ((__GNUC__ >= 14) || (__STDC_VERSION__ >= 202311L)) && !defined(__cplusplus)
 #  define _SD_ENUM_TYPE_S64(id) id : int64_t
 #else
 #  define _SD_ENUM_TYPE_S64(id) id


### PR DESCRIPTION
The EDG parser version 6.8 now supports C23 enums with fixed underlying types, and VSCode ships with it, so this workaround can now be removed without breaking VSCode's internal parser.

https://en.cppreference.com/c/compiler_support/23

This reverts commit e01ca3afdb297fe879eaabd02901ad2a4b547d0c.