### PR TITLE
sysext: IMAGE_ID, IMAGE_VERSION in extension-release

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -149,17 +149,6 @@ CHANGES WITH 262 in spe:
           and the "documentation" key is now an array of strings. Consumers
           of this interface must update their JSON parsing accordingly.
 
-        * systemd-sysext/systemd-confext now match IMAGE_ID= and
-          IMAGE_VERSION= fields from extension-release files against the host
-          os-release. If an extension declares IMAGE_ID= or IMAGE_VERSION=, the
-          host must declare the same field with a matching value, or the
-          extension is rejected. Previously these fields were ignored during
-          validation and could appear in extension-release files as harmless
-          descriptive metadata. Extensions that set IMAGE_ID= or IMAGE_VERSION=
-          without intending them as host constraints should remove these fields
-          or prefix them with SYSEXT_/CONFEXT_ to describe the extension
-          itself.
-
         Changes in the system and service manager:
 
         * The manager now embeds a basic set of unit files (basic.target,

--- a/NEWS
+++ b/NEWS
@@ -149,6 +149,17 @@ CHANGES WITH 262 in spe:
           and the "documentation" key is now an array of strings. Consumers
           of this interface must update their JSON parsing accordingly.
 
+        * systemd-sysext/systemd-confext now match IMAGE_ID= and
+          IMAGE_VERSION= fields from extension-release files against the host
+          os-release. If an extension declares IMAGE_ID= or IMAGE_VERSION=, the
+          host must declare the same field with a matching value, or the
+          extension is rejected. Previously these fields were ignored during
+          validation and could appear in extension-release files as harmless
+          descriptive metadata. Extensions that set IMAGE_ID= or IMAGE_VERSION=
+          without intending them as host constraints should remove these fields
+          or prefix them with SYSEXT_/CONFEXT_ to describe the extension
+          itself.
+
         Changes in the system and service manager:
 
         * The manager now embeds a basic set of unit files (basic.target,

--- a/man/os-release.xml
+++ b/man/os-release.xml
@@ -111,7 +111,9 @@
       matches the base OS. This is typically implemented by checking that the extension <varname>ID=</varname>
       option either matches the host <varname>ID=</varname> option or is included the host <varname>ID_LIKE=</varname>
       option, and either <varname>SYSEXT_LEVEL=</varname> exists and matches too, or if it is not present,
-      <varname>VERSION_ID=</varname> exists and matches. This ensures ABI/API compatibility between the
+      <varname>VERSION_ID=</varname> exists and matches. If the extension image sets
+      <varname>IMAGE_ID=</varname> and/or <varname>IMAGE_VERSION=</varname>, the host must also declare
+      these fields and the values must match. This ensures ABI/API compatibility between the
       layers and prevents merging of an incompatible image in an overlay.</para>
 
       <para>In order to identify the extension image itself, the same fields defined below can be added to the
@@ -337,6 +339,12 @@
           those that are not managed via images but put together and updated from individual packages and on
           the local system.</para>
 
+          <para>When used in an <filename>extension-release</filename> file, this field is matched against
+          the host <filename>os-release</filename>. If the extension declares <varname>IMAGE_ID=</varname>,
+          the host must also set <varname>IMAGE_ID=</varname> with the same value, or the extension is
+          rejected. To describe the extension image itself rather than constrain the host, use the prefixed
+          variant (e.g. <varname>SYSEXT_IMAGE_ID=</varname>) instead.</para>
+
           <para>Examples: <literal>IMAGE_ID=vendorx-cashier-system</literal>,
           <literal>IMAGE_ID=netbook-image</literal>.</para>
 
@@ -354,6 +362,10 @@
           <para>It is recommended to follow the <ulink
           url="https://uapi-group.org/specifications/specs/version_format_specification/">UAPI.10 Version
           Format Specification</ulink> for this version string, but this is generally not enforced.</para>
+
+          <para>When used in an <filename>extension-release</filename> file, this field is matched against
+          the host <filename>os-release</filename>, analogous to <varname>IMAGE_ID=</varname> described
+          above.</para>
 
           <para>Examples: <literal>IMAGE_VERSION=33</literal>, <literal>IMAGE_VERSION=47.1rc1</literal>.
           </para>

--- a/src/core/namespace.c
+++ b/src/core/namespace.c
@@ -1671,6 +1671,8 @@ static int mount_image(
                                 "VERSION_ID", &rdata.os_release_version_id,
                                 image_class_info[IMAGE_SYSEXT].level_env, &rdata.os_release_sysext_level,
                                 image_class_info[IMAGE_CONFEXT].level_env, &rdata.os_release_confext_level,
+                                "IMAGE_ID", &rdata.os_release_image_id,
+                                "IMAGE_VERSION", &rdata.os_release_image_version,
                                 NULL);
                 if (r < 0)
                         return log_debug_errno(r, "Failed to acquire 'os-release' data of OS tree '%s': %m", empty_to_root(root_directory));
@@ -1988,6 +1990,7 @@ static int apply_one_mount(
         case MOUNT_EXTENSION_DIRECTORY: {
                 _cleanup_free_ char *host_os_release_id = NULL, *host_os_release_id_like = NULL,
                                 *host_os_release_version_id = NULL, *host_os_release_level = NULL,
+                                *host_os_release_image_id = NULL, *host_os_release_image_version = NULL,
                                 *extension_name = NULL;
                 _cleanup_strv_free_ char **extension_release = NULL;
                 ImageClass class = IMAGE_SYSEXT;
@@ -2026,6 +2029,8 @@ static int apply_one_mount(
                                 "ID_LIKE", &host_os_release_id_like,
                                 "VERSION_ID", &host_os_release_version_id,
                                 image_class_info[class].level_env, &host_os_release_level,
+                                "IMAGE_ID", &host_os_release_image_id,
+                                "IMAGE_VERSION", &host_os_release_image_version,
                                 NULL);
                 if (r < 0)
                         return log_debug_errno(r, "Failed to acquire 'os-release' data of OS tree '%s': %m", empty_to_root(root_directory));
@@ -2038,6 +2043,8 @@ static int apply_one_mount(
                                 host_os_release_id_like,
                                 host_os_release_version_id,
                                 host_os_release_level,
+                                host_os_release_image_id,
+                                host_os_release_image_version,
                                 /* host_extension_scope= */ NULL, /* Leave empty, we need to accept both system and portable */
                                 extension_release,
                                 class);

--- a/src/portable/portable.c
+++ b/src/portable/portable.c
@@ -811,7 +811,8 @@ static int extract_image_and_extensions(
                 ImagePolicy **ret_pinned_ext_image_policy,
                 sd_bus_error *error) {
 
-        _cleanup_free_ char *id = NULL, *id_like = NULL, *version_id = NULL, *sysext_level = NULL, *confext_level = NULL;
+        _cleanup_free_ char *id = NULL, *id_like = NULL, *version_id = NULL, *sysext_level = NULL, *confext_level = NULL,
+                        *image_id = NULL, *image_version = NULL;
         _cleanup_(image_policy_freep) ImagePolicy *pinned_root_image_policy = NULL, *pinned_ext_image_policy = NULL;
         _cleanup_(portable_metadata_unrefp) PortableMetadata *os_release = NULL;
         _cleanup_ordered_hashmap_free_ OrderedHashmap *extension_images = NULL, *extension_releases = NULL;
@@ -924,6 +925,8 @@ static int extract_image_and_extensions(
                                 "VERSION_ID", &version_id,
                                 "SYSEXT_LEVEL", &sysext_level,
                                 "CONFEXT_LEVEL", &confext_level,
+                                "IMAGE_ID", &image_id,
+                                "IMAGE_VERSION", &image_version,
                                 "PORTABLE_PREFIXES", &prefixes,
                                 "PORTABLE_SCOPE", &portable_scope_str);
                 if (r < 0)
@@ -1009,9 +1012,9 @@ static int extract_image_and_extensions(
                         return r;
 
                 if (validate_extension) {
-                        r = extension_release_validate(ext->path, id, id_like, version_id, sysext_level, "portable", extension_release, IMAGE_SYSEXT);
+                        r = extension_release_validate(ext->path, id, id_like, version_id, sysext_level, image_id, image_version, "portable", extension_release, IMAGE_SYSEXT);
                         if (r < 0)
-                                r = extension_release_validate(ext->path, id, id_like, version_id, confext_level, "portable", extension_release, IMAGE_CONFEXT);
+                                r = extension_release_validate(ext->path, id, id_like, version_id, confext_level, image_id, image_version, "portable", extension_release, IMAGE_CONFEXT);
 
                         if (r == 0)
                                 return sd_bus_error_set_errnof(error, ESTALE, "Image %s extension-release metadata does not match the root's", ext->path);

--- a/src/shared/dissect-image.c
+++ b/src/shared/dissect-image.c
@@ -5068,6 +5068,8 @@ int verity_dissect_and_mount(
                                         extension_release_data->os_release_id_like,
                                         extension_release_data->os_release_version_id,
                                         class == IMAGE_SYSEXT ? extension_release_data->os_release_sysext_level : extension_release_data->os_release_confext_level,
+                                        extension_release_data->os_release_image_id,
+                                        extension_release_data->os_release_image_version,
                                         extension_release_data->os_release_extension_scope,
                                         extension_release,
                                         class);
@@ -5096,6 +5098,8 @@ void extension_release_data_done(ExtensionReleaseData *data) {
         data->os_release_version_id = mfree(data->os_release_version_id);
         data->os_release_sysext_level = mfree(data->os_release_sysext_level);
         data->os_release_confext_level = mfree(data->os_release_confext_level);
+        data->os_release_image_id = mfree(data->os_release_image_id);
+        data->os_release_image_version = mfree(data->os_release_image_version);
         data->os_release_extension_scope = mfree(data->os_release_extension_scope);
 }
 

--- a/src/shared/dissect-image.h
+++ b/src/shared/dissect-image.h
@@ -145,6 +145,8 @@ typedef struct ExtensionReleaseData {
         char *os_release_version_id;
         char *os_release_sysext_level;
         char *os_release_confext_level;
+        char *os_release_image_id;
+        char *os_release_image_version;
         char *os_release_extension_scope;
 } ExtensionReleaseData;
 

--- a/src/shared/extension-util.c
+++ b/src/shared/extension-util.c
@@ -16,11 +16,14 @@ int extension_release_validate(
                 const char *host_os_release_id_like,
                 const char *host_os_release_version_id,
                 const char *host_os_extension_release_level,
+                const char *host_os_release_image_id,
+                const char *host_os_release_image_version,
                 const char *host_extension_scope,
                 char **extension_release,
                 ImageClass image_class) {
 
-        const char *extension_release_id = NULL, *extension_release_level = NULL, *extension_architecture = NULL;
+        const char *extension_release_id = NULL, *extension_release_level = NULL, *extension_architecture = NULL,
+                   *extension_release_image_id = NULL, *extension_release_image_version = NULL;
         const char *extension_level = image_class == IMAGE_CONFEXT ? "CONFEXT_LEVEL" : "SYSEXT_LEVEL";
         const char *extension_scope = image_class == IMAGE_CONFEXT ? "CONFEXT_SCOPE" : "SYSEXT_SCOPE";
         _cleanup_strv_free_ char **id_like_l = NULL;
@@ -71,6 +74,38 @@ int extension_release_validate(
                 log_debug("Extension '%s' does not contain ID in release file but requested to match '%s' or be '_any'",
                         name, host_os_release_id);
                 return 0;
+        }
+
+        /* If the extension has an IMAGE_ID declared, then it must match the host IMAGE_ID */
+        extension_release_image_id = strv_env_pairs_get(extension_release, "IMAGE_ID");
+        if (!isempty(extension_release_image_id)) {
+                if (isempty(host_os_release_image_id)) {
+                        log_debug("Extension '%s' requires IMAGE_ID '%s', but host has no IMAGE_ID set.",
+                                  name, extension_release_image_id);
+                        return 0;
+                }
+
+                if (!streq(host_os_release_image_id, extension_release_image_id)) {
+                        log_debug("Extension '%s' is for image '%s', but deployed on top of image '%s'.",
+                                  name, extension_release_image_id, host_os_release_image_id);
+                        return 0;
+                }
+        }
+
+        /* If the extension has an IMAGE_VERSION declared, then it must match the host IMAGE_VERSION */
+        extension_release_image_version = strv_env_pairs_get(extension_release, "IMAGE_VERSION");
+        if (!isempty(extension_release_image_version)) {
+                if (isempty(host_os_release_image_version)) {
+                        log_debug("Extension '%s' requires IMAGE_VERSION '%s', but host has no IMAGE_VERSION set.",
+                                  name, extension_release_image_version);
+                        return 0;
+                }
+
+                if (!streq(host_os_release_image_version, extension_release_image_version)) {
+                        log_debug("Extension '%s' is for image version '%s', but deployed on top of image version '%s'.",
+                                  name, extension_release_image_version, host_os_release_image_version);
+                        return 0;
+                }
         }
 
         /* A sysext(or confext) with no host OS dependency (static binaries or scripts) can match

--- a/src/shared/extension-util.h
+++ b/src/shared/extension-util.h
@@ -12,6 +12,8 @@ int extension_release_validate(
                 const char *host_os_release_id_like,
                 const char *host_os_release_version_id,
                 const char *host_os_extension_release_level,
+                const char *host_os_release_image_id,
+                const char *host_os_release_image_version,
                 const char *host_extension_scope,
                 char **extension_release,
                 ImageClass image_class);

--- a/src/sysext/sysext.c
+++ b/src/sysext/sysext.c
@@ -1964,6 +1964,7 @@ static int merge_subprocess(
 
         _cleanup_free_ char *host_os_release_id = NULL, *host_os_release_id_like = NULL,
                         *host_os_release_version_id = NULL, *host_os_release_api_level = NULL,
+                        *host_os_release_image_id = NULL, *host_os_release_image_version = NULL,
                         *filename = NULL, *old_origin_content = NULL,
                         *extensions_origin_content = NULL, *root_resolved = NULL;
         _cleanup_strv_free_ char **extensions = NULL, **extensions_v = NULL, **paths = NULL;
@@ -2009,7 +2010,9 @@ static int merge_subprocess(
                         "ID", &host_os_release_id,
                         "ID_LIKE", &host_os_release_id_like,
                         "VERSION_ID", &host_os_release_version_id,
-                        image_class_info[c->image_class].level_env, &host_os_release_api_level);
+                        image_class_info[c->image_class].level_env, &host_os_release_api_level,
+                        "IMAGE_ID", &host_os_release_image_id,
+                        "IMAGE_VERSION", &host_os_release_image_version);
         if (r < 0)
                 return log_error_errno(r, "Failed to acquire 'os-release' data of OS tree '%s': %m", empty_to_root(c->root));
         if (isempty(host_os_release_id))
@@ -2167,6 +2170,8 @@ static int merge_subprocess(
                                         host_os_release_id_like,
                                         host_os_release_version_id,
                                         host_os_release_api_level,
+                                        host_os_release_image_id,
+                                        host_os_release_image_version,
                                         is_initrd ? "initrd" : "system",
                                         image_extension_release(img, c->image_class),
                                         c->image_class);

--- a/test/units/TEST-50-DISSECT.DDI.sh
+++ b/test/units/TEST-50-DISSECT.DDI.sh
@@ -17,6 +17,12 @@ fi
 openssl req -config "$OPENSSL_CONFIG" -subj="/CN=waldo" \
             -x509 -sha256 -nodes -days 365 -newkey rsa:4096 \
             -keyout /tmp/test-50-privkey.key -out /tmp/test-50-cert.crt
+
+# Add IMAGE_ID and IMAGE_VERSION to host os-release so extensions declaring
+# these fields pass validation.
+cp /usr/lib/os-release /usr/lib/os-release.bak
+echo -e "IMAGE_ID=waldo\nIMAGE_VERSION=7" >>/usr/lib/os-release
+
 mkdir -p /tmp/test-50-confext/etc/extension-release.d/
 echo "foobar50" >/tmp/test-50-confext/etc/waldo
 {
@@ -68,3 +74,4 @@ test -f /usr/waldo
 rm /run/verity.d/test-50-cert.crt /run/extensions/waldo.sysext.raw /tmp/test-50-cert.crt /tmp/test-50-privkey.key
 systemd-sysext refresh
 test ! -f /usr/waldo
+mv /usr/lib/os-release.bak /usr/lib/os-release

--- a/test/units/TEST-50-DISSECT.sysext.sh
+++ b/test/units/TEST-50-DISSECT.sysext.sh
@@ -163,6 +163,26 @@ prepare_extension_image_with_matching_id_like() {
     prepend_trap "rm -rf ${ext_dir@Q}"
 }
 
+prepare_extension_image_with_image_id() {
+    local root=${1:-}
+    local hierarchy=${2:?}
+    local image_id=${3:?}
+    local ext_dir ext_release name
+
+    name="test-extension-image-id"
+    ext_dir="$root/var/lib/extensions/$name"
+    ext_release="$ext_dir/usr/lib/extension-release.d/extension-release.$name"
+    mkdir -p "${ext_release%/*}"
+    {
+        echo "ID=testtest"
+        echo "IMAGE_ID=$image_id"
+    } >"$ext_release"
+    mkdir -p "$ext_dir/$hierarchy"
+    touch "$ext_dir$hierarchy/preexisting-file-in-extension-image"
+
+    prepend_trap "rm -rf ${ext_dir@Q}"
+}
+
 prepare_extension_image_raw() {
     local root=${1:-}
     local hierarchy=${2:?}
@@ -1249,6 +1269,90 @@ extension_verify_after_merge "$fake_root" "$hierarchy" -e -h
 
 run_systemd_sysext "$fake_root" unmerge
 extension_verify_after_unmerge "$fake_root" "$hierarchy" -h
+)
+
+
+( init_trap
+: "Check if merging an extension with matching IMAGE_ID succeeds"
+fake_root=${roots_dir:+"$roots_dir/matching-image-id"}
+hierarchy=/opt
+
+prepare_root "$fake_root" "$hierarchy"
+echo "IMAGE_ID=testimage" >>"$fake_root/usr/lib/os-release"
+prepare_extension_image_with_image_id "$fake_root" "$hierarchy" "testimage"
+prepare_read_only_hierarchy "$fake_root" "$hierarchy"
+
+run_systemd_sysext "$fake_root" merge
+extension_verify_after_merge "$fake_root" "$hierarchy" -e -h
+
+run_systemd_sysext "$fake_root" unmerge
+extension_verify_after_unmerge "$fake_root" "$hierarchy" -h
+)
+
+
+( init_trap
+: "Check if merging an extension with mismatched IMAGE_ID fails"
+fake_root=${roots_dir:+"$roots_dir/mismatched-image-id"}
+hierarchy=/opt
+
+prepare_root "$fake_root" "$hierarchy"
+echo "IMAGE_ID=testimage" >>"$fake_root/usr/lib/os-release"
+prepare_extension_image_with_image_id "$fake_root" "$hierarchy" "otherid"
+prepare_read_only_hierarchy "$fake_root" "$hierarchy"
+
+run_systemd_sysext "$fake_root" merge
+if run_systemd_sysext "$fake_root" status --json=pretty | jq -r '.[].extensions' | grep -v '^none$' ; then
+    echo >&2 "Extension with mismatched IMAGE_ID should not have been loaded"
+    exit 1
+fi
+)
+
+
+( init_trap
+: "Check if merging an extension with IMAGE_ID fails when host has no IMAGE_ID"
+fake_root=${roots_dir:+"$roots_dir/image-id-no-host"}
+hierarchy=/opt
+
+prepare_root "$fake_root" "$hierarchy"
+prepare_extension_image_with_image_id "$fake_root" "$hierarchy" "testimage"
+prepare_read_only_hierarchy "$fake_root" "$hierarchy"
+
+run_systemd_sysext "$fake_root" merge
+if run_systemd_sysext "$fake_root" status --json=pretty | jq -r '.[].extensions' | grep -v '^none$' ; then
+    echo >&2 "Extension with IMAGE_ID should not have been loaded when host has no IMAGE_ID"
+    exit 1
+fi
+)
+
+
+( init_trap
+: "Check if merging an extension with matching IMAGE_ID but mismatched IMAGE_VERSION fails"
+fake_root=${roots_dir:+"$roots_dir/mismatched-image-version"}
+hierarchy=/opt
+
+prepare_root "$fake_root" "$hierarchy"
+echo -e "IMAGE_ID=testimage\nIMAGE_VERSION=1.0" >>"$fake_root/usr/lib/os-release"
+
+name="test-extension-image-version"
+ext_dir="$fake_root/var/lib/extensions/$name"
+ext_release="$ext_dir/usr/lib/extension-release.d/extension-release.$name"
+mkdir -p "${ext_release%/*}"
+{
+    echo "ID=testtest"
+    echo "IMAGE_ID=testimage"
+    echo "IMAGE_VERSION=2.0"
+} >"$ext_release"
+mkdir -p "$ext_dir/$hierarchy"
+touch "$ext_dir$hierarchy/preexisting-file-in-extension-image"
+prepend_trap "rm -rf ${ext_dir@Q}"
+
+prepare_read_only_hierarchy "$fake_root" "$hierarchy"
+
+run_systemd_sysext "$fake_root" merge
+if run_systemd_sysext "$fake_root" status --json=pretty | jq -r '.[].extensions' | grep -v '^none$' ; then
+    echo >&2 "Extension with mismatched IMAGE_VERSION should not have been loaded"
+    exit 1
+fi
 )
 
 


### PR DESCRIPTION
Extend extension_release_validate() to optionally match IMAGE_ID and IMAGE_VERSION fields from the extension's extension-release file against the host's os-release if they are provided.

Previously, extensions could only be gated on ID + VERSION_ID (or SYSEXT_LEVEL), which ties them to a distro release. IMAGE_ID and IMAGE_VERSION allow extensions to target a specific image (e.g. a specific appliance or OS image) rather than just the underlying distro.

These valuse are checked before checking the VERSION_ID so they can return earlier (as they are more specific).

While it is possible to do this matching through SYSEXT_LEVEL I'd just be putting those values into there concatenated. It feels nicer to be able to match them separately if defined.

The two fields are checked independently of each other and act as additional constraints on top of the existing validation thus they should not affect the loading of pre-existing sysexts that do *not* define these fields.

If they do define these fields then things will break when they are loaded on systems where the host also defines IMAGE_ID/IMAGE_VERSION.