### PR TITLE
repart: keep shallow_join_strv() terminated

### DIFF
--- a/src/repart/repart.c
+++ b/src/repart/repart.c
@@ -6492,12 +6492,13 @@ static int shallow_join_strv(char ***ret, char **a, char **b) {
 
         STRV_FOREACH(i, a)
                 *(iter++) = *i;
+        *iter = NULL;
 
         STRV_FOREACH(i, b)
-                if (!strv_contains(joined, *i))
+                if (!strv_contains(joined, *i)) {
                         *(iter++) = *i;
-
-        *iter = NULL;
+                        *iter = NULL;
+                }
 
         *ret = TAKE_PTR(joined);
         return 0;


### PR DESCRIPTION
it avoids a potential out-of-bounds read when deduplicating the second strv.