### PR TITLE
coredump: do not leak TID and thread name in the host to container

### DIFF
--- a/src/coredump/coredump-send.c
+++ b/src/coredump/coredump-send.c
@@ -301,6 +301,10 @@ int coredump_send_to_container(CoredumpContext *context) {
                 context->uid = ucred.uid;
                 context->gid = ucred.gid;
 
+                /* Do not leak the TID and thread name. */
+                context->tid = 0;
+                context->thread_name = mfree(context->thread_name);
+
                 r = coredump_context_build_iovw(context);
                 if (r < 0)
                         _exit(EXIT_FAILURE);


### PR DESCRIPTION
PID, UID, and GID are converted by sending struct ucred, however, there is no simple way to covert TID. Of course, we can send pidfd points to the TID to the container PID namespace, but that requires an uptodate systemd-coredump in the coredump. Let's drop the TID and thread name when we transfer core to the container.

Fixes 4c7af7d9d1cd40e2f36a87787ce2fab32400bf89.