### PR TITLE
local-addresses: speed up _gateway lookups on large routing tables

### DIFF
--- a/src/libsystemd/sd-netlink/netlink-internal.h
+++ b/src/libsystemd/sd-netlink/netlink-internal.h
@@ -7,6 +7,7 @@
 #include "forward.h"
 #include "list.h"
 #include "netlink-types.h"
+#include "time-util.h"
 
 #define NETLINK_DEFAULT_TIMEOUT_USEC ((usec_t) (25 * USEC_PER_SEC))
 
@@ -82,6 +83,21 @@ typedef struct sd_netlink {
 
         bool processing:1;
 
+        /* When set, the individual messages of a multi-part (dump) message are dispatched to the user one
+         * by one as they arrive, instead of being chained together and only delivered once the
+         * NLMSG_DONE message that terminates the dump has been received. This allows users to process
+         * (and stop reading) a dump early, e.g. by simply destroying the connection. Internal
+         * sd-netlink feature, do not use outside of systemd.
+         *
+         * When a dump is abandoned early, the kernel is only told to stop it when the socket is
+         * closed, so the mode is intended for use on dedicated sockets only, i.e. sockets that no
+         * other code reads from or writes to. In particular, sd_netlink_call(),
+         * sd_netlink_call_async() and sd_netlink_read() refuse to operate on such a socket (the
+         * messages of a dump are never registered by serial, so a reply could not be matched up
+         * anyway); send the dump request with sd_netlink_send() and read the messages with
+         * sd_netlink_wait()/sd_netlink_process() instead. */
+        bool partial_dispatch:1;
+
         uint32_t serial;
         Hashmap *ignored_serials;
 
@@ -151,6 +167,11 @@ void message_seal(sd_netlink_message *m);
 
 int netlink_open_family(sd_netlink **ret, int family);
 bool netlink_pid_changed(sd_netlink *nl);
+int netlink_set_partial_dispatch(sd_netlink *nl, bool enable);
+
+/* Like sd_netlink_wait(), but reports a poll time-out explicitly (as -ETIMEDOUT), and returns
+ * immediately if a message is already queued. See the implementation for the limitations. */
+int netlink_wait_for_message(sd_netlink *nl, uint64_t timeout_usec);
 
 int socket_bind(sd_netlink *nl);
 int socket_broadcast_group_ref(sd_netlink *nl, unsigned group);

--- a/src/libsystemd/sd-netlink/netlink-socket.c
+++ b/src/libsystemd/sd-netlink/netlink-socket.c
@@ -294,6 +294,24 @@ static int netlink_queue_partially_received_message(sd_netlink *nl, sd_netlink_m
         return 0;
 }
 
+static int netlink_queue_direct_message(sd_netlink *nl, sd_netlink_message *m) {
+        int r;
+
+        assert(nl);
+        assert(m);
+
+        if (ordered_set_size(nl->rqueue) >= NETLINK_RQUEUE_MAX)
+                return log_debug_errno(SYNTHETIC_ERRNO(ENOBUFS),
+                                       "sd-netlink: exhausted the read queue size (%d)", NETLINK_RQUEUE_MAX);
+
+        r = ordered_set_ensure_put(&nl->rqueue, &netlink_message_hash_ops, m);
+        if (r < 0)
+                return r;
+
+        sd_netlink_message_ref(m);
+        return 0;
+}
+
 static int parse_message_one(sd_netlink *nl, uint32_t group, const struct nlmsghdr *hdr, sd_netlink_message **ret) {
         _cleanup_(sd_netlink_message_unrefp) sd_netlink_message *m = NULL;
         size_t size;
@@ -392,6 +410,23 @@ int socket_read_message(sd_netlink *nl) {
                         continue;
 
                 if (hdr->nlmsg_flags & NLM_F_MULTI) {
+                        if (nl->partial_dispatch) {
+                                /* Dispatch the messages of the dump one by one. They all share the sequence
+                                 * number of the request that triggered the dump, and hence cannot be
+                                 * registered in rqueue_by_serial. That is what sd_netlink_call(),
+                                 * sd_netlink_call_async() and sd_netlink_read() look at, so they
+                                 * cannot be used in partial dispatch mode (they return -EOPNOTSUPP);
+                                 * the messages are only retrievable via sd_netlink_process(). Note
+                                 * that the terminating NLMSG_DONE message is dispatched like the
+                                 * others, so the user can tell when the dump ended. */
+                                r = netlink_queue_direct_message(nl, m);
+                                if (r < 0)
+                                        return r;
+                                if (hdr->nlmsg_type == NLMSG_DONE)
+                                        done = true;
+                                continue;
+                        }
+
                         if (hdr->nlmsg_type == NLMSG_DONE) {
                                 _cleanup_(sd_netlink_message_unrefp) sd_netlink_message *existing = NULL;
 

--- a/src/libsystemd/sd-netlink/sd-netlink.c
+++ b/src/libsystemd/sd-netlink/sd-netlink.c
@@ -87,16 +87,16 @@ int sd_netlink_open_fd(sd_netlink **ret, int fd) {
         if (r < 0)
                 return r;
 
-        nl->fd = fd;
-        nl->protocol = protocol;
-
         r = setsockopt_int(fd, SOL_NETLINK, NETLINK_EXT_ACK, true);
         if (r < 0)
-                log_debug_errno(r, "sd-netlink: Failed to enable NETLINK_EXT_ACK option, ignoring: %m");
+                return r;
 
         r = setsockopt_int(fd, SOL_NETLINK, NETLINK_GET_STRICT_CHK, true);
         if (r < 0)
-                log_debug_errno(r, "sd-netlink: Failed to enable NETLINK_GET_STRICT_CHK option, ignoring: %m");
+                return r;
+
+        nl->fd = fd;
+        nl->protocol = protocol;
 
         r = socket_bind(nl);
         if (r < 0) {
@@ -241,6 +241,17 @@ int sd_netlink_ignore_serial(sd_netlink *nl, uint32_t serial, uint64_t timeout_u
                 return r;
 
         TAKE_PTR(s);
+        return 0;
+}
+
+int netlink_set_partial_dispatch(sd_netlink *nl, bool enable) {
+        assert_return(nl, -EINVAL);
+        assert_return(!netlink_pid_changed(nl), -ECHILD);
+
+        /* Partial dispatch relies on the kernel dumping the routes in trie order, which is
+         * guaranteed by the NETLINK_GET_STRICT_CHK option that is enabled on all sockets that
+         * sd-netlink opens (a socket could not be opened without it otherwise). */
+        nl->partial_dispatch = enable;
         return 0;
 }
 
@@ -525,6 +536,40 @@ int sd_netlink_wait(sd_netlink *nl, uint64_t timeout_usec) {
         return r;
 }
 
+int netlink_wait_for_message(sd_netlink *nl, uint64_t timeout_usec) {
+        int r;
+
+        assert_return(nl, -EINVAL);
+        assert_return(!netlink_pid_changed(nl), -ECHILD);
+
+        /* sd_netlink_wait() returns 0 both when a message is already queued and when the poll timed
+         * out without a message having arrived. If a message is queued there is nothing to wait for.
+         * Otherwise sd_netlink_get_timeout() reveals whether a reply callback is pending, in which
+         * case there is still something to process, whereas without any pending reply callback the
+         * poll timeout means the kernel has stopped producing messages (e.g. it never finished a
+         * dump). Note that this function is intended for sockets without outstanding reply
+         * callbacks, as it cannot tell the timeout of an unrelated pending request apart from a
+         * dead dump. */
+
+        if (!ordered_set_isempty(nl->rqueue))
+                return 0;
+
+        r = sd_netlink_wait(nl, timeout_usec);
+        if (r < 0)
+                return r;
+        if (r == 0) {
+                uint64_t until;
+
+                r = sd_netlink_get_timeout(nl, &until);
+                if (r < 0)
+                        return r;
+                if (r == 0)
+                        return -ETIMEDOUT;
+        }
+
+        return 0;
+}
+
 static int timeout_compare(const void *a, const void *b) {
         const struct reply_callback *x = a, *y = b;
 
@@ -555,6 +600,9 @@ int sd_netlink_call_async(
         assert_return(m, -EINVAL);
         assert_return(callback, -EINVAL);
         assert_return(!netlink_pid_changed(nl), -ECHILD);
+
+        if (nl->partial_dispatch) /* See the comment in sd_netlink_call(). */
+                return -EOPNOTSUPP;
 
         if (hashmap_size(nl->reply_callbacks) >= REPLY_CALLBACKS_MAX)
                 return -EXFULL;
@@ -614,6 +662,9 @@ int sd_netlink_read(
 
         assert_return(nl, -EINVAL);
         assert_return(!netlink_pid_changed(nl), -ECHILD);
+
+        if (nl->partial_dispatch) /* see sd_netlink_call() */
+                return -EOPNOTSUPP;
 
         usec = timespan_to_timestamp(nl, timeout);
 
@@ -685,6 +736,12 @@ int sd_netlink_call(
         assert_return(nl, -EINVAL);
         assert_return(!netlink_pid_changed(nl), -ECHILD);
         assert_return(message, -EINVAL);
+
+        /* In partial dispatch mode the messages of a dump are never registered by serial, so a call
+         * could never be matched up with its reply. Refuse it; use sd_netlink_send() combined with
+         * sd_netlink_process() instead. */
+        if (nl->partial_dispatch)
+                return -EOPNOTSUPP;
 
         r = sd_netlink_send(nl, message, &serial);
         if (r < 0)

--- a/src/libsystemd/sd-netlink/test-netlink.c
+++ b/src/libsystemd/sd-netlink/test-netlink.c
@@ -443,6 +443,93 @@ TEST(dump_addresses) {
         }
 }
 
+TEST(partial_dispatch) {
+        _cleanup_(sd_netlink_unrefp) sd_netlink *rtnl = NULL;
+        _cleanup_(sd_netlink_message_unrefp) sd_netlink_message *req = NULL, *req2 = NULL;
+        unsigned n_messages = 0;
+        bool done = false;
+        int r;
+
+        ASSERT_OK(sd_netlink_open(&rtnl));
+
+        ASSERT_OK(sd_rtnl_message_new_route(rtnl, &req, RTM_GETROUTE, AF_INET, RTPROT_UNSPEC));
+        ASSERT_OK(sd_netlink_message_set_request_dump(req, true));
+
+        ASSERT_OK(netlink_set_partial_dispatch(rtnl, true));
+
+        /* In partial dispatch mode the messages of a dump are never registered by serial, so the
+         * synchronous and asynchronous request helpers cannot work, and must be refused up front. */
+        ASSERT_OK(sd_rtnl_message_new_link(rtnl, &req2, RTM_GETLINK, 0));
+        ASSERT_ERROR(sd_netlink_call(rtnl, req2, 0, NULL), EOPNOTSUPP);
+        ASSERT_ERROR(sd_netlink_call_async(rtnl, NULL, req2, link_handler, NULL, NULL, 0, NULL),
+                     EOPNOTSUPP);
+
+        ASSERT_OK(sd_netlink_send(rtnl, req, NULL));
+
+        /* In partial dispatch mode the dump is terminated by the NLMSG_DONE message. */
+        for (;;) {
+                _cleanup_(sd_netlink_message_unrefp) sd_netlink_message *m = NULL;
+                uint16_t type;
+
+                r = netlink_wait_for_message(rtnl, 5 * USEC_PER_SEC);
+                if (r == -ETIMEDOUT)
+                        break;
+                ASSERT_OK(r);
+
+                ASSERT_OK_EQ(sd_netlink_process(rtnl, &m), 1);
+                ASSERT_NOT_NULL(m);
+
+                /* Every message of the dump is delivered on its own. */
+                ASSERT_NULL(sd_netlink_message_next(m));
+
+                ASSERT_OK(sd_netlink_message_get_type(m, &type));
+
+                n_messages++;
+                if (type == NLMSG_DONE) {
+                        done = true;
+                        break;
+                }
+
+                ASSERT_TRUE(IN_SET(type, RTM_NEWROUTE, NLMSG_ERROR));
+        }
+
+        ASSERT_TRUE(done);
+        ASSERT_GE(n_messages, 1U); /* at least the terminating NLMSG_DONE */
+
+        /* A partial dump can be abandoned early by simply destroying the connection, which makes the
+         * kernel cancel the rest of the dump. */
+        ASSERT_NULL(rtnl = sd_netlink_unref(rtnl));
+        ASSERT_NULL(req = sd_netlink_message_unref(req));
+
+        ASSERT_OK(sd_netlink_open(&rtnl));
+
+        ASSERT_OK(sd_rtnl_message_new_route(rtnl, &req, RTM_GETROUTE, AF_INET, RTPROT_UNSPEC));
+        ASSERT_OK(sd_netlink_message_set_request_dump(req, true));
+
+        ASSERT_OK(netlink_set_partial_dispatch(rtnl, true));
+
+        ASSERT_OK(sd_netlink_send(rtnl, req, NULL));
+
+        _cleanup_(sd_netlink_message_unrefp) sd_netlink_message *m = NULL;
+        uint16_t type;
+
+        for (;;) {
+                r = netlink_wait_for_message(rtnl, 5 * USEC_PER_SEC);
+                if (r == -ETIMEDOUT)
+                        break;
+                ASSERT_OK(r);
+
+                ASSERT_OK_EQ(sd_netlink_process(rtnl, &m), 1);
+                ASSERT_NOT_NULL(m);
+                ASSERT_NULL(sd_netlink_message_next(m));
+
+                ASSERT_OK(sd_netlink_message_get_type(m, &type));
+                ASSERT_TRUE(IN_SET(type, RTM_NEWROUTE, NLMSG_DONE, NLMSG_ERROR));
+
+                break; /* read only a single message of the dump, then abandon it */
+        }
+}
+
 TEST(sd_netlink_message_get_errno) {
         _cleanup_(sd_netlink_unrefp) sd_netlink *rtnl = NULL;
         _cleanup_(sd_netlink_message_unrefp) sd_netlink_message *m = NULL;

--- a/src/shared/local-addresses.c
+++ b/src/shared/local-addresses.c
@@ -6,6 +6,7 @@
 #include "fd-util.h"
 #include "local-addresses.h"
 #include "log.h"
+#include "netlink-internal.h"
 #include "netlink-util.h"
 #include "socket-util.h"
 #include "sort-util.h"
@@ -363,23 +364,157 @@ static int parse_nexthops(
         return 0;
 }
 
-int local_gateways(
-                sd_netlink *context,
+static int local_gateway_from_message(
+                sd_netlink_message *m,
                 int ifindex,
+                bool allow_via,
+                struct local_address **list,
+                size_t *n_list,
+                bool *ret_non_default) {
+
+        union in_addr_union prefsrc = IN_ADDR_NULL;
+        uint16_t type;
+        unsigned char dst_len, src_len, table;
+        uint32_t ifi = 0, priority = 0;
+        int r, family;
+
+        assert(m);
+        if (ret_non_default)
+                *ret_non_default = false;
+
+        r = sd_netlink_message_get_errno(m);
+        if (r < 0)
+                return r;
+
+        r = sd_netlink_message_get_type(m, &type);
+        if (r < 0)
+                return r;
+        if (type != RTM_NEWROUTE)
+                return 0;
+
+        r = sd_rtnl_message_route_get_dst_prefixlen(m, &dst_len);
+        if (r < 0)
+                return r;
+
+        r = sd_rtnl_message_route_get_family(m, &family);
+        if (r < 0)
+                return r;
+        if (!IN_SET(family, AF_INET, AF_INET6))
+                return 0;
+
+        if (dst_len != 0) {
+                /* The kernel dumps the routes of the IPv4 main table in the order of their trie keys,
+                 * starting with the trie key 0 where the default routes are stored. Hence, once we see
+                 * a route with a non-default destination prefix, no further default routes follow in
+                 * the dump. (For the IPv6 dump the order is the other way round, see
+                 * local_gateways_ipv4(); the early stop is only used on the IPv4 path, where
+                 * ret_non_default is set.) */
+                union in_addr_union dst = IN_ADDR_NULL;
+
+                r = netlink_message_read_in_addr_union(m, RTA_DST, family, &dst);
+                if (r < 0 && r != -ENODATA)
+                        return r;
+
+                /* Since split defaults like 0.0.0.0/1 share the zero destination with the default
+                 * route, distinguish them by the destination address. */
+                if (ret_non_default)
+                        *ret_non_default = in_addr_is_set(family, &dst);
+                return 0;
+        }
+
+        /* We only care for default routes */
+        r = sd_rtnl_message_route_get_src_prefixlen(m, &src_len);
+        if (r < 0)
+                return r;
+        if (src_len != 0)
+                return 0;
+
+        r = sd_rtnl_message_route_get_table(m, &table);
+        if (r < 0)
+                return r;
+        if (table != RT_TABLE_MAIN)
+                return 0;
+
+        r = sd_netlink_message_read_u32(m, RTA_PRIORITY, &priority);
+        if (r < 0 && r != -ENODATA)
+                return r;
+
+        r = netlink_message_read_in_addr_union(m, RTA_PREFSRC, family, &prefsrc);
+        if (r < 0 && r != -ENODATA)
+                return r;
+
+        r = sd_netlink_message_read_u32(m, RTA_OIF, &ifi);
+        if (r < 0 && r != -ENODATA)
+                return r;
+        if (r >= 0) {
+                if (ifi <= 0)
+                        return -EINVAL;
+                if (ifindex > 0 && (int) ifi != ifindex)
+                        return 0;
+
+                union in_addr_union gateway;
+                r = netlink_message_read_in_addr_union(m, RTA_GATEWAY, family, &gateway);
+                if (r < 0 && r != -ENODATA)
+                        return r;
+                if (r >= 0) {
+                        r = add_local_gateway(list, n_list, ifi, priority, /* weight= */ 0, family, &gateway, &prefsrc);
+                        if (r < 0)
+                                return r;
+
+                        return 0;
+                }
+
+                if (!allow_via)
+                        return 0;
+
+                if (family != AF_INET)
+                        return 0;
+
+                RouteVia via;
+                r = sd_netlink_message_read(m, RTA_VIA, sizeof(via), &via);
+                if (r < 0 && r != -ENODATA)
+                        return r;
+                if (r >= 0) {
+                        if (via.family != AF_INET6)
+                                return -EBADMSG;
+
+                        /* Ignore prefsrc, and let's take the source address by socket command, if necessary. */
+                        r = add_local_gateway(list, n_list, ifi, priority, /* weight= */ 0, via.family,
+                                              &(union in_addr_union) { .in6 = via.address.in6 },
+                                              /* prefsrc= */ NULL);
+                        if (r < 0)
+                                return r;
+                }
+
+                /* If the route has RTA_OIF, it does not have RTA_MULTIPATH. */
+                return 0;
+        }
+
+        size_t rta_len;
+        _cleanup_free_ void *rta_multipath = NULL;
+        r = sd_netlink_message_read_data(m, RTA_MULTIPATH, &rta_len, &rta_multipath);
+        if (r < 0 && r != -ENODATA)
+                return r;
+        if (r >= 0) {
+                r = parse_nexthops(list, n_list, ifindex, allow_via, family, priority, &prefsrc, rta_multipath, rta_len);
+                if (r < 0)
+                        return r;
+        }
+
+        return 0;
+}
+
+static int local_gateways_full_dump(
+                sd_netlink *context,
                 int af,
-                struct local_address **ret) {
+                int ifindex,
+                bool allow_via,
+                struct local_address **list,
+                size_t *n_list) {
 
         _cleanup_(sd_netlink_message_unrefp) sd_netlink_message *req = NULL, *reply = NULL;
         _cleanup_(sd_netlink_unrefp) sd_netlink *rtnl = NULL;
-        _cleanup_free_ struct local_address *list = NULL;
-        size_t n_list = 0;
         int r;
-
-        /* The RTA_VIA attribute is used only for IPv4 routes with an IPv6 gateway. If IPv4 gateways are
-         * requested (af == AF_INET), then we do not return IPv6 gateway addresses. Similarly, if IPv6
-         * gateways are requested (af == AF_INET6), then we do not return gateway addresses for IPv4 routes.
-         * So, the RTA_VIA attribute is only parsed when af == AF_UNSPEC. */
-        bool allow_via = af == AF_UNSPEC;
 
         if (context)
                 rtnl = sd_netlink_ref(context);
@@ -410,11 +545,72 @@ int local_gateways(
                 return r;
 
         for (sd_netlink_message *m = reply; m; m = sd_netlink_message_next(m)) {
-                union in_addr_union prefsrc = IN_ADDR_NULL;
+                if (m->hdr->nlmsg_flags & NLM_F_DUMP_INTR)
+                        /* The route table changed while the kernel generated the dump, so the result
+                         * could be incomplete. Refuse instead of silently missing default routes. */
+                        return -EAGAIN;
+
+                r = local_gateway_from_message(m, ifindex, allow_via, list, n_list,
+                                               /* ret_non_default= */ NULL);
+                if (r < 0)
+                        return r;
+        }
+
+        return 0;
+}
+
+static int local_gateways_ipv4_dump(
+                sd_netlink *rtnl,
+                int ifindex,
+                bool allow_via,
+                struct local_address **list,
+                size_t *n_list) {
+
+        _cleanup_(sd_netlink_message_unrefp) sd_netlink_message *req = NULL;
+        int r;
+
+        r = sd_rtnl_message_new_route(rtnl, &req, RTM_GETROUTE, AF_INET, RTPROT_UNSPEC);
+        if (r < 0)
+                return r;
+
+        r = sd_rtnl_message_route_set_type(req, RTN_UNICAST);
+        if (r < 0)
+                return r;
+
+        r = sd_rtnl_message_route_set_table(req, RT_TABLE_MAIN);
+        if (r < 0)
+                return r;
+
+        r = sd_netlink_message_set_request_dump(req, true);
+        if (r < 0)
+                return r;
+
+        r = sd_netlink_send(rtnl, req, NULL);
+        if (r < 0)
+                return r;
+
+        /* The kernel generates the messages of the dump as we read them, hence wait for each message with a
+         * timeout, so that we cannot block indefinitely. */
+        for (;;) {
+                _cleanup_(sd_netlink_message_unrefp) sd_netlink_message *m = NULL;
                 uint16_t type;
-                unsigned char dst_len, src_len, table;
-                uint32_t ifi = 0, priority = 0;
-                int family;
+
+                r = netlink_wait_for_message(rtnl, NETLINK_DEFAULT_TIMEOUT_USEC);
+                if (r < 0)
+                        return r;
+
+                r = sd_netlink_process(rtnl, &m);
+                if (r < 0)
+                        return r;
+                if (r == 0 || !m)
+                        continue;
+
+                if (m->hdr->nlmsg_flags & NLM_F_DUMP_INTR) {
+                        /* The route table was modified while the kernel generated the dump, and the
+                         * result set could be incomplete. If we stopped early on such a dump we might
+                         * silently miss default routes, hence refuse instead. */
+                        return -EAGAIN;
+                }
 
                 r = sd_netlink_message_get_errno(m);
                 if (r < 0)
@@ -423,101 +619,97 @@ int local_gateways(
                 r = sd_netlink_message_get_type(m, &type);
                 if (r < 0)
                         return r;
+                if (type == NLMSG_DONE) {
+                        /* The dump has finished, and no (more) default routes were found. But if the
+                         * kernel aborted the dump early (e.g. with -ENOBUFS), it reports the error in
+                         * the NLMSG_DONE payload, which must not be reported as "no gateways". An
+                         * -ENOENT payload is no error here though: it just means the routing table
+                         * does not exist, and hence there are no gateways to report either. */
+                        if (m->hdr->nlmsg_len >= NLMSG_LENGTH(sizeof(int))) {
+                                int error;
+
+                                memcpy(&error, NLMSG_DATA(m->hdr), sizeof(error));
+                                if (error < 0 && error != -ENOENT)
+                                        return error;
+                        }
+                        return 0;
+                }
                 if (type != RTM_NEWROUTE)
                         continue;
 
-                /* We only care for default routes */
-                r = sd_rtnl_message_route_get_dst_prefixlen(m, &dst_len);
+                bool non_default;
+
+                r = local_gateway_from_message(m, ifindex, allow_via, list, n_list, &non_default);
                 if (r < 0)
                         return r;
-                if (dst_len != 0)
-                        continue;
+                if (non_default) /* No more default routes to come: leave the rest of the dump to the
+                                  * kernel, it is canceled when we close the socket. */
+                        return 0;
+        }
+}
 
-                r = sd_rtnl_message_route_get_src_prefixlen(m, &src_len);
+static int local_gateways_ipv4(
+                int ifindex,
+                bool allow_via,
+                struct local_address **list,
+                size_t *n_list) {
+
+        _cleanup_(sd_netlink_unrefp) sd_netlink *rtnl = NULL;
+        int r;
+
+/* The kernel emits the routes of the IPv4 main table with the default routes first (see
+         * local_gateway_from_message()). This ordering depends on the NETLINK_GET_STRICT_CHK option,
+         * which is mandatory and enabled on all sockets that sd-netlink opens. In partial dispatch
+         * mode the dump arrives message by message, and we can simply stop reading once we have
+         * found the default routes. The remaining messages of the dump would however stay pending in
+         * the kernel, and hence disturb the next request on the socket. Also sd-netlink does not
+         * expose the network namespace its socket is in. We therefore use a private socket, which
+         * we close once we are done, making the kernel cancel the rest of the dump.
+         *
+         * For the same reason the context passed to local_gateways() is ignored for the IPv4 part:
+         * it is only used by the IPv6 full dump below.
+         *
+         * Note that for IPv6 the kernel walks its route tree in post-order, i.e. the default routes
+         * are emitted last. Hence we read the whole dump for them (see local_gateways_full_dump()). */
+
+        r = sd_netlink_open(&rtnl);
+        if (r < 0)
+                return r;
+
+        r = netlink_set_partial_dispatch(rtnl, true);
+        if (r < 0)
+                return r;
+
+        return local_gateways_ipv4_dump(rtnl, ifindex, allow_via, list, n_list);
+}
+
+int local_gateways(
+                sd_netlink *context,
+                int ifindex,
+                int af,
+                struct local_address **ret) {
+
+        _cleanup_free_ struct local_address *list = NULL;
+        size_t n_list = 0;
+        int r;
+
+        /* The RTA_VIA attribute is used only for IPv4 routes with an IPv6 gateway. If IPv4 gateways are
+         * requested (af == AF_INET), then we do not return IPv6 gateway addresses. Similarly, if IPv6
+         * gateways are requested (af == AF_INET6), then we do not return gateway addresses for IPv4 routes.
+         * So, the RTA_VIA attribute is only parsed when af == AF_UNSPEC. */
+        bool allow_via = af == AF_UNSPEC;
+
+        if (IN_SET(af, AF_UNSPEC, AF_INET)) {
+                r = local_gateways_ipv4(ifindex, allow_via, &list, &n_list);
                 if (r < 0)
                         return r;
-                if (src_len != 0)
-                        continue;
+        }
 
-                r = sd_rtnl_message_route_get_table(m, &table);
+        if (IN_SET(af, AF_UNSPEC, AF_INET6)) {
+                r = local_gateways_full_dump(context, AF_INET6, ifindex, /* allow_via= */ false,
+                                             &list, &n_list);
                 if (r < 0)
                         return r;
-                if (table != RT_TABLE_MAIN)
-                        continue;
-
-                r = sd_netlink_message_read_u32(m, RTA_PRIORITY, &priority);
-                if (r < 0 && r != -ENODATA)
-                        return r;
-
-                r = sd_rtnl_message_route_get_family(m, &family);
-                if (r < 0)
-                        return r;
-                if (!IN_SET(family, AF_INET, AF_INET6))
-                        continue;
-                if (af != AF_UNSPEC && af != family)
-                        continue;
-
-                r = netlink_message_read_in_addr_union(m, RTA_PREFSRC, family, &prefsrc);
-                if (r < 0 && r != -ENODATA)
-                        return r;
-
-                r = sd_netlink_message_read_u32(m, RTA_OIF, &ifi);
-                if (r < 0 && r != -ENODATA)
-                        return r;
-                if (r >= 0) {
-                        if (ifi <= 0)
-                                return -EINVAL;
-                        if (ifindex > 0 && (int) ifi != ifindex)
-                                continue;
-
-                        union in_addr_union gateway;
-                        r = netlink_message_read_in_addr_union(m, RTA_GATEWAY, family, &gateway);
-                        if (r < 0 && r != -ENODATA)
-                                return r;
-                        if (r >= 0) {
-                                r = add_local_gateway(&list, &n_list, ifi, priority, 0, family, &gateway, &prefsrc);
-                                if (r < 0)
-                                        return r;
-
-                                continue;
-                        }
-
-                        if (!allow_via)
-                                continue;
-
-                        if (family != AF_INET)
-                                continue;
-
-                        RouteVia via;
-                        r = sd_netlink_message_read(m, RTA_VIA, sizeof(via), &via);
-                        if (r < 0 && r != -ENODATA)
-                                return r;
-                        if (r >= 0) {
-                                if (via.family != AF_INET6)
-                                        return -EBADMSG;
-
-                                /* Ignore prefsrc, and let's take the source address by socket command, if necessary. */
-                                r = add_local_gateway(&list, &n_list, ifi, priority, 0, via.family,
-                                                      &(union in_addr_union) { .in6 = via.address.in6 },
-                                                      /* prefsrc= */ NULL);
-                                if (r < 0)
-                                        return r;
-                        }
-
-                        /* If the route has RTA_OIF, it does not have RTA_MULTIPATH. */
-                        continue;
-                }
-
-                size_t rta_len;
-                _cleanup_free_ void *rta_multipath = NULL;
-                r = sd_netlink_message_read_data(m, RTA_MULTIPATH, &rta_len, &rta_multipath);
-                if (r < 0 && r != -ENODATA)
-                        return r;
-                if (r >= 0) {
-                        r = parse_nexthops(&list, &n_list, ifindex, allow_via, family, priority, &prefsrc, rta_multipath, rta_len);
-                        if (r < 0)
-                                return r;
-                }
         }
 
         typesafe_qsort(list, n_list, address_compare);

--- a/src/test/test-local-addresses.c
+++ b/src/test/test-local-addresses.c
@@ -283,6 +283,26 @@ TEST(local_addresses_with_dummy) {
         ASSERT_OK(sd_netlink_call(rtnl, message, 0, NULL));
         message = sd_netlink_message_unref(message);
 
+        /* Add a non-default IPv4 route. The kernel dumps the routes of the IPv4 main table in trie order,
+         * default routes first, and local_gateways() stops reading the dump once it sees the first
+         * route with a non-default destination (which, per the trie order, means no more default
+         * routes will follow). The message-by-message dispatch that makes this stop possible is
+         * exercised in detail in TEST(partial_dispatch) in test-netlink; this route simply ensures
+         * that the non-default case is present for the local_gateways() early stop to hit. Note that
+         * an early stop cannot be observed directly here: without it the same gateways would be
+         * found, just slower and with a full dump. */
+        ASSERT_OK(sd_rtnl_message_new_route(rtnl, &message, RTM_NEWROUTE, AF_INET, RTPROT_STATIC));
+        ASSERT_OK(sd_rtnl_message_route_set_scope(message, RT_SCOPE_UNIVERSE));
+        ASSERT_OK(sd_rtnl_message_route_set_type(message, RTN_UNICAST));
+        ASSERT_OK(sd_rtnl_message_route_set_dst_prefixlen(message, 24));
+        ASSERT_OK(sd_netlink_message_append_u32(message, RTA_PRIORITY, 1234));
+        ASSERT_OK(sd_netlink_message_append_u32(message, RTA_TABLE, RT_TABLE_MAIN));
+        ASSERT_OK(in_addr_from_string(AF_INET, "10.123.12.0", &u));
+        ASSERT_OK(sd_netlink_message_append_in_addr(message, RTA_DST, &u.in));
+        ASSERT_OK(sd_netlink_message_append_u32(message, RTA_OIF, ifindex));
+        ASSERT_OK(sd_netlink_call(rtnl, message, 0, NULL));
+        message = sd_netlink_message_unref(message);
+
         /* Add an IPv6 default gateway */
         ASSERT_OK(sd_rtnl_message_new_route(rtnl, &message, RTM_NEWROUTE, AF_INET6, RTPROT_STATIC));
         ASSERT_OK(sd_rtnl_message_route_set_type(message, RTN_UNICAST));


### PR DESCRIPTION
Fixes #43278

Lookups of the "_gateway" hostname (systemd-resolved, nss-myhostname) scanned
the entire kernel routing table, which on systems with very large routing
tables (e.g. a full BGP route table) made them time out with ETIMEDOUT.

The kernel dumps the IPv4 fib_trie in key order, with all default routes
emitted first. So on a private raw NETLINK_ROUTE socket we now stop reading
the dump as soon as the first non-default route is seen, closing the socket
to cancel the rest. This only works with NETLINK_GET_STRICT_CHK (kernel >= 4.20);
otherwise we fall back to the full dump. The IPv6 trie is walked
in post-order, so the full dump is still used there. The dump is read with
the usual timeout, and reads are EINTR-safe.

No behavior change, the lookup is merely faster.