### PR TITLE
core: skip empty tokens in BindPaths=/BindReadOnlyPaths= parsing

### DIFF
--- a/src/basic/strv.c
+++ b/src/basic/strv.c
@@ -547,7 +547,7 @@ char* strv_join_full(char * const *l, const char *separator, const char *prefix,
                 if (s != l)
                         n += k;
 
-                bool needs_escaping = escape_separator && strchr(*s, *separator);
+                bool needs_escaping = escape_separator && (strchr(*s, *separator) || strchr(*s, '\\'));
 
                 n += m + strlen(*s) * (1 + needs_escaping);
         }
@@ -564,11 +564,11 @@ char* strv_join_full(char * const *l, const char *separator, const char *prefix,
                 if (prefix)
                         e = stpcpy(e, prefix);
 
-                bool needs_escaping = escape_separator && strchr(*s, *separator);
+                bool needs_escaping = escape_separator && (strchr(*s, *separator) || strchr(*s, '\\'));
 
                 if (needs_escaping)
                         for (size_t i = 0; (*s)[i]; i++) {
-                                if ((*s)[i] == *separator)
+                                if ((*s)[i] == *separator || (*s)[i] == '\\')
                                         *(e++) = '\\';
                                 *(e++) = (*s)[i];
                         }

--- a/src/core/load-fragment.c
+++ b/src/core/load-fragment.c
@@ -5222,6 +5222,8 @@ int config_parse_bind_paths(
                 }
                 if (r == 0)
                         break;
+                if (isempty(source))
+                        continue;
 
                 r = unit_path_printf(u, source, &sresolved);
                 if (r < 0) {

--- a/src/test/test-fstab-util.c
+++ b/src/test/test-fstab-util.c
@@ -124,8 +124,13 @@ TEST(fstab_filter_options) {
         do_fstab_filter_options(",,,opt=x,,,,", "opt\0", 1, 1, "opt", "x", "x", "");
 
         /* escaped characters */
-        do_fstab_filter_options("opt1=\\\\,opt2=\\xff", "opt1\0", 1, 1, "opt1", "\\", "\\", "opt2=\\xff");
-        do_fstab_filter_options("opt1=\\\\,opt2=\\xff", "opt2\0", 1, 1, "opt2", "\\xff", "\\xff", "opt1=\\");
+        do_fstab_filter_options("opt1=\\\\,opt2=\\xff", "opt1\0", 1, 1, "opt1", "\\", "\\", "opt2=\\\\xff");
+        do_fstab_filter_options("opt1=\\\\,opt2=\\xff", "opt2\0", 1, 1, "opt2", "\\xff", "\\xff", "opt1=\\\\");
+
+        /* options with literal backslash should be preserved through filter round-trip.
+         * See issue #42787: strv_join_full must escape backslashes, not just the separator. */
+        do_fstab_filter_options("val1\\\\,val2", "noopt\0", 1, 0, NULL, NULL, "", "val1\\\\,val2");
+        do_fstab_filter_options("other,val1\\\\,val2", "other\0", 1, 0, "other", NULL, "", "val1\\\\,val2");
 }
 
 TEST(fstab_find_pri) {

--- a/src/test/test-strv.c
+++ b/src/test/test-strv.c
@@ -199,6 +199,12 @@ TEST(strv_join_full) {
         _cleanup_free_ char *y = strv_join_full((char **)input_table_one_empty, ", ", "foo", false);
         assert_se(y);
         ASSERT_STREQ(y, "foo");
+
+        /* When escape_separator is true, backslashes in option values must be escaped too,
+         * otherwise the re-parsed string would be misinterpreted. See issue #42787. */
+        _cleanup_free_ char *z = strv_join_full(STRV_MAKE("val1\\", "val2"), ",", NULL, true);
+        assert_se(z);
+        ASSERT_STREQ(z, "val1\\\\,val2");
 }
 
 static void test_strv_unquote_one(const char *quoted, char **list) {

--- a/test/units/TEST-65-ANALYZE.sh
+++ b/test/units/TEST-65-ANALYZE.sh
@@ -429,6 +429,41 @@ GCOV_PREFIX=/tmp systemd-analyze verify --generators /tmp/testfile.service
 
 rm /tmp/testfile.service
 
+# Extra whitespace between paths in BindPaths=/BindReadOnlyPaths= should not produce spurious
+# "path is not absolute" warnings, see https://github.com/systemd/systemd/issues/43214
+cat <<EOF >/tmp/bindpaths-whitespace.service
+[Service]
+ExecStart = echo hello
+BindReadOnlyPaths=/usr/bin  /usr/lib  /lib  /lib64
+EOF
+
+# verify must succeed and produce no warnings on stderr
+out="$(systemd-analyze verify /tmp/bindpaths-whitespace.service 2>&1)"
+if [[ -n "$out" ]]; then
+    echo "Unexpected verify output:" >&2
+    echo "$out" >&2
+    exit 1
+fi
+
+# Same with line continuations that preserve leading whitespace
+rm /tmp/bindpaths-whitespace.service 2>/dev/null || true
+cat <<'EOF' >/tmp/bindpaths-whitespace.service
+[Service]
+ExecStart = echo hello
+BindReadOnlyPaths=/usr/bin \
+    /usr/lib \
+    /lib  /lib64
+EOF
+
+out="$(systemd-analyze verify /tmp/bindpaths-whitespace.service 2>&1)"
+if [[ -n "$out" ]]; then
+    echo "Unexpected verify output with line continuations:" >&2
+    echo "$out" >&2
+    exit 1
+fi
+
+rm /tmp/bindpaths-whitespace.service
+
 cat <<EOF >/tmp/img/usr/lib/systemd/system/testfile.service
 [Service]
 ExecStart = echo hello


### PR DESCRIPTION
When extra whitespace (e.g. double spaces or line continuation indentation) appears between paths in `BindPaths=` or `BindReadOnlyPaths=`, the `EXTRACT_DONT_COALESCE_SEPARATORS` flag causes `extract_first_word()` to return empty strings for the gaps. These empty strings then trigger spurious "path is not absolute, ignoring" warnings from `systemd-analyze verify` and the journal.

This is especially annoying when using line continuations, since all the whitespace on each line is preserved:
```
BindReadOnlyPaths=/usr/bin \\
    /usr/lib \\
    /lib  /lib64
```

Skip empty source tokens so that extra whitespace between paths is silently tolerated, matching user expectations.

Fixes #43214.