### PR TITLE
shell-completion: add completion for machinectl restart

### DIFF
--- a/shell-completion/bash/machinectl
+++ b/shell-completion/bash/machinectl
@@ -45,7 +45,7 @@ _machinectl() {
 
     local -A VERBS=(
         [STANDALONE]='list list-images clean pull-tar pull-raw list-transfers cancel-transfer import-fs'
-        [MACHINES]='status show start stop login shell enable disable poweroff reboot pause resume terminate kill
+        [MACHINES]='status show start stop login shell enable disable poweroff reboot restart pause resume terminate kill
                     image-status show-image remove export-tar export-raw'
         [MACHINES_OR_FILES]='edit cat'
         [MACHINE_ONLY]='clone rename set-limit bind-volume unbind-volume'

--- a/shell-completion/zsh/_machinectl
+++ b/shell-completion/zsh/_machinectl
@@ -38,6 +38,7 @@
         "disable:Disable automatic container start at boot"
         "poweroff:Power off one or more VMs/containers"
         "reboot:Reboot one or more VMs/containers"
+        "restart:Restart one or more VMs/containers (equal to reboot)"
         "pause:Pause one or more machines"
         "resume:Resume one or more previously paused machines"
         "terminate:Terminate one or more VMs/containers"
@@ -81,7 +82,7 @@
         start|enable|disable)
             _machinectl_images ;;
 
-        status|show|poweroff|reboot|pause|resume|terminate|kill)
+        status|show|poweroff|reboot|restart|pause|resume|terminate|kill)
             _sd_machines ;;
 
         login|shell)


### PR DESCRIPTION
The `restart` verb was added to machinectl as a convenience alias for `reboot`, but its shell completions were never updated. Add it to both the bash and zsh completions.