### PR TITLE
crypto-util: zero-pad ECC point coordinates to curve width

### DIFF
--- a/src/shared/crypto-util.c
+++ b/src/shared/crypto-util.c
@@ -110,6 +110,7 @@ DLSYM_PROTOTYPE(EC_GROUP_get0_generator) = NULL;
 DLSYM_PROTOTYPE(EC_GROUP_get0_order) = NULL;
 DLSYM_PROTOTYPE(EC_GROUP_get_curve) = NULL;
 DLSYM_PROTOTYPE(EC_GROUP_get_curve_name) = NULL;
+static DLSYM_PROTOTYPE(EC_GROUP_get_degree) = NULL;
 DLSYM_PROTOTYPE(EC_GROUP_get_field_type) = NULL;
 DLSYM_PROTOTYPE(EC_GROUP_new_by_curve_name) = NULL;
 DLSYM_PROTOTYPE(EC_POINT_free) = NULL;
@@ -435,6 +436,7 @@ int dlopen_libcrypto(int log_level) {
                         DLSYM_ARG(EC_GROUP_get0_order),
                         DLSYM_ARG(EC_GROUP_get_curve),
                         DLSYM_ARG(EC_GROUP_get_curve_name),
+                        DLSYM_ARG(EC_GROUP_get_degree),
                         DLSYM_ARG(EC_GROUP_get_field_type),
                         DLSYM_ARG(EC_GROUP_new_by_curve_name),
                         DLSYM_ARG(EC_POINT_free),
@@ -1735,24 +1737,43 @@ int ecc_pkey_to_curve_x_y(
         if (!sym_EVP_PKEY_get_bn_param(pkey, OSSL_PKEY_PARAM_EC_PUB_Y, &bn_y))
                 return log_openssl_errors(LOG_DEBUG, "Failed to get ECC point y");
 
-        size_t x_size = sym_BN_num_bytes(bn_x), y_size = sym_BN_num_bytes(bn_y);
-        _cleanup_free_ void *x = malloc(x_size), *y = malloc(y_size);
+        /* The affine coordinates are elements of the curve's underlying field and must be
+         * marshalled at the fixed field width. BN_bn2bin() writes the minimal big-endian
+         * encoding, dropping any leading zero bytes, so a coordinate whose most significant byte
+         * is zero (roughly 1 in 256 keys per coordinate) comes out one or more bytes short. A short
+         * coordinate makes callers such as tpm2_tpm2b_public_from_openssl_pkey() build a
+         * TPM2B_PUBLIC that TPM2_LoadExternal() rejects with TPM_RC_KEY. The object name hashes
+         * the marshalled public area, so the name a TPM derives for the key also stops matching
+         * the name systemd computes in software. Size the buffers to the field width and
+         * zero-pad. */
+        _cleanup_(EC_GROUP_freep) EC_GROUP *group = sym_EC_GROUP_new_by_curve_name(curve_id);
+        if (!group)
+                return log_openssl_errors(LOG_DEBUG, "ECC curve id %d not supported", curve_id);
+
+        int bits = sym_EC_GROUP_get_degree(group);
+        assert(bits > 0);
+
+        size_t size = DIV_ROUND_UP(bits, 8);
+        _cleanup_free_ void *x = malloc(size), *y = malloc(size);
         if (!x || !y)
                 return log_oom_debug();
 
-        assert(sym_BN_bn2bin(bn_x, x) == (int) x_size);
-        assert(sym_BN_bn2bin(bn_y, y) == (int) y_size);
+        if (sym_BN_bn2binpad(bn_x, x, size) < 0)
+                return log_debug_errno(SYNTHETIC_ERRNO(EIO), "Failed to marshal ECC point x to %zu bytes.", size);
+
+        if (sym_BN_bn2binpad(bn_y, y, size) < 0)
+                return log_debug_errno(SYNTHETIC_ERRNO(EIO), "Failed to marshal ECC point y to %zu bytes.", size);
 
         if (ret_curve_id)
                 *ret_curve_id = curve_id;
         if (ret_x)
                 *ret_x = TAKE_PTR(x);
         if (ret_x_size)
-                *ret_x_size = x_size;
+                *ret_x_size = size;
         if (ret_y)
                 *ret_y = TAKE_PTR(y);
         if (ret_y_size)
-                *ret_y_size = y_size;
+                *ret_y_size = size;
 
         return 0;
 }

--- a/src/test/test-crypto-util.c
+++ b/src/test/test-crypto-util.c
@@ -89,6 +89,48 @@ TEST(ecc_pkey_curve_x_y) {
         assert_se(memcmp_nn(y, y_len, y2, y2_size) == 0);
 }
 
+TEST(ecc_pkey_curve_x_y_leading_zero) {
+        /* Regression test: a P-384 public key whose x-coordinate has a most significant zero
+         * byte. BN_bn2bin() would strip it and return a 47-byte coordinate; ecc_pkey_to_curve_x_y()
+         * must zero-pad both coordinates to the 48-byte P-384 field width. */
+        DEFINE_HEX_PTR(key, "2d2d2d2d2d424547494e205055424c4943204b45592d2d2d2d2d0a4d485977454159484b6f5a497a6a3043415159464b34454541434944596741454147625a626d4a32534231424a4879633178674f7a4a646e67586767566254700a5a76515070516b54564779387362777677734872635a4871307a5a76782f316c4336787a5a64615648433147303835786c636c4a7770435a57685571576866730a2f6a70337a436d6e446a49754a79505735435148494930652b575a47706263490a2d2d2d2d2d454e44205055424c4943204b45592d2d2d2d2d0a");
+        _cleanup_(EVP_PKEY_freep) EVP_PKEY *pkey = NULL;
+        ASSERT_OK(openssl_pubkey_from_pem(key, key_len, &pkey));
+
+        _cleanup_free_ void *x = NULL, *y = NULL;
+        size_t x_size, y_size;
+        int curve_id;
+        ASSERT_OK(ecc_pkey_to_curve_x_y(pkey, &curve_id, &x, &x_size, &y, &y_size));
+        ASSERT_EQ(curve_id, NID_secp384r1);
+
+        DEFINE_HEX_PTR(expected_x, "0066d96e6276481d41247c9cd7180ecc976781782055b4e966f40fa50913546cbcb1bc2fc2c1eb7191ead3366fc7fd65");
+        ASSERT_EQ(memcmp_nn(x, x_size, expected_x, expected_x_len), 0);
+
+        DEFINE_HEX_PTR(expected_y, "0bac7365d6951c2d46d3ce7195c949c290995a152a5a17ecfe3a77cc29a70e322e2723d6e42407208d1ef96646a5b708");
+        ASSERT_EQ(memcmp_nn(y, y_size, expected_y, expected_y_len), 0);
+}
+
+TEST(ecc_pkey_curve_x_y_p521) {
+        /* P-521's field width is not a whole number of bytes: DIV_ROUND_UP(521, 8) is 66, and only
+         * the low bit of the leading byte can ever be set, so roughly half of all coordinates
+         * encode minimally in 65 bytes. This is a pinned key whose x-coordinate is one of them. */
+        DEFINE_HEX_PTR(key, "2d2d2d2d2d424547494e205055424c4943204b45592d2d2d2d2d0a4d4947624d42414742797147534d343941674547425375424241416a41344747414151416f527a475046566f7935437a474b6c385359757848345764365375470a4c66674135624d2b527258474c31794273584b443434366f4c30767530664e71717a6e667a456d3959395447634a394c385771784a3774325665514255466e460a6b6a2f49324137637a4843625a6b6b795753796656706e39666b70414542473166354c53464d7244667965664953324573353035334a366441434462796458550a435958353948514f4c443044794f3851734d6f3d0a2d2d2d2d2d454e44205055424c4943204b45592d2d2d2d2d0a");
+        _cleanup_(EVP_PKEY_freep) EVP_PKEY *pkey = NULL;
+        ASSERT_OK(openssl_pubkey_from_pem(key, key_len, &pkey));
+
+        _cleanup_free_ void *x = NULL, *y = NULL;
+        size_t x_size, y_size;
+        int curve_id;
+        ASSERT_OK(ecc_pkey_to_curve_x_y(pkey, &curve_id, &x, &x_size, &y, &y_size));
+        ASSERT_EQ(curve_id, NID_secp521r1);
+
+        DEFINE_HEX_PTR(expected_x, "00a11cc63c5568cb90b318a97c498bb11f859de92b862df800e5b33e46b5c62f5c81b17283e38ea82f4beed1f36aab39dfcc49bd63d4c6709f4bf16ab127bb7655e4");
+        ASSERT_EQ(memcmp_nn(x, x_size, expected_x, expected_x_len), 0);
+
+        DEFINE_HEX_PTR(expected_y, "015059c5923fc8d80edccc709b664932592c9f5699fd7e4a401011b57f92d214cac37f279f212d84b39d39dc9e9d0020dbc9d5d40985f9f4740e2c3d03c8ef10b0ca");
+        ASSERT_EQ(memcmp_nn(y, y_size, expected_y, expected_y_len), 0);
+}
+
 TEST(invalid) {
         _cleanup_(EVP_PKEY_freep) EVP_PKEY *pkey = NULL;
 

--- a/src/test/test-tpm2.c
+++ b/src/test/test-tpm2.c
@@ -901,7 +901,7 @@ static void check_tpm2b_public_name(const TPM2B_PUBLIC *public, const char *hexn
         assert_se(memcmp_nn(name.name, name.size, expected, expected_len) == 0);
 }
 
-static void check_tpm2b_public_from_ecc_pem(const char *pem, const char *hexx, const char *hexy, const char *hexfp, const char *hexname) {
+static void check_tpm2b_public_from_ecc_pem(const char *pem, TPMI_ECC_CURVE curve, const char *hexx, const char *hexy, const char *hexfp, const char *hexname) {
         TPM2B_PUBLIC public = {};
         TPMT_PUBLIC *p = &public.publicArea;
 
@@ -909,7 +909,7 @@ static void check_tpm2b_public_from_ecc_pem(const char *pem, const char *hexx, c
         get_tpm2b_public_from_pem(key, key_len, &public);
 
         assert_se(p->type == TPM2_ALG_ECC);
-        assert_se(p->parameters.eccDetail.curveID == TPM2_ECC_NIST_P256);
+        assert_se(p->parameters.eccDetail.curveID == curve);
 
         DEFINE_HEX_PTR(expected_x, hexx);
         assert_se(memcmp_nn(p->unique.ecc.x.buffer, p->unique.ecc.x.size, expected_x, expected_x_len) == 0);
@@ -944,10 +944,23 @@ static void check_tpm2b_public_from_rsa_pem(const char *pem, const char *hexn, u
 TEST(tpm2b_public_from_openssl_pkey) {
         /* standard ECC key */
         check_tpm2b_public_from_ecc_pem("2d2d2d2d2d424547494e205055424c4943204b45592d2d2d2d2d0a4d466b77457759484b6f5a497a6a3043415159494b6f5a497a6a30444151634451674145726a6e4575424c73496c3972687068777976584e50686a346a426e500a44586e794a304b395579724e6764365335413532542b6f5376746b436a365a726c34685847337741515558706f426c532b7448717452714c35513d3d0a2d2d2d2d2d454e44205055424c4943204b45592d2d2d2d2d0a",
+                                        TPM2_ECC_NIST_P256,
                                         "ae39c4b812ec225f6b869870caf5cd3e18f88c19cf0d79f22742bd532acd81de",
                                         "92e40e764fea12bed9028fa66b9788571b7c004145e9a01952fad1eab51a8be5",
                                         "cd3373293b62a52b48c12100e80ea9bfd806266ce76893a5ec31cb128052d97c",
                                         "000b5c127e4dbaf8fb7bac641e8db25a84a48db876ca7ee3bd317ae1a4554ff72f17");
+
+        /* ECC key whose x-coordinate has a most significant zero byte. The unpadded marshalling
+         * this used to produce made unique.ecc.x 47 bytes instead of 48, which both TPM2_LoadExternal()
+         * rejects and gives the object a different name. The name below is the one the padded
+         * public area must hash to; it is derived from the TPM 2.0 spec (nameAlg || SHA256 of the
+         * marshalled TPMT_PUBLIC), not from this implementation. */
+        check_tpm2b_public_from_ecc_pem("2d2d2d2d2d424547494e205055424c4943204b45592d2d2d2d2d0a4d485977454159484b6f5a497a6a3043415159464b34454541434944596741454147625a626d4a32534231424a4879633178674f7a4a646e67586767566254700a5a76515070516b54564779387362777677734872635a4871307a5a76782f316c4336787a5a64615648433147303835786c636c4a7770435a57685571576866730a2f6a70337a436d6e446a49754a79505735435148494930652b575a47706263490a2d2d2d2d2d454e44205055424c4943204b45592d2d2d2d2d0a",
+                                        TPM2_ECC_NIST_P384,
+                                        "0066d96e6276481d41247c9cd7180ecc976781782055b4e966f40fa50913546cbcb1bc2fc2c1eb7191ead3366fc7fd65",
+                                        "0bac7365d6951c2d46d3ce7195c949c290995a152a5a17ecfe3a77cc29a70e322e2723d6e42407208d1ef96646a5b708",
+                                        "a9943d99a720879eb87b6a96bbcf3f6d7b0116aff3ba49081172796a295a496a",
+                                        "000b0ddf2c9d545c6662b10d1f2d0a4a115eedab13f4e18da9f8c45d20d926b2c90c");
 
         /* standard RSA key */
         check_tpm2b_public_from_rsa_pem("2d2d2d2d2d424547494e205055424c4943204b45592d2d2d2d2d0a4d494942496a414e42676b71686b6947397730424151454641414f43415138414d49494243674b4341514541795639434950652f505852337a436f63787045300a6a575262546c3568585844436b472f584b79374b6d2f4439584942334b734f5a31436a5937375571372f674359363170697838697552756a73413464503165380a593445336c68556d374a332b6473766b626f4b64553243626d52494c2f6675627771694c4d587a41673342575278747234547545443533527a373634554650640a307a70304b68775231496230444c67772f344e67566f314146763378784b4d6478774d45683567676b73733038326332706c354a504e32587677426f744e6b4d0a5471526c745a4a35355244436170696e7153334577376675646c4e735851357746766c7432377a7637344b585165616d704c59433037584f6761304c676c536b0a79754774586b6a50542f735542544a705374615769674d5a6f714b7479563463515a58436b4a52684459614c47587673504233687a766d5671636e6b47654e540a65774944415141420a2d2d2d2d2d454e44205055424c4943204b45592d2d2d2d2d0a",


### PR DESCRIPTION
Addresses the coordinate marshalling defect in #43391 (the enroll-time key-type validation question there is a separate decision; this change does not touch it). Supersedes #43392, which I closed by mistake with a bad force-push.

ecc_pkey_to_curve_x_y() used BN_num_bytes() + BN_bn2bin(), which strip leading zero bytes, so just under 1% of EC keys on the byte-aligned curves and about half on P-521 produce a TPM2B_PUBLIC whose unique.ecc.x or .y is short of the curve width, and TPM2_LoadExternal rejects that with TPM_RC_KEY at unseal. Pad to the field width with BN_bn2binpad() instead (EC_GROUP_get_degree added to the dlsym table). All callers inherit the fix, including tpm2_calculate_seal_ecc_seed(), which carries the same latent exposure. Padding is a no-op for full-width coordinates, so only keys a reference-conformant TPM rejects today change their marshalled bytes and object name; already-enrolled short-coordinate tokens stay broken and need re-enrolling.

Because the width now comes from the group rather than from the BIGNUM being written, BN_bn2binpad() can fail where BN_bn2bin() could not. It reports that through its return value without touching the OpenSSL error queue, so both calls return -EIO through log_debug_errno(). The group-construction failure keeps log_openssl_errors() because it does raise, and its message now matches the sibling converter including the curve id. The degree is a plain assert, matching the other non-failing libcrypto getters in this file, and EC_GROUP_get_degree is file-local.

The tests pin the full expected coordinates for a P-384 key and a P-521 key that each carry a leading zero byte, P-521 being the curve where the field width is not a whole number of bytes. test-tpm2 pins the TPM object name for the P-384 key, derived independently from the marshalling rules rather than read back out of the implementation. That name is the invariant the comment above tpm2_tpm2b_public_from_openssl_pkey() guards, and this change alters it for exactly the keys a conformant TPM rejects today.

Verified on main (c44e952): the short-key reproducer from #43391 fails with 0x2dc unpatched and clears LoadExternal on this branch, converging on the same session policy digest as the RSA and full-width controls. Full meson test: 1917 passing, 0 failing, 22 skipped, matching an unpatched control build on the same machine. Reverting the padding fix makes all three pinned tests fail.

Fixes: #43391