### PR TITLE
hwdb: mark ASUS ROG Flow Z13 (GZ302EA) touchpad as internal

### DIFF
--- a/hwdb.d/70-touchpad.hwdb
+++ b/hwdb.d/70-touchpad.hwdb
@@ -39,6 +39,15 @@
 # ID_INPUT_TOUCHPAD_INTEGRATION=internal
 
 ###########################################################
+# ASUS ROG Flow Z13 (GZ302EA)
+###########################################################
+# The USB port is reported as removable by firmware, so 65-integration.rules
+# classifies the touchpad as external and libinput skips disable-while-typing.
+# The touchpad is physically integrated; mark it internal to enable DWT.
+touchpad:usb:v0b05p1a30:name:ASUSTeK Computer Inc. GZ302EA-Keyboard Touchpad:*
+ ID_INPUT_TOUCHPAD_INTEGRATION=internal
+
+###########################################################
 # Lenovo IdeaPad Duet3 10IGL5 (82AT)
 ###########################################################
 touchpad:bluetooth:v17efp60fa:*


### PR DESCRIPTION
The ASUS ROG Flow Z13 (GZ302EA) keyboard/touchpad accessory (USB `0B05:1A30`) is incorrectly classified as external because its USB port is reported as removable by firmware. As a result, libinput disables features that depend on the touchpad being integrated, such as disable-while-typing.

This is the same issue previously addressed for the Microsoft Surface Type Cover in PR #43262.

Add a `70-touchpad.hwdb` entry for USB device `0B05:1A30` that sets `ID_INPUT_TOUCHPAD_INTEGRATION=internal` following the existing Surface Type Cover entry.

Without the override:

```text
❯ udevadm info /dev/input/event8 | grep INTEGRATION
E: ID_INTEGRATION=external
E: ID_INPUT_TOUCHPAD_INTEGRATION=external
```

With the override:

```text
❯ udevadm info /dev/input/event8 | grep INTEGRATION
E: ID_INTEGRATION=internal
E: ID_INPUT_TOUCHPAD_INTEGRATION=internal
```

❯ udevadm info /dev/input/event8 
P: /devices/pci0000:00/0000:00:08.3/0000:c6:00.0/usb3/3-4/3-4:1.3/0003:0B05:1A30.000E/input/input41/event8 
M: event8 
R: 8 J: c13:72 U: input 
D: c 13:72 N: input/event8 
L: 0 S: input/by-path/pci-0000:c6:00.0-usbv2-0:4:1.3-event-mouse 
S: input/by-path/pci-0000:c6:00.0-usb-0:4:1.3-event-mouse 
S: input/by-id/usb-ASUSTeK_Computer_Inc._GZ302EA-Keyboard-if03-event-mouse 
E: DEVPATH=/devices/pci0000:00/0000:00:08.3/0000:c6:00.0/usb3/3-4/3-4:1.3/0003:0B05:1A30.000E/input/input41/event8 E: DEVNAME=/dev/input/event8 
E: MAJOR=13 E: MINOR=72 
E: SUBSYSTEM=input 
E: USEC_INITIALIZED=1105136804 E: ID_INPUT=1 
E: ID_INPUT_TOUCHPAD=1 
E: ID_INPUT_WIDTH_MM=126 
E: ID_INPUT_HEIGHT_MM=70 
E: ID_BUS=usb 
E: ID_MODEL=GZ302EA-Keyboard 
E: ID_MODEL_ENC=GZ302EA-Keyboard 
E: ID_MODEL_ID=1a30 
E: ID_SERIAL=ASUSTeK_Computer_Inc._GZ302EA-Keyboard 
E: ID_VENDOR=ASUSTeK_Computer_Inc. 
E: ID_VENDOR_ENC=ASUSTeK\x20Computer\x20Inc. 
E: ID_VENDOR_ID=0b05 
E: ID_REVISION=0002 
E: ID_TYPE=hid 
E: ID_USB_MODEL=GZ302EA-Keyboard 
E: ID_USB_MODEL_ENC=GZ302EA-Keyboard 
E: ID_USB_MODEL_ID=1a30 
E: ID_USB_SERIAL=ASUSTeK_Computer_Inc._GZ302EA-Keyboard 
E: ID_USB_VENDOR=ASUSTeK_Computer_Inc. 
E: ID_USB_VENDOR_ENC=ASUSTeK\x20Computer\x20Inc. 
E: ID_USB_VENDOR_ID=0b05 
E: ID_USB_REVISION=0002 
E: ID_USB_TYPE=hid 
E: ID_USB_INTERFACES=:030101: 
E: ID_USB_INTERFACE_NUM=03 
E: ID_USB_DRIVER=usbhid 
E: ID_PATH_WITH_USB_REVISION=pci-0000:c6:00.0-usbv2-0:4:1.3 
E: ID_PATH=pci-0000:c6:00.0-usb-0:4:1.3 
E: ID_PATH_TAG=pci-0000_c6_00_0-usb-0_4_1_3 
E: ID_INTEGRATION=external
E: ID_INPUT_TOUCHPAD_INTEGRATION=external 
E: LIBINPUT_DEVICE_GROUP=3/b05/1a30:usb-0000:c6:00.0-4 
E: DMI_VENDOR=ASUSTeK COMPUTER INC. 
E: DMI_FAMILY=ROG Flow Z13 
E: DEVLINKS=/dev/input/by-path/pci-0000:c6:00.0-usbv2-0:4:1.3-event-mouse /dev/input/by-path/pci-0000:c6:00.0-usb-0:4:1.3-event-mouse /dev/input/by-id/usb-ASUSTeK_Computer_Inc._GZ302EA-Keyboard-if03-event-mouse

Reference: https://github.com/systemd/systemd/pull/43262