### PR TITLE
sd-netlink: avoid repeated multipart append scans

### DIFF
--- a/src/libsystemd/sd-netlink/netlink-internal.h
+++ b/src/libsystemd/sd-netlink/netlink-internal.h
@@ -128,6 +128,7 @@ typedef struct sd_netlink_message {
         bool sealed:1;
 
         sd_netlink_message *next; /* next in a chain of multi-part messages */
+        sd_netlink_message *tail; /* last message in a multi-part chain */
 } sd_netlink_message;
 
 int message_new_empty(sd_netlink *nl, sd_netlink_message **ret);

--- a/src/libsystemd/sd-netlink/netlink-socket.c
+++ b/src/libsystemd/sd-netlink/netlink-socket.c
@@ -411,9 +411,11 @@ int socket_read_message(sd_netlink *nl) {
                                 if (existing) {
                                         /* This is the continuation of the previously read messages.
                                          * Let's append this message at the end. */
-                                        while (existing->next)
-                                                existing = existing->next;
-                                        existing->next = TAKE_PTR(m);
+                                        if (existing->tail)
+                                                existing->tail->next = m;
+                                        else
+                                                existing->next = m;
+                                        existing->tail = TAKE_PTR(m);
                                 } else {
                                         /* This is the first message. Put it into the queue for partially
                                          * received messages. */


### PR DESCRIPTION
This optimization reduces the complexity of a local operation, preventing it from degrading to O(n²) and keeping it linear (O(n)).