### PR TITLE
vmspawn: run VM startup in fiber, propagate qemu's exit status and stderr

### DIFF
--- a/man/systemd-vmspawn.xml
+++ b/man/systemd-vmspawn.xml
@@ -1006,6 +1006,7 @@ $ ssh root@vsock/$my_vsock_cid -i /run/user/$UID/systemd/vmspawn/machine-*-syste
     <title>Exit status</title>
 
     <para>If an error occurred the value errno is propagated to the return code.
+    If QEMU or a helper process failed, a non-zero exit status is returned.
     If EXIT_STATUS is supplied by the running image that is returned.
     Otherwise, EXIT_SUCCESS is returned.</para>
   </refsect1>

--- a/src/basic/process-util.c
+++ b/src/basic/process-util.c
@@ -1498,10 +1498,14 @@ int pidref_safe_fork_full(
                                 if (pidref_transport_fds[0] >= 0) {
                                         /* Wait for the intermediary child to exit so the caller can be
                                          * certain the actual child process has been reparented by the time
-                                         * this function returns. */
+                                         * this function returns. Acquire a pidfd so the wait can suspend on
+                                         * it when we run on a fiber. */
+                                        _cleanup_(pidref_done) PidRef pidref = PIDREF_MAKE_FROM_PID(pid);
+                                        (void) pidref_set_pid(&pidref, pid);
+
                                         r = pidref_wait_for_terminate_and_check(
                                                         name,
-                                                        &PIDREF_MAKE_FROM_PID(pid),
+                                                        &pidref,
                                                         FLAGS_SET(flags, FORK_LOG) ? WAIT_LOG : 0);
                                         if (r < 0)
                                                 return log_full_errno(prio, r, "Failed to wait for intermediary process: %m");
@@ -1578,9 +1582,13 @@ int pidref_safe_fork_full(
                                 (void) sigprocmask(SIG_SETMASK, &ss, NULL);
                         }
 
+                        /* Acquire a pidfd so the wait can suspend on it when we run on a fiber. */
+                        _cleanup_(pidref_done) PidRef pidref = PIDREF_MAKE_FROM_PID(pid);
+                        (void) pidref_set_pid(&pidref, pid);
+
                         r = pidref_wait_for_terminate_and_check(
                                         name,
-                                        &PIDREF_MAKE_FROM_PID(pid),
+                                        &pidref,
                                         FLAGS_SET(flags, FORK_LOG) ? WAIT_LOG : 0);
                         if (r < 0)
                                 return r;

--- a/src/vmspawn/test-vmspawn-util.c
+++ b/src/vmspawn/test-vmspawn-util.c
@@ -10,6 +10,7 @@
 #include "rm-rf.h"
 #include "set.h"
 #include "string-util.h"
+#include "strv.h"
 #include "tests.h"
 #include "tmpfile-util.h"
 #include "vmspawn-util.h"
@@ -214,6 +215,71 @@ TEST(find_ovmf_config) {
         ASSERT_TRUE(sd_json_variant_is_object(json));
 
         ASSERT_OK_ERRNO(unsetenv("XDG_CONFIG_HOME"));
+}
+
+static void collect_line(const char *line, size_t len, void *userdata) {
+        char ***lines = ASSERT_PTR(userdata);
+        _cleanup_free_ char *copy = strndup(line, len);
+        ASSERT_NOT_NULL(copy);
+        ASSERT_OK(strv_consume(lines, TAKE_PTR(copy)));
+}
+
+TEST(line_buffer) {
+        _cleanup_(line_buffer_done) LineBuffer b = {};
+        _cleanup_strv_free_ char **lines = NULL;
+
+        ASSERT_OK(line_buffer_feed(&b, "foo\nbar\nba", 10, collect_line, &lines));
+        ASSERT_EQ(strv_length(lines), 2u);
+        ASSERT_STREQ(lines[0], "foo");
+        ASSERT_STREQ(lines[1], "bar");
+
+        ASSERT_OK(line_buffer_feed(&b, "z\n", 2, collect_line, &lines));   /* stitches "ba"+"z" */
+        ASSERT_STREQ(lines[2], "baz");
+
+        ASSERT_OK(line_buffer_feed(&b, "\n", 1, collect_line, &lines));    /* empty line */
+        ASSERT_STREQ(lines[3], "");
+
+        ASSERT_OK(line_buffer_feed(&b, "tail", 4, collect_line, &lines));  /* no newline */
+        ASSERT_EQ(strv_length(lines), 4u);
+        line_buffer_flush(&b, collect_line, &lines);
+        ASSERT_STREQ(lines[4], "tail");
+
+        line_buffer_flush(&b, collect_line, &lines);                       /* no-op */
+        ASSERT_EQ(strv_length(lines), 5u);
+
+        /* overlong line: forced break at LINE_MAX */
+        _cleanup_free_ char *big = new(char, LINE_MAX + 2);
+        ASSERT_NOT_NULL(big);
+        memset(big, 'x', LINE_MAX + 2);
+        ASSERT_OK(line_buffer_feed(&b, big, LINE_MAX + 2, collect_line, &lines));
+        ASSERT_EQ(strv_length(lines), 6u);
+        ASSERT_EQ(strlen(lines[5]), (size_t) LINE_MAX);
+        ASSERT_EQ(b.len, 2u);
+        line_buffer_flush(&b, collect_line, &lines);
+        ASSERT_STREQ(lines[6], "xx");
+
+        /* NUL breaks a line, just like LF */
+        ASSERT_OK(line_buffer_feed(&b, "a\0b\n", 4, collect_line, &lines));
+        ASSERT_EQ(strv_length(lines), 9u);
+        ASSERT_STREQ(lines[7], "a");
+        ASSERT_STREQ(lines[8], "b");
+
+        /* forced break with something already buffered: the break has to account for that */
+        ASSERT_OK(line_buffer_feed(&b, "abc", 3, collect_line, &lines));
+        ASSERT_EQ(strv_length(lines), 9u);
+        ASSERT_EQ(b.len, 3u);
+        ASSERT_OK(line_buffer_feed(&b, big, LINE_MAX, collect_line, &lines));
+        ASSERT_EQ(strv_length(lines), 10u);
+        ASSERT_EQ(strlen(lines[9]), (size_t) LINE_MAX);
+        ASSERT_NOT_NULL(startswith(lines[9], "abc"));
+        ASSERT_EQ(b.len, 3u);
+        line_buffer_flush(&b, collect_line, &lines);
+        ASSERT_STREQ(lines[10], "xxx");
+
+        /* exactly LINE_MAX without a line break is buffered, not emitted */
+        ASSERT_OK(line_buffer_feed(&b, big, LINE_MAX, collect_line, &lines));
+        ASSERT_EQ(strv_length(lines), 11u);
+        ASSERT_EQ(b.len, (size_t) LINE_MAX);
 }
 
 DEFINE_TEST_MAIN(LOG_INFO);

--- a/src/vmspawn/vmspawn-qmp.c
+++ b/src/vmspawn/vmspawn-qmp.c
@@ -1913,20 +1913,22 @@ int vmspawn_qmp_probe_features(VmspawnQmpBridge *bridge) {
         while (!qmp_client_is_idle(bridge->qmp)) {
                 r = qmp_client_process(bridge->qmp);
                 if (r < 0)
-                        return log_error_errno(r, "QMP probe pump failed: %m");
+                        return log_full_errno(ERRNO_IS_NEG_DISCONNECT(r) ? LOG_WARNING : LOG_ERR, r,
+                                              "QMP probe pump failed: %m");
                 if (r > 0)
                         continue;
 
                 r = qmp_client_wait(bridge->qmp, USEC_INFINITY);
                 if (r < 0)
-                        return log_error_errno(r, "QMP probe wait failed: %m");
+                        return log_full_errno(ERRNO_IS_NEG_DISCONNECT(r) ? LOG_WARNING : LOG_ERR, r,
+                                              "QMP probe wait failed: %m");
         }
 
         /* If fail_pending() drained the slots (transport dropped mid-probe), features can't be
          * trusted and we have no QMP channel for device setup anyway. */
         if (qmp_client_is_disconnected(bridge->qmp))
-                return log_error_errno(SYNTHETIC_ERRNO(ECONNRESET),
-                                       "QMP connection dropped during feature probing");
+                return log_warning_errno(SYNTHETIC_ERRNO(ECONNRESET),
+                                         "QMP connection dropped during feature probing");
 
         return 0;
 }

--- a/src/vmspawn/vmspawn-util.c
+++ b/src/vmspawn/vmspawn-util.c
@@ -717,3 +717,71 @@ char* escape_qemu_value(const char *s) {
 
         return e;
 }
+
+int line_buffer_feed(LineBuffer *b, const char *p, size_t n, line_buffer_emit_t emit, void *userdata) {
+        assert(b);
+        assert(p || n == 0);
+        assert(emit);
+
+        while (n > 0) {
+                /* Break lines at NUL as well as at LF, mirroring how journald splits stdout streams. */
+                const char *nl = memchr(p, '\n', n);
+                const char *sep = memchr(p, 0, nl ? (size_t) (nl - p) : n) ?: nl;
+                size_t l = sep ? (size_t) (sep - p) : n;
+
+                /* Force a line break if a single line grows beyond LINE_MAX, so the writer can never
+                 * make us buffer unbound amount of data. */
+                if (b->len + l > LINE_MAX) {
+                        size_t k = LINE_MAX - b->len;
+
+                        if (!GREEDY_REALLOC(b->buf, b->len + k + 1))
+                                return -ENOMEM;
+                        memcpy(b->buf + b->len, p, k);
+                        b->len += k;
+                        b->buf[b->len] = 0;
+
+                        emit(b->buf, b->len, userdata);
+                        b->len = 0;
+
+                        p += k;
+                        n -= k;
+                        continue;
+                }
+
+                if (!GREEDY_REALLOC(b->buf, b->len + l + 1))
+                        return -ENOMEM;
+                memcpy(b->buf + b->len, p, l);
+                b->len += l;
+                b->buf[b->len] = 0;
+
+                if (!sep)
+                        return 0;
+
+                emit(b->buf, b->len, userdata);
+                b->len = 0;
+
+                p = sep + 1;
+                n -= l + 1;
+        }
+
+        return 0;
+}
+
+void line_buffer_flush(LineBuffer *b, line_buffer_emit_t emit, void *userdata) {
+        assert(b);
+        assert(emit);
+
+        if (b->len == 0)
+                return;
+
+        emit(b->buf, b->len, userdata);
+        b->len = 0;
+}
+
+void line_buffer_done(LineBuffer *b) {
+        if (!b)
+                return;
+
+        b->buf = mfree(b->buf);
+        b->len = 0;
+}

--- a/src/vmspawn/vmspawn-util.h
+++ b/src/vmspawn/vmspawn-util.h
@@ -153,3 +153,14 @@ int find_qemu_binary(char **ret_qemu_binary);
 int vsock_fix_child_cid(int vhost_device_fd, unsigned *machine_cid, const char *machine);
 
 char* escape_qemu_value(const char *s);
+
+typedef void (*line_buffer_emit_t)(const char *line, size_t len, void *userdata);
+
+typedef struct LineBuffer {
+        char *buf;      /* partial line accumulation across feeds, NUL-terminated */
+        size_t len;
+} LineBuffer;
+
+int line_buffer_feed(LineBuffer *b, const char *p, size_t n, line_buffer_emit_t emit, void *userdata);
+void line_buffer_flush(LineBuffer *b, line_buffer_emit_t emit, void *userdata);
+void line_buffer_done(LineBuffer *b);

--- a/src/vmspawn/vmspawn.c
+++ b/src/vmspawn/vmspawn.c
@@ -2596,6 +2596,104 @@ static int discover_ovmf_config(OvmfConfig **ret, sd_json_variant **ret_firmware
         return 0;
 }
 
+/* Bound the total volume of qemu stderr we forward to the journal, so a hostile guest that
+ * makes qemu emit diagnostics can't flood the host log. */
+#define QEMU_STDERR_LOG_MAX (64U*1024U)
+
+typedef struct QemuStderrContext {
+        int fd;                 /* Borrowed read end of stderr pipe. */
+        LineBuffer buffer;
+        sd_future *fiber;       /* Reader fiber, owned. */
+        size_t n_logged;        /* Bytes forwarded, capped at QEMU_STDERR_LOG_MAX. */
+        bool suppressed;
+} QemuStderrContext;
+
+static void log_qemu_stderr_line(const char *line, size_t len, void *userdata) {
+        QemuStderrContext *c = ASSERT_PTR(userdata);
+
+        assert(line);
+
+        if (len == 0 || c->suppressed)
+                return;
+
+        bool hit_limit = c->n_logged + len >= QEMU_STDERR_LOG_MAX;
+        if (hit_limit) {
+                len = QEMU_STDERR_LOG_MAX - c->n_logged;
+                c->suppressed = true;
+        }
+
+        c->n_logged += len;
+
+        /* Lines can carry arbitrary bytes, and we don't want control sequences from a
+         * VM reaching the terminal we log to. */
+        _cleanup_free_ char *bounded = strndup(line, len);
+        _cleanup_free_ char *escaped = bounded ? utf8_escape_non_printable(bounded) : NULL;
+        if (!escaped)
+                return (void) log_oom_debug();
+
+        /* qemu prefixes its messages with its binary name, so no extra attribution is needed. */
+        log_warning("%s", escaped);
+
+        if (hit_limit)
+                log_warning("Too much qemu stderr output, suppressing the rest.");
+}
+
+static int qemu_stderr_pump(QemuStderrContext *c, bool on_fiber) {
+        assert(c);
+        assert(c->fd >= 0);
+
+        for (;;) {
+                char buf[4096];
+                ssize_t n;
+
+                if (on_fiber) {
+                        n = sd_fiber_read(c->fd, buf, sizeof(buf));
+                        /* spurious wake-up: sd_fiber_read() retries only once */
+                        if (n == -EINTR || n == -EAGAIN)
+                                continue;
+                        if (n == -ECANCELED)
+                                return (int) n;
+                } else {
+                        n = read(c->fd, buf, sizeof(buf));
+                        if (n < 0) {
+                                if (errno == EINTR)
+                                        continue;
+                                if (errno == EAGAIN) /* Nothing queued anymore, we are done. */
+                                        break;
+
+                                n = -errno;
+                        }
+                }
+                if (n < 0) {
+                        log_warning_errno((int) n, "Failed to read qemu stderr, ignoring: %m");
+                        break;
+                }
+                if (n == 0) /* EOF, qemu closed its stderr */
+                        break;
+
+                if (line_buffer_feed(&c->buffer, buf, (size_t) n, log_qemu_stderr_line, c) < 0)
+                        return log_oom();
+        }
+
+        line_buffer_flush(&c->buffer, log_qemu_stderr_line, c);
+        return 0;
+}
+
+static int qemu_stderr_fiber(void *userdata) {
+        return qemu_stderr_pump(ASSERT_PTR(userdata), /* on_fiber= */ true);
+}
+
+static void qemu_stderr_context_done(QemuStderrContext *c) {
+        assert(c);
+
+        /* The reader fiber is nested in the main fiber, so unwinding it is our responsibility. Cancel
+         * and wait for it, then drain anything still queued and flush the final partial line. */
+        c->fiber = sd_future_cancel_wait_unref(c->fiber);
+        if (c->fd >= 0)
+                (void) qemu_stderr_pump(c, /* on_fiber= */ false);
+        line_buffer_done(&c->buffer);
+}
+
 static int vm_setup_qmp(
                 sd_event *event,
                 MachineConfig *config,
@@ -3887,6 +3985,20 @@ static int run_virtual_machine(int kvm_device_fd, int vhost_device_fd) {
                 log_debug("Executing: %s", joined);
         }
 
+        /* Capture qemu's stderr via a pipe, so it doesn't interleave with the guest console on the PTY,
+         * and so that early startup failures are visible in all console modes. */
+        _cleanup_close_pair_ int qemu_stderr_pipe[2] = EBADF_PAIR;
+        if (pipe2(qemu_stderr_pipe, O_CLOEXEC) < 0)
+                return log_error_errno(errno, "Failed to allocate qemu stderr pipe: %m");
+
+        r = fd_nonblock(qemu_stderr_pipe[0], true);
+        if (r < 0)
+                return log_error_errno(r, "Failed to make qemu stderr pipe non-blocking: %m");
+
+        _cleanup_(qemu_stderr_context_done) QemuStderrContext qemu_stderr = {
+                .fd = qemu_stderr_pipe[0],
+        };
+
         _cleanup_close_ int child_pty = -EBADF;
         if (master >= 0) {
                 child_pty = pty_open_peer(master, O_RDWR|O_CLOEXEC|O_NOCTTY);
@@ -3898,10 +4010,13 @@ static int run_virtual_machine(int kvm_device_fd, int vhost_device_fd) {
         _cleanup_(pidref_done_sigterm_wait) PidRef child_pidref = PIDREF_NULL;
         r = pidref_safe_fork_full(
                         qemu_binary,
-                        child_pty >= 0 ? (const int[]) { child_pty, child_pty, child_pty } : NULL,
+                        (const int[]) {
+                                child_pty >= 0 ? child_pty : STDIN_FILENO,
+                                child_pty >= 0 ? child_pty : STDOUT_FILENO,
+                                qemu_stderr_pipe[1],
+                        },
                         pass_fds, n_pass_fds,
-                        FORK_RESET_SIGNALS|FORK_CLOSE_ALL_FDS|FORK_DEATHSIG_SIGTERM|FORK_LOG|FORK_CLOEXEC_OFF|FORK_RLIMIT_NOFILE_SAFE|
-                        (child_pty >= 0 ? FORK_REARRANGE_STDIO : 0),
+                        FORK_RESET_SIGNALS|FORK_CLOSE_ALL_FDS|FORK_DEATHSIG_SIGTERM|FORK_LOG|FORK_CLOEXEC_OFF|FORK_RLIMIT_NOFILE_SAFE|FORK_REARRANGE_STDIO,
                         &child_pidref);
         if (r < 0)
                 return r;
@@ -3917,9 +4032,11 @@ static int run_virtual_machine(int kvm_device_fd, int vhost_device_fd) {
                 _exit(EXIT_FAILURE);
         }
 
-        /* Close QEMU's end of the QMP socketpair in the parent. We don't need it anymore. */
+        /* Close QEMU's end of the PTY, the QMP socketpair and the stderr pipe in the parent.
+         * We don't need them anymore. */
         child_pty = safe_close(child_pty);
         bridge_fds[1] = safe_close(bridge_fds[1]);
+        qemu_stderr_pipe[1] = safe_close(qemu_stderr_pipe[1]);
 
         /* Resolve the exit future when the child exits */
         _cleanup_(sd_event_source_unrefp) sd_event_source *child_source = NULL;
@@ -3929,6 +4046,14 @@ static int run_virtual_machine(int kvm_device_fd, int vhost_device_fd) {
 
         (void) sd_event_source_set_priority(child_source, SD_EVENT_PRIORITY_NORMAL - 10);
         (void) sd_event_source_set_description(child_source, "vmspawn-qemu-exit");
+
+        r = sd_fiber_new(event, "qemu-stderr", qemu_stderr_fiber, &qemu_stderr, /* destroy= */ NULL, &qemu_stderr.fiber);
+        if (r < 0)
+                return log_error_errno(r, "Failed to allocate qemu stderr fiber: %m");
+
+        r = sd_future_set_priority(qemu_stderr.fiber, SD_EVENT_PRIORITY_NORMAL - 20);
+        if (r < 0)
+                return log_error_errno(r, "Failed to set qemu stderr fiber priority: %m");
 
         r = prepare_device_info(runtime_dir, &config);
         if (r < 0)

--- a/src/vmspawn/vmspawn.c
+++ b/src/vmspawn/vmspawn.c
@@ -12,6 +12,7 @@
 #include "sd-bus.h"
 #include "sd-daemon.h"
 #include "sd-event.h"
+#include "sd-future.h"
 #include "sd-id128.h"
 #include "sd-json.h"
 #include "sd-varlink.h"
@@ -139,6 +140,7 @@ typedef struct SSHInfo {
 typedef struct ShutdownInfo {
         SSHInfo *ssh_info;
         PidRef *pidref;
+        sd_future *vm_exit;
 } ShutdownInfo;
 
 static bool arg_quiet = false;
@@ -1275,14 +1277,32 @@ fallback:
                 }
         }
 
-        return sd_event_exit(sd_event_source_get_event(s), 0);
+        return sd_future_resolve(shutdown_info->vm_exit, 0);
 }
 
-static int on_child_exit(sd_event_source *s, const siginfo_t *si, void *userdata) {
-        assert(s);
-        assert(si);
+static void* vm_exit_future_alloc(void) {
+        return new0(char, 1);
+}
 
-        /* Let's first do some logging about the exit status of the child. */
+static void vm_exit_future_free(sd_future *f) {
+        free(sd_future_get_private(f));
+}
+
+static int vm_exit_future_cancel(sd_future *f) {
+        return sd_future_resolve(f, -ECANCELED);
+}
+
+static const sd_future_ops vm_exit_future_ops = {
+        .size   = sizeof(sd_future_ops),
+        .alloc  = vm_exit_future_alloc,
+        .free   = vm_exit_future_free,
+        .cancel = vm_exit_future_cancel,
+};
+
+/* Logs about the exit status of a child and turns it into what we want to report: the exit status
+ * itself if it exited, a synthetic error if it died some other way. */
+static int child_exit_status(const siginfo_t *si) {
+        assert(si);
 
         int ret;
         if (si->si_code == CLD_EXITED) {
@@ -1305,11 +1325,30 @@ static int on_child_exit(sd_event_source *s, const siginfo_t *si, void *userdata
                                       "Got unexpected exit code %i from child.",
                                       si->si_code);
 
-        /* Regardless of whether the main qemu process or an auxiliary process died, let's exit either way
-         * as it's very likely that the main qemu process won't be able to operate properly anymore if one
-         * of the auxiliary processes died. */
+        return ret;
+}
 
-        sd_event_exit(sd_event_source_get_event(s), ret);
+static int on_child_exit(sd_event_source *s, const siginfo_t *si, void *userdata) {
+        assert(s);
+
+        (void) sd_future_resolve(ASSERT_PTR(userdata), child_exit_status(si));
+        return 0;
+}
+
+static int on_helper_exit(sd_event_source *s, const siginfo_t *si, void *userdata) {
+        assert(s);
+        assert(si);
+
+        /* Helpers are released by the guest as it shuts down, regularly before qemu itself is done
+         * exiting, so a clean exit here says nothing about how the VM fared: leave that verdict to
+         * qemu. A helper that fails or gets killed is a different matter, the main qemu process is
+         * very likely not able to operate properly anymore, so let that end the VM. */
+
+        int ret = child_exit_status(si);
+        if (ret == 0)
+                return 0;
+
+        (void) sd_future_resolve(ASSERT_PTR(userdata), ret);
         return 0;
 }
 
@@ -2088,7 +2127,7 @@ static int on_request_stop(sd_bus_message *m, void *userdata, sd_bus_error *erro
         assert(m);
 
         log_info("VM termination requested. Exiting.");
-        sd_event_exit(sd_bus_get_event(sd_bus_message_get_bus(m)), 0);
+        (void) sd_future_resolve(ASSERT_PTR(userdata), 0);
 
         return 0;
 }
@@ -2575,6 +2614,7 @@ static int run_virtual_machine(int kvm_device_fd, int vhost_device_fd) {
          * state, and the QEMU config file all live below it, and pulling it out from under them gives
          * spurious errors and can leave the directory behind. */
         _cleanup_(rm_rf_physical_and_freep) char *runtime_dir = NULL;
+        _cleanup_(sd_future_cancel_wait_unrefp) sd_future *vm_exit_future = NULL;
         sd_event_source **children = NULL;
         size_t n_children = 0, n_pass_fds = 0;
         int r;
@@ -3231,10 +3271,16 @@ static int run_virtual_machine(int kvm_device_fd, int vhost_device_fd) {
                 }
         }
 
-        _cleanup_(sd_event_unrefp) sd_event *event = NULL;
-        r = sd_event_new(&event);
+        sd_event *event = ASSERT_PTR(sd_fiber_get_event());
+
+        r = sd_future_new(&vm_exit_future_ops, &vm_exit_future);
         if (r < 0)
-                return log_error_errno(r, "Failed to get default event loop: %m");
+                return log_error_errno(r, "Failed to allocate VM exit future: %m");
+
+        /* sd_future_new() on a fiber installs a resume-this-fiber-on-resolve trampoline. We suspend in
+         * plenty of other waits before awaiting this future, and a resolve mid-startup must not resume us
+         * out of one of those. Drop the callback; sd_fiber_await() wakes us via its own wait future. */
+        (void) sd_future_set_callback(vm_exit_future, NULL, NULL);
 
         (void) sd_event_set_watchdog(event, true);
 
@@ -3282,7 +3328,7 @@ static int run_virtual_machine(int kvm_device_fd, int vhost_device_fd) {
                         return r;
 
                 _cleanup_(sd_event_source_unrefp) sd_event_source *source = NULL;
-                r = event_add_child_pidref(event, &source, &child, WEXITED, on_child_exit, /* userdata= */ NULL);
+                r = event_add_child_pidref(event, &source, &child, WEXITED, on_helper_exit, vm_exit_future);
                 if (r < 0)
                         return r;
 
@@ -3357,7 +3403,7 @@ static int run_virtual_machine(int kvm_device_fd, int vhost_device_fd) {
                         return r;
 
                 _cleanup_(sd_event_source_unrefp) sd_event_source *source = NULL;
-                r = event_add_child_pidref(event, &source, &child, WEXITED, on_child_exit, /* userdata= */ NULL);
+                r = event_add_child_pidref(event, &source, &child, WEXITED, on_helper_exit, vm_exit_future);
                 if (r < 0)
                         return r;
 
@@ -3476,7 +3522,7 @@ static int run_virtual_machine(int kvm_device_fd, int vhost_device_fd) {
                         log_debug_errno(r, "Failed to start tpm, ignoring: %m");
                 } else {
                         _cleanup_(sd_event_source_unrefp) sd_event_source *source = NULL;
-                        r = event_add_child_pidref(event, &source, &child, WEXITED, on_child_exit, /* userdata= */ NULL);
+                        r = event_add_child_pidref(event, &source, &child, WEXITED, on_helper_exit, vm_exit_future);
                         if (r < 0)
                                 return r;
 
@@ -3536,7 +3582,7 @@ static int run_virtual_machine(int kvm_device_fd, int vhost_device_fd) {
                         return r;
 
                 _cleanup_(sd_event_source_unrefp) sd_event_source *source = NULL;
-                r = event_add_child_pidref(event, &source, &child, WEXITED, on_child_exit, /* userdata= */ NULL);
+                r = event_add_child_pidref(event, &source, &child, WEXITED, on_helper_exit, vm_exit_future);
                 if (r < 0)
                         return r;
 
@@ -3885,7 +3931,7 @@ static int run_virtual_machine(int kvm_device_fd, int vhost_device_fd) {
                                 "RequestStop",
                                 on_request_stop,
                                 /* install_callback= */ NULL,
-                                /* userdata= */ NULL);
+                                vm_exit_future);
                 if (r < 0)
                         return log_error_errno(r, "Failed to request RequestStop match: %m");
         }
@@ -3991,11 +4037,18 @@ static int run_virtual_machine(int kvm_device_fd, int vhost_device_fd) {
         ShutdownInfo shutdown_info = {
                 .ssh_info = &ssh_info,
                 .pidref = &child_pidref,
+                .vm_exit = vm_exit_future,
         };
 
-        (void) sd_event_add_signal(event, NULL, SIGINT | SD_EVENT_SIGNAL_PROCMASK, shutdown_vm_graceful, &shutdown_info);
-        (void) sd_event_add_signal(event, NULL, SIGTERM | SD_EVENT_SIGNAL_PROCMASK, shutdown_vm_graceful, &shutdown_info);
-        (void) sd_event_add_signal(event, NULL, (SIGRTMIN+4) | SD_EVENT_SIGNAL_PROCMASK, shutdown_vm_graceful, &shutdown_info);
+        _cleanup_(sd_event_source_unrefp) sd_event_source
+                *sigint_source = NULL, *sigterm_source = NULL, *sigrtmin4_source = NULL;
+
+        (void) sd_event_add_signal(event, &sigint_source, SIGINT | SD_EVENT_SIGNAL_PROCMASK,
+                                   shutdown_vm_graceful, &shutdown_info);
+        (void) sd_event_add_signal(event, &sigterm_source, SIGTERM | SD_EVENT_SIGNAL_PROCMASK,
+                                   shutdown_vm_graceful, &shutdown_info);
+        (void) sd_event_add_signal(event, &sigrtmin4_source, (SIGRTMIN+4) | SD_EVENT_SIGNAL_PROCMASK,
+                                   shutdown_vm_graceful, &shutdown_info);
 
         (void) sd_event_add_signal(event, NULL, (SIGRTMIN+18) | SD_EVENT_SIGNAL_PROCMASK, sigrtmin18_handler, NULL);
 
@@ -4003,10 +4056,14 @@ static int run_virtual_machine(int kvm_device_fd, int vhost_device_fd) {
         if (r < 0)
                 log_debug_errno(r, "Failed to allocate memory pressure event source, ignoring: %m");
 
-        /* Exit when the child exits */
-        r = event_add_child_pidref(event, /* ret= */ NULL, &child_pidref, WEXITED, on_child_exit, /* userdata= */ NULL);
+        /* Resolve the exit future when the child exits */
+        _cleanup_(sd_event_source_unrefp) sd_event_source *child_source = NULL;
+        r = event_add_child_pidref(event, &child_source, &child_pidref, WEXITED, on_child_exit, vm_exit_future);
         if (r < 0)
                 return log_error_errno(r, "Failed to watch qemu process: %m");
+
+        (void) sd_event_source_set_priority(child_source, SD_EVENT_PRIORITY_NORMAL - 10);
+        (void) sd_event_source_set_description(child_source, "vmspawn-qemu-exit");
 
         _cleanup_(osc_context_closep) sd_id128_t osc_context_id = SD_ID128_NULL;
         _cleanup_(pty_forward_freep) PTYForward *forward = NULL;
@@ -4038,9 +4095,13 @@ static int run_virtual_machine(int kvm_device_fd, int vhost_device_fd) {
                 }
         }
 
-        r = sd_event_loop(event);
+        r = sd_fiber_await(vm_exit_future);
+        if (sd_future_state(vm_exit_future) != SD_FUTURE_RESOLVED)
+                /* Interrupted: sd_event_exit() was called somewhere (fatal QMP error, …) and
+                 * cancelled us. The loop's exit code is the verdict. */
+                return r;
         if (r < 0)
-                return log_error_errno(r, "Failed to run event loop: %m");
+                return log_error_errno(r, "VM died abnormally: %m");
 
         /* Kill if it is not dead yet anyway */
         if (scope_allocated)
@@ -4048,7 +4109,7 @@ static int run_virtual_machine(int kvm_device_fd, int vhost_device_fd) {
 
         unregister_machine_with_fallback_and_log(&machine_ctx, arg_machine);
 
-        /* qemu died with a failure exit status, propagate it */
+        /* qemu or one of the helpers died with a failure exit status, propagate it */
         if (r > 0)
                 return r;
 
@@ -4348,7 +4409,15 @@ static int run(int argc, char *argv[]) {
                 }
         }
 
-        return run_virtual_machine(kvm_device_fd, vhost_device_fd);
+        r = run_virtual_machine(kvm_device_fd, vhost_device_fd);
+        if (r <= 0)
+                return r;
+
+        r = sd_event_exit(ASSERT_PTR(sd_fiber_get_event()), r);
+        if (r < 0)
+                return log_error_errno(r, "Failed to set exit code: %m");
+
+        return 0;
 }
 
-DEFINE_MAIN_FUNCTION_WITH_POSITIVE_FAILURE(run);
+DEFINE_MAIN_FUNCTION_FIBER(run);

--- a/src/vmspawn/vmspawn.c
+++ b/src/vmspawn/vmspawn.c
@@ -4048,6 +4048,10 @@ static int run_virtual_machine(int kvm_device_fd, int vhost_device_fd) {
 
         unregister_machine_with_fallback_and_log(&machine_ctx, arg_machine);
 
+        /* qemu died with a failure exit status, propagate it */
+        if (r > 0)
+                return r;
+
         if (use_vsock) {
                 if (exit_status == INT_MAX) {
                         log_debug("Couldn't retrieve inner EXIT_STATUS from VSOCK");

--- a/src/vmspawn/vmspawn.c
+++ b/src/vmspawn/vmspawn.c
@@ -32,6 +32,7 @@
 #include "discover-image.h"
 #include "dissect-image.h"
 #include "dlopen-note.h"
+#include "errno-util.h"
 #include "escape.h"
 #include "ether-addr-util.h"
 #include "event-util.h"
@@ -2595,6 +2596,57 @@ static int discover_ovmf_config(OvmfConfig **ret, sd_json_variant **ret_firmware
         return 0;
 }
 
+static int vm_setup_qmp(
+                sd_event *event,
+                MachineConfig *config,
+                int bridge_fd,
+                VmspawnQmpBridge **ret) {
+
+        int r;
+
+        assert(event);
+        assert(config);
+        assert(bridge_fd >= 0);
+        assert(ret);
+
+        _cleanup_(vmspawn_qmp_bridge_freep) VmspawnQmpBridge *bridge = NULL;
+        r = vmspawn_qmp_init(&bridge, bridge_fd, event);
+        if (r < 0)
+                return r;
+
+        /* Probe QEMU feature availability synchronously before device setup consumes the flags. */
+        r = vmspawn_qmp_probe_features(bridge);
+        if (r < 0)
+                return r;
+
+        /* Device setup — all before resuming vCPUs */
+        r = vmspawn_qmp_setup_drives(bridge, &config->drives);
+        if (r < 0)
+                return r;
+
+        if (config->network.type) {
+                r = vmspawn_qmp_setup_network(bridge, &config->network);
+                if (r < 0)
+                        return r;
+        }
+
+        r = vmspawn_qmp_setup_virtiofs(bridge, &config->virtiofs);
+        if (r < 0)
+                return r;
+
+        r = vmspawn_qmp_setup_vsock(bridge, &config->vsock);
+        if (r < 0)
+                return r;
+
+        /* Resume vCPUs and switch to async event processing */
+        r = vmspawn_qmp_start(bridge);
+        if (r < 0)
+                return r;
+
+        *ret = TAKE_PTR(bridge);
+        return 0;
+}
+
 static int run_virtual_machine(int kvm_device_fd, int vhost_device_fd) {
         _cleanup_(ovmf_config_freep) OvmfConfig *ovmf_config = NULL;
         _cleanup_free_ char *qemu_binary = NULL, *mem = NULL;
@@ -3869,44 +3921,40 @@ static int run_virtual_machine(int kvm_device_fd, int vhost_device_fd) {
         child_pty = safe_close(child_pty);
         bridge_fds[1] = safe_close(bridge_fds[1]);
 
+        /* Resolve the exit future when the child exits */
+        _cleanup_(sd_event_source_unrefp) sd_event_source *child_source = NULL;
+        r = event_add_child_pidref(event, &child_source, &child_pidref, WEXITED, on_child_exit, vm_exit_future);
+        if (r < 0)
+                return log_error_errno(r, "Failed to watch qemu process: %m");
+
+        (void) sd_event_source_set_priority(child_source, SD_EVENT_PRIORITY_NORMAL - 10);
+        (void) sd_event_source_set_description(child_source, "vmspawn-qemu-exit");
+
         r = prepare_device_info(runtime_dir, &config);
         if (r < 0)
                 return r;
 
         /* Connect to VMM backend */
         _cleanup_(vmspawn_qmp_bridge_freep) VmspawnQmpBridge *bridge = NULL;
-        r = vmspawn_qmp_init(&bridge, TAKE_FD(bridge_fds[0]), event);
-        if (r < 0)
-                return r;
-
-        /* Probe QEMU feature availability synchronously before device setup consumes the flags. */
-        r = vmspawn_qmp_probe_features(bridge);
-        if (r < 0)
-                return r;
-
-        /* Device setup — all before resuming vCPUs */
-        r = vmspawn_qmp_setup_drives(bridge, &config.drives);
-        if (r < 0)
-                return r;
-
-        if (config.network.type) {
-                r = vmspawn_qmp_setup_network(bridge, &config.network);
-                if (r < 0)
+        r = vm_setup_qmp(event, &config, TAKE_FD(bridge_fds[0]), &bridge);
+        if (r < 0) {
+                /* A dropped QMP connection during startup usually means qemu itself died, the
+                 * disconnect is just the symptom. Wait a moment for the child watch to observe the
+                 * death, so that qemu's exit status becomes the verdict. If qemu is actually still
+                 * alive, the disconnect remains the error. */
+                if (!ERRNO_IS_NEG_DISCONNECT(r))
                         return r;
+
+                SD_FIBER_TIMEOUT(5 * USEC_PER_SEC);
+                int status = sd_fiber_await(vm_exit_future);
+                if (sd_future_state(vm_exit_future) != SD_FUTURE_RESOLVED)
+                        /* -ETIME: qemu is alive, disconnect is the real error.
+                         * -ECANCELED: loop is exiting and its exit code is the real error. */
+                        return status == -ECANCELED ? status : r;
+
+                /* Only a failure verdict supersedes the disconnect error. */
+                return status != 0 ? status : r;
         }
-
-        r = vmspawn_qmp_setup_virtiofs(bridge, &config.virtiofs);
-        if (r < 0)
-                return r;
-
-        r = vmspawn_qmp_setup_vsock(bridge, &config.vsock);
-        if (r < 0)
-                return r;
-
-        /* Resume vCPUs and switch to async event processing */
-        r = vmspawn_qmp_start(bridge);
-        if (r < 0)
-                return r;
 
         /* Varlink server for VM control */
         _cleanup_(vmspawn_varlink_context_freep) VmspawnVarlinkContext *varlink_ctx = NULL;
@@ -4055,15 +4103,6 @@ static int run_virtual_machine(int kvm_device_fd, int vhost_device_fd) {
         r = sd_event_add_memory_pressure(event, NULL, NULL, NULL);
         if (r < 0)
                 log_debug_errno(r, "Failed to allocate memory pressure event source, ignoring: %m");
-
-        /* Resolve the exit future when the child exits */
-        _cleanup_(sd_event_source_unrefp) sd_event_source *child_source = NULL;
-        r = event_add_child_pidref(event, &child_source, &child_pidref, WEXITED, on_child_exit, vm_exit_future);
-        if (r < 0)
-                return log_error_errno(r, "Failed to watch qemu process: %m");
-
-        (void) sd_event_source_set_priority(child_source, SD_EVENT_PRIORITY_NORMAL - 10);
-        (void) sd_event_source_set_description(child_source, "vmspawn-qemu-exit");
 
         _cleanup_(osc_context_closep) sd_id128_t osc_context_id = SD_ID128_NULL;
         _cleanup_(pty_forward_freep) PTYForward *forward = NULL;

--- a/test/units/TEST-87-AUX-UTILS-VM.vmspawn.sh
+++ b/test/units/TEST-87-AUX-UTILS-VM.vmspawn.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: LGPL-2.1-or-later
-# Test vmspawn QMP-varlink bridge and machinectl VM control verbs.
+# Test vmspawn: QMP-varlink bridge, machinectl VM control verbs, and error reporting.
 set -eux
 set -o pipefail
 
@@ -291,5 +291,28 @@ echo "Parallel terminate succeeded, both VMs gone"
 timeout 10 bash -c "while kill -0 '$VMSPAWN_PID' 2>/dev/null; do sleep .5; done"
 timeout 10 bash -c "while kill -0 '$VMSPAWN2_PID' 2>/dev/null; do sleep .5; done"
 echo "Both vmspawn processes exited"
+
+# --- Regression test: early qemu failure ---
+# qemu dies before the QMP handshake; vmspawn must log qemu's stderr (in the PTY modes it
+# previously vanished into the never-forwarded PTY) and report a failure rather than success.
+for console in headless read-only; do
+    OUT="$WORKDIR/early-fail-$console.log"
+    rc=0
+    SYSTEMD_VMSPAWN_QEMU_EXTRA=-bogus timeout 60 systemd-vmspawn \
+        --machine="${MACHINE}-fail" \
+        --register=no \
+        --console="$console" \
+        --directory="$WORKDIR/root" \
+        --linux="$KERNEL" \
+        --tpm=no \
+        &>"$OUT" || rc=$?
+    cat "$OUT"
+
+    # Whichever of qemu and the helper processes we notice dying first determines the exit status,
+    # so only assert that a failure is reported at all, not which status it is.
+    [[ $rc -ne 0 ]]
+    grep -E '(invalid|unknown) option' "$OUT" >/dev/null
+done
+echo "Regression test: early qemu failure passed"
 
 echo "All vmspawn QMP-varlink bridge tests passed"

--- a/tools/check-help.sh
+++ b/tools/check-help.sh
@@ -10,6 +10,16 @@ set -o pipefail
 BINARY="${1:?}"
 export SYSTEMD_LOG_LEVEL=info
 
+# Sanitizer runtime warnings are not program output, so drop them before checking that a binary
+# keeps its stderr clean. Binaries that run their main function on a fiber make ASan warn about
+# makecontext()/swapcontext() and about ignoring __asan_handle_no_return. Only WARNING lines are
+# filtered, an actual ==pid==ERROR: report still counts as output.
+drop_sanitizer_warnings() {
+    grep -v -e '^==[0-9]*==WARNING: ' \
+            -e '^False positive error reports may follow$' \
+            -e '^For details see https://github.com/google/sanitizers/'
+}
+
 if [[ ! -x "$BINARY" ]]; then
     echo "$BINARY is not an executable"
     exit 1
@@ -29,7 +39,7 @@ if ! "$BINARY" --help | grep . >/dev/null; then
 fi
 
 # no --help output to stderr
-if "$BINARY" --help 2>&1 1>/dev/null | grep .; then
+if "$BINARY" --help 2>&1 1>/dev/null | drop_sanitizer_warnings | grep .; then
     echo "$(basename "$BINARY") --help prints to stderr"
     exit 3
 fi

--- a/tools/check-version.sh
+++ b/tools/check-version.sh
@@ -11,6 +11,16 @@ BINARY="${1:?}"
 VERSION="${2:?}"
 export SYSTEMD_LOG_LEVEL=info
 
+# Sanitizer runtime warnings are not program output, so drop them before checking that a binary
+# keeps its stderr clean. Binaries that run their main function on a fiber make ASan warn about
+# makecontext()/swapcontext() and about ignoring __asan_handle_no_return. Only WARNING lines are
+# filtered, an actual ==pid==ERROR: report still counts as output.
+drop_sanitizer_warnings() {
+    grep -v -e '^==[0-9]*==WARNING: ' \
+            -e '^False positive error reports may follow$' \
+            -e '^For details see https://github.com/google/sanitizers/'
+}
+
 if [[ ! -x "$BINARY" ]]; then
     echo "$BINARY is not an executable"
     exit 1
@@ -23,7 +33,7 @@ if ! "$BINARY" --version | grep . >/dev/null; then
 fi
 
 # no --version output to stderr
-if "$BINARY" --version 2>&1 1>/dev/null | grep .; then
+if "$BINARY" --version 2>&1 1>/dev/null | drop_sanitizer_warnings | grep .; then
     echo "$(basename "$BINARY") --version prints to stderr"
     exit 3
 fi


### PR DESCRIPTION
Fixes https://github.com/systemd/systemd/issues/41378

Maybe we could even move the line buffer util into shared, I think I spotted at least one sport where this implementation would be an upgrade of the status-quo.