### PR TITLE
mount-util: enumerate mounts with libmount's statmount() support

### DIFF
--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -129,6 +129,11 @@ All tools:
   for example in `systemd-nspawn`, will be logged to the audit log, if the
   kernel supports this.
 
+* `$SYSTEMD_LISTMOUNT=0` — if set, the mount table is read by parsing
+  `/proc/self/mountinfo` even where the kernel supports `listmount()` and
+  `statmount()`, just as it is on kernels without the two syscalls. This is
+  the fallback path, so the knob is mostly useful for testing it.
+
 * `$SYSTEMD_ENABLE_LOG_CONTEXT` — if set, extra fields will always be logged to
   the journal instead of only when logging in debug mode.
 

--- a/src/core/namespace.c
+++ b/src/core/namespace.c
@@ -2203,7 +2203,6 @@ static int make_read_only(const MountEntry *m, char **deny_list, FILE *proc_self
         int r;
 
         assert(m);
-        assert(proc_self_mountinfo);
 
         if (m->state != MOUNT_APPLIED)
                 return 0;
@@ -2249,7 +2248,6 @@ static int make_noexec(const MountEntry *m, char **deny_list, FILE *proc_self_mo
         int r;
 
         assert(m);
-        assert(proc_self_mountinfo);
 
         if (m->state != MOUNT_APPLIED)
                 return 0;
@@ -2284,7 +2282,6 @@ static int make_nosuid(const MountEntry *m, FILE *proc_self_mountinfo) {
         int r;
 
         assert(m);
-        assert(proc_self_mountinfo);
 
         if (m->state != MOUNT_APPLIED)
                 return 0;
@@ -2422,16 +2419,11 @@ static int apply_mounts(
                 return 0;
 
         /* Open /proc/self/mountinfo now as it may become unavailable if we mount anything on top of
-         * /proc. For example, this is the case with the option: 'InaccessiblePaths=/proc'. */
-        proc_self_mountinfo = fopen("/proc/self/mountinfo", "re");
-        if (!proc_self_mountinfo) {
-                r = -errno;
-
-                if (reterr_path)
-                        *reterr_path = strdup("/proc/self/mountinfo");
-
-                return log_debug_errno(r, "Failed to open %s: %m", "/proc/self/mountinfo");
-        }
+         * /proc. For example, this is the case with the option: 'InaccessiblePaths=/proc'. Not fatal
+         * if it fails: the mount-util functions this is handed to enumerate through
+         * listmount()/statmount() where the kernel and libmount can, and only their fallback needs
+         * the file. */
+        proc_self_mountinfo = mount_open_proc_self_mountinfo();
 
         /* First round, establish all mounts we need */
         for (;;) {

--- a/src/shared/libmount-util.c
+++ b/src/shared/libmount-util.c
@@ -1,5 +1,7 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
+#include <sys/mount.h>
+
 #include "libmount-util.h"
 #include "log.h"
 
@@ -7,6 +9,8 @@
 
 #include <stdio.h>
 
+#include "env-util.h"
+#include "errno-util.h"
 #include "fstab-util.h"
 #include "mountpoint-util.h"
 
@@ -41,6 +45,14 @@ DLSYM_PROTOTYPE(mnt_table_parse_mtab) = NULL;
 DLSYM_PROTOTYPE(mnt_table_parse_stream) = NULL;
 DLSYM_PROTOTYPE(mnt_table_parse_swaps) = NULL;
 DLSYM_PROTOTYPE(mnt_unref_monitor) = NULL;
+
+/* Since util-linux 2.41 */
+DLSYM_PROTOTYPE(mnt_new_statmnt) = NULL;
+DLSYM_PROTOTYPE(mnt_statmnt_set_mask) = NULL;
+DLSYM_PROTOTYPE(mnt_table_fetch_listmount) = NULL;
+DLSYM_PROTOTYPE(mnt_table_listmount_set_id) = NULL;
+DLSYM_PROTOTYPE(mnt_table_refer_statmnt) = NULL;
+DLSYM_PROTOTYPE(mnt_unref_statmnt) = NULL;
 
 int libmount_parse_full(
                 const char *path,
@@ -90,6 +102,103 @@ int libmount_parse_fstab(
         struct libmnt_iter **ret_iter) {
 
         return libmount_parse_full(fstab_path(), NULL, MNT_ITER_FORWARD, ret_table, ret_iter);
+}
+
+DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_RENAME(struct libmnt_statmnt*, sym_mnt_unref_statmnt, mnt_unref_statmntp, NULL);
+
+int libmount_parse_kernel(
+                uint64_t mask,
+                int direction,
+                struct libmnt_table **ret_table,
+                struct libmnt_iter **ret_iter) {
+
+        /* Latched once we learn this process can never get a kernel-built table, because the
+         * kernel has no listmount()/statmount() or the runtime libmount is too old to use them.
+         * Neither can change while we are running, so later calls skip the dlopen and the probe
+         * syscall too. */
+        static bool unsupported = false;
+
+        _cleanup_(mnt_free_tablep) struct libmnt_table *table = NULL;
+        _cleanup_(mnt_free_iterp) struct libmnt_iter *iter = NULL;
+        _cleanup_(mnt_unref_statmntp) struct libmnt_statmnt *sm = NULL;
+        int r;
+
+        assert(mask != 0);
+        assert(IN_SET(direction, MNT_ITER_FORWARD, MNT_ITER_BACKWARD));
+        assert(ret_table);
+        assert(ret_iter);
+
+        if (unsupported)
+                return -EOPNOTSUPP;
+
+        /* An opt-out for tests and debugging: $SYSTEMD_LISTMOUNT=0 sends every caller down its
+         * mountinfo fallback, as on a kernel without listmount(). Read on each call rather than
+         * latched, so one process can exercise both backends. */
+        r = secure_getenv_bool("SYSTEMD_LISTMOUNT");
+        if (r == 0)
+                return -EOPNOTSUPP;
+        if (r < 0 && r != -ENXIO)
+                log_debug_errno(r, "Failed to parse $SYSTEMD_LISTMOUNT, ignoring: %m");
+
+        r = dlopen_libmount(LOG_DEBUG);
+        if (r < 0)
+                return r;
+
+        /* Older libmount: no statmount() support to speak of. All six are checked before any is
+         * used, including the unref we only reach through the cleanup handler below. */
+        if (!sym_mnt_new_statmnt || !sym_mnt_unref_statmnt || !sym_mnt_statmnt_set_mask ||
+            !sym_mnt_table_refer_statmnt || !sym_mnt_table_listmount_set_id ||
+            !sym_mnt_table_fetch_listmount) {
+                unsupported = true;
+                return -EOPNOTSUPP;
+        }
+
+        /* libmount probes the syscall inside mnt_new_statmnt() and returns NULL with ENOSYS when
+         * the kernel cannot do it, which is a fall-back-to-mountinfo answer rather than an
+         * error. */
+        errno = 0;
+        sm = sym_mnt_new_statmnt();
+        if (!sm) {
+                if (ERRNO_IS_NOT_SUPPORTED(errno)) {
+                        unsupported = true;
+                        return -EOPNOTSUPP;
+                }
+
+                return errno_or_else(ENOMEM);
+        }
+
+        table = sym_mnt_new_table();
+        iter = sym_mnt_new_iter(direction);
+        if (!table || !iter)
+                return -ENOMEM;
+
+        /* Propagation info is what makes reading /proc/self/mountinfo expensive: the kernel
+         * walks each mount's peer group to compute it. When those bits are absent from the
+         * mask, the kernel skips that walk. Callers pass only the fields they use. */
+        r = sym_mnt_statmnt_set_mask(sm, mask);
+        if (r < 0)
+                return r;
+
+        r = sym_mnt_table_refer_statmnt(table, sm);
+        if (r < 0)
+                return r;
+
+        r = sym_mnt_table_listmount_set_id(table, LSMT_ROOT);
+        if (r >= 0)
+                r = sym_mnt_table_fetch_listmount(table);
+        if (r < 0) {
+                /* libmount reports "this kernel cannot do it" as ENOSYS, which the caller must not
+                 * tell apart from an older libmount: both mean use /proc/self/mountinfo instead. */
+                if (!ERRNO_IS_NEG_NOT_SUPPORTED(r))
+                        return r;
+
+                unsupported = true;
+                return -EOPNOTSUPP;
+        }
+
+        *ret_table = TAKE_PTR(table);
+        *ret_iter = TAKE_PTR(iter);
+        return 0;
 }
 
 int libmount_is_leaf(
@@ -145,10 +254,11 @@ int libmount_fs_id_matches_path(struct libmnt_fs *fs, const char *path) {
 int dlopen_libmount(int log_level) {
 #if HAVE_LIBMOUNT
         static void *libmount_dl = NULL;
+        int r;
 
         LIBMOUNT_NOTE(suggested);
 
-        return dlopen_many_sym_or_warn(
+        r = dlopen_many_sym_or_warn(
                         &libmount_dl,
                         "libmount.so.1",
                         log_level,
@@ -183,6 +293,23 @@ int dlopen_libmount(int log_level) {
                         DLSYM_ARG(mnt_table_parse_stream),
                         DLSYM_ARG(mnt_table_parse_swaps),
                         DLSYM_ARG(mnt_unref_monitor));
+        if (r < 0)
+                return r;
+
+        /* Available since util-linux 2.41; libmount_parse_kernel() checks for them and returns
+         * -EOPNOTSUPP when an older libmount left them NULL, and its callers then parse mountinfo
+         * instead. Resolved on every call on
+         * purpose: it is idempotent, and it guarantees the pointers are in place by the time any
+         * call returns, rather than only after the call that happened to load the library
+         * finishes. */
+        DLSYM_OPTIONAL(libmount_dl, mnt_new_statmnt);
+        DLSYM_OPTIONAL(libmount_dl, mnt_statmnt_set_mask);
+        DLSYM_OPTIONAL(libmount_dl, mnt_table_fetch_listmount);
+        DLSYM_OPTIONAL(libmount_dl, mnt_table_listmount_set_id);
+        DLSYM_OPTIONAL(libmount_dl, mnt_table_refer_statmnt);
+        DLSYM_OPTIONAL(libmount_dl, mnt_unref_statmnt);
+
+        return r;
 #else
         return log_full_errno(log_level, SYNTHETIC_ERRNO(EOPNOTSUPP),
                               "libmount support is not compiled in.");

--- a/src/shared/libmount-util.c
+++ b/src/shared/libmount-util.c
@@ -47,6 +47,7 @@ DLSYM_PROTOTYPE(mnt_table_parse_swaps) = NULL;
 DLSYM_PROTOTYPE(mnt_unref_monitor) = NULL;
 
 /* Since util-linux 2.41 */
+DLSYM_PROTOTYPE(mnt_fs_get_uniq_id) = NULL;
 DLSYM_PROTOTYPE(mnt_new_statmnt) = NULL;
 DLSYM_PROTOTYPE(mnt_statmnt_set_mask) = NULL;
 DLSYM_PROTOTYPE(mnt_table_fetch_listmount) = NULL;
@@ -302,6 +303,7 @@ int dlopen_libmount(int log_level) {
          * purpose: it is idempotent, and it guarantees the pointers are in place by the time any
          * call returns, rather than only after the call that happened to load the library
          * finishes. */
+        DLSYM_OPTIONAL(libmount_dl, mnt_fs_get_uniq_id);
         DLSYM_OPTIONAL(libmount_dl, mnt_new_statmnt);
         DLSYM_OPTIONAL(libmount_dl, mnt_statmnt_set_mask);
         DLSYM_OPTIONAL(libmount_dl, mnt_table_fetch_listmount);

--- a/src/shared/libmount-util.h
+++ b/src/shared/libmount-util.h
@@ -27,6 +27,7 @@ extern int mnt_statmnt_set_mask(struct libmnt_statmnt *sm, uint64_t mask);
 extern int mnt_table_refer_statmnt(struct libmnt_table *tb, struct libmnt_statmnt *sm);
 extern int mnt_table_listmount_set_id(struct libmnt_table *tb, uint64_t id);
 extern int mnt_table_fetch_listmount(struct libmnt_table *tb);
+extern uint64_t mnt_fs_get_uniq_id(struct libmnt_fs *fs);
 /* NOLINTEND(readability-redundant-declaration) */
 REENABLE_WARNING;
 
@@ -62,6 +63,7 @@ extern DLSYM_PROTOTYPE(mnt_table_parse_stream);
 extern DLSYM_PROTOTYPE(mnt_table_parse_swaps);
 extern DLSYM_PROTOTYPE(mnt_unref_monitor);
 
+extern DLSYM_PROTOTYPE(mnt_fs_get_uniq_id);
 extern DLSYM_PROTOTYPE(mnt_new_statmnt);
 extern DLSYM_PROTOTYPE(mnt_statmnt_set_mask);
 extern DLSYM_PROTOTYPE(mnt_table_fetch_listmount);

--- a/src/shared/libmount-util.h
+++ b/src/shared/libmount-util.h
@@ -14,6 +14,22 @@
 
 #include "dlfcn-util.h"
 
+/* The statmount()/listmount() API support is available since util-linux 2.41. Always redeclare so
+ * DLSYM_PROTOTYPE's typeof() resolves on older headers; suppress the warning when newer libmount
+ * already declares them. These are resolved with DLSYM_OPTIONAL, so the pointers stay NULL when the
+ * runtime libmount is older, and callers fall back to parsing /proc/self/mountinfo. */
+struct libmnt_statmnt;
+DISABLE_WARNING_REDUNDANT_DECLS;
+/* NOLINTBEGIN(readability-redundant-declaration) */
+extern struct libmnt_statmnt *mnt_new_statmnt(void);
+extern void mnt_unref_statmnt(struct libmnt_statmnt *sm);
+extern int mnt_statmnt_set_mask(struct libmnt_statmnt *sm, uint64_t mask);
+extern int mnt_table_refer_statmnt(struct libmnt_table *tb, struct libmnt_statmnt *sm);
+extern int mnt_table_listmount_set_id(struct libmnt_table *tb, uint64_t id);
+extern int mnt_table_fetch_listmount(struct libmnt_table *tb);
+/* NOLINTEND(readability-redundant-declaration) */
+REENABLE_WARNING;
+
 extern DLSYM_PROTOTYPE(mnt_free_iter);
 extern DLSYM_PROTOTYPE(mnt_free_table);
 extern DLSYM_PROTOTYPE(mnt_fs_get_fs_options);
@@ -46,6 +62,13 @@ extern DLSYM_PROTOTYPE(mnt_table_parse_stream);
 extern DLSYM_PROTOTYPE(mnt_table_parse_swaps);
 extern DLSYM_PROTOTYPE(mnt_unref_monitor);
 
+extern DLSYM_PROTOTYPE(mnt_new_statmnt);
+extern DLSYM_PROTOTYPE(mnt_statmnt_set_mask);
+extern DLSYM_PROTOTYPE(mnt_table_fetch_listmount);
+extern DLSYM_PROTOTYPE(mnt_table_listmount_set_id);
+extern DLSYM_PROTOTYPE(mnt_table_refer_statmnt);
+extern DLSYM_PROTOTYPE(mnt_unref_statmnt);
+
 DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_RENAME(struct libmnt_table*, sym_mnt_free_table, mnt_free_tablep, NULL);
 DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_RENAME(struct libmnt_iter*, sym_mnt_free_iter, mnt_free_iterp, NULL);
 
@@ -70,6 +93,23 @@ static inline int libmount_parse_with_utab(
 
         return libmount_parse_full(NULL, NULL, MNT_ITER_FORWARD, ret_table, ret_iter);
 }
+
+/* Builds a mount table equivalent to the one libmount_parse_mountinfo() builds, but through
+ * listmount()/statmount() instead of /proc/self/mountinfo, fetching only the fields the caller
+ * sets in 'mask'. Equivalent is not identical: libmount does not render every field the same way
+ * through the two backends. Its statmount() path spells strict atime out in the VFS options
+ * string where mountinfo expresses it by omitting any atime option, and a subtyped filesystem's
+ * bare type is reported here ("fuse") where mountinfo reports both ("fuse.sshfs") unless both
+ * the kernel and libmount can deliver the subtype (statmount() reports it only on Linux 6.13
+ * and later). A caller comparing entries against a mountinfo table must normalise those
+ * fields itself. Returns -EOPNOTSUPP when the runtime libmount or the kernel lacks the syscalls,
+ * and also when $SYSTEMD_LISTMOUNT=0 forces the same answer, so the caller can fall back to the
+ * mountinfo parse. */
+int libmount_parse_kernel(
+                uint64_t mask,
+                int direction,
+                struct libmnt_table **ret_table,
+                struct libmnt_iter **ret_iter);
 
 int libmount_parse_fstab(struct libmnt_table **ret_table, struct libmnt_iter **ret_iter);
 

--- a/src/shared/mount-util.c
+++ b/src/shared/mount-util.c
@@ -39,6 +39,164 @@
 #include "tmpfile-util.h"
 #include "user-util.h"
 
+#if HAVE_LIBMOUNT
+/* Enumerating mounts through /proc/self/mountinfo makes the kernel compute the propagation fields for
+ * every line, which walks each mount's whole peer group; inside a service's mount namespace that is
+ * O(mounts x peers) per read. The kernel-backed table from libmount_parse_kernel() skips those fields,
+ * which is the entire speedup. Both paths produce libmnt_fs objects, so only the table's origin
+ * differs. */
+
+typedef struct MountSnapshotEntry {
+        char *path;
+        char *fstype;
+        unsigned long flags;
+} MountSnapshotEntry;
+
+static void mount_snapshot_entry_done(MountSnapshotEntry *e) {
+        assert(e);
+
+        e->path = mfree(e->path);
+        e->fstype = mfree(e->fstype);
+}
+
+static DEFINE_ARRAY_FREE_FUNC(mount_snapshot_entry_array_free, MountSnapshotEntry, mount_snapshot_entry_done);
+
+typedef struct MountSnapshot {
+        MountSnapshotEntry *entries;
+        size_t n;
+} MountSnapshot;
+
+static void mount_snapshot_done(MountSnapshot *s) {
+        assert(s);
+
+        mount_snapshot_entry_array_free(s->entries, s->n);
+        s->entries = NULL;
+        s->n = 0;
+}
+
+/* Reads a mount's flags out of a table entry.
+ *
+ * Returns -ENODATA when the options string is not available at all, which on a kernel-built table
+ * means the per-mount statmount() fetch failed; the mountinfo parse always fills the string in.
+ * That case must not read as "no flags set": these flags are what the remount paths preserve
+ * across a remount, so flags misread as 0 would strip nosuid/nodev/noexec from the mount.
+ *
+ * libmount's statmount() path spells strict atime out as "strictatime", while mountinfo expresses
+ * it by omitting any atime option, so the same mount yields MS_STRICTATIME through one table and
+ * nothing through the other. That is deliberate on libmount's side, so mask the bit off here and
+ * the flags no longer depend on which libmount we happened to dlopen. The mountinfo path never
+ * sets it, so this costs that path nothing. */
+static int mount_fs_flags(struct libmnt_fs *fs, unsigned long *ret) {
+        unsigned long flags = 0;
+        const char *opts;
+        int r;
+
+        assert(fs);
+        assert(ret);
+
+        opts = sym_mnt_fs_get_vfs_options(fs);
+        if (!opts)
+                return -ENODATA;
+
+        r = sym_mnt_optstr_get_flags(opts, &flags, sym_mnt_get_builtin_optmap(MNT_LINUX_MAP));
+        if (r < 0)
+                return r;
+
+        *ret = flags & ~MS_STRICTATIME;
+        return 0;
+}
+
+/* Collects the mount point of every entry in 'table', plus the filesystem type when 'mask' includes
+ * STATMOUNT_FS_TYPE and the per-mount flags when it includes STATMOUNT_MNT_BASIC, into an array the
+ * caller owns, so the loops below iterate over their own snapshot rather than over libmount's table
+ * while unmounting and remounting the very mounts it describes. */
+static int mount_snapshot_from_table(
+                struct libmnt_table *table,
+                struct libmnt_iter *iter,
+                uint64_t mask,
+                MountSnapshot *ret) {
+
+        MountSnapshotEntry *list = NULL;
+        size_t n = 0;
+        int r;
+
+        assert(table);
+        assert(iter);
+        assert(ret);
+
+        CLEANUP_ARRAY(list, n, mount_snapshot_entry_array_free);
+
+        for (;;) {
+                _cleanup_free_ char *p = NULL, *t = NULL;
+                const char *path, *type = NULL;
+                unsigned long flags = 0;
+                struct libmnt_fs *fs;
+
+                r = sym_mnt_table_next_fs(table, iter, &fs);
+                if (r == 1)
+                        break;
+                if (r < 0)
+                        return log_debug_errno(r, "Failed to get next entry from mount table: %m");
+
+                path = sym_mnt_fs_get_target(fs);
+                if (isempty(path)) /* A parsed mountinfo line always has one; be defensive anyway */
+                        continue;
+
+                if (FLAGS_SET(mask, STATMOUNT_FS_TYPE))
+                        type = sym_mnt_fs_get_fstype(fs);
+
+                if (FLAGS_SET(mask, STATMOUNT_MNT_BASIC)) {
+                        r = mount_fs_flags(fs, &flags);
+                        if (r < 0)
+                                return log_debug_errno(r, "Failed to read the mount flags of '%s': %m", path);
+                }
+
+                if (!GREEDY_REALLOC(list, n + 1))
+                        return -ENOMEM;
+
+                r = strdup_to(&p, path);
+                if (r < 0)
+                        return r;
+
+                r = strdup_to(&t, type);   /* NULL type stays NULL */
+                if (r < 0)
+                        return r;
+
+                list[n++] = (MountSnapshotEntry) {
+                        .path = TAKE_PTR(p),
+                        .fstype = TAKE_PTR(t),
+                        .flags = flags,
+                };
+        }
+
+        *ret = (MountSnapshot) {
+                .entries = TAKE_PTR(list),
+                .n = n,
+        };
+        return 0;
+}
+
+/* Parses /proc/self/mountinfo, iterated in 'direction' order, and collects the snapshot from it.
+ * 'mask' names the STATMOUNT_* fields the caller reads. */
+static int mount_snapshot_acquire(FILE *proc_self_mountinfo, uint64_t mask, int direction, MountSnapshot *ret) {
+        _cleanup_(mnt_free_tablep) struct libmnt_table *table = NULL;
+        _cleanup_(mnt_free_iterp) struct libmnt_iter *iter = NULL;
+        int r;
+
+        assert(proc_self_mountinfo);
+        assert(ret);
+
+        rewind(proc_self_mountinfo);
+
+        r = libmount_parse_full("/proc/self/mountinfo", proc_self_mountinfo, direction, &table, &iter);
+        if (r < 0)
+                return log_debug_errno(r, "Failed to parse /proc/self/mountinfo: %m");
+
+        return mount_snapshot_from_table(table, iter, mask, ret);
+}
+
+#endif /* HAVE_LIBMOUNT */
+
 int umount_recursive_full(const char *prefix, int flags, char **keep) {
 #if HAVE_LIBMOUNT
         _cleanup_fclose_ FILE *f = NULL;
@@ -52,28 +210,19 @@ int umount_recursive_full(const char *prefix, int flags, char **keep) {
                 return log_debug_errno(errno, "Failed to open %s: %m", "/proc/self/mountinfo");
 
         for (;;) {
-                _cleanup_(mnt_free_tablep) struct libmnt_table *table = NULL;
-                _cleanup_(mnt_free_iterp) struct libmnt_iter *iter = NULL;
+                _cleanup_(mount_snapshot_done) MountSnapshot snapshot = {};
                 bool again = false;
 
-                r = libmount_parse_full("/proc/self/mountinfo", f, MNT_ITER_BACKWARD, &table, &iter);
+                /* Walking the table backwards reaches every mount before the mount it was made
+                 * on: children before parents, the top of an overmount stack before what it
+                 * hides. Only the mount point is used below. */
+                r = mount_snapshot_acquire(f, STATMOUNT_MNT_POINT, MNT_ITER_BACKWARD, &snapshot);
                 if (r < 0)
-                        return log_debug_errno(r, "Failed to parse /proc/self/mountinfo: %m");
+                        return log_debug_errno(r, "Failed to enumerate mounts: %m");
 
-                for (;;) {
+                FOREACH_ARRAY(e, snapshot.entries, snapshot.n) {
                         bool shall_keep = false;
-                        struct libmnt_fs *fs;
-                        const char *path;
-
-                        r = sym_mnt_table_next_fs(table, iter, &fs);
-                        if (r == 1)
-                                break;
-                        if (r < 0)
-                                return log_debug_errno(r, "Failed to get next entry from /proc/self/mountinfo: %m");
-
-                        path = sym_mnt_fs_get_target(fs);
-                        if (!path)
-                                continue;
+                        const char *path = e->path;
 
                         if (prefix && !path_startswith(path, prefix)) {
                                 // FIXME: This is extremely noisy, we're probably doing something very wrong
@@ -108,8 +257,6 @@ int umount_recursive_full(const char *prefix, int flags, char **keep) {
 
                 if (!again)
                         break;
-
-                rewind(f);
         }
 
         return n;
@@ -236,41 +383,31 @@ int bind_remount_recursive_with_mountinfo(
          * remount operation. Note that we'll ignore the deny list for the top-level path. */
 
         for (;;) {
-                _cleanup_(mnt_free_tablep) struct libmnt_table *table = NULL;
-                _cleanup_(mnt_free_iterp) struct libmnt_iter *iter = NULL;
+                _cleanup_(mount_snapshot_done) MountSnapshot snapshot = {};
                 _cleanup_hashmap_free_ Hashmap *todo = NULL;
                 bool top_autofs = false;
 
                 if (n_tries++ >= 32) /* Let's not retry this loop forever */
                         return -EBUSY;
 
-                rewind(proc_self_mountinfo);
-
-                r = libmount_parse_mountinfo(proc_self_mountinfo, &table, &iter);
+                /* The fields the loop below reads: the mount point, the filesystem type for the
+                 * autofs check, and the flags to reapply. */
+                r = mount_snapshot_acquire(proc_self_mountinfo,
+                                           STATMOUNT_MNT_BASIC|STATMOUNT_MNT_POINT|STATMOUNT_FS_TYPE|STATMOUNT_FS_SUBTYPE,
+                                           MNT_ITER_FORWARD, &snapshot);
                 if (r < 0)
-                        return log_debug_errno(r, "Failed to parse /proc/self/mountinfo: %m");
+                        return log_debug_errno(r, "Failed to enumerate mounts: %m");
 
-                for (;;) {
+                FOREACH_ARRAY(e, snapshot.entries, snapshot.n) {
                         _cleanup_free_ char *d = NULL;
-                        const char *path, *type, *opts;
-                        unsigned long flags = 0;
-                        struct libmnt_fs *fs;
+                        const char *path = e->path;
+                        const char *type = e->fstype;
+                        unsigned long flags = e->flags;
 
-                        r = sym_mnt_table_next_fs(table, iter, &fs);
-                        if (r == 1) /* EOF */
-                                break;
-                        if (r < 0)
-                                return log_debug_errno(r, "Failed to get next entry from /proc/self/mountinfo: %m");
-
-                        path = sym_mnt_fs_get_target(fs);
-                        if (!path)
+                        if (!type) /* No filesystem type reported; the autofs check below needs one */
                                 continue;
 
                         if (!path_startswith(path, prefix))
-                                continue;
-
-                        type = sym_mnt_fs_get_fstype(fs);
-                        if (!type)
                                 continue;
 
                         /* Let's ignore autofs mounts. If they aren't triggered yet, we want to avoid
@@ -305,13 +442,6 @@ int bind_remount_recursive_with_mountinfo(
 
                                 if (deny_listed)
                                         continue;
-                        }
-
-                        opts = sym_mnt_fs_get_vfs_options(fs);
-                        if (opts) {
-                                r = sym_mnt_optstr_get_flags(opts, &flags, sym_mnt_get_builtin_optmap(MNT_LINUX_MAP));
-                                if (r < 0)
-                                        log_debug_errno(r, "Could not get flags for '%s', ignoring: %m", path);
                         }
 
                         d = strdup(path);

--- a/src/shared/mount-util.c
+++ b/src/shared/mount-util.c
@@ -74,7 +74,7 @@ static void mount_snapshot_done(MountSnapshot *s) {
         s->n = 0;
 }
 
-/* Reads a mount's flags out of a table entry.
+/* Reads a mount's flags the way the mountinfo table reports them.
  *
  * Returns -ENODATA when the options string is not available at all, which on a kernel-built table
  * means the per-mount statmount() fetch failed; the mountinfo parse always fills the string in.
@@ -106,10 +106,19 @@ static int mount_fs_flags(struct libmnt_fs *fs, unsigned long *ret) {
         return 0;
 }
 
-/* Collects the mount point of every entry in 'table', plus the filesystem type when 'mask' includes
- * STATMOUNT_FS_TYPE and the per-mount flags when it includes STATMOUNT_MNT_BASIC, into an array the
- * caller owns, so the loops below iterate over their own snapshot rather than over libmount's table
- * while unmounting and remounting the very mounts it describes. */
+/* Collects the mount point of every entry in 'table', plus the filesystem type when 'mask'
+ * includes STATMOUNT_FS_TYPE and the per-mount flags when it includes STATMOUNT_MNT_BASIC. The
+ * table is whatever the caller built: from listmount()/statmount(), or from parsing
+ * /proc/self/mountinfo.
+ *
+ * Returns -ENODATA if any entry cannot be read in full, which on a kernel-built table means that
+ * entry's statmount() failed: the mount may have been unmounted between listmount() and
+ * statmount(), but listmount() and statmount() also apply their permission and allocation checks
+ * differently, so a live mount can fail too. Neither dropping the entry nor reading its flags as 0
+ * is safe, because both make an incomplete enumeration look like a complete one: a caller applying
+ * ProtectSystem= would report success over a submount it never remounted. The caller re-reads the
+ * whole snapshot from mountinfo instead, which renders every field of every line in one pass and
+ * so cannot be partially readable. */
 static int mount_snapshot_from_table(
                 struct libmnt_table *table,
                 struct libmnt_iter *iter,
@@ -139,11 +148,20 @@ static int mount_snapshot_from_table(
                         return log_debug_errno(r, "Failed to get next entry from mount table: %m");
 
                 path = sym_mnt_fs_get_target(fs);
-                if (isempty(path)) /* A parsed mountinfo line always has one; be defensive anyway */
-                        continue;
+                if (isempty(path))
+                        return log_debug_errno(SYNTHETIC_ERRNO(ENODATA),
+                                               "Failed to read the mount point of mount %" PRIu64 ".",
+                                               sym_mnt_fs_get_uniq_id ? sym_mnt_fs_get_uniq_id(fs) : (uint64_t) sym_mnt_fs_get_id(fs));
 
-                if (FLAGS_SET(mask, STATMOUNT_FS_TYPE))
+                if (FLAGS_SET(mask, STATMOUNT_FS_TYPE)) {
                         type = sym_mnt_fs_get_fstype(fs);
+                        if (!type)
+                                /* The callers that request types pick which mounts to remount by
+                                 * them, so an entry with a silently missing type would drop out
+                                 * of their set the same way a missing entry would. */
+                                return log_debug_errno(SYNTHETIC_ERRNO(ENODATA),
+                                                       "Failed to read the filesystem type of '%s'.", path);
+                }
 
                 if (FLAGS_SET(mask, STATMOUNT_MNT_BASIC)) {
                         r = mount_fs_flags(fs, &flags);
@@ -176,55 +194,150 @@ static int mount_snapshot_from_table(
         return 0;
 }
 
-/* Parses /proc/self/mountinfo, iterated in 'direction' order, and collects the snapshot from it.
- * 'mask' names the STATMOUNT_* fields the caller reads. */
-static int mount_snapshot_acquire(FILE *proc_self_mountinfo, uint64_t mask, int direction, MountSnapshot *ret) {
+/* Builds the mount table through one backend, iterated in 'direction' order: from
+ * listmount()/statmount() with 'mask' when 'from_kernel', from parsing 'proc_self_mountinfo'
+ * otherwise. */
+static int mount_table_build(
+                bool from_kernel,
+                FILE *proc_self_mountinfo,
+                uint64_t mask,
+                int direction,
+                struct libmnt_table **ret_table,
+                struct libmnt_iter **ret_iter) {
+
+        assert(from_kernel || proc_self_mountinfo);
+        assert(ret_table);
+        assert(ret_iter);
+
+        if (from_kernel)
+                return libmount_parse_kernel(mask, direction, ret_table, ret_iter);
+
+        rewind(proc_self_mountinfo);
+        return libmount_parse_full("/proc/self/mountinfo", proc_self_mountinfo, direction, ret_table, ret_iter);
+}
+
+/* Builds the mount table through one backend and collects the snapshot from it. */
+static int mount_snapshot_acquire_one(
+                bool from_kernel,
+                FILE *proc_self_mountinfo,
+                uint64_t mask,
+                int direction,
+                MountSnapshot *ret) {
+
         _cleanup_(mnt_free_tablep) struct libmnt_table *table = NULL;
         _cleanup_(mnt_free_iterp) struct libmnt_iter *iter = NULL;
         int r;
 
-        assert(proc_self_mountinfo);
         assert(ret);
 
-        rewind(proc_self_mountinfo);
-
-        r = libmount_parse_full("/proc/self/mountinfo", proc_self_mountinfo, direction, &table, &iter);
+        r = mount_table_build(from_kernel, proc_self_mountinfo, mask, direction, &table, &iter);
         if (r < 0)
-                return log_debug_errno(r, "Failed to parse /proc/self/mountinfo: %m");
+                return r;
 
         return mount_snapshot_from_table(table, iter, mask, ret);
 }
 
-/* Looks one mount point's flags up in /proc/self/mountinfo.
+/* Snapshots the mount table, preferring listmount()/statmount() and falling back to
+ * /proc/self/mountinfo. Any failure of the fast path falls back, not just the unavailability
+ * errnos: an unexpected errno from a per-mount fetch must not be the thing that aborts namespace
+ * setup, and an enumeration that could only be read in part (-ENODATA) must not be handed on as if
+ * it were whole.
  *
- * Returns -ENOENT if 'path' does not exist and -EINVAL if it exists but is not a mount point, which
- * is what bind_remount_one_with_mountinfo() has always returned for those two cases. */
-static int mount_flags_by_path(FILE *proc_self_mountinfo, const char *path, unsigned long *ret) {
+ * 'proc_self_mountinfo' may be NULL, since the kernel path has no use for /proc at all, e.g.
+ * because /proc is masked or already unmounted; then there is nothing to fall back to and the
+ * kernel path's error is returned. */
+static int mount_snapshot_acquire(FILE *proc_self_mountinfo, uint64_t mask, int direction, MountSnapshot *ret) {
+        int r;
+
+        assert(ret);
+
+        r = mount_snapshot_acquire_one(/* from_kernel= */ true, NULL, mask, direction, ret);
+        if (r >= 0)
+                return 0;
+        if (r != -EOPNOTSUPP)
+                log_debug_errno(r, "listmount() enumeration failed%s: %m",
+                                proc_self_mountinfo ? ", falling back to mountinfo" : "");
+        if (!proc_self_mountinfo)
+                return r;
+
+        r = mount_snapshot_acquire_one(/* from_kernel= */ false, proc_self_mountinfo, mask, direction, ret);
+        if (r < 0)
+                return log_debug_errno(r, "Failed to enumerate mounts through /proc/self/mountinfo: %m");
+
+        return 0;
+}
+
+/* Looks one mount point's flags up through one backend. Returns -ESRCH when the table has no such
+ * mount, which the caller must not confuse with "not a mount point": a kernel-built table also
+ * lacks an entry whose statmount() failed. */
+static int mount_flags_by_path_one(
+                bool from_kernel,
+                FILE *proc_self_mountinfo,
+                const char *path,
+                unsigned long *ret) {
+
         _cleanup_(mnt_free_tablep) struct libmnt_table *table = NULL;
         _cleanup_(mnt_free_iterp) struct libmnt_iter *iter = NULL;
         struct libmnt_fs *fs;
         int r;
 
-        assert(proc_self_mountinfo);
         assert(path);
         assert(ret);
 
-        rewind(proc_self_mountinfo);
-
-        r = libmount_parse_mountinfo(proc_self_mountinfo, &table, &iter);
+        /* The flags and the mount point are all this reads; no filesystem type. */
+        r = mount_table_build(from_kernel, proc_self_mountinfo,
+                              STATMOUNT_MNT_BASIC|STATMOUNT_MNT_POINT,
+                              MNT_ITER_FORWARD, &table, &iter);
         if (r < 0)
-                return log_debug_errno(r, "Failed to parse /proc/self/mountinfo: %m");
+                return r;
 
         fs = sym_mnt_table_find_target(table, path, MNT_ITER_FORWARD);
-        if (!fs) {
-                r = access_nofollow(path, F_OK); /* Hmm, it's not in the mount table, but does it exist at all? */
-                if (r < 0)
-                        return r;
-
-                return -EINVAL; /* Not a mount point we recognize */
-        }
+        if (!fs)
+                return -ESRCH;
 
         return mount_fs_flags(fs, ret);
+}
+
+/* Look up the current mount flags of exactly one mount point, preferring the kernel-backed table for the
+ * same reason as above: parsing all of /proc/self/mountinfo to find one entry is disproportionately
+ * expensive, and this function runs once per mount entry during namespace setup.
+ *
+ * Returns -EINVAL if 'path' exists but is not a mount point, matching what the mountinfo path has
+ * always returned there, so the caller keeps its existing handling of that case. Only the mountinfo
+ * table may conclude that, because a mount missing from the kernel table, or carrying no readable
+ * options, is a mount whose statmount() failed rather than a path that is not mounted. */
+static int mount_flags_by_path(FILE *proc_self_mountinfo, const char *path, unsigned long *ret) {
+        int q, r;
+
+        assert(path);
+        assert(ret);
+
+        r = mount_flags_by_path_one(/* from_kernel= */ true, NULL, path, ret);
+        if (r >= 0)
+                return 0;
+        if (!IN_SET(r, -EOPNOTSUPP, -ESRCH, -ENODATA))
+                log_debug_errno(r, "listmount() lookup of '%s' failed%s: %m",
+                                path, proc_self_mountinfo ? ", falling back to mountinfo" : "");
+
+        if (proc_self_mountinfo) {
+                r = mount_flags_by_path_one(/* from_kernel= */ false, proc_self_mountinfo, path, ret);
+                if (r >= 0)
+                        return 0;
+        }
+
+        /* Neither lookup succeeded. A missing path is -ENOENT to the caller no matter which
+         * backend failed or why, including when none was available at all (a libmount without
+         * statmount() support and no mountinfo stream): namespace.c drops a mount marked
+         * ignorable on -ENOENT and fails namespace setup on anything else. A path that does
+         * exist propagates the backend's own error, and -EINVAL is reserved for one that exists
+         * while no table lists it. */
+        q = access_nofollow(path, F_OK);
+        if (q < 0)
+                return q;
+        if (r != -ESRCH)
+                return r;
+
+        return -EINVAL; /* Exists, and not a mount point we recognize */
 }
 
 #endif /* HAVE_LIBMOUNT */
@@ -433,11 +546,8 @@ int bind_remount_recursive_with_mountinfo(
                 FOREACH_ARRAY(e, snapshot.entries, snapshot.n) {
                         _cleanup_free_ char *d = NULL;
                         const char *path = e->path;
-                        const char *type = e->fstype;
+                        const char *type = e->fstype;   /* non-NULL: the snapshot was taken with STATMOUNT_FS_TYPE */
                         unsigned long flags = e->flags;
-
-                        if (!type) /* No filesystem type reported; the autofs check below needs one */
-                                continue;
 
                         if (!path_startswith(path, prefix))
                                 continue;
@@ -486,6 +596,10 @@ int bind_remount_recursive_with_mountinfo(
                                  * it means a mount point is overmounted, and libmount returns the "bottom" (or
                                  * older one) first, but we want to reapply the flags from the "top" (or newer
                                  * one). See: https://github.com/systemd/systemd/issues/20032
+                                 * This does not depend on which backend built the table: every kernel with
+                                 * listmount() also serves /proc/self/mountinfo from the same mount rbtree, in
+                                 * the same unique-mount-ID order (fs/namespace.c, m_next() and listmnt_next()
+                                 * both step through it with rb_next()).
                                  * Note that this shouldn't really fail, as we were just told that the key
                                  * exists, and it's an update so we want 'd' to be freed immediately. */
                                 r = hashmap_update(todo, d, ULONG_TO_PTR(flags));

--- a/src/shared/mount-util.c
+++ b/src/shared/mount-util.c
@@ -503,6 +503,7 @@ int bind_remount_recursive_with_mountinfo(
         _cleanup_fclose_ FILE *proc_self_mountinfo_opened = NULL;
         _cleanup_set_free_ Set *done = NULL;
         unsigned n_tries = 0;
+        bool made_top_mount = false;
         int r;
 
         if (!proc_self_mountinfo) {
@@ -615,10 +616,19 @@ int bind_remount_recursive_with_mountinfo(
                 if (!set_contains(done, prefix) &&
                     !(top_autofs || hashmap_contains(todo, prefix))) {
 
+                        /* A mount we made has to show up in the next snapshot. If it does not, some
+                         * enumeration is at fault, and mounting again would just stack another bind
+                         * mount on the same path every pass until the retry counter runs out. */
+                        if (made_top_mount)
+                                return log_debug_errno(SYNTHETIC_ERRNO(ENODATA),
+                                                       "Made '%s' a mount, but it has not appeared in the mount table.", prefix);
+
                         /* The prefix directory itself is not yet a mount, make it one. */
                         r = mount_nofollow(prefix, prefix, NULL, MS_BIND|MS_REC, NULL);
                         if (r < 0)
                                 return r;
+
+                        made_top_mount = true;
 
                         /* Immediately rescan, so that we pick up the new mount's flags */
                         continue;

--- a/src/shared/mount-util.c
+++ b/src/shared/mount-util.c
@@ -195,6 +195,38 @@ static int mount_snapshot_acquire(FILE *proc_self_mountinfo, uint64_t mask, int 
         return mount_snapshot_from_table(table, iter, mask, ret);
 }
 
+/* Looks one mount point's flags up in /proc/self/mountinfo.
+ *
+ * Returns -ENOENT if 'path' does not exist and -EINVAL if it exists but is not a mount point, which
+ * is what bind_remount_one_with_mountinfo() has always returned for those two cases. */
+static int mount_flags_by_path(FILE *proc_self_mountinfo, const char *path, unsigned long *ret) {
+        _cleanup_(mnt_free_tablep) struct libmnt_table *table = NULL;
+        _cleanup_(mnt_free_iterp) struct libmnt_iter *iter = NULL;
+        struct libmnt_fs *fs;
+        int r;
+
+        assert(proc_self_mountinfo);
+        assert(path);
+        assert(ret);
+
+        rewind(proc_self_mountinfo);
+
+        r = libmount_parse_mountinfo(proc_self_mountinfo, &table, &iter);
+        if (r < 0)
+                return log_debug_errno(r, "Failed to parse /proc/self/mountinfo: %m");
+
+        fs = sym_mnt_table_find_target(table, path, MNT_ITER_FORWARD);
+        if (!fs) {
+                r = access_nofollow(path, F_OK); /* Hmm, it's not in the mount table, but does it exist at all? */
+                if (r < 0)
+                        return r;
+
+                return -EINVAL; /* Not a mount point we recognize */
+        }
+
+        return mount_fs_flags(fs, ret);
+}
+
 #endif /* HAVE_LIBMOUNT */
 
 int umount_recursive_full(const char *prefix, int flags, char **keep) {
@@ -573,41 +605,12 @@ int bind_remount_one_with_mountinfo(
         }
 
 #if HAVE_LIBMOUNT
-        _cleanup_(mnt_free_tablep) struct libmnt_table *table = NULL;
         unsigned long flags = 0;
-        struct libmnt_fs *fs;
-        const char *opts;
         int r;
 
-        rewind(proc_self_mountinfo);
-
-        r = dlopen_libmount(LOG_DEBUG);
+        r = mount_flags_by_path(proc_self_mountinfo, path, &flags);
         if (r < 0)
                 return r;
-
-        table = sym_mnt_new_table();
-        if (!table)
-                return -ENOMEM;
-
-        r = sym_mnt_table_parse_stream(table, proc_self_mountinfo, "/proc/self/mountinfo");
-        if (r < 0)
-                return r;
-
-        fs = sym_mnt_table_find_target(table, path, MNT_ITER_FORWARD);
-        if (!fs) {
-                r = access_nofollow(path, F_OK); /* Hmm, it's not in the mount table, but does it exist at all? */
-                if (r < 0)
-                        return r;
-
-                return -EINVAL; /* Not a mount point we recognize */
-        }
-
-        opts = sym_mnt_fs_get_vfs_options(fs);
-        if (opts) {
-                r = sym_mnt_optstr_get_flags(opts, &flags, sym_mnt_get_builtin_optmap(MNT_LINUX_MAP));
-                if (r < 0)
-                        log_debug_errno(r, "Could not get flags for '%s', ignoring: %m", path);
-        }
 
         r = mount_nofollow(NULL, path, NULL, ((flags & ~flags_mask)|MS_BIND|MS_REMOUNT|new_flags) & ~MS_RELATIME, NULL);
         if (r < 0) {

--- a/src/shared/mount-util.c
+++ b/src/shared/mount-util.c
@@ -303,9 +303,10 @@ static int mount_flags_by_path_one(
  * expensive, and this function runs once per mount entry during namespace setup.
  *
  * Returns -EINVAL if 'path' exists but is not a mount point, matching what the mountinfo path has
- * always returned there, so the caller keeps its existing handling of that case. Only the mountinfo
- * table may conclude that, because a mount missing from the kernel table, or carrying no readable
- * options, is a mount whose statmount() failed rather than a path that is not mounted. */
+ * always returned there, so the caller keeps its existing handling of that case. A mount missing
+ * from the kernel table is not proof of that on its own, since the entry's statmount() may have
+ * failed, so the mountinfo table settles it; when there is no mountinfo stream at all, a
+ * kernel-table miss on a path that exists is all the answer there is. */
 static int mount_flags_by_path(FILE *proc_self_mountinfo, const char *path, unsigned long *ret) {
         int q, r;
 
@@ -342,6 +343,25 @@ static int mount_flags_by_path(FILE *proc_self_mountinfo, const char *path, unsi
 
 #endif /* HAVE_LIBMOUNT */
 
+FILE* mount_open_proc_self_mountinfo(void) {
+        _cleanup_fclose_ FILE *f = NULL;
+        int r;
+
+        /* Opens /proc/self/mountinfo for the mount table functions in this file. Returns NULL if it
+         * cannot be opened, which is not fatal on its own: those functions enumerate through
+         * listmount()/statmount() where that is available, and only their fallback reads the file.
+         * Callers pin it early because /proc can be masked or unmounted by the very operation they
+         * are about to perform. */
+
+        r = fopen_unlocked("/proc/self/mountinfo", "re", &f);
+        if (r < 0) {
+                log_debug_errno(r, "Failed to open /proc/self/mountinfo, relying on listmount(): %m");
+                return NULL;
+        }
+
+        return TAKE_PTR(f);
+}
+
 int umount_recursive_full(const char *prefix, int flags, char **keep) {
 #if HAVE_LIBMOUNT
         _cleanup_fclose_ FILE *f = NULL;
@@ -350,9 +370,7 @@ int umount_recursive_full(const char *prefix, int flags, char **keep) {
         /* Try to umount everything recursively below a directory. Also, take care of stacked mounts, and
          * keep unmounting them until they are gone. */
 
-        f = fopen("/proc/self/mountinfo", "re"); /* Pin the file, in case we unmount /proc/ as part of the logic here */
-        if (!f)
-                return log_debug_errno(errno, "Failed to open %s: %m", "/proc/self/mountinfo");
+        f = mount_open_proc_self_mountinfo(); /* Pin the file, in case we unmount /proc/ as part of the logic here */
 
         for (;;) {
                 _cleanup_(mount_snapshot_done) MountSnapshot snapshot = {};
@@ -500,19 +518,10 @@ int bind_remount_recursive_with_mountinfo(
         }
 
 #if HAVE_LIBMOUNT
-        _cleanup_fclose_ FILE *proc_self_mountinfo_opened = NULL;
         _cleanup_set_free_ Set *done = NULL;
         unsigned n_tries = 0;
         bool made_top_mount = false;
         int r;
-
-        if (!proc_self_mountinfo) {
-                r = fopen_unlocked("/proc/self/mountinfo", "re", &proc_self_mountinfo_opened);
-                if (r < 0)
-                        return r;
-
-                proc_self_mountinfo = proc_self_mountinfo_opened;
-        }
 
         /* Recursively remount a directory (and all its submounts) with desired flags (MS_READONLY,
          * MS_NOSUID, MS_NOEXEC). If the directory is already mounted, we reuse the mount and simply mark it
@@ -702,6 +711,14 @@ int bind_remount_recursive_with_mountinfo(
 #endif
 }
 
+int bind_remount_recursive(const char *prefix, unsigned long new_flags, unsigned long flags_mask, char **deny_list) {
+        /* Opens the mountinfo fallback itself; a NULL stream handed to the function above means "no
+         * fallback available", which callers like namespace.c use after pinning the file early. */
+        _cleanup_fclose_ FILE *proc_self_mountinfo = mount_open_proc_self_mountinfo();
+
+        return bind_remount_recursive_with_mountinfo(prefix, new_flags, flags_mask, deny_list, proc_self_mountinfo);
+}
+
 int bind_remount_one_with_mountinfo(
                 const char *path,
                 unsigned long new_flags,
@@ -709,7 +726,6 @@ int bind_remount_one_with_mountinfo(
                 FILE *proc_self_mountinfo) {
 
         assert(path);
-        assert(proc_self_mountinfo);
 
         if ((flags_mask & ~MS_CONVERTIBLE_FLAGS) == 0 && !skip_mount_set_attr) {
                 /* Let's take a shortcut for all the flags we know how to convert into mount_setattr() flags */
@@ -757,9 +773,7 @@ int bind_remount_one_with_mountinfo(
 int bind_remount_one(const char *path, unsigned long new_flags, unsigned long flags_mask) {
         _cleanup_fclose_ FILE *proc_self_mountinfo = NULL;
 
-        proc_self_mountinfo = fopen("/proc/self/mountinfo", "re");
-        if (!proc_self_mountinfo)
-                return log_debug_errno(errno, "Failed to open %s: %m", "/proc/self/mountinfo");
+        proc_self_mountinfo = mount_open_proc_self_mountinfo();
 
         return bind_remount_one_with_mountinfo(path, new_flags, flags_mask, proc_self_mountinfo);
 }

--- a/src/shared/mount-util.h
+++ b/src/shared/mount-util.h
@@ -23,9 +23,12 @@ static inline int umount_recursive(const char *prefix, int flags) {
 }
 
 int bind_remount_recursive_with_mountinfo(const char *prefix, unsigned long new_flags, unsigned long flags_mask, char **deny_list, FILE *proc_self_mountinfo);
-static inline int bind_remount_recursive(const char *prefix, unsigned long new_flags, unsigned long flags_mask, char **deny_list) {
-        return bind_remount_recursive_with_mountinfo(prefix, new_flags, flags_mask, deny_list, NULL);
-}
+int bind_remount_recursive(const char *prefix, unsigned long new_flags, unsigned long flags_mask, char **deny_list);
+
+/* Opens /proc/self/mountinfo for the mount table functions in this file, or returns NULL with a
+ * debug log: the listmount()/statmount() enumeration they prefer needs no /proc, and they treat a
+ * NULL file as "no fallback available". */
+FILE* mount_open_proc_self_mountinfo(void);
 
 int bind_remount_one_with_mountinfo(const char *path, unsigned long new_flags, unsigned long flags_mask, FILE *proc_self_mountinfo);
 int bind_remount_one(const char *path, unsigned long new_flags, unsigned long flags_mask);

--- a/src/test/test-mount-util.c
+++ b/src/test/test-mount-util.c
@@ -11,6 +11,7 @@
 #include "fd-util.h"
 #include "fileio.h"
 #include "fs-util.h"
+#include "hashmap.h"
 #include "libmount-util.h"
 #include "mkdir.h"
 #include "mount-util.h"
@@ -41,6 +42,31 @@
                 return (void) log_tests_skipped("Not privileged");      \
         if (running_in_chroot() != 0)                                   \
                 return (void) log_tests_skipped("running in chroot");
+
+/* Only a probe verdict of -EOPNOTSUPP may skip the kernel-table pass; any other probe error must
+ * fail the test loudly rather than silently shrink its coverage. */
+#define SKIP_UNLESS_KERNEL_TABLE(backend, have_kernel)                                             \
+        if (streq(backend, "1")) {                                                                 \
+                if ((have_kernel) == -EOPNOTSUPP) {                                                \
+                        log_notice("listmount()/statmount() are not available, skipping the kernel-table pass."); \
+                        continue;                                                                  \
+                }                                                                                  \
+                ASSERT_OK(have_kernel);                                                            \
+        }
+
+/* Whether libmount_parse_kernel() can deliver a table here. $SYSTEMD_LISTMOUNT=1 only means "do
+ * not force the mountinfo fallback": when the kernel or the runtime libmount lacks the syscalls,
+ * a pass run under it degrades to the mountinfo path and passes without touching the code it was
+ * meant to cover. The per-backend loops below probe this first and skip that pass visibly, but
+ * only on -EOPNOTSUPP: any other error is unexpected and must fail the test rather than shrink
+ * it. An ambient $SYSTEMD_LISTMOUNT=0 also reads as -EOPNOTSUPP, by design: that is the
+ * documented opt-out, and it takes the same visible-skip path. */
+static int have_kernel_mount_table(void) {
+        _cleanup_(mnt_free_tablep) struct libmnt_table *table = NULL;
+        _cleanup_(mnt_free_iterp) struct libmnt_iter *iter = NULL;
+
+        return libmount_parse_kernel(STATMOUNT_MNT_POINT, MNT_ITER_FORWARD, &table, &iter);
+}
 
 TEST(mount_option_mangle) {
         char *opts = NULL;
@@ -154,70 +180,220 @@ TEST(bind_remount_recursive) {
 
         CHECK_PRIV;
 
+        int have_kernel = have_kernel_mount_table();
+
         assert_se(mkdtemp_malloc("/tmp/XXXXXX", &tmp) >= 0);
         subdir = path_join(tmp, "subdir");
         assert_se(subdir);
         assert_se(mkdir(subdir, 0755) >= 0);
 
-        FOREACH_STRING(p, "/usr", "/sys", "/", tmp) {
-                r = ASSERT_OK(pidref_safe_fork("(bind-remount-recursive)", FORK_COMMON_FLAGS, NULL));
+        /* Each child runs once through listmount()/statmount() where the kernel has them, and once
+         * forced onto the mountinfo fallback; the variable only ever reaches the forked child. */
+        FOREACH_STRING(backend, "1", "0") {
+                SKIP_UNLESS_KERNEL_TABLE(backend, have_kernel);
+
+                FOREACH_STRING(p, "/usr", "/sys", "/", tmp) {
+                        r = ASSERT_OK(pidref_safe_fork("(bind-remount-recursive)", FORK_COMMON_FLAGS, NULL));
+                        if (r == 0) { /* child */
+                                struct statvfs svfs;
+
+                                ASSERT_OK_ERRNO(setenv("SYSTEMD_LISTMOUNT", backend, /* overwrite= */ true));
+
+                                /* Check that the subdir is writable (it must be because it's in /tmp) */
+                                assert_se(statvfs(subdir, &svfs) >= 0);
+                                assert_se(!FLAGS_SET(svfs.f_flag, ST_RDONLY));
+
+                                /* Make the subdir a bind mount carrying nosuid, so there is a flag
+                                 * outside the mask below whose survival can be checked */
+                                assert_se(mount_nofollow(subdir, subdir, NULL, MS_BIND|MS_REC, NULL) >= 0);
+                                assert_se(mount_nofollow(NULL, subdir, NULL, MS_BIND|MS_REMOUNT|MS_NOSUID, NULL) >= 0);
+
+                                /* Ensure it's still writable */
+                                assert_se(statvfs(subdir, &svfs) >= 0);
+                                assert_se(!FLAGS_SET(svfs.f_flag, ST_RDONLY));
+
+                                /* Now mark the path we currently run for read-only. For the private
+                                 * tmpdir the mask carries a bit mount_setattr() cannot express, so
+                                 * that prefix skips the shortcut and reapplies each mount's
+                                 * looked-up flags through the enumerated table under both
+                                 * backends; the other prefixes keep covering the shortcut. */
+                                assert_se(bind_remount_recursive(p, MS_RDONLY,
+                                                                 MS_RDONLY | (path_equal(p, tmp) ? MS_SYNCHRONOUS : 0),
+                                                                 path_equal(p, "/sys") ? STRV_MAKE("/sys/kernel") : NULL) >= 0);
+
+                                /* Ensure that this worked on the top-level */
+                                assert_se(statvfs(p, &svfs) >= 0);
+                                assert_se(FLAGS_SET(svfs.f_flag, ST_RDONLY));
+
+                                /* And ensure this had an effect on the subdir exactly if we are talking about a path above the subdir */
+                                assert_se(statvfs(subdir, &svfs) >= 0);
+                                assert_se(FLAGS_SET(svfs.f_flag, ST_RDONLY) == !!path_startswith(subdir, p));
+
+                                /* The table path must have preserved the nosuid outside its mask */
+                                if (path_equal(p, tmp))
+                                        assert_se(FLAGS_SET(svfs.f_flag, ST_NOSUID));
+
+                                _exit(EXIT_SUCCESS);
+                        }
+                }
+        }
+}
+
+TEST(bind_remount_one) {
+        _cleanup_(rm_rf_physical_and_freep) char *t = NULL;
+        int r;
+
+        CHECK_PRIV;
+
+        int have_kernel = have_kernel_mount_table();
+
+        ASSERT_OK(mkdtemp_malloc(NULL, &t));
+
+        /* As above: one pass per backend, decided in the forked child. The mount-point cases with
+         * a convertible mask return through the mount_setattr() shortcut; the tmpfs case's mask
+         * carries a bit mount_setattr() cannot express, so it is the one that reaches the mount
+         * table lookup on a path that is actually a mount, and the flags outside the mask must
+         * come back out of the table: the remount may not strip the tmpfs's nosuid/nodev. */
+        FOREACH_STRING(backend, "1", "0") {
+                SKIP_UNLESS_KERNEL_TABLE(backend, have_kernel);
+
+                r = ASSERT_OK(pidref_safe_fork("(remount-one-with-mountinfo)", FORK_COMMON_FLAGS, NULL));
+                if (r == 0) { /* child */
+                        _cleanup_fclose_ FILE *proc_self_mountinfo = NULL;
+                        struct statvfs svfs;
+
+                        ASSERT_OK_ERRNO(setenv("SYSTEMD_LISTMOUNT", backend, /* overwrite= */ true));
+
+                        assert_se(fopen_unlocked("/proc/self/mountinfo", "re", &proc_self_mountinfo) >= 0);
+
+                        assert_se(bind_remount_one_with_mountinfo("/run", MS_RDONLY, MS_RDONLY, proc_self_mountinfo) >= 0);
+                        assert_se(bind_remount_one_with_mountinfo("/run", MS_NOEXEC, MS_RDONLY|MS_NOEXEC, proc_self_mountinfo) >= 0);
+                        assert_se(bind_remount_one_with_mountinfo("/proc/idontexist", MS_RDONLY, MS_RDONLY, proc_self_mountinfo) == -ENOENT);
+                        assert_se(bind_remount_one_with_mountinfo("/proc/self", MS_RDONLY, MS_RDONLY, proc_self_mountinfo) == -EINVAL);
+                        assert_se(bind_remount_one_with_mountinfo("/", MS_RDONLY, MS_RDONLY, proc_self_mountinfo) >= 0);
+
+                        ASSERT_OK(mount_nofollow_verbose(LOG_ERR, "tmpfs", t, "tmpfs", MS_NOSUID|MS_NODEV, NULL));
+                        ASSERT_OK(bind_remount_one_with_mountinfo(t, MS_RDONLY, MS_RDONLY|MS_SYNCHRONOUS, proc_self_mountinfo));
+                        ASSERT_OK_ERRNO(statvfs(t, &svfs));
+                        ASSERT_TRUE(FLAGS_SET(svfs.f_flag, ST_RDONLY));
+                        ASSERT_TRUE(FLAGS_SET(svfs.f_flag, ST_NOSUID));
+                        ASSERT_TRUE(FLAGS_SET(svfs.f_flag, ST_NODEV));
+
+                        _exit(EXIT_SUCCESS);
+                }
+
+                r = ASSERT_OK(pidref_safe_fork("(remount-one)", FORK_COMMON_FLAGS, NULL));
                 if (r == 0) { /* child */
                         struct statvfs svfs;
 
-                        /* Check that the subdir is writable (it must be because it's in /tmp) */
-                        assert_se(statvfs(subdir, &svfs) >= 0);
-                        assert_se(!FLAGS_SET(svfs.f_flag, ST_RDONLY));
+                        ASSERT_OK_ERRNO(setenv("SYSTEMD_LISTMOUNT", backend, /* overwrite= */ true));
 
-                        /* Make the subdir a bind mount */
-                        assert_se(mount_nofollow(subdir, subdir, NULL, MS_BIND|MS_REC, NULL) >= 0);
+                        assert_se(bind_remount_one("/run", MS_RDONLY, MS_RDONLY) >= 0);
+                        assert_se(bind_remount_one("/run", MS_NOEXEC, MS_RDONLY|MS_NOEXEC) >= 0);
+                        assert_se(bind_remount_one("/proc/idontexist", MS_RDONLY, MS_RDONLY) == -ENOENT);
+                        assert_se(bind_remount_one("/proc/self", MS_RDONLY, MS_RDONLY) == -EINVAL);
+                        assert_se(bind_remount_one("/", MS_RDONLY, MS_RDONLY) >= 0);
 
-                        /* Ensure it's still writable */
-                        assert_se(statvfs(subdir, &svfs) >= 0);
-                        assert_se(!FLAGS_SET(svfs.f_flag, ST_RDONLY));
-
-                        /* Now mark the path we currently run for read-only */
-                        assert_se(bind_remount_recursive(p, MS_RDONLY, MS_RDONLY, path_equal(p, "/sys") ? STRV_MAKE("/sys/kernel") : NULL) >= 0);
-
-                        /* Ensure that this worked on the top-level */
-                        assert_se(statvfs(p, &svfs) >= 0);
-                        assert_se(FLAGS_SET(svfs.f_flag, ST_RDONLY));
-
-                        /* And ensure this had an effect on the subdir exactly if we are talking about a path above the subdir */
-                        assert_se(statvfs(subdir, &svfs) >= 0);
-                        assert_se(FLAGS_SET(svfs.f_flag, ST_RDONLY) == !!path_startswith(subdir, p));
+                        ASSERT_OK(mount_nofollow_verbose(LOG_ERR, "tmpfs", t, "tmpfs", MS_NOSUID|MS_NODEV, NULL));
+                        ASSERT_OK(bind_remount_one(t, MS_RDONLY, MS_RDONLY|MS_SYNCHRONOUS));
+                        ASSERT_OK_ERRNO(statvfs(t, &svfs));
+                        ASSERT_TRUE(FLAGS_SET(svfs.f_flag, ST_RDONLY));
+                        ASSERT_TRUE(FLAGS_SET(svfs.f_flag, ST_NOSUID));
+                        ASSERT_TRUE(FLAGS_SET(svfs.f_flag, ST_NODEV));
 
                         _exit(EXIT_SUCCESS);
                 }
         }
 }
 
-TEST(bind_remount_one) {
+TEST(bind_remount_one_nonexistent) {
+        _cleanup_(rm_rf_physical_and_freep) char *t = NULL;
         int r;
+
+        /* A path that is not there at all must report -ENOENT rather than -EINVAL, which is
+         * reserved for "exists but is not a mount point". namespace.c drops an entry marked
+         * ignorable on the first and fails namespace setup on the second. Passing no mountinfo
+         * stream also covers the kernel-only enumeration path, where the mount table lookup and
+         * the existence check come from different places. */
+
+        ASSERT_ERROR(bind_remount_one_with_mountinfo("/run/test-mount-util-does-not-exist", MS_RDONLY, MS_RDONLY, NULL), ENOENT);
+
+        /* The -EINVAL half needs a backend that can say no table lists the path: the kernel
+         * table concludes it here, and without one the kernel path's -EOPNOTSUPP comes through
+         * instead, since there is nothing to consult. */
+        ASSERT_OK(mkdtemp_malloc("/tmp/test-mount-util.XXXXXX", &t));
+        r = bind_remount_one_with_mountinfo(t, MS_RDONLY, MS_RDONLY, NULL);
+        if (r == -EOPNOTSUPP)
+                return (void) log_tests_skipped("listmount()/statmount() are not available");
+        ASSERT_ERROR(r, EINVAL);
+}
+
+TEST(remount_and_umount_with_proc_masked) {
+        _cleanup_(rm_rf_physical_and_freep) char *t = NULL;
+        _cleanup_free_ char *subdir = NULL;
+        int r;
+
+        /* Namespace setup no longer requires /proc/self/mountinfo. What is checkable under a
+         * masked /proc splits three ways: a recursive read-only remount still works where
+         * mount_setattr() can express it; umount_recursive() still works outright, since its
+         * enumeration comes from the kernel table and umount2() takes a plain path; and when
+         * $SYSTEMD_LISTMOUNT=0 leaves no backend at all, both fail rather than skip their work
+         * silently. The classic per-mount remount is not reachable without /proc whatever built
+         * the table: mount_fd() addresses the mount target through /proc/self/fd/ and reports
+         * ENOSYS when /proc is not there. */
 
         CHECK_PRIV;
 
-        r = ASSERT_OK(pidref_safe_fork("(remount-one-with-mountinfo)", FORK_COMMON_FLAGS, NULL));
+        r = have_kernel_mount_table();
+        if (r == -EOPNOTSUPP)
+                return (void) log_tests_skipped("listmount()/statmount() are not available");
+        ASSERT_OK(r);
+
+        ASSERT_OK(mkdtemp_malloc(NULL, &t));
+        ASSERT_NOT_NULL(subdir = path_join(t, "subdir"));
+
+        r = ASSERT_OK(pidref_safe_fork("(proc-masked)", FORK_COMMON_FLAGS, NULL));
         if (r == 0) { /* child */
-                _cleanup_fclose_ FILE *proc_self_mountinfo = NULL;
+                struct statvfs svfs;
 
-                assert_se(fopen_unlocked("/proc/self/mountinfo", "re", &proc_self_mountinfo) >= 0);
+                ASSERT_OK_ERRNO(setenv("SYSTEMD_LISTMOUNT", "1", /* overwrite= */ true));
 
-                assert_se(bind_remount_one_with_mountinfo("/run", MS_RDONLY, MS_RDONLY, proc_self_mountinfo) >= 0);
-                assert_se(bind_remount_one_with_mountinfo("/run", MS_NOEXEC, MS_RDONLY|MS_NOEXEC, proc_self_mountinfo) >= 0);
-                assert_se(bind_remount_one_with_mountinfo("/proc/idontexist", MS_RDONLY, MS_RDONLY, proc_self_mountinfo) == -ENOENT);
-                assert_se(bind_remount_one_with_mountinfo("/proc/self", MS_RDONLY, MS_RDONLY, proc_self_mountinfo) == -EINVAL);
-                assert_se(bind_remount_one_with_mountinfo("/", MS_RDONLY, MS_RDONLY, proc_self_mountinfo) >= 0);
+                ASSERT_OK(mount_nofollow_verbose(LOG_ERR, "tmpfs", t, "tmpfs", 0, NULL));
+                ASSERT_OK_ERRNO(mkdir(subdir, 0755));
+                /* noexec is the canary the parent lacks: as long as statvfs(subdir) reports it,
+                 * the subdir mount is still there and the flags below really are the subdir's,
+                 * not the identically read-only parent's showing through after a detach. */
+                ASSERT_OK(mount_nofollow_verbose(LOG_ERR, "tmpfs", subdir, "tmpfs", MS_NOEXEC, NULL));
 
-                _exit(EXIT_SUCCESS);
-        }
+                /* Mask /proc, as InaccessiblePaths=/proc would */
+                ASSERT_OK(mount_nofollow_verbose(LOG_ERR, "tmpfs", "/proc", "tmpfs", 0, NULL));
+                ASSERT_LT(access("/proc/self/mountinfo", F_OK), 0);
 
-        r = ASSERT_OK(pidref_safe_fork("(remount-one)", FORK_COMMON_FLAGS, NULL));
-        if (r == 0) { /* child */
-                assert_se(bind_remount_one("/run", MS_RDONLY, MS_RDONLY) >= 0);
-                assert_se(bind_remount_one("/run", MS_NOEXEC, MS_RDONLY|MS_NOEXEC) >= 0);
-                assert_se(bind_remount_one("/proc/idontexist", MS_RDONLY, MS_RDONLY) == -ENOENT);
-                assert_se(bind_remount_one("/proc/self", MS_RDONLY, MS_RDONLY) == -EINVAL);
-                assert_se(bind_remount_one("/", MS_RDONLY, MS_RDONLY) >= 0);
+                ASSERT_OK(bind_remount_recursive(t, MS_RDONLY, MS_RDONLY, NULL));
+                ASSERT_OK_ERRNO(statvfs(t, &svfs));
+                ASSERT_TRUE(FLAGS_SET(svfs.f_flag, ST_RDONLY));
+                ASSERT_OK_ERRNO(statvfs(subdir, &svfs));
+                ASSERT_TRUE(FLAGS_SET(svfs.f_flag, ST_RDONLY));
+                ASSERT_TRUE(FLAGS_SET(svfs.f_flag, ST_NOEXEC));
+
+                /* No kernel table and no /proc: fail-closed, and the tree is untouched. The
+                 * remount mask carries a bit mount_setattr() cannot express, so the shortcut
+                 * cannot answer for it and enumeration itself has to fail. ST_RDONLY alone
+                 * cannot show the tree is untouched: had the failed umount detached subdir,
+                 * statvfs() would read the parent, which is just as read-only. The noexec
+                 * canary only exists on the subdir mount, so it pins the read to it. */
+                ASSERT_OK_ERRNO(setenv("SYSTEMD_LISTMOUNT", "0", /* overwrite= */ true));
+                ASSERT_ERROR(bind_remount_recursive(t, MS_RDONLY, MS_RDONLY|MS_SYNCHRONOUS, NULL), EOPNOTSUPP);
+                ASSERT_ERROR(umount_recursive(t, MNT_DETACH), EOPNOTSUPP);
+                ASSERT_OK_ERRNO(statvfs(subdir, &svfs));
+                ASSERT_TRUE(FLAGS_SET(svfs.f_flag, ST_RDONLY));
+                ASSERT_TRUE(FLAGS_SET(svfs.f_flag, ST_NOEXEC));
+
+                /* The kernel table alone must carry the whole umount */
+                ASSERT_OK_ERRNO(setenv("SYSTEMD_LISTMOUNT", "1", /* overwrite= */ true));
+                ASSERT_OK(umount_recursive(t, MNT_DETACH));
+                ASSERT_OK_ERRNO(statvfs(t, &svfs));
+                ASSERT_FALSE(FLAGS_SET(svfs.f_flag, ST_RDONLY));
 
                 _exit(EXIT_SUCCESS);
         }
@@ -334,48 +510,194 @@ TEST(umount_recursive) {
 
         CHECK_PRIV;
 
-        FOREACH_ELEMENT(t, test_table) {
-                r = ASSERT_OK(pidref_safe_fork("(umount-rec)", FORK_COMMON_FLAGS, NULL));
-                if (r == 0) { /* child */
-                        _cleanup_(mnt_free_tablep) struct libmnt_table *table = NULL;
-                        _cleanup_(mnt_free_iterp) struct libmnt_iter *iter = NULL;
-                        _cleanup_fclose_ FILE *f = NULL;
-                        _cleanup_free_ char *k = NULL;
+        int have_kernel = have_kernel_mount_table();
 
-                        /* Open /p/s/m file before we unmount everything (which might include /proc/) */
-                        f = fopen("/proc/self/mountinfo", "re");
-                        if (!f) {
-                                log_error_errno(errno, "Failed to open %s: %m", "/proc/self/mountinfo");
-                                _exit(EXIT_FAILURE);
-                        }
+        /* As above: one pass per backend, decided in the forked child. */
+        FOREACH_STRING(backend, "1", "0") {
+                SKIP_UNLESS_KERNEL_TABLE(backend, have_kernel);
 
-                        assert_se(k = strv_join((char**) t->keep, " "));
-                        log_info("detaching just %s (keep: %s)", strna(t->prefix), strna(empty_to_null(k)));
+                FOREACH_ELEMENT(t, test_table) {
+                        r = ASSERT_OK(pidref_safe_fork("(umount-rec)", FORK_COMMON_FLAGS, NULL));
+                        if (r == 0) { /* child */
+                                _cleanup_(mnt_free_tablep) struct libmnt_table *table = NULL;
+                                _cleanup_(mnt_free_iterp) struct libmnt_iter *iter = NULL;
+                                _cleanup_fclose_ FILE *f = NULL;
+                                _cleanup_free_ char *k = NULL;
 
-                        assert_se(umount_recursive_full(t->prefix, MNT_DETACH, (char**) t->keep) >= 0);
+                                ASSERT_OK_ERRNO(setenv("SYSTEMD_LISTMOUNT", backend, /* overwrite= */ true));
 
-                        r = libmount_parse_mountinfo(f, &table, &iter);
-                        if (r < 0) {
-                                log_error_errno(r, "Failed to parse /proc/self/mountinfo: %m");
-                                _exit(EXIT_FAILURE);
-                        }
-
-                        for (;;) {
-                                struct libmnt_fs *fs;
-
-                                r = sym_mnt_table_next_fs(table, iter, &fs);
-                                if (r == 1)
-                                        break;
-                                if (r < 0) {
-                                        log_error_errno(r, "Failed to get next entry from /proc/self/mountinfo: %m");
+                                /* Open /p/s/m file before we unmount everything (which might include /proc/) */
+                                f = fopen("/proc/self/mountinfo", "re");
+                                if (!f) {
+                                        log_error_errno(errno, "Failed to open %s: %m", "/proc/self/mountinfo");
                                         _exit(EXIT_FAILURE);
                                 }
 
-                                log_debug("left after complete umount: %s", sym_mnt_fs_get_target(fs));
-                        }
+                                assert_se(k = strv_join((char**) t->keep, " "));
+                                log_info("detaching just %s (keep: %s)", strna(t->prefix), strna(empty_to_null(k)));
 
-                        _exit(EXIT_SUCCESS);
+                                assert_se(umount_recursive_full(t->prefix, MNT_DETACH, (char**) t->keep) >= 0);
+
+                                r = libmount_parse_mountinfo(f, &table, &iter);
+                                if (r < 0) {
+                                        log_error_errno(r, "Failed to parse /proc/self/mountinfo: %m");
+                                        _exit(EXIT_FAILURE);
+                                }
+
+                                for (;;) {
+                                        struct libmnt_fs *fs;
+
+                                        r = sym_mnt_table_next_fs(table, iter, &fs);
+                                        if (r == 1)
+                                                break;
+                                        if (r < 0) {
+                                                log_error_errno(r, "Failed to get next entry from /proc/self/mountinfo: %m");
+                                                _exit(EXIT_FAILURE);
+                                        }
+
+                                        log_debug("left after complete umount: %s", sym_mnt_fs_get_target(fs));
+                                }
+
+                                _exit(EXIT_SUCCESS);
+                        }
                 }
+        }
+}
+
+/* The fields the dedup check below reads from each entry: the mount point, the filesystem type,
+ * and the VFS option flags. */
+#define DEDUP_STATMOUNT_MASK \
+        (STATMOUNT_MNT_BASIC|STATMOUNT_MNT_POINT|STATMOUNT_FS_TYPE)
+
+/* "<fstype> <flags>" for one entry, as mount_snapshot_from_table() would record it, or NULL when
+ * the entry cannot be read in full. */
+static char* mount_dedup_value(struct libmnt_fs *fs) {
+        unsigned long fl = 0;
+        const char *opts;
+        char *v;
+
+        ASSERT_NOT_NULL(fs);
+
+        opts = sym_mnt_fs_get_vfs_options(fs);
+        if (!opts) /* The mount vanished between listmount() and statmount() */
+                return NULL;
+
+        ASSERT_OK(sym_mnt_optstr_get_flags(opts, &fl, sym_mnt_get_builtin_optmap(MNT_LINUX_MAP)));
+        fl &= ~MS_STRICTATIME; /* As mount_fs_flags() does */
+
+        ASSERT_OK(asprintf(&v, "%s %lx", strempty(sym_mnt_fs_get_fstype(fs)), fl));
+        return v;
+}
+
+TEST(mount_table_kernel_dedup_direction) {
+        _cleanup_(rm_rf_physical_and_freep) char *t = NULL;
+        int r;
+
+        /* bind_remount_recursive_with_mountinfo() walks the kernel table forwards and lets the
+         * last entry for a path win; the umount path walks backwards and acts on the top of an
+         * overmount stack first. Both orders must find the same mount for every overmounted
+         * path. One snapshot, walked both ways, so there is no second table to race against.
+         * The child stacks two tmpfs mounts on a directory of its own first, so at least one
+         * overmounted path exists whatever the host's table looks like, and the winner there is
+         * known: the top mount, the one carrying MS_NOSUID. */
+
+        CHECK_PRIV;
+
+        r = have_kernel_mount_table();
+        if (r == -EOPNOTSUPP)
+                return (void) log_tests_skipped("listmount()/statmount() are not available");
+        ASSERT_OK(r);
+
+        ASSERT_OK(mkdtemp_malloc(NULL, &t));
+
+        r = ASSERT_OK(pidref_safe_fork("(dedup-direction)", FORK_COMMON_FLAGS, NULL));
+        if (r == 0) { /* child */
+                _cleanup_(mnt_free_tablep) struct libmnt_table *kernel_table = NULL;
+                _cleanup_(mnt_free_iterp) struct libmnt_iter *kernel_iter = NULL, *forward_iter = NULL;
+                _cleanup_hashmap_free_ Hashmap *backward = NULL, *forward = NULL;
+                const char *fw_path;
+                char *backward_v;
+
+                ASSERT_OK(mount_nofollow_verbose(LOG_ERR, "tmpfs", t, "tmpfs", 0, NULL));
+                ASSERT_OK(mount_nofollow_verbose(LOG_ERR, "tmpfs", t, "tmpfs", MS_NOSUID, NULL));
+
+                ASSERT_OK(libmount_parse_kernel(DEDUP_STATMOUNT_MASK, MNT_ITER_BACKWARD,
+                                                &kernel_table, &kernel_iter));
+
+                for (;;) {
+                        _cleanup_free_ char *p = NULL, *v = NULL;
+                        const char *path;
+                        struct libmnt_fs *fs;
+
+                        r = sym_mnt_table_next_fs(kernel_table, kernel_iter, &fs);
+                        if (r == 1)
+                                break;
+                        ASSERT_OK_ZERO(r);
+
+                        path = sym_mnt_fs_get_target(fs);
+                        if (isempty(path))
+                                continue;
+
+                        v = mount_dedup_value(fs);
+                        if (!v)
+                                continue;
+
+                        ASSERT_NOT_NULL(p = strdup(path));
+
+                        r = hashmap_ensure_put(&backward, &string_hash_ops_free_free, p, v);
+                        if (r == -EEXIST) /* An overmounted path; the topmost mount is already stored */
+                                continue;
+                        ASSERT_OK(r);
+                        TAKE_PTR(p);
+                        TAKE_PTR(v);
+                }
+
+                ASSERT_NOT_NULL(forward_iter = sym_mnt_new_iter(MNT_ITER_FORWARD));
+                for (;;) {
+                        _cleanup_free_ char *p = NULL, *v = NULL, *old_key = NULL;
+                        const char *path;
+                        struct libmnt_fs *fs;
+
+                        r = sym_mnt_table_next_fs(kernel_table, forward_iter, &fs);
+                        if (r == 1)
+                                break;
+                        ASSERT_OK_ZERO(r);
+
+                        path = sym_mnt_fs_get_target(fs);
+                        if (isempty(path))
+                                continue;
+
+                        v = mount_dedup_value(fs);
+                        if (!v)
+                                continue;
+
+                        /* hashmap_remove2() hands back the removed key and returns the removed
+                         * value, which has no owner anymore and is freed right here. */
+                        free(hashmap_remove2(forward, path, (void**) &old_key));
+
+                        ASSERT_NOT_NULL(p = strdup(path));
+                        ASSERT_OK(hashmap_ensure_put(&forward, &string_hash_ops_free_free, p, v));
+                        TAKE_PTR(p);
+                        TAKE_PTR(v);
+                }
+
+                ASSERT_EQ(hashmap_size(forward), hashmap_size(backward));
+                HASHMAP_FOREACH_KEY(backward_v, fw_path, backward) {
+                        const char *fw_v = hashmap_get(forward, fw_path);
+                        if (!streq_ptr(fw_v, backward_v))
+                                log_error("Iteration direction changed the winner at '%s': forward '%s', backward '%s'",
+                                          fw_path, strnull(fw_v), backward_v);
+                        ASSERT_STREQ(fw_v, backward_v);
+                }
+
+                /* The stacked pair above guarantees the dedup branches ran, and pins the winner:
+                 * both directions must have kept the top mount. */
+                const char *stacked_v = ASSERT_NOT_NULL(hashmap_get(forward, t));
+                unsigned long stacked_flags = 0;
+                ASSERT_EQ(sscanf(stacked_v, "tmpfs %lx", &stacked_flags), 1);
+                ASSERT_TRUE(FLAGS_SET(stacked_flags, MS_NOSUID));
+
+                _exit(EXIT_SUCCESS);
         }
 }
 


### PR DESCRIPTION
Reading /proc/self/mountinfo makes the kernel compute the "master:" and
"propagate_from:" propagation fields for every line, via
get_dominating_id(), which walks the entire peer group of each mount's
master. Inside a service's mount namespace every mount is a slave of the
host's peer group, so that is O(mounts x peers) per read, and
umount_recursive_full() and bind_remount_recursive_with_mountinfo() read
the file repeatedly.

Measured on a host with ~1000 mounts sharing one peer group: 0.46s per
read, and a unit with ProtectSystem=full, ProtectHome=yes and
PrivateTmp=yes took over two minutes to start, blowing through its start
timeout. That is the bug that started this: chronyd could not start on
my devserver for two weeks.

libmount 2.41 can build the same table from listmount()/statmount()
while fetching only the fields we use, and never the propagation info
that costs all the time. Building both tables twenty times over 1,046
mounts: the kernel-backed table costs 0.0019s either way, while the
mountinfo parse costs 0.0037s in a normal namespace and 0.694s inside a
slave one. So it is 2x on a plain host and 365x where these functions
actually run.

Six commits:

1. libmount_parse_kernel(), the dlopen plumbing and the cached no-support verdict. No callers.
2. Collect mount tables into a snapshot, still reading mountinfo.
3. Look up one mount's flags through a helper.
4. Prefer the kernel-backed table, fall back to mountinfo.
5. Stop requiring /proc/self/mountinfo, since the kernel path has no use for it.
6. Tests: the kernel table dedup conventions and the errno contract.

Each commit builds and passes test-mount-util standalone on two architectures and four libmount
versions. x86-64 (6.16 kernel): libmount 2.37.4, which has no statmount() API, so the mountinfo
fallback runs, and a util-linux master build, where the kernel path ran the parity comparison
over 1,059 mounts. aarch64 (Ubuntu 24.04, 6.18 kernel): libmount 2.39.3, again the fallback,
and a util-linux master build, kernel path, 27 mounts.

At the series tip the aarch64 machine also ran the full unit suite: 1742 of 1744 pass, and the
two failures are ukify dist checks missing python tooling that fail identically at the merge
base. The fallback was also exercised by fault injection: strace -e
inject=statmount:error=ENOENT:when=50 kills one per-mount fetch mid-enumeration, and the
snapshot is retaken from mountinfo rather than returning a smaller table.

Both syscalls landed in Linux 6.8, but libmount probes listmount() with
LISTMOUNT_REVERSE, which is 6.11, so in practice that is the floor for
the fast path. Older kernels answer EINVAL, libmount reports ENOSYS, and
we fall back.

The parity test found that libmount's own two paths disagree: a subtyped
mount reads "fuse" through statmount() where mountinfo reads
"fuse.sshfs". That is fixed in util-linux#4535, merged. Production
compares the type only against "autofs", which has no subtype, and the
parity test tolerates exactly the subtype shape, so nothing here
depended on that landing.
