### PR TITLE
docs: fix link to `CONTRIBUTING.md`

### DIFF
--- a/docs/HACKING.md
+++ b/docs/HACKING.md
@@ -12,7 +12,7 @@ feature, please feel invited to fix it, and submit your work as a
 [GitHub Pull Request (PR)](https://github.com/systemd/systemd/pull/new).
 
 Please make sure to follow our [Coding Style](/CODING_STYLE) when submitting
-patches. Also have a look at our [Contribution Guidelines](/CONTRIBUTING).
+patches. Also have a look at our [Contribution Guidelines](CONTRIBUTING.md).
 
 When adding new functionality, tests should be added. For shared functionality
 (in `src/basic/` and `src/shared/`) unit tests should be sufficient. The general


### PR DESCRIPTION
... in `docs/HACKING.md`.