### PR TITLE
cgtop: use dynamic width for CPU% column

### DIFF
--- a/src/cgtop/cgtop.c
+++ b/src/cgtop/cgtop.c
@@ -598,21 +598,21 @@ static void display(Hashmap *a) {
 
         typesafe_qsort(array, n, group_compare);
 
-/* Find the longest names in one run */
-for (unsigned j = 0; j < n; j++) {
-        maxtcpu = MAX(maxtcpu,
-                      strlen(MAYBE_FORMAT_TIMESPAN((usec_t) (array[j]->cpu_usage / NSEC_PER_USEC), 0)));
-        maxtpath = MAX(maxtpath,
-                       strlen(array[j]->path));
-}
+        /* Find the longest names in one run */
+        for (unsigned j = 0; j < n; j++) {
+                maxtcpu = MAX(maxtcpu,
+                              strlen(MAYBE_FORMAT_TIMESPAN((usec_t) (array[j]->cpu_usage / NSEC_PER_USEC), 0)));
+                maxtpath = MAX(maxtpath,
+                               strlen(array[j]->path));
+        }
 
-if (arg_cpu_type == CPU_PERCENTAGE) {
-        unsigned n_cpus;
-        if (cpus_online(&n_cpus) >= 0)
+        if (arg_cpu_type == CPU_PERCENTAGE) {
+                unsigned n_cpus;
+                if (cpus_online(&n_cpus) >= 0)
                         maxpcpu = MAX(maxpcpu, DECIMAL_STR_WIDTH(n_cpus) + STRLEN("00.0"));
-}
+        }
 
-rows = lines();
+        rows = lines();
         if (rows <= 10)
                 rows = 10;
 

--- a/src/cgtop/cgtop.c
+++ b/src/cgtop/cgtop.c
@@ -7,6 +7,7 @@
 #include "build.h"
 #include "cgroup-show.h"
 #include "cgroup-util.h"
+#include "cpu-set-util.h"
 #include "fd-util.h"
 #include "fileio.h"
 #include "format-table.h"
@@ -581,7 +582,8 @@ static void display(Hashmap *a) {
         Group *g;
         Group **array;
         signed path_columns;
-        unsigned rows, n = 0, maxtcpu = 0, maxtpath = 3; /* 3 for ellipsize() to work properly */
+        unsigned rows, n = 0, maxtcpu = 0, maxtpath = 3, /* 3 for ellipsize() to work properly */
+                maxpcpu = 6; /* minimum width for "%CPU" header */
 
         assert(a);
 
@@ -596,21 +598,27 @@ static void display(Hashmap *a) {
 
         typesafe_qsort(array, n, group_compare);
 
-        /* Find the longest names in one run */
-        for (unsigned j = 0; j < n; j++) {
-                maxtcpu = MAX(maxtcpu,
-                              strlen(MAYBE_FORMAT_TIMESPAN((usec_t) (array[j]->cpu_usage / NSEC_PER_USEC), 0)));
-                maxtpath = MAX(maxtpath,
-                               strlen(array[j]->path));
-        }
+/* Find the longest names in one run */
+for (unsigned j = 0; j < n; j++) {
+        maxtcpu = MAX(maxtcpu,
+                      strlen(MAYBE_FORMAT_TIMESPAN((usec_t) (array[j]->cpu_usage / NSEC_PER_USEC), 0)));
+        maxtpath = MAX(maxtpath,
+                       strlen(array[j]->path));
+}
 
-        rows = lines();
+if (arg_cpu_type == CPU_PERCENTAGE) {
+        unsigned n_cpus;
+        if (cpus_online(&n_cpus) >= 0)
+                        maxpcpu = MAX(maxpcpu, DECIMAL_STR_WIDTH(n_cpus) + STRLEN("00.0"));
+}
+
+rows = lines();
         if (rows <= 10)
                 rows = 10;
 
         if (on_tty()) {
                 const char *on, *off;
-                int cpu_len = arg_cpu_type == CPU_PERCENTAGE ? 6 : maxtcpu;
+                int cpu_len = arg_cpu_type == CPU_PERCENTAGE ? (int) maxpcpu : (int) maxtcpu;
 
                 path_columns = columns() - 36 - cpu_len;
                 if (path_columns < 10)
@@ -660,9 +668,9 @@ static void display(Hashmap *a) {
 
                 if (arg_cpu_type == CPU_PERCENTAGE) {
                         if (g->cpu_valid)
-                                printf(" %6.1f", g->cpu_fraction*100);
+                                printf(" %*.1f", (int) maxpcpu, g->cpu_fraction*100);
                         else
-                                fputs("      -", stdout);
+                                printf(" %*s", (int) maxpcpu, "-");
                 } else
                         printf(" %*s",
                                (int) maxtcpu,


### PR DESCRIPTION
On many-CPU hosts, the CPU% column in systemd-cgtop can exceed the
hardcoded %6.1f format width (e.g. 12769.4% on a 128-CPU host),
causing column overflow and table misalignment.

Follow the existing `maxtcpu` pattern used for the CPU Time column:
dynamically compute the maximum width of CPU percentage values via
`snprintf(NULL, 0, "%.1f", ...)` and use it for both the header and
data rows.

Fixes #39819
