### PR TITLE
man: fix seven cross-references with the wrong section number

### DIFF
--- a/man/kernel-command-line.xml
+++ b/man/kernel-command-line.xml
@@ -648,7 +648,7 @@
 
         <listitem><para>Takes a boolean argument or the special value <literal>headless</literal>, defaults to
         on. If off,
-        <citerefentry><refentrytitle>systemd-firstboot.service</refentrytitle><manvolnum>8</manvolnum></citerefentry>
+        <citerefentry><refentrytitle>systemd-firstboot.service</refentrytitle><manvolnum>1</manvolnum></citerefentry>
         and
         <citerefentry><refentrytitle>systemd-homed-firstboot.service</refentrytitle><manvolnum>1</manvolnum></citerefentry>
         will not query the user for basic system settings, even if the system boots up for the first time and
@@ -913,7 +913,7 @@
         <member><citerefentry><refentrytitle>systemd-backlight@.service</refentrytitle><manvolnum>8</manvolnum></citerefentry></member>
         <member><citerefentry><refentrytitle>systemd-rfkill.service</refentrytitle><manvolnum>8</manvolnum></citerefentry></member>
         <member><citerefentry><refentrytitle>systemd-hibernate-resume-generator</refentrytitle><manvolnum>8</manvolnum></citerefentry></member>
-        <member><citerefentry><refentrytitle>systemd-firstboot.service</refentrytitle><manvolnum>8</manvolnum></citerefentry></member>
+        <member><citerefentry><refentrytitle>systemd-firstboot.service</refentrytitle><manvolnum>1</manvolnum></citerefentry></member>
         <member><citerefentry><refentrytitle>bootctl</refentrytitle><manvolnum>1</manvolnum></citerefentry></member>
       </simplelist></para>
   </refsect1>

--- a/man/systemd-coredump.xml
+++ b/man/systemd-coredump.xml
@@ -107,7 +107,7 @@
         which ensures that coredumps of a container are attempted to be forwarded to
         <filename>systemd-coredump@.service</filename> running inside the container, i.e the container gets
         to process and store its own core dumps. Note that
-        <citerefentry><refentrytitle>systemd-nspawn</refentrytitle><manvolnum>8</manvolnum></citerefentry>
+        <citerefentry><refentrytitle>systemd-nspawn</refentrytitle><manvolnum>1</manvolnum></citerefentry>
         defaults to this mode if invoked with the <option>--boot</option> switch. This mode of operation is
         generally recommended for security reasons: the security-sensitive processing of the core dump is
         done within the confinements of the container itself, by the container's own code, backed by the

--- a/man/systemd-repart.xml
+++ b/man/systemd-repart.xml
@@ -832,7 +832,7 @@ systemd-repart -C \
 systemd-confext refresh</programlisting>
 
       <para>The DDI generated that way may be applied to the system with
-      <citerefentry><refentrytitle>systemd-confext</refentrytitle><manvolnum>1</manvolnum></citerefentry>.</para>
+      <citerefentry><refentrytitle>systemd-confext</refentrytitle><manvolnum>8</manvolnum></citerefentry>.</para>
     </example>
 
     <example>

--- a/man/systemd-vconsole-setup.service.xml
+++ b/man/systemd-vconsole-setup.service.xml
@@ -71,7 +71,7 @@
         credentials.</para>
 
         <para>Note the relationship to the <varname>firstboot.keymap</varname> credential understood by
-        <citerefentry><refentrytitle>systemd-firstboot.service</refentrytitle><manvolnum>8</manvolnum></citerefentry>:
+        <citerefentry><refentrytitle>systemd-firstboot.service</refentrytitle><manvolnum>1</manvolnum></citerefentry>:
         both ultimately affect the same setting, but <varname>firstboot.keymap</varname> is written into
         <filename>/etc/vconsole.conf</filename> on first boot (if not already configured), and then read from
         there by <command>systemd-vconsole-setup</command>, while <varname>vconsole.keymap</varname> is read

--- a/man/systemd.special.xml
+++ b/man/systemd.special.xml
@@ -1047,7 +1047,7 @@ WantedBy=sleep.target</programlisting>
           <listitem><para>This template unit is used to order mount units and other consumers of block
           devices after services that synthesize these block devices. In particular, this is intended to be
           used with storage services (such as
-          <citerefentry><refentrytitle>systemd-cryptsetup@.service</refentrytitle><manvolnum>5</manvolnum></citerefentry>/
+          <citerefentry><refentrytitle>systemd-cryptsetup@.service</refentrytitle><manvolnum>8</manvolnum></citerefentry>/
           <citerefentry><refentrytitle>systemd-veritysetup@.service</refentrytitle><manvolnum>8</manvolnum></citerefentry>)
           that allocate and manage a virtual block device. Storage services are ordered before an instance of
           <filename>blockdev@.target</filename>, and the consumer units after it. The ordering is

--- a/man/systemd.system-credentials.xml
+++ b/man/systemd.system-credentials.xml
@@ -570,7 +570,7 @@
           <filename>/etc/userdb/foobar.group</filename>. Symlinks for the uid/gid will also be created in
           <filename>/etc/userdb/</filename>, as well as the corresponding<filename>.membership</filename>
           files. See
-          <citerefentry><refentrytitle>systemd-userdbd.service</refentrytitle><manvolnum>7</manvolnum></citerefentry>,
+          <citerefentry><refentrytitle>systemd-userdbd.service</refentrytitle><manvolnum>8</manvolnum></citerefentry>,
           <citerefentry><refentrytitle>nss-systemd</refentrytitle><manvolnum>8</manvolnum></citerefentry>, and
           <citerefentry><refentrytitle>userdbctl</refentrytitle><manvolnum>1</manvolnum></citerefentry>
           for details.</para>


### PR DESCRIPTION
Seven `<citerefentry>` cross-references name a page that exists but give a section it is not installed in. The generated link therefore does not resolve, and `man <page>` from the printed reference sends the reader to the wrong section.

| Reference | Written as | Installed as | Sites |
|---|---|---|---|
| `systemd-confext` | 1 | **8** | `systemd-repart.xml:835` |
| `systemd-cryptsetup@.service` | 5 | **8** | `systemd.special.xml:1050` |
| `systemd-firstboot.service` | 8 | **1** | `systemd-vconsole-setup.service.xml:74`, `kernel-command-line.xml:651`, `:916` |
| `systemd-nspawn` | 8 | **1** | `systemd-coredump.xml:110` |
| `systemd-userdbd.service` | 7 | **8** | `systemd.system-credentials.xml:573` |

The correct section for each comes from the `<refmeta>` of the page that defines it — `systemd-sysext.xml` for `systemd-confext`, `systemd-cryptsetup.xml`, `systemd-firstboot.xml`, `systemd-nspawn.xml` and `systemd-userdbd.service.xml` respectively — cross-checked against `man/rules/meson.build`.

One of them corroborates itself: in `systemd.special.xml` the reference sits next to `systemd-veritysetup@.service`, which already correctly says `8`, and both are installed the same way.

## How these were found

I extracted every `citerefentry` in `man/` and `docs/` and resolved it against the page list in `man/rules/meson.build`, including aliases. That file is generated by `update-man-rules.py`, so it is the authoritative list of what actually ships. I then reported only the references whose target *is* shipped but under a different section — those are unambiguous, since the section is not a matter of judgement.

There is no existing check for this: `tools/check-docs-urls.sh` only validates external URLs under `docs/`, and nothing in `man/meson.build` validates cross-references.

## What I deliberately left alone

The same sweep flags a further set of references that I did **not** touch, because they are not the same kind of thing:

- Pages owned by other projects — `nsswitch.conf(5)`, `pam.conf(5)`, `resolv.conf(5)`, `sysctl.conf(5)`. These are provided by glibc, PAM and procps, not by systemd.
- References to `sd_json_*` and `sd_varlink_*` pages that are not written yet (for example `sd_json_build(3)`, `sd_varlink_call(3)`). Those look like deliberate forward references to documentation that is still outstanding rather than mistakes, so repointing or removing them is a call for whoever is writing that documentation.
- `systemd.directives(7)`, referenced 21 times. It is absent from `man/rules/meson.build` only because it is generated at build time by the custom target in `man/meson.build:122` and registered at section 7. The references are correct.

## Verification

- Each replacement section was read from the defining page's own `<refmeta>`, not inferred.
- After the change the sweep reports no remaining references to a shipped page under the wrong section.
- All six files still parse; the only parse complaint is the build-time entity `&FALLBACK_DEFAULT_TARGET;` in `systemd.special.xml`, which is defined in `man/custom-entities.ent.in` and substituted by meson — the unmodified file reports it identically, so it is unrelated to this change.
- Documentation only: 6 files, `+7/-7`, no code changes.

A script did the extraction and the cross-referencing here, the same way one would use `grep` or `coccinelle` for it; the sections themselves were checked one by one against the defining pages, and the exclusions above were each looked at individually before being set aside.
