### PR TITLE
resolved: drop dead assignment

### DIFF
--- a/src/resolve/resolved-link-bus.c
+++ b/src/resolve/resolved-link-bus.c
@@ -393,7 +393,7 @@ int bus_link_method_set_domains(sd_bus_message *message, void *userdata, sd_bus_
                 else {
                         r = dns_search_domain_new(l->manager, &d, DNS_SEARCH_DOMAIN_LINK, l, /* delegate= */ NULL, name);
                         if (r == -E2BIG) {
-                                changed = dns_search_domain_unlink_marked(l->search_domains) || changed;
+                                dns_search_domain_unlink_marked(l->search_domains);
                                 r = dns_search_domain_new(l->manager, &d, DNS_SEARCH_DOMAIN_LINK, l, /* delegate= */ NULL, name);
                         }
                         if (r < 0)


### PR DESCRIPTION
The 'changed' variable is either unused on error or unconditionally overwritten on success, so coverity warns about it. Drop the unused assignment.

CID#1685266

Follow-up for a572dd2f607a14d065a5c9538393cee037daca58