### PR TITLE
virt: detect Alibaba Cloud ECS as KVM

### DIFF
--- a/src/basic/virt.c
+++ b/src/basic/virt.c
@@ -180,6 +180,7 @@ static Virtualization detect_vm_dmi_vendor(void) {
                 { "KVM",                   VIRTUALIZATION_KVM       },
                 { "OpenStack",             VIRTUALIZATION_KVM       }, /* Detect OpenStack instance as KVM in non x86 architecture */
                 { "KubeVirt",              VIRTUALIZATION_KVM       }, /* Detect KubeVirt instance as KVM in non x86 architecture */
+                { "Alibaba Cloud ECS",     VIRTUALIZATION_KVM       }, /* narrower than bare "Alibaba Cloud" sys_vendor */
                 { "Amazon EC2",            VIRTUALIZATION_AMAZON    },
                 { "QEMU",                  VIRTUALIZATION_QEMU      },
                 { "VMware",                VIRTUALIZATION_VMWARE    }, /* https://kb.vmware.com/s/article/1009458 */


### PR DESCRIPTION
   ## Problem                                                                                                                                                                                                      
                                                                                                                                                                                                                   
   Alibaba Cloud ECS instances expose the following DMI strings:                                                                                                                                                   
                                                                                                                                                                                                                   
 ```                                                                                                                                                                                                               
                                                                                                                                                                                                                   
 /sys/class/dmi/id/product_name: Alibaba Cloud ECS                                                                                                                                                                 
 /sys/class/dmi/id/sys_vendor:   Alibaba Cloud                                                                                                                                                                     
 /sys/class/dmi/id/bios_vendor:  Alibaba Cloud ECS                                                                                                                                                                 
                                                                                                                                                                                                                   
 ```                                                                                                                                                                                                               
                                                                                                                                                                                                                   
   None of these match the entries in `dmi_vendor_table[]`, so `systemd-detect-virt --vm` reports `"none"` on these machines, even though they run on a KVM-based hypervisor. This is especially visible on ARM64  
 instances, where the CPUID detection path is x86-only (compiled out on ARM64) and `/proc/device-tree` is not populated.                                                                                           
                                                                                                                                                                                                                   
   ## Fix                                                                                                                                                                                                          
                                                                                                                                                                                                                   
   Add `"Alibaba Cloud ECS"` → `VIRTUALIZATION_KVM` to `dmi_vendor_table[]`:                                                                                                                                       
                                                                                                                                                                                                                   
   ```c                                                                                                                                                                                                            
   { "Alibaba Cloud ECS",   VIRTUALIZATION_KVM       }, /* Detect Alibaba Cloud ECS as KVM, but not bare-metal (X-Dragon) instances */                                                                             
 ```                                                                                                                                                                                                               
                                                                                                                                                                                                                   
 The string matches product_name and bios_vendor (both are "Alibaba Cloud ECS" on ECS VMs), but does not match the bare "Alibaba Cloud" sys_vendor prefix — reducing the false-positive surface for bare-metal     
 (X-Dragon) instances compared to the original broader prefix.                                                                                                                                                     
                                                                                                                                                                                                                   
 The existing "back to DMI" fallback path in detect_vm() reports "kvm" on both x86 and ARM64.                                                                                                                      
                                                                                                                                                                                                                   
 Verification                                                                                                                                                                                                      
                                                                                                                                                                                                                   
 Tested with real DMI data from a customer environment (ARM64 Alibaba Cloud ECS instance):                                                                                                                         
   | Scenario | Before | After |                                                                                                                                                                                   
   |---|---|---|                                                                                                                                                                                                   
   | ECS VM<br>`product_name=Alibaba Cloud ECS` | `none` | `kvm` |                                                                                                                                                 
   | Bare-metal<br>`sys_vendor=Alibaba Cloud` | — | not misreported |                                                                                                                                                                                                                    
                                                                                                                                              
                                                                                                                                                                                                                   
 Limitation                                                                                                                                                                                                        
                                                                                                                                                                                                                   
 The "Alibaba Cloud ECS" prefix also matches bios_vendor, which is "Alibaba Cloud ECS" on ECS VMs. Since detect_vm_dmi_vendor() scans all DMI fields in the same loop, a bare-metal (X-Dragon) host whose          
 bios_vendor (or product_name) carries the same prefix would still be misclassified as KVM — the protection is not based on field ordering. Fully resolving this VM-vs-bare-metal ambiguity would require the same 
 SMBIOS BIOS-Characteristics bit check that the Amazon EC2 entry uses, but that needs verification of bare-metal SMBIOS behavior first. Can be a follow-up.