### PR TITLE
resolved: propagate EDE through DNS stub

### DIFF
--- a/src/resolve/resolved-dns-query.c
+++ b/src/resolve/resolved-dns-query.c
@@ -1097,6 +1097,14 @@ int dns_query_go(DnsQuery *q) {
         return dns_query_go_scopes(q);
 }
 
+static int dns_query_copy_answer_ede(DnsQuery *q, DnsTransaction *t) {
+        assert(q);
+        assert(t);
+
+        q->answer_ede_rcode = t->answer_ede_rcode;
+        return free_and_strdup_warn(&q->answer_ede_msg, t->answer_ede_msg);
+}
+
 static void dns_query_accept(DnsQuery *q, DnsQueryCandidate *c) {
         DnsTransactionState state = DNS_TRANSACTION_NO_SERVERS;
         bool has_authenticated = false, has_non_authenticated = false, has_confidential = false, has_non_confidential = false;
@@ -1120,6 +1128,8 @@ static void dns_query_accept(DnsQuery *q, DnsQueryCandidate *c) {
                 state = DNS_TRANSACTION_ERRNO;
                 q->answer = dns_answer_unref(q->answer);
                 q->answer_rcode = 0;
+                q->answer_ede_rcode = _DNS_EDE_RCODE_INVALID;
+                q->answer_ede_msg = mfree(q->answer_ede_msg);
                 q->answer_dnssec_result = _DNSSEC_RESULT_INVALID;
                 q->answer_query_flags = 0;
                 q->answer_errno = c->error_code;
@@ -1143,10 +1153,20 @@ static void dns_query_accept(DnsQuery *q, DnsQueryCandidate *c) {
                                 /* Override non-successful previous answers */
                                 DNS_ANSWER_REPLACE(q->answer, dns_answer_ref(t->answer));
                                 q->answer_query_flags = dns_transaction_source_to_query_flags(t->answer_source);
+
+                                r = dns_query_copy_answer_ede(q, t);
+                                if (r < 0)
+                                        goto fail;
                         }
 
                         q->answer_rcode = t->answer_rcode;
                         q->answer_errno = 0;
+
+                        if (q->answer_ede_rcode < 0 && t->answer_ede_rcode >= 0) {
+                                r = dns_query_copy_answer_ede(q, t);
+                                if (r < 0)
+                                        goto fail;
+                        }
 
                         DNS_PACKET_REPLACE(q->answer_full_packet, dns_packet_ref(t->received));
 
@@ -1186,8 +1206,7 @@ static void dns_query_accept(DnsQuery *q, DnsQueryCandidate *c) {
 
                         DNS_ANSWER_REPLACE(q->answer, dns_answer_ref(t->answer));
                         q->answer_rcode = t->answer_rcode;
-                        q->answer_ede_rcode = t->answer_ede_rcode;
-                        r = free_and_strdup_warn(&q->answer_ede_msg, t->answer_ede_msg);
+                        r = dns_query_copy_answer_ede(q, t);
                         if (r < 0)
                                 goto fail;
                         q->answer_dnssec_result = t->answer_dnssec_result;

--- a/src/resolve/resolved-dns-server.c
+++ b/src/resolve/resolved-dns-server.c
@@ -685,7 +685,7 @@ int dns_server_adjust_opt(DnsServer *server, DnsPacket *packet, DnsServerFeature
 
         log_debug("Announcing packet size %zu in egress EDNS(0) packet.", packet_size);
 
-        return dns_packet_append_opt(packet, packet_size, edns_do, /* include_rfc6975= */ true, NULL, 0, NULL);
+        return dns_packet_append_opt(packet, packet_size, edns_do, /* include_rfc6975= */ true, /* nsid= */ NULL, 0, _DNS_EDE_RCODE_INVALID, /* ede_msg= */ NULL, /* ret_start= */ NULL);
 }
 
 int dns_server_ifindex(const DnsServer *s) {

--- a/src/resolve/resolved-dns-stub.c
+++ b/src/resolve/resolved-dns-stub.c
@@ -469,6 +469,8 @@ static int dns_stub_finish_reply_packet(
                 bool edns0_do,  /* set the EDNS0 DNSSEC OK bit? */
                 bool ad,        /* set the DNSSEC authenticated data bit? */
                 bool cd,        /* set the DNSSEC checking disabled bit? */
+                int ede_rcode,  /* EDNS0 Extended DNS Error code */
+                const char *ede_msg, /* EDNS0 Extended DNS Error message */
                 uint16_t max_udp_size, /* The maximum UDP datagram size to advertise to clients */
                 bool nsid) {    /* whether to add NSID */
 
@@ -477,7 +479,7 @@ static int dns_stub_finish_reply_packet(
         assert(p);
 
         if (add_opt) {
-                r = dns_packet_append_opt(p, max_udp_size, edns0_do, /* include_rfc6975= */ false, nsid ? nsid_string() : NULL, rcode, NULL);
+                r = dns_packet_append_opt(p, max_udp_size, edns0_do, /* include_rfc6975= */ false, nsid ? nsid_string() : NULL, rcode, ede_rcode, ede_msg, /* ret_start= */ NULL);
                 if (r == -EMSGSIZE) /* Hit the size limit? then indicate truncation */
                         tc = true;
                 else if (r < 0)
@@ -657,6 +659,8 @@ static int dns_stub_send_reply(
                         edns0_do,
                         (DNS_PACKET_AD(q->request_packet) || dns_packet_do(q->request_packet)) && dns_query_fully_authenticated(q),
                         FLAGS_SET(q->flags, SD_RESOLVED_NO_VALIDATE),
+                        q->answer_ede_rcode,
+                        q->answer_ede_msg,
                         q->stub_listener_extra ? ADVERTISE_EXTRA_DATAGRAM_SIZE_MAX : ADVERTISE_DATAGRAM_SIZE_MAX,
                         dns_packet_has_nsid_request(q->request_packet) > 0 && !q->stub_listener_extra);
         if (r < 0)
@@ -699,6 +703,8 @@ static int dns_stub_send_failure(
                         dns_packet_do(p),
                         (DNS_PACKET_AD(p) || dns_packet_do(p)) && authenticated,
                         DNS_PACKET_CD(p),
+                        _DNS_EDE_RCODE_INVALID,
+                        /* ede_msg= */ NULL,
                         l ? ADVERTISE_EXTRA_DATAGRAM_SIZE_MAX : ADVERTISE_DATAGRAM_SIZE_MAX,
                         dns_packet_has_nsid_request(p) > 0 && !l);
         if (r < 0)

--- a/src/resolve/resolved-dns-transaction.c
+++ b/src/resolve/resolved-dns-transaction.c
@@ -70,6 +70,34 @@ static int dnssec_result_to_ede_rcode(DnssecResult result) {
         }
 }
 
+static bool dns_ede_rcode_is_cacheable(int ede_rcode) {
+        return dns_ede_rcode_is_dnssec(ede_rcode) ||
+                IN_SET(ede_rcode,
+                       DNS_EDE_RCODE_FORGED_ANSWER,
+                       DNS_EDE_RCODE_BLOCKED,
+                       DNS_EDE_RCODE_CENSORED,
+                       DNS_EDE_RCODE_FILTERED,
+                       DNS_EDE_RCODE_PROHIBITED);
+}
+
+static int dns_transaction_copy_cacheable_ede(DnsTransaction *t, DnsPacket *p) {
+        _cleanup_free_ char *ede_msg = NULL;
+        int ede_rcode, r;
+
+        assert(t);
+        assert(p);
+
+        r = dns_packet_ede_rcode(p, &ede_rcode, &ede_msg);
+        if (r < 0)
+                return r == -ENOENT ? 0 : r;
+
+        if (!dns_ede_rcode_is_cacheable(ede_rcode))
+                return 0;
+
+        t->answer_ede_rcode = ede_rcode;
+        return free_and_strdup(&t->answer_ede_msg, ede_msg);
+}
+
 static void dns_transaction_reset_answer(DnsTransaction *t) {
         assert(t);
 
@@ -899,8 +927,8 @@ static void dns_transaction_cache_answer(DnsTransaction *t) {
                       dns_transaction_key(t),
                       t->answer_rcode,
                       t->answer,
-                      /* If neither DO nor EDE is set, the full packet isn't useful to cache */
-                      dns_packet_do(t->received) || t->answer_ede_rcode > 0 || t->answer_ede_msg ? t->received : NULL,
+                      /* If neither DO nor a cacheable EDE is set, the full packet isn't useful to cache */
+                      dns_packet_do(t->received) || dns_ede_rcode_is_cacheable(t->answer_ede_rcode) ? t->received : NULL,
                       t->answer_query_flags,
                       t->answer_dnssec_result,
                       t->answer_nsec_ttl,
@@ -1891,14 +1919,13 @@ static int dns_transaction_prepare(DnsTransaction *t, usec_t ts) {
                                 }
 
                                 t->answer_source = DNS_TRANSACTION_CACHE;
+                                if (t->received)
+                                        (void) dns_transaction_copy_cacheable_ede(t, t->received);
+
                                 if (t->answer_rcode == DNS_RCODE_SUCCESS)
                                         dns_transaction_complete(t, DNS_TRANSACTION_SUCCESS);
-                                else {
-                                        if (t->received)
-                                                (void) dns_packet_ede_rcode(t->received, &t->answer_ede_rcode, &t->answer_ede_msg);
-
+                                else
                                         dns_transaction_complete(t, DNS_TRANSACTION_RCODE_FAILURE);
-                                }
                                 return 0;
                         }
                 }

--- a/src/resolve/resolved-dns-transaction.c
+++ b/src/resolve/resolved-dns-transaction.c
@@ -34,6 +34,42 @@
 
 #define TRANSACTIONS_MAX 4096
 
+static int dnssec_result_to_ede_rcode(DnssecResult result) {
+        switch (result) {
+
+        case DNSSEC_INVALID:
+                return DNS_EDE_RCODE_DNSSEC_BOGUS;
+
+        case DNSSEC_SIGNATURE_EXPIRED:
+                return DNS_EDE_RCODE_SIG_EXPIRED;
+
+        case DNSSEC_UNSUPPORTED_ALGORITHM:
+                return DNS_EDE_RCODE_UNSUPPORTED_DNSKEY_ALG;
+
+        case DNSSEC_TOO_MANY_VALIDATIONS:
+        case DNSSEC_FAILED_AUXILIARY:
+                return DNS_EDE_RCODE_DNSSEC_INDETERMINATE;
+
+        case DNSSEC_NO_SIGNATURE:
+                return DNS_EDE_RCODE_RRSIG_MISSING;
+
+        case DNSSEC_MISSING_KEY:
+                return DNS_EDE_RCODE_DNSKEY_MISSING;
+
+        case DNSSEC_UNSIGNED:
+                return DNS_EDE_RCODE_DNSSEC_INDETERMINATE;
+
+        case DNSSEC_NSEC_MISMATCH:
+                return DNS_EDE_RCODE_NSEC_MISSING;
+
+        case DNSSEC_INCOMPATIBLE_SERVER:
+                return DNS_EDE_RCODE_NOT_SUPPORTED;
+
+        default:
+                return _DNS_EDE_RCODE_INVALID;
+        }
+}
+
 static void dns_transaction_reset_answer(DnsTransaction *t) {
         assert(t);
 
@@ -414,6 +450,9 @@ void dns_transaction_complete(DnsTransaction *t, DnsTransactionState state) {
         assert(!DNS_TRANSACTION_IS_LIVE(state));
 
         if (state == DNS_TRANSACTION_DNSSEC_FAILED) {
+                if (t->answer_ede_rcode < 0)
+                        t->answer_ede_rcode = dnssec_result_to_ede_rcode(t->answer_dnssec_result);
+
                 dns_resource_key_to_string(dns_transaction_key(t), key_str, sizeof key_str);
 
                 log_struct(LOG_NOTICE,

--- a/src/resolve/resolved-dns-transaction.c
+++ b/src/resolve/resolved-dns-transaction.c
@@ -98,6 +98,16 @@ static int dns_transaction_copy_cacheable_ede(DnsTransaction *t, DnsPacket *p) {
         return free_and_strdup(&t->answer_ede_msg, ede_msg);
 }
 
+static void dns_transaction_set_stale_ede(DnsTransaction *t) {
+        assert(t);
+
+        if (t->answer_rcode != DNS_RCODE_SUCCESS)
+                return;
+
+        t->answer_ede_rcode = DNS_EDE_RCODE_STALE_ANSWER;
+        t->answer_ede_msg = mfree(t->answer_ede_msg);
+}
+
 static void dns_transaction_reset_answer(DnsTransaction *t) {
         assert(t);
 
@@ -1903,7 +1913,9 @@ static int dns_transaction_prepare(DnsTransaction *t, usec_t ts) {
                                  * packet. */
                                 dns_transaction_reset_answer(t);
                         else {
-                                if (t->n_attempts > 1 && !FLAGS_SET(query_flags, SD_RESOLVED_NO_STALE)) {
+                                bool serve_stale = t->n_attempts > 1 && !FLAGS_SET(query_flags, SD_RESOLVED_NO_STALE);
+
+                                if (serve_stale) {
 
                                         if (t->answer_rcode == DNS_RCODE_SUCCESS) {
                                                 if (t->seen_timeout)
@@ -1921,6 +1933,8 @@ static int dns_transaction_prepare(DnsTransaction *t, usec_t ts) {
                                 t->answer_source = DNS_TRANSACTION_CACHE;
                                 if (t->received)
                                         (void) dns_transaction_copy_cacheable_ede(t, t->received);
+                                if (serve_stale)
+                                        dns_transaction_set_stale_ede(t);
 
                                 if (t->answer_rcode == DNS_RCODE_SUCCESS)
                                         dns_transaction_complete(t, DNS_TRANSACTION_SUCCESS);

--- a/src/resolve/test-dns-packet-append.c
+++ b/src/resolve/test-dns-packet-append.c
@@ -1,5 +1,6 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
+#include "alloc-util.h"
 #include "dns-answer.h"
 #include "dns-packet.h"
 #include "dns-question.h"
@@ -284,7 +285,7 @@ TEST(packet_append_opt_basic) {
         DNS_PACKET_ID(packet) = htobe16(42);
         DNS_PACKET_HEADER(packet)->flags = htobe16(DNS_PACKET_MAKE_FLAGS(0, 0, 0, 0, 1, 0, 0, 0, DNS_RCODE_SUCCESS));
 
-        ASSERT_OK(dns_packet_append_opt(packet, 512, false, false, NULL, 0, NULL));
+        ASSERT_OK(dns_packet_append_opt(packet, 512, false, false, NULL, 0, _DNS_EDE_RCODE_INVALID, NULL, NULL));
 
         const uint8_t data[] = {
                         0x00, 0x2a,     BIT_RD, DNS_RCODE_SUCCESS,
@@ -312,7 +313,7 @@ TEST(packet_append_opt_change_max_udp) {
         DNS_PACKET_ID(packet) = htobe16(42);
         DNS_PACKET_HEADER(packet)->flags = htobe16(DNS_PACKET_MAKE_FLAGS(0, 0, 0, 0, 1, 0, 0, 0, DNS_RCODE_SUCCESS));
 
-        ASSERT_OK(dns_packet_append_opt(packet, 4100, false, false, NULL, 0, NULL));
+        ASSERT_OK(dns_packet_append_opt(packet, 4100, false, false, NULL, 0, _DNS_EDE_RCODE_INVALID, NULL, NULL));
 
         const uint8_t data[] = {
                         0x00, 0x2a,     BIT_RD, DNS_RCODE_SUCCESS,
@@ -340,7 +341,7 @@ TEST(packet_append_opt_dnssec_ok) {
         DNS_PACKET_ID(packet) = htobe16(42);
         DNS_PACKET_HEADER(packet)->flags = htobe16(DNS_PACKET_MAKE_FLAGS(0, 0, 0, 0, 1, 0, 0, 0, DNS_RCODE_SUCCESS));
 
-        ASSERT_OK(dns_packet_append_opt(packet, 512, true, false, NULL, 0, NULL));
+        ASSERT_OK(dns_packet_append_opt(packet, 512, true, false, NULL, 0, _DNS_EDE_RCODE_INVALID, NULL, NULL));
 
         const uint8_t data[] = {
                         0x00, 0x2a,     BIT_RD, DNS_RCODE_SUCCESS,
@@ -368,7 +369,7 @@ TEST(packet_append_opt_rcode) {
         DNS_PACKET_ID(packet) = htobe16(42);
         DNS_PACKET_HEADER(packet)->flags = htobe16(DNS_PACKET_MAKE_FLAGS(0, 0, 0, 0, 1, 0, 0, 0, DNS_RCODE_SUCCESS));
 
-        ASSERT_OK(dns_packet_append_opt(packet, 512, false, false, NULL, 0x97a, NULL));
+        ASSERT_OK(dns_packet_append_opt(packet, 512, false, false, NULL, 0x97a, _DNS_EDE_RCODE_INVALID, NULL, NULL));
 
         const uint8_t data[] = {
                         0x00, 0x2a,     BIT_RD, DNS_RCODE_SUCCESS,
@@ -396,7 +397,7 @@ TEST(packet_append_opt_nsid) {
         DNS_PACKET_ID(packet) = htobe16(42);
         DNS_PACKET_HEADER(packet)->flags = htobe16(DNS_PACKET_MAKE_FLAGS(0, 0, 0, 0, 1, 0, 0, 0, DNS_RCODE_SUCCESS));
 
-        ASSERT_OK(dns_packet_append_opt(packet, 512, false, false, "nsid.example.com", 0, NULL));
+        ASSERT_OK(dns_packet_append_opt(packet, 512, false, false, "nsid.example.com", 0, _DNS_EDE_RCODE_INVALID, NULL, NULL));
 
         const uint8_t data[] = {
                         0x00, 0x2a,     BIT_RD, DNS_RCODE_SUCCESS,
@@ -419,6 +420,145 @@ TEST(packet_append_opt_nsid) {
         ASSERT_EQ(memcmp(DNS_PACKET_DATA(packet), data, sizeof(data)), 0);
 }
 
+TEST(packet_append_opt_ede) {
+        _cleanup_free_ char *ede_msg = NULL;
+        _cleanup_(dns_packet_unrefp) DnsPacket *packet = NULL;
+        int ede_rcode;
+
+        ASSERT_OK(dns_packet_new(&packet, DNS_PROTOCOL_DNS, 0, DNS_PACKET_SIZE_MAX));
+        ASSERT_NOT_NULL(packet);
+
+        DNS_PACKET_ID(packet) = htobe16(42);
+        DNS_PACKET_HEADER(packet)->flags = htobe16(DNS_PACKET_MAKE_FLAGS(0, 0, 0, 0, 1, 0, 0, 0, DNS_RCODE_SUCCESS));
+
+        ASSERT_OK(dns_packet_append_opt(packet, 512, false, false, NULL, 0, DNS_EDE_RCODE_FILTERED, "Filtered by policy", NULL));
+
+        const uint8_t data[] = {
+                        0x00, 0x2a,     BIT_RD, DNS_RCODE_SUCCESS,
+                        0x00, 0x00,     0x00, 0x00,     0x00, 0x00,     0x00, 0x01,
+
+        /* root */      0x00,
+        /* OPT */       0x00, 0x29,
+        /* udp max */   0x02, 0x00,
+        /* rcode */     0x00,
+        /* version */   0x00,
+        /* flags */     0x00, 0x00,
+        /* rdata */     0x00, 0x18,
+        /* EDE */       0x00, 0x0f,
+                        0x00, 0x14,
+                        0x00, 0x11,
+                        'F', 'i', 'l', 't', 'e', 'r', 'e', 'd',
+                        ' ', 'b', 'y', ' ', 'p', 'o', 'l', 'i',
+                        'c', 'y'
+        };
+
+        ASSERT_EQ(packet->size, sizeof(data));
+        ASSERT_EQ(memcmp(DNS_PACKET_DATA(packet), data, sizeof(data)), 0);
+
+        ASSERT_OK(dns_packet_extract(packet));
+        ASSERT_OK(dns_packet_ede_rcode(packet, &ede_rcode, &ede_msg));
+        ASSERT_EQ(ede_rcode, DNS_EDE_RCODE_FILTERED);
+        ASSERT_STREQ(ede_msg, "Filtered by policy");
+}
+
+TEST(packet_append_opt_ede_without_text) {
+        _cleanup_free_ char *ede_msg = NULL;
+        _cleanup_(dns_packet_unrefp) DnsPacket *packet = NULL;
+        int ede_rcode;
+
+        ASSERT_OK(dns_packet_new(&packet, DNS_PROTOCOL_DNS, 0, DNS_PACKET_SIZE_MAX));
+        ASSERT_NOT_NULL(packet);
+
+        DNS_PACKET_ID(packet) = htobe16(42);
+        DNS_PACKET_HEADER(packet)->flags = htobe16(DNS_PACKET_MAKE_FLAGS(0, 0, 0, 0, 1, 0, 0, 0, DNS_RCODE_SUCCESS));
+
+        ASSERT_OK(dns_packet_append_opt(packet, 512, false, false, NULL, 0, DNS_EDE_RCODE_STALE_ANSWER, NULL, NULL));
+
+        const uint8_t data[] = {
+                        0x00, 0x2a,     BIT_RD, DNS_RCODE_SUCCESS,
+                        0x00, 0x00,     0x00, 0x00,     0x00, 0x00,     0x00, 0x01,
+
+        /* root */      0x00,
+        /* OPT */       0x00, 0x29,
+        /* udp max */   0x02, 0x00,
+        /* rcode */     0x00,
+        /* version */   0x00,
+        /* flags */     0x00, 0x00,
+        /* rdata */     0x00, 0x06,
+        /* EDE */       0x00, 0x0f,
+                        0x00, 0x02,
+                        0x00, 0x03
+        };
+
+        ASSERT_EQ(packet->size, sizeof(data));
+        ASSERT_EQ(memcmp(DNS_PACKET_DATA(packet), data, sizeof(data)), 0);
+
+        ASSERT_OK(dns_packet_extract(packet));
+        ASSERT_OK(dns_packet_ede_rcode(packet, &ede_rcode, &ede_msg));
+        ASSERT_EQ(ede_rcode, DNS_EDE_RCODE_STALE_ANSWER);
+        ASSERT_STREQ(ede_msg, "");
+}
+
+TEST(packet_append_opt_ede_unknown_code) {
+        _cleanup_free_ char *ede_msg = NULL;
+        _cleanup_(dns_packet_unrefp) DnsPacket *packet = NULL;
+        int ede_rcode;
+
+        ASSERT_OK(dns_packet_new(&packet, DNS_PROTOCOL_DNS, 0, DNS_PACKET_SIZE_MAX));
+        ASSERT_NOT_NULL(packet);
+
+        DNS_PACKET_ID(packet) = htobe16(42);
+        DNS_PACKET_HEADER(packet)->flags = htobe16(DNS_PACKET_MAKE_FLAGS(0, 0, 0, 0, 1, 0, 0, 0, DNS_RCODE_SUCCESS));
+
+        ASSERT_OK(dns_packet_append_opt(packet, 512, false, false, NULL, 0, 65000, "private", NULL));
+
+        ASSERT_OK(dns_packet_extract(packet));
+        ASSERT_OK(dns_packet_ede_rcode(packet, &ede_rcode, &ede_msg));
+        ASSERT_EQ(ede_rcode, 65000);
+        ASSERT_STREQ(ede_msg, "private");
+}
+
+TEST(packet_append_opt_ede_with_nsid) {
+        _cleanup_free_ char *ede_msg = NULL;
+        _cleanup_(dns_packet_unrefp) DnsPacket *packet = NULL;
+        int ede_rcode;
+
+        ASSERT_OK(dns_packet_new(&packet, DNS_PROTOCOL_DNS, 0, DNS_PACKET_SIZE_MAX));
+        ASSERT_NOT_NULL(packet);
+
+        DNS_PACKET_ID(packet) = htobe16(42);
+        DNS_PACKET_HEADER(packet)->flags = htobe16(DNS_PACKET_MAKE_FLAGS(0, 0, 0, 0, 1, 0, 0, 0, DNS_RCODE_SUCCESS));
+
+        ASSERT_OK(dns_packet_append_opt(packet, 512, false, false, "node", 0, DNS_EDE_RCODE_PROHIBITED, NULL, NULL));
+
+        ASSERT_OK(dns_packet_extract(packet));
+        ASSERT_OK(dns_packet_ede_rcode(packet, &ede_rcode, &ede_msg));
+        ASSERT_EQ(ede_rcode, DNS_EDE_RCODE_PROHIBITED);
+        ASSERT_STREQ(ede_msg, "");
+}
+
+TEST(packet_append_opt_ede_too_large) {
+        _cleanup_free_ char *ede_msg = NULL;
+        _cleanup_(dns_packet_unrefp) DnsPacket *packet = NULL;
+
+        ASSERT_OK(dns_packet_new(&packet, DNS_PROTOCOL_DNS, 0, DNS_PACKET_SIZE_MAX));
+        ASSERT_NOT_NULL(packet);
+
+        DNS_PACKET_ID(packet) = htobe16(42);
+        DNS_PACKET_HEADER(packet)->flags = htobe16(DNS_PACKET_MAKE_FLAGS(0, 0, 0, 0, 1, 0, 0, 0, DNS_RCODE_SUCCESS));
+
+        ede_msg = new(char, UINT16_MAX - 4);
+        ASSERT_NOT_NULL(ede_msg);
+        memset(ede_msg, 'x', UINT16_MAX - 5);
+        ede_msg[UINT16_MAX - 5] = 0;
+
+        ASSERT_ERROR(dns_packet_append_opt(packet, 512, false, false, NULL, 0, DNS_EDE_RCODE_OTHER, ede_msg, NULL), E2BIG);
+        ASSERT_EQ(packet->size, DNS_PACKET_HEADER_SIZE);
+        ASSERT_EQ(DNS_PACKET_ARCOUNT(packet), 0);
+        ASSERT_EQ(packet->opt_start, SIZE_MAX);
+        ASSERT_EQ(packet->opt_size, SIZE_MAX);
+}
+
 TEST(packet_append_key_and_opt) {
         _cleanup_(dns_packet_unrefp) DnsPacket *packet = NULL;
         _cleanup_(dns_resource_key_unrefp) DnsResourceKey *key = NULL;
@@ -434,7 +574,7 @@ TEST(packet_append_key_and_opt) {
         ASSERT_NOT_NULL(key);
         ASSERT_OK(dns_packet_append_key(packet, key, 0, NULL));
 
-        ASSERT_OK(dns_packet_append_opt(packet, 512, false, false, NULL, 0, NULL));
+        ASSERT_OK(dns_packet_append_opt(packet, 512, false, false, NULL, 0, _DNS_EDE_RCODE_INVALID, NULL, NULL));
 
         const uint8_t data[] = {
                         0x00, 0x2a,     BIT_RD, DNS_RCODE_SUCCESS,
@@ -474,7 +614,7 @@ TEST(packet_truncate_opt) {
         ASSERT_NOT_NULL(key);
         ASSERT_OK(dns_packet_append_key(packet, key, 0, NULL));
 
-        ASSERT_OK(dns_packet_append_opt(packet, 512, false, false, NULL, 0, NULL));
+        ASSERT_OK(dns_packet_append_opt(packet, 512, false, false, NULL, 0, _DNS_EDE_RCODE_INVALID, NULL, NULL));
 
         ASSERT_TRUE(dns_packet_truncate_opt(packet));
 
@@ -506,7 +646,7 @@ TEST(packet_patch_max_udp_size) {
         DNS_PACKET_ID(packet) = htobe16(42);
         DNS_PACKET_HEADER(packet)->flags = htobe16(DNS_PACKET_MAKE_FLAGS(0, 0, 0, 0, 1, 0, 0, 0, DNS_RCODE_SUCCESS));
 
-        ASSERT_OK(dns_packet_append_opt(packet, 512, false, false, NULL, 0, NULL));
+        ASSERT_OK(dns_packet_append_opt(packet, 512, false, false, NULL, 0, _DNS_EDE_RCODE_INVALID, NULL, NULL));
 
         ASSERT_TRUE(dns_packet_patch_max_udp_size(packet, 4097));
 

--- a/src/resolve/test-dns-packet-extract.c
+++ b/src/resolve/test-dns-packet-extract.c
@@ -3520,6 +3520,78 @@ TEST(packet_ede_rcode_non_ede_code) {
         ASSERT_ERROR(dns_packet_ede_rcode(packet, &ret_ede_rcode, &ret_ede_msg), ENOENT);
 }
 
+TEST(packet_ede_rcode_after_non_ede_code) {
+        _cleanup_(dns_packet_unrefp) DnsPacket *packet = NULL;
+        _cleanup_free_ char *ret_ede_msg;
+        int ret_ede_rcode;
+
+        ASSERT_OK(dns_packet_new(&packet, DNS_PROTOCOL_DNS, 0, DNS_PACKET_SIZE_MAX));
+        ASSERT_NOT_NULL(packet);
+        dns_packet_truncate(packet, 0);
+
+        const uint8_t data[] = {
+                        0x00, 0x42,     BIT_QR | BIT_AA, DNS_RCODE_SUCCESS,
+                        0x00, 0x00,     0x00, 0x00,     0x00, 0x00,     0x00, 0x01,
+
+        /* name */      0x00,
+        /* OPT */       0x00, 0x29,
+        /* udp max */   0x02, 0x01,
+        /* rcode */     0x00,
+        /* version */   0x00,
+        /* flags */     0x80, 0x00,
+        /* rdata */     0x00, 0x15,
+        /* NSID */      0x00, 0x03,
+                        0x00, 0x04,
+                        'n', 'o', 'd', 'e',
+        /* EDE */       0x00, 0x0f,
+                        0x00, 0x09,
+                        0x00, 0x12,     /* Prohibited */
+                        'b', 'l', 'o', 'c', 'k', 'd', 0x00
+        };
+
+        ASSERT_OK(dns_packet_append_blob(packet, data, sizeof(data), NULL));
+
+        ASSERT_OK(dns_packet_extract(packet));
+
+        ASSERT_OK(dns_packet_ede_rcode(packet, &ret_ede_rcode, &ret_ede_msg));
+        ASSERT_EQ(ret_ede_rcode, DNS_EDE_RCODE_PROHIBITED);
+        ASSERT_STREQ(ret_ede_msg, "blockd");
+}
+
+TEST(packet_ede_rcode_no_extra_text) {
+        _cleanup_(dns_packet_unrefp) DnsPacket *packet = NULL;
+        _cleanup_free_ char *ret_ede_msg;
+        int ret_ede_rcode;
+
+        ASSERT_OK(dns_packet_new(&packet, DNS_PROTOCOL_DNS, 0, DNS_PACKET_SIZE_MAX));
+        ASSERT_NOT_NULL(packet);
+        dns_packet_truncate(packet, 0);
+
+        const uint8_t data[] = {
+                        0x00, 0x42,     BIT_QR | BIT_AA, DNS_RCODE_SUCCESS,
+                        0x00, 0x00,     0x00, 0x00,     0x00, 0x00,     0x00, 0x01,
+
+        /* name */      0x00,
+        /* OPT */       0x00, 0x29,
+        /* udp max */   0x02, 0x01,
+        /* rcode */     0x00,
+        /* version */   0x00,
+        /* flags */     0x80, 0x00,
+        /* rdata */     0x00, 0x06,
+        /* EDE */       0x00, 0x0f,
+                        0x00, 0x02,
+                        0x00, 0x04      /* Forged Answer */
+        };
+
+        ASSERT_OK(dns_packet_append_blob(packet, data, sizeof(data), NULL));
+
+        ASSERT_OK(dns_packet_extract(packet));
+
+        ASSERT_OK(dns_packet_ede_rcode(packet, &ret_ede_rcode, &ret_ede_msg));
+        ASSERT_EQ(ret_ede_rcode, DNS_EDE_RCODE_FORGED_ANSWER);
+        ASSERT_STREQ(ret_ede_msg, "");
+}
+
 TEST(packet_ede_rcode_malformed_ede_payload) {
         _cleanup_(dns_packet_unrefp) DnsPacket *packet = NULL;
         int ret_ede_rcode;
@@ -3551,6 +3623,38 @@ TEST(packet_ede_rcode_malformed_ede_payload) {
         ASSERT_OK(dns_packet_extract(packet));
 
         ASSERT_ERROR(dns_packet_ede_rcode(packet, &ret_ede_rcode, &ret_ede_msg), ENOENT);
+}
+
+TEST(packet_ede_rcode_truncated_info_code) {
+        _cleanup_(dns_packet_unrefp) DnsPacket *packet = NULL;
+        int ret_ede_rcode;
+        char *ret_ede_msg;
+
+        ASSERT_OK(dns_packet_new(&packet, DNS_PROTOCOL_DNS, 0, DNS_PACKET_SIZE_MAX));
+        ASSERT_NOT_NULL(packet);
+        dns_packet_truncate(packet, 0);
+
+        const uint8_t data[] = {
+                        0x00, 0x42,     BIT_QR | BIT_AA, DNS_RCODE_SUCCESS,
+                        0x00, 0x00,     0x00, 0x00,     0x00, 0x00,     0x00, 0x01,
+
+        /* name */      0x00,
+        /* OPT */       0x00, 0x29,
+        /* udp max */   0x02, 0x01,
+        /* rcode */     0x00,
+        /* version */   0x00,
+        /* flags */     0x80, 0x00,
+        /* rdata */     0x00, 0x05,
+        /* EDE */       0x00, 0x0f,
+                        0x00, 0x01,
+                        0x00
+        };
+
+        ASSERT_OK(dns_packet_append_blob(packet, data, sizeof(data), NULL));
+
+        ASSERT_OK(dns_packet_extract(packet));
+
+        ASSERT_ERROR(dns_packet_ede_rcode(packet, &ret_ede_rcode, &ret_ede_msg), EBADMSG);
 }
 
 /* ================================================================
@@ -4698,9 +4802,26 @@ TEST(dns_ede_rcode_is_dnssec) {
         ASSERT_TRUE(dns_ede_rcode_is_dnssec(DNS_EDE_RCODE_NO_ZONE_KEY_BIT));
         ASSERT_TRUE(dns_ede_rcode_is_dnssec(DNS_EDE_RCODE_NSEC_MISSING));
 
+        ASSERT_FALSE(dns_ede_rcode_is_dnssec(DNS_EDE_RCODE_OTHER));
+        ASSERT_FALSE(dns_ede_rcode_is_dnssec(DNS_EDE_RCODE_STALE_ANSWER));
+        ASSERT_FALSE(dns_ede_rcode_is_dnssec(DNS_EDE_RCODE_FORGED_ANSWER));
+        ASSERT_FALSE(dns_ede_rcode_is_dnssec(DNS_EDE_RCODE_CACHED_ERROR));
+        ASSERT_FALSE(dns_ede_rcode_is_dnssec(DNS_EDE_RCODE_NOT_READY));
         ASSERT_FALSE(dns_ede_rcode_is_dnssec(DNS_EDE_RCODE_BLOCKED));
         ASSERT_FALSE(dns_ede_rcode_is_dnssec(DNS_EDE_RCODE_CENSORED));
-        ASSERT_FALSE(dns_ede_rcode_is_dnssec(DNS_EDE_RCODE_OTHER));
+        ASSERT_FALSE(dns_ede_rcode_is_dnssec(DNS_EDE_RCODE_FILTERED));
+        ASSERT_FALSE(dns_ede_rcode_is_dnssec(DNS_EDE_RCODE_PROHIBITED));
+        ASSERT_FALSE(dns_ede_rcode_is_dnssec(DNS_EDE_RCODE_STALE_NXDOMAIN_ANSWER));
+        ASSERT_FALSE(dns_ede_rcode_is_dnssec(DNS_EDE_RCODE_NOT_AUTHORITATIVE));
+        ASSERT_FALSE(dns_ede_rcode_is_dnssec(DNS_EDE_RCODE_NOT_SUPPORTED));
+        ASSERT_FALSE(dns_ede_rcode_is_dnssec(DNS_EDE_RCODE_UNREACH_AUTHORITY));
+        ASSERT_FALSE(dns_ede_rcode_is_dnssec(DNS_EDE_RCODE_NET_ERROR));
+        ASSERT_FALSE(dns_ede_rcode_is_dnssec(DNS_EDE_RCODE_INVALID_DATA));
+        ASSERT_FALSE(dns_ede_rcode_is_dnssec(DNS_EDE_RCODE_SIG_NEVER));
+        ASSERT_FALSE(dns_ede_rcode_is_dnssec(DNS_EDE_RCODE_TOO_EARLY));
+        ASSERT_FALSE(dns_ede_rcode_is_dnssec(DNS_EDE_RCODE_UNSUPPORTED_NSEC3_ITER));
+        ASSERT_FALSE(dns_ede_rcode_is_dnssec(DNS_EDE_RCODE_TRANSPORT_POLICY));
+        ASSERT_FALSE(dns_ede_rcode_is_dnssec(DNS_EDE_RCODE_SYNTHESIZED));
 }
 
 /* ================================================================
@@ -4731,22 +4852,37 @@ TEST(format_dns_rcode) {
  * ================================================================ */
 
 TEST(format_dns_ede_rcode) {
-        const char *str;
-
-        str = FORMAT_DNS_EDE_RCODE(DNS_EDE_RCODE_DNSSEC_BOGUS);
-        ASSERT_STREQ(str, "DNSSEC Bogus");
-
-        str = FORMAT_DNS_EDE_RCODE(DNS_EDE_RCODE_SIG_EXPIRED);
-        ASSERT_STREQ(str, "Signature Expired");
-
-        str = FORMAT_DNS_EDE_RCODE(DNS_EDE_RCODE_CENSORED);
-        ASSERT_STREQ(str, "Censored");
-
-        str = FORMAT_DNS_EDE_RCODE(DNS_EDE_RCODE_OTHER);
-        ASSERT_STREQ(str, "Other");
-
-        str = FORMAT_DNS_EDE_RCODE(DNS_EDE_RCODE_STALE_NXDOMAIN_ANSWER);
-        ASSERT_STREQ(str, "Stale NXDOMAIN Answer");
+        ASSERT_STREQ(FORMAT_DNS_EDE_RCODE(DNS_EDE_RCODE_OTHER), "Other");
+        ASSERT_STREQ(FORMAT_DNS_EDE_RCODE(DNS_EDE_RCODE_UNSUPPORTED_DNSKEY_ALG), "Unsupported DNSKEY Algorithm");
+        ASSERT_STREQ(FORMAT_DNS_EDE_RCODE(DNS_EDE_RCODE_UNSUPPORTED_DS_DIGEST), "Unsupported DS Digest Type");
+        ASSERT_STREQ(FORMAT_DNS_EDE_RCODE(DNS_EDE_RCODE_STALE_ANSWER), "Stale Answer");
+        ASSERT_STREQ(FORMAT_DNS_EDE_RCODE(DNS_EDE_RCODE_FORGED_ANSWER), "Forged Answer");
+        ASSERT_STREQ(FORMAT_DNS_EDE_RCODE(DNS_EDE_RCODE_DNSSEC_INDETERMINATE), "DNSSEC Indeterminate");
+        ASSERT_STREQ(FORMAT_DNS_EDE_RCODE(DNS_EDE_RCODE_DNSSEC_BOGUS), "DNSSEC Bogus");
+        ASSERT_STREQ(FORMAT_DNS_EDE_RCODE(DNS_EDE_RCODE_SIG_EXPIRED), "Signature Expired");
+        ASSERT_STREQ(FORMAT_DNS_EDE_RCODE(DNS_EDE_RCODE_SIG_NOT_YET_VALID), "Signature Not Yet Valid");
+        ASSERT_STREQ(FORMAT_DNS_EDE_RCODE(DNS_EDE_RCODE_DNSKEY_MISSING), "DNSKEY Missing");
+        ASSERT_STREQ(FORMAT_DNS_EDE_RCODE(DNS_EDE_RCODE_RRSIG_MISSING), "RRSIG Missing");
+        ASSERT_STREQ(FORMAT_DNS_EDE_RCODE(DNS_EDE_RCODE_NO_ZONE_KEY_BIT), "No Zone Key Bit Set");
+        ASSERT_STREQ(FORMAT_DNS_EDE_RCODE(DNS_EDE_RCODE_NSEC_MISSING), "NSEC Missing");
+        ASSERT_STREQ(FORMAT_DNS_EDE_RCODE(DNS_EDE_RCODE_CACHED_ERROR), "Cached Error");
+        ASSERT_STREQ(FORMAT_DNS_EDE_RCODE(DNS_EDE_RCODE_NOT_READY), "Not Ready");
+        ASSERT_STREQ(FORMAT_DNS_EDE_RCODE(DNS_EDE_RCODE_BLOCKED), "Blocked");
+        ASSERT_STREQ(FORMAT_DNS_EDE_RCODE(DNS_EDE_RCODE_CENSORED), "Censored");
+        ASSERT_STREQ(FORMAT_DNS_EDE_RCODE(DNS_EDE_RCODE_FILTERED), "Filtered");
+        ASSERT_STREQ(FORMAT_DNS_EDE_RCODE(DNS_EDE_RCODE_PROHIBITED), "Prohibited");
+        ASSERT_STREQ(FORMAT_DNS_EDE_RCODE(DNS_EDE_RCODE_STALE_NXDOMAIN_ANSWER), "Stale NXDOMAIN Answer");
+        ASSERT_STREQ(FORMAT_DNS_EDE_RCODE(DNS_EDE_RCODE_NOT_AUTHORITATIVE), "Not Authoritative");
+        ASSERT_STREQ(FORMAT_DNS_EDE_RCODE(DNS_EDE_RCODE_NOT_SUPPORTED), "Not Supported");
+        ASSERT_STREQ(FORMAT_DNS_EDE_RCODE(DNS_EDE_RCODE_UNREACH_AUTHORITY), "No Reachable Authority");
+        ASSERT_STREQ(FORMAT_DNS_EDE_RCODE(DNS_EDE_RCODE_NET_ERROR), "Network Error");
+        ASSERT_STREQ(FORMAT_DNS_EDE_RCODE(DNS_EDE_RCODE_INVALID_DATA), "Invalid Data");
+        ASSERT_STREQ(FORMAT_DNS_EDE_RCODE(DNS_EDE_RCODE_SIG_NEVER), "Signature Never Valid");
+        ASSERT_STREQ(FORMAT_DNS_EDE_RCODE(DNS_EDE_RCODE_TOO_EARLY), "Too Early");
+        ASSERT_STREQ(FORMAT_DNS_EDE_RCODE(DNS_EDE_RCODE_UNSUPPORTED_NSEC3_ITER), "Unsupported NSEC3 Iterations");
+        ASSERT_STREQ(FORMAT_DNS_EDE_RCODE(DNS_EDE_RCODE_TRANSPORT_POLICY), "Impossible Transport Policy");
+        ASSERT_STREQ(FORMAT_DNS_EDE_RCODE(DNS_EDE_RCODE_SYNTHESIZED), "Synthesized");
+        ASSERT_STREQ(FORMAT_DNS_EDE_RCODE(65000), "65000");
 }
 
 /* ================================================================

--- a/src/resolve/test-resolved-dummy-server.c
+++ b/src/resolve/test-resolved-dummy-server.c
@@ -3,8 +3,10 @@
 #include "sd-daemon.h"
 #include "sd-event.h"
 
+#include "dns-answer.h"
 #include "dns-packet.h"
 #include "dns-question.h"
+#include "dns-rr.h"
 #include "dns-type.h"
 #include "errno-util.h"
 #include "fd-util.h"
@@ -356,6 +358,51 @@ static int server_handle_edns_code_zero(DnsPacket *packet, DnsPacket *reply) {
         return reply_append_edns(packet, reply, "\xF0\x9F\x90\xB1", DNS_RCODE_SERVFAIL, DNS_EDE_RCODE_OTHER);
 }
 
+static int server_handle_edns_success_with_address(DnsPacket *packet, DnsPacket *reply, int ede_rcode) {
+        _cleanup_(dns_answer_unrefp) DnsAnswer *answer = NULL;
+        DnsResourceRecord *rr = NULL;
+        const char *name;
+        int r;
+
+        assert(packet);
+        assert(reply);
+
+        name = dns_question_first_name(packet->question);
+        assert(name);
+
+        rr = dns_resource_record_new_full(DNS_CLASS_IN, DNS_TYPE_A, name);
+        if (!rr)
+                return -ENOMEM;
+
+        rr->ttl = 60;
+        rr->a.in_addr.s_addr = htobe32(0);
+
+        answer = dns_answer_new(1);
+        if (!answer) {
+                dns_resource_record_unref(rr);
+                return -ENOMEM;
+        }
+
+        r = dns_answer_add(answer, rr, 1, 0, NULL);
+        dns_resource_record_unref(rr);
+        if (r < 0)
+                return r;
+
+        r = dns_packet_append_answer(reply, answer, NULL);
+        if (r < 0)
+                return r;
+
+        DNS_PACKET_HEADER(reply)->ancount = htobe16(dns_answer_size(answer));
+        return reply_append_edns(packet, reply, NULL, DNS_RCODE_SUCCESS, ede_rcode);
+}
+
+static int server_handle_edns_filtered_nxdomain(DnsPacket *packet, DnsPacket *reply) {
+        assert(packet);
+        assert(reply);
+
+        return reply_append_edns(packet, reply, NULL, DNS_RCODE_NXDOMAIN, DNS_EDE_RCODE_FILTERED);
+}
+
 static int on_dns_packet(sd_event_source *s, int fd, uint32_t revents, void *userdata) {
         _cleanup_(dns_packet_unrefp) DnsPacket *packet = NULL;
         _cleanup_(dns_packet_unrefp) DnsPacket *reply = NULL;
@@ -397,12 +444,21 @@ static int on_dns_packet(sd_event_source *s, int fd, uint32_t revents, void *use
                 r = server_handle_edns_bogus_dnssec(packet, reply);
         else if (streq_ptr(name, "edns-extra-text.forwarded.test"))
                 r = server_handle_edns_extra_text(packet, reply);
-        else if (streq_ptr(name, "edns-invalid-code.forwarded.test"))
+        else if (streq_ptr(name, "edns-invalid-code.forwarded.test") ||
+                 streq_ptr(name, "edns-invalid-code-varlink.forwarded.test"))
                 r = server_handle_edns_invalid_code(packet, reply, NULL);
-        else if (streq_ptr(name, "edns-invalid-code-with-extra-text.forwarded.test"))
+        else if (streq_ptr(name, "edns-invalid-code-with-extra-text.forwarded.test") ||
+                 streq_ptr(name, "edns-invalid-code-with-extra-text-varlink.forwarded.test"))
                 r = server_handle_edns_invalid_code(packet, reply, "Hello [#]$%~ World");
-        else if (streq_ptr(name, "edns-code-zero.forwarded.test"))
+        else if (streq_ptr(name, "edns-code-zero.forwarded.test") ||
+                 streq_ptr(name, "edns-code-zero-varlink.forwarded.test"))
                 r = server_handle_edns_code_zero(packet, reply);
+        else if (streq_ptr(name, "edns-forged.forwarded.test"))
+                r = server_handle_edns_success_with_address(packet, reply, DNS_EDE_RCODE_FORGED_ANSWER);
+        else if (streq_ptr(name, "edns-net-error.forwarded.test"))
+                r = server_handle_edns_success_with_address(packet, reply, DNS_EDE_RCODE_NET_ERROR);
+        else if (streq_ptr(name, "edns-filtered-nxdomain.forwarded.test"))
+                r = server_handle_edns_filtered_nxdomain(packet, reply);
         else
                 r = log_debug_errno(SYNTHETIC_ERRNO(EFAULT), "Unhandled name '%s', ignoring.", name);
         if (r < 0)

--- a/src/shared/dns-packet.c
+++ b/src/shared/dns-packet.c
@@ -816,9 +816,40 @@ int dns_packet_append_opt(
                 bool include_rfc6975,
                 const char *nsid,
                 int rcode,
+                int ede_rcode,
+                const char *ede_msg,
                 size_t *ret_start) {
 
-        size_t saved_size;
+        static const uint8_t rfc6975[] = {
+
+                0, DNS_EDNS_OPT_DAU, /* OPTION_CODE */
+#if HAVE_OPENSSL
+                0, 7, /* LIST_LENGTH */
+#else
+                0, 6, /* LIST_LENGTH */
+#endif
+                DNSSEC_ALGORITHM_RSASHA1,
+                DNSSEC_ALGORITHM_RSASHA1_NSEC3_SHA1,
+                DNSSEC_ALGORITHM_RSASHA256,
+                DNSSEC_ALGORITHM_RSASHA512,
+                DNSSEC_ALGORITHM_ECDSAP256SHA256,
+                DNSSEC_ALGORITHM_ECDSAP384SHA384,
+#if HAVE_OPENSSL
+                DNSSEC_ALGORITHM_ED25519,
+#endif
+
+                0, DNS_EDNS_OPT_DHU, /* OPTION_CODE */
+                0, 3, /* LIST_LENGTH */
+                DNSSEC_DIGEST_SHA1,
+                DNSSEC_DIGEST_SHA256,
+                DNSSEC_DIGEST_SHA384,
+
+                0, DNS_EDNS_OPT_N3U, /* OPTION_CODE */
+                0, 1, /* LIST_LENGTH */
+                NSEC3_ALGORITHM_SHA1,
+        };
+        size_t ede_msg_len = isempty(ede_msg) ? 0 : strlen(ede_msg), nsid_len = isempty(nsid) ? 0 : strlen(nsid),
+               rdlength = 0, saved_size;
         int r;
 
         assert(p);
@@ -826,11 +857,32 @@ int dns_packet_append_opt(
         assert(max_udp_size >= DNS_PACKET_UNICAST_SIZE_MAX);
         assert(rcode >= 0);
         assert(rcode <= _DNS_RCODE_MAX);
+        assert(ede_rcode < 0 || ede_rcode <= UINT16_MAX);
 
         if (p->opt_start != SIZE_MAX)
                 return -EBUSY;
 
         assert(p->opt_size == SIZE_MAX);
+
+        if (edns0_do && include_rfc6975)
+                rdlength += sizeof(rfc6975);
+
+        if (nsid) {
+                if (nsid_len > UINT16_MAX - 4)
+                        return -E2BIG;
+
+                rdlength += 4 + nsid_len;
+        }
+
+        if (ede_rcode >= 0) {
+                if (ede_msg_len > UINT16_MAX - 2)
+                        return -E2BIG;
+
+                rdlength += 4 + 2 + ede_msg_len;
+        }
+
+        if (rdlength > UINT16_MAX)
+                return -E2BIG;
 
         saved_size = p->size;
 
@@ -859,70 +911,51 @@ int dns_packet_append_opt(
         if (r < 0)
                 goto fail;
 
-        if (edns0_do && include_rfc6975) {
-                /* If DO is on and this is requested, also append RFC6975 Algorithm data. This is supposed to
-                 * be done on queries, not on replies, hencer callers should turn this off when finishing off
-                 * replies. */
-
-                static const uint8_t rfc6975[] = {
-
-                        0, DNS_EDNS_OPT_DAU, /* OPTION_CODE */
-#if HAVE_OPENSSL
-                        0, 7, /* LIST_LENGTH */
-#else
-                        0, 6, /* LIST_LENGTH */
-#endif
-                        DNSSEC_ALGORITHM_RSASHA1,
-                        DNSSEC_ALGORITHM_RSASHA1_NSEC3_SHA1,
-                        DNSSEC_ALGORITHM_RSASHA256,
-                        DNSSEC_ALGORITHM_RSASHA512,
-                        DNSSEC_ALGORITHM_ECDSAP256SHA256,
-                        DNSSEC_ALGORITHM_ECDSAP384SHA384,
-#if HAVE_OPENSSL
-                        DNSSEC_ALGORITHM_ED25519,
-#endif
-
-                        0, DNS_EDNS_OPT_DHU, /* OPTION_CODE */
-                        0, 3, /* LIST_LENGTH */
-                        DNSSEC_DIGEST_SHA1,
-                        DNSSEC_DIGEST_SHA256,
-                        DNSSEC_DIGEST_SHA384,
-
-                        0, DNS_EDNS_OPT_N3U, /* OPTION_CODE */
-                        0, 1, /* LIST_LENGTH */
-                        NSEC3_ALGORITHM_SHA1,
-                };
-
-                r = dns_packet_append_uint16(p, sizeof(rfc6975), NULL); /* RDLENGTH */
-                if (r < 0)
-                        goto fail;
-
-                r = dns_packet_append_blob(p, rfc6975, sizeof(rfc6975), NULL); /* the payload, as defined above */
-
-        } else if (nsid) {
-
-                if (strlen(nsid) > UINT16_MAX - 4) {
-                        r = -E2BIG;
-                        goto fail;
-                }
-
-                r = dns_packet_append_uint16(p, 4 + strlen(nsid), NULL); /* RDLENGTH */
-                if (r < 0)
-                        goto fail;
-
-                r = dns_packet_append_uint16(p, 3, NULL); /* OPTION-CODE: NSID */
-                if (r < 0)
-                        goto fail;
-
-                r = dns_packet_append_uint16(p, strlen(nsid), NULL); /* OPTION-LENGTH */
-                if (r < 0)
-                        goto fail;
-
-                r = dns_packet_append_blob(p, nsid, strlen(nsid), NULL);
-        } else
-                r = dns_packet_append_uint16(p, 0, NULL);
+        r = dns_packet_append_uint16(p, rdlength, NULL); /* RDLENGTH */
         if (r < 0)
                 goto fail;
+
+        if (edns0_do && include_rfc6975) {
+                /* If DO is on and this is requested, also append RFC6975 Algorithm data. This is supposed to
+                 * be done on queries, not on replies, hence callers should turn this off when finishing off
+                 * replies. */
+
+                r = dns_packet_append_blob(p, rfc6975, sizeof(rfc6975), NULL); /* the payload, as defined above */
+                if (r < 0)
+                        goto fail;
+        }
+
+        if (nsid) {
+                r = dns_packet_append_uint16(p, DNS_EDNS_OPT_NSID, NULL); /* OPTION-CODE */
+                if (r < 0)
+                        goto fail;
+
+                r = dns_packet_append_uint16(p, nsid_len, NULL); /* OPTION-LENGTH */
+                if (r < 0)
+                        goto fail;
+
+                r = dns_packet_append_blob(p, nsid, nsid_len, NULL);
+                if (r < 0)
+                        goto fail;
+        }
+
+        if (ede_rcode >= 0) {
+                r = dns_packet_append_uint16(p, DNS_EDNS_OPT_EXT_ERROR, NULL); /* OPTION-CODE */
+                if (r < 0)
+                        goto fail;
+
+                r = dns_packet_append_uint16(p, 2 + ede_msg_len, NULL); /* OPTION-LENGTH */
+                if (r < 0)
+                        goto fail;
+
+                r = dns_packet_append_uint16(p, ede_rcode, NULL); /* INFO-CODE */
+                if (r < 0)
+                        goto fail;
+
+                r = dns_packet_append_blob(p, strempty(ede_msg), ede_msg_len, NULL); /* EXTRA-TEXT */
+                if (r < 0)
+                        goto fail;
+        }
 
         DNS_PACKET_HEADER(p)->arcount = htobe16(DNS_PACKET_ARCOUNT(p) + 1);
 

--- a/src/shared/dns-packet.h
+++ b/src/shared/dns-packet.h
@@ -184,7 +184,8 @@ int dns_packet_append_label(DnsPacket *p, const char *d, size_t l, bool canonica
 int dns_packet_append_name(DnsPacket *p, const char *name, bool allow_compression, bool canonical_candidate, size_t *start);
 int dns_packet_append_key(DnsPacket *p, const DnsResourceKey *key, DnsAnswerFlags flags, size_t *start);
 int dns_packet_append_rr(DnsPacket *p, const DnsResourceRecord *rr, DnsAnswerFlags flags, size_t *start, size_t *rdata_start);
-int dns_packet_append_opt(DnsPacket *p, uint16_t max_udp_size, bool edns0_do, bool include_rfc6975, const char *nsid, int rcode, size_t *ret_start);
+int dns_packet_append_opt(DnsPacket *p, uint16_t max_udp_size, bool edns0_do, bool include_rfc6975, const char *nsid,
+                int rcode, int ede_rcode, const char *ede_msg, size_t *ret_start);
 int dns_packet_append_question(DnsPacket *p, DnsQuestion *q);
 int dns_packet_append_answer(DnsPacket *p, DnsAnswer *a, unsigned *completed);
 

--- a/test/units/TEST-75-RESOLVED.sh
+++ b/test/units/TEST-75-RESOLVED.sh
@@ -1065,8 +1065,9 @@ testcase_11_nft() {
     sleep 2
     drop_dns_outbound_traffic
     # Make sure we give sd-resolved enough time to timeout (5-10s) and serve the stale data (see above)
-    run dig +tries=1 +timeout=15 stale1.unsigned.test -t A
+    run dig +tries=1 +timeout=15 +comments +answer +additional stale1.unsigned.test -t A
     grep -qE "NOERROR" "$RUN_OUT"
+    grep -qF "EDE: 3 (Stale Answer)" "$RUN_OUT"
     grep -qE "10.0.0.112" "$RUN_OUT"
 
     nft flush ruleset

--- a/test/units/TEST-75-RESOLVED.sh
+++ b/test/units/TEST-75-RESOLVED.sh
@@ -788,30 +788,41 @@ testcase_08_resolved() {
     journalctl --sync
     journalctl -u systemd-resolved.service --cursor-file="$JOURNAL_CURSOR" --grep "Server returned error: SERVFAIL \(Censored: Nothing to see here!\)"
 
+    # Same error, forwarded through the DNS stub.
+    run dig +noall +comments +additional edns-extra-text.forwarded.test A
+    grep -qF "status: SERVFAIL" "$RUN_OUT"
+    grep -qF "EDE: 16 (Censored)" "$RUN_OUT"
+    grep -qF "Nothing to see here!" "$RUN_OUT"
+
+    # The stub should only include an EDE option when the client request included EDNS.
+    run dig +noedns +noall +comments +additional edns-extra-text.forwarded.test A
+    grep -qF "status: SERVFAIL" "$RUN_OUT"
+    (! grep -qF "EDE:" "$RUN_OUT")
+
     # SERVFAIL + EDE code 0: Other + extra text
     (! run resolvectl query edns-code-zero.forwarded.test)
     grep -qE "^edns-code-zero.forwarded.test:.+: SERVFAIL \(Other: 🐱\)" "$RUN_OUT"
-    (! run varlinkctl call /run/systemd/resolve/io.systemd.Resolve io.systemd.Resolve.ResolveHostname '{"name" : "edns-code-zero.forwarded.test"}')
+    (! run varlinkctl call /run/systemd/resolve/io.systemd.Resolve io.systemd.Resolve.ResolveHostname '{"name" : "edns-code-zero-varlink.forwarded.test"}')
     grep -qF "io.systemd.Resolve.DNSError" "$RUN_OUT"
-    grep -qF '{"rcode":2,"extendedDNSErrorCode":0,"extendedDNSErrorMessage":"🐱","queryString":"edns-code-zero.forwarded.test"}' "$RUN_OUT"
+    grep -qF '{"rcode":2,"extendedDNSErrorCode":0,"extendedDNSErrorMessage":"🐱","queryString":"edns-code-zero-varlink.forwarded.test"}' "$RUN_OUT"
     journalctl --sync
     journalctl -u systemd-resolved.service --cursor-file="$JOURNAL_CURSOR" --grep "Server returned error: SERVFAIL \(Other: 🐱\)"
 
     # SERVFAIL + invalid EDE code
     (! run resolvectl query edns-invalid-code.forwarded.test)
     grep -qE "^edns-invalid-code.forwarded.test:.+: SERVFAIL \([0-9]+\)" "$RUN_OUT"
-    (! run varlinkctl call /run/systemd/resolve/io.systemd.Resolve io.systemd.Resolve.ResolveHostname '{"name" : "edns-invalid-code.forwarded.test"}')
+    (! run varlinkctl call /run/systemd/resolve/io.systemd.Resolve io.systemd.Resolve.ResolveHostname '{"name" : "edns-invalid-code-varlink.forwarded.test"}')
     grep -qF "io.systemd.Resolve.DNSError" "$RUN_OUT"
-    grep -qE '{"rcode":2,"extendedDNSErrorCode":[0-9]+,"queryString":"edns-invalid-code.forwarded.test"}' "$RUN_OUT"
+    grep -qE '{"rcode":2,"extendedDNSErrorCode":[0-9]+,"queryString":"edns-invalid-code-varlink.forwarded.test"}' "$RUN_OUT"
     journalctl --sync
     journalctl -u systemd-resolved.service --cursor-file="$JOURNAL_CURSOR" --grep "Server returned error: SERVFAIL \(\d+\)"
 
     # SERVFAIL + invalid EDE code + extra text
     (! run resolvectl query edns-invalid-code-with-extra-text.forwarded.test)
     grep -qE '^edns-invalid-code-with-extra-text.forwarded.test:.+: SERVFAIL \([0-9]+: Hello \[#\]\$%~ World\)' "$RUN_OUT"
-    (! run varlinkctl call /run/systemd/resolve/io.systemd.Resolve io.systemd.Resolve.ResolveHostname '{"name" : "edns-invalid-code-with-extra-text.forwarded.test"}')
+    (! run varlinkctl call /run/systemd/resolve/io.systemd.Resolve io.systemd.Resolve.ResolveHostname '{"name" : "edns-invalid-code-with-extra-text-varlink.forwarded.test"}')
     grep -qF "io.systemd.Resolve.DNSError" "$RUN_OUT"
-    grep -qE '{"rcode":2,"extendedDNSErrorCode":[0-9]+,"extendedDNSErrorMessage":"Hello \[#\]\$%~ World","queryString":"edns-invalid-code-with-extra-text.forwarded.test"}' "$RUN_OUT"
+    grep -qE '{"rcode":2,"extendedDNSErrorCode":[0-9]+,"extendedDNSErrorMessage":"Hello \[#\]\$%~ World","queryString":"edns-invalid-code-with-extra-text-varlink.forwarded.test"}' "$RUN_OUT"
     journalctl --sync
     journalctl -u systemd-resolved.service --cursor-file="$JOURNAL_CURSOR" --grep "Server returned error: SERVFAIL \(\d+: Hello \[\#\]\\$%~ World\)"
 }

--- a/test/units/TEST-75-RESOLVED.sh
+++ b/test/units/TEST-75-RESOLVED.sh
@@ -825,6 +825,34 @@ testcase_08_resolved() {
     grep -qE '{"rcode":2,"extendedDNSErrorCode":[0-9]+,"extendedDNSErrorMessage":"Hello \[#\]\$%~ World","queryString":"edns-invalid-code-with-extra-text-varlink.forwarded.test"}' "$RUN_OUT"
     journalctl --sync
     journalctl -u systemd-resolved.service --cursor-file="$JOURNAL_CURSOR" --grep "Server returned error: SERVFAIL \(\d+: Hello \[\#\]\\$%~ World\)"
+
+    # NOERROR + EDE code 4: Forged Answer, forwarded through the DNS stub
+    run dig +noall +comments +answer +additional edns-forged.forwarded.test A
+    grep -qF "status: NOERROR" "$RUN_OUT"
+    grep -qF "EDE: 4 (Forged Answer)" "$RUN_OUT"
+    grep -qE '^edns-forged\.forwarded\.test\.[[:space:]]+[0-9]+[[:space:]]+IN[[:space:]]+A[[:space:]]+0\.0\.0\.0' "$RUN_OUT"
+
+    # Same response from cache should retain the EDE option.
+    run dig +noall +comments +answer +additional edns-forged.forwarded.test A
+    grep -qF "status: NOERROR" "$RUN_OUT"
+    grep -qF "EDE: 4 (Forged Answer)" "$RUN_OUT"
+    grep -qE '^edns-forged\.forwarded\.test\.[[:space:]]+[0-9]+[[:space:]]+IN[[:space:]]+A[[:space:]]+0\.0\.0\.0' "$RUN_OUT"
+
+    # A non-cacheable EDE should be forwarded live, but not restored from cache.
+    run dig +noall +comments +answer +additional edns-net-error.forwarded.test A
+    grep -qF "status: NOERROR" "$RUN_OUT"
+    grep -qF "EDE: 23 (Network Error)" "$RUN_OUT"
+    grep -qE '^edns-net-error\.forwarded\.test\.[[:space:]]+[0-9]+[[:space:]]+IN[[:space:]]+A[[:space:]]+0\.0\.0\.0' "$RUN_OUT"
+
+    run dig +noall +comments +answer +additional edns-net-error.forwarded.test A
+    grep -qF "status: NOERROR" "$RUN_OUT"
+    (! grep -qF "EDE: 23 (Network Error)" "$RUN_OUT")
+    grep -qE '^edns-net-error\.forwarded\.test\.[[:space:]]+[0-9]+[[:space:]]+IN[[:space:]]+A[[:space:]]+0\.0\.0\.0' "$RUN_OUT"
+
+    # NXDOMAIN + EDE code 17: Filtered, forwarded through the DNS stub.
+    run dig +noall +comments +additional edns-filtered-nxdomain.forwarded.test A
+    grep -qF "status: NXDOMAIN" "$RUN_OUT"
+    grep -qF "EDE: 17 (Filtered)" "$RUN_OUT"
 }
 
 testcase_09_resolvectl_showcache() {


### PR DESCRIPTION
## Summary

Add Extended DNS Error (EDE) support to systemd-resolved DNS stub replies.

## What changed

- The DNS stub can now include EDE options in replies.
- EDE information from upstream replies is preserved and returned to clients.
- Cached EDEs are only reused when the EDE is safe to cache.
- Stale cached replies now include EDE

Closes #42938