### PR TITLE
test: fix race in TEST-07-PID1 multi-unit transaction subtest

### DIFF
--- a/test/units/TEST-07-PID1.multi-units-transaction.sh
+++ b/test/units/TEST-07-PID1.multi-units-transaction.sh
@@ -402,8 +402,12 @@ ExecStart=/bin/true
 EOF
 systemctl daemon-reload
 
-systemctl start issue8102-nop-main.service
+# Stopping the dependency while ExecStart is still running will fail the unit
+# rather than making it inactive, so we wait here explicitly for the dependency
+# too to prevent a race on the status after stop.
+systemctl start issue8102-nop-main.service issue8102-nop-dep.service
 [[ "$(systemctl show -P ActiveState issue8102-nop-main.service)" == active ]]
+[[ "$(systemctl show -P ActiveState issue8102-nop-dep.service)" == active ]]
 
 # Stop just the dependency. Wants= is a weak dependency, so the main unit stays
 # active while the dependency goes inactive.


### PR DESCRIPTION
Test failed with the following in https://github.com/systemd/systemd/actions/runs/31604147515/job/94237970237:

```
TEST-07-PID1.sh[20020]: + systemctl stop issue8102-nop-dep.service
TEST-07-PID1.sh[20409]: ++ systemctl show -P ActiveState issue8102-nop-dep.service
TEST-07-PID1.sh[20020]: + [[ failed == inactive ]]
```

systemctl start only waits for the jobs of the units named on the command line, so the start job pulled in for issue8102-nop-dep.service via Wants= was not waited for. When the following stop landed while its ExecStart= was still running, the process was SIGTERMed, and since Type=oneshot does not treat termination by signal as a clean exit, the unit ended up failed instead of inactive:

```
issue8102-nop-dep.service: Changed start -> stop-sigterm
issue8102-nop-dep.service: Main process exited, code=killed, status=15/TERM
issue8102-nop-dep.service: Failed with result 'signal'.
```

Start both units explicitly so both jobs are waited for.