### PR TITLE
strv: escape backslashes in strv_join_full when escape_separator is set

### DIFF
--- a/src/basic/strv.c
+++ b/src/basic/strv.c
@@ -547,7 +547,7 @@ char* strv_join_full(char * const *l, const char *separator, const char *prefix,
                 if (s != l)
                         n += k;
 
-                bool needs_escaping = escape_separator && strchr(*s, *separator);
+                bool needs_escaping = escape_separator && (strchr(*s, *separator) || strchr(*s, '\\'));
 
                 n += m + strlen(*s) * (1 + needs_escaping);
         }
@@ -564,11 +564,11 @@ char* strv_join_full(char * const *l, const char *separator, const char *prefix,
                 if (prefix)
                         e = stpcpy(e, prefix);
 
-                bool needs_escaping = escape_separator && strchr(*s, *separator);
+                bool needs_escaping = escape_separator && (strchr(*s, *separator) || strchr(*s, '\\'));
 
                 if (needs_escaping)
                         for (size_t i = 0; (*s)[i]; i++) {
-                                if ((*s)[i] == *separator)
+                                if ((*s)[i] == *separator || (*s)[i] == '\\')
                                         *(e++) = '\\';
                                 *(e++) = (*s)[i];
                         }

--- a/src/test/test-fstab-util.c
+++ b/src/test/test-fstab-util.c
@@ -124,8 +124,13 @@ TEST(fstab_filter_options) {
         do_fstab_filter_options(",,,opt=x,,,,", "opt\0", 1, 1, "opt", "x", "x", "");
 
         /* escaped characters */
-        do_fstab_filter_options("opt1=\\\\,opt2=\\xff", "opt1\0", 1, 1, "opt1", "\\", "\\", "opt2=\\xff");
-        do_fstab_filter_options("opt1=\\\\,opt2=\\xff", "opt2\0", 1, 1, "opt2", "\\xff", "\\xff", "opt1=\\");
+        do_fstab_filter_options("opt1=\\\\,opt2=\\xff", "opt1\0", 1, 1, "opt1", "\\", "\\", "opt2=\\\\xff");
+        do_fstab_filter_options("opt1=\\\\,opt2=\\xff", "opt2\0", 1, 1, "opt2", "\\xff", "\\xff", "opt1=\\\\");
+
+        /* options with literal backslash should be preserved through filter round-trip.
+         * See issue #42787: strv_join_full must escape backslashes, not just the separator. */
+        do_fstab_filter_options("val1\\\\,val2", "noopt\0", 1, 0, NULL, NULL, "", "val1\\\\,val2");
+        do_fstab_filter_options("other,val1\\\\,val2", "other\0", 1, 0, "other", NULL, "", "val1\\\\,val2");
 }
 
 TEST(fstab_find_pri) {

--- a/src/test/test-strv.c
+++ b/src/test/test-strv.c
@@ -199,6 +199,12 @@ TEST(strv_join_full) {
         _cleanup_free_ char *y = strv_join_full((char **)input_table_one_empty, ", ", "foo", false);
         assert_se(y);
         ASSERT_STREQ(y, "foo");
+
+        /* When escape_separator is true, backslashes in option values must be escaped too,
+         * otherwise the re-parsed string would be misinterpreted. See issue #42787. */
+        _cleanup_free_ char *z = strv_join_full(STRV_MAKE("val1\\", "val2"), ",", NULL, true);
+        assert_se(z);
+        ASSERT_STREQ(z, "val1\\\\,val2");
 }
 
 static void test_strv_unquote_one(const char *quoted, char **list) {


### PR DESCRIPTION
When `strv_join_full()` is called with `escape_separator=true`, it only escaped the separator character but not backslashes. This means that option values containing literal backslashes would lose the escaping when round-tripped through `fstab_filter_options()`, causing mount options to be misinterpreted.

For example, fstab options `val1\\,val2` (two options: `val1\` and `val2`) would be split correctly into `["val1\", "val2"]`, but re-joining would produce `val1\,val2` which, when re-parsed, is treated as a single option `val1,val2`.

This also affects the fstab-generator: when an option contains a literal backslash, the generated mount unit's `Options=` would be written without re-escaping the backslash, corrupting the options.

Fix by also escaping backslash characters when `escape_separator` is set, so that the round-trip through split+join preserves the original escaping.

Fixes #42787.