### PR TITLE
test/units: add missing -m 0700 to mkdir of `root/.ssh`

### DIFF
--- a/test/units/TEST-74-AUX-UTILS.ssh.sh
+++ b/test/units/TEST-74-AUX-UTILS.ssh.sh
@@ -31,7 +31,8 @@ removesshid() {
 
 ssh-keygen -N '' -C '' -t rsa -f "$ROOTID"
 
-mkdir -p 0700 /root/.ssh
+# shellcheck disable=SC2174
+mkdir -p -m 0700 /root/.ssh
 # Add a newline in case authorized_keys wasn't terminated correctly.
 echo >>/root/.ssh/authorized_keys
 cat "$ROOTID".pub >>/root/.ssh/authorized_keys


### PR DESCRIPTION
`mkdir` without `-m` treats `0700` as another directory name argument.

Follow-up to https://github.com/systemd/systemd/commit/52d863defcd05d0b676ce743b9eaf1060131f9a1