### PR TITLE
options: reject an empty long option name

### DIFF
--- a/src/shared/options.c
+++ b/src/shared/options.c
@@ -223,6 +223,16 @@ int option_parse(
                                 /* argument (if any) is separate */
                                 optname = state->argv[state->optind];
 
+                        /* An empty name, i.e. "--=…", would be a prefix of every option, so reject it
+                         * right away rather than let it match. */
+                        if (isempty(optname + 2)) {
+                                r = log_full_errno(LOG_ERR + state->log_level_shift,
+                                                   SYNTHETIC_ERRNO(EINVAL),
+                                                   "%s: unrecognized option '%s'",
+                                                   program_invocation_short_name, optname);
+                                goto fail;
+                        }
+
                         const Option *last_partial = NULL;
                         unsigned n_partial_matches = 0;  /* The commandline option matches a defined prefix. */
 

--- a/src/test/test-options.c
+++ b/src/test/test-options.c
@@ -1580,4 +1580,24 @@ TEST(option_get_synopsis) {
         test_option_get_synopsis_one(&(const Option) { 0, OPTION_POSITIONAL_ENTRY, 'u', "(fixed)", "unused" }, "/",  true, "(fixed)");
 }
 
+TEST(option_empty_long_name) {
+        static const Option one_option[] = {
+                { 1, .short_code = 'o', .long_code = "output", .metavar = "ARG" },
+                {}
+        };
+
+        static const Option two_options[] = {
+                { 1, .short_code = 'o', .long_code = "output", .metavar = "ARG" },
+                { 2, .long_code = "help" },
+                {}
+        };
+
+        /* "--=…" carries an empty long option name, which must not prefix-match every defined option.
+         * With a single option defined that would otherwise look like a unique partial match. */
+        test_option_invalid_one(STRV_MAKE("arg0", "--=foo"), one_option);
+        test_option_invalid_one(STRV_MAKE("arg0", "--="), one_option);
+        test_option_invalid_one(STRV_MAKE("arg0", "--=foo"), two_options);
+        test_option_invalid_one(STRV_MAKE("arg0", "--="), two_options);
+}
+
 DEFINE_TEST_MAIN(LOG_DEBUG);


### PR DESCRIPTION
`option_parse()` splits a long option at `=` and then matches `optname + 2` against every defined `long_code` with `startswith()`. For an argument of the form `--=VALUE` that leaves an empty name, and the empty string is a prefix of every option, so each one is recorded as a partial match.

What the user sees depends on how many long options the namespace defines. With several, every option is reported as a candidate:

```
$ systemd-detect-virt --=foo
systemd-detect-virt: option '--' is ambiguous; possibilities: --help, --version, --quiet, --container, --private-users, --vm, --chroot, --list, --cvm, --list-cvm
```

With exactly one, the empty name is a unique partial match, so `--=foo` is accepted as that option and `VALUE` is handed to the handler as its argument. The added test covers that case: before this commit it parses `--=foo` as `--output=foo` instead of failing.

Reject an empty long option name up front instead:

```
$ systemd-detect-virt --=foo
systemd-detect-virt: unrecognized option '--=foo'
```

A bare `--` is unaffected, it is still handled earlier as the end-of-options marker.
