### PR TITLE
networkd: add support for DHCPv6 address registration (RFC 9686)

### DIFF
--- a/man/systemd.network.xml
+++ b/man/systemd.network.xml
@@ -3354,6 +3354,21 @@ MultiPathRoute=2001:db8::1@eth0</programlisting>
         </listitem>
       </varlistentry>
 
+      <varlistentry>
+        <term><varname>RegisterAddresses=</varname></term>
+        <listitem>
+          <para>Takes a boolean. If set to true, the DHCPv6 client sends an ADDR-REG-INFORM message
+          for each IPv6 address with global scope that was not itself obtained via DHCPv6, including
+          statically configured, SLAAC, and temporary (privacy extension) addresses, to inform the
+          DHCPv6 server that the address is in use, as defined in
+          <ulink url="https://www.rfc-editor.org/rfc/rfc9686.html">RFC 9686</ulink>.
+          Registration only takes place when the server indicates support by including the
+          ADDR-REG-ENABLE option in its replies. Defaults to false.</para>
+
+          <xi:include href="version-info.xml" xpointer="v262"/>
+        </listitem>
+      </varlistentry>
+
       <!-- How to communicate with the server -->
 
       <varlistentry>

--- a/mkosi/mkosi.conf.d/arch/mkosi.conf
+++ b/mkosi/mkosi.conf.d/arch/mkosi.conf
@@ -28,6 +28,7 @@ Packages=
         inetutils
         iproute
         iputils
+        kea
         knot
         liburing
         linux

--- a/mkosi/mkosi.conf.d/centos-fedora/mkosi.conf
+++ b/mkosi/mkosi.conf.d/centos-fedora/mkosi.conf
@@ -40,6 +40,7 @@ Packages=
         iproute-tc
         iputils
         iscsi-initiator-utils
+        kea
         kernel-core
         knot
         libcap-ng-utils

--- a/mkosi/mkosi.conf.d/fedora/mkosi.conf
+++ b/mkosi/mkosi.conf.d/fedora/mkosi.conf
@@ -4,7 +4,7 @@
 Distribution=fedora
 
 [Distribution]
-Release=rawhide
+Release=44
 
 [Content]
 Packages=

--- a/mkosi/mkosi.conf.d/opensuse/mkosi.conf
+++ b/mkosi/mkosi.conf.d/opensuse/mkosi.conf
@@ -50,6 +50,7 @@ Packages=
         hostname
         iproute2
         iputils
+        kea
         kernel-default
         kmod
         knot

--- a/mkosi/mkosi.extra.common/usr/lib/systemd/system-preset/00-mkosi.preset
+++ b/mkosi/mkosi.extra.common/usr/lib/systemd/system-preset/00-mkosi.preset
@@ -8,6 +8,15 @@ disable sshd.service
 disable dnsmasq.service
 disable isc-dhcp-server.service
 disable isc-dhcp-server6.service
+# Package/service names differ between distributions (Fedora ships kea-dhcp*.service,
+# Debian/Ubuntu ship kea-dhcp*-server.service), so disable both variants.
+disable kea-dhcp4.service
+disable kea-dhcp6.service
+disable kea-dhcp-ddns.service
+disable kea-ctrl-agent.service
+disable kea-dhcp4-server.service
+disable kea-dhcp6-server.service
+disable kea-dhcp-ddns-server.service
 
 # Make sure dbus-broker is started by default on Debian/Ubuntu.
 enable dbus-broker.service

--- a/mkosi/mkosi.postinst.chroot
+++ b/mkosi/mkosi.postinst.chroot
@@ -45,6 +45,8 @@ rm -f /etc/default/keyboard
 
 # These don't ship proper units with [Install] directives so we have to mask them instead.
 systemctl mask isc-dhcp-server.service
+systemctl mask kea-dhcp6.service
+systemctl mask kea-dhcp6-server.service
 systemctl mask mdmonitor.service
 
 # Fedora disables the userdb ssh dropin by default, but helpfully leaves it available in

--- a/src/libsystemd-network/dhcp6-addr-reg.c
+++ b/src/libsystemd-network/dhcp6-addr-reg.c
@@ -1,0 +1,736 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+/***
+  DHCPv6 Address Registration (RFC 9686).
+***/
+
+#include <linux/ipv6.h>
+#include <netinet/in.h>
+#include <string.h>
+
+#include "sd-dhcp6-option.h"
+
+#include "alloc-util.h"
+#include "dhcp6-addr-reg.h"
+#include "dhcp6-internal.h"
+#include "errno-util.h"
+#include "event-util.h"
+#include "fd-util.h"
+#include "hashmap.h"
+#include "in-addr-util.h"
+#include "iovec-util.h"
+#include "random-util.h"
+#include "socket-util.h"
+#include "time-util.h"
+
+/* RFC 9686 Section 4.5: initial retransmission time: 1 sec, maximum retry count: 3 */
+#define DHCP6_ADDR_REG_IRT (1 * USEC_PER_SEC)
+#define DHCP6_ADDR_REG_MRC 3U
+
+/* RFC 9686 Section 4.6.1: refresh interval is 80% of the current valid lifetime */
+#define DHCP6_ADDR_REG_REFRESH_RATIO 0.8
+
+ /* Errata 8600 replaces the original 1% tolerance interval of RFC 9686 4.6.1 with 3 seconds */
+#define DHCP6_ADDR_REG_LIFETIME_TOLERANCE_USEC (3 * USEC_PER_SEC)
+
+/* RFC 9686 Section 4.6.2: static addresses refreshed every 4 hours */
+#define DHCP6_ADDR_REG_STATIC_REFRESH_USEC (4 * USEC_PER_HOUR)
+
+typedef struct DHCP6AddrRegistration {
+        sd_dhcp6_client *client;
+        struct in6_addr address;
+
+        sd_event_source *timeout_resend;
+        sd_event_source *timeout_refresh;
+
+        be32_t transaction_id;
+        usec_t transaction_start;
+        usec_t retransmit_time;
+        unsigned retransmit_count;
+
+        usec_t valid_until_usec;     /* absolute CLOCK_BOOTTIME timestamp, or 0 for de-registration, or USEC_INFINITY */
+        usec_t preferred_until_usec; /* absolute CLOCK_BOOTTIME timestamp, or 0, or USEC_INFINITY */
+
+        usec_t next_refresh_time; /* NextAddrRegRefreshTime, absolute */
+} DHCP6AddrRegistration;
+
+static DHCP6AddrRegistration *dhcp6_addr_reg_free(DHCP6AddrRegistration *reg);
+DEFINE_TRIVIAL_CLEANUP_FUNC(DHCP6AddrRegistration *, dhcp6_addr_reg_free);
+
+static int dhcp6_addr_reg_update_refresh_time(DHCP6AddrRegistration *reg);
+
+static int dhcp6_network_bind_addr_reg_socket(int ifindex) {
+        union sockaddr_union src = {
+                .in6.sin6_family = AF_INET6,
+                .in6.sin6_addr = in6addr_any,
+                .in6.sin6_port = htobe16(DHCP6_PORT_CLIENT),
+        };
+        _cleanup_close_ int s = -EBADF;
+        int r;
+
+        /*
+         * Address registration uses the global-scoped address being registered as the
+         * source address for ADDR-REG-INFORM messages and as destination address for
+         * the ADDR-REG-REPLY. Since the main DHCPv6 client socket is bound to the
+         * link-local address, it can't be used here and we need a dedicated socket.
+         * Linux delivers each incoming datagram to the most specific matching socket;
+         * therefore, the ADDR-REG-REPLY message to the global-scoped address will
+         * be delivered to this socket. */
+        s = socket(AF_INET6, SOCK_DGRAM | SOCK_CLOEXEC | SOCK_NONBLOCK, IPPROTO_UDP);
+        if (s < 0)
+                return -errno;
+
+        r = setsockopt_int(s, IPPROTO_IPV6, IPV6_V6ONLY, true);
+        if (r < 0)
+                return r;
+
+        r = setsockopt_int(s, IPPROTO_IPV6, IPV6_MULTICAST_LOOP, false);
+        if (r < 0)
+                return r;
+
+        r = setsockopt_int(s, SOL_SOCKET, SO_REUSEADDR, true);
+        if (r < 0)
+                return r;
+
+        r = setsockopt_int(s, IPPROTO_IPV6, IPV6_RECVPKTINFO, true);
+        if (r < 0)
+                return r;
+
+        r = socket_bind_to_ifindex(s, ifindex);
+        if (r < 0)
+                return r;
+
+        r = bind(s, &src.sa, sizeof(src.in6));
+        if (r < 0)
+                return -errno;
+
+        return TAKE_FD(s);
+}
+
+static int dhcp6_network_send_addr_reg(
+                int s, int ifindex, const struct in6_addr *src_address, const void *packet, size_t len) {
+        CMSG_BUFFER_TYPE(CMSG_SPACE(sizeof(struct in6_pktinfo))) control = {};
+        union sockaddr_union dest = {
+                .in6.sin6_family = AF_INET6,
+                .in6.sin6_addr = IN6_ADDR_ALL_DHCP6_RELAY_AGENTS_AND_SERVERS,
+                .in6.sin6_port = htobe16(DHCP6_PORT_SERVER),
+        };
+        struct iovec iov = IOVEC_MAKE((void *) packet, len);
+        struct msghdr msg = {
+                .msg_name = &dest.sa,
+                .msg_namelen = sizeof(dest.in6),
+                .msg_iov = &iov,
+                .msg_iovlen = 1,
+                .msg_control = &control,
+                .msg_controllen = sizeof(control),
+        };
+        struct cmsghdr *cmsg;
+
+        assert(src_address);
+        assert(ifindex > 0);
+        assert(packet);
+        assert(len > 0);
+
+        /* 4.2: the ADDR-REG-INFORM message MUST be sent from the address being registered */
+        cmsg = CMSG_FIRSTHDR(&msg);
+        cmsg->cmsg_len = CMSG_LEN(sizeof(struct in6_pktinfo));
+        cmsg->cmsg_level = IPPROTO_IPV6;
+        cmsg->cmsg_type = IPV6_PKTINFO;
+
+        *CMSG_TYPED_DATA(cmsg, struct in6_pktinfo) = (struct in6_pktinfo) {
+                .ipi6_addr = *src_address,
+                .ipi6_ifindex = ifindex,
+        };
+
+        if (sendmsg(s, &msg, 0) < 0)
+                return -errno;
+
+        return 0;
+}
+
+static DHCP6AddrRegistration *dhcp6_addr_reg_free(DHCP6AddrRegistration *reg) {
+        if (!reg)
+                return NULL;
+
+        if (reg->client)
+                hashmap_remove(reg->client->addr_registrations, &reg->address);
+
+        sd_event_source_disable_unref(reg->timeout_resend);
+        sd_event_source_disable_unref(reg->timeout_refresh);
+
+        return mfree(reg);
+}
+
+static int dhcp6_addr_reg_new(sd_dhcp6_client *client, const struct in6_addr *address, DHCP6AddrRegistration **ret) {
+        _cleanup_(dhcp6_addr_reg_freep) DHCP6AddrRegistration *reg = NULL;
+
+        assert(client);
+        assert(address);
+        assert(ret);
+
+        reg = new(DHCP6AddrRegistration, 1);
+        if (!reg)
+                return -ENOMEM;
+
+        *reg = (DHCP6AddrRegistration) {
+                .client = client,
+                .address = *address,
+        };
+
+        *ret = TAKE_PTR(reg);
+        return 0;
+}
+
+static usec_t addr_reg_timeout_compute_random(usec_t val) {
+        return usec_sub_unsigned(val, random_u64_range(val / 10));
+}
+
+static uint32_t addr_reg_lifetime_to_sec(usec_t lifetime_usec, usec_t now_usec) {
+        if (lifetime_usec == USEC_INFINITY)
+                return UINT32_MAX;
+        if (now_usec >= lifetime_usec)
+                return 0;
+
+        return (uint32_t) ((lifetime_usec - now_usec) / USEC_PER_SEC);
+}
+
+static int dhcp6_addr_reg_send(DHCP6AddrRegistration *reg) {
+        sd_dhcp6_client *client;
+        _cleanup_free_ uint8_t *buf = NULL;
+        DHCP6Message *message;
+        struct iaaddr iaaddr;
+        usec_t now_usec, elapsed_usec;
+        be16_t elapsed_time;
+        size_t offset;
+        int r;
+
+        assert(reg);
+        client = reg->client;
+        assert(client);
+
+        if (!GREEDY_REALLOC0(buf, offsetof(DHCP6Message, options)))
+                return -ENOMEM;
+
+        message = (DHCP6Message *) buf;
+        message->transaction_id = reg->transaction_id;
+        message->type = DHCP6_MESSAGE_ADDR_REG_INFORM;
+
+        offset = offsetof(DHCP6Message, options);
+
+        /* 4.2: the client MUST include the Client Identifier option [RFC8415] in the ADDR-REG-INFORM message. */
+        assert(sd_dhcp_duid_is_set(&client->duid));
+        r = dhcp6_option_append(&buf, &offset, SD_DHCP6_OPTION_CLIENTID, client->duid.size, &client->duid.duid);
+        if (r < 0)
+                return r;
+
+        r = sd_event_now(client->event, CLOCK_BOOTTIME, &now_usec);
+        if (r < 0)
+                return r;
+
+        iaaddr = (struct iaaddr) {
+                .address = reg->address,
+                .lifetime_valid = htobe32(addr_reg_lifetime_to_sec(reg->valid_until_usec, now_usec)),
+                .lifetime_preferred = htobe32(addr_reg_lifetime_to_sec(reg->preferred_until_usec, now_usec)),
+        };
+
+        r = dhcp6_option_append(&buf, &offset, SD_DHCP6_OPTION_IAADDR, sizeof(struct iaaddr), &iaaddr);
+        if (r < 0)
+                return r;
+
+        /* RFC 8415 21.9: A client MUST include an Elapsed Time option in messages to indicate how long
+         * the client has been trying to complete a DHCP message exchange. */
+        elapsed_usec = MIN(
+                        usec_sub_unsigned(now_usec, reg->transaction_start) / USEC_PER_MSEC / 10,
+                        (usec_t) UINT16_MAX);
+        elapsed_time = htobe16(elapsed_usec);
+        r = dhcp6_option_append(&buf, &offset, SD_DHCP6_OPTION_ELAPSED_TIME, sizeof(elapsed_time), &elapsed_time);
+        if (r < 0)
+                return r;
+
+        r = dhcp6_network_send_addr_reg(client->addr_reg_fd, client->ifindex, &reg->address, buf, offset);
+        if (r < 0)
+                return r;
+
+        log_dhcp6_client(
+                        client,
+                        "Address registration: sent ADDR-REG-INFORM (%u/%u) for %s",
+                        reg->retransmit_count + 1,
+                        DHCP6_ADDR_REG_MRC,
+                        IN6_ADDR_TO_STRING(&reg->address));
+
+        return 0;
+}
+
+static int dhcp6_addr_reg_timeout_resend(sd_event_source *s, uint64_t usec, void *userdata) {
+        DHCP6AddrRegistration *reg = ASSERT_PTR(userdata);
+        int r;
+
+        if (reg->retransmit_count >= DHCP6_ADDR_REG_MRC) {
+                log_dhcp6_client(
+                                reg->client,
+                                "Address registration: no reply received for %s",
+                                IN6_ADDR_TO_STRING(&reg->address));
+
+                if (reg->valid_until_usec == 0)
+                        /* The address is no longer valid and was (unsuccessfully) unregistered */
+                        dhcp6_addr_reg_free(reg);
+
+                return 0;
+        }
+
+        r = dhcp6_addr_reg_send(reg);
+        if (r < 0)
+                log_dhcp6_client_errno(
+                                reg->client,
+                                r,
+                                "Address registration: failed to send ADDR-REG-INFORM for %s: %m",
+                                IN6_ADDR_TO_STRING(&reg->address));
+
+        reg->retransmit_count++;
+
+        if (reg->retransmit_time == 0)
+                reg->retransmit_time = addr_reg_timeout_compute_random(DHCP6_ADDR_REG_IRT);
+        else
+                reg->retransmit_time = usec_add(
+                                reg->retransmit_time, addr_reg_timeout_compute_random(reg->retransmit_time));
+
+        return event_reset_time_relative(
+                        reg->client->event,
+                        &reg->timeout_resend,
+                        CLOCK_BOOTTIME,
+                        reg->retransmit_time,
+                        10 * USEC_PER_MSEC,
+                        dhcp6_addr_reg_timeout_resend,
+                        reg,
+                        reg->client->event_priority,
+                        "dhcp6-addr-reg-resend",
+                        true);
+}
+
+static int dhcp6_addr_reg_start_transaction(DHCP6AddrRegistration *reg, bool one_shot) {
+        sd_dhcp6_client *client;
+        int r;
+
+        assert(reg);
+        client = reg->client;
+        assert(client);
+
+        r = sd_event_now(client->event, CLOCK_BOOTTIME, &reg->transaction_start);
+        if (r < 0)
+                return r;
+
+        reg->retransmit_count = 0;
+        reg->retransmit_time = 0;
+        reg->transaction_id = random_u32() & htobe32(0x00ffffff);
+
+        if (one_shot)
+                return dhcp6_addr_reg_send(reg);
+
+        return event_reset_time(
+                        client->event,
+                        &reg->timeout_resend,
+                        CLOCK_BOOTTIME,
+                        0,
+                        0,
+                        dhcp6_addr_reg_timeout_resend,
+                        reg,
+                        client->event_priority,
+                        "dhcp6-addr-reg-resend",
+                        true);
+}
+
+static usec_t addr_reg_refresh_interval(DHCP6AddrRegistration *reg, usec_t now) {
+        if (reg->valid_until_usec == USEC_INFINITY)
+                return DHCP6_ADDR_REG_STATIC_REFRESH_USEC;
+
+        if (reg->valid_until_usec <= now)
+                return 0;
+
+        return (usec_t) ((double) usec_sub_unsigned(reg->valid_until_usec, now) *
+                         DHCP6_ADDR_REG_REFRESH_RATIO * reg->client->addr_reg_desync_multiplier);
+}
+
+static int dhcp6_addr_reg_timeout_refresh(sd_event_source *s, uint64_t usec, void *userdata) {
+        DHCP6AddrRegistration *reg = ASSERT_PTR(userdata);
+        sd_dhcp6_client *client;
+        int r;
+
+        client = reg->client;
+        assert(client);
+
+        log_dhcp6_client(
+                        client,
+                        "Address registration: refreshing registration for %s",
+                        IN6_ADDR_TO_STRING(&reg->address));
+
+        r = dhcp6_addr_reg_update_refresh_time(reg);
+        if (r < 0) {
+                log_dhcp6_client_errno(
+                                client,
+                                r,
+                                "Address registration: failed to set next refresh for %s: %m",
+                                IN6_ADDR_TO_STRING(&reg->address));
+                /* Still proceed with the current refresh */
+        }
+
+        r = dhcp6_addr_reg_start_transaction(reg, false);
+        if (r < 0) {
+                log_dhcp6_client_errno(
+                                client,
+                                r,
+                                "Address registration: failed to start refresh for %s: %m",
+                                IN6_ADDR_TO_STRING(&reg->address));
+        }
+
+        return 0;
+}
+
+/*
+ * Updates the NextAddrRegRefreshTime as per RFC 9686 4.6.1 (for SLAAC addresses) and
+ * 4.6.2 (for static addresses).
+ */
+static int dhcp6_addr_reg_update_refresh_time(DHCP6AddrRegistration *reg) {
+        sd_dhcp6_client *client;
+        usec_t now;
+        int r;
+
+        assert(reg);
+        client = reg->client;
+        assert(client);
+
+        if (reg->valid_until_usec == 0)
+                /* Already de-registered */
+                return 0;
+
+        r = sd_event_now(client->event, CLOCK_BOOTTIME, &now);
+        if (r < 0)
+                return r;
+
+        reg->next_refresh_time = usec_add(now, addr_reg_refresh_interval(reg, now));
+
+        if (reg->valid_until_usec == USEC_INFINITY)
+                /* Section 4.6.2: static addresses are refreshed on a fixed interval */
+                return event_reset_time(
+                                client->event,
+                                &reg->timeout_refresh,
+                                CLOCK_BOOTTIME,
+                                reg->next_refresh_time,
+                                USEC_PER_SEC,
+                                dhcp6_addr_reg_timeout_refresh,
+                                reg,
+                                client->event_priority,
+                                "dhcp6-addr-reg-refresh",
+                                true);
+
+        /* Section 4.6.1: for SLAAC addresses, NextAddrRegRefreshTime is recorded but no
+         * timer is armed. Refreshes are event-driven: when a PIO changes the valid
+         * lifetime by more than the tolerance, we schedule a refresh. */
+        (void) event_source_disable(reg->timeout_refresh);
+
+        return 0;
+}
+
+static int dhcp6_addr_reg_receive(sd_event_source *s, int fd, uint32_t revents, void *userdata) {
+        _cleanup_free_ DHCP6Message *message = NULL;
+        sd_dhcp6_client *client = ASSERT_PTR(userdata);
+        DHCP6AddrRegistration *reg;
+        struct iovec iov;
+        CMSG_BUFFER_TYPE(CMSG_SPACE(sizeof(struct in6_pktinfo))) control = {};
+        union sockaddr_union sa = {};
+        struct msghdr msg = {
+                .msg_name = &sa.sa,
+                .msg_namelen = sizeof(sa),
+                .msg_iov = &iov,
+                .msg_iovlen = 1,
+                .msg_control = &control,
+                .msg_controllen = sizeof(control),
+        };
+        struct in6_pktinfo *pktinfo;
+        bool iaaddr_found;
+        ssize_t buflen;
+        ssize_t len;
+        int r;
+
+        buflen = next_datagram_size_fd(fd);
+        if (ERRNO_IS_NEG_TRANSIENT(buflen) || ERRNO_IS_NEG_DISCONNECT(buflen))
+                return 0;
+        if (buflen < 0) {
+                log_dhcp6_client_errno(
+                                client,
+                                buflen,
+                                "Address registration: failed to determine datagram size to read, ignoring: %m");
+                return 0;
+        }
+
+        message = malloc(buflen);
+        if (!message)
+                return -ENOMEM;
+
+        iov = IOVEC_MAKE(message, buflen);
+
+        len = recvmsg_safe(fd, &msg, MSG_DONTWAIT);
+        if (ERRNO_IS_NEG_TRANSIENT(len) || ERRNO_IS_NEG_DISCONNECT(len))
+                return 0;
+        if (len < 0) {
+                log_dhcp6_client_errno(
+                                client, len, "Address registration: could not receive message, ignoring: %m");
+                return 0;
+        }
+        if ((size_t) len < sizeof(DHCP6Message)) {
+                log_dhcp6_client(client, "Address registration: too small to be DHCPv6 message: ignoring");
+                return 0;
+        }
+
+        if (msg.msg_namelen != sizeof(struct sockaddr_in6) || sa.in6.sin6_family != AF_INET6 ||
+            sa.in6.sin6_port != htobe16(DHCP6_PORT_SERVER)) {
+                log_dhcp6_client(client, "Address registration: received message from invalid source, ignoring.");
+                return 0;
+        }
+
+        if (message->type != DHCP6_MESSAGE_ADDR_REG_REPLY)
+                return 0;
+
+        pktinfo = CMSG_FIND_DATA(&msg, IPPROTO_IPV6, IPV6_PKTINFO, struct in6_pktinfo);
+        if (!pktinfo) {
+                log_dhcp6_client(
+                                client,
+                                "Address registration: cannot determine destination address for reply, ignoring");
+                return 0;
+        }
+
+        reg = hashmap_get(client->addr_registrations, &pktinfo->ipi6_addr);
+        if (!reg) {
+                log_dhcp6_client(client, "Address registration: got reply for unregistered address, ignoring");
+                return 0;
+        }
+
+        if (reg->transaction_id != (message->transaction_id & htobe32(0x00ffffff))) {
+                log_dhcp6_client(client, "Address registration: wrong transaction id in reply, ignoring");
+                return 0;
+        }
+
+        /* Check that the message contains an IA Address option with the address being registered */
+        iaaddr_found = false;
+        len -= sizeof(DHCP6Message);
+        for (size_t offset = 0; offset < (size_t) len;) {
+                uint16_t optcode;
+                size_t optlen;
+                const uint8_t *optval;
+
+                r = dhcp6_option_parse(message->options, len, &offset, &optcode, &optlen, &optval);
+                if (r < 0)
+                        break;
+
+                if (optcode == SD_DHCP6_OPTION_IAADDR && optlen >= sizeof(struct iaaddr)) {
+                        struct iaaddr ia_addr;
+                        struct in6_addr addr;
+
+                        memcpy(&ia_addr, optval, sizeof(ia_addr));
+                        addr = ia_addr.address;
+
+                        if (in6_addr_equal(&addr, &reg->address)) {
+                                iaaddr_found = true;
+                                break;
+                        }
+                }
+        }
+        if (!iaaddr_found) {
+                log_dhcp6_client(
+                                client,
+                                "Address registration: missing IA Address option in reply for %s",
+                                IN6_ADDR_TO_STRING(&reg->address));
+                return 0;
+        }
+
+        log_dhcp6_client(
+                        client,
+                        "Address registration: received ADDR-REG-REPLY for %s",
+                        IN6_ADDR_TO_STRING(&reg->address));
+
+        reg->timeout_resend = sd_event_source_disable_unref(reg->timeout_resend);
+
+        if (reg->valid_until_usec == 0) {
+                /* The address is no longer valid and was unregistered */
+                dhcp6_addr_reg_free(reg);
+        }
+
+        return 0;
+}
+
+static int dhcp6_client_ensure_addr_reg_socket(sd_dhcp6_client *client) {
+        int r;
+
+        assert(client);
+
+        if (client->addr_reg_fd >= 0)
+                return 0;
+
+        /* 4.6.1: AddrRegDesyncMultiplier is a random value uniformly distributed between 0.9 and 1.1
+         * (inclusive) and is chosen by the client when it starts the registration process. */
+        client->addr_reg_desync_multiplier = 0.9 + 0.2 * ((double) random_u32() / (double) UINT32_MAX);
+
+        r = dhcp6_network_bind_addr_reg_socket(client->ifindex);
+        if (r < 0)
+                return log_dhcp6_client_errno(client, r, "Address registration: failed to bind socket: %m");
+
+        client->addr_reg_fd = r;
+
+        r = sd_event_add_io(
+                        client->event,
+                        &client->addr_reg_receive,
+                        client->addr_reg_fd,
+                        EPOLLIN,
+                        dhcp6_addr_reg_receive,
+                        client);
+        if (r < 0) {
+                client->addr_reg_fd = safe_close(client->addr_reg_fd);
+                return r;
+        }
+
+        sd_event_source_set_description(client->addr_reg_receive, "dhcp6-addr-reg-receive");
+        sd_event_source_set_priority(client->addr_reg_receive, client->event_priority);
+
+        return 0;
+}
+
+static bool addr_reg_lifetime_changed_with_tolerance(usec_t old_usec, usec_t new_usec) {
+        usec_t diff;
+
+        if (old_usec == new_usec)
+                return false;
+
+        if (old_usec == USEC_INFINITY || new_usec == USEC_INFINITY)
+                return true;
+
+        diff = old_usec > new_usec ? (old_usec - new_usec) : (new_usec - old_usec);
+        return diff > DHCP6_ADDR_REG_LIFETIME_TOLERANCE_USEC;
+}
+
+static int dhcp6_addr_reg_update_lifetime(
+                DHCP6AddrRegistration *reg, usec_t valid_until_usec, usec_t preferred_until_usec) {
+        sd_dhcp6_client *client;
+        bool changed;
+        usec_t refresh_time;
+        usec_t now;
+        int r;
+
+        assert(reg);
+        client = reg->client;
+        assert(client);
+
+        r = sd_event_now(reg->client->event, CLOCK_BOOTTIME, &now);
+        if (r < 0)
+                return r;
+
+        changed = addr_reg_lifetime_changed_with_tolerance(reg->valid_until_usec, valid_until_usec);
+
+        reg->valid_until_usec = valid_until_usec;
+        reg->preferred_until_usec = preferred_until_usec;
+
+        if (valid_until_usec == 0) {
+                log_dhcp6_client(
+                                client,
+                                "Address registration: deregistering %s",
+                                IN6_ADDR_TO_STRING(&reg->address));
+                return dhcp6_addr_reg_start_transaction(reg, false);
+        }
+
+        if (!changed)
+                return 0;
+
+        refresh_time = MIN(reg->next_refresh_time, usec_add(now, addr_reg_refresh_interval(reg, now)));
+
+        if (refresh_time <= now)
+                return dhcp6_addr_reg_start_transaction(reg, false);
+
+        return event_reset_time_relative(
+                        reg->client->event,
+                        &reg->timeout_refresh,
+                        CLOCK_BOOTTIME,
+                        usec_sub_unsigned(refresh_time, now),
+                        USEC_PER_SEC,
+                        dhcp6_addr_reg_timeout_refresh,
+                        reg,
+                        reg->client->event_priority,
+                        "dhcp6-addr-reg-refresh",
+                        true);
+}
+
+int dhcp6_client_register_address(
+                sd_dhcp6_client *client,
+                const struct in6_addr *address,
+                usec_t valid_until_usec,
+                usec_t preferred_until_usec) {
+        DHCP6AddrRegistration *reg;
+        int r;
+
+        assert(client);
+        assert(address);
+
+        reg = hashmap_get(client->addr_registrations, address);
+        if (reg)
+                return dhcp6_addr_reg_update_lifetime(reg, valid_until_usec, preferred_until_usec);
+
+        if (valid_until_usec == 0)
+                return 0;
+
+        r = dhcp6_client_ensure_addr_reg_socket(client);
+        if (r < 0)
+                return r;
+
+        r = dhcp6_addr_reg_new(client, address, &reg);
+        if (r < 0)
+                return r;
+
+        r = hashmap_ensure_put(&client->addr_registrations, &in6_addr_hash_ops, &reg->address, reg);
+        if (r < 0) {
+                dhcp6_addr_reg_free(reg);
+                return r;
+        }
+
+        reg->valid_until_usec = valid_until_usec;
+        reg->preferred_until_usec = preferred_until_usec;
+
+        r = dhcp6_addr_reg_update_refresh_time(reg);
+        if (r < 0) {
+                log_dhcp6_client_errno(
+                                client,
+                                r,
+                                "Address registration: failed to set next refresh for %s: %m",
+                                IN6_ADDR_TO_STRING(&reg->address));
+                /* Still proceed with the registration */
+        }
+
+        log_dhcp6_client(client, "Address registration: registering %s", IN6_ADDR_TO_STRING(address));
+
+        return dhcp6_addr_reg_start_transaction(reg, false);
+}
+
+void dhcp6_client_drop_address_registration(sd_dhcp6_client *client, const struct in6_addr *address) {
+        DHCP6AddrRegistration *reg;
+
+        assert(client);
+        assert(address);
+
+        reg = hashmap_get(client->addr_registrations, address);
+        if (reg)
+                dhcp6_addr_reg_free(reg);
+}
+
+void dhcp6_client_addr_reg_flush(sd_dhcp6_client *client) {
+        DHCP6AddrRegistration *reg;
+
+        assert(client);
+
+        while ((reg = hashmap_first(client->addr_registrations))) {
+                if (reg->valid_until_usec != 0) {
+                        reg->valid_until_usec = 0;
+                        reg->preferred_until_usec = 0;
+                        (void) dhcp6_addr_reg_start_transaction(reg, true);
+                }
+                dhcp6_addr_reg_free(reg);
+        }
+
+        client->addr_reg_receive = sd_event_source_disable_unref(client->addr_reg_receive);
+        client->addr_registrations = hashmap_free(client->addr_registrations);
+        client->addr_reg_fd = safe_close(client->addr_reg_fd);
+}

--- a/src/libsystemd-network/dhcp6-addr-reg.h
+++ b/src/libsystemd-network/dhcp6-addr-reg.h
@@ -1,0 +1,30 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#pragma once
+
+/***
+  DHCPv6 Address Registration (RFC 9686).
+***/
+
+#include <netinet/in.h>
+
+#include "forward.h"
+
+/* Registers (or updates, or de-registers when valid_until_usec == 0) the given global-scope address
+ * with the DHCPv6 server(s) on the link, per RFC 9686. valid_until_usec and preferred_until_usec are
+ * absolute CLOCK_BOOTTIME timestamps, not durations; USEC_INFINITY marks a lifetime as never
+ * expiring. This creates (on first call for a given address) or reuses the shared per-client socket
+ * used for ADDR-REG-INFORM/ADDR-REG-REPLY exchanges, and takes care of retransmission and periodic
+ * refresh of the registration for as long as the client exists. */
+int dhcp6_client_register_address(
+                sd_dhcp6_client *client,
+                const struct in6_addr *address,
+                usec_t valid_until_usec,
+                usec_t preferred_until_usec);
+
+/* Drops the registration tracking entry for a single address without sending a de-registration
+ * message. Use this when the address is already gone from the interface and sending is impossible. */
+void dhcp6_client_drop_address_registration(sd_dhcp6_client *client, const struct in6_addr *address);
+
+/* Tears down all address registrations of the client, best-effort notifying the server(s) that the
+ * addresses are no longer in use, and releases the shared socket. Safe to call multiple times. */
+void dhcp6_client_addr_reg_flush(sd_dhcp6_client *client);

--- a/src/libsystemd-network/dhcp6-internal.h
+++ b/src/libsystemd-network/dhcp6-internal.h
@@ -70,6 +70,12 @@ struct sd_dhcp6_client {
         bool rapid_commit;
         bool register_addresses;
 
+        /* RFC 9686 DHCPv6 address registration. */
+        Hashmap *addr_registrations; /* struct in6_addr* -> DHCP6AddrRegistration* */
+        double addr_reg_desync_multiplier;
+        int addr_reg_fd;
+        sd_event_source *addr_reg_receive;
+
         struct sd_dhcp6_lease *lease;
 
         sd_dhcp6_client_callback_t callback;

--- a/src/libsystemd-network/dhcp6-internal.h
+++ b/src/libsystemd-network/dhcp6-internal.h
@@ -68,6 +68,7 @@ struct sd_dhcp6_client {
         OrderedHashmap *extra_options;
         OrderedSet *vendor_options;
         bool rapid_commit;
+        bool register_addresses;
 
         struct sd_dhcp6_lease *lease;
 

--- a/src/libsystemd-network/dhcp6-lease-internal.h
+++ b/src/libsystemd-network/dhcp6-lease-internal.h
@@ -21,6 +21,7 @@ struct sd_dhcp6_lease {
         size_t serverid_len;
         uint8_t preference;
         bool rapid_commit;
+        bool register_addresses;
         triple_timestamp timestamp;
         usec_t lifetime_t1;
         usec_t lifetime_t2;
@@ -60,6 +61,8 @@ int dhcp6_lease_set_preference(sd_dhcp6_lease *lease, uint8_t preference);
 int dhcp6_lease_get_preference(sd_dhcp6_lease *lease, uint8_t *ret);
 int dhcp6_lease_set_rapid_commit(sd_dhcp6_lease *lease);
 int dhcp6_lease_get_rapid_commit(sd_dhcp6_lease *lease, bool *ret);
+int dhcp6_lease_set_register_addresses(sd_dhcp6_lease *lease);
+int dhcp6_lease_get_register_addresses(sd_dhcp6_lease *lease, bool *ret);
 
 int dhcp6_lease_add_dns(sd_dhcp6_lease *lease, const uint8_t *optval, size_t optlen);
 int dhcp6_lease_add_domains(sd_dhcp6_lease *lease, const uint8_t *optval, size_t optlen);

--- a/src/libsystemd-network/dhcp6-option.c
+++ b/src/libsystemd-network/dhcp6-option.c
@@ -213,8 +213,9 @@ bool dhcp6_option_can_request(uint16_t option) {
         case SD_DHCP6_OPTION_REGISTERED_DOMAIN:
         case SD_DHCP6_OPTION_FORWARD_DIST_MANAGER:
         case SD_DHCP6_OPTION_REVERSE_DIST_MANAGER:
-        case SD_DHCP6_OPTION_ADDR_REG_ENABLE:
                 return true;
+        case SD_DHCP6_OPTION_ADDR_REG_ENABLE:
+                return false; /* Automatically set when RegisterAddresses is enabled. */
         default:
                 return false;
         }

--- a/src/libsystemd-network/meson.build
+++ b/src/libsystemd-network/meson.build
@@ -12,6 +12,7 @@ libsystemd_network_sources = files(
         'dhcp-route.c',
         'dhcp-server-request.c',
         'dhcp-server-send.c',
+        'dhcp6-addr-reg.c',
         'dhcp6-network.c',
         'dhcp6-option.c',
         'dhcp6-protocol.c',

--- a/src/libsystemd-network/sd-dhcp6-client.c
+++ b/src/libsystemd-network/sd-dhcp6-client.c
@@ -515,6 +515,29 @@ int sd_dhcp6_client_set_rapid_commit(sd_dhcp6_client *client, int enable) {
         return 0;
 }
 
+int sd_dhcp6_client_set_register_addresses(sd_dhcp6_client *client, int enable) {
+        assert_return(client, -EINVAL);
+        assert_return(!sd_dhcp6_client_is_running(client), -EBUSY);
+
+        client->register_addresses = enable;
+        return 0;
+}
+
+int sd_dhcp6_client_register_address(
+                sd_dhcp6_client *client,
+                const struct in6_addr *address,
+                uint64_t valid_until_usec,
+                uint64_t preferred_until_usec) {
+
+        assert_return(client, -EINVAL);
+        assert_return(client->register_addresses, -EINVAL);
+        assert_return(address, -EINVAL);
+        assert_return(client->ifindex > 0, -EINVAL);
+        assert_return(valid_until_usec == 0 || preferred_until_usec <= valid_until_usec, -EINVAL);
+
+        return dhcp6_client_register_address(client, address, valid_until_usec, preferred_until_usec);
+}
+
 int sd_dhcp6_client_set_send_release(sd_dhcp6_client *client, int enable) {
         assert_return(client, -EINVAL);
 
@@ -681,8 +704,9 @@ static DHCP6MessageType client_message_type_from_state(sd_dhcp6_client *client) 
 
 static int client_append_oro(sd_dhcp6_client *client, uint8_t **buf, size_t *offset) {
         _cleanup_free_ be16_t *p = NULL;
+        be16_t extra[3];
+        size_t n_extra = 0, n;
         be16_t *req_opts;
-        size_t n;
 
         assert(client);
         assert(buf);
@@ -690,38 +714,39 @@ static int client_append_oro(sd_dhcp6_client *client, uint8_t **buf, size_t *off
         assert(offset);
 
         switch (client->state) {
-        case DHCP6_STATE_INFORMATION_REQUEST:
-                n = client->n_req_opts;
-                p = new(be16_t, n + 2);
-                if (!p)
-                        return -ENOMEM;
-
-                memcpy_safe(p, client->req_opts, n * sizeof(be16_t));
-                p[n++] = htobe16(SD_DHCP6_OPTION_INFORMATION_REFRESH_TIME); /* RFC 8415 section 21.23 */
-                p[n++] = htobe16(SD_DHCP6_OPTION_INF_MAX_RT); /* RFC 8415 section 21.25 */
-
-                typesafe_qsort(p, n, be16_compare_func);
-                req_opts = p;
-                break;
-
-        case DHCP6_STATE_SOLICITATION:
-                n = client->n_req_opts;
-                p = new(be16_t, n + 1);
-                if (!p)
-                        return -ENOMEM;
-
-                memcpy_safe(p, client->req_opts, n * sizeof(be16_t));
-                p[n++] = htobe16(SD_DHCP6_OPTION_SOL_MAX_RT); /* RFC 8415 section 21.24 */
-
-                typesafe_qsort(p, n, be16_compare_func);
-                req_opts = p;
-                break;
-
         case DHCP6_STATE_STOPPING:
                 return 0;
 
+        case DHCP6_STATE_INFORMATION_REQUEST:
+                extra[n_extra++] = htobe16(SD_DHCP6_OPTION_INFORMATION_REFRESH_TIME); /* RFC 8415 section 21.23 */
+                extra[n_extra++] = htobe16(SD_DHCP6_OPTION_INF_MAX_RT); /* RFC 8415 section 21.25 */
+                break;
+
+        case DHCP6_STATE_SOLICITATION:
+                extra[n_extra++] = htobe16(SD_DHCP6_OPTION_SOL_MAX_RT); /* RFC 8415 section 21.24 */
+                break;
+
         default:
-                n = client->n_req_opts;
+                break;
+        }
+
+        if (client->register_addresses)
+                extra[n_extra++] = htobe16(SD_DHCP6_OPTION_ADDR_REG_ENABLE);
+
+        n = client->n_req_opts;
+
+        if (n_extra > 0) {
+                p = new(be16_t, n + n_extra);
+                if (!p)
+                        return -ENOMEM;
+
+                memcpy_safe(p, client->req_opts, n * sizeof(be16_t));
+                memcpy(p + n, extra, n_extra * sizeof(be16_t));
+                n += n_extra;
+
+                typesafe_qsort(p, n, be16_compare_func);
+                req_opts = p;
+        } else {
                 req_opts = client->req_opts;
         }
 

--- a/src/libsystemd-network/sd-dhcp6-client.c
+++ b/src/libsystemd-network/sd-dhcp6-client.c
@@ -12,6 +12,7 @@
 #include "alloc-util.h"
 #include "device-util.h"
 #include "dhcp-duid-internal.h"
+#include "dhcp6-addr-reg.h"
 #include "dhcp6-client-internal.h"
 #include "dhcp6-internal.h"
 #include "dhcp6-lease-internal.h"
@@ -1443,6 +1444,8 @@ int sd_dhcp6_client_stop(sd_dhcp6_client *client) {
         client->receive_message = sd_event_source_unref(client->receive_message);
         client->fd = safe_close(client->fd);
 
+        dhcp6_client_addr_reg_flush(client);
+
         return 0;
 }
 
@@ -1567,6 +1570,8 @@ static sd_dhcp6_client *dhcp6_client_free(sd_dhcp6_client *client) {
 
         sd_dhcp6_lease_unref(client->lease);
 
+        dhcp6_client_addr_reg_flush(client);
+
         sd_event_source_disable_unref(client->receive_message);
         sd_event_source_disable_unref(client->timeout_resend);
         sd_event_source_disable_unref(client->timeout_expire);
@@ -1610,6 +1615,7 @@ int sd_dhcp6_client_new(sd_dhcp6_client **ret) {
                 .request_ia = DHCP6_REQUEST_IA_NA | DHCP6_REQUEST_IA_PD,
                 .fd = -EBADF,
                 .rapid_commit = true,
+                .addr_reg_fd = -EBADF,
         };
 
         *ret = TAKE_PTR(client);

--- a/src/libsystemd-network/sd-dhcp6-lease.c
+++ b/src/libsystemd-network/sd-dhcp6-lease.c
@@ -246,6 +246,21 @@ int dhcp6_lease_get_rapid_commit(sd_dhcp6_lease *lease, bool *ret) {
         return 0;
 }
 
+int dhcp6_lease_set_register_addresses(sd_dhcp6_lease *lease) {
+        assert(lease);
+
+        lease->register_addresses = true;
+        return 0;
+}
+
+int dhcp6_lease_get_register_addresses(sd_dhcp6_lease *lease, bool *ret) {
+        assert(lease);
+        assert(ret);
+
+        *ret = lease->register_addresses;
+        return 0;
+}
+
 int sd_dhcp6_lease_get_address(sd_dhcp6_lease *lease, struct in6_addr *ret) {
         assert_return(lease, -EINVAL);
 
@@ -1027,6 +1042,15 @@ static int dhcp6_lease_parse_message(
                         r = dhcp6_lease_add_vendor_option(lease, optval, optlen);
                         if (r < 0)
                                 log_dhcp6_client_errno(client, r, "Failed to parse vendor option, ignoring: %m");
+
+                        break;
+                case SD_DHCP6_OPTION_ADDR_REG_ENABLE:
+                        if (optlen != 0)
+                                log_dhcp6_client(client, "Received address registration enable option with an invalid length (%zu), ignoring.", optlen);
+
+                        r = dhcp6_lease_set_register_addresses(lease);
+                        if (r < 0)
+                                return log_dhcp6_client_errno(client, r, "Failed to set address registration flag: %m");
 
                         break;
                 }

--- a/src/network/networkd-address.c
+++ b/src/network/networkd-address.c
@@ -21,6 +21,7 @@
 #include "networkd-dhcp-prefix-delegation.h"
 #include "networkd-dhcp-relay.h"
 #include "networkd-dhcp-server.h"
+#include "networkd-dhcp6.h"
 #include "networkd-ipv4acd.h"
 #include "networkd-link.h"
 #include "networkd-manager.h"
@@ -834,6 +835,14 @@ static int address_update(Address *address) {
                         return r;
         }
 
+        r = dhcp6_register_address(link, address);
+        if (r < 0)
+                log_link_warning_errno(
+                                link,
+                                r,
+                                "Could not start the registration of %s via DHCPv6, ignoring: %m",
+                                IN6_ADDR_TO_STRING(&address->in_addr.in6));
+
         link_update_operstate(link, /* also_update_master= */ true);
         link_check_ready(link);
         return 0;
@@ -932,6 +941,10 @@ static int address_drop(Address *in, bool removed_by_us) {
         ipv4acd_detach(link, address);
 
         (void) link_dhcp_relay_address_dropped(link, address);
+
+        /* The address is already gone from the kernel at this point. Just clean up the local
+         * registration tracking entry; de-registration was sent (if possible) from address_remove(). */
+        dhcp6_drop_address_registration(link, address);
 
         address_detach(address);
 
@@ -1289,6 +1302,16 @@ int address_remove(Address *address, Link *link) {
         (void) address_get(link, address, &address);
 
         log_address_debug(address, "Removing", link);
+
+        /* Send de-registration while the address is still present on the interface, so that
+         * sendmsg() can use it as source address. */
+        r = dhcp6_unregister_address(link, address);
+        if (r < 0)
+                log_link_warning_errno(
+                                link,
+                                r,
+                                "Could not de-register %s via DHCPv6, ignoring: %m",
+                                IN6_ADDR_TO_STRING(&address->in_addr.in6));
 
         r = sd_rtnl_message_new_addr(link->manager->rtnl, &m, RTM_DELADDR,
                                      link->ifindex, address->family);

--- a/src/network/networkd-dhcp6.c
+++ b/src/network/networkd-dhcp6.c
@@ -776,6 +776,12 @@ static int dhcp6_configure(Link *link) {
                                             "DHCPv6 CLIENT: Failed to %s sending release message on stop: %m",
                                             enable_disable(link->network->dhcp6_send_release));
 
+        r = sd_dhcp6_client_set_register_addresses(client, link->network->dhcp6_register_addresses);
+        if (r < 0)
+                return log_link_debug_errno(link, r,
+                                            "DHCPv6 CLIENT: Failed to %s address registration: %m",
+                                            enable_disable(link->network->dhcp6_register_addresses));
+
         link->dhcp6_client = TAKE_PTR(client);
 
         return 0;

--- a/src/network/networkd-dhcp6.c
+++ b/src/network/networkd-dhcp6.c
@@ -4,11 +4,13 @@
 ***/
 
 #include <linux/if_addr.h>
+#include <linux/rtnetlink.h>
 #include <stdio.h>
 
 #include "sd-dhcp6-protocol.h"
 
 #include "conf-parser.h"
+#include "dhcp6-addr-reg.h"
 #include "dhcp6-client-internal.h"
 #include "dhcp6-lease-internal.h"
 #include "errno-util.h"
@@ -307,6 +309,92 @@ static int dhcp6_request_hostname(Link *link) {
         return 0;
 }
 
+static int dhcp6_register_address_with_lifetimes(
+                Link *link, Address *address, usec_t lifetime_valid_usec, usec_t lifetime_preferred_usec) {
+        bool enable;
+        int r;
+
+        assert(link);
+        assert(address);
+
+        if (!link->network || !link->network->dhcp6_register_addresses)
+                return 0;
+
+        if (address->family != AF_INET6)
+                return 0;
+
+        if (address->scope != RT_SCOPE_UNIVERSE)
+                return 0;
+
+        if (address->source == NETWORK_CONFIG_SOURCE_DHCP6)
+                return 0;
+
+        if (lifetime_valid_usec > 0 && !address_is_ready(address))
+                return 0;
+
+        if (!link->dhcp6_client || !link->dhcp6_lease)
+                return 0;
+
+        /* RFC 9686 section 4.2 says: "The client SHOULD NOT send the ADDR-REG-INFORM message
+         * unless it has received a Router Advertisement (RA) message with either the M or O
+         * flags set to 1". We don't explicitly check for the flags, but only that a lease is
+         * present. If the user forced enabled DHCPv6 with "DHCP=WithoutRA" and the DHCPv6
+         * server supports registration, it seems acceptable to send the ADDR-REG-INFORM.
+         */
+
+        r = dhcp6_lease_get_register_addresses(link->dhcp6_lease, &enable);
+        if (r < 0)
+                return r;
+        if (!enable)
+                return 0;
+
+        return sd_dhcp6_client_register_address(
+                        link->dhcp6_client, &address->in_addr.in6, lifetime_valid_usec, lifetime_preferred_usec);
+}
+
+int dhcp6_register_address(Link *link, Address *address) {
+        return dhcp6_register_address_with_lifetimes(
+                        link, address, address->lifetime_valid_usec, address->lifetime_preferred_usec);
+}
+
+int dhcp6_unregister_address(Link *link, Address *address) {
+        return dhcp6_register_address_with_lifetimes(link, address, 0, 0);
+}
+
+void dhcp6_drop_address_registration(Link *link, Address *address) {
+        assert(link);
+        assert(address);
+
+        if (address->family != AF_INET6)
+                return;
+
+        if (!link->dhcp6_client)
+                return;
+
+        dhcp6_client_drop_address_registration(link->dhcp6_client, &address->in_addr.in6);
+}
+
+static void dhcp6_register_existing_addresses(Link *link) {
+        Address *address;
+        bool enable = false;
+
+        assert(link);
+
+        if (!link->dhcp6_client || !link->dhcp6_lease)
+                return;
+
+        (void) dhcp6_lease_get_register_addresses(link->dhcp6_lease, &enable);
+        if (!enable) {
+                /* The new lease does not advertise address registration support.
+                 * Flush any registrations created under a previous lease. */
+                dhcp6_client_addr_reg_flush(link->dhcp6_client);
+                return;
+        }
+
+        SET_FOREACH(address, link->addresses)
+                dhcp6_register_address(link, address);
+}
+
 static int dhcp6_lease_ip_acquired(sd_dhcp6_client *client, Link *link) {
         _cleanup_(sd_dhcp6_lease_unrefp) sd_dhcp6_lease *lease_old = NULL;
         sd_dhcp6_lease *lease;
@@ -320,6 +408,8 @@ static int dhcp6_lease_ip_acquired(sd_dhcp6_client *client, Link *link) {
 
         lease_old = TAKE_PTR(link->dhcp6_lease);
         link->dhcp6_lease = sd_dhcp6_lease_ref(lease);
+
+        dhcp6_register_existing_addresses(link);
 
         r = dhcp6_request_hostname(link);
         if (r < 0)
@@ -365,6 +455,8 @@ static int dhcp6_lease_information_acquired(sd_dhcp6_client *client, Link *link)
                 return log_link_error_errno(link, r, "Failed to get DHCPv6 lease: %m");
 
         unref_and_replace_new_ref(link->dhcp6_lease, lease, sd_dhcp6_lease_ref, sd_dhcp6_lease_unref);
+
+        dhcp6_register_existing_addresses(link);
 
         link_dirty(link);
         return 0;

--- a/src/network/networkd-dhcp6.h
+++ b/src/network/networkd-dhcp6.h
@@ -16,6 +16,9 @@ int dhcp6_check_ready(Link *link);
 int dhcp6_update_mac(Link *link);
 int dhcp6_start(Link *link);
 int dhcp6_start_on_ra(Link *link, bool information_request);
+int dhcp6_register_address(Link *link, Address *address);
+int dhcp6_unregister_address(Link *link, Address *address);
+void dhcp6_drop_address_registration(Link *link, Address *address);
 
 int link_request_dhcp6_client(Link *link);
 int link_drop_dhcp6_config(Link *link, Network *network);

--- a/src/network/networkd-network-gperf.gperf
+++ b/src/network/networkd-network-gperf.gperf
@@ -336,6 +336,7 @@ DHCPv6.NetLabel,                                 config_parse_string,           
 DHCPv6.SendRelease,                              config_parse_bool,                              0,                                      offsetof(Network, dhcp6_send_release)
 DHCPv6.NFTSet,                                   config_parse_nft_set,                           NFT_SET_PARSE_NETWORK,                  offsetof(Network, dhcp6_nft_set_context)
 DHCPv6.RouteTable,                               config_parse_dhcp_or_ra_route_table,            NETWORK_CONFIG_SOURCE_DHCP6,            0
+DHCPv6.RegisterAddresses,                        config_parse_bool,                              0,                                      offsetof(Network, dhcp6_register_addresses)
 IPv6AcceptRA.UseRedirect,                        config_parse_bool,                              0,                                      offsetof(Network, ndisc_use_redirect)
 IPv6AcceptRA.UseGateway,                         config_parse_bool,                              0,                                      offsetof(Network, ndisc_use_gateway)
 IPv6AcceptRA.UseRoutePrefix,                     config_parse_bool,                              0,                                      offsetof(Network, ndisc_use_route_prefix)

--- a/src/network/networkd-network.h
+++ b/src/network/networkd-network.h
@@ -208,6 +208,7 @@ typedef struct Network {
         NFTSetContext dhcp6_nft_set_context;
         uint32_t dhcp6_route_table;
         bool dhcp6_route_table_set;
+        bool dhcp6_register_addresses;
 
         /* DHCP Relay Agent Support */
         DHCPRelayInterfaceMode dhcp_relay_interface_mode;

--- a/src/systemd/sd-dhcp6-client.h
+++ b/src/systemd/sd-dhcp6-client.h
@@ -113,6 +113,16 @@ int sd_dhcp6_client_add_vendor_option(sd_dhcp6_client *client,
                                       sd_dhcp6_option *v);
 int sd_dhcp6_client_set_rapid_commit(sd_dhcp6_client *client, int enable);
 int sd_dhcp6_client_set_send_release(sd_dhcp6_client *client, int enable);
+int sd_dhcp6_client_set_register_addresses(sd_dhcp6_client *client, int enable);
+
+/* Registers (or updates, or de-registers) an address via DHCPv6, per RFC 9686. The
+ * timestamps are absolute and valid_until_usec == 0 de-registers the address.
+ * USEC_INFINITY indicates a never-expiring address (e.g. statically configured). */
+int sd_dhcp6_client_register_address(
+                sd_dhcp6_client *client,
+                const struct in6_addr *address,
+                uint64_t valid_until_usec,
+                uint64_t preferred_until_usec);
 
 int sd_dhcp6_client_get_lease(
                 sd_dhcp6_client *client,

--- a/test/test-network/conf/25-dhcp6-addr-reg-client.network
+++ b/test/test-network/conf/25-dhcp6-addr-reg-client.network
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+[Match]
+Name=veth99
+
+[Network]
+DHCP=yes
+IPv6AcceptRA=yes
+IPv6PrivacyExtensions=yes
+
+[Address]
+Address=2001:db8:1::4242/64
+
+[Address]
+Address=2001:db8:1::4343/64
+
+[Address]
+Address=fd00::1/64
+
+[DHCPv6]
+RegisterAddresses=yes
+SendHostname=yes
+Hostname=test-hostname
+DUIDType=vendor
+DUIDRawData=00:00:ab:11:00:11:22:33:44:55:66:77

--- a/test/test-network/conf/25-dhcp6-addr-reg-server.network
+++ b/test/test-network/conf/25-dhcp6-addr-reg-server.network
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+[Match]
+Name=veth-peer
+
+[Network]
+IPv6AcceptRA=no
+Address=2001:db8:1::1/64
+IPv6Forwarding=yes

--- a/test/test-network/conf/kea/kea-dhcp6-addr-reg.conf
+++ b/test/test-network/conf/kea/kea-dhcp6-addr-reg.conf
@@ -1,0 +1,38 @@
+{
+  "Dhcp6": {
+    "interfaces-config": {
+      "interfaces": [
+        "veth-peer"
+      ]
+    },
+    "lease-database": {
+      "type": "memfile",
+      "persist": true,
+      "name": "/run/networkd-ci/test-kea-dhcp6.leases"
+    },
+    "valid-lifetime": 28800,
+    "option-data": [
+      {
+        "name": "addr-reg-enable"
+      }
+    ],
+    "subnet6": [
+      {
+        "id": 1,
+        "interface": "veth-peer",
+        "subnet": "2001:db8:1::/64",
+        "pools": [
+          {
+            "pool": "2001:db8:1::a00 - 2001:db8:1::aff"
+          }
+        ],
+        "reservations": [
+          {
+            "duid": "00:02:00:00:ab:11:00:11:22:33:44:55:66:77",
+            "ip-addresses": [ "2001:db8:1::a12"]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/test/test-network/conf/kea/kea-dhcp6-no-addr-reg.conf
+++ b/test/test-network/conf/kea/kea-dhcp6-no-addr-reg.conf
@@ -1,0 +1,33 @@
+{
+  "Dhcp6": {
+    "interfaces-config": {
+      "interfaces": [
+        "veth-peer"
+      ]
+    },
+    "lease-database": {
+      "type": "memfile",
+      "persist": true,
+      "name": "/run/networkd-ci/test-kea-dhcp6.leases"
+    },
+    "valid-lifetime": 28800,
+    "subnet6": [
+      {
+        "id": 1,
+        "interface": "veth-peer",
+        "subnet": "2001:db8:1::/64",
+        "pools": [
+          {
+            "pool": "2001:db8:1::a00 - 2001:db8:1::aff"
+          }
+        ],
+        "reservations": [
+          {
+            "duid": "00:02:00:00:ab:11:00:11:22:33:44:55:66:77",
+            "ip-addresses": [ "2001:db8:1::a12"]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/test/test-network/conf/radvd/addr-reg.conf
+++ b/test/test-network/conf/radvd/addr-reg.conf
@@ -1,0 +1,11 @@
+interface veth-peer
+{
+        AdvSendAdvert on;
+        AdvManagedFlag on;
+
+        prefix 2001:db8:1::/64
+        {
+                AdvOnLink on;
+                AdvAutonomous on;
+        };
+};

--- a/test/test-network/systemd-networkd-tests.py
+++ b/test/test-network/systemd-networkd-tests.py
@@ -25,6 +25,7 @@
 # Otherwise the path is recognized as a test case, and the test run will fail.
 
 import argparse
+import csv
 import datetime
 import enum
 import errno
@@ -61,6 +62,12 @@ isc_dhcpd_pid_file = '/run/networkd-ci/test-isc-dhcpd.pid'
 isc_dhcpd_lease_file = '/run/networkd-ci/test-isc-dhcpd.lease'
 
 radvd_pid_file = '/run/networkd-ci/test-radvd.pid'
+
+kea_dhcp6_conf_file = '/run/networkd-ci/kea/test-kea-dhcp6.conf'
+kea_dhcp6_pid_file = '/run/networkd-ci/test-kea-dhcp6.kea-dhcp6.pid'
+kea_dhcp6_log_file = '/run/networkd-ci/test-kea-dhcp6.log'
+kea_dhcp6_lease_file = '/run/networkd-ci/test-kea-dhcp6.leases'
+kea_dhcp6_process = None
 
 systemd_lib_paths = ['/usr/lib/systemd', '/lib/systemd']
 which_paths = ':'.join(systemd_lib_paths + os.getenv('PATH', os.defpath).lstrip(':').split(':'))
@@ -1055,6 +1062,82 @@ def stop_radvd():
     stop_by_pid_file(radvd_pid_file)
 
 
+def kea_dhcp6_env():
+    return os.environ | {
+        'KEA_PIDFILE_DIR': networkd_ci_temp_dir,
+        'KEA_DHCP_DATA_DIR': networkd_ci_temp_dir,
+    }
+
+
+def start_kea_dhcp6(conf_file):
+    global kea_dhcp6_process
+
+    # The PID file name is derived from the configuration file name and is
+    # "[runstatedir]/kea/[conf name].kea-dhcp6.pid". Therefore, copy the configuration
+    # file to a known name, so that the PID file name is always the same.
+    cp(os.path.join(networkd_ci_temp_dir, 'kea', conf_file), kea_dhcp6_conf_file)
+
+    with open(kea_dhcp6_log_file, mode='w', encoding='utf-8') as log:
+        kea_dhcp6_process = subprocess.Popen(
+            ['kea-dhcp6', '-c', kea_dhcp6_conf_file], env=kea_dhcp6_env(), stdout=log, stderr=log
+        )
+
+    for _ in range(50):
+        if os.path.exists(kea_dhcp6_pid_file):
+            return
+        time.sleep(0.1)
+
+    print('### kea-dhcp6 log BEGIN')
+    with open(kea_dhcp6_log_file, encoding='utf-8') as log:
+        print(log.read())
+    print('### kea-dhcp6 log END')
+    raise TimeoutError('Timed out waiting for kea-dhcp6 to create its PID file')
+
+
+def stop_kea_dhcp6():
+    global kea_dhcp6_process
+
+    stop_by_pid_file(kea_dhcp6_pid_file)
+    if kea_dhcp6_process:
+        kea_dhcp6_process.wait()
+        kea_dhcp6_process = None
+    rm_f(kea_dhcp6_conf_file)
+    rm_f(kea_dhcp6_log_file)
+    rm_f(kea_dhcp6_lease_file)
+
+
+def kea_dhcp6_check_config(conf_file):
+    if not shutil.which('kea-dhcp6'):
+        print('kea-dhcp6 is not installed, assuming the config check failed')
+        return False
+
+    # Note: can't use networkd_ci_temp_dir here, as this command may run before that dir is
+    #       set up (one instance is @unittest.skipX())
+    config_file_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'conf/kea', conf_file)
+    with open(config_file_path, encoding='utf-8') as f:
+        config = json.load(f)
+
+    # kea-dhcp6 -t requires any interface mentioned in the config file to exist in the
+    # system. Since this check is executed before the test runs, replace the interface name
+    # with the loopback one which always exists.
+    dhcp6 = config['Dhcp6']
+    if 'interfaces-config' in dhcp6:
+        dhcp6['interfaces-config']['interfaces'] = ['lo']
+    for subnet in dhcp6.get('subnet6', ()):
+        if 'interface' in subnet:
+            subnet['interface'] = 'lo'
+
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.json') as f:
+        json.dump(config, f)
+        f.flush()
+        return call(f'kea-dhcp6 -t {f.name}', env=kea_dhcp6_env()) == 0
+
+
+def read_kea_dhcp6_leases():
+    with open(kea_dhcp6_lease_file, encoding='utf-8') as f:
+        return list(csv.DictReader(f))
+
+
 def start_modem_manager_mock(*additional_options):
     dbus_policy_src = os.path.join(networkd_ci_temp_dir, 'mock-modem-manager.conf')
     cp(dbus_policy_src, '/etc/dbus-1/system.d/mock-modem-manager.conf')
@@ -1230,6 +1313,7 @@ def tear_down_common():
     stop_dnsmasq()
     stop_isc_dhcpd()
     stop_radvd()
+    stop_kea_dhcp6()
 
     # 2. remove modules
     call_quiet('rmmod netdevsim')
@@ -10230,6 +10314,192 @@ Address={ipv6_address}
         check(self, True, False)
         check(self, False, True)
         check(self, False, False)
+
+    @unittest.skipUnless(
+        kea_dhcp6_check_config('kea-dhcp6-addr-reg.conf'),
+        'kea-dhcp6 is not installed or does not support the required configuration',
+    )
+    def test_dhcp6_address_registration(self):
+        # RFC 9686: DHCPv6 Address Registration. radvd announces the M (managed) bit
+        # and a prefix, so that the client runs SLAAC and also starts DHCPv6. The client
+        # has three additional static addresses: two in the same prefix and a ULA.
+        # IPv6PrivacyExtensions is enabled, so the client also gets a temporary address.
+        # When DHCPv6.RegisterAddresses is enabled, the client tries to register all the
+        # global addresses (SLAAC, temporary and static): the server registers them into
+        # its lease database, except for the ULA which is outside of the configured prefix.
+
+        copy_network_unit(
+            '25-veth.netdev',
+            '25-dhcp6-addr-reg-server.network',
+            '25-dhcp6-addr-reg-client.network',
+        )
+        start_networkd()
+        self.wait_online('veth-peer:routable')
+
+        start_kea_dhcp6(conf_file='kea-dhcp6-addr-reg.conf')
+        start_radvd(config_file='addr-reg.conf')
+
+        self.wait_online('veth99:routable')
+
+        # SLAAC address, EUI-64 based
+        self.wait_address('veth99', '2001:db8:1:0:1034:56ff:fe78:9abc/64', ipv='-6')
+
+        # Static addresses configured in the .network file
+        self.wait_address('veth99', '2001:db8:1::4242/64', ipv='-6')
+        self.wait_address('veth99', '2001:db8:1::4343/64', ipv='-6')
+        self.wait_address('veth99', 'fd00::1/64', ipv='-6')
+
+        # DHCPv6 address
+        self.wait_address('veth99', '2001:db8:1::a12/128', ipv='-6')
+
+        # SLAAC temporary address: not predictable, wait for it and extract it
+        self.wait_address(
+            'veth99',
+            r'inet6 2001:db8:1:[0-9a-f:]*/64 .*scope global temporary dynamic',
+            ipv='-6',
+        )
+        output = check_output('ip -6 --json address show dev veth99')
+        temporary_address = None
+        for i in json.loads(output)[0]['addr_info']:
+            if i.get('scope') == 'global' and i.get('temporary', False):
+                temporary_address = i['local']
+                break
+        self.assertIsNotNone(temporary_address, 'Temporary address not found on veth99')
+        print(f'### temporary address: {temporary_address}')
+
+        # Poll the kea lease file until all the expected entries show up.
+        expected_addresses = {
+            '2001:db8:1:0:1034:56ff:fe78:9abc',
+            '2001:db8:1::4242',
+            '2001:db8:1::4343',
+            '2001:db8:1::a12',
+            temporary_address,
+        }
+        leases = []
+        for _ in range(60):
+            if os.path.exists(kea_dhcp6_lease_file):
+                leases = read_kea_dhcp6_leases()
+                found_addresses = {lease['address'] for lease in leases}
+                if expected_addresses.issubset(found_addresses):
+                    break
+            time.sleep(0.5)
+        else:
+            self.fail(f'Timed out waiting for kea DHCPv6 leases: {leases}')
+
+        print('### kea DHCPv6 lease file')
+        for lease in leases:
+            print(lease)
+
+        leases_by_address = {lease['address']: lease for lease in leases}
+
+        # Check the lease state:
+        #  - STATE_DEFAULT    = 0  (address assigned via DHCP)
+        #  - STATE_REGISTERED = 4  (address registered via RFC 9686)
+
+        self.assertEqual(leases_by_address['2001:db8:1::a12']['state'], '0')
+
+        for address in (
+            '2001:db8:1:0:1034:56ff:fe78:9abc',
+            '2001:db8:1::4242',
+            '2001:db8:1::4343',
+            temporary_address,
+        ):
+            self.assertEqual(leases_by_address[address]['state'], '4')
+
+        # The ULA address is not in the prefix served by kea, so it must not be registered.
+        # Wait for networkd to exhaust retransmissions for fd00::1 (proves the attempt
+        # was made and kea did not reply, i.e. the address is outside configured subnets).
+        for _ in range(60):
+            log = read_networkd_log()
+            if 'no reply received for fd00::1' in log:
+                break
+            time.sleep(0.5)
+        else:
+            self.fail('Timed out waiting for fd00::1 registration attempt to complete')
+
+        # Re-read leases after kea had a chance to process the attempt.
+        leases = read_kea_dhcp6_leases()
+        leases_by_address = {lease['address']: lease for lease in leases}
+        self.assertNotIn('fd00::1', leases_by_address)
+
+        # De-registration: remove one of the static addresses from the .network file
+        # and reload.
+        unit = os.path.join(network_unit_dir, '25-dhcp6-addr-reg-client.network')
+        with open(unit, encoding='utf-8') as f:
+            contents = f.read()
+        with open(unit, mode='w', encoding='utf-8') as f:
+            f.write(contents.replace('[Address]\nAddress=2001:db8:1::4242/64\n\n', ''))
+        networkctl_reload()
+        self.wait_online('veth99:routable')
+        self.wait_address_dropped('veth99', '2001:db8:1::4242', ipv='-6')
+
+        deregistered_lease = None
+        for _ in range(60):
+            leases = read_kea_dhcp6_leases()
+            # The de-registered address is stored as a new entry with valid_lifetime 0
+            deregistered_lease = next(
+                (
+                    lease
+                    for lease in leases
+                    if lease['address'] == '2001:db8:1::4242'
+                    and lease['state'] == '4'
+                    and lease['valid_lifetime'] == '0'
+                ),
+                None,
+            )
+
+            if deregistered_lease is not None:
+                break
+            time.sleep(0.5)
+        else:
+            print('### kea DHCPv6 lease file after de-registration')
+            for lease in read_kea_dhcp6_leases():
+                print(lease)
+            self.fail(f'Timed out waiting for kea to de-register 2001:db8:1::4242: {deregistered_lease}')
+
+    @unittest.skipUnless(
+        kea_dhcp6_check_config('kea-dhcp6-no-addr-reg.conf'),
+        'kea-dhcp6 is not installed or does not support the required configuration',
+    )
+    def test_dhcp6_address_registration_not_negotiated(self):
+        # The client enables RegisterAddresses=yes, but the server does not advertise
+        # addr-reg-enable. During DHCPv6 negotiation the client must notice that the
+        # server does not support RFC 9686 and must not attempt any registration.
+
+        copy_network_unit(
+            '25-veth.netdev',
+            '25-dhcp6-addr-reg-server.network',
+            '25-dhcp6-addr-reg-client.network',
+        )
+        start_networkd()
+        self.wait_online('veth-peer:routable')
+
+        start_kea_dhcp6(conf_file='kea-dhcp6-no-addr-reg.conf')
+        start_radvd(config_file='addr-reg.conf')
+
+        self.wait_online('veth99:routable')
+
+        # The reserved address is still assigned normally via DHCPv6 IA_NA.
+        self.wait_address('veth99', '2001:db8:1::a12/128', ipv='-6')
+
+        # Wait for SLAAC and static addresses to be configured, so that we know
+        # the client had a chance to attempt registration.
+        self.wait_address('veth99', '2001:db8:1::4242/64', ipv='-6')
+        self.wait_address('veth99', '2001:db8:1::4343/64', ipv='-6')
+        time.sleep(5)
+
+        leases = read_kea_dhcp6_leases() if os.path.exists(kea_dhcp6_lease_file) else []
+        print('### kea DHCPv6 lease file (no address registration expected)')
+        for lease in leases:
+            print(lease)
+
+        # Only the normal DHCPv6-assigned address must be present; no registered leases.
+        registered = [lease for lease in leases if lease['state'] == '4']
+        self.assertEqual(registered, [], f'Unexpected registered leases: {registered}')
+
+        # Verify the client never attempted registration by checking the logs.
+        log = read_networkd_log()
+        self.assertNotIn('Address registration:', log)
 
 
 class NetworkdDHCPPDTests(unittest.TestCase, Utilities):


### PR DESCRIPTION
Add support for RFC 9686 (_"Registering Self-Generated IPv6 Addresses Using DHCPv6"_), which allows clients to inform a DHCPv6 server about self-generated SLAAC and static IPv6 addresses. This feature can be used to track the addresses in use on the network for troubleshooting and forensic purposes.

Clients register addresses by sending an ADDR-REG-INFORM message containing an "IA Address" option with the address being registered. The server replies with an ADDR-REG-REPLY message to confirm the request.

The protocol includes a retransmission mechanism to handle potential message losses, and a refresh mechanism to ensure that the server always has an accurate view of the registered addresses and their lifetimes. At the moment, the coalescing of refresh messages described as optional in section 4.6.3 of the RFC is not implemented yet, and all refreshes are sent exactly when the timer expires.

To avoid cluttering the DHCPv6 code, this functionality is implemented in a separate file (`dhcp6-addr-reg.c`).

The protocol uses the address being registered as the source address for ADDR-REG-INFORM messages and as the destination address for ADDR-REG-REPLY messages. Since the main DHCPv6 socket is bound to the IPv6 link-local address, another dedicated socket is used.

This implementation was tested with the RFC 9686 implementation in the Kea DHCPv6 server: https://kea.readthedocs.io/en/stable/arm/dhcp6-srv.html#address-registration-rfc-9686-support

https://github.com/systemd/systemd/issues/38424