### PR TITLE
cryptsetup-generator: validate UUIDs from luks.uuid and luks.name

### DIFF
--- a/src/cryptsetup/cryptsetup-generator.c
+++ b/src/cryptsetup/cryptsetup-generator.c
@@ -614,15 +614,27 @@ static crypto_device *get_crypto_device(const char *uuid) {
         return d;
 }
 
-static bool warn_uuid_invalid(const char *uuid, const char *key) {
-        assert(key);
+static int parse_uuid_or_warn(const char *uuid, const char *key, char **ret) {
+        int r;
+        sd_id128_t id;
+        _cleanup_free_ char *canonical = NULL;
 
-        if (!id128_is_valid(uuid)) {
+        assert(uuid);
+        assert(key);
+        assert(ret);
+
+        r = sd_id128_from_string(uuid, &id);
+        if (r < 0) {
                 log_warning("Failed to parse %s= kernel command line switch. UUID is invalid, ignoring.", key);
-                return true;
+                return 0;
         }
 
-        return false;
+        canonical = strdup(SD_ID128_TO_UUID_STRING(id));
+        if (!canonical)
+                return log_oom();
+
+        *ret = TAKE_PTR(canonical);
+        return 1;
 }
 
 static int filter_header_device(const char *options,
@@ -682,15 +694,25 @@ static int parse_proc_cmdline_item(const char *key, const char *value, void *dat
                         arg_read_crypttab = r;
 
         } else if (streq(key, "luks.uuid")) {
+                const char *unprefixed_uuid;
 
                 if (proc_cmdline_value_missing(key, value))
                         return 0;
 
-                d = get_crypto_device(startswith(value, "luks-") ?: value);
+                unprefixed_uuid = startswith(value, "luks-") ?: value;
+                arg_allow_list = true;
+
+                r = parse_uuid_or_warn(unprefixed_uuid, key, &uuid);
+                if (r < 0)
+                        return r;
+                if (r == 0)
+                        return 0;
+
+                d = get_crypto_device(uuid);
                 if (!d)
                         return log_oom();
 
-                d->create = arg_allow_list = true;
+                d->create = true;
 
         } else if (streq(key, "luks.options")) {
                 _cleanup_free_ char *headerdev = NULL, *filtered_headerdev_options = NULL;
@@ -702,10 +724,14 @@ static int parse_proc_cmdline_item(const char *key, const char *value, void *dat
                 if (r != 2)
                         return free_and_strdup_warn(&arg_default_options, value);
 
-                if (warn_uuid_invalid(uuid, key))
+                _cleanup_free_ char *canonical_uuid = NULL;
+                r = parse_uuid_or_warn(uuid, key, &canonical_uuid);
+                if (r < 0)
+                        return r;
+                if (r == 0)
                         return 0;
 
-                d = get_crypto_device(uuid);
+                d = get_crypto_device(canonical_uuid);
                 if (!d)
                         return log_oom();
 
@@ -731,10 +757,14 @@ static int parse_proc_cmdline_item(const char *key, const char *value, void *dat
                 if (!uuid)
                         return log_oom();
 
-                if (warn_uuid_invalid(uuid, key))
+                _cleanup_free_ char *canonical_uuid = NULL;
+                r = parse_uuid_or_warn(uuid, key, &canonical_uuid);
+                if (r < 0)
+                        return r;
+                if (r == 0)
                         return 0;
 
-                d = get_crypto_device(uuid);
+                d = get_crypto_device(canonical_uuid);
                 if (!d)
                         return log_oom();
 
@@ -762,10 +792,14 @@ static int parse_proc_cmdline_item(const char *key, const char *value, void *dat
                 if (!uuid)
                         return log_oom();
 
-                if (warn_uuid_invalid(uuid, key))
+                _cleanup_free_ char *canonical_uuid = NULL;
+                r = parse_uuid_or_warn(uuid, key, &canonical_uuid);
+                if (r < 0)
+                        return r;
+                if (r == 0)
                         return 0;
 
-                d = get_crypto_device(uuid);
+                d = get_crypto_device(canonical_uuid);
                 if (!d)
                         return log_oom();
 
@@ -781,11 +815,21 @@ static int parse_proc_cmdline_item(const char *key, const char *value, void *dat
 
                 r = sscanf(value, "%m[0-9a-fA-F-]=%ms", &uuid, &uuid_value);
                 if (r == 2) {
-                        d = get_crypto_device(uuid);
+                        _cleanup_free_ char *canonical_uuid = NULL;
+
+                        arg_allow_list = true;
+
+                        r = parse_uuid_or_warn(uuid, key, &canonical_uuid);
+                        if (r < 0)
+                                return r;
+                        if (r == 0)
+                                return 0;
+
+                        d = get_crypto_device(canonical_uuid);
                         if (!d)
                                 return log_oom();
 
-                        d->create = arg_allow_list = true;
+                        d->create = true;
 
                         free_and_replace(d->name, uuid_value);
                 } else

--- a/test/units/TEST-81-GENERATORS.cryptsetup-generator.sh
+++ b/test/units/TEST-81-GENERATORS.cryptsetup-generator.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: LGPL-2.1-or-later
+set -eux
+set -o pipefail
+
+# shellcheck source=test/units/generator-utils.sh
+. "$(dirname "$0")/generator-utils.sh"
+
+GENERATOR_BIN="${GENERATOR_BIN:-/usr/lib/systemd/system-generators/systemd-cryptsetup-generator}"
+OUT_DIR="$(mktemp -d /tmp/cryptsetup-generator.XXX)"
+CRYPTTAB_FILE="$(mktemp /tmp/cryptsetup-generator-crypttab.XXX)"
+
+at_exit() {
+    rm -fr "${OUT_DIR:?}" "${CRYPTTAB_FILE:?}"
+}
+
+trap at_exit EXIT
+
+test -x "${GENERATOR_BIN:?}"
+
+check_no_cryptsetup_units() {
+    [[ "$(find "$OUT_DIR" ! -type d | wc -l)" -eq 0 ]]
+}
+
+cryptsetup_unit_path() {
+    echo "$OUT_DIR/normal/systemd-cryptsetup@$(systemd-escape "${1:?}").service"
+}
+
+UUID="b40f1abf-2a53-400a-889a-2eccc27eaa40"
+UUID_HEX_UPPER="B40F1ABF2A53400A889A2ECCC27EAA40"
+CRYPTTAB_UUID="a40f1abf-2a53-400a-889a-2eccc27eaa40"
+
+: "cryptsetup-generator: valid luks.uuid"
+SYSTEMD_CRYPTTAB=/dev/null SYSTEMD_PROC_CMDLINE="luks.uuid=$UUID" run_and_list "$GENERATOR_BIN" "$OUT_DIR"
+test -e "$(cryptsetup_unit_path "luks-$UUID")"
+
+: "cryptsetup-generator: valid luks.uuid with luks- prefix"
+SYSTEMD_CRYPTTAB=/dev/null SYSTEMD_PROC_CMDLINE="luks.uuid=luks-$UUID" run_and_list "$GENERATOR_BIN" "$OUT_DIR"
+test -e "$(cryptsetup_unit_path "luks-$UUID")"
+
+: "cryptsetup-generator: valid luks.uuid canonicalized"
+SYSTEMD_CRYPTTAB=/dev/null SYSTEMD_PROC_CMDLINE="luks.uuid=$UUID_HEX_UPPER" run_and_list "$GENERATOR_BIN" "$OUT_DIR"
+test -e "$(cryptsetup_unit_path "luks-$UUID")"
+
+: "cryptsetup-generator: invalid luks.uuid"
+SYSTEMD_CRYPTTAB=/dev/null SYSTEMD_PROC_CMDLINE="luks.uuid=not-a-uuid" run_and_list "$GENERATOR_BIN" "$OUT_DIR"
+check_no_cryptsetup_units
+
+: "cryptsetup-generator: invalid luks.uuid with luks- prefix"
+SYSTEMD_CRYPTTAB=/dev/null SYSTEMD_PROC_CMDLINE="luks.uuid=luks-not-a-uuid" run_and_list "$GENERATOR_BIN" "$OUT_DIR"
+check_no_cryptsetup_units
+
+: "cryptsetup-generator: invalid luks.uuid enables allow-list"
+printf 'other UUID=%s none -\n' "$CRYPTTAB_UUID" >"$CRYPTTAB_FILE"
+SYSTEMD_CRYPTTAB="$CRYPTTAB_FILE" SYSTEMD_PROC_CMDLINE="luks.uuid=not-a-uuid" run_and_list "$GENERATOR_BIN" "$OUT_DIR"
+check_no_cryptsetup_units
+
+: "cryptsetup-generator: valid luks.name"
+SYSTEMD_CRYPTTAB=/dev/null SYSTEMD_PROC_CMDLINE="luks.name=$UUID=mydisk" run_and_list "$GENERATOR_BIN" "$OUT_DIR"
+test -e "$(cryptsetup_unit_path mydisk)"
+
+: "cryptsetup-generator: invalid luks.name"
+SYSTEMD_CRYPTTAB=/dev/null SYSTEMD_PROC_CMDLINE="luks.name=deadbeef=root" run_and_list "$GENERATOR_BIN" "$OUT_DIR"
+check_no_cryptsetup_units
+
+: "cryptsetup-generator: invalid luks.name enables allow-list"
+SYSTEMD_CRYPTTAB="$CRYPTTAB_FILE" SYSTEMD_PROC_CMDLINE="luks.name=deadbeef=root" run_and_list "$GENERATOR_BIN" "$OUT_DIR"
+check_no_cryptsetup_units


### PR DESCRIPTION
The generator accepted arbitrary strings from luks.uuid= and from the
UUID side of luks.name=. Such values were then treated as LUKS
UUIDs and could produce cryptsetup units for invalid device paths.

Validate both inputs with the existing warn_uuid_invalid() helper,
preserving the supported luks- prefix stripping for luks.uuid=. Add
generator coverage for valid and invalid kernel command line inputs.