### PR TITLE
hwdb: Add HP EliteBook 845 G7 Fn+F11 airplane mode key mapping

### DIFF
--- a/hwdb.d/60-keyboard.hwdb
+++ b/hwdb.d/60-keyboard.hwdb
@@ -868,6 +868,7 @@ evdev:atkbd:dmi:bvn*:bvr*:bd*:svnHP:pnHPEliteBookFolioG1:*
 # HP EliteBook 845 G7
 evdev:atkbd:dmi:bvn*:bvr*:bd*:svnHP*:pnHPEliteBook845G7*:pvr*
  KEYBOARD_KEY_68=unknown                                # Fn+F12 HP Programmable Key
+ KEYBOARD_KEY_f8=!wlan                                  # Fn+F11 airplane mode switch 
 
 # HP ProBook 650
 evdev:atkbd:dmi:bvn*:bvr*:bd*:svnHewlett-Packard*:pnHP*ProBook*650*:*


### PR DESCRIPTION
Add a hwdb entry for the HP EliteBook 845 G7 laptop.

The Fn+F11 airplane mode key is reported as KEY_F8 by the atkbd driver. Map it to !wlan to expose the correct wireless radio switch event to userspace. 

I no longer have access to the device, so this was not retested
with the current systemd version. The mapping is based on previous
evtest/udev data collected from an HP EliteBook 845 G7.