### PR TITLE
hwdb: add Blue Microphones Yeti X

### DIFF
--- a/hwdb.d/70-av-production.hwdb
+++ b/hwdb.d/70-av-production.hwdb
@@ -57,6 +57,13 @@ usb:v33AEp0004*
 usb:v33AEp0007*
  ID_AV_PRODUCTION_CONTROLLER=1
 
+###################
+# Blue Microphones
+###################
+# Yeti X
+usb:v046Dp0AAF*
+ ID_AV_PRODUCTION_CONTROLLER=1
+
 ################
 # Contour
 ################


### PR DESCRIPTION
This microphone has vendor specific HID controls to control gain, output, monitoring levels, polar patterns, etc.

Naming is completely based on names reported by the USB device itself (`manufacturer` and `product`). 

Information about this microphone:
- https://micpedia.com/microphone/blue-yeti-x/
- https://www.logitechg.com/en-us/shop/p/yeti-x-professional-microphone
