### PR TITLE
TEST-92-TPM2-SWTPM: set a higher priority

### DIFF
--- a/test/integration-tests/TEST-92-TPM2-SWTPM/meson.build
+++ b/test/integration-tests/TEST-92-TPM2-SWTPM/meson.build
@@ -21,5 +21,6 @@ integration_tests += [
                         'systemd.tpm2_software_fallback=yes',
                         'systemd.default_device_timeout_sec=300',
                 ],
+                'priority' : 10,
         },
 ]


### PR DESCRIPTION
TEST-92-TPM2-SWTPM requires about 15 minutes on GitHub, if it starts at the very end, the total CI run simply waits for the test finished, and wastes the last 15 minutes. Starting earlier should slightly improve the performance.