### PR TITLE
creds: preserve key selection over varlink

### DIFF
--- a/src/creds/creds.c
+++ b/src/creds/creds.c
@@ -125,7 +125,7 @@ static sd_id128_t cred_key_id[_CRED_KEY_TYPE_MAX] = {
         [CRED_KEY_TYPE_AUTO]             = _CRED_AUTO,
         [CRED_KEY_TYPE_AUTO_INITRD]      = _CRED_AUTO_INITRD,
         [CRED_KEY_TYPE_HOST]             = CRED_AES256_GCM_BY_HOST,
-        [CRED_KEY_TYPE_TPM2]             = CRED_AES256_GCM_BY_TPM2_HMAC_PINNED_SRK,
+        [CRED_KEY_TYPE_TPM2]             = _CRED_AUTO_TPM2,
         [CRED_KEY_TYPE_TPM2_PUBLIC]      = CRED_AES256_GCM_BY_TPM2_HMAC_WITH_PK_PINNED_SRK,
         [CRED_KEY_TYPE_HOST_TPM2]        = CRED_AES256_GCM_BY_HOST_AND_TPM2_HMAC_PINNED_SRK,
         [CRED_KEY_TYPE_TPM2_HOST]        = CRED_AES256_GCM_BY_HOST_AND_TPM2_HMAC_PINNED_SRK,
@@ -606,6 +606,7 @@ static int verb_encrypt(int argc, char *argv[], uintptr_t _data, void *userdata)
                 (void) polkit_agent_open_if_enabled(BUS_TRANSPORT_LOCAL, arg_ask_password);
 
                 r = ipc_encrypt_credential(
+                                arg_with_key,
                                 name,
                                 timestamp,
                                 arg_not_after,
@@ -1029,20 +1030,9 @@ static int parse_argv(int argc, char *argv[], char ***ret_args) {
         if (uid_is_valid(arg_uid)) {
                 /* If a UID is specified, then switch to scoped credentials */
 
-                if (sd_id128_equal(arg_with_key, _CRED_AUTO))
-                        arg_with_key = _CRED_AUTO_SCOPED;
-                else if (sd_id128_in_set(arg_with_key, CRED_AES256_GCM_BY_HOST, CRED_AES256_GCM_BY_HOST_SCOPED))
-                        arg_with_key = CRED_AES256_GCM_BY_HOST_SCOPED;
-                else if (sd_id128_in_set(arg_with_key, CRED_AES256_GCM_BY_HOST_AND_TPM2_HMAC, CRED_AES256_GCM_BY_HOST_AND_TPM2_HMAC_SCOPED))
-                        arg_with_key = CRED_AES256_GCM_BY_HOST_AND_TPM2_HMAC_SCOPED;
-                else if (sd_id128_in_set(arg_with_key, CRED_AES256_GCM_BY_HOST_AND_TPM2_HMAC_WITH_PK, CRED_AES256_GCM_BY_HOST_AND_TPM2_HMAC_WITH_PK_SCOPED))
-                        arg_with_key = CRED_AES256_GCM_BY_HOST_AND_TPM2_HMAC_WITH_PK_SCOPED;
-                else if (sd_id128_in_set(arg_with_key, CRED_AES256_GCM_BY_HOST_AND_TPM2_HMAC_PINNED_SRK, CRED_AES256_GCM_BY_HOST_AND_TPM2_HMAC_SCOPED_PINNED_SRK))
-                        arg_with_key = CRED_AES256_GCM_BY_HOST_AND_TPM2_HMAC_SCOPED_PINNED_SRK;
-                else if (sd_id128_in_set(arg_with_key, CRED_AES256_GCM_BY_HOST_AND_TPM2_HMAC_WITH_PK_PINNED_SRK, CRED_AES256_GCM_BY_HOST_AND_TPM2_HMAC_WITH_PK_SCOPED_PINNED_SRK))
-                        arg_with_key = CRED_AES256_GCM_BY_HOST_AND_TPM2_HMAC_WITH_PK_SCOPED_PINNED_SRK;
-                else
-                        return log_error_errno(SYNTHETIC_ERRNO(EOPNOTSUPP), "Selected key not available in --uid= scoped mode, refusing.");
+                r = credential_key_make_scoped(&arg_with_key);
+                if (r < 0)
+                        return log_error_errno(r, "Selected key not available in --uid= scoped mode, refusing.");
         }
 
         if (arg_tpm2_pcr_mask == UINT32_MAX)
@@ -1264,6 +1254,14 @@ static int vl_method_encrypt(sd_varlink *link, sd_json_variant *parameters, sd_v
         if (r < 0)
                 return r;
 
+        if (sd_id128_is_null(p.with_key))
+                p.with_key = _CRED_AUTO;
+        if (p.scope == CREDENTIAL_USER) {
+                r = credential_key_make_scoped(&p.with_key);
+                if (r < 0)
+                        return sd_varlink_error_invalid_parameter_name(link, "withKey");
+        }
+
         r = sd_varlink_get_peer_uid(link, &peer_uid);
         if (r < 0)
                 return r;
@@ -1284,7 +1282,7 @@ static int vl_method_encrypt(sd_varlink *link, sd_json_variant *parameters, sd_v
         }
 
         r = encrypt_credential_and_warn(
-                        sd_id128_is_null(p.with_key) ? (p.scope == CREDENTIAL_USER ? _CRED_AUTO_SCOPED : _CRED_AUTO) : p.with_key,
+                        p.with_key,
                         p.name,
                         p.timestamp,
                         p.not_after,

--- a/src/shared/creds-util.c
+++ b/src/shared/creds-util.c
@@ -1715,12 +1715,96 @@ int decrypt_credential_and_warn(const char *validate_name, usec_t validate_times
 
 #endif
 
-int ipc_encrypt_credential(const char *name, usec_t timestamp, usec_t not_after, uid_t uid, const struct iovec *input, CredentialFlags flags, struct iovec *ret) {
+int credential_key_make_scoped(sd_id128_t *with_key) {
+        static const struct {
+                sd_id128_t unscoped;
+                sd_id128_t scoped;
+        } table[] = {
+                { _CRED_AUTO, _CRED_AUTO_SCOPED },
+                { CRED_AES256_GCM_BY_HOST, CRED_AES256_GCM_BY_HOST_SCOPED },
+                {
+                        CRED_AES256_GCM_BY_HOST_AND_TPM2_HMAC,
+                        CRED_AES256_GCM_BY_HOST_AND_TPM2_HMAC_SCOPED,
+                },
+                {
+                        CRED_AES256_GCM_BY_HOST_AND_TPM2_HMAC_WITH_PK,
+                        CRED_AES256_GCM_BY_HOST_AND_TPM2_HMAC_WITH_PK_SCOPED,
+                },
+                {
+                        CRED_AES256_GCM_BY_HOST_AND_TPM2_HMAC_PINNED_SRK,
+                        CRED_AES256_GCM_BY_HOST_AND_TPM2_HMAC_SCOPED_PINNED_SRK,
+                },
+                {
+                        CRED_AES256_GCM_BY_HOST_AND_TPM2_HMAC_WITH_PK_PINNED_SRK,
+                        CRED_AES256_GCM_BY_HOST_AND_TPM2_HMAC_WITH_PK_SCOPED_PINNED_SRK,
+                },
+        };
+
+        assert(with_key);
+
+        FOREACH_ELEMENT(i, table)
+                if (sd_id128_in_set(*with_key, i->unscoped, i->scoped)) {
+                        *with_key = i->scoped;
+                        return 0;
+                }
+
+        return -EOPNOTSUPP;
+}
+
+int credential_key_to_varlink(sd_id128_t with_key, const char **ret) {
+        const char *s;
+
+        assert(ret);
+
+        if (sd_id128_in_set(with_key, _CRED_AUTO, _CRED_AUTO_SCOPED))
+                s = "auto";
+        else if (sd_id128_equal(with_key, _CRED_AUTO_TPM2))
+                s = "tpm2";
+        else if (sd_id128_equal(with_key, _CRED_AUTO_INITRD))
+                s = "auto_initrd";
+        else if (sd_id128_in_set(with_key, CRED_AES256_GCM_BY_HOST, CRED_AES256_GCM_BY_HOST_SCOPED))
+                s = "host";
+        else if (sd_id128_in_set(
+                                with_key,
+                                CRED_AES256_GCM_BY_TPM2_HMAC_WITH_PK,
+                                CRED_AES256_GCM_BY_TPM2_HMAC_WITH_PK_PINNED_SRK))
+                s = "tpm2_with_public_key";
+        else if (sd_id128_in_set(
+                                with_key,
+                                CRED_AES256_GCM_BY_HOST_AND_TPM2_HMAC,
+                                CRED_AES256_GCM_BY_HOST_AND_TPM2_HMAC_SCOPED,
+                                CRED_AES256_GCM_BY_HOST_AND_TPM2_HMAC_PINNED_SRK,
+                                CRED_AES256_GCM_BY_HOST_AND_TPM2_HMAC_SCOPED_PINNED_SRK))
+                s = "host_tpm2";
+        else if (sd_id128_in_set(
+                                with_key,
+                                CRED_AES256_GCM_BY_HOST_AND_TPM2_HMAC_WITH_PK,
+                                CRED_AES256_GCM_BY_HOST_AND_TPM2_HMAC_WITH_PK_SCOPED,
+                                CRED_AES256_GCM_BY_HOST_AND_TPM2_HMAC_WITH_PK_PINNED_SRK,
+                                CRED_AES256_GCM_BY_HOST_AND_TPM2_HMAC_WITH_PK_SCOPED_PINNED_SRK))
+                s = "host_tpm2_with_public_key";
+        else if (sd_id128_equal(with_key, CRED_AES256_GCM_BY_NULL))
+                s = "null";
+        else
+                return -EOPNOTSUPP;
+
+        *ret = s;
+        return 0;
+}
+
+int ipc_encrypt_credential(sd_id128_t with_key, const char *name, usec_t timestamp, usec_t not_after, uid_t uid, const struct iovec *input, CredentialFlags flags, struct iovec *ret) {
         _cleanup_(sd_varlink_unrefp) sd_varlink *vl = NULL;
+        const char *with_key_name = NULL;
         int r;
 
         assert(input && iovec_is_valid(input));
         assert(ret);
+
+        if (!sd_id128_in_set(with_key, _CRED_AUTO, _CRED_AUTO_SCOPED)) {
+                r = credential_key_to_varlink(with_key, &with_key_name);
+                if (r < 0)
+                        return log_error_errno(r, "Failed to serialize credential key type: %m");
+        }
 
         r = sd_varlink_connect_address(&vl, "/run/systemd/io.systemd.Credentials");
         if (r < 0)
@@ -1751,6 +1835,7 @@ int ipc_encrypt_credential(const char *name, usec_t timestamp, usec_t not_after,
                         SD_JSON_BUILD_PAIR_CONDITION(timestamp != USEC_INFINITY, "timestamp", SD_JSON_BUILD_UNSIGNED(timestamp)),
                         SD_JSON_BUILD_PAIR_CONDITION(not_after != USEC_INFINITY, "notAfter",  SD_JSON_BUILD_UNSIGNED(not_after)),
                         SD_JSON_BUILD_PAIR_CONDITION(!FLAGS_SET(flags, CREDENTIAL_ANY_SCOPE), "scope", SD_JSON_BUILD_STRING(uid_is_valid(uid) ? "user" : "system")),
+                        SD_JSON_BUILD_PAIR_CONDITION(!!with_key_name, "withKey", SD_JSON_BUILD_STRING(with_key_name)),
                         SD_JSON_BUILD_PAIR_CONDITION(uid_is_valid(uid), "uid", SD_JSON_BUILD_UNSIGNED(uid)),
                         SD_JSON_BUILD_PAIR_CONDITION((flags & (CREDENTIAL_ALLOW_NULL|CREDENTIAL_REFUSE_NULL)) != 0, "allowNull", SD_JSON_BUILD_BOOLEAN(flags & CREDENTIAL_ALLOW_NULL)),
                         SD_JSON_BUILD_PAIR_BOOLEAN("allowInteractiveAuthentication", FLAGS_SET(flags, CREDENTIAL_IPC_ALLOW_INTERACTIVE)));

--- a/src/shared/creds-util.h
+++ b/src/shared/creds-util.h
@@ -231,7 +231,10 @@ bool credential_boot_policy_accepts_null(CredentialBootPolicy policy, bool first
 int encrypt_credential_and_warn(sd_id128_t with_key, const char *name, usec_t timestamp, usec_t not_after, const char *tpm2_device, uint32_t tpm2_hash_pcr_mask, const char *tpm2_pubkey_path, uint32_t tpm2_pubkey_pcr_mask, uid_t uid, const struct iovec *input, CredentialFlags flags, struct iovec *ret);
 int decrypt_credential_and_warn(const char *validate_name, usec_t validate_timestamp, const char *tpm2_device, const char *tpm2_signature_path, uid_t uid, const struct iovec *input, CredentialFlags flags, struct iovec *ret);
 
-int ipc_encrypt_credential(const char *name, usec_t timestamp, usec_t not_after, uid_t uid, const struct iovec *input, CredentialFlags flags, struct iovec *ret);
+int credential_key_make_scoped(sd_id128_t *with_key);
+int credential_key_to_varlink(sd_id128_t with_key, const char **ret);
+
+int ipc_encrypt_credential(sd_id128_t with_key, const char *name, usec_t timestamp, usec_t not_after, uid_t uid, const struct iovec *input, CredentialFlags flags, struct iovec *ret);
 int ipc_decrypt_credential(const char *validate_name, usec_t validate_timestamp, uid_t uid, const struct iovec *input, CredentialFlags flags, struct iovec *ret);
 
 int get_global_boot_credentials_path(char **ret);

--- a/src/shared/varlink-io.systemd.Credentials.c
+++ b/src/shared/varlink-io.systemd.Credentials.c
@@ -18,7 +18,7 @@ static SD_VARLINK_DEFINE_ENUM_TYPE(
                 SD_VARLINK_DEFINE_ENUM_VALUE(auto_initrd),
                 SD_VARLINK_FIELD_COMMENT("Bind to the host key only, i.e. not the TPM"),
                 SD_VARLINK_DEFINE_ENUM_VALUE(host),
-                SD_VARLINK_FIELD_COMMENT("Bind to the TPM only, not the host key"),
+                SD_VARLINK_FIELD_COMMENT("Bind to the TPM only, automatically selecting whether a public-key policy is used"),
                 SD_VARLINK_DEFINE_ENUM_VALUE(tpm2),
                 SD_VARLINK_FIELD_COMMENT("Bind to the TPM only (using a public key identifying the UKI), not the host key"),
                 SD_VARLINK_DEFINE_ENUM_VALUE(tpm2_with_public_key),

--- a/src/test/test-creds.c
+++ b/src/test/test-creds.c
@@ -120,6 +120,105 @@ TEST(credential_glob_valid) {
         ASSERT_TRUE(credential_glob_valid(buf));
 }
 
+TEST(credential_key_scope) {
+        static const struct {
+                sd_id128_t unscoped;
+                sd_id128_t scoped;
+        } compatible[] = {
+                { _CRED_AUTO, _CRED_AUTO_SCOPED },
+                { CRED_AES256_GCM_BY_HOST, CRED_AES256_GCM_BY_HOST_SCOPED },
+                {
+                        CRED_AES256_GCM_BY_HOST_AND_TPM2_HMAC,
+                        CRED_AES256_GCM_BY_HOST_AND_TPM2_HMAC_SCOPED,
+                },
+                {
+                        CRED_AES256_GCM_BY_HOST_AND_TPM2_HMAC_WITH_PK,
+                        CRED_AES256_GCM_BY_HOST_AND_TPM2_HMAC_WITH_PK_SCOPED,
+                },
+                {
+                        CRED_AES256_GCM_BY_HOST_AND_TPM2_HMAC_PINNED_SRK,
+                        CRED_AES256_GCM_BY_HOST_AND_TPM2_HMAC_SCOPED_PINNED_SRK,
+                },
+                {
+                        CRED_AES256_GCM_BY_HOST_AND_TPM2_HMAC_WITH_PK_PINNED_SRK,
+                        CRED_AES256_GCM_BY_HOST_AND_TPM2_HMAC_WITH_PK_SCOPED_PINNED_SRK,
+                },
+        };
+        static const sd_id128_t incompatible[] = {
+                _CRED_AUTO_TPM2,
+                _CRED_AUTO_HOST_AND_TPM2,
+                _CRED_AUTO_INITRD,
+                CRED_AES256_GCM_BY_TPM2_HMAC,
+                CRED_AES256_GCM_BY_TPM2_HMAC_WITH_PK,
+                CRED_AES256_GCM_BY_TPM2_HMAC_PINNED_SRK,
+                CRED_AES256_GCM_BY_TPM2_HMAC_WITH_PK_PINNED_SRK,
+                CRED_AES256_GCM_BY_NULL,
+                SD_ID128_NULL,
+        };
+
+        FOREACH_ELEMENT(i, compatible) {
+                sd_id128_t id = i->unscoped;
+                ASSERT_OK(credential_key_make_scoped(&id));
+                ASSERT_EQ_ID128(id, i->scoped);
+
+                id = i->scoped;
+                ASSERT_OK(credential_key_make_scoped(&id));
+                ASSERT_EQ_ID128(id, i->scoped);
+        }
+
+        FOREACH_ELEMENT(i, incompatible) {
+                sd_id128_t id = *i;
+                ASSERT_ERROR(credential_key_make_scoped(&id), EOPNOTSUPP);
+                ASSERT_EQ_ID128(id, *i);
+        }
+}
+
+TEST(credential_key_varlink) {
+        static const struct {
+                sd_id128_t id;
+                const char *name;
+        } compatible[] = {
+                { _CRED_AUTO, "auto" },
+                { _CRED_AUTO_SCOPED, "auto" },
+                { _CRED_AUTO_TPM2, "tpm2" },
+                { _CRED_AUTO_INITRD, "auto_initrd" },
+                { CRED_AES256_GCM_BY_HOST, "host" },
+                { CRED_AES256_GCM_BY_HOST_SCOPED, "host" },
+                { CRED_AES256_GCM_BY_TPM2_HMAC_WITH_PK, "tpm2_with_public_key" },
+                { CRED_AES256_GCM_BY_TPM2_HMAC_WITH_PK_PINNED_SRK, "tpm2_with_public_key" },
+                { CRED_AES256_GCM_BY_HOST_AND_TPM2_HMAC, "host_tpm2" },
+                { CRED_AES256_GCM_BY_HOST_AND_TPM2_HMAC_SCOPED, "host_tpm2" },
+                { CRED_AES256_GCM_BY_HOST_AND_TPM2_HMAC_PINNED_SRK, "host_tpm2" },
+                { CRED_AES256_GCM_BY_HOST_AND_TPM2_HMAC_SCOPED_PINNED_SRK, "host_tpm2" },
+                { CRED_AES256_GCM_BY_HOST_AND_TPM2_HMAC_WITH_PK, "host_tpm2_with_public_key" },
+                { CRED_AES256_GCM_BY_HOST_AND_TPM2_HMAC_WITH_PK_SCOPED, "host_tpm2_with_public_key" },
+                { CRED_AES256_GCM_BY_HOST_AND_TPM2_HMAC_WITH_PK_PINNED_SRK, "host_tpm2_with_public_key" },
+                {
+                        CRED_AES256_GCM_BY_HOST_AND_TPM2_HMAC_WITH_PK_SCOPED_PINNED_SRK,
+                        "host_tpm2_with_public_key",
+                },
+                { CRED_AES256_GCM_BY_NULL, "null" },
+        };
+        static const sd_id128_t incompatible[] = {
+                _CRED_AUTO_HOST_AND_TPM2,
+                CRED_AES256_GCM_BY_TPM2_HMAC,
+                CRED_AES256_GCM_BY_TPM2_HMAC_PINNED_SRK,
+                SD_ID128_NULL,
+        };
+
+        FOREACH_ELEMENT(i, compatible) {
+                const char *name = NULL;
+                ASSERT_OK(credential_key_to_varlink(i->id, &name));
+                ASSERT_STREQ(name, i->name);
+        }
+
+        FOREACH_ELEMENT(i, incompatible) {
+                const char *name = NULL;
+                ASSERT_ERROR(credential_key_to_varlink(*i, &name), EOPNOTSUPP);
+                ASSERT_NULL(name);
+        }
+}
+
 static void test_encrypt_decrypt_with(sd_id128_t mode, uid_t uid) {
         static const struct iovec plaintext = CONST_IOVEC_MAKE_STRING("this is a super secret string");
         int r;

--- a/test/units/TEST-54-CREDS.sh
+++ b/test/units/TEST-54-CREDS.sh
@@ -22,6 +22,12 @@ run_with_cred_compare() (
     diff "$log_file" <(echo -ne "$exp")
 )
 
+credential_id() {
+    local credential="${1:?}"
+
+    base64 --decode "$credential" | od -An -tx1 -N16 | tr -d '[:space:]'
+}
+
 test_mount_with_credential() {
     local credfile tmpdir unit mount_path mount_test
     credfile="/tmp/mount-cred"
@@ -549,6 +555,25 @@ varlinkctl call /run/systemd/io.systemd.Credentials io.systemd.Credentials.Encry
 cmp /tmp/vlcredsdata /tmp/vlcredsdata2
 rm /tmp/vlcredsdata2
 
+# Scope and key type are independent. An explicit compatible key type must still
+# produce a user-scoped credential.
+varlinkctl call --json=short /run/systemd/io.systemd.Credentials io.systemd.Credentials.Encrypt \
+    "{\"data\":\"$DATA\",\"scope\":\"user\",\"withKey\":\"host\"}" >/tmp/vlcredsreply
+jq -r .blob /tmp/vlcredsreply >/tmp/vlcred
+assert_eq "$(credential_id /tmp/vlcred)" "55b9ed1d38594d43a8319d2ebb332ac6"
+jq '. + {"scope":"user"}' /tmp/vlcredsreply | \
+    varlinkctl call --json=short /run/systemd/io.systemd.Credentials io.systemd.Credentials.Decrypt >/tmp/vlcredsdata2
+cmp /tmp/vlcredsdata /tmp/vlcredsdata2
+(! jq '. + {"scope":"system"}' /tmp/vlcredsreply | \
+    varlinkctl call --json=short /run/systemd/io.systemd.Credentials io.systemd.Credentials.Decrypt)
+rm /tmp/vlcred /tmp/vlcredsdata2 /tmp/vlcredsreply
+
+# Key types that cannot be user-scoped must be rejected before encryption.
+(! varlinkctl call /run/systemd/io.systemd.Credentials io.systemd.Credentials.Encrypt \
+    "{\"data\":\"$DATA\",\"scope\":\"user\",\"withKey\":\"tpm2\"}")
+(! varlinkctl call /run/systemd/io.systemd.Credentials io.systemd.Credentials.Encrypt \
+    "{\"data\":\"$DATA\",\"scope\":\"user\",\"withKey\":\"null\"}")
+
 varlinkctl call /run/systemd/io.systemd.Credentials io.systemd.Credentials.Encrypt "{\"data\":\"$DATA\",\"withKey\":\"null\"}" | \
     jq '.["allowNull"] = true' |
     varlinkctl call --json=short /run/systemd/io.systemd.Credentials io.systemd.Credentials.Decrypt >/tmp/vlcredsdata2
@@ -595,7 +620,27 @@ test_mount_with_credential
 # Fully unpriv operation
 dd if=/dev/urandom of=/tmp/brummbaer.data bs=4096 count=1
 run0 -u testuser --pipe mkdir -p /home/testuser/.config/credstore.encrypted
-run0 -u testuser --pipe systemd-creds encrypt --user --name=brummbaer - /home/testuser/.config/credstore.encrypted/brummbaer < /tmp/brummbaer.data
+run0 -u testuser --pipe \
+    systemd-creds encrypt --user --name=brummbaer \
+    - /home/testuser/.config/credstore.encrypted/brummbaer </tmp/brummbaer.data
+
+run0 -u testuser --pipe \
+    systemd-creds encrypt --user --with-key=host --name=brummbaer-host \
+    - /home/testuser/.config/credstore.encrypted/brummbaer-host </tmp/brummbaer.data
+assert_eq \
+    "$(credential_id /home/testuser/.config/credstore.encrypted/brummbaer-host)" \
+    "55b9ed1d38594d43a8319d2ebb332ac6"
+
+if [[ ! -e /dev/tpmrm0 ]]; then
+    (! run0 -u testuser --pipe \
+        systemd-creds encrypt --user --with-key=host+tpm2 --name=brummbaer-tpm2 \
+        - /home/testuser/.config/credstore.encrypted/brummbaer-tpm2 \
+        </tmp/brummbaer.data 2>/tmp/brummbaer-tpm2.err)
+    cat /tmp/brummbaer-tpm2.err
+    (! grep -Fq InvalidParameter /tmp/brummbaer-tpm2.err)
+    rm -f /tmp/brummbaer-tpm2.err
+fi
+
 run0 -u testuser --pipe systemd-run --user --pipe -p ImportCredential=brummbaer systemd-creds cat brummbaer | cmp /tmp/brummbaer.data
 
 # https://github.com/systemd/systemd/pull/40108


### PR DESCRIPTION
An unprivileged `systemd-creds encrypt` request doesn't preserve an
explicit `--with-key=` selection when it delegates encryption to
`io.systemd.Credentials.Encrypt`. The service applies its auto policy
instead. In a TPM-less environment, `--user --with-key=host+tpm2`
succeeds with `CRED_AES256_GCM_BY_HOST_SCOPED` instead of failing.

A direct Varlink request with `scope=user` and `withKey=host` passes the
unscoped host key ID to `encrypt_credential_and_warn()`. The service only
applies user scope when `withKey` is omitted.

The client passes the semantic key selection and serializes canonical
Varlink values. The service scopes compatible explicit keys and rejects
selections without a scoped form. `-T` and `--with-key=tpm2` both map to
`_CRED_AUTO_TPM2`, preserving automatic public-key policy selection
across delegation.

`systemd:test-creds` passes. Captured delegated requests use canonical
enum names for every supported CLI spelling. In a TPM-less namespace,
delegated `host+tpm2` fails with `ENOTRECOVERABLE`. With a private
software TPM, `-T` and `--with-key=tpm2` select the no-public-key scheme
without a configured PCR public key and the public-key scheme with one.
The complete `TEST-54-CREDS` integration test wasn't run locally.
