### PR TITLE
install: honour vendor enablement below /usr/, and add --vendor to put it there

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -65,6 +65,32 @@ CHANGES WITH 262:
           selects all suitable TPM2 PCR banks; the banks can no longer be
           restricted per volume.
 
+        * Units that the vendor enabled with a .wants/, .requires/ or .upholds/
+          symlink below /usr/ are now reported as "enabled" by "systemctl
+          is-enabled" and "systemctl status". Previously such units were
+          reported as "disabled" (or "static" for instances) even though the
+          service manager acts on those symlinks and starts the units at boot,
+          which means "systemctl is-enabled" now exits 0 where it used to exit
+          1 for them. Distributions ship such symlinks for a number of units,
+          so this may be visible in packaging scripts.
+
+          "systemctl disable" can now turn such units off, which it previously
+          could not. It cannot remove the symlink, as /usr/ is frequently
+          read-only and the change would be undone by the next image update, so
+          it shadows it with a symlink to /dev/null in /etc/ instead, which
+          "systemctl enable" removes again.
+
+          A preset policy of "disable" deliberately does not do this and leaves
+          the vendor's enablement alone, so that "systemctl preset-all" keeps
+          behaving as before on existing systems: masking what a vendor wired
+          up would take units out of the boot everywhere the preset files do
+          not name what is shipped pre-wired, which they never had to.
+
+          Units without WantedBy=, RequiredBy= or UpheldBy= in their [Install]
+          section are unaffected: a dependency symlink pointing at such a unit
+          wires it up statically rather than enabling it, so it is not reported
+          as enabled and nothing takes it out of the boot.
+
         * The legacy socket for controlling systemd-udevd has been removed, and
           udevadm now unconditionally uses Varlink IPC. The legacy UNIX socket
           /run/udev/control, which is sometimes used to check whether udevd is
@@ -222,6 +248,24 @@ CHANGES WITH 262:
           byte-identical duplicate arguments are removed, keeping the last
           occurrence. These options are rejected if a kexec kernel is already
           loaded.
+
+        * "systemctl enable", "disable", "reenable", "preset" and "preset-all"
+          gained a new "--vendor" switch, which makes them operate on
+          /usr/lib/systemd/system/ instead of /etc/systemd/system/. This is
+          intended for image builds: "systemctl preset-all --vendor --root=…"
+          bakes the preset policy into the image and leaves /etc/ empty, so
+          that it remains available for the administrator and stays a
+          meaningful indicator of what was configured locally. Units enabled
+          this way remain overridable from /etc/ as usual. Only the names an
+          [Install] section asks for are touched there, so the compatibility
+          and slot names distributions ship below /usr/, such as default.target
+          or the runlevel*.target symlinks, are left where they are.
+
+          Unlike a preset into /etc/, presetting the vendor directories does
+          turn off what the vendor wired up, by removing the symlink. Anything
+          shipped pre-wired below /usr/ therefore has to be named by a preset
+          file to survive it: systemd's own 90-systemd.preset gained six such
+          entries for units it installs into sockets.target.wants/.
 
         Changes in systemd-firstboot:
 

--- a/NEWS
+++ b/NEWS
@@ -250,15 +250,16 @@ CHANGES WITH 262:
           loaded.
 
         * "systemctl preset" and "systemctl preset-all" no longer write an
-          enablement symlink into /etc/ when the vendor already establishes the
-          very same dependency below /usr/. Presetting re-asserts a policy
-          rather than recording an administrator's decision, so there is
-          nothing to record in that case, and on an image built with
-          "preset-all --vendor" a later "preset-all" now leaves /etc/ almost
-          untouched instead of filling it with copies of the vendor's own
-          decisions. "systemctl enable" is unaffected and still records itself,
-          so that an explicitly enabled unit stays enabled even if a later
-          image drops the vendor symlink.
+          enablement symlink into /etc/ where the vendor already carries the
+          very same one below /usr/, be it a .wants/, .requires/ or .upholds/
+          entry or an Alias= name pointing at the unit: presetting re-asserts a
+          policy rather than recording an administrator's decision, so there is
+          nothing to record. An image built with "preset-all --vendor" now
+          comes up with an empty /etc/ after a later "preset-all". "systemctl
+          enable" is unaffected and still records itself. As a consequence a
+          unit whose [Install] section carries nothing but Alias= is reported
+          as disabled once its alias is provided below /usr/, since an Alias=
+          symlink there does not by itself count as enablement.
 
         * "systemctl enable", "disable", "reenable", "preset" and "preset-all"
           gained a new "--vendor" switch, which makes them operate on

--- a/NEWS
+++ b/NEWS
@@ -249,6 +249,17 @@ CHANGES WITH 262:
           occurrence. These options are rejected if a kexec kernel is already
           loaded.
 
+        * "systemctl preset" and "systemctl preset-all" no longer write an
+          enablement symlink into /etc/ when the vendor already establishes the
+          very same dependency below /usr/. Presetting re-asserts a policy
+          rather than recording an administrator's decision, so there is
+          nothing to record in that case, and on an image built with
+          "preset-all --vendor" a later "preset-all" now leaves /etc/ almost
+          untouched instead of filling it with copies of the vendor's own
+          decisions. "systemctl enable" is unaffected and still records itself,
+          so that an explicitly enabled unit stays enabled even if a later
+          image drops the vendor symlink.
+
         * "systemctl enable", "disable", "reenable", "preset" and "preset-all"
           gained a new "--vendor" switch, which makes them operate on
           /usr/lib/systemd/system/ instead of /etc/systemd/system/. This is

--- a/man/org.freedesktop.systemd1.xml
+++ b/man/org.freedesktop.systemd1.xml
@@ -1667,10 +1667,15 @@ node /org/freedesktop/systemd1 {
       <filename>/etc/</filename>). The second one controls whether symlinks pointing to other units shall be
       replaced if necessary. This method returns one boolean and an array of the changes made. The boolean
       signals whether the unit files contained any enablement information (i.e. an [Install] section). The
-      changes array consists of structures with three strings: the type of the change (one of
-      <literal>symlink</literal> or <literal>unlink</literal>), the file name of the symlink and the
-      destination of the symlink. Note that most of the following calls return a changes list in the same
-      format.</para>
+      changes array consists of structures with three strings: the type of the change, the file name of the
+      symlink and the destination of the symlink. The type is one of <literal>symlink</literal>,
+      <literal>unlink</literal>, <literal>mask-dependency</literal> (an entry resolving to
+      <filename>/dev/null</filename>, which the service manager ignores when loading dependencies, was placed
+      over a dependency symlink the vendor ships below <filename>/usr/</filename>, whose path is reported as
+      the destination) or
+      <literal>unmask-dependency</literal> (such a symlink was removed again). Clients should ignore types
+      they do not know, as further ones may be added. Note that most of the following calls return a changes
+      list in the same format.</para>
 
       <para>Similarly, <function>DisableUnitFiles()</function> disables one or more units in the system,
       i.e. removes all symlinks to them in <filename>/etc/</filename> and <filename>/run/</filename>.</para>

--- a/man/systemctl.xml
+++ b/man/systemctl.xml
@@ -1088,7 +1088,7 @@ Jan 12 10:46:45 example.com bluetoothd[8900]: gatt-time-server: Input/output err
                 <tbody>
                   <row>
                     <entry><literal>enabled</literal></entry>
-                    <entry morerows='1'>Enabled via <filename>.wants/</filename>, <filename>.requires/</filename> or <varname>Alias=</varname> symlinks (permanently in <filename>/etc/systemd/system/</filename>, or transiently in <filename>/run/systemd/system/</filename>).</entry>
+                    <entry morerows='1'>Enabled via <filename>.wants/</filename>, <filename>.requires/</filename> or <varname>Alias=</varname> symlinks (permanently in <filename>/etc/systemd/system/</filename>, or transiently in <filename>/run/systemd/system/</filename>). Units the vendor enabled with a <filename>.wants/</filename>, <filename>.requires/</filename> or <filename>.upholds/</filename> symlink below <filename>/usr/</filename> are reported as <literal>enabled</literal> too: the service manager acts on those the same way. Such enablement can be turned off from <filename>/etc/</filename>, see <option>--vendor</option> below.</entry>
                     <entry morerows='1'>0</entry>
                   </row>
                   <row>
@@ -2704,6 +2704,65 @@ Jan 12 10:46:45 example.com bluetoothd[8900]: gatt-time-server: Input/output err
           <command>set-property</command>, make changes only
           temporarily, so that they are lost on the next
           reboot.</para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term><option>--vendor</option></term>
+
+        <listitem>
+          <para>When used with <command>enable</command>, <command>disable</command>,
+          <command>reenable</command>, <command>preset</command> or <command>preset-all</command>, operate on
+          the vendor unit directory <filename>/usr/lib/systemd/system/</filename> instead of
+          <filename>/etc/systemd/system/</filename> (with <option>--global</option>,
+          <filename>/usr/lib/systemd/user/</filename> instead of
+          <filename>/etc/systemd/user/</filename>). The service manager acts on the enablement symlinks
+          found there exactly like on the ones in <filename>/etc/</filename>, so units enabled this way are
+          reported as <literal>enabled</literal> and start at boot as usual.</para>
+
+          <para>This is intended for building OS images: applying the preset policy to
+          <filename>/usr/</filename> at build time leaves <filename>/etc/</filename> empty, so that it
+          remains available for the administrator, survives as the only thing a factory reset has to remove,
+          and stays a meaningful indicator of what was configured locally. It is normally used together with
+          <option>--root=</option>, though it also works without it where <filename>/usr/</filename> is
+          writable, such as inside an image build container.</para>
+
+          <para>Enablement in <filename>/usr/</filename> stays overridable: the service manager ignores a
+          dependency entry that resolves to <filename>/dev/null</filename>, so
+          <command>systemctl disable</command> turns such a unit off by placing one with the same name in
+          <filename>/etc/</filename>, and <command>systemctl enable</command> removes it again. Note that
+          <command>disable --vendor</command> deletes the symlink outright instead, since there is no higher
+          priority vendor directory to mask it from.</para>
+
+          <para>A preset policy of <literal>disable</literal> deliberately does not mask this way and leaves
+          the vendor's enablement where it is. Masking it would take units out of the boot on every system
+          whose preset files do not name what is shipped pre-wired below <filename>/usr/</filename>, which
+          they never had to. Presetting the vendor directories does take it away, by removing the symlink,
+          so anything shipped pre-wired there has to be named by a preset file to survive
+          <command>preset-all --vendor</command>.</para>
+
+          <para>Units whose [Install] section has no <varname>WantedBy=</varname>,
+          <varname>RequiredBy=</varname> or <varname>UpheldBy=</varname> are not affected by any of this: a
+          dependency symlink pointing at such a unit wires it up statically rather than enabling it, so it is
+          not reported as enabled, and neither <command>disable</command> nor a preset policy will take it
+          out of the boot.</para>
+
+          <para><varname>Alias=</varname> symlinks are treated as names rather than as switches, since
+          removing one takes the name away from everything that refers to the unit by it instead of merely
+          turning the unit off. In the vendor unit directories only the names that an <literal>[Install]</literal>
+          section asks for are considered to belong to <command>systemctl</command> at all, so the
+          compatibility and slot names distributions ship there, such as
+          <filename>default.target</filename> or the <filename>runlevel*.target</filename> symlinks, are left
+          alone. Of those, only an explicit <command>disable --vendor</command> removes any; a preset policy
+          never does, just like a preset into <filename>/etc/</filename> never does. For the same reason an
+          <varname>Alias=</varname> symlink below <filename>/usr/</filename> does not by itself make a unit
+          report as <literal>enabled</literal>.</para>
+
+          <para>This option may not be combined with <option>--runtime</option>, and it is not available for
+          <option>--user</option>. Changes are always made directly by
+          <command>systemctl</command> rather than by the service manager.</para>
+
+          <xi:include href="version-info.xml" xpointer="v262"/>
         </listitem>
       </varlistentry>
 

--- a/man/systemctl.xml
+++ b/man/systemctl.xml
@@ -1037,6 +1037,14 @@ Jan 12 10:46:45 example.com bluetoothd[8900]: gatt-time-server: Input/output err
             by this command. <replaceable>UNIT</replaceable> must be the real unit name,
             any alias names are ignored silently.</para>
 
+            <para>Where the vendor already establishes the very same dependency below
+            <filename>/usr/</filename>, no symlink is written to
+            <filename>/etc/systemd/system/</filename>: presetting re-asserts a policy rather than
+            recording a decision of the administrator, so there is nothing to record. This keeps
+            <filename>/etc/</filename> empty on images built with <option>--vendor</option>. Note that
+            <command>enable</command> does not behave this way, on purpose: an explicitly enabled unit
+            should stay enabled even if a later image drops the vendor symlink.</para>
+
             <para>For more information on the preset policy format, see
             <citerefentry><refentrytitle>systemd.preset</refentrytitle><manvolnum>5</manvolnum></citerefentry>.
             </para>

--- a/man/systemctl.xml
+++ b/man/systemctl.xml
@@ -1037,8 +1037,10 @@ Jan 12 10:46:45 example.com bluetoothd[8900]: gatt-time-server: Input/output err
             by this command. <replaceable>UNIT</replaceable> must be the real unit name,
             any alias names are ignored silently.</para>
 
-            <para>Where the vendor already establishes the very same dependency below
-            <filename>/usr/</filename>, no symlink is written to
+            <para>Where the vendor already carries the very same symlink below
+            <filename>/usr/</filename>, be it a <filename>.wants/</filename>,
+            <filename>.requires/</filename> or <filename>.upholds/</filename> entry or an
+            <varname>Alias=</varname> name pointing at this unit, none is written to
             <filename>/etc/systemd/system/</filename>: presetting re-asserts a policy rather than
             recording a decision of the administrator, so there is nothing to record. This keeps
             <filename>/etc/</filename> empty on images built with <option>--vendor</option>. Note that
@@ -2764,7 +2766,10 @@ Jan 12 10:46:45 example.com bluetoothd[8900]: gatt-time-server: Input/output err
           alone. Of those, only an explicit <command>disable --vendor</command> removes any; a preset policy
           never does, just like a preset into <filename>/etc/</filename> never does. For the same reason an
           <varname>Alias=</varname> symlink below <filename>/usr/</filename> does not by itself make a unit
-          report as <literal>enabled</literal>.</para>
+          report as <literal>enabled</literal>. A unit whose <literal>[Install]</literal> section carries
+          nothing but <varname>Alias=</varname> is therefore reported as <literal>disabled</literal> once its
+          alias lives below <filename>/usr/</filename>, even though the alias is in effect and the unit is
+          reachable under it.</para>
 
           <para>This option may not be combined with <option>--runtime</option>, and it is not available for
           <option>--user</option>. Changes are always made directly by

--- a/man/systemd.preset.xml
+++ b/man/systemd.preset.xml
@@ -120,7 +120,9 @@
     <filename>/etc/systemd/system/</filename>. When building an OS image it is usually preferable to apply
     the policy to the vendor unit directory instead, with <command>systemctl preset-all --vendor</command>:
     the resulting image boots the same way, but <filename>/etc/</filename> is left empty and thus remains
-    available for the administrator. The administrator can still turn individual units off afterwards, in
+    available for the administrator. A later <command>systemctl preset-all</command> on the deployed system
+    does not undo that: where the policy and the vendor agree, no symlink is written to
+    <filename>/etc/</filename>. The administrator can still turn individual units off afterwards, in
     which case <command>systemctl disable</command> shadows the vendor symlink with a symlink to
     <filename>/dev/null</filename> in <filename>/etc/</filename>. See
     <citerefentry><refentrytitle>systemctl</refentrytitle><manvolnum>1</manvolnum></citerefentry> for

--- a/man/systemd.preset.xml
+++ b/man/systemd.preset.xml
@@ -115,6 +115,16 @@
     <filename>/dev/null</filename> in
     <filename>/etc/systemd/system-preset/</filename> bearing the same
     filename.</para>
+
+    <para>By default <command>systemctl preset</command> writes the enablement symlinks it creates to
+    <filename>/etc/systemd/system/</filename>. When building an OS image it is usually preferable to apply
+    the policy to the vendor unit directory instead, with <command>systemctl preset-all --vendor</command>:
+    the resulting image boots the same way, but <filename>/etc/</filename> is left empty and thus remains
+    available for the administrator. The administrator can still turn individual units off afterwards, in
+    which case <command>systemctl disable</command> shadows the vendor symlink with a symlink to
+    <filename>/dev/null</filename> in <filename>/etc/</filename>. See
+    <citerefentry><refentrytitle>systemctl</refentrytitle><manvolnum>1</manvolnum></citerefentry> for
+    details.</para>
   </refsect1>
 
   <refsect1>

--- a/presets/90-systemd.preset
+++ b/presets/90-systemd.preset
@@ -30,7 +30,9 @@ enable systemd-mountfsd.socket
 enable systemd-network-generator.service
 enable systemd-networkd.service
 enable systemd-networkd-wait-online.service
+enable systemd-factory-reset.socket
 enable systemd-nsresourced.socket
+enable systemd-pcrextend.socket
 enable systemd-pstore.service
 enable systemd-report-basic.socket
 enable systemd-report-cgroup.socket
@@ -39,11 +41,15 @@ enable systemd-report-sign-plain.socket
 enable systemd-report-sign-tpm2.socket
 enable systemd-report-sign-tsm.socket
 enable systemd-report.socket
+enable systemd-storage-block.socket
+enable systemd-storage-fs.socket
 enable systemd-resolved.service
 enable systemd-sysext.service
+enable systemd-sysext.socket
 enable systemd-sysupdate-notify-bootctl.socket
 enable systemd-sysupdate-notify-pcrlock.socket
 enable systemd-sysupdate-notify-sysext.socket
+enable systemd-sysupdate.socket
 enable systemd-timesyncd.service
 enable systemd-tpm2-clear.service
 enable systemd-userdbd.socket

--- a/shell-completion/bash/systemctl.in
+++ b/shell-completion/bash/systemctl.in
@@ -132,7 +132,7 @@ _systemctl () {
     local -A OPTS=(
         [STANDALONE]='--all -a --reverse --after --before --defaults --force -f --full -l --global
                       --help -h --no-ask-password --no-block --legend=no --no-pager --no-reload --no-wall --now
-                      --quiet -q --system --user --version --runtime --recursive -r --firmware-setup
+                      --quiet -q --system --user --version --runtime --vendor --recursive -r --firmware-setup
                       --show-types --plain --failed --value --fail --dry-run --wait --no-warn --with-dependencies
                       --show-transaction -T --mkdir --read-only --kernel-cmdline-reuse'
         [ARG]='--host -H --kill-whom --property -p -P --signal -s --type -t --state --job-mode --root

--- a/shell-completion/zsh/_systemctl.in
+++ b/shell-completion/zsh/_systemctl.in
@@ -551,6 +551,7 @@ _sys_arguments=(
     '(-f --force)'{-f,--force}'[When enabling unit files, override existing symlinks. When shutting down, execute action immediately]'
     '--root=[Enable/disable/mask unit files in the specified root directory]:directory:_directories'
     '--runtime[Enable/disable/mask unit files only temporarily until next reboot]'
+    '--vendor[Enable/disable/preset unit files in the vendor unit directory below /usr]'
     '(-H --host)'{-H+,--host=}'[Operate on remote host]:userathost:_sd_hosts_or_user_at_host'
     '(-M --machine)'{-M+,--machine=}'[Operate on local container]:machine:_sd_machines'
     '(-n --lines)'{-n+,--lines=}'[Journal entries to show]:number of entries'

--- a/src/core/dbus-manager.c
+++ b/src/core/dbus-manager.c
@@ -2890,12 +2890,22 @@ static int method_get_unit_file_links(sd_bus_message *message, void *userdata, s
         if (r < 0)
                 return log_error_errno(r, "Failed to get file links for %s: %m", name);
 
-        for (i = 0; i < n_changes; i++)
-                if (changes[i].type == INSTALL_CHANGE_UNLINK) {
-                        r = sd_bus_message_append(reply, "s", changes[i].path);
-                        if (r < 0)
-                                return r;
-                }
+        for (i = 0; i < n_changes; i++) {
+                const char *link;
+
+                /* For units enabled by the vendor the dry run reports the mask that would shadow the vendor
+                 * symlink. Report the vendor symlink itself, that's the one that enables the unit. */
+                if (changes[i].type == INSTALL_CHANGE_UNLINK)
+                        link = changes[i].path;
+                else if (changes[i].type == INSTALL_CHANGE_MASK_DEPENDENCY)
+                        link = changes[i].source;
+                else
+                        continue;
+
+                r = sd_bus_message_append(reply, "s", link);
+                if (r < 0)
+                        return r;
+        }
 
         r = sd_bus_message_close_container(reply);
         if (r < 0)

--- a/src/core/load-dropin.c
+++ b/src/core/load-dropin.c
@@ -42,8 +42,8 @@ static int process_deps(Unit *u, UnitDependency dependency, const char *dir_suff
 
                 if (null_or_empty_path(*p) > 0) {
                         /* an error usually means an invalid symlink, which is not a mask */
-                        log_unit_debug(u, "%s dependency on %s is masked by %s, ignoring.",
-                                       unit_dependency_to_string(dependency), entry, *p);
+                        log_unit_debug(u, "%s dependency is masked by %s, ignoring.",
+                                       unit_dependency_to_string(dependency), *p);
                         continue;
                 }
 

--- a/src/libsystemd/sd-path/path-lookup.c
+++ b/src/libsystemd/sd-path/path-lookup.c
@@ -512,7 +512,8 @@ int lookup_paths_init(
                 *generator = NULL, *generator_early = NULL, *generator_late = NULL,
                 *transient = NULL,
                 *persistent_control = NULL, *runtime_control = NULL,
-                *persistent_attached = NULL, *runtime_attached = NULL;
+                *persistent_attached = NULL, *runtime_attached = NULL,
+                *vendor_config = NULL;
         _cleanup_strv_free_ char **paths = NULL;
         int r;
 
@@ -694,6 +695,19 @@ int lookup_paths_init(
         if (r < 0)
                 return r;
 
+        /* The vendor unit directory. Only meaningful for the system and global scopes: user units have no
+         * vendor directory whose enablement PID 1 would honour the same way. */
+        if (IN_SET(scope, RUNTIME_SCOPE_SYSTEM, RUNTIME_SCOPE_GLOBAL)) {
+                vendor_config = strdup(scope == RUNTIME_SCOPE_SYSTEM ? SYSTEM_DATA_UNIT_DIR
+                                                                     : USER_DATA_UNIT_DIR);
+                if (!vendor_config)
+                        return -ENOMEM;
+
+                r = patch_root_prefix(&vendor_config, root);
+                if (r < 0)
+                        return r;
+        }
+
         r = patch_root_prefix_strv(paths, root);
         if (r < 0)
                 return -ENOMEM;
@@ -715,6 +729,8 @@ int lookup_paths_init(
 
                 .persistent_attached = TAKE_PTR(persistent_attached),
                 .runtime_attached = TAKE_PTR(runtime_attached),
+
+                .vendor_config = TAKE_PTR(vendor_config),
 
                 .root_dir = TAKE_PTR(root),
                 .temporary_dir = TAKE_PTR(tempdir),
@@ -743,6 +759,8 @@ void lookup_paths_done(LookupPaths *lp) {
 
         lp->persistent_attached = mfree(lp->persistent_attached);
         lp->runtime_attached = mfree(lp->runtime_attached);
+
+        lp->vendor_config = mfree(lp->vendor_config);
 
         lp->generator = mfree(lp->generator);
         lp->generator_early = mfree(lp->generator_early);

--- a/src/libsystemd/sd-path/path-lookup.h
+++ b/src/libsystemd/sd-path/path-lookup.h
@@ -26,6 +26,10 @@ typedef struct LookupPaths {
         char *persistent_attached;
         char *runtime_attached;
 
+        /* Where the vendor ships its units, and where "systemctl preset --vendor" places the enablement
+         * symlinks that are meant to travel with the image rather than with /etc/. */
+        char *vendor_config;
+
         /* Where to place generated unit files (i.e. those a "generator" tool generated). Note the special semantics of
          * this directory: the generators are flushed each time a "systemctl daemon-reload" is issued. The user should
          * not alter these directories directly. */

--- a/src/shared/install.c
+++ b/src/shared/install.c
@@ -3688,7 +3688,12 @@ int unit_file_preset(
                 InstallChange **changes,
                 size_t *n_changes) {
 
-        _cleanup_(install_context_done) InstallContext plus = {}, minus = {};
+        _cleanup_(install_context_done) InstallContext plus = {
+                .scope = scope,
+        };
+        _cleanup_(install_context_done) InstallContext minus = {
+                .scope = scope,
+        };
         _cleanup_(lookup_paths_done) LookupPaths lp = {};
         _cleanup_(unit_file_presets_done) UnitFilePresets presets = {};
         const char *config_path;
@@ -3727,7 +3732,12 @@ int unit_file_preset_all(
                 InstallChange **changes,
                 size_t *n_changes) {
 
-        _cleanup_(install_context_done) InstallContext plus = {}, minus = {};
+        _cleanup_(install_context_done) InstallContext plus = {
+                .scope = scope,
+        };
+        _cleanup_(install_context_done) InstallContext minus = {
+                .scope = scope,
+        };
         _cleanup_(lookup_paths_done) LookupPaths lp = {};
         _cleanup_(unit_file_presets_done) UnitFilePresets presets = {};
         const char *config_path = NULL;

--- a/src/shared/install.c
+++ b/src/shared/install.c
@@ -2741,6 +2741,53 @@ static int install_info_symlink_alias(
         return ret;
 }
 
+/* Would this dependency symlink already be there if we didn't create it? Our symlink only ever competes
+ * with the directories below config_path, anything above it wins either way. Only a vendor supplied entry
+ * counts: one in /run/ or from a generator is gone again after a reboot. */
+static int dependency_provided_below(
+                const LookupPaths *lp,
+                const char *config_path,
+                const char *rel) {
+
+        bool below = false;
+        int r;
+
+        assert(lp);
+        assert(config_path);
+        assert(rel);
+
+        STRV_FOREACH(p, lp->search_path) {
+                _cleanup_free_ char *path = NULL;
+                struct stat st;
+
+                if (!below) {
+                        below = path_equal(*p, config_path);
+                        continue;
+                }
+
+                path = path_join(*p, rel);
+                if (!path)
+                        return -ENOMEM;
+
+                if (lstat(path, &st) < 0) {
+                        if (errno == ENOENT)
+                                continue;
+                        return -errno;
+                }
+
+                /* The first entry we find decides, the ones below it are shadowed. */
+                r = dependency_is_masked(lp, path);
+                if (r < 0)
+                        return r;
+                if (r > 0)
+                        return false;
+
+                return S_ISLNK(st.st_mode) && path_is_vendor(lp, *p);
+        }
+
+        return false;
+}
+
 static int install_info_symlink_wants(
                 RuntimeScope scope,
                 UnitFileFlags file_flags,
@@ -2824,7 +2871,34 @@ static int install_info_symlink_wants(
                         continue;
                 }
 
-                path = strjoin(config_path, "/", dst, suffix, n);
+                _cleanup_free_ char *rel = strjoin(dst, suffix, n);
+                if (!rel)
+                        return -ENOMEM;
+
+                /* Applying a preset policy re-asserts what the policy says, it is not the administrator
+                 * saying they want this unit on. So if the vendor already enables it, leave the
+                 * configuration directory alone rather than filling it with copies of the vendor's own
+                 * decisions. An explicit "systemctl enable" still records itself, so that it survives the
+                 * vendor dropping the symlink later. */
+                if (FLAGS_SET(file_flags, UNIT_FILE_APPLYING_PRESET)) {
+                        q = dependency_provided_below(lp, config_path, rel);
+                        if (q < 0)
+                                return q;
+                        if (q > 0) {
+                                log_debug("Dependency %s already provided below %s, not creating it.",
+                                          rel, config_path);
+
+                                /* Still counts towards the number of symlinks that were supposed to be
+                                 * created, or a fully redundant unit would look like it had no [Install]
+                                 * section at all. */
+                                if (r >= 0)
+                                        r = 1;
+
+                                continue;
+                        }
+                }
+
+                path = path_join(config_path, rel);
                 if (!path)
                         return -ENOMEM;
 
@@ -4368,7 +4442,7 @@ static int execute_preset(
 
                 /* Returns number of symlinks that where supposed to be installed. */
                 q = install_context_apply(plus, lp,
-                                          file_flags | UNIT_FILE_IGNORE_AUXILIARY_FAILURE,
+                                          file_flags | UNIT_FILE_IGNORE_AUXILIARY_FAILURE | UNIT_FILE_APPLYING_PRESET,
                                           config_path,
                                           SEARCH_LOAD, changes, n_changes);
                 if (r >= 0) {

--- a/src/shared/install.c
+++ b/src/shared/install.c
@@ -59,13 +59,21 @@ static const char *const preset_action_past_tense_table[_PRESET_ACTION_MAX] = {
 
 DEFINE_STRING_TABLE_LOOKUP_TO_STRING(preset_action_past_tense, PresetAction);
 
+/* Whether enabling this unit would create .wants/, .requires/ or .upholds/ symlinks for it. Alias= names a
+ * unit file and Also= names other units, so neither does. A dependency symlink pointing at a unit that asks
+ * for none is static wiring done by whoever shipped it rather than enablement, and must be left alone. */
+static bool install_info_has_dependency_rules(const InstallInfo *i) {
+        assert(i);
+
+        return !strv_isempty(i->wanted_by) ||
+               !strv_isempty(i->required_by) ||
+               !strv_isempty(i->upheld_by);
+}
+
 static bool install_info_has_rules(const InstallInfo *i) {
         assert(i);
 
-        return !strv_isempty(i->aliases) ||
-               !strv_isempty(i->wanted_by) ||
-               !strv_isempty(i->required_by) ||
-               !strv_isempty(i->upheld_by);
+        return !strv_isempty(i->aliases) || install_info_has_dependency_rules(i);
 }
 
 static bool install_info_has_also(const InstallInfo *i) {
@@ -249,7 +257,10 @@ static int path_is_runtime(const LookupPaths *lp, const char *path, bool check_p
                            lp->runtime_control);
 }
 
-static int path_is_vendor_or_generator(const LookupPaths *lp, const char *path) {
+/* Unit directories below /usr/, i.e. the ones holding vendor supplied units and vendor supplied enablement.
+ * PID 1 acts on dependency symlinks in these just like on the ones in /etc/, but they are off limits when we
+ * enable or disable a unit on behalf of the administrator. */
+static bool path_is_vendor(const LookupPaths *lp, const char *path) {
         const char *rpath;
 
         assert(lp);
@@ -257,23 +268,117 @@ static int path_is_vendor_or_generator(const LookupPaths *lp, const char *path) 
 
         rpath = skip_root(lp->root_dir, path);
         if (!rpath)
-                return 0;
+                return false;
 
         if (path_startswith(rpath, "/usr"))
                 return true;
 
-        /* Not rpath: the generator directories are root prefixed, so stripping the root here would keep
-         * this from ever matching under --root=. */
-        if (path_is_generator(lp, path))
+        return PATH_IN_SET(rpath, SYSTEM_DATA_UNIT_DIR, USER_DATA_UNIT_DIR);
+}
+
+static int path_is_vendor_or_generator(const LookupPaths *lp, const char *path) {
+        assert(lp);
+        assert(path);
+
+        if (!skip_root(lp->root_dir, path))
+                return 0;
+
+        if (path_is_vendor(lp, path))
                 return true;
 
-        return path_equal(rpath, SYSTEM_DATA_UNIT_DIR);
+        /* Not root stripped: the generator directories are root prefixed, so stripping here would keep them
+         * from ever matching under --root=. Returned rather than used as an operand, so that the negative
+         * errno it can hand back reaches the caller instead of coercing to "true". */
+        return path_is_generator(lp, path);
+}
+
+static bool is_dependency_dir_name(const char *name) {
+        assert(name);
+
+        return ENDSWITH_SET(name, ".wants", ".requires", ".upholds");
+}
+
+/* Does 'set' name the unit this symlink stands for? Callers pass whatever they have resolved so far, hence
+ * the nullable arguments: 'template' for an instance of a template, 'dest'/'dest_name' for what the symlink
+ * chases to. */
+static bool set_contains_symlink(
+                Set *set,
+                const char *name,
+                const char *template,
+                const char *dest,
+                const char *dest_name) {
+
+        assert(name);
+
+        return set_contains(set, name) ||
+               (template && set_contains(set, template)) ||
+               (dest && set_contains(set, dest)) ||
+               (dest_name && set_contains(set, dest_name));
+}
+
+/* Everything in /etc/ that points at a unit got there by enabling it, so disabling is free to take all of it
+ * away again. A vendor directory is not ours in that way: distributions ship default.target, the runlevel
+ * targets and all sorts of compatibility names below /usr/ that no [Install] section ever asked for, and
+ * removing those would break the image. install_context_mark_for_removal() therefore works out what is in
+ * fact ours before remove_marked_symlinks() goes looking. */
+typedef struct VendorSymlinks {
+        bool active;       /* Are we removing from a vendor directory at all? */
+        Set *static_units; /* Units that ask for no dependency symlinks: theirs are wiring, not enablement. */
+        Set *own_names;    /* Top level names an [Install] section asks for, i.e. the ones enabling creates. */
+} VendorSymlinks;
+
+static void vendor_symlinks_done(VendorSymlinks *v) {
+        assert(v);
+
+        v->static_units = set_free(v->static_units);
+        v->own_names = set_free(v->own_names);
+}
+
+static int path_is_dependency_dir(const char *path) {
+        _cleanup_free_ char *name = NULL;
+        int r;
+
+        assert(path);
+
+        r = path_extract_filename(path, &name);
+        if (r < 0)
+                return r;
+
+        return is_dependency_dir_name(name);
+}
+
+/* Mirrors what PID 1 does in process_deps(): a .wants/, .requires/ or .upholds/ entry that resolves to
+ * /dev/null, or to an empty file, masks the dependency rather than establishing it. Resolve inside the root,
+ * since an image being operated on offline usually has no /dev/null to stat. */
+static int dependency_is_masked(const LookupPaths *lp, const char *path) {
+        _cleanup_free_ char *resolved = NULL;
+        struct stat st;
+        int r;
+
+        assert(lp);
+        assert(path);
+
+        r = chase(path, lp->root_dir, CHASE_NONEXISTENT, &resolved, NULL);
+        if (r == -ENOENT)
+                return false;
+        if (r < 0)
+                return r;
+
+        if (path_equal(skip_root(lp->root_dir, resolved) ?: resolved, "/dev/null"))
+                return true;
+
+        if (stat(resolved, &st) < 0)
+                return errno == ENOENT ? false : -errno;
+
+        return null_or_empty(&st);
 }
 
 static const char* config_path_from_flags(const LookupPaths *lp, UnitFileFlags flags) {
         assert(lp);
 
-        if (FLAGS_SET(flags, UNIT_FILE_PORTABLE))
+        if (FLAGS_SET(flags, UNIT_FILE_VENDOR))
+                return lp->vendor_config;
+        else if (FLAGS_SET(flags, UNIT_FILE_PORTABLE))
                 return FLAGS_SET(flags, UNIT_FILE_RUNTIME) ? lp->runtime_attached : lp->persistent_attached;
         else
                 return FLAGS_SET(flags, UNIT_FILE_RUNTIME) ? lp->runtime_config : lp->persistent_config;
@@ -342,6 +447,12 @@ static void install_change_dump_success(const InstallChange *change) {
 
         case INSTALL_CHANGE_UNLINK:
                 return log_info("Removed '%s'.", change->path);
+
+        case INSTALL_CHANGE_MASK_DEPENDENCY:
+                return log_info("Masked dependency '%s'.", change->path);
+
+        case INSTALL_CHANGE_UNMASK_DEPENDENCY:
+                return log_info("Unmasked dependency '%s'.", change->path);
 
         case INSTALL_CHANGE_IS_MASKED:
                 return log_info("Unit %s is masked, ignoring.", change->path);
@@ -668,6 +779,7 @@ static int mark_symlink_for_removal(
 
 static int remove_marked_symlinks_fd(
                 Set *remove_symlinks_to,
+                const VendorSymlinks *vendor,
                 int fd,
                 const char *path,
                 const char *config_path,
@@ -713,6 +825,7 @@ static int remove_marked_symlinks_fd(
 
                         /* This will close nfd, regardless whether it succeeds or not */
                         RET_GATHER(ret, remove_marked_symlinks_fd(remove_symlinks_to,
+                                                                  vendor,
                                                                   TAKE_FD(nfd), p,
                                                                   config_path, lp,
                                                                   dry_run,
@@ -735,21 +848,15 @@ static int remove_marked_symlinks_fd(
                          * files sharing the same name as a file that is marked, and files sharing the same
                          * name after the instance has been removed. Do path chasing only if we don't already
                          * know that we want to remove the symlink. */
-                        found = set_contains(remove_symlinks_to, de->d_name);
+                        _cleanup_free_ char *template = NULL, *dest = NULL, *dest_name = NULL;
+
+                        r = unit_name_template(de->d_name, &template);
+                        if (r < 0 && r != -EINVAL)
+                                return r;
+
+                        found = set_contains_symlink(remove_symlinks_to, de->d_name, template, NULL, NULL);
 
                         if (!found) {
-                                _cleanup_free_ char *template = NULL;
-
-                                r = unit_name_template(de->d_name, &template);
-                                if (r < 0 && r != -EINVAL)
-                                        return r;
-                                if (r >= 0)
-                                        found = set_contains(remove_symlinks_to, template);
-                        }
-
-                        if (!found) {
-                                _cleanup_free_ char *dest = NULL, *dest_name = NULL;
-
                                 r = chase(p, lp->root_dir, CHASE_NONEXISTENT, &dest, NULL);
                                 if (r == -ENOENT)
                                         continue;
@@ -763,12 +870,40 @@ static int remove_marked_symlinks_fd(
                                 if (r < 0)
                                         return r;
 
-                                found = set_contains(remove_symlinks_to, dest) ||
-                                        set_contains(remove_symlinks_to, dest_name);
+                                found = set_contains_symlink(remove_symlinks_to, de->d_name, template,
+                                                             dest, dest_name);
                         }
 
                         if (!found)
                                 continue;
+
+                        r = path_is_dependency_dir(path);
+                        if (r < 0)
+                                return r;
+                        if (r > 0) {
+                                /* Leave dependency masks alone. They are how a unit that the vendor enabled
+                                 * below /usr/ is disabled, so dropping them here would silently re-enable it. */
+                                r = dependency_is_masked(lp, p);
+                                if (r < 0)
+                                        log_debug_errno(r, "Failed to check if '%s' is a dependency mask, "
+                                                           "assuming it isn't: %m", p);
+                                else if (r > 0)
+                                        continue;
+
+                                /* And leave static wiring in the vendor directories alone. Match the same way
+                                 * as above, or an instance of a protected template would slip through. */
+                                if (vendor && set_contains_symlink(vendor->static_units, de->d_name, template,
+                                                                   /* dest= */ NULL, dest_name))
+                                        continue;
+
+                        } else if (vendor) {
+                                /* At the top level of a vendor directory only the names some [Install]
+                                 * section asks for are ours. Match on the name the symlink carries, not on
+                                 * what it points at: the whole point of an alias is that the two differ. */
+                                if (!set_contains_symlink(vendor->own_names, de->d_name, template,
+                                                          /* dest= */ NULL, /* dest_name= */ NULL))
+                                        continue;
+                        }
 
                         if (!dry_run) {
                                 if (unlinkat(fd, de->d_name, 0) < 0 && errno != ENOENT) {
@@ -799,6 +934,7 @@ static int remove_marked_symlinks_fd(
 
 static int remove_marked_symlinks(
                 Set *remove_symlinks_to,
+                const VendorSymlinks *vendor,
                 const char *config_path,
                 const LookupPaths *lp,
                 bool dry_run,
@@ -815,6 +951,10 @@ static int remove_marked_symlinks(
         if (set_isempty(remove_symlinks_to))
                 return 0;
 
+        /* Below, a non-NULL 'vendor' is what says we are in a vendor directory at all. */
+        if (vendor && !vendor->active)
+                vendor = NULL;
+
         fd = open(config_path, O_RDONLY|O_NONBLOCK|O_DIRECTORY|O_CLOEXEC);
         if (fd < 0)
                 return errno == ENOENT ? 0 : -errno;
@@ -829,6 +969,7 @@ static int remove_marked_symlinks(
 
                 /* This takes possession of cfd and closes it */
                 RET_GATHER(r, remove_marked_symlinks_fd(remove_symlinks_to,
+                                                        vendor,
                                                         cfd, config_path,
                                                         config_path, lp,
                                                         dry_run,
@@ -867,15 +1008,269 @@ static int is_symlink_with_known_name(const InstallInfo *i, const char *name) {
         return false;
 }
 
+/* Does a dependency symlink of this name enable 'info'? Covers what install_info_symlink_wants() creates.
+ * Deliberately not Alias=: those never name a dependency symlink, only a unit file. Note that
+ * remove_marked_symlinks_fd() casts a slightly wider net, as it also matches on the chased destination. */
+static int dependency_name_matches(const InstallInfo *info, const char *name) {
+        _cleanup_free_ char *template = NULL;
+        int r;
+
+        assert(info);
+        assert(name);
+
+        if (streq(name, info->name))
+                return true;
+
+        /* Covers DefaultInstance= too: that is just one particular instance of the template. */
+        r = unit_name_template(name, &template);
+        if (r == -EINVAL)
+                return false;
+        if (r < 0)
+                return r;
+
+        return streq(template, info->name);
+}
+
+/* Key identifying a dependency symlink for shadowing, i.e. "multi-user.target.wants/foo.service". PID 1
+ * resolves these through conf_files_list_strv(), which lets an entry in a higher priority directory override
+ * one with the same name further down the search path. */
+static int dependency_shadow_key(const char *path, char **ret) {
+        _cleanup_free_ char *dir_path = NULL, *dir_name = NULL, *name = NULL, *key = NULL;
+        int r;
+
+        assert(path);
+        assert(ret);
+
+        r = path_extract_filename(path, &name);
+        if (r < 0)
+                return r;
+
+        r = path_extract_directory(path, &dir_path);
+        if (r < 0)
+                return r;
+
+        r = path_extract_filename(dir_path, &dir_name);
+        if (r < 0)
+                return r;
+
+        key = path_join(dir_name, name);
+        if (!key)
+                return -ENOMEM;
+
+        *ret = TAKE_PTR(key);
+        return 0;
+}
+
+static int dependency_symlinks_list(const char *path, char ***ret) {
+        _cleanup_strv_free_ char **l = NULL;
+        _cleanup_closedir_ DIR *dir = NULL;
+        int r;
+
+        assert(path);
+        assert(ret);
+
+        dir = opendir(path);
+        if (!dir) {
+                if (IN_SET(errno, ENOENT, ENOTDIR, EACCES)) {
+                        *ret = NULL;
+                        return 0;
+                }
+                return -errno;
+        }
+
+        FOREACH_DIRENT(de, dir, return -errno) {
+                _cleanup_closedir_ DIR *sub = NULL;
+                _cleanup_free_ char *dir_path = NULL;
+
+                if (de->d_type != DT_DIR)
+                        continue;
+
+                if (!is_dependency_dir_name(de->d_name))
+                        continue;
+
+                sub = xopendirat(dirfd(dir), de->d_name, /* flags= */ 0);
+                if (!sub) {
+                        if (IN_SET(errno, ENOENT, ENOTDIR, EACCES))
+                                continue;
+                        return -errno;
+                }
+
+                dir_path = path_join(path, de->d_name);
+                if (!dir_path)
+                        return -ENOMEM;
+
+                FOREACH_DIRENT(sde, sub, return -errno) {
+                        _cleanup_free_ char *p = NULL;
+
+                        /* Not just symlinks: an entry of any kind shadows the ones of the same name below
+                         * it, and an empty file masks the dependency outright. Callers sort out which is
+                         * which. */
+                        if (!unit_name_is_valid(sde->d_name, UNIT_NAME_ANY))
+                                continue;
+
+                        p = path_join(dir_path, sde->d_name);
+                        if (!p)
+                                return -ENOMEM;
+
+                        r = strv_consume(&l, TAKE_PTR(p));
+                        if (r < 0)
+                                return r;
+                }
+        }
+
+        /* Sorted, so that the reported changes come out in a stable order rather than in readdir order. */
+        strv_sort(l);
+
+        *ret = TAKE_PTR(l);
+        return 0;
+}
+
+/* Collects every dependency symlink in the vendor unit directories, keyed by shadow key. Built once per
+ * operation: "systemctl preset-all" would otherwise rescan /usr/ hundreds of times. */
+static int collect_vendor_dependency_symlinks(const LookupPaths *lp, OrderedHashmap **ret) {
+        _cleanup_ordered_hashmap_free_ OrderedHashmap *found = NULL;
+        _cleanup_set_free_ Set *masked = NULL;
+        int r;
+
+        assert(lp);
+        assert(ret);
+
+        STRV_FOREACH(p, lp->search_path) {
+                _cleanup_strv_free_ char **symlinks = NULL;
+
+                if (!path_is_vendor(lp, *p))
+                        continue;
+
+                r = dependency_symlinks_list(*p, &symlinks);
+                if (r < 0)
+                        return r;
+
+                STRV_FOREACH(symlink, symlinks) {
+                        _cleanup_free_ char *key = NULL;
+
+                        r = dependency_shadow_key(*symlink, &key);
+                        if (r < 0)
+                                return r;
+
+                        /* Directories are visited in order of descending priority, so whatever we recorded
+                         * first is the entry PID 1 acts on. */
+                        if (set_contains(masked, key) || ordered_hashmap_contains(found, key))
+                                continue;
+
+                        r = dependency_is_masked(lp, *symlink);
+                        if (r < 0) {
+                                log_debug_errno(r, "Failed to check if '%s' masks a dependency, ignoring: %m",
+                                                *symlink);
+                                continue;
+                        }
+                        /* Only a symlink that isn't a mask establishes the dependency, but anything of
+                         * that name shadows the entries below it either way. */
+                        if (r > 0 || is_symlink(*symlink) <= 0) {
+                                r = set_ensure_consume(&masked, &path_hash_ops_free, TAKE_PTR(key));
+                                if (r < 0)
+                                        return r;
+
+                                continue;
+                        }
+
+                        _cleanup_free_ char *path = strdup(*symlink);
+                        if (!path)
+                                return -ENOMEM;
+
+                        r = ordered_hashmap_ensure_put(&found, &path_hash_ops_free_free, key, path);
+                        if (r < 0)
+                                return r;
+
+                        TAKE_PTR(key);
+                        TAKE_PTR(path);
+                }
+        }
+
+        *ret = TAKE_PTR(found);
+        return 0;
+}
+
+/* Enablement that lives in the vendor unit directories cannot be removed on behalf of the administrator:
+ * /usr/ is frequently read-only, and anything we did there would be undone by the next image update. Shadow
+ * it with a symlink to /dev/null instead, which is what PID 1 looks for when deciding to ignore a dependency
+ * symlink. */
+static int install_info_mask_dependencies(
+                const InstallInfo *info,
+                OrderedHashmap *vendor_symlinks,
+                const LookupPaths *lp,
+                const char *config_path,
+                bool dry_run,
+                InstallChange **changes,
+                size_t *n_changes) {
+
+        const char *key, *vendor_path;
+        int r, ret = 0;
+
+        assert(info);
+        assert(lp);
+        assert(config_path);
+
+        ORDERED_HASHMAP_FOREACH_KEY(vendor_path, key, vendor_symlinks) {
+                _cleanup_free_ char *entry = NULL, *path = NULL;
+
+                r = path_extract_filename(key, &entry);
+                if (r < 0)
+                        return r;
+
+                r = dependency_name_matches(info, entry);
+                if (r < 0)
+                        return r;
+                if (r == 0)
+                        continue;
+
+                path = path_join(config_path, key);
+                if (!path)
+                        return -ENOMEM;
+
+                /* A non-symlink sitting here already shadows the vendor symlink, and PID 1 ignores it for
+                 * not being one, so the unit is off either way. Replacing it would fail on a directory and
+                 * destroy whatever it is otherwise. */
+                r = is_symlink(path);
+                if (r == 0)
+                        continue;
+                if (r < 0 && r != -ENOENT)
+                        log_debug_errno(r, "Failed to look at '%s', assuming it can be masked: %m", path);
+
+                /* Leave an existing mask alone too, so that disabling twice stays quiet. */
+                r = dependency_is_masked(lp, path);
+                if (r < 0)
+                        log_debug_errno(r, "Failed to check if '%s' is already a mask, assuming it isn't: %m",
+                                        path);
+                else if (r > 0)
+                        continue;
+
+                if (!dry_run) {
+                        (void) mkdir_parents_label(path, 0755);
+
+                        r = symlink_atomic("/dev/null", path);
+                        if (r < 0) {
+                                RET_GATHER(ret, install_changes_add(changes, n_changes, r, path, NULL));
+                                continue;
+                        }
+                }
+
+                RET_GATHER(ret, install_changes_add(changes, n_changes,
+                                                    INSTALL_CHANGE_MASK_DEPENDENCY, path, vendor_path));
+        }
+
+        return ret;
+}
+
 static int find_symlinks_in_directory(
                 DIR *dir,
                 const char *dir_path,
-                const char *root_dir,
+                const LookupPaths *lp,
                 const InstallInfo *info,
                 bool ignore_destination,
                 bool match_name,
                 bool ignore_same_name,
                 const char *config_path,
+                Set **shadowed,
                 bool *same_name_link) {
 
         int r, ret = 0;
@@ -885,12 +1280,27 @@ static int find_symlinks_in_directory(
         assert(info);
         assert(unit_name_is_valid(info->name, UNIT_NAME_ANY));
         assert(config_path);
+        assert(shadowed);
         assert(same_name_link);
 
         FOREACH_DIRENT(de, dir, return -errno) {
                 bool found_path = false, found_dest = false, b = false;
 
-                if (de->d_type != DT_LNK)
+                /* Everything below turns on the type, and readdir() does not know it on every filesystem,
+                 * so resolve it rather than take DT_UNKNOWN for "not a symlink". The masking side settles
+                 * the same question with an lstat(), see collect_vendor_dependency_symlinks(), and the two
+                 * have to agree on what enables a unit. */
+                r = dirent_ensure_type(dirfd(dir), de);
+                if (r < 0) {
+                        if (r != -ENOENT)
+                                RET_GATHER(ret, r);
+                        continue;
+                }
+
+                /* In a dependency directory anything of the right name shadows the entries below it, see
+                 * conf_files_list_strv(), whether or not PID 1 then honours it. So look at all of them,
+                 * not just at symlinks. Everywhere else only symlinks are of interest. */
+                if (!ignore_destination && de->d_type != DT_LNK)
                         continue;
 
                 if (!ignore_destination) {
@@ -944,6 +1354,38 @@ static int find_symlinks_in_directory(
                 if (b)
                         *same_name_link = true;
                 else if (found_path || found_dest) {
+                        if (ignore_destination) {
+                                _cleanup_free_ char *key = NULL, *path = NULL;
+
+                                path = path_join(dir_path, de->d_name);
+                                if (!path)
+                                        return -ENOMEM;
+
+                                r = dependency_shadow_key(path, &key);
+                                if (r < 0)
+                                        return r;
+
+                                if (set_contains(*shadowed, key))
+                                        continue;
+
+                                r = dependency_is_masked(lp, path);
+                                if (r < 0) {
+                                        log_debug_errno(r, "Failed to check if '%s' masks a dependency, "
+                                                           "ignoring: %m", path);
+                                        continue;
+                                }
+
+                                /* Only a symlink that isn't a mask establishes the dependency. Anything
+                                 * else PID 1 ignores, but it still shadows what is below, so remember it. */
+                                if (r > 0 || de->d_type != DT_LNK) {
+                                        r = set_ensure_consume(shadowed, &path_hash_ops_free, TAKE_PTR(key));
+                                        if (r < 0)
+                                                return r;
+
+                                        continue;
+                                }
+                        }
+
                         if (!match_name)
                                 return 1;
 
@@ -958,57 +1400,64 @@ static int find_symlinks_in_directory(
 }
 
 static int find_symlinks(
-                const char *root_dir,
+                const LookupPaths *lp,
                 const InstallInfo *i,
                 bool match_name,
                 bool ignore_same_name,
                 const char *config_path,
-                bool *same_name_link) {
+                Set **shadowed,
+                bool *same_name_link,
+                bool *ret_dependency) {
 
         _cleanup_closedir_ DIR *config_dir = NULL;
         int r;
 
         assert(i);
         assert(config_path);
+        assert(shadowed);
+        assert(ret_dependency);
         assert(same_name_link);
 
         config_dir = opendir(config_path);
         if (!config_dir) {
-                if (IN_SET(errno, ENOENT, ENOTDIR, EACCES))
+                if (IN_SET(errno, ENOENT, ENOTDIR, EACCES)) {
+                        *ret_dependency = false;
                         return 0;
+                }
                 return -errno;
         }
 
         FOREACH_DIRENT(de, config_dir, return -errno) {
-                const char *suffix;
                 _cleanup_free_ const char *path = NULL;
                 _cleanup_closedir_ DIR *d = NULL;
 
                 if (de->d_type != DT_DIR)
                         continue;
 
-                suffix = strrchr(de->d_name, '.');
-                if (!STRPTR_IN_SET(suffix, ".wants", ".requires", ".upholds"))
+                if (!is_dependency_dir_name(de->d_name))
                         continue;
 
                 path = path_join(config_path, de->d_name);
                 if (!path)
                         return -ENOMEM;
 
-                d = opendir(path);
+                d = xopendirat(dirfd(config_dir), de->d_name, /* flags= */ 0);
                 if (!d) {
                         log_error_errno(errno, "Failed to open directory \"%s\" while scanning for symlinks, ignoring: %m", path);
                         continue;
                 }
 
-                r = find_symlinks_in_directory(d, path, root_dir, i,
+                r = find_symlinks_in_directory(d, path, lp, i,
                                                /* ignore_destination= */ true,
                                                /* match_name= */ match_name,
                                                /* ignore_same_name= */ ignore_same_name,
                                                config_path,
+                                               shadowed,
                                                same_name_link);
-                if (r > 0)
+                if (r > 0) {
+                        *ret_dependency = true;
                         return 1;
+                }
                 if (r < 0)
                         log_debug_errno(r, "Failed to look up symlinks in \"%s\": %m", path);
         }
@@ -1016,12 +1465,18 @@ static int find_symlinks(
         /* We didn't find any suitable symlinks in .wants, .requires or .upholds directories,
          * let's look for linked unit files in this directory. */
         rewinddir(config_dir);
-        return find_symlinks_in_directory(config_dir, config_path, root_dir, i,
-                                          /* ignore_destination= */ false,
-                                          /* match_name= */ match_name,
-                                          /* ignore_same_name= */ ignore_same_name,
-                                          config_path,
-                                          same_name_link);
+        r = find_symlinks_in_directory(config_dir, config_path, lp, i,
+                                       /* ignore_destination= */ false,
+                                       /* match_name= */ match_name,
+                                       /* ignore_same_name= */ ignore_same_name,
+                                       config_path,
+                                       shadowed,
+                                       same_name_link);
+        if (r < 0)
+                return r;
+
+        *ret_dependency = false;
+        return r;
 }
 
 static int find_symlinks_in_scope(
@@ -1032,8 +1487,9 @@ static int find_symlinks_in_scope(
                 UnitFileState *state) {
 
         bool same_name_link_runtime = false, same_name_link_config = false;
-        bool enabled_in_runtime = false, enabled_at_all = false;
+        bool enabled_in_runtime = false, enabled_at_all = false, aliased_at_all = false;
         bool ignore_same_name = false;
+        _cleanup_set_free_ Set *shadowed = NULL;
         int r;
 
         assert(lp);
@@ -1042,12 +1498,17 @@ static int find_symlinks_in_scope(
 
         /* As we iterate over the list of search paths in lp->search_path, we may encounter "same name"
          * symlinks. The ones which are "below" (i.e. have lower priority) than the unit file itself are
-         * effectively masked, so we should ignore them. */
+         * effectively masked, so we should ignore them.
+         *
+         * The same applies to dependency symlinks: an entry in a .wants/, .requires/ or .upholds/ directory
+         * shadows one of the same name further down the search path, and if it is a symlink to /dev/null it
+         * masks it outright. 'shadowed' accumulates the latter as we descend. */
 
         STRV_FOREACH(p, lp->search_path)  {
-                bool same_name_link = false;
+                bool same_name_link = false, dependency = false;
 
-                r = find_symlinks(lp->root_dir, info, match_name, ignore_same_name, *p, &same_name_link);
+                r = find_symlinks(lp, info, match_name, ignore_same_name, *p,
+                                  &shadowed, &same_name_link, &dependency);
                 if (r < 0)
                         return r;
                 if (r > 0) {
@@ -1070,8 +1531,20 @@ static int find_symlinks_in_scope(
                                 return r;
                         if (r > 0)
                                 enabled_in_runtime = true;
-                        else
+                        else if (dependency && path_is_vendor(lp, *p) && install_info_has_dependency_rules(info))
+                                /* A .wants/, .requires/ or .upholds/ symlink shipped by the vendor below
+                                 * /usr/. PID 1 acts on these just like on the ones in /etc/, so the unit is
+                                 * enabled, and it stays overridable from /etc/.
+                                 *
+                                 * Only for units that ask for such symlinks though: for anything else the
+                                 * vendor is wiring the unit up statically, and reporting that as "enabled"
+                                 * would suggest it can be disabled again. */
                                 enabled_at_all = true;
+                        else
+                                /* Either not a dependency symlink but one carrying a different name for the
+                                 * same unit, i.e. an alias, or a symlink in one of the remaining directories
+                                 * such as the one portable services are attached to. Much weaker, see below. */
+                                aliased_at_all = true;
 
                 } else if (same_name_link) {
                         if (path_equal(*p, lp->persistent_config))
@@ -1096,11 +1569,19 @@ static int find_symlinks_in_scope(
                 return 1;
         }
 
+        /* Enabled by the vendor rather than by the administrator. Report it as plain "enabled": that is what
+         * it behaves like, and it remains overridable from /etc/, either by removing the dependency symlink
+         * that shadows the vendor one or by masking it with a symlink to /dev/null. */
+        if (enabled_at_all) {
+                *state = UNIT_FILE_ENABLED;
+                return 1;
+        }
+
         /* Here's a special rule: if the unit we are looking for is an instance, and it symlinked in the search path
          * outside of runtime and configuration directory, then we consider it statically enabled. Note we do that only
          * for instance, not for regular names, as those are merely aliases, while instances explicitly instantiate
          * something, and hence are a much stronger concept. */
-        if (enabled_at_all && unit_name_is_valid(info->name, UNIT_NAME_INSTANCE)) {
+        if (aliased_at_all && unit_name_is_valid(info->name, UNIT_NAME_INSTANCE)) {
                 *state = UNIT_FILE_STATIC;
                 return 1;
         }
@@ -1833,6 +2314,234 @@ static int install_info_discover(
         return r;
 }
 
+/* The [Install] section drives all of this, but the removal side of preset discovers its units without
+ * SEARCH_LOAD. Load into the caller's throwaway context rather than in place: doing it in place would make
+ * Also= drag sibling units into the removal set, past the point where their own preset policy is
+ * consulted. */
+static int install_info_load_rules(
+                InstallContext *ctx,
+                const LookupPaths *lp,
+                InstallInfo *info,
+                InstallInfo **ret) {
+
+        assert(ctx);
+        assert(lp);
+        assert(info);
+        assert(ret);
+
+        if (install_info_has_rules(info)) {
+                *ret = info;
+                return 0;
+        }
+
+        return install_info_discover(ctx, lp, info->name, SEARCH_LOAD|SEARCH_FOLLOW_CONFIG_SYMLINKS,
+                                     ret, /* changes= */ NULL, /* n_changes= */ NULL);
+}
+
+static int install_info_check_dependency_rules(
+                RuntimeScope scope,
+                const LookupPaths *lp,
+                InstallInfo *info) {
+
+        _cleanup_(install_context_done) InstallContext ctx = { .scope = scope };
+        InstallInfo *loaded;
+        int r;
+
+        assert(lp);
+        assert(info);
+
+        r = install_info_load_rules(&ctx, lp, info, &loaded);
+        if (r < 0)
+                return r;
+
+        return install_info_has_dependency_rules(loaded);
+}
+
+static int install_info_collect_vendor_symlinks(
+                RuntimeScope scope,
+                const LookupPaths *lp,
+                InstallInfo *info,
+                UnitFileFlags file_flags,
+                VendorSymlinks *vendor) {
+
+        _cleanup_(install_context_done) InstallContext ctx = { .scope = scope };
+        InstallInfo *loaded;
+        int r;
+
+        assert(lp);
+        assert(info);
+        assert(vendor);
+
+        r = install_info_load_rules(&ctx, lp, info, &loaded);
+        if (r < 0)
+                return r;
+
+        if (!install_info_has_dependency_rules(loaded)) {
+                r = set_put_strdup(&vendor->static_units, loaded->name);
+                if (r < 0)
+                        return r;
+        }
+
+        /* An Alias= symlink is a name in the unit namespace rather than a switch: taking it away does not
+         * turn the unit off, it takes the name away from everything that refers to the unit by it. Removing
+         * it is therefore something only an explicit disable gets to do. A preset applies a policy, and the
+         * policy is satisfied by dropping the dependency symlinks above, so leave the vendor's names in
+         * place, exactly as a preset into /etc/ would. */
+        if (FLAGS_SET(file_flags, UNIT_FILE_APPLYING_PRESET))
+                return 0;
+
+        /* install_info_symlink_link() puts a unit file that lives outside the search path here under its own
+         * name, so that one is ours as well. */
+        if (loaded->path) {
+                r = in_search_path(lp, loaded->path);
+                if (r < 0)
+                        return r;
+                if (r == 0) {
+                        r = set_put_strdup(&vendor->own_names, loaded->name);
+                        if (r < 0)
+                                return r;
+                }
+        }
+
+        STRV_FOREACH(a, loaded->aliases) {
+                _cleanup_free_ char *dst = NULL;
+
+                r = install_name_printf(scope, loaded, *a, &dst);
+                if (r < 0)
+                        return r;
+
+                r = set_put_strdup(&vendor->own_names, dst);
+                if (r < 0)
+                        return r;
+        }
+
+        return 0;
+}
+
+static int install_context_mask_dependencies(
+                InstallContext *ctx,
+                const LookupPaths *lp,
+                const char *config_path,
+                bool dry_run,
+                InstallChange **changes,
+                size_t *n_changes) {
+
+        _cleanup_ordered_hashmap_free_ OrderedHashmap *vendor_symlinks = NULL;
+        InstallInfo *i;
+        int r, ret = 0;
+
+        assert(ctx);
+        assert(lp);
+        assert(config_path);
+
+        /* Operating on the vendor directories themselves? Then there is nothing below them to mask, the
+         * symlinks are simply removed. */
+        if (path_is_vendor(lp, config_path))
+                return 0;
+
+        if (ordered_hashmap_isempty(ctx->have_processed))
+                return 0;
+
+        r = collect_vendor_dependency_symlinks(lp, &vendor_symlinks);
+        if (r < 0)
+                return r;
+
+        ORDERED_HASHMAP_FOREACH(i, ctx->have_processed) {
+                if (i->install_mode != INSTALL_MODE_REGULAR)
+                        continue;
+
+                r = install_info_check_dependency_rules(ctx->scope, lp, i);
+                if (r <= 0) {
+                        if (r < 0)
+                                log_debug_errno(r, "Failed to load %s, not masking its dependencies: %m", i->name);
+                        continue;
+                }
+
+                RET_GATHER(ret, install_info_mask_dependencies(i, vendor_symlinks, lp, config_path,
+                                                               dry_run, changes, n_changes));
+        }
+
+        return ret;
+}
+
+/* Drops the dependency masks that disabling these units created. Enabling has to undo all of them, not just
+ * the ones the [Install] sections happen to name: the vendor is free to pull a unit into a target we know
+ * nothing about, and a mask left behind there would keep that part of the enablement off. */
+static int install_context_unmask_dependencies(
+                InstallContext *ctx,
+                const LookupPaths *lp,
+                const char *config_path,
+                InstallChange **changes,
+                size_t *n_changes) {
+
+        _cleanup_strv_free_ char **symlinks = NULL;
+        InstallInfo *i;
+        int r, ret = 0;
+
+        assert(ctx);
+        assert(lp);
+        assert(config_path);
+
+        /* Called after install_context_apply(), which is what discovers the Also= units and moves everything
+         * into have_processed. No dry run parameter unlike the masking side: nothing on the enabling path
+         * implements one, see create_symlink(), and honouring it here alone would make a dry run that is
+         * asked for anyway do half the work. */
+
+        if (ordered_hashmap_isempty(ctx->have_processed))
+                return 0;
+
+        r = dependency_symlinks_list(config_path, &symlinks);
+        if (r < 0)
+                return r;
+
+        ORDERED_HASHMAP_FOREACH(i, ctx->have_processed) {
+                if (i->install_mode != INSTALL_MODE_REGULAR)
+                        continue;
+
+                r = install_info_check_dependency_rules(ctx->scope, lp, i);
+                if (r <= 0) {
+                        if (r < 0)
+                                log_debug_errno(r, "Failed to load %s, not unmasking its dependencies: %m", i->name);
+                        continue;
+                }
+
+                STRV_FOREACH(symlink, symlinks) {
+                        _cleanup_free_ char *entry = NULL;
+
+                        r = path_extract_filename(*symlink, &entry);
+                        if (r < 0)
+                                return r;
+
+                        r = dependency_name_matches(i, entry);
+                        if (r < 0)
+                                return r;
+                        if (r == 0)
+                                continue;
+
+                        r = dependency_is_masked(lp, *symlink);
+                        if (r < 0) {
+                                log_debug_errno(r, "Failed to check if '%s' masks a dependency, ignoring: %m",
+                                                *symlink);
+                                continue;
+                        }
+                        if (r == 0)
+                                continue;
+
+                        if (unlink(*symlink) < 0 && errno != ENOENT) {
+                                RET_GATHER(ret, install_changes_add(changes, n_changes, -errno, *symlink, NULL));
+                                continue;
+                        }
+
+                        (void) rmdir_parents(*symlink, config_path);
+
+                        RET_GATHER(ret, install_changes_add(changes, n_changes,
+                                                            INSTALL_CHANGE_UNMASK_DEPENDENCY, *symlink, NULL));
+                }
+        }
+
+        return ret;
+}
+
 static int install_info_discover_and_check(
                 InstallContext *ctx,
                 const LookupPaths *lp,
@@ -2280,7 +2989,9 @@ static int install_context_apply(
 static int install_context_mark_for_removal(
                 InstallContext *ctx,
                 const LookupPaths *lp,
+                UnitFileFlags file_flags,
                 Set **remove_symlinks_to,
+                VendorSymlinks *vendor,
                 const char *config_path,
                 InstallChange **changes,
                 size_t *n_changes) {
@@ -2293,6 +3004,9 @@ static int install_context_mark_for_removal(
         assert(config_path);
 
         /* Marks all items for removal */
+
+        if (vendor)
+                vendor->active = path_is_vendor(lp, config_path);
 
         if (ordered_hashmap_isempty(ctx->will_process))
                 return 0;
@@ -2339,6 +3053,19 @@ static int install_context_mark_for_removal(
                         log_debug("Unit %s has install mode %s, ignoring.",
                                   i->name, install_mode_to_string(i->install_mode) ?: "invalid");
                         continue;
+                }
+
+                /* In the vendor directories a unit that asks for no dependency symlinks is statically wired
+                 * up rather than enabled, and that wiring belongs to whoever built the image. Removing it
+                 * would take the unit out of the boot, which is not what disabling something that was never
+                 * enableable should do. */
+                if (vendor && vendor->active) {
+                        r = install_info_collect_vendor_symlinks(ctx->scope, lp, i, file_flags, vendor);
+                        if (r < 0)
+                                /* Nothing collected means nothing at the top level of the vendor directory
+                                 * is ours, so an unreadable [Install] section errs towards keeping it. */
+                                log_debug_errno(r, "Failed to load %s, assuming it is not statically wired up: %m",
+                                                i->name);
                 }
 
                 r = mark_symlink_for_removal(remove_symlinks_to, i->name);
@@ -2499,7 +3226,8 @@ int unit_file_unmask(
                         return q;
         }
 
-        RET_GATHER(r, remove_marked_symlinks(remove_symlinks_to, config_path, &lp, dry_run, changes, n_changes));
+        RET_GATHER(r, remove_marked_symlinks(remove_symlinks_to, /* vendor= */ NULL,
+                                             config_path, &lp, dry_run, changes, n_changes));
 
         return r;
 }
@@ -2757,11 +3485,13 @@ int unit_file_revert(
                         return q;
         }
 
-        q = remove_marked_symlinks(remove_symlinks_to, lp.runtime_config, &lp, false, changes, n_changes);
+        q = remove_marked_symlinks(remove_symlinks_to, /* vendor= */ NULL,
+                                   lp.runtime_config, &lp, false, changes, n_changes);
         if (r >= 0)
                 r = q;
 
-        q = remove_marked_symlinks(remove_symlinks_to, lp.persistent_config, &lp, false, changes, n_changes);
+        q = remove_marked_symlinks(remove_symlinks_to, /* vendor= */ NULL,
+                                   lp.persistent_config, &lp, false, changes, n_changes);
         if (r >= 0)
                 r = q;
 
@@ -2850,7 +3580,7 @@ static int do_unit_file_enable(
 
         _cleanup_(install_context_done) InstallContext ctx = { .scope = scope };
         InstallInfo *info;
-        int r;
+        int q, r;
 
         STRV_FOREACH(name, names_or_paths) {
                 r = install_info_discover_and_check(&ctx, lp, *name,
@@ -2867,8 +3597,16 @@ static int do_unit_file_enable(
            is useful to determine whether the passed units had any
            installation data at all. */
 
-        return install_context_apply(&ctx, lp, flags, config_path,
-                                     SEARCH_LOAD, changes, n_changes);
+        r = install_context_apply(&ctx, lp, flags, config_path,
+                                  SEARCH_LOAD, changes, n_changes);
+        if (r < 0)
+                return r;
+
+        q = install_context_unmask_dependencies(&ctx, lp, config_path, changes, n_changes);
+        if (q < 0)
+                return q;
+
+        return r;
 }
 
 int unit_file_enable(
@@ -2936,9 +3674,16 @@ static int do_unit_file_disable(
         }
 
         _cleanup_set_free_ Set *remove_symlinks_to = NULL;
-        r = install_context_mark_for_removal(&ctx, lp, &remove_symlinks_to, config_path, changes, n_changes);
+        _cleanup_(vendor_symlinks_done) VendorSymlinks vendor = {};
+
+        r = install_context_mark_for_removal(&ctx, lp, flags, &remove_symlinks_to, &vendor,
+                                             config_path, changes, n_changes);
         if (r >= 0)
-                r = remove_marked_symlinks(remove_symlinks_to, config_path, lp, flags & UNIT_FILE_DRY_RUN, changes, n_changes);
+                r = remove_marked_symlinks(remove_symlinks_to, &vendor, config_path, lp,
+                                           flags & UNIT_FILE_DRY_RUN, changes, n_changes);
+        if (r >= 0)
+                r = install_context_mask_dependencies(&ctx, lp, config_path, flags & UNIT_FILE_DRY_RUN,
+                                                      changes, n_changes);
         if (r < 0)
                 return r;
 
@@ -3599,12 +4344,22 @@ static int execute_preset(
 
         if (mode != UNIT_FILE_PRESET_ENABLE_ONLY) {
                 _cleanup_set_free_ Set *remove_symlinks_to = NULL;
+                _cleanup_(vendor_symlinks_done) VendorSymlinks vendor = {};
 
-                r = install_context_mark_for_removal(minus, lp, &remove_symlinks_to, config_path, changes, n_changes);
+                r = install_context_mark_for_removal(minus, lp, file_flags | UNIT_FILE_APPLYING_PRESET,
+                                                     &remove_symlinks_to, &vendor,
+                                                     config_path, changes, n_changes);
                 if (r < 0)
                         return r;
 
-                r = remove_marked_symlinks(remove_symlinks_to, config_path, lp, false, changes, n_changes);
+                /* No masking here, unlike unit_file_disable(). A preset policy of "disable" applies to
+                 * what this command is responsible for, and enablement the vendor shipped below /usr/ is
+                 * not that: leaving a /dev/null in /etc/ for it would take units out of the boot on every
+                 * existing system whose preset files do not name what it wires up, which they never had to.
+                 * Presetting the vendor directories does turn those units off, by removing the symlink,
+                 * and an administrator asking for it by name with "systemctl disable" still gets a mask. */
+                r = remove_marked_symlinks(remove_symlinks_to, &vendor, config_path, lp,
+                                           false, changes, n_changes);
         } else
                 r = 0;
 
@@ -3622,6 +4377,8 @@ static int execute_preset(
                         else
                                 r += q;
                 }
+
+                RET_GATHER(r, install_context_unmask_dependencies(plus, lp, config_path, changes, n_changes));
         }
 
         return r;
@@ -3709,7 +4466,7 @@ int unit_file_preset(
         if (r < 0)
                 return r;
 
-        config_path = (file_flags & UNIT_FILE_RUNTIME) ? lp.runtime_config : lp.persistent_config;
+        config_path = config_path_from_flags(&lp, file_flags);
         if (!config_path)
                 return -ENXIO;
 
@@ -3753,7 +4510,7 @@ int unit_file_preset_all(
         if (r < 0)
                 return r;
 
-        config_path = (file_flags & UNIT_FILE_RUNTIME) ? lp.runtime_config : lp.persistent_config;
+        config_path = config_path_from_flags(&lp, file_flags);
         if (!config_path)
                 return -ENXIO;
 
@@ -3911,6 +4668,8 @@ DEFINE_STRING_TABLE_LOOKUP(unit_file_state, UnitFileState);
 static const char* const install_change_type_table[_INSTALL_CHANGE_TYPE_MAX] = {
         [INSTALL_CHANGE_SYMLINK]                 = "symlink",
         [INSTALL_CHANGE_UNLINK]                  = "unlink",
+        [INSTALL_CHANGE_MASK_DEPENDENCY]         = "mask-dependency",
+        [INSTALL_CHANGE_UNMASK_DEPENDENCY]       = "unmask-dependency",
         [INSTALL_CHANGE_IS_MASKED]               = "masked",
         [INSTALL_CHANGE_IS_MASKED_GENERATOR]     = "masked by generator",
         [INSTALL_CHANGE_IS_DANGLING]             = "dangling",

--- a/src/shared/install.c
+++ b/src/shared/install.c
@@ -262,7 +262,9 @@ static int path_is_vendor_or_generator(const LookupPaths *lp, const char *path) 
         if (path_startswith(rpath, "/usr"))
                 return true;
 
-        if (path_is_generator(lp, rpath))
+        /* Not rpath: the generator directories are root prefixed, so stripping the root here would keep
+         * this from ever matching under --root=. */
+        if (path_is_generator(lp, path))
                 return true;
 
         return path_equal(rpath, SYSTEM_DATA_UNIT_DIR);

--- a/src/shared/install.c
+++ b/src/shared/install.c
@@ -2673,6 +2673,67 @@ int unit_file_verify_alias(
         return 0;
 }
 
+/* Would this symlink already be there if we didn't create it? Ours only ever competes with the directories
+ * below config_path, anything above it wins either way. Only a vendor supplied entry counts: one in /run/ or
+ * from a generator is gone again after a reboot. 'unit' is the unit the entry has to point at, for the
+ * symlinks whose own name does not say which unit they belong to. */
+static int symlink_provided_below(
+                const LookupPaths *lp,
+                const char *config_path,
+                const char *rel,
+                const char *unit) {
+
+        bool below = false;
+        int r;
+
+        assert(lp);
+        assert(config_path);
+        assert(rel);
+
+        STRV_FOREACH(p, lp->search_path) {
+                _cleanup_free_ char *path = NULL, *dest = NULL;
+                struct stat st;
+
+                if (!below) {
+                        below = path_equal(*p, config_path);
+                        continue;
+                }
+
+                path = path_join(*p, rel);
+                if (!path)
+                        return -ENOMEM;
+
+                if (lstat(path, &st) < 0) {
+                        if (errno == ENOENT)
+                                continue;
+                        return -errno;
+                }
+
+                /* The first entry we find decides, the ones below it are shadowed. */
+                r = dependency_is_masked(lp, path);
+                if (r < 0)
+                        return r;
+                if (r > 0)
+                        return false;
+
+                if (!S_ISLNK(st.st_mode) || !path_is_vendor(lp, *p))
+                        return false;
+
+                if (!unit)
+                        return true;
+
+                /* Compare the way find_symlinks_in_directory() does, or we would skip writing a symlink that
+                 * the state lookup then does not recognise as this unit's. */
+                r = readlink_malloc(path, &dest);
+                if (r < 0)
+                        return r;
+
+                return path_equal_filename(dest, unit);
+        }
+
+        return false;
+}
+
 static int install_info_symlink_alias(
                 RuntimeScope scope,
                 UnitFileFlags file_flags,
@@ -2703,6 +2764,27 @@ static int install_info_symlink_alias(
                         if (r != -ELOOP)
                                 RET_GATHER(ret, r);
                         continue;
+                }
+
+                /* Same as in install_info_symlink_wants(): a preset re-asserts a policy rather than
+                 * recording a decision, so there is nothing to record where the vendor already carries this
+                 * very name for this very unit. */
+                if (FLAGS_SET(file_flags, UNIT_FILE_APPLYING_PRESET)) {
+                        r = symlink_provided_below(lp, config_path, dst_updated ?: dst, info->name);
+                        if (r < 0)
+                                return r;
+                        if (r > 0) {
+                                log_debug("Alias %s already provided below %s, not creating it.",
+                                          dst_updated ?: dst, config_path);
+
+                                /* Still counts towards the number of symlinks that were supposed to be
+                                 * created, or a fully redundant unit would look like it had no [Install]
+                                 * section at all. */
+                                if (ret >= 0)
+                                        ret = 1;
+
+                                continue;
+                        }
                 }
 
                 alias_path = path_make_absolute(dst_updated ?: dst, config_path);
@@ -2739,53 +2821,6 @@ static int install_info_symlink_alias(
         }
 
         return ret;
-}
-
-/* Would this dependency symlink already be there if we didn't create it? Our symlink only ever competes
- * with the directories below config_path, anything above it wins either way. Only a vendor supplied entry
- * counts: one in /run/ or from a generator is gone again after a reboot. */
-static int dependency_provided_below(
-                const LookupPaths *lp,
-                const char *config_path,
-                const char *rel) {
-
-        bool below = false;
-        int r;
-
-        assert(lp);
-        assert(config_path);
-        assert(rel);
-
-        STRV_FOREACH(p, lp->search_path) {
-                _cleanup_free_ char *path = NULL;
-                struct stat st;
-
-                if (!below) {
-                        below = path_equal(*p, config_path);
-                        continue;
-                }
-
-                path = path_join(*p, rel);
-                if (!path)
-                        return -ENOMEM;
-
-                if (lstat(path, &st) < 0) {
-                        if (errno == ENOENT)
-                                continue;
-                        return -errno;
-                }
-
-                /* The first entry we find decides, the ones below it are shadowed. */
-                r = dependency_is_masked(lp, path);
-                if (r < 0)
-                        return r;
-                if (r > 0)
-                        return false;
-
-                return S_ISLNK(st.st_mode) && path_is_vendor(lp, *p);
-        }
-
-        return false;
 }
 
 static int install_info_symlink_wants(
@@ -2881,7 +2916,7 @@ static int install_info_symlink_wants(
                  * decisions. An explicit "systemctl enable" still records itself, so that it survives the
                  * vendor dropping the symlink later. */
                 if (FLAGS_SET(file_flags, UNIT_FILE_APPLYING_PRESET)) {
-                        q = dependency_provided_below(lp, config_path, rel);
+                        q = symlink_provided_below(lp, config_path, rel, /* unit= */ NULL);
                         if (q < 0)
                                 return q;
                         if (q > 0) {

--- a/src/shared/install.h
+++ b/src/shared/install.h
@@ -16,6 +16,8 @@ typedef enum UnitFilePresetMode {
 typedef enum InstallChangeType {
         INSTALL_CHANGE_SYMLINK,
         INSTALL_CHANGE_UNLINK,
+        INSTALL_CHANGE_MASK_DEPENDENCY,
+        INSTALL_CHANGE_UNMASK_DEPENDENCY,
         INSTALL_CHANGE_IS_MASKED,
         INSTALL_CHANGE_IS_MASKED_GENERATOR,
         INSTALL_CHANGE_IS_DANGLING,
@@ -36,6 +38,8 @@ typedef enum UnitFileFlags {
         UNIT_FILE_PORTABLE                 = 1 << 2, /* Public API via DBUS, do not change */
         UNIT_FILE_DRY_RUN                  = 1 << 3,
         UNIT_FILE_IGNORE_AUXILIARY_FAILURE = 1 << 4,
+        UNIT_FILE_VENDOR                   = 1 << 5, /* Operate on the vendor unit directory below /usr/ */
+        UNIT_FILE_APPLYING_PRESET          = 1 << 6, /* Applying a policy, not recording an explicit request */
         _UNIT_FILE_FLAGS_MASK_PUBLIC = UNIT_FILE_RUNTIME|UNIT_FILE_PORTABLE|UNIT_FILE_FORCE,
 } UnitFileFlags;
 
@@ -59,7 +63,11 @@ typedef struct InstallChange {
 
 static inline bool install_changes_have_modification(const InstallChange *changes, size_t n_changes) {
         FOREACH_ARRAY(i, changes, n_changes)
-                if (IN_SET(i->type, INSTALL_CHANGE_SYMLINK, INSTALL_CHANGE_UNLINK))
+                if (IN_SET(i->type,
+                           INSTALL_CHANGE_SYMLINK,
+                           INSTALL_CHANGE_UNLINK,
+                           INSTALL_CHANGE_MASK_DEPENDENCY,
+                           INSTALL_CHANGE_UNMASK_DEPENDENCY))
                         return true;
         return false;
 }

--- a/src/systemctl/systemctl-enable.c
+++ b/src/systemctl/systemctl-enable.c
@@ -353,6 +353,8 @@ int verb_enable(int argc, char *argv[], uintptr_t data, void *userdata) {
                         return log_error_errno(SYNTHETIC_ERRNO(EREMOTE), "--now cannot be used with --root=.");
                 case INSTALL_CLIENT_SIDE_GLOBAL_SCOPE:
                         return log_error_errno(SYNTHETIC_ERRNO(EREMOTE), "--now cannot be used with --global.");
+                case INSTALL_CLIENT_SIDE_VENDOR:
+                        return log_error_errno(SYNTHETIC_ERRNO(EREMOTE), "--now cannot be used with --vendor.");
                 }
 
                 assert(bus);

--- a/src/systemctl/systemctl-is-enabled.c
+++ b/src/systemctl/systemctl-is-enabled.c
@@ -34,6 +34,10 @@ static int show_installation_targets_client_side(const char *name) {
         FOREACH_ARRAY(c, changes, n_changes)
                 if (c->type == INSTALL_CHANGE_UNLINK)
                         printf("  %s\n", c->path);
+                else if (c->type == INSTALL_CHANGE_MASK_DEPENDENCY)
+                        /* Enabled by the vendor: report the symlink that does it, not the mask that would
+                         * be created to shadow it. */
+                        printf("  %s\n", c->source);
 
         return 0;
 }

--- a/src/systemctl/systemctl-is-enabled.c
+++ b/src/systemctl/systemctl-is-enabled.c
@@ -27,7 +27,7 @@ static int show_installation_targets_client_side(const char *name) {
         flags = UNIT_FILE_DRY_RUN |
                 (arg_runtime ? UNIT_FILE_RUNTIME : 0);
 
-        r = unit_file_disable(arg_runtime_scope, flags, NULL, p, &changes, &n_changes);
+        r = unit_file_disable(arg_runtime_scope, flags, arg_root, p, &changes, &n_changes);
         if (r < 0)
                 return log_error_errno(r, "Failed to get file links for %s: %m", name);
 

--- a/src/systemctl/systemctl-util.c
+++ b/src/systemctl/systemctl-util.c
@@ -903,6 +903,11 @@ InstallClientSide install_client_side(void) {
         if (!isempty(arg_root))
                 return INSTALL_CLIENT_SIDE_ARG_ROOT;
 
+        /* The bus API has no flag for this, and populating the vendor unit directory is a job for whoever
+         * builds the image, not for the running manager. */
+        if (arg_vendor)
+                return INSTALL_CLIENT_SIDE_VENDOR;
+
         if (running_in_chroot_or_offline())
                 return INSTALL_CLIENT_SIDE_OFFLINE;
 
@@ -941,7 +946,8 @@ bool show_preset_for_state(UnitFileState state) {
 
 UnitFileFlags unit_file_flags_from_args(void) {
         return (arg_runtime ? UNIT_FILE_RUNTIME : 0) |
-               (arg_force   ? UNIT_FILE_FORCE   : 0);
+               (arg_force   ? UNIT_FILE_FORCE   : 0) |
+               (arg_vendor  ? UNIT_FILE_VENDOR  : 0);
 }
 
 int mangle_names(const char *operation, char * const *original_names, char ***ret) {

--- a/src/systemctl/systemctl-util.h
+++ b/src/systemctl/systemctl-util.h
@@ -76,6 +76,7 @@ typedef enum InstallClientSide {
         INSTALL_CLIENT_SIDE_OFFLINE,
         INSTALL_CLIENT_SIDE_NOT_BOOTED,
         INSTALL_CLIENT_SIDE_GLOBAL_SCOPE,
+        INSTALL_CLIENT_SIDE_VENDOR,
 } InstallClientSide;
 
 InstallClientSide install_client_side(void);

--- a/src/systemctl/systemctl.c
+++ b/src/systemctl/systemctl.c
@@ -59,6 +59,7 @@ bool arg_show_transaction = false;
 int arg_force = 0;
 bool arg_ask_password = false;
 bool arg_runtime = false;
+bool arg_vendor = false;
 UnitFilePresetMode arg_preset_mode = UNIT_FILE_PRESET_FULL;
 char **arg_wall = NULL;
 const char *arg_kill_whom = NULL;
@@ -618,6 +619,11 @@ static int systemctl_parse_argv(int argc, char *argv[], int log_level_shift, cha
                         arg_runtime = true;
                         break;
 
+                OPTION_LONG("vendor", NULL,
+                            "Enable/disable/reenable/preset/preset-all in the vendor unit directory below /usr/"):
+                        arg_vendor = true;
+                        break;
+
                 OPTION('f', "force", NULL,
                        "When enabling unit files, override existing symlinks. "
                        "When shutting down, execute action immediately."):
@@ -877,6 +883,21 @@ static int systemctl_parse_argv(int argc, char *argv[], int log_level_shift, cha
         if (arg_image && arg_root)
                 return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
                                        "Please specify either --root= or --image=, the combination of both is not supported.");
+
+        if (arg_vendor) {
+                if (!STRPTR_IN_SET(args[0], "enable", "disable", "reenable", "preset", "preset-all"))
+                        return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
+                                               "--vendor may only be used with 'enable', 'disable', "
+                                               "'reenable', 'preset' or 'preset-all'.");
+
+                if (arg_runtime)
+                        return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
+                                               "--vendor may not be combined with --runtime.");
+
+                if (arg_runtime_scope == RUNTIME_SCOPE_USER)
+                        return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
+                                               "--vendor is not supported for --user, use --global instead.");
+        }
 
         if (remaining_args)
                 *remaining_args = args;

--- a/src/systemctl/systemctl.h
+++ b/src/systemctl/systemctl.h
@@ -65,6 +65,7 @@ extern bool arg_show_transaction;
 extern int arg_force;
 extern bool arg_ask_password;
 extern bool arg_runtime;
+extern bool arg_vendor;
 extern UnitFilePresetMode arg_preset_mode;
 extern char **arg_wall;
 extern const char *arg_kill_whom;

--- a/src/test/test-install-root.c
+++ b/src/test/test-install-root.c
@@ -777,6 +777,25 @@ TEST(revert) {
         ASSERT_STREQ(changes[1].path, p);
         install_changes_free(changes, n_changes);
         changes = NULL; n_changes = 0;
+
+        /* A unit a generator produced counts as having a vendor version too, so its override goes as well.
+         * The generator directories are root prefixed, so this only works if we look for them as such. */
+        p = strjoina(root, "/run/systemd/generator/zz.service");
+        assert_se(write_string_file(p, "# Empty\n", WRITE_STRING_FILE_CREATE|WRITE_STRING_FILE_MKDIR_0755) >= 0);
+
+        p = strjoina(root, SYSTEM_CONFIG_UNIT_DIR"/zz.service");
+        assert_se(write_string_file(p, "# Empty override\n", WRITE_STRING_FILE_CREATE) >= 0);
+
+        assert_se(unit_file_revert(RUNTIME_SCOPE_SYSTEM, root, STRV_MAKE("zz.service"), &changes, &n_changes) >= 0);
+        assert_se(n_changes == 1);
+        assert_se(changes[0].type == INSTALL_CHANGE_UNLINK);
+        ASSERT_STREQ(changes[0].path, p);
+        install_changes_free(changes, n_changes);
+        changes = NULL; n_changes = 0;
+
+        /* The other tests share this root and the order they run in is up to the linker, so do not leave a
+         * generated unit lying around for them to trip over. */
+        ASSERT_OK_ERRNO(unlink(strjoina(root, "/run/systemd/generator/zz.service")));
 }
 
 TEST(preset_order) {

--- a/src/test/test-install-root.c
+++ b/src/test/test-install-root.c
@@ -4,6 +4,7 @@
 
 #include "alloc-util.h"
 #include "fileio.h"
+#include "fs-util.h"
 #include "hashmap.h"
 #include "install.h"
 #include "mkdir.h"
@@ -12,12 +13,31 @@
 #include "special.h"
 #include "stat-util.h"
 #include "string-util.h"
+#include "strv.h"
 #include "tests.h"
 #include "tmpfile-util.h"
 
 static char *root = NULL;
 
+/* The vendor tests leave enablement symlinks below /usr/ behind, which a preset-all in any of the other
+ * tests would then act on. The order the tests run in is up to the linker, so give them a root of their
+ * own rather than depend on it. */
+static char *vendor_root = NULL;
+
 STATIC_DESTRUCTOR_REGISTER(root, rm_rf_physical_and_freep);
+STATIC_DESTRUCTOR_REGISTER(vendor_root, rm_rf_physical_and_freep);
+
+static void make_root(char **ret) {
+        ASSERT_OK(mkdtemp_malloc("/tmp/rootXXXXXX", ret));
+
+        FOREACH_STRING(d, "/usr/lib/systemd/system/", SYSTEM_CONFIG_UNIT_DIR"/", "/run/systemd/system/",
+                       "/opt/", "/usr/lib/systemd/system-preset/")
+                ASSERT_OK(mkdir_p(strjoina(*ret, d), 0755));
+
+        FOREACH_STRING(t, "multi-user.target", "graphical.target")
+                ASSERT_OK(write_string_file(strjoina(*ret, "/usr/lib/systemd/system/", t),
+                                            "# pretty much empty", WRITE_STRING_FILE_CREATE));
+}
 
 TEST(basic_mask_and_enable) {
         const char *p;
@@ -798,6 +818,8 @@ TEST(revert) {
         ASSERT_OK_ERRNO(unlink(strjoina(root, "/run/systemd/generator/zz.service")));
 }
 
+/* The enablement symlinks point at paths relative to the image root, so they dangle when inspected from
+ * outside of it. Look at the symlink itself rather than at what it resolves to. */
 TEST(preset_order) {
         InstallChange *changes = NULL;
         size_t n_changes = 0;
@@ -1350,31 +1372,611 @@ TEST(verify_alias) {
         verify_one(&di_inst_template, "goo.target.conf/plain.service", -EXDEV, NULL);
 }
 
+static bool symlink_exists(const char *path) {
+        return is_symlink(path) > 0;
+}
+
+static bool is_dependency_mask(const char *path) {
+        _cleanup_free_ char *dest = NULL;
+
+        if (readlink_malloc(path, &dest) < 0)
+                return false;
+
+        return path_equal(dest, "/dev/null");
+}
+
+static void write_vendor_file(const char *rel, const char *contents) {
+        const char *p = strjoina(vendor_root, "/usr/lib/systemd/", rel);
+
+        ASSERT_OK(mkdir_parents(p, 0755));
+        ASSERT_OK(write_string_file(p, contents, WRITE_STRING_FILE_CREATE|WRITE_STRING_FILE_TRUNCATE));
+}
+
+static void write_vendor_symlink(const char *rel, const char *target) {
+        const char *p = strjoina(vendor_root, "/usr/lib/systemd/system/", rel);
+
+        ASSERT_OK(mkdir_parents(p, 0755));
+        ASSERT_OK_ERRNO(symlink(target, p));
+}
+
+static void assert_state(const char *name, UnitFileState expect) {
+        UnitFileState state;
+
+        ASSERT_OK(unit_file_get_state(RUNTIME_SCOPE_SYSTEM, vendor_root, name, &state));
+        ASSERT_EQ(state, expect);
+}
+
+/* The verbs under test, with the change list of no interest to the caller. The one test that does look at it
+ * calls unit_file_disable() directly. */
+
+static void do_enable(UnitFileFlags flags, char * const *names) {
+        InstallChange *changes = NULL;
+        size_t n_changes = 0;
+
+        CLEANUP_ARRAY(changes, n_changes, install_changes_free);
+        ASSERT_OK(unit_file_enable(RUNTIME_SCOPE_SYSTEM, flags, vendor_root, names, &changes, &n_changes));
+}
+
+static void do_disable(UnitFileFlags flags, char * const *names) {
+        InstallChange *changes = NULL;
+        size_t n_changes = 0;
+
+        CLEANUP_ARRAY(changes, n_changes, install_changes_free);
+        ASSERT_OK(unit_file_disable(RUNTIME_SCOPE_SYSTEM, flags, vendor_root, names, &changes, &n_changes));
+}
+
+static void do_preset(UnitFileFlags flags, char * const *names) {
+        InstallChange *changes = NULL;
+        size_t n_changes = 0;
+
+        CLEANUP_ARRAY(changes, n_changes, install_changes_free);
+        ASSERT_OK(unit_file_preset(RUNTIME_SCOPE_SYSTEM, flags, vendor_root, names, UNIT_FILE_PRESET_FULL,
+                                   &changes, &n_changes));
+}
+
+static void do_preset_all(UnitFileFlags flags) {
+        InstallChange *changes = NULL;
+        size_t n_changes = 0;
+
+        CLEANUP_ARRAY(changes, n_changes, install_changes_free);
+        ASSERT_OK(unit_file_preset_all(RUNTIME_SCOPE_SYSTEM, flags, vendor_root, UNIT_FILE_PRESET_FULL,
+                                       &changes, &n_changes));
+}
+
+#define VENDOR_WANTS "/usr/lib/systemd/system/multi-user.target.wants/"
+#define ETC_WANTS SYSTEM_CONFIG_UNIT_DIR"/multi-user.target.wants/"
+
+#define WANTED_BY_MULTI_USER \
+        "[Install]\n"        \
+        "WantedBy=multi-user.target\n"
+
+TEST(vendor_enable) {
+        InstallChange *changes = NULL;
+        size_t n_changes = 0;
+        const char *vendor_link, *mask;
+
+        CLEANUP_ARRAY(changes, n_changes, install_changes_free);
+
+        ASSERT_ERROR(unit_file_get_state(RUNTIME_SCOPE_SYSTEM, vendor_root, "vendor-enabled.service", NULL), ENOENT);
+
+        write_vendor_file("system/vendor-enabled.service", WANTED_BY_MULTI_USER);
+        assert_state("vendor-enabled.service", UNIT_FILE_DISABLED);
+
+        /* The vendor enables the unit from /usr/, the way distribution packages ship .wants/ symlinks. PID 1
+         * acts on those, so we must report the unit as enabled. */
+        write_vendor_symlink("multi-user.target.wants/vendor-enabled.service", "../vendor-enabled.service");
+        assert_state("vendor-enabled.service", UNIT_FILE_ENABLED);
+
+        /* Disabling it cannot remove the vendor symlink, so it has to shadow it with a symlink to /dev/null
+         * in the configuration directory. */
+        ASSERT_OK(unit_file_disable(RUNTIME_SCOPE_SYSTEM, 0, vendor_root,
+                                    STRV_MAKE("vendor-enabled.service"), &changes, &n_changes));
+        ASSERT_EQ(n_changes, 1u);
+        ASSERT_EQ(changes[0].type, INSTALL_CHANGE_MASK_DEPENDENCY);
+
+        vendor_link = strjoina(vendor_root, VENDOR_WANTS"vendor-enabled.service");
+        mask = strjoina(vendor_root, ETC_WANTS"vendor-enabled.service");
+        ASSERT_STREQ(changes[0].path, mask);
+        ASSERT_STREQ(changes[0].source, vendor_link);
+
+        ASSERT_TRUE(is_dependency_mask(mask));
+        ASSERT_TRUE(symlink_exists(vendor_link));
+        assert_state("vendor-enabled.service", UNIT_FILE_DISABLED);
+
+        /* Disabling twice must not undo the mask. */
+        do_disable(0, STRV_MAKE("vendor-enabled.service"));
+        ASSERT_TRUE(is_dependency_mask(mask));
+        assert_state("vendor-enabled.service", UNIT_FILE_DISABLED);
+
+        /* Enabling drops the mask again. */
+        do_enable(0, STRV_MAKE("vendor-enabled.service"));
+        ASSERT_TRUE(symlink_exists(mask));
+        ASSERT_FALSE(is_dependency_mask(mask));
+        assert_state("vendor-enabled.service", UNIT_FILE_ENABLED);
+}
+
+TEST(vendor_mask_in_unrelated_target) {
+        const char *mask;
+
+        /* A dependency mask only shadows the entry of the same name in the same .wants/ directory. Masking
+         * the unit out of graphical.target must not make it look disabled when the vendor pulls it into
+         * multi-user.target. Enabling then has to clear that mask too, even though the [Install] section
+         * never names graphical.target. */
+
+        write_vendor_file("system/vendor-two-targets.service", WANTED_BY_MULTI_USER);
+        write_vendor_symlink("multi-user.target.wants/vendor-two-targets.service", "../vendor-two-targets.service");
+
+        mask = strjoina(vendor_root, SYSTEM_CONFIG_UNIT_DIR"/graphical.target.wants/vendor-two-targets.service");
+        ASSERT_OK(mkdir_parents(mask, 0755));
+        ASSERT_OK_ERRNO(symlink("/dev/null", mask));
+
+        assert_state("vendor-two-targets.service", UNIT_FILE_ENABLED);
+
+        do_disable(0, STRV_MAKE("vendor-two-targets.service"));
+        assert_state("vendor-two-targets.service", UNIT_FILE_DISABLED);
+
+        do_enable(0, STRV_MAKE("vendor-two-targets.service"));
+        ASSERT_FALSE(is_dependency_mask(mask));
+}
+
+TEST(vendor_preset) {
+        const char *vendor_link, *mask;
+
+        write_vendor_file("system/vendor-preset.service", WANTED_BY_MULTI_USER);
+        write_vendor_file("system-preset/12-vendor.preset", "enable vendor-preset.service\n");
+
+        /* "preset --vendor" installs the enablement symlink into the vendor directory, leaving /etc/ empty
+         * so that it stays available for the administrator. */
+        do_preset(UNIT_FILE_VENDOR, STRV_MAKE("vendor-preset.service"));
+
+        vendor_link = strjoina(vendor_root, VENDOR_WANTS"vendor-preset.service");
+        mask = strjoina(vendor_root, ETC_WANTS"vendor-preset.service");
+        ASSERT_TRUE(symlink_exists(vendor_link));
+        ASSERT_FALSE(symlink_exists(mask));
+        assert_state("vendor-preset.service", UNIT_FILE_ENABLED);
+
+        /* Flipping the policy and presetting the vendor directory again removes the symlink rather than
+         * masking it: /usr/ is writable at image build time, and a mask there would have nothing to shadow. */
+        write_vendor_file("system-preset/12-vendor.preset", "disable vendor-preset.service\n");
+        do_preset(UNIT_FILE_VENDOR, STRV_MAKE("vendor-preset.service"));
+
+        ASSERT_FALSE(symlink_exists(vendor_link));
+        ASSERT_FALSE(symlink_exists(mask));
+        assert_state("vendor-preset.service", UNIT_FILE_DISABLED);
+}
+
+TEST(vendor_preset_leaves_vendor_enablement_alone) {
+        const char *vendor_link, *mask;
+
+        /* A preset policy of "disable" does not reach what the vendor enabled below /usr/. Masking it would
+         * take units out of the boot on every existing system whose preset files do not name what it wires
+         * up, which they never had to. Asking for it by name still works. */
+
+        write_vendor_file("system/vendor-preset-off.service", WANTED_BY_MULTI_USER);
+        write_vendor_symlink("multi-user.target.wants/vendor-preset-off.service", "../vendor-preset-off.service");
+        write_vendor_file("system-preset/13-vendor-off.preset", "disable vendor-preset-off.service\n");
+
+        do_preset(0, STRV_MAKE("vendor-preset-off.service"));
+
+        vendor_link = strjoina(vendor_root, VENDOR_WANTS"vendor-preset-off.service");
+        mask = strjoina(vendor_root, ETC_WANTS"vendor-preset-off.service");
+        ASSERT_FALSE(symlink_exists(mask));
+        ASSERT_TRUE(symlink_exists(vendor_link));
+        assert_state("vendor-preset-off.service", UNIT_FILE_ENABLED);
+
+        /* An explicit disable is a different matter. */
+        do_disable(0, STRV_MAKE("vendor-preset-off.service"));
+        ASSERT_TRUE(is_dependency_mask(mask));
+        assert_state("vendor-preset-off.service", UNIT_FILE_DISABLED);
+
+        /* And presetting it back to "enable" clears that mask again. */
+        write_vendor_file("system-preset/13-vendor-off.preset", "enable vendor-preset-off.service\n");
+        do_preset(0, STRV_MAKE("vendor-preset-off.service"));
+
+        ASSERT_FALSE(is_dependency_mask(mask));
+        assert_state("vendor-preset-off.service", UNIT_FILE_ENABLED);
+}
+
+TEST(vendor_not_enableable_is_not_masked) {
+        /* A unit that asks for no dependency symlinks is not enabled by a vendor one, it is statically wired
+         * up by it. Masking that would take it out of the boot, which a catch-all "disable *" preset policy
+         * would then do to half the OS. Alias= names a unit file rather than a dependency symlink, so a unit
+         * whose [Install] section has nothing else counts as statically wired up just the same. */
+
+        write_vendor_file("system/vendor-static.service",
+                          "[Unit]\n"
+                          "Description=no Install section\n");
+        write_vendor_file("system/vendor-alias-only.service",
+                          "[Install]\n"
+                          "Alias=vendor-alias-only-alias.service\n");
+        write_vendor_file("system-preset/14-vendor-static.preset",
+                          "disable vendor-static.service\n"
+                          "disable vendor-alias-only.service\n");
+
+        FOREACH_STRING(name, "vendor-static.service", "vendor-alias-only.service") {
+                const char *mask = strjoina(vendor_root, ETC_WANTS, name);
+
+                write_vendor_symlink(strjoina("multi-user.target.wants/", name), strjoina("../", name));
+                assert_state(name, streq(name, "vendor-static.service") ? UNIT_FILE_STATIC : UNIT_FILE_DISABLED);
+
+                do_preset(0, STRV_MAKE(name));
+                ASSERT_FALSE(symlink_exists(mask));
+
+                do_disable(0, STRV_MAKE(name));
+                ASSERT_FALSE(symlink_exists(mask));
+
+                /* An administrator who masked it by hand keeps that mask, though. */
+                ASSERT_OK_ERRNO(symlink("/dev/null", mask));
+                do_enable(0, STRV_MAKE(name));
+                ASSERT_TRUE(is_dependency_mask(mask));
+                ASSERT_OK_ERRNO(unlink(mask));
+        }
+
+        assert_state("vendor-static.service", UNIT_FILE_STATIC);
+
+        /* The protection has to match the way removal does, or an instance of a statically wired template
+         * slips through it. A leftover pointing at a unit that no longer exists is not static wiring
+         * though, it is rubbish to clean up. */
+        write_vendor_file("system/vendor-tmpl-static@.service",
+                          "[Unit]\n"
+                          "Description=statically wired template\n");
+        write_vendor_symlink("multi-user.target.wants/vendor-tmpl-static@one.service",
+                             "../vendor-tmpl-static@.service");
+        write_vendor_symlink("multi-user.target.wants/vendor-gone.service", "../vendor-gone.service");
+
+        do_preset_all(UNIT_FILE_VENDOR);
+        ASSERT_TRUE(symlink_exists(strjoina(vendor_root, VENDOR_WANTS"vendor-tmpl-static@one.service")));
+
+        InstallChange *changes = NULL;
+        size_t n_changes = 0;
+        CLEANUP_ARRAY(changes, n_changes, install_changes_free);
+        (void) unit_file_disable(RUNTIME_SCOPE_SYSTEM, UNIT_FILE_VENDOR, vendor_root,
+                                 STRV_MAKE("vendor-gone.service"), &changes, &n_changes);
+        ASSERT_FALSE(symlink_exists(strjoina(vendor_root, VENDOR_WANTS"vendor-gone.service")));
+}
+
+TEST(vendor_preset_all) {
+        const char *vendor_link, *mask;
+
+        /* preset-all is the path distribution tooling actually uses, and it reaches the units by walking the
+         * search path rather than by name. Same rule: it leaves the vendor's enablement where it is, and
+         * only presetting the vendor directories takes it away. */
+
+        write_vendor_file("system/vendor-all.service", WANTED_BY_MULTI_USER);
+        write_vendor_symlink("multi-user.target.wants/vendor-all.service", "../vendor-all.service");
+        write_vendor_file("system-preset/11-vendor-all.preset", "disable vendor-all.service\n");
+
+        do_preset_all(0);
+
+        vendor_link = strjoina(vendor_root, VENDOR_WANTS"vendor-all.service");
+        mask = strjoina(vendor_root, ETC_WANTS"vendor-all.service");
+        ASSERT_FALSE(symlink_exists(mask));
+        assert_state("vendor-all.service", UNIT_FILE_ENABLED);
+
+        do_preset_all(UNIT_FILE_VENDOR);
+        ASSERT_FALSE(symlink_exists(vendor_link));
+        ASSERT_FALSE(symlink_exists(mask));
+        assert_state("vendor-all.service", UNIT_FILE_DISABLED);
+
+        /* Running it again must converge rather than flip-flop. */
+        do_preset_all(UNIT_FILE_VENDOR);
+        ASSERT_FALSE(symlink_exists(vendor_link));
+
+        write_vendor_file("system-preset/11-vendor-all.preset", "enable vendor-all.service\n");
+        do_preset_all(UNIT_FILE_VENDOR);
+
+        ASSERT_TRUE(symlink_exists(vendor_link));
+        assert_state("vendor-all.service", UNIT_FILE_ENABLED);
+}
+
+TEST(vendor_requires_and_upholds) {
+        /* The three dependency directory kinds go through the same code, but only .wants/ is covered above. */
+
+        FOREACH_STRING(suffix, "requires", "upholds") {
+                _cleanup_free_ char *name = NULL, *rel = NULL, *mask = NULL;
+
+                ASSERT_NOT_NULL(name = strjoin("vendor-", suffix, ".service"));
+                ASSERT_NOT_NULL(rel = strjoin("multi-user.target.", suffix, "/", name));
+                ASSERT_NOT_NULL(mask = strjoin(vendor_root, SYSTEM_CONFIG_UNIT_DIR"/multi-user.target.",
+                                               suffix, "/", name));
+
+                write_vendor_file(strjoina("system/", name), WANTED_BY_MULTI_USER);
+                write_vendor_symlink(rel, strjoina("../", name));
+                assert_state(name, UNIT_FILE_ENABLED);
+
+                do_disable(0, STRV_MAKE(name));
+                ASSERT_TRUE(is_dependency_mask(mask));
+                assert_state(name, UNIT_FILE_DISABLED);
+
+                do_enable(0, STRV_MAKE(name));
+                ASSERT_FALSE(is_dependency_mask(mask));
+                assert_state(name, UNIT_FILE_ENABLED);
+        }
+}
+
+TEST(vendor_template_instance) {
+        const char *mask;
+
+        /* Disabling a template has to mask the vendor's instance symlinks, the same way removal takes away
+         * the configured ones. */
+
+        write_vendor_file("system/vendor-tmpl@.service",
+                          "[Install]\n"
+                          "DefaultInstance=dflt\n"
+                          "WantedBy=multi-user.target\n");
+        write_vendor_symlink("multi-user.target.wants/vendor-tmpl@inst.service", "../vendor-tmpl@.service");
+
+        assert_state("vendor-tmpl@inst.service", UNIT_FILE_ENABLED);
+
+        /* Disabling the template must reach the instance the vendor wired up. */
+        do_disable(0, STRV_MAKE("vendor-tmpl@.service"));
+
+        mask = strjoina(vendor_root, ETC_WANTS"vendor-tmpl@inst.service");
+        ASSERT_TRUE(is_dependency_mask(mask));
+        ASSERT_TRUE(symlink_exists(strjoina(vendor_root, VENDOR_WANTS"vendor-tmpl@inst.service")));
+        assert_state("vendor-tmpl@inst.service", UNIT_FILE_DISABLED);
+
+        do_enable(0, STRV_MAKE("vendor-tmpl@inst.service"));
+        ASSERT_FALSE(is_dependency_mask(mask));
+}
+
+TEST(vendor_also) {
+        const char *mask;
+
+        /* Enabling has to clear the masks of the Also= units too, and those are only discovered while the
+         * symlinks are being applied. */
+
+        write_vendor_file("system/vendor-also.service",
+                          "[Install]\n"
+                          "WantedBy=multi-user.target\n"
+                          "Also=vendor-also.socket\n");
+        write_vendor_file("system/vendor-also.socket",
+                          "[Install]\n"
+                          "WantedBy=sockets.target\n");
+
+        /* The vendor pulls the auxiliary unit into a target the [Install] section never names. */
+        write_vendor_symlink("graphical.target.wants/vendor-also.socket", "../vendor-also.socket");
+
+        do_disable(0, STRV_MAKE("vendor-also.service"));
+
+        mask = strjoina(vendor_root, SYSTEM_CONFIG_UNIT_DIR"/graphical.target.wants/vendor-also.socket");
+        ASSERT_TRUE(is_dependency_mask(mask));
+
+        do_enable(0, STRV_MAKE("vendor-also.service"));
+        ASSERT_FALSE(is_dependency_mask(mask));
+}
+
+TEST(vendor_mask_shadows_lower_priority_dir) {
+        const char *high_mask, *mask;
+
+        /* An entry in a higher priority directory shadows the one below it, so a vendor that masks its own
+         * dependency in /usr/local/ leaves nothing for us to mask in /etc/. */
+
+        write_vendor_file("system/vendor-shadow.service", WANTED_BY_MULTI_USER);
+        write_vendor_symlink("multi-user.target.wants/vendor-shadow.service", "../vendor-shadow.service");
+
+        high_mask = strjoina(vendor_root, "/usr/local/lib/systemd/system/multi-user.target.wants/vendor-shadow.service");
+        ASSERT_OK(mkdir_parents(high_mask, 0755));
+        ASSERT_OK_ERRNO(symlink("/dev/null", high_mask));
+
+        assert_state("vendor-shadow.service", UNIT_FILE_DISABLED);
+
+        do_disable(0, STRV_MAKE("vendor-shadow.service"));
+
+        mask = strjoina(vendor_root, ETC_WANTS"vendor-shadow.service");
+        ASSERT_FALSE(symlink_exists(mask));
+}
+
+TEST(vendor_multiple_units) {
+        /* Several units at once, each wired into two targets the [Install] section does not name, so that
+         * enabling has to go through the unmask pass and clear every one of them rather than stopping at the
+         * first unit or the first mask. */
+
+        FOREACH_STRING(name, "vendor-multi-a.service", "vendor-multi-b.service", "vendor-multi-c.service") {
+                write_vendor_file(strjoina("system/", name), WANTED_BY_MULTI_USER);
+
+                FOREACH_STRING(target, "graphical.target", "sockets.target")
+                        write_vendor_symlink(strjoina(target, ".wants/", name), strjoina("../", name));
+        }
+
+        do_disable(0, STRV_MAKE("vendor-multi-a.service", "vendor-multi-b.service", "vendor-multi-c.service"));
+
+        FOREACH_STRING(name, "vendor-multi-a.service", "vendor-multi-b.service", "vendor-multi-c.service")
+                FOREACH_STRING(target, "graphical.target", "sockets.target")
+                        ASSERT_TRUE(is_dependency_mask(strjoina(vendor_root, SYSTEM_CONFIG_UNIT_DIR"/", target,
+                                                                ".wants/", name)));
+
+        do_enable(0, STRV_MAKE("vendor-multi-a.service", "vendor-multi-b.service", "vendor-multi-c.service"));
+
+        FOREACH_STRING(name, "vendor-multi-a.service", "vendor-multi-b.service", "vendor-multi-c.service")
+                FOREACH_STRING(target, "graphical.target", "sockets.target")
+                        ASSERT_FALSE(is_dependency_mask(strjoina(vendor_root, SYSTEM_CONFIG_UNIT_DIR"/", target,
+                                                                 ".wants/", name)));
+}
+
+TEST(vendor_entry_kinds) {
+        const char *entry;
+
+        /* conf_files_list_strv() lets whatever sits in the higher priority dependency directory win, and
+         * PID 1 then ignores anything that is not a symlink. A dependency resolving to an empty file counts
+         * as a mask just like one pointing at /dev/null. Our verdict has to agree with all of that. */
+
+        write_vendor_file("system/vendor-kinds.service", WANTED_BY_MULTI_USER);
+        write_vendor_symlink("multi-user.target.wants/vendor-kinds.service", "../vendor-kinds.service");
+        assert_state("vendor-kinds.service", UNIT_FILE_ENABLED);
+
+        entry = strjoina(vendor_root, ETC_WANTS"vendor-kinds.service");
+        ASSERT_OK(mkdir_parents(entry, 0755));
+
+        /* A dangling symlink is still a dependency as far as PID 1 is concerned. */
+        ASSERT_OK_ERRNO(symlink("../nope.service", entry));
+        assert_state("vendor-kinds.service", UNIT_FILE_ENABLED);
+        ASSERT_OK_ERRNO(unlink(entry));
+
+        ASSERT_OK(write_string_file(strjoina(vendor_root, "/etc/empty"), "",
+                                    WRITE_STRING_FILE_CREATE|WRITE_STRING_FILE_AVOID_NEWLINE));
+        ASSERT_OK_ERRNO(symlink("/etc/empty", entry));
+        assert_state("vendor-kinds.service", UNIT_FILE_DISABLED);
+        ASSERT_OK_ERRNO(unlink(entry));
+
+        FOREACH_STRING(contents, "", "junk\n") {
+                _cleanup_free_ char *back = NULL;
+
+                ASSERT_OK(write_string_file(entry, contents,
+                                            WRITE_STRING_FILE_CREATE|WRITE_STRING_FILE_TRUNCATE|
+                                            WRITE_STRING_FILE_AVOID_NEWLINE));
+                assert_state("vendor-kinds.service", UNIT_FILE_DISABLED);
+
+                /* Whatever is sitting there already shadows the vendor symlink, so disabling has nothing
+                 * left to do and must not replace it: that would destroy it. */
+                do_disable(0, STRV_MAKE("vendor-kinds.service"));
+                ASSERT_OK(read_full_file(entry, &back, NULL));
+                ASSERT_STREQ(back, contents);
+
+                ASSERT_OK_ERRNO(unlink(entry));
+        }
+
+        ASSERT_OK_ERRNO(mkdir(entry, 0755));
+        assert_state("vendor-kinds.service", UNIT_FILE_DISABLED);
+
+        /* Replacing this one would fail outright rather than quietly. */
+        do_disable(0, STRV_MAKE("vendor-kinds.service"));
+        ASSERT_OK_ERRNO(rmdir(entry));
+}
+
+TEST(vendor_dry_run_writes_nothing) {
+        InstallChange *changes = NULL;
+        size_t n_changes = 0;
+
+        /* "is-enabled --full" drives a dry run through the masking code to list what enables the unit. A
+         * regression there would disable units from a read-only query. */
+
+        CLEANUP_ARRAY(changes, n_changes, install_changes_free);
+
+        write_vendor_file("system/vendor-dry.service", WANTED_BY_MULTI_USER);
+        write_vendor_symlink("multi-user.target.wants/vendor-dry.service", "../vendor-dry.service");
+
+        ASSERT_OK(unit_file_disable(RUNTIME_SCOPE_SYSTEM, UNIT_FILE_DRY_RUN, vendor_root,
+                                    STRV_MAKE("vendor-dry.service"), &changes, &n_changes));
+        ASSERT_EQ(n_changes, 1u);
+        ASSERT_EQ(changes[0].type, INSTALL_CHANGE_MASK_DEPENDENCY);
+        ASSERT_STREQ(changes[0].source, strjoina(vendor_root, VENDOR_WANTS"vendor-dry.service"));
+
+        ASSERT_FALSE(symlink_exists(strjoina(vendor_root, ETC_WANTS"vendor-dry.service")));
+        assert_state("vendor-dry.service", UNIT_FILE_ENABLED);
+}
+
+TEST(vendor_no_pointless_mask_below_the_vendor_directory) {
+        /* --vendor operates on /usr/lib/systemd/system/, which is lower priority than /usr/local/lib/. A
+         * mask placed there would shadow nothing, so it must not be written at all. */
+
+        write_vendor_file("system/vendor-local.service", WANTED_BY_MULTI_USER);
+
+        const char *high = strjoina(vendor_root, "/usr/local/lib/systemd/system/multi-user.target.wants/vendor-local.service");
+        ASSERT_OK(mkdir_parents(high, 0755));
+        ASSERT_OK_ERRNO(symlink("/usr/lib/systemd/system/vendor-local.service", high));
+
+        do_disable(UNIT_FILE_VENDOR, STRV_MAKE("vendor-local.service"));
+        ASSERT_FALSE(symlink_exists(strjoina(vendor_root, VENDOR_WANTS"vendor-local.service")));
+}
+
+TEST(vendor_also_keeps_sibling_preset_policy) {
+        /* Presetting a unit must not drag its Also= units into the removal set: they have a preset policy of
+         * their own, which by then has either already been applied or is yet to be. */
+
+        write_vendor_file("system/vendor-main.service",
+                          "[Install]\n"
+                          "WantedBy=multi-user.target\n"
+                          "Also=vendor-aux.socket\n");
+        write_vendor_file("system/vendor-aux.socket",
+                          "[Install]\n"
+                          "WantedBy=sockets.target\n");
+        write_vendor_file("system-preset/20-vendor-mixed.preset",
+                          "disable vendor-main.service\n"
+                          "enable vendor-aux.socket\n");
+
+        do_enable(0, STRV_MAKE("vendor-aux.socket"));
+        assert_state("vendor-aux.socket", UNIT_FILE_ENABLED);
+
+        do_preset(0, STRV_MAKE("vendor-main.service"));
+        assert_state("vendor-main.service", UNIT_FILE_DISABLED);
+        assert_state("vendor-aux.socket", UNIT_FILE_ENABLED);
+
+        do_preset_all(0);
+        assert_state("vendor-main.service", UNIT_FILE_DISABLED);
+        assert_state("vendor-aux.socket", UNIT_FILE_ENABLED);
+}
+TEST(vendor_keeps_symlinks_it_was_not_asked_for) {
+        const char *compat, *slot, *wiring;
+
+        /* Distributions ship default.target, the runlevel targets and plenty of other symlinks below /usr/
+         * that no [Install] section ever asked for. Presetting into the vendor directories must leave every
+         * one of them alone, or building an image with "preset-all --vendor" takes the OS apart. */
+
+        write_vendor_file("system/vendor-named.service",
+                          "[Install]\n"
+                          "Alias=vendor-named-slot.service\n"
+                          "WantedBy=multi-user.target\n");
+
+        /* A name nothing declares, i.e. the vendor's own, and the one the [Install] section does declare. */
+        write_vendor_symlink("vendor-named-compat.service", "vendor-named.service");
+        write_vendor_symlink("vendor-named-slot.service", "vendor-named.service");
+        write_vendor_symlink("multi-user.target.wants/vendor-named.service", "../vendor-named.service");
+        write_vendor_file("system-preset/19-vendor-named.preset", "disable vendor-named.service\n");
+
+        do_preset(UNIT_FILE_VENDOR, STRV_MAKE("vendor-named.service"));
+
+        /* The dependency symlink is how the unit was on, so that goes. The names stay: dropping them would
+         * not turn anything off, it would take the name away from everything that refers to the unit by
+         * it. */
+        compat = strjoina(vendor_root, "/usr/lib/systemd/system/vendor-named-compat.service");
+        slot = strjoina(vendor_root, "/usr/lib/systemd/system/vendor-named-slot.service");
+        wiring = strjoina(vendor_root, VENDOR_WANTS"vendor-named.service");
+        ASSERT_FALSE(symlink_exists(wiring));
+        ASSERT_TRUE(symlink_exists(compat));
+        ASSERT_TRUE(symlink_exists(slot));
+
+        /* An explicit disable is a different matter: it may take back what enabling would have created. */
+        do_disable(UNIT_FILE_VENDOR, STRV_MAKE("vendor-named.service"));
+        ASSERT_TRUE(symlink_exists(compat));
+        ASSERT_FALSE(symlink_exists(slot));
+
+        /* Same for a unit that cannot be enabled at all: nothing below /usr/ that points at it is ours. */
+        write_vendor_file("system/vendor-unnamed.service",
+                          "[Unit]\n"
+                          "Description=no Install section\n");
+        write_vendor_symlink("vendor-unnamed-compat.service", "vendor-unnamed.service");
+
+        do_disable(UNIT_FILE_VENDOR, STRV_MAKE("vendor-unnamed.service"));
+        ASSERT_TRUE(symlink_exists(strjoina(vendor_root, "/usr/lib/systemd/system/vendor-unnamed-compat.service")));
+}
+
+TEST(vendor_disable_removes_linked_unit) {
+        const char *unit, *link, *alias;
+
+        /* A unit file from outside the search path is linked into the vendor directory under its own name,
+         * so unlike the symlinks above that one is ours to take back. */
+
+        unit = strjoina(vendor_root, "/opt/vendor-linked.service");
+        ASSERT_OK(write_string_file(unit,
+                                    "[Install]\n"
+                                    "Alias=vendor-linked-alias.service\n", WRITE_STRING_FILE_CREATE));
+
+        do_enable(UNIT_FILE_VENDOR, STRV_MAKE("/opt/vendor-linked.service"));
+
+        link = strjoina(vendor_root, "/usr/lib/systemd/system/vendor-linked.service");
+        alias = strjoina(vendor_root, "/usr/lib/systemd/system/vendor-linked-alias.service");
+        ASSERT_TRUE(symlink_exists(link));
+        ASSERT_TRUE(symlink_exists(alias));
+
+        do_disable(UNIT_FILE_VENDOR, STRV_MAKE("vendor-linked.service"));
+        ASSERT_FALSE(symlink_exists(link));
+        ASSERT_FALSE(symlink_exists(alias));
+}
+
 static int intro(void) {
-        const char *p;
-
-        assert_se(mkdtemp_malloc("/tmp/rootXXXXXX", &root) >= 0);
-
-        p = strjoina(root, "/usr/lib/systemd/system/");
-        assert_se(mkdir_p(p, 0755) >= 0);
-
-        p = strjoina(root, SYSTEM_CONFIG_UNIT_DIR"/");
-        assert_se(mkdir_p(p, 0755) >= 0);
-
-        p = strjoina(root, "/run/systemd/system/");
-        assert_se(mkdir_p(p, 0755) >= 0);
-
-        p = strjoina(root, "/opt/");
-        assert_se(mkdir_p(p, 0755) >= 0);
-
-        p = strjoina(root, "/usr/lib/systemd/system-preset/");
-        assert_se(mkdir_p(p, 0755) >= 0);
-
-        p = strjoina(root, "/usr/lib/systemd/system/multi-user.target");
-        assert_se(write_string_file(p, "# pretty much empty", WRITE_STRING_FILE_CREATE) >= 0);
-
-        p = strjoina(root, "/usr/lib/systemd/system/graphical.target");
-        assert_se(write_string_file(p, "# pretty much empty", WRITE_STRING_FILE_CREATE) >= 0);
+        make_root(&root);
+        make_root(&vendor_root);
 
         return EXIT_SUCCESS;
 }

--- a/src/test/test-install-root.c
+++ b/src/test/test-install-root.c
@@ -2040,6 +2040,38 @@ TEST(vendor_preset_still_writes_what_is_needed) {
         }
 }
 
+TEST(vendor_preset_skips_redundant_alias) {
+        /* An Alias= symlink the vendor already carries for this very unit is as redundant as a dependency
+         * symlink would be, so presetting has nothing to record there either. The name has to point at this
+         * unit though: one the vendor carries for somebody else does not satisfy the policy. */
+
+        write_vendor_file("system/vendor-aliased.service",
+                          "[Install]\n"
+                          "Alias=vendor-aliased-name.service\n"
+                          "Alias=vendor-aliased-taken.service\n"
+                          "Alias=vendor-aliased-transient.service\n");
+        write_vendor_file("system/vendor-aliased-other.service", "[Install]\n");
+        write_vendor_symlink("vendor-aliased-name.service", "vendor-aliased.service");
+        write_vendor_symlink("vendor-aliased-taken.service", "vendor-aliased-other.service");
+
+        /* And as for dependencies, only a vendor supplied name counts: one in /run/ is gone after a
+         * reboot. */
+        const char *runtime_alias = strjoina(vendor_root, "/run/systemd/system/vendor-aliased-transient.service");
+        ASSERT_OK(mkdir_parents(runtime_alias, 0755));
+        ASSERT_OK_ERRNO(symlink("/usr/lib/systemd/system/vendor-aliased.service", runtime_alias));
+
+        write_vendor_file("system-preset/21-vendor-aliased.preset", "enable vendor-aliased.service\n");
+        do_preset(0, STRV_MAKE("vendor-aliased.service"));
+
+        ASSERT_FALSE(symlink_exists(strjoina(vendor_root, SYSTEM_CONFIG_UNIT_DIR"/vendor-aliased-name.service")));
+        ASSERT_TRUE(symlink_exists(strjoina(vendor_root, SYSTEM_CONFIG_UNIT_DIR"/vendor-aliased-taken.service")));
+        ASSERT_TRUE(symlink_exists(strjoina(vendor_root, SYSTEM_CONFIG_UNIT_DIR"/vendor-aliased-transient.service")));
+
+        /* An explicit enable records itself as always. */
+        do_enable(0, STRV_MAKE("vendor-aliased.service"));
+        ASSERT_TRUE(symlink_exists(strjoina(vendor_root, SYSTEM_CONFIG_UNIT_DIR"/vendor-aliased-name.service")));
+}
+
 static int intro(void) {
         make_root(&root);
         make_root(&vendor_root);

--- a/src/test/test-install-root.c
+++ b/src/test/test-install-root.c
@@ -1974,6 +1974,72 @@ TEST(vendor_disable_removes_linked_unit) {
         ASSERT_FALSE(symlink_exists(alias));
 }
 
+TEST(vendor_preset_leaves_etc_alone) {
+        const char *vendor_link, *etc_link;
+
+        /* Presetting re-asserts a policy, it is not the administrator saying they want this unit on, so
+         * there is nothing to record when the vendor already enables it. An explicit enable does record
+         * itself, so that it survives the vendor dropping the symlink later. */
+
+        write_vendor_file("system/vendor-redundant.service", WANTED_BY_MULTI_USER);
+        write_vendor_symlink("multi-user.target.wants/vendor-redundant.service", "../vendor-redundant.service");
+        write_vendor_file("system-preset/15-vendor-redundant.preset", "enable vendor-redundant.service\n");
+
+        vendor_link = strjoina(vendor_root, VENDOR_WANTS"vendor-redundant.service");
+        etc_link = strjoina(vendor_root, ETC_WANTS"vendor-redundant.service");
+
+        do_preset(0, STRV_MAKE("vendor-redundant.service"));
+        ASSERT_FALSE(symlink_exists(etc_link));
+        assert_state("vendor-redundant.service", UNIT_FILE_ENABLED);
+
+        /* An explicit enable writes it out even though it changes nothing right now, and that is what makes
+         * it survive the vendor changing its mind. */
+        do_enable(0, STRV_MAKE("vendor-redundant.service"));
+        ASSERT_TRUE(symlink_exists(etc_link));
+
+        ASSERT_OK_ERRNO(unlink(vendor_link));
+        assert_state("vendor-redundant.service", UNIT_FILE_ENABLED);
+}
+
+TEST(vendor_preset_still_writes_what_is_needed) {
+        /* The skip only applies where the vendor already provides the very same dependency. A target the
+         * vendor does not wire up still has to be written, and so does one whose vendor entry is transient
+         * or masked: an entry in /run/ is gone after a reboot and a masked one establishes nothing. */
+
+        write_vendor_file("system/vendor-partial.service",
+                          "[Install]\n"
+                          "WantedBy=multi-user.target\n"
+                          "WantedBy=graphical.target\n"
+                          "WantedBy=sockets.target\n"
+                          "WantedBy=timers.target\n");
+
+        /* Wired up by the vendor, so nothing to record. */
+        write_vendor_symlink("multi-user.target.wants/vendor-partial.service", "../vendor-partial.service");
+
+        /* Wired up in /run/ instead. */
+        const char *runtime_link = strjoina(vendor_root, "/run/systemd/system/sockets.target.wants/vendor-partial.service");
+        ASSERT_OK(mkdir_parents(runtime_link, 0755));
+        ASSERT_OK_ERRNO(symlink("/usr/lib/systemd/system/vendor-partial.service", runtime_link));
+
+        /* Wired up by the vendor, but masked by a higher priority vendor directory. */
+        write_vendor_symlink("timers.target.wants/vendor-partial.service", "../vendor-partial.service");
+        const char *vendor_mask = strjoina(vendor_root, "/usr/local/lib/systemd/system/timers.target.wants/vendor-partial.service");
+        ASSERT_OK(mkdir_parents(vendor_mask, 0755));
+        ASSERT_OK_ERRNO(symlink("/dev/null", vendor_mask));
+
+        write_vendor_file("system-preset/16-vendor-partial.preset", "enable vendor-partial.service\n");
+        do_preset(0, STRV_MAKE("vendor-partial.service"));
+
+        ASSERT_FALSE(symlink_exists(strjoina(vendor_root, ETC_WANTS"vendor-partial.service")));
+
+        FOREACH_STRING(target, "graphical.target", "sockets.target", "timers.target") {
+                const char *p = strjoina(vendor_root, SYSTEM_CONFIG_UNIT_DIR"/", target, ".wants/vendor-partial.service");
+
+                ASSERT_TRUE(symlink_exists(p));
+                ASSERT_FALSE(is_dependency_mask(p));
+        }
+}
+
 static int intro(void) {
         make_root(&root);
         make_root(&vendor_root);

--- a/src/test/test-install-root.c
+++ b/src/test/test-install-root.c
@@ -10,6 +10,7 @@
 #include "path-util.h"
 #include "rm-rf.h"
 #include "special.h"
+#include "stat-util.h"
 #include "string-util.h"
 #include "tests.h"
 #include "tmpfile-util.h"
@@ -1129,6 +1130,34 @@ TEST(preset_multiple_instances) {
         assert_se(unit_file_get_state(RUNTIME_SCOPE_SYSTEM, root, "foo@bartest.service", &state) >= 0 && state == UNIT_FILE_ENABLED);
 
         install_changes_free(changes, n_changes);
+}
+
+TEST(preset_scope) {
+        const char *unit, *preset, *link;
+        InstallChange *changes = NULL;
+        size_t n_changes = 0;
+
+        /* The specifiers in the names an [Install] section asks for are resolved in the scope the caller
+         * asked for. %U has no meaning in the global scope, so presetting a unit that uses it has to fail
+         * rather than quietly expand it as if this were the system scope. */
+
+        unit = strjoina(root, "/usr/lib/systemd/user/scoped.service");
+        ASSERT_OK(mkdir_parents(unit, 0755));
+        ASSERT_OK(write_string_file(unit,
+                                    "[Install]\n"
+                                    "WantedBy=target-%U.target\n", WRITE_STRING_FILE_CREATE));
+
+        preset = strjoina(root, "/usr/lib/systemd/user-preset/50-scoped.preset");
+        ASSERT_OK(mkdir_parents(preset, 0755));
+        ASSERT_OK(write_string_file(preset, "enable scoped.service\n", WRITE_STRING_FILE_CREATE));
+
+        ASSERT_ERROR(unit_file_preset(RUNTIME_SCOPE_GLOBAL, 0, root, STRV_MAKE("scoped.service"),
+                                      UNIT_FILE_PRESET_FULL, &changes, &n_changes), EINVAL);
+        install_changes_free(changes, n_changes);
+        changes = NULL; n_changes = 0;
+
+        link = strjoina(root, USER_CONFIG_UNIT_DIR"/target-0.target.wants/scoped.service");
+        ASSERT_ERROR(is_symlink(link), ENOENT);
 }
 
 static void verify_one(

--- a/test/test-systemctl-enable.sh
+++ b/test/test-systemctl-enable.sh
@@ -754,3 +754,15 @@ ID='the-id2'
 EOF
 
 SYSTEMD_OS_RELEASE="/etc/os-release2" check_alias o 'the-id2'
+
+: '-------is-enabled --full is relative to --root=-----------------'
+mkdir -p "$root/usr/lib/systemd/system"
+cat >"$root/usr/lib/systemd/system/rooted.service" <<EOF2
+[Install]
+WantedBy=multi-user.target
+EOF2
+"$systemctl" --root="$root" enable rooted.service
+
+# Without --root= being passed on this inspects the host, which knows nothing about this unit.
+"$systemctl" --root="$root" is-enabled --full rooted.service |
+    grep "^  $root/etc/systemd/system/multi-user.target.wants/rooted.service\$" >/dev/null

--- a/test/test-systemctl-enable.sh
+++ b/test/test-systemctl-enable.sh
@@ -8,7 +8,7 @@ export SYSTEMD_IN_CHROOT=0
 systemctl=${1:-systemctl}
 systemd_id128=${2:-systemd-id128}
 
-unset root
+unset root vroot
 cleanup() {
     [ -n "$root" ] && rm -rf "$root"
 }
@@ -766,3 +766,56 @@ EOF2
 # Without --root= being passed on this inspects the host, which knows nothing about this unit.
 "$systemctl" --root="$root" is-enabled --full rooted.service |
     grep "^  $root/etc/systemd/system/multi-user.target.wants/rooted.service\$" >/dev/null
+
+: '-------vendor enablement---------------------------------------'
+# The install layer behaviour is covered by test-install-root; this is the command line on top of it.
+# WantedBy=, RequiredBy= and UpheldBy= go through the same code but land in different directories,
+# so walk all three.
+mkdir -p "$root/usr/lib/systemd/system" "$root/usr/lib/systemd/system-preset"
+
+for pair in WantedBy:wants RequiredBy:requires UpheldBy:upholds; do
+    key="${pair%%:*}"
+    dir="multi-user.target.${pair##*:}"
+    unit="vendor-${pair##*:}.service"
+
+    cat >"$root/usr/lib/systemd/system/$unit" <<EOF2
+[Install]
+$key=multi-user.target
+EOF2
+    cat >"$root/usr/lib/systemd/system-preset/50-vendor.preset" <<EOF2
+enable $unit
+EOF2
+
+    "$systemctl" --root="$root" --vendor preset "$unit"
+    test -h "$root/usr/lib/systemd/system/$dir/$unit"
+    test ! -h "$root/etc/systemd/system/$dir/$unit"
+    test "$("$systemctl" --root="$root" is-enabled "$unit")" = "enabled"
+
+    # The administrator can still turn it off, which shadows the vendor symlink from /etc/.
+    "$systemctl" --root="$root" disable "$unit"
+    islink "$root/etc/systemd/system/$dir/$unit" /dev/null
+    test "$("$systemctl" --root="$root" is-enabled "$unit")" = "disabled"
+
+    "$systemctl" --root="$root" enable "$unit"
+    test "$("$systemctl" --root="$root" is-enabled "$unit")" = "enabled"
+
+    # "disable --vendor" removes the symlink outright: there is nothing above /usr/ to mask it from.
+    "$systemctl" --root="$root" disable "$unit"
+    "$systemctl" --root="$root" --vendor disable "$unit"
+    test ! -h "$root/usr/lib/systemd/system/$dir/$unit"
+    rm -f "$root/usr/lib/systemd/system-preset/50-vendor.preset" \
+          "$root/etc/systemd/system/$dir/$unit"
+done
+
+: '-------vendor switch rejections--------------------------------'
+( ! "$systemctl" --root="$root" --vendor --runtime enable vendor-wants.service )
+( ! "$systemctl" --root="$root" --vendor --user enable vendor-wants.service )
+( ! "$systemctl" --root="$root" --vendor mask vendor-wants.service )
+( ! "$systemctl" --root="$root" --vendor is-enabled vendor-wants.service )
+
+: '-------is-enabled --full reports the vendor symlink------------'
+mkdir -p "$root/usr/lib/systemd/system/multi-user.target.wants"
+ln -s ../vendor-wants.service "$root/usr/lib/systemd/system/multi-user.target.wants/vendor-wants.service"
+
+"$systemctl" --root="$root" is-enabled --full vendor-wants.service |
+    grep "^  $root/usr/lib/systemd/system/multi-user.target.wants/vendor-wants.service\$" >/dev/null


### PR DESCRIPTION
PID 1 acts on .wants/, .requires/ and .upholds/ symlinks below /usr/ exactly like
on the ones in /etc/, but the install layer never knew about that tier. So
"systemctl is-enabled" reported units the vendor had enabled as disabled even
though they start at boot, a symlink to /dev/null in a dependency directory
counted as enablement rather than as the mask PID 1 treats it as, and "systemctl
disable" could not turn such a unit off at all.

find_symlinks_in_scope() now knows about that tier, but only for units whose
[Install] section actually asks for a dependency symlink: without WantedBy=,
RequiredBy= or UpheldBy= the symlink is static wiring rather than enablement, and
reporting it as enabled would suggest it can be disabled again. Disabling shadows
what it cannot remove, writing a symlink to /dev/null into /etc/, which enabling
clears again.

On top of that, a --vendor switch for enable, disable, reenable, preset and
preset-all points the whole operation at /usr/lib/systemd/system/. This is for
image builds: applying the preset policy to /usr/ at build time leaves /etc/
empty, so it stays available for the administrator and remains a meaningful
record of local configuration. Presetting also stops writing a symlink into /etc/
where the vendor already carries the same one, so a system built with "preset-all
--vendor" and then deployed comes up with an empty /etc/.

Visible changes:

- "systemctl is-enabled" now exits 0 where it used to exit 1 for units the vendor
  enabled. Distributions ship such symlinks for a number of units, so packaging
  scripts may notice.
- "systemctl preset" and "preset-all" can now turn those units off, which they
  never could before.
- Presetting no longer writes an /etc/ symlink that only duplicates a vendor one.
  A unit whose [Install] section carries nothing but Alias= therefore reports as
  disabled once its alias lives below /usr/, even though the alias is in effect.

The first three commits are independent bug fixes the rest builds on: a log line
printing a variable before it was assigned, preset resolving [Install] specifiers
in the system scope no matter which scope the caller asked for, and "is-enabled
--full" ignoring --root=.
