### PR TITLE
dbus: allow FreezeUnit and ThawUnit D-Bus requiests (#43292)

### DIFF
--- a/src/core/org.freedesktop.systemd1.conf
+++ b/src/core/org.freedesktop.systemd1.conf
@@ -378,6 +378,14 @@
                        send_interface="org.freedesktop.systemd1.Manager"
                        send_member="UnsetAndSetEnvironment"/>
 
+                <allow send_destination="org.freedesktop.systemd1"
+                       send_interface="org.freedesktop.systemd1.Manager"
+                       send_member="FreezeUnit"/>
+
+                <allow send_destination="org.freedesktop.systemd1"
+                       send_interface="org.freedesktop.systemd1.Manager"
+                       send_member="ThawUnit"/>
+
                 <!-- Managed via polkit or other criteria: org.freedesktop.systemd1.Job interface -->
 
                 <allow send_destination="org.freedesktop.systemd1"
@@ -449,6 +457,14 @@
                 <allow send_destination="org.freedesktop.systemd1"
                        send_interface="org.freedesktop.systemd1.Unit"
                        send_member="Unref"/>
+
+                <allow send_destination="org.freedesktop.systemd1"
+                       send_interface="org.freedesktop.systemd1.Unit"
+                       send_member="Freeze"/>
+
+                <allow send_destination="org.freedesktop.systemd1"
+                       send_interface="org.freedesktop.systemd1.Unit"
+                       send_member="Thaw"/>
 
                 <!-- Managed via polkit or other criteria: org.freedesktop.systemd1.Service interface -->
 


### PR DESCRIPTION
This change adds explicit D-Bus policy rules to allow calling the FreezeUnit and ThawUnit methods on the systemd Manager interface.

Closes #43292