### PR TITLE
getty: strip whitespace from getty.auto credential

### DIFF
--- a/src/getty-generator/getty-generator.c
+++ b/src/getty-generator/getty-generator.c
@@ -267,9 +267,11 @@ static void parse_credentials(void) {
         if (r < 0)
                 log_debug_errno(r, "Failed to read credential 'getty.auto', ignoring: %m");
         else if (r > 0) {
-                r = parse_getty_sources(value, &arg_getty_sources);
+                const char *p = strstrip(value);
+
+                r = parse_getty_sources(p, &arg_getty_sources);
                 if (r < 0)
-                        log_warning_errno(r, "Invalid 'getty.auto' credential, ignoring: %s", value);
+                        log_warning_errno(r, "Invalid 'getty.auto' credential, ignoring: %s", p);
         }
 }
 

--- a/test/units/TEST-81-GENERATORS.getty-generator.sh
+++ b/test/units/TEST-81-GENERATORS.getty-generator.sh
@@ -11,9 +11,10 @@ set +o histexpand
 
 GENERATOR_BIN="/usr/lib/systemd/system-generators/systemd-getty-generator"
 OUT_DIR="$(mktemp -d /tmp/getty-generator.XXX)"
+CREDENTIALS_DIR="$(mktemp -d /tmp/getty-generator-creds.XXX)"
 
 at_exit() {
-    rm -frv "${OUT_DIR:?}"
+    rm -frv "${OUT_DIR:?}" "${CREDENTIALS_DIR:?}"
 }
 
 trap at_exit EXIT
@@ -128,6 +129,12 @@ if in_container; then
     PID1_ENVIRON="container_ttys=tty0 pts/0 /dev/tty0\0SYSTEMD_GETTY_AUTO=0" run_and_list "$GENERATOR_BIN" "$OUT_DIR"
     check_none
 
+    : "getty-generator: getty.auto=false credential with trailing newline (container)"
+    printf 'false\n' >"$CREDENTIALS_DIR/getty.auto"
+    PID1_ENVIRON="container_ttys=tty0 pts/0 /dev/tty0" CREDENTIALS_DIRECTORY="$CREDENTIALS_DIR" run_and_list "$GENERATOR_BIN" "$OUT_DIR"
+    check_none
+    rm -f "$CREDENTIALS_DIR/getty.auto"
+
     : "getty-generator: SYSTEMD_GETTY_AUTO=console in PID1's environment (container)"
     PID1_ENVIRON="container_ttys=tty0 pts/0 /dev/tty0\0SYSTEMD_GETTY_AUTO=console" run_and_list "$GENERATOR_BIN" "$OUT_DIR"
     check_none
@@ -186,6 +193,12 @@ check_builtin
 : "getty-generator: SYSTEMD_GETTY_AUTO=0 in PID1's environment"
 PID1_ENVIRON="SYSTEMD_GETTY_AUTO=0" run_and_list "$GENERATOR_BIN" "$OUT_DIR"
 check_none
+
+: "getty-generator: getty.auto=false credential with trailing newline"
+printf 'false\n' >"$CREDENTIALS_DIR/getty.auto"
+CREDENTIALS_DIRECTORY="$CREDENTIALS_DIR" run_and_list "$GENERATOR_BIN" "$OUT_DIR"
+check_none
+rm -f "$CREDENTIALS_DIR/getty.auto"
 
 : "getty-generator: SYSTEMD_GETTY_AUTO=container in PID1's environment"
 PID1_ENVIRON="SYSTEMD_GETTY_AUTO=container" run_and_list "$GENERATOR_BIN" "$OUT_DIR"


### PR DESCRIPTION
Follow-up for: 3a883e89bc1f73c70cb9bd245d5ccc1d805990d7