### PR TITLE
test: retry the reload-signal warning reads in TEST-80-NOTIFYACCESS

### DIFF
--- a/test/units/TEST-80-NOTIFYACCESS.sh
+++ b/test/units/TEST-80-NOTIFYACCESS.sh
@@ -191,19 +191,44 @@ cleanup_notify_reload() {
         /tmp/reload-wellbehaved-in /tmp/reload-wellbehaved-out
 }
 
+# journalctl can transiently open no journal file at all, which is indistinguishable from the
+# journal being empty. Both the cursor this leaves behind and the read that later uses it have
+# to tolerate that, or the flake moves from one to the other.
+seed_journal_cursor() {
+    local cursor_file="${1:?}"
+
+    # Remove the file inside the loop, so a retry starts from no file at all rather than from
+    # whatever the failed attempt left behind: journalctl reads --cursor-file as input when it
+    # exists, and "test -s" should mean "this attempt produced a cursor".
+    timeout 30 bash -xec 'until rm -f "$1" && journalctl --sync && journalctl -q -n 0 --cursor-file="$1" && test -s "$1"; do sleep 1; done' bash "$cursor_file"
+}
+
+assert_reload_signal_warning() {
+    local unit="${1:?}"
+    local cursor_file="${2:?}"
+    local cursor
+
+    # Without a cursor the search starts at the head of the journal and can match a warning left
+    # by an earlier subtest. seed_journal_cursor() guarantees one.
+    cursor="$(cat "$cursor_file")"
+    test -n "$cursor"
+
+    # Pass the cursor by value, because a read rewrites --cursor-file even when it matched
+    # nothing, which would move a later attempt past the message it is waiting for.
+    timeout 30 bash -xec 'until journalctl --sync && journalctl -u "$1" --after-cursor="$2" --grep "lacks handler for reload signal" >/dev/null; do sleep 1; done' bash "$unit" "$cursor"
+}
+
 trap cleanup_notify_reload EXIT
 cleanup_notify_reload
 
 # Test 1: Service without signal handler should fail to start
 mkfifo /tmp/reload-nohandler-in /tmp/reload-nohandler-out
-journalctl -q -n 0 --cursor-file=/tmp/reload-nohandler-cursor
+seed_journal_cursor /tmp/reload-nohandler-cursor
 (! systemctl start notify-reload-no-handler.service)
 assert_eq "$(systemctl show notify-reload-no-handler.service -P SubState)" "failed"
 assert_eq "$(systemctl show notify-reload-no-handler.service -P Result)" "protocol"
 # Verify error was logged about missing signal handler
-journalctl --sync
-journalctl -u notify-reload-no-handler.service --cursor-file=/tmp/reload-nohandler-cursor \
-    --grep "lacks handler for reload signal" >/dev/null
+assert_reload_signal_warning notify-reload-no-handler.service /tmp/reload-nohandler-cursor
 systemctl reset-failed notify-reload-no-handler.service
 rm -f /tmp/reload-nohandler-in /tmp/reload-nohandler-out
 
@@ -226,14 +251,12 @@ assert_eq "$response" "handler-removed"
 
 # Reload should succeed (with warning) even though handler is gone - service will be killed by SIGHUP
 # but that's intentional after the first start succeeds
-journalctl -q -n 0 --cursor-file=/tmp/reload-toggle-cursor
+seed_journal_cursor /tmp/reload-toggle-cursor
 systemctl reload --no-block notify-reload-toggle-handler.service
 # The service will die from SIGHUP since the handler is removed
 timeout 10 bash -c 'while systemctl is-active --quiet notify-reload-toggle-handler.service; do sleep .5; done'
 # Verify warning was logged
-journalctl --sync
-journalctl -u notify-reload-toggle-handler.service --cursor-file=/tmp/reload-toggle-cursor \
-    --grep "lacks handler for reload signal" >/dev/null
+assert_reload_signal_warning notify-reload-toggle-handler.service /tmp/reload-toggle-cursor
 rm -f /tmp/reload-toggle-in /tmp/reload-toggle-out
 
 # Test 4: Well-behaved service with handler should work correctly


### PR DESCRIPTION
TEST-80-NOTIFYACCESS intermittently fails one of its two `lacks handler for reload signal` journal checks, on main as well as on pull requests. The read can come up empty even though PID 1 logged the warning.

Both checks set a journal cursor, exercise the service so that PID 1 logs the warning, sync, and then read once:

```sh
journalctl -u notify-reload-toggle-handler.service --cursor-file=/tmp/reload-toggle-cursor \
    --grep "lacks handler for reload signal" >/dev/null
```

Under `set -e` an empty read fails the test, and it does not distinguish a missing message from journalctl having no journal file to search.

In the failed-test journal that CI archived for run 31194630990, PID 1 had logged the warning:

```
systemd[1]: notify-reload-toggle-handler.service: Main process 774 lacks handler for reload signal HUP, sending reload signal anyway.
```

That entry has journal sequence number 22288, and the entries logging `journalctl --sync` and the failing read are 22416 and 22425, so the warning was written and synced before the read ran. The read's own debug output shows it opened nothing to search:

```
Failed to open journal file /run/log/journal/<id>/system.journal: No data available
Journal file /run/log/journal/<id>/system.journal is truncated, ignoring file
mmap cache statistics: 0 category cache hit, 0 window list hit, 1 miss, 0 files, 0 windows, 0 unused
```

The check that passed earlier in the same run reported `1 files, 2 windows`, and replaying the failing query against the archived journal finds the entry. Both checks are affected: run 31168026078 on main failed the first one, and run 31197601533, an unrelated pull request, failed the second.

So retry the read, as `TEST-04-JOURNAL.journal-remote.sh`, `TEST-55-OOMD.sh`, and `TEST-75-RESOLVED.sh` already do around journal greps.

The cursor is passed by value rather than through `--cursor-file`, because journalctl rewrites that file even on a read that matched nothing. Seeding a cursor from an early entry of the archived journal and then running a read whose pattern matches nothing exits 1 and leaves the file holding the same cursor that a matching read writes, so a later attempt would resume from the end of the journal instead of from where the first one started. The cursor also has to be non-empty, otherwise the search begins at the head and can match a warning left by an earlier subtest.

Since a retry can also hide a real failure, I checked the outcomes against a stub journalctl: present on the first read passes in one attempt, present only on the third read passes in three, never present fails with exit 124, and a missing cursor file fails immediately. The one-shot form fails the third-read case, which models the CI failure.

`shellcheck -x` is clean on the file.
