### PR TITLE
[wip] analyze: add a socket-activated unit verification API

### DIFF
--- a/src/analyze/analyze-condition.c
+++ b/src/analyze/analyze-condition.c
@@ -105,7 +105,7 @@ static int verify_conditions(char **lines, RuntimeScope scope, const char *unit,
         if (unit) {
                 _cleanup_free_ char *prepared = NULL;
 
-                r = verify_prepare_filename(unit, &prepared);
+                r = verify_prepare_filename(unit, arg_instance, &prepared);
                 if (r < 0)
                         return log_error_errno(r, "Failed to prepare filename %s: %m", unit);
 

--- a/src/analyze/analyze-security.c
+++ b/src/analyze/analyze-security.c
@@ -2758,7 +2758,7 @@ static int offline_security_checks(
 
                 log_debug("Handling %s...", *filename);
 
-                k = verify_prepare_filename(*filename, &prepared);
+                k = verify_prepare_filename(*filename, arg_instance, &prepared);
                 if (k < 0) {
                         log_warning_errno(k, "Failed to prepare filename %s: %m", *filename);
                         RET_GATHER(r, k);

--- a/src/analyze/analyze-verify-util.c
+++ b/src/analyze/analyze-verify-util.c
@@ -4,44 +4,26 @@
 #include <unistd.h>
 
 #include "sd-bus.h"
+#include "sd-messages.h"
 
 #include "all-units.h"
 #include "alloc-util.h"
-#include "analyze.h"
 #include "analyze-verify-util.h"
 #include "bus-error.h"
+#include "dbus-unit.h"
+#include "env-util.h"
 #include "errno-util.h"
 #include "log.h"
 #include "manager.h"
 #include "pager.h"
 #include "path-util.h"
-#include "set.h"
 #include "string-table.h"
 #include "string-util.h"
 #include "strv.h"
 #include "unit-name.h"
 #include "unit-serialize.h"
 
-static void log_syntax_callback(const char *unit, int level, void *userdata) {
-        Set **s = ASSERT_PTR(userdata);
-        int r;
-
-        assert(unit);
-
-        if (level > LOG_WARNING)
-                return;
-
-        if (*s == POINTER_MAX)
-                return;
-
-        r = set_put_strdup(s, unit);
-        if (r < 0) {
-                set_free(*s);
-                *s = POINTER_MAX;
-        }
-}
-
-int verify_prepare_filename(const char *filename, char **ret) {
+int verify_prepare_filename(const char *filename, const char *instance, char **ret) {
         _cleanup_free_ char *abspath = NULL, *name = NULL, *dir = NULL, *with_instance = NULL;
         char *c;
         int r;
@@ -61,7 +43,7 @@ int verify_prepare_filename(const char *filename, char **ret) {
                 return -EINVAL;
 
         if (unit_name_is_valid(name, UNIT_NAME_TEMPLATE)) {
-                r = unit_name_replace_instance(name, arg_instance, &with_instance);
+                r = unit_name_replace_instance(name, instance, &with_instance);
                 if (r < 0)
                         return r;
         }
@@ -126,7 +108,7 @@ static int find_unit_directory(const char *p, char **ret) {
         return 0;
 }
 
-int verify_set_unit_path(char **filenames) {
+int verify_set_unit_path(char * const *filenames) {
         _cleanup_strv_free_ char **ans = NULL;
         _cleanup_free_ char *joined = NULL;
         const char *old;
@@ -164,7 +146,192 @@ int verify_set_unit_path(char **filenames) {
             !strextend_with_separator(&joined, ":", streq_ptr(old, ":") ? "" : strempty(old)))
                 return -ENOMEM;
 
-        assert_se(setenv_unit_path(joined) >= 0);
+        return setenv_unit_path(joined);
+}
+
+static bool verify_error_is_fatal(int r) {
+        return ERRNO_IS_NEG_RESOURCE(r) || r == -E2BIG;
+}
+
+typedef struct VerifyCallbackContext {
+        VerifyUnitsResult *result;
+
+        /* First error raised by a callback which cannot return errors through its source API. */
+        int error;
+} VerifyCallbackContext;
+
+static void verify_diagnostic_done(VerifyDiagnostic *diagnostic) {
+        if (!diagnostic)
+                return;
+
+        free(diagnostic->message);
+        free(diagnostic->unit);
+        free(diagnostic->configuration_file);
+        free(diagnostic->message_id);
+
+        *diagnostic = (VerifyDiagnostic) {};
+}
+
+void verify_units_result_done(VerifyUnitsResult *result) {
+        if (!result)
+                return;
+
+        FOREACH_ARRAY(diagnostic, result->diagnostics, result->n_diagnostics)
+                verify_diagnostic_done(diagnostic);
+
+        free(result->diagnostics);
+        *result = (VerifyUnitsResult) {};
+}
+
+static int verify_diagnostic_add(
+                VerifyCallbackContext *context,
+                int priority,
+                const char *message,
+                const char *unit,
+                const char *configuration_file,
+                unsigned configuration_line,
+                const char *message_id) {
+
+        _cleanup_(verify_diagnostic_done) VerifyDiagnostic diagnostic = {
+                .priority = priority,
+                .configuration_line = configuration_line,
+        };
+
+        assert(context);
+        assert(context->result);
+        assert(message);
+
+        diagnostic.message = strdup(message);
+        if (!diagnostic.message)
+                return -ENOMEM;
+
+        if (unit) {
+                diagnostic.unit = strdup(unit);
+                if (!diagnostic.unit)
+                        return -ENOMEM;
+        }
+
+        if (configuration_file) {
+                diagnostic.configuration_file = strdup(configuration_file);
+                if (!diagnostic.configuration_file)
+                        return -ENOMEM;
+        }
+
+        if (message_id) {
+                diagnostic.message_id = strdup(message_id);
+                if (!diagnostic.message_id)
+                        return -ENOMEM;
+        }
+
+        if (!GREEDY_REALLOC(context->result->diagnostics, context->result->n_diagnostics + 1))
+                return -ENOMEM;
+
+        context->result->diagnostics[context->result->n_diagnostics++] = TAKE_STRUCT(diagnostic);
+        return 1;
+}
+
+static void verify_manager_diagnostic_callback(const ManagerDiagnostic *record, void *userdata) {
+        VerifyCallbackContext *context = ASSERT_PTR(userdata);
+        int r;
+
+        assert(record);
+
+        if (context->error < 0)
+                return;
+        if (record->priority > LOG_INFO)
+                return;
+
+        r = verify_diagnostic_add(
+                        context,
+                        record->priority,
+                        record->message,
+                        record->unit,
+                        record->configuration_file,
+                        record->configuration_line,
+                        record->message_id);
+        if (r < 0)
+                context->error = r;
+}
+
+static void verify_manager_diagnostic_callback_clearp(Manager **manager) {
+        assert(manager);
+
+        if (!*manager)
+                return;
+
+        (*manager)->test_run_diagnostic_callback = NULL;
+        (*manager)->test_run_diagnostic_userdata = NULL;
+}
+
+static void verify_syntax_callback(const LogSyntaxRecord *record, void *userdata) {
+        VerifyCallbackContext *context = ASSERT_PTR(userdata);
+        int r;
+
+        assert(record);
+
+        if (context->error < 0)
+                return;
+        if (record->priority > LOG_INFO)
+                return;
+
+        r = verify_diagnostic_add(
+                        context,
+                        record->priority,
+                        record->message,
+                        record->unit,
+                        record->config_file,
+                        record->config_line,
+                        SD_MESSAGE_INVALID_CONFIGURATION_STR);
+        if (r < 0)
+                context->error = r;
+}
+
+static int verify_callback_get_error(const VerifyCallbackContext *context) {
+        assert(context);
+
+        return context->error;
+}
+
+static bool verify_diagnostic_is_syntax_warning(const VerifyDiagnostic *diagnostic) {
+        assert(diagnostic);
+
+        return diagnostic->priority <= LOG_WARNING &&
+                diagnostic->unit &&
+                streq_ptr(diagnostic->message_id, SD_MESSAGE_INVALID_CONFIGURATION_STR);
+}
+
+static int verify_diagnostics_syntax_status(
+                const VerifyUnitsResult *result,
+                char * const *filenames,
+                RecursiveErrors recursive_errors) {
+
+        assert(result);
+
+        if (IN_SET(recursive_errors, RECURSIVE_ERRORS_YES, RECURSIVE_ERRORS_NO)) {
+                FOREACH_ARRAY(diagnostic, result->diagnostics, result->n_diagnostics)
+                        if (verify_diagnostic_is_syntax_warning(diagnostic))
+                                return -ENOTRECOVERABLE;
+
+                return 0;
+        }
+
+        if (recursive_errors != RECURSIVE_ERRORS_ONE)
+                return 0;
+
+        STRV_FOREACH(filename, filenames) {
+                _cleanup_free_ char *unit_file = NULL;
+                int r;
+
+                r = path_extract_filename(*filename, &unit_file);
+                if (r < 0)
+                        return log_error_errno(r, "Failed to extract file name from '%s': %m", *filename);
+
+                FOREACH_ARRAY(diagnostic, result->diagnostics, result->n_diagnostics)
+                        if (verify_diagnostic_is_syntax_warning(diagnostic) &&
+                            streq(diagnostic->unit, unit_file))
+                                return -ENOTRECOVERABLE;
+        }
+
         return 0;
 }
 
@@ -206,19 +373,29 @@ int verify_executable(Unit *u, const ExecCommand *exec, const char *root) {
 }
 
 static int verify_executables(Unit *u, const char *root) {
-        int r = 0;
+        int r = 0, k;
 
         assert(u);
 
         if (u->type == UNIT_SERVICE)
                 FOREACH_ELEMENT(i, SERVICE(u)->exec_command)
-                        LIST_FOREACH(command, j, *i)
-                                RET_GATHER(r, verify_executable(u, j, root));
+                        LIST_FOREACH(command, j, *i) {
+                                k = verify_executable(u, j, root);
+                                if (verify_error_is_fatal(k))
+                                        return k;
+
+                                RET_GATHER(r, k);
+                        }
 
         if (u->type == UNIT_SOCKET)
                 FOREACH_ELEMENT(i, SOCKET(u)->exec_command)
-                        LIST_FOREACH(command, j, *i)
-                                RET_GATHER(r, verify_executable(u, j, root));
+                        LIST_FOREACH(command, j, *i) {
+                                k = verify_executable(u, j, root);
+                                if (verify_error_is_fatal(k))
+                                        return k;
+
+                                RET_GATHER(r, k);
+                        }
 
         return r;
 }
@@ -232,6 +409,9 @@ static int verify_documentation(Unit *u, bool check_man) {
                 if (check_man && startswith(*p, "man:")) {
                         k = show_man_page(*p + 4, true);
                         if (k != 0) {
+                                if (verify_error_is_fatal(k))
+                                        return k;
+
                                 if (k < 0)
                                         log_unit_error_errno(u, k, "Can't show %s: %m", *p + 4);
                                 else {
@@ -249,136 +429,347 @@ static int verify_documentation(Unit *u, bool check_man) {
         return r;
 }
 
-static int verify_unit(Unit *u, bool check_man, const char *root) {
+static int verify_unit(Unit *u, bool check_man, const char *root, bool suppress_output) {
         _cleanup_(sd_bus_error_free) sd_bus_error error = SD_BUS_ERROR_NULL;
-        int r;
+        int r, k;
 
         assert(u);
 
-        if (DEBUG_LOGGING)
+        if (!suppress_output && DEBUG_LOGGING)
                 unit_dump(u, stdout, "\t");
 
         log_unit_debug(u, "Creating %s/start job", u->id);
         r = manager_add_job(u->manager, JOB_START, u, JOB_REPLACE, &error, /* ret= */ NULL);
-        if (r < 0)
-                log_unit_error_errno(u, r, "Failed to create %s/start: %s", u->id, bus_error_message(&error, r));
+        if (r < 0) {
+                log_unit_error_errno(
+                                u, r, "Failed to create %s/start: %s", u->id, bus_error_message(&error, r));
+                if (verify_error_is_fatal(r))
+                        return r;
+        }
 
-        RET_GATHER(r, verify_socket(u));
-        RET_GATHER(r, verify_executables(u, root));
-        RET_GATHER(r, verify_documentation(u, check_man));
+        k = verify_socket(u);
+        if (verify_error_is_fatal(k))
+                return k;
+        RET_GATHER(r, k);
+
+        k = verify_executables(u, root);
+        if (verify_error_is_fatal(k))
+                return k;
+        RET_GATHER(r, k);
+
+        k = verify_documentation(u, check_man);
+        if (verify_error_is_fatal(k))
+                return k;
+        RET_GATHER(r, k);
 
         return r;
 }
 
-static void set_destroy_ignore_pointer_max(Set **s) {
-        assert(s);
+static int verify_load_startable_unit(
+                Manager *m,
+                const char *path,
+                VerifyCallbackContext *context,
+                Unit **ret,
+                int *ret_status) {
 
-        if (*s == POINTER_MAX)
-                return;
-        set_free(*s);
+        _cleanup_(sd_bus_error_free) sd_bus_error error = SD_BUS_ERROR_NULL;
+        Unit *unit;
+        int r, k;
+
+        assert(m);
+        assert(path);
+        assert(context);
+        assert(ret);
+        assert(ret_status);
+
+        r = manager_load_unit(m, /* name= */ NULL, path, &error, &unit);
+        if (r < 0) {
+                if (verify_error_is_fatal(r))
+                        return r;
+
+                const char *message = bus_error_message(&error, r);
+
+                log_error_errno(r, "Failed to load unit file %s: %s", path, message);
+
+                k = verify_diagnostic_add(
+                                context,
+                                LOG_ERR,
+                                message,
+                                last_path_component(path),
+                                path,
+                                0,
+                                /* message_id= */ NULL);
+                if (k < 0)
+                        return k;
+
+                *ret_status = r;
+                return 0;
+        }
+
+        r = bus_unit_validate_load_state(unit, &error);
+        if (r < 0) {
+                if (verify_error_is_fatal(r))
+                        return r;
+
+                const char *message = bus_error_message(&error, r);
+
+                log_error_errno(r, "%s", message);
+
+                k = verify_diagnostic_add(
+                                context,
+                                LOG_ERR,
+                                message,
+                                unit->id,
+                                unit->fragment_path ?: path,
+                                0,
+                                /* message_id= */ NULL);
+                if (k < 0)
+                        return k;
+
+                *ret_status = r;
+                return 0;
+        }
+
+        *ret = unit;
+        *ret_status = 0;
+        return 0;
 }
 
-int verify_units(
-                char **filenames,
-                RuntimeScope scope,
-                bool check_man,
-                bool run_generators,
-                RecursiveErrors recursive_errors,
-                const char *root) {
+static int verify_prepare_filename_and_report(
+                const char *filename,
+                const char *instance,
+                VerifyCallbackContext *context,
+                char **ret,
+                int *ret_status) {
+
+        _cleanup_free_ char *message = NULL;
+        int r, k;
+
+        assert(filename);
+        assert(instance);
+        assert(context);
+        assert(ret);
+        assert(ret_status);
+
+        r = verify_prepare_filename(filename, instance, ret);
+        if (r >= 0) {
+                *ret_status = 0;
+                return 0;
+        }
+
+        log_error_errno(r, "Failed to prepare filename %s: %m", filename);
+        if (verify_error_is_fatal(r))
+                return r;
+
+        message = strjoin("Failed to prepare filename ", filename, ": ", STRERROR(r));
+        if (!message)
+                return -ENOMEM;
+
+        k = verify_diagnostic_add(
+                        context,
+                        LOG_ERR,
+                        message,
+                        /* unit= */ NULL,
+                        filename,
+                        0,
+                        /* message_id= */ NULL);
+        if (k < 0)
+                return k;
+
+        *ret_status = r;
+        return 0;
+}
+
+static int verify_units_internal(const VerifyUnitsParameters *parameters, VerifyUnitsResult *ret) {
+        _cleanup_(verify_units_result_done) VerifyUnitsResult result = {};
+        VerifyCallbackContext context = {
+                .result = &result,
+        };
+        _cleanup_(manager_freep) Manager *m = NULL;
+        _cleanup_(verify_manager_diagnostic_callback_clearp) Manager *diagnostic_manager = NULL;
+        _cleanup_free_ char *saved_unit_path = NULL;
+        _cleanup_free_ Unit **units = NULL;
+        size_t n_filenames, count = 0;
+        int r, k, status = 0;
+
+        assert(parameters);
+        assert(ret);
+
+        n_filenames = strv_length(parameters->filenames);
+
+        if (n_filenames == 0) {
+                *ret = TAKE_STRUCT(result);
+                return 0;
+        }
+
+        assert(parameters->instance);
 
         const ManagerTestRunFlags flags =
                 MANAGER_TEST_RUN_MINIMAL |
-                MANAGER_TEST_RUN_ENV_GENERATORS |
+                parameters->run_environment_generators * MANAGER_TEST_RUN_ENV_GENERATORS |
                 MANAGER_TEST_DONT_OPEN_EXECUTOR |
-                (recursive_errors == RECURSIVE_ERRORS_NO) * MANAGER_TEST_RUN_IGNORE_DEPENDENCIES |
-                run_generators * MANAGER_TEST_RUN_GENERATORS;
+                (parameters->recursive_errors == RECURSIVE_ERRORS_NO) *
+                        MANAGER_TEST_RUN_IGNORE_DEPENDENCIES |
+                parameters->run_unit_generators * MANAGER_TEST_RUN_GENERATORS;
 
-        _cleanup_(manager_freep) Manager *m = NULL;
-        _cleanup_(set_destroy_ignore_pointer_max) Set *s = NULL;
-        _unused_ _cleanup_(clear_log_syntax_callback) dummy_t dummy;
-        Unit *units[strv_length(filenames)];
-        int r, k, count = 0;
+        if (!parameters->lookup_path_override) {
+                const char *unit_path = getenv("SYSTEMD_UNIT_PATH");
 
-        if (strv_isempty(filenames))
-                return 0;
+                if (unit_path) {
+                        saved_unit_path = strdup(unit_path);
+                        if (!saved_unit_path)
+                                return log_oom();
+                }
 
-        /* Allow systemd-analyze to hook in a callback function so that it can get
-         * all the required log data from the function itself without having to rely
-         * on a global set variable for the same */
-        set_log_syntax_callback(log_syntax_callback, &s);
+                r = verify_set_unit_path(parameters->filenames);
+                if (r < 0)
+                        return log_error_errno(r, "Failed to set unit load path: %m");
+        }
 
-        /* set the path */
-        r = verify_set_unit_path(filenames);
+        r = manager_new(parameters->runtime_scope, flags, &m);
         if (r < 0)
-                return log_error_errno(r, "Failed to set unit load path: %m");
+                log_error_errno(r, "Failed to initialize manager: %m");
+        else {
+                log_debug("Starting manager...");
 
-        r = manager_new(scope, flags, &m);
-        if (r < 0)
-                return log_error_errno(r, "Failed to initialize manager: %m");
+                r = manager_startup(
+                                m,
+                                /* serialization= */ NULL,
+                                /* fds= */ NULL,
+                                /* named_listen_fds= */ NULL,
+                                parameters->root);
+        }
 
-        log_debug("Starting manager...");
-
-        r = manager_startup(m, /* serialization= */ NULL, /* fds= */ NULL, /* named_listen_fds= */ NULL, root);
+        if (!parameters->lookup_path_override) {
+                k = set_unset_env("SYSTEMD_UNIT_PATH", saved_unit_path, /* overwrite= */ true);
+                if (k < 0)
+                        return log_error_errno(k, "Failed to restore unit load path: %m");
+        }
         if (r < 0)
                 return r;
 
+        if (parameters->lookup_path_override) {
+                _cleanup_strv_free_ char **search_path = NULL;
+
+                search_path = strv_copy(parameters->lookup_path_override);
+                if (!search_path)
+                        return -ENOMEM;
+
+                strv_free_and_replace(m->lookup_paths.search_path, search_path);
+        }
+
         manager_clear_jobs(m);
 
-        log_debug("Loading remaining units from the command line...");
+        /* These callbacks are scoped to the temporary manager and syntax parser, so diagnostics and
+         * their effect on the result do not depend on presentation through the ambient log target. */
+        _unused_ _cleanup_(clear_log_syntax_callback) dummy_t syntax_callback_cleanup;
+        set_log_syntax_callback(verify_syntax_callback, &context);
+        assert(!m->test_run_diagnostic_callback);
+        m->test_run_diagnostic_callback = verify_manager_diagnostic_callback;
+        m->test_run_diagnostic_userdata = &context;
+        diagnostic_manager = m;
+        m->no_console_output = parameters->suppress_output;
 
-        STRV_FOREACH(filename, filenames) {
+        units = new(Unit*, n_filenames);
+        if (!units)
+                return -ENOMEM;
+
+        log_debug("Loading requested units...");
+
+        STRV_FOREACH(filename, parameters->filenames) {
                 _cleanup_free_ char *prepared = NULL;
+                int finding_status;
 
                 log_debug("Handling %s...", *filename);
 
-                k = verify_prepare_filename(*filename, &prepared);
-                if (k < 0) {
-                        log_error_errno(k, "Failed to prepare filename %s: %m", *filename);
-                        RET_GATHER(r, k);
+                k = verify_prepare_filename_and_report(
+                                *filename,
+                                parameters->instance,
+                                &context,
+                                &prepared,
+                                &finding_status);
+                if (k < 0)
+                        return k;
+
+                if (finding_status < 0) {
+                        RET_GATHER(status, finding_status);
                         continue;
                 }
 
-                k = manager_load_startable_unit_or_warn(m, /* name= */ NULL, prepared, LOG_ERR, &units[count]);
-                if (k < 0) {
-                        RET_GATHER(r, k);
+                k = verify_load_startable_unit(
+                                m,
+                                prepared,
+                                &context,
+                                &units[count],
+                                &finding_status);
+                if (k < 0)
+                        return k;
+
+                k = verify_callback_get_error(&context);
+                if (k < 0)
+                        return k;
+
+                if (finding_status < 0) {
+                        RET_GATHER(status, finding_status);
                         continue;
                 }
 
                 count++;
         }
 
-        FOREACH_ARRAY(i, units, count)
-                RET_GATHER(r, verify_unit(*i, check_man, root));
+        FOREACH_ARRAY(i, units, count) {
+                k = verify_unit(
+                                *i,
+                                parameters->check_man,
+                                parameters->root,
+                                parameters->suppress_output);
 
-        if (s == POINTER_MAX)
-                return log_oom();
+                r = verify_callback_get_error(&context);
+                if (r < 0)
+                        return r;
 
-        if (set_isempty(s) || r != 0)
-                return r;
+                if (k < 0) {
+                        if (verify_error_is_fatal(k))
+                                return k;
 
-        /* If all previous verifications succeeded, then either the recursive parsing of all the
-         * associated dependencies with RECURSIVE_ERRORS_YES or the parsing of the specified unit file
-         * with RECURSIVE_ERRORS_NO must have yielded a syntax warning and hence, a non-empty set. */
-        if (IN_SET(recursive_errors, RECURSIVE_ERRORS_YES, RECURSIVE_ERRORS_NO))
-                return -ENOTRECOVERABLE;
-
-        /* If all previous verifications succeeded, then the non-empty set could have resulted from
-         * a syntax warning encountered during the recursive parsing of the specified unit file and
-         * its direct dependencies. Hence, search for any of the filenames in the set and if found,
-         * return a non-zero process exit status. */
-        if (recursive_errors == RECURSIVE_ERRORS_ONE)
-                STRV_FOREACH(filename, filenames) {
-                        _cleanup_free_ char *unit_file = NULL;
-
-                        r = path_extract_filename(*filename, &unit_file);
-                        if (r < 0)
-                                return log_error_errno(r, "Failed to extract file name from '%s': %m", *filename);
-
-                        if (set_contains(s, unit_file))
-                                return -ENOTRECOVERABLE;
+                        RET_GATHER(status, k);
                 }
+        }
 
+        if (status == 0) {
+                k = verify_diagnostics_syntax_status(
+                                &result,
+                                parameters->filenames,
+                                parameters->recursive_errors);
+                if (k < 0) {
+                        if (verify_error_is_fatal(k))
+                                return k;
+
+                        status = k;
+                }
+        }
+
+        result.legacy_status = status;
+        *ret = TAKE_STRUCT(result);
         return 0;
+}
+
+int verify_units(const VerifyUnitsParameters *parameters, VerifyUnitsResult *ret) {
+        LogTarget saved_target;
+        int r;
+
+        assert(parameters);
+        assert(ret);
+
+        if (!parameters->suppress_output)
+                return verify_units_internal(parameters, ret);
+
+        saved_target = log_get_target();
+        log_set_target(LOG_TARGET_NULL);
+        r = verify_units_internal(parameters, ret);
+        log_set_target(saved_target);
+
+        return r;
 }
 
 static const char* const recursive_errors_table[_RECURSIVE_ERRORS_MAX] = {

--- a/src/analyze/analyze-verify-util.h
+++ b/src/analyze/analyze-verify-util.h
@@ -2,21 +2,61 @@
 #pragma once
 
 #include "forward.h"
+#include "runtime-scope.h"
 
 typedef struct ExecCommand ExecCommand;
 typedef struct Unit Unit;
 
+typedef struct VerifyDiagnostic {
+        int priority;
+        char *message;
+        char *unit;
+        char *configuration_file;
+        unsigned configuration_line;
+        char *message_id;
+} VerifyDiagnostic;
+
 typedef enum RecursiveErrors {
         RECURSIVE_ERRORS_YES,               /* Look for errors in all associated units */
         RECURSIVE_ERRORS_NO,                /* Don't look for errors in any but the selected unit */
-        RECURSIVE_ERRORS_ONE,               /* Look for errors in the selected unit and its direct dependencies */
+        RECURSIVE_ERRORS_ONE,               /* Look for errors in the selected unit and its direct
+                                             * dependencies */
         _RECURSIVE_ERRORS_MAX,
         _RECURSIVE_ERRORS_INVALID = -EINVAL,
 } RecursiveErrors;
 
-int verify_set_unit_path(char **filenames);
-int verify_prepare_filename(const char *filename, char **ret);
+typedef struct VerifyUnitsParameters {
+        /* NULL or an empty list is a successful no-op; adapters may expand it before calling. */
+        char * const *filenames;
+        RuntimeScope runtime_scope;
+        RecursiveErrors recursive_errors;
+        const char *root;
+        const char *instance;
+        /* Borrowed complete search path to install instead of deriving one from filenames. */
+        char * const *lookup_path_override;
+        bool check_man;
+        bool run_unit_generators;
+        bool run_environment_generators;
+        bool suppress_output;
+} VerifyUnitsParameters;
+
+typedef struct VerifyUnitsResult {
+        VerifyDiagnostic *diagnostics;
+        size_t n_diagnostics;
+
+        /* A negative value means verification completed and found a problem. This is kept separate
+         * from verify_units()'s return value to preserve the legacy CLI exit status. */
+        int legacy_status;
+} VerifyUnitsResult;
+
+int verify_set_unit_path(char * const *filenames);
+int verify_prepare_filename(const char *filename, const char *instance, char **ret);
+void verify_units_result_done(VerifyUnitsResult *result);
 int verify_executable(Unit *u, const ExecCommand *exec, const char *root);
-int verify_units(char **filenames, RuntimeScope scope, bool check_man, bool run_generators, RecursiveErrors recursive_errors, const char *root);
+
+/* Returns a negative error when verification could not be completed, without updating ret. A completed
+ * verification returns zero; findings are reported through ret independently of the ambient log level,
+ * which only controls their presentation. NULL or empty filenames are a successful no-op. */
+int verify_units(const VerifyUnitsParameters *parameters, VerifyUnitsResult *ret);
 
 DECLARE_STRING_TABLE_LOOKUP(recursive_errors, RecursiveErrors);

--- a/src/analyze/analyze-verify-varlink.c
+++ b/src/analyze/analyze-verify-varlink.c
@@ -1,0 +1,318 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include "sd-json.h"
+#include "sd-varlink.h"
+
+#include "alloc-util.h"
+#include "analyze-verify-util.h"
+#include "analyze-verify-varlink.h"
+#include "hashmap.h"
+#include "install.h"
+#include "json-util.h"
+#include "log.h"
+#include "path-lookup.h"
+#include "path-util.h"
+#include "runtime-scope.h"
+#include "string-util.h"
+#include "strv.h"
+#include "unit-name.h"
+#include "varlink-io.systemd.Analyze.h"
+#include "varlink-util.h"
+
+static const char* diagnostic_severity(int priority) {
+        priority = LOG_PRI(priority);
+
+        if (priority <= LOG_ERR)
+                return "error";
+        if (priority == LOG_WARNING)
+                return "warning";
+        if (priority == LOG_NOTICE)
+                return "notice";
+
+        return "info";
+}
+
+int verify_result_build_varlink_reply(
+                const VerifyUnitsResult *result,
+                sd_json_variant **ret) {
+
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *array = NULL;
+        int r;
+
+        assert(result);
+        assert(ret);
+
+        FOREACH_ARRAY(diagnostic, result->diagnostics, result->n_diagnostics) {
+                r = sd_json_variant_append_arraybo(
+                                &array,
+                                SD_JSON_BUILD_PAIR_STRING(
+                                                "severity", diagnostic_severity(diagnostic->priority)),
+                                SD_JSON_BUILD_PAIR_STRING("message", diagnostic->message),
+                                SD_JSON_BUILD_PAIR_CONDITION(
+                                                !!diagnostic->unit,
+                                                "unit",
+                                                SD_JSON_BUILD_STRING(diagnostic->unit)),
+                                SD_JSON_BUILD_PAIR_CONDITION(
+                                                !!diagnostic->configuration_file,
+                                                "configurationFile",
+                                                SD_JSON_BUILD_STRING(diagnostic->configuration_file)),
+                                SD_JSON_BUILD_PAIR_CONDITION(
+                                                diagnostic->configuration_line > 0,
+                                                "configurationLine",
+                                                SD_JSON_BUILD_UNSIGNED(diagnostic->configuration_line)),
+                                SD_JSON_BUILD_PAIR_CONDITION(
+                                                !!diagnostic->message_id,
+                                                "messageId",
+                                                SD_JSON_BUILD_STRING(diagnostic->message_id)));
+                if (r < 0)
+                        return r;
+        }
+
+        if (!array) {
+                r = sd_json_variant_new_array(&array, /* array= */ NULL, /* n= */ 0);
+                if (r < 0)
+                        return r;
+        }
+
+        return sd_json_buildo(ret, SD_JSON_BUILD_PAIR_VARIANT("diagnostics", array));
+}
+
+static bool unit_file_is_selected(const UnitFileList *unit_file) {
+        assert(unit_file);
+
+        return !IN_SET(unit_file->state, UNIT_FILE_ALIAS, UNIT_FILE_MASKED, UNIT_FILE_MASKED_RUNTIME);
+}
+
+static int instance_candidate(size_t n, size_t length_max, char **ret) {
+        static const char alphabet[] = ALPHANUMERICAL ":-_.\\@";
+        _cleanup_free_ char *instance = NULL;
+        size_t encoded;
+
+        assert(ret);
+
+        if (!ADD_SAFE(&encoded, n, 1))
+                return -E2BIG;
+
+        size_t length = 0;
+        for (size_t k = encoded; k > 0; k = (k - 1) / (ELEMENTSOF(alphabet) - 1))
+                length++;
+
+        if (length > length_max)
+                return -E2BIG;
+
+        instance = new(char, length + 1);
+        if (!instance)
+                return -ENOMEM;
+
+        size_t k = encoded;
+        for (size_t i = length; i > 0; i--) {
+                k--;
+                instance[i - 1] = alphabet[k % (ELEMENTSOF(alphabet) - 1)];
+                k /= ELEMENTSOF(alphabet) - 1;
+        }
+        instance[length] = 0;
+
+        *ret = TAKE_PTR(instance);
+        return 0;
+}
+
+static int instantiate_template_path(
+                Hashmap *unit_files,
+                const char *name,
+                const char *path,
+                char **ret) {
+
+        size_t instance_length_max;
+        int r;
+
+        assert(unit_files);
+        assert(unit_name_is_valid(name, UNIT_NAME_TEMPLATE));
+        assert(path);
+        assert(ret);
+
+        instance_length_max = UNIT_NAME_MAX - 1 - strlen(name);
+
+        for (size_t n = 0;; n++) {
+                _cleanup_free_ char *candidate = NULL, *directory = NULL, *instantiated = NULL;
+
+                r = instance_candidate(n, instance_length_max, &candidate);
+                if (r == -E2BIG)
+                        break;
+                if (r < 0)
+                        return r;
+
+                r = unit_name_replace_instance(name, candidate, &instantiated);
+                if (r < 0)
+                        return r;
+                if (hashmap_contains(unit_files, instantiated))
+                        continue;
+
+                r = path_extract_directory(path, &directory);
+                if (r < 0)
+                        return r;
+
+                *ret = path_join(directory, instantiated);
+                return *ret ? 0 : -ENOMEM;
+        }
+
+        /* Keep an uninstantiable template so the ordinary verifier reports it and continues. */
+        return strdup_to(ret, path);
+}
+
+int verify_varlink_collect_unit_files(
+                RuntimeScope runtime_scope,
+                const char *root,
+                char ***ret_paths,
+                char ***ret_lookup_path) {
+
+        _cleanup_(lookup_paths_done) LookupPaths lookup_paths = {};
+        _cleanup_hashmap_free_ Hashmap *unit_files = NULL;
+        _cleanup_strv_free_ char **paths = NULL;
+        int r;
+
+        assert(IN_SET(runtime_scope, RUNTIME_SCOPE_SYSTEM, RUNTIME_SCOPE_USER));
+        assert(ret_paths);
+        assert(ret_lookup_path);
+
+        r = lookup_paths_init(&lookup_paths, runtime_scope, /* flags= */ 0, root);
+        if (r < 0)
+                return r;
+
+        r = unit_file_get_list(
+                        runtime_scope,
+                        root,
+                        /* states= */ NULL,
+                        /* patterns= */ NULL,
+                        &unit_files);
+        if (r < 0)
+                return r;
+
+        /* Preserve lookup-path order and make diagnostic order within each directory deterministic. */
+        STRV_FOREACH(directory, lookup_paths.search_path) {
+                _cleanup_strv_free_ char **directory_paths = NULL;
+                const char *name;
+                UnitFileList *unit_file;
+
+                HASHMAP_FOREACH_KEY(unit_file, name, unit_files) {
+                        _cleanup_free_ char *path = NULL;
+
+                        if (!unit_file_is_selected(unit_file))
+                                continue;
+
+                        const char *relative = path_startswith(unit_file->path, *directory);
+                        if (!relative || strchr(relative, '/'))
+                                continue;
+
+                        if (unit_name_is_valid(name, UNIT_NAME_TEMPLATE))
+                                r = instantiate_template_path(unit_files, name, unit_file->path, &path);
+                        else
+                                r = strdup_to(&path, unit_file->path);
+                        if (r < 0)
+                                return r;
+
+                        r = strv_consume(&directory_paths, TAKE_PTR(path));
+                        if (r < 0)
+                                return r;
+                }
+
+                strv_sort(directory_paths);
+                r = strv_extend_strv(&paths, directory_paths, /* filter_duplicates= */ false);
+                if (r < 0)
+                        return r;
+        }
+
+        *ret_paths = TAKE_PTR(paths);
+        *ret_lookup_path = TAKE_PTR(lookup_paths.search_path);
+        return 0;
+}
+
+static int vl_method_verify(
+                sd_varlink *link,
+                sd_json_variant *parameters,
+                sd_varlink_method_flags_t flags,
+                void *userdata) {
+
+        static const sd_json_dispatch_field dispatch_table[] = {
+                { "unitFiles", SD_JSON_VARIANT_ARRAY, json_dispatch_strv_path, 0,
+                  SD_JSON_NULLABLE|SD_JSON_STRICT },
+                {}
+        };
+
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *reply = NULL;
+        _cleanup_(verify_units_result_done) VerifyUnitsResult result = {};
+        _cleanup_strv_free_ char **unit_files = NULL, **lookup_path_override = NULL;
+        RuntimeScope runtime_scope;
+        int r;
+
+        assert(link);
+        assert(parameters);
+        assert(userdata);
+
+        runtime_scope = *(RuntimeScope*) userdata;
+        assert(IN_SET(runtime_scope, RUNTIME_SCOPE_SYSTEM, RUNTIME_SCOPE_USER));
+
+        r = sd_varlink_dispatch(link, parameters, dispatch_table, &unit_files);
+        if (r != 0)
+                return r;
+
+        if (strv_isempty(unit_files)) {
+                unit_files = strv_free(unit_files);
+
+                r = verify_varlink_collect_unit_files(
+                                runtime_scope,
+                                /* root= */ NULL,
+                                &unit_files,
+                                &lookup_path_override);
+                if (r < 0)
+                        return r;
+        }
+
+        const VerifyUnitsParameters verify_parameters = {
+                .filenames = unit_files,
+                .runtime_scope = runtime_scope,
+                .recursive_errors = RECURSIVE_ERRORS_YES,
+                .instance = "test_instance",
+                .lookup_path_override = lookup_path_override,
+                .suppress_output = true,
+        };
+
+        r = verify_units(&verify_parameters, &result);
+        if (r < 0)
+                return r;
+
+        r = verify_result_build_varlink_reply(&result, &reply);
+        if (r < 0)
+                return r;
+
+        return sd_varlink_reply(link, reply);
+}
+
+int verify_varlink_server(RuntimeScope runtime_scope) {
+        _cleanup_(sd_varlink_server_unrefp) sd_varlink_server *server = NULL;
+        int r;
+
+        assert(IN_SET(runtime_scope, RUNTIME_SCOPE_SYSTEM, RUNTIME_SCOPE_USER));
+
+        r = varlink_server_new(
+                        &server,
+                        SD_VARLINK_SERVER_ROOT_ONLY |
+                                SD_VARLINK_SERVER_MYSELF_ONLY |
+                                SD_VARLINK_SERVER_INHERIT_USERDATA,
+                        &runtime_scope);
+        if (r < 0)
+                return log_error_errno(r, "Failed to allocate Varlink server: %m");
+
+        r = sd_varlink_server_add_interface(server, &vl_interface_io_systemd_Analyze);
+        if (r < 0)
+                return log_error_errno(r, "Failed to add Varlink interface: %m");
+
+        r = sd_varlink_server_bind_method(server, "io.systemd.Analyze.Verify", vl_method_verify);
+        if (r < 0)
+                return log_error_errno(r, "Failed to bind Varlink method: %m");
+
+        r = sd_varlink_server_loop_auto(server);
+        if (r < 0)
+                return log_error_errno(r, "Failed to run Varlink event loop: %m");
+
+        return 0;
+}

--- a/src/analyze/analyze-verify-varlink.h
+++ b/src/analyze/analyze-verify-varlink.h
@@ -1,0 +1,15 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#pragma once
+
+#include "sd-json.h"
+
+#include "analyze-verify-util.h"
+#include "runtime-scope.h"
+
+int verify_result_build_varlink_reply(const VerifyUnitsResult *result, sd_json_variant **ret);
+int verify_varlink_collect_unit_files(
+                RuntimeScope runtime_scope,
+                const char *root,
+                char ***ret_paths,
+                char ***ret_lookup_path);
+int verify_varlink_server(RuntimeScope runtime_scope);

--- a/src/analyze/analyze-verify.c
+++ b/src/analyze/analyze-verify.c
@@ -60,6 +60,7 @@ static int process_aliases(char *argv[], char *tempdir, char ***ret) {
 }
 
 int verb_verify(int argc, char *argv[], uintptr_t _data, void *userdata) {
+        _cleanup_(verify_units_result_done) VerifyUnitsResult result = {};
         _cleanup_strv_free_ char **filenames = NULL;
         _cleanup_(rm_rf_physical_and_freep) char *tempdir = NULL;
         int r;
@@ -72,5 +73,20 @@ int verb_verify(int argc, char *argv[], uintptr_t _data, void *userdata) {
         if (r < 0)
                 return log_error_errno(r, "Couldn't process aliases: %m");
 
-        return verify_units(filenames, arg_runtime_scope, arg_man, arg_generators, arg_recursive_errors, arg_root);
+        const VerifyUnitsParameters parameters = {
+                .filenames = filenames,
+                .runtime_scope = arg_runtime_scope,
+                .recursive_errors = arg_recursive_errors,
+                .root = arg_root,
+                .instance = arg_instance,
+                .check_man = arg_man,
+                .run_unit_generators = arg_generators,
+                .run_environment_generators = true,
+        };
+
+        r = verify_units(&parameters, &result);
+        if (r < 0)
+                return r;
+
+        return result.legacy_status;
 }

--- a/src/analyze/meson.build
+++ b/src/analyze/meson.build
@@ -62,8 +62,27 @@ executables += [
                 ],
                 'install' : conf.get('ENABLE_ANALYZE') == 1 ? 'yes' : 'no',
         },
+        # Keep this API available even when the full systemd-analyze CLI is not installed.
+        libexec_template + {
+                'name' : 'systemd-analyze-verify',
+                'sources' : files('systemd-analyze-verify.c'),
+                'export' : files('analyze-verify-varlink.c'),
+                'import' : ['systemd-analyze'],
+                'link_with' : [
+                        libcore,
+                        libshared,
+                ],
+                'install' : 'yes',
+        },
         core_test_template + {
                 'sources' : files('test-verify.c'),
                 'import' : ['systemd-analyze'],
+        },
+        core_test_template + {
+                'sources' : files('test-analyze-verify-varlink.c'),
+                'import' : [
+                        'systemd-analyze',
+                        'systemd-analyze-verify',
+                ],
         },
 ]

--- a/src/analyze/systemd-analyze-verify.c
+++ b/src/analyze/systemd-analyze-verify.c
@@ -1,0 +1,111 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include "sd-varlink.h"
+
+#include "analyze-verify-varlink.h"
+#include "ansi-color.h"
+#include "build.h"
+#include "dlopen-note.h"
+#include "format-table.h"
+#include "log.h"
+#include "main-func.h"
+#include "options.h"
+#include "runtime-scope.h"
+
+static RuntimeScope arg_runtime_scope = _RUNTIME_SCOPE_INVALID;
+
+static int help(void) {
+        _cleanup_(table_unrefp) Table *options = NULL;
+        int r;
+
+        r = option_parser_get_help_table(&options);
+        if (r < 0)
+                return r;
+
+        printf("%s [OPTIONS...]\n"
+               "\n%sVerify systemd unit files over Varlink%s\n"
+               "\n%sOptions:%s\n",
+               program_invocation_short_name,
+               ansi_highlight(),
+               ansi_normal(),
+               ansi_underline(),
+               ansi_normal());
+
+        return table_print_or_warn(options);
+}
+
+static int parse_argv(int argc, char *argv[]) {
+        int r;
+
+        assert(argc >= 0);
+        assert(argv);
+
+        OptionParser opts = { argc, argv };
+
+        FOREACH_OPTION_OR_RETURN(c, &opts)
+                switch (c) {
+                OPTION_COMMON_HELP:
+                        return help();
+
+                OPTION_COMMON_VERSION:
+                        return version();
+
+                OPTION_COMMON_SYSTEM:
+                        if (arg_runtime_scope >= 0)
+                                return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
+                                                       "Please specify exactly one of --system or --user.");
+                        arg_runtime_scope = RUNTIME_SCOPE_SYSTEM;
+                        break;
+
+                OPTION_COMMON_USER:
+                        if (arg_runtime_scope >= 0)
+                                return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
+                                                       "Please specify exactly one of --system or --user.");
+                        arg_runtime_scope = RUNTIME_SCOPE_USER;
+                        break;
+                }
+
+        if (option_parser_get_n_args(&opts) > 0)
+                return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
+                                       "This program takes no positional arguments.");
+
+        if (arg_runtime_scope < 0)
+                return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
+                                       "Please specify exactly one of --system or --user.");
+
+        r = sd_varlink_invocation(SD_VARLINK_ALLOW_ACCEPT);
+        if (r < 0)
+                return log_error_errno(r, "Failed to check if invoked in Varlink mode: %m");
+        if (r == 0)
+                return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
+                                       "This program can only run as a Varlink service.");
+
+        return 1;
+}
+
+static int run(int argc, char *argv[]) {
+        int r;
+
+        LIBACL_NOTE(suggested);
+        LIBAPPARMOR_NOTE(suggested);
+        LIBAUDIT_NOTE(suggested);
+        LIBBLKID_NOTE(suggested);
+        LIBBPF_NOTE(suggested);
+        LIBCRYPTO_NOTE(suggested);
+        LIBCRYPTSETUP_NOTE(suggested);
+        LIBMOUNT_NOTE(suggested);
+        LIBPCRE2_NOTE(suggested);
+        LIBSECCOMP_NOTE(suggested);
+        LIBSELINUX_NOTE(suggested);
+        TPM2_NOTE(suggested);
+
+        log_setup();
+
+        r = parse_argv(argc, argv);
+        if (r <= 0)
+                return r;
+
+        return verify_varlink_server(arg_runtime_scope);
+}
+
+DEFINE_MAIN_FUNCTION(run);

--- a/src/analyze/test-analyze-verify-varlink.c
+++ b/src/analyze/test-analyze-verify-varlink.c
@@ -1,0 +1,384 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include <unistd.h>
+
+#include "sd-json.h"
+#include "sd-messages.h"
+
+#include "analyze-verify-util.h"
+#include "analyze-verify-varlink.h"
+#include "fileio.h"
+#include "log.h"
+#include "mkdir.h"
+#include "path-util.h"
+#include "rm-rf.h"
+#include "string-util.h"
+#include "strv.h"
+#include "tests.h"
+#include "tmpfile-util.h"
+#include "unit-name.h"
+#include "varlink-idl-util.h"
+#include "varlink-io.systemd.Analyze.h"
+
+TEST(build_reply) {
+        VerifyDiagnostic items[] = {
+                {
+                        .priority = LOG_EMERG,
+                        .message = (char*) "first",
+                        .unit = (char*) "first.service",
+                        .configuration_file = (char*) "/tmp/first.service",
+                        .configuration_line = 7,
+                        .message_id = (char*) SD_MESSAGE_INVALID_CONFIGURATION_STR,
+                },
+                { .priority = LOG_ERR,     .message = (char*) "second" },
+                { .priority = LOG_WARNING, .message = (char*) "third"  },
+                { .priority = LOG_NOTICE,  .message = (char*) "fourth" },
+                { .priority = LOG_INFO,    .message = (char*) "fifth"  },
+                { .priority = LOG_DAEMON|LOG_ERR, .message = (char*) "sixth" },
+        };
+        const VerifyUnitsResult result = {
+                .diagnostics = items,
+                .n_diagnostics = ELEMENTSOF(items),
+        };
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *reply = NULL;
+
+        ASSERT_OK(verify_result_build_varlink_reply(&result, &reply));
+
+        const sd_varlink_symbol *method = ASSERT_NOT_NULL(varlink_idl_find_symbol(
+                        &vl_interface_io_systemd_Analyze,
+                        SD_VARLINK_METHOD,
+                        "Verify"));
+        ASSERT_OK(varlink_idl_validate_method_reply(
+                        method,
+                        reply,
+                        /* flags= */ 0,
+                        /* reterr_bad_field= */ NULL));
+
+        sd_json_variant *array = ASSERT_NOT_NULL(sd_json_variant_by_key(reply, "diagnostics"));
+        ASSERT_TRUE(sd_json_variant_is_array(array));
+        ASSERT_EQ(sd_json_variant_elements(array), ELEMENTSOF(items));
+
+        static const char * const severities[] = {
+                "error",
+                "error",
+                "warning",
+                "notice",
+                "info",
+                "error",
+        };
+
+        FOREACH_ELEMENT(severity, severities) {
+                size_t i = severity - severities;
+                sd_json_variant *diagnostic = ASSERT_NOT_NULL(sd_json_variant_by_index(array, i));
+
+                ASSERT_STREQ(
+                                sd_json_variant_string(sd_json_variant_by_key(diagnostic, "severity")),
+                                *severity);
+                ASSERT_STREQ(sd_json_variant_string(sd_json_variant_by_key(diagnostic, "message")),
+                             items[i].message);
+        }
+
+        sd_json_variant *first = ASSERT_NOT_NULL(sd_json_variant_by_index(array, 0));
+        ASSERT_STREQ(sd_json_variant_string(sd_json_variant_by_key(first, "unit")), "first.service");
+        ASSERT_STREQ(sd_json_variant_string(sd_json_variant_by_key(first, "configurationFile")),
+                     "/tmp/first.service");
+        ASSERT_EQ(sd_json_variant_unsigned(sd_json_variant_by_key(first, "configurationLine")), 7u);
+        ASSERT_STREQ(sd_json_variant_string(sd_json_variant_by_key(first, "messageId")),
+                     SD_MESSAGE_INVALID_CONFIGURATION_STR);
+
+        sd_json_variant *second = ASSERT_NOT_NULL(sd_json_variant_by_index(array, 1));
+        ASSERT_NULL(sd_json_variant_by_key(second, "unit"));
+        ASSERT_NULL(sd_json_variant_by_key(second, "configurationFile"));
+        ASSERT_NULL(sd_json_variant_by_key(second, "configurationLine"));
+        ASSERT_NULL(sd_json_variant_by_key(second, "messageId"));
+}
+
+TEST(empty_reply) {
+        const VerifyUnitsResult result = {};
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *reply = NULL;
+
+        ASSERT_OK(verify_result_build_varlink_reply(&result, &reply));
+
+        sd_json_variant *array = ASSERT_NOT_NULL(sd_json_variant_by_key(reply, "diagnostics"));
+        ASSERT_TRUE(sd_json_variant_is_array(array));
+        ASSERT_EQ(sd_json_variant_elements(array), 0u);
+}
+
+TEST(reply_serialization) {
+        VerifyDiagnostic diagnostic = {
+                .priority = LOG_WARNING,
+                .message = (char*) "quote: \"; control: \n",
+        };
+        const VerifyUnitsResult result = {
+                .diagnostics = &diagnostic,
+                .n_diagnostics = 1,
+        };
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *envelope = NULL, *reply = NULL;
+        _cleanup_free_ char *formatted = NULL;
+
+        ASSERT_OK(verify_result_build_varlink_reply(&result, &reply));
+        ASSERT_OK(sd_json_buildo(&envelope, SD_JSON_BUILD_PAIR_VARIANT("parameters", reply)));
+        ASSERT_OK(sd_json_variant_format(envelope, /* flags= */ 0, &formatted));
+        ASSERT_STREQ(
+                        formatted,
+                        "{\"parameters\":{\"diagnostics\":[{\"severity\":\"warning\","
+                        "\"message\":\"quote: \\\"; control: \\n\"}]}}");
+}
+
+static void mask_single_character_instances_except(
+                const char *directory,
+                const char *template,
+                const char *except) {
+
+        assert(directory);
+        assert(unit_name_is_valid(template, UNIT_NAME_TEMPLATE));
+        assert(unit_instance_is_valid(except));
+        assert(strlen(except) == 1);
+
+        for (unsigned c = 1; c < 128; c++) {
+                char instance[] = { (char) c, 0 };
+                _cleanup_free_ char *name = NULL, *path = NULL;
+
+                if (!unit_instance_is_valid(instance) || streq(instance, except))
+                        continue;
+
+                ASSERT_OK(unit_name_replace_instance(template, instance, &name));
+                path = ASSERT_NOT_NULL(path_join(directory, name));
+                ASSERT_OK_ERRNO(symlink("/dev/null", path));
+        }
+}
+
+TEST(collect_unit_files) {
+        _cleanup_(verify_units_result_done) VerifyUnitsResult result = {};
+        _cleanup_(rm_rf_physical_and_freep) char *tmp = NULL;
+        _cleanup_strv_free_ char **paths = NULL, **lookup_path = NULL;
+        _cleanup_free_ char *high = NULL, *local = NULL, *low = NULL, *runtime = NULL;
+        _cleanup_free_ char *broken = NULL, *duplicate_high = NULL, *duplicate_low = NULL;
+        _cleanup_free_ char *local_unit = NULL, *regular = NULL, *real = NULL;
+        _cleanup_free_ char *template = NULL, *concrete = NULL, *template_mask = NULL;
+        _cleanup_free_ char *long_padding = NULL, *long_name = NULL, *long_template = NULL;
+        _cleanup_free_ char *other_padding = NULL, *other_name = NULL, *other_template = NULL;
+        _cleanup_free_ char *max_padding = NULL, *max_name = NULL, *max_template = NULL;
+        _cleanup_free_ char *alias = NULL, *masked = NULL, *runtime_masked = NULL;
+        _cleanup_free_ char *template_name = NULL;
+        const char *entry;
+        int r;
+
+        ASSERT_OK(mkdtemp_malloc("/tmp/test-analyze:verify-varlink.XXXXXX", &tmp));
+        high = ASSERT_NOT_NULL(path_join(tmp, SYSTEM_CONFIG_UNIT_DIR));
+        local = ASSERT_NOT_NULL(path_join(tmp, "/usr/local/lib/systemd/system"));
+        low = ASSERT_NOT_NULL(path_join(tmp, SYSTEM_DATA_UNIT_DIR));
+        runtime = ASSERT_NOT_NULL(path_join(tmp, "/run/systemd/system"));
+
+        duplicate_high = ASSERT_NOT_NULL(path_join(high, "duplicate.service"));
+        duplicate_low = ASSERT_NOT_NULL(path_join(low, "duplicate.service"));
+        local_unit = ASSERT_NOT_NULL(path_join(local, "local.service"));
+        regular = ASSERT_NOT_NULL(path_join(low, "regular.service"));
+        real = ASSERT_NOT_NULL(path_join(high, "real.service"));
+        template = ASSERT_NOT_NULL(path_join(low, "template@.target"));
+        concrete = ASSERT_NOT_NULL(path_join(low, "template@a.target"));
+        template_mask = ASSERT_NOT_NULL(path_join(high, "template@b.target"));
+        broken = ASSERT_NOT_NULL(path_join(low, "broken.service"));
+        alias = ASSERT_NOT_NULL(path_join(high, "alias.service"));
+        masked = ASSERT_NOT_NULL(path_join(high, "masked.service"));
+        runtime_masked = ASSERT_NOT_NULL(path_join(runtime, "runtime-masked.service"));
+
+        long_padding = ASSERT_NOT_NULL(strrep(
+                        "x", UNIT_NAME_MAX - 2 - STRLEN("@.target") - STRLEN("long-")));
+        long_name = ASSERT_NOT_NULL(strjoin("long-", long_padding, "@.target"));
+        ASSERT_EQ(strlen(long_name), (size_t) UNIT_NAME_MAX - 2);
+        long_template = ASSERT_NOT_NULL(path_join(low, long_name));
+
+        other_padding = ASSERT_NOT_NULL(strrep(
+                        "y", UNIT_NAME_MAX - 2 - STRLEN("@.target") - STRLEN("other-")));
+        other_name = ASSERT_NOT_NULL(strjoin("other-", other_padding, "@.target"));
+        ASSERT_EQ(strlen(other_name), (size_t) UNIT_NAME_MAX - 2);
+        other_template = ASSERT_NOT_NULL(path_join(low, other_name));
+
+        max_padding = ASSERT_NOT_NULL(strrep(
+                        "z", UNIT_NAME_MAX - 1 - STRLEN("@.target") - STRLEN("max-")));
+        max_name = ASSERT_NOT_NULL(strjoin("max-", max_padding, "@.target"));
+        ASSERT_EQ(strlen(max_name), (size_t) UNIT_NAME_MAX - 1);
+        max_template = ASSERT_NOT_NULL(path_join(low, max_name));
+
+        FOREACH_ARGUMENT(
+                        entry,
+                        duplicate_high,
+                        duplicate_low,
+                        local_unit,
+                        regular,
+                        real,
+                        concrete,
+                        long_template,
+                        other_template,
+                        max_template)
+                ASSERT_OK(write_string_file(
+                                entry,
+                                "[Unit]\n",
+                                WRITE_STRING_FILE_CREATE|WRITE_STRING_FILE_MKDIR_0755));
+        ASSERT_OK(write_string_file(
+                        template,
+                        "[Unit]\nUnknownTemplateSetting=yes\n",
+                        WRITE_STRING_FILE_CREATE));
+
+        ASSERT_OK_ERRNO(symlink("missing.service", broken));
+        ASSERT_OK_ERRNO(symlink("real.service", alias));
+        ASSERT_OK_ERRNO(symlink("/dev/null", masked));
+        ASSERT_OK_ERRNO(symlink("/dev/null", template_mask));
+        ASSERT_OK(mkdir_p(runtime, 0755));
+        ASSERT_OK_ERRNO(symlink("/dev/null", runtime_masked));
+
+        /* Each of these one-character-capacity templates has a free instance, but no instance is free
+         * for both. This makes a global instance choice impossible while per-template choices work. */
+        mask_single_character_instances_except(high, long_name, "a");
+        mask_single_character_instances_except(high, other_name, "b");
+
+        ASSERT_OK(verify_varlink_collect_unit_files(
+                        RUNTIME_SCOPE_SYSTEM,
+                        tmp,
+                        &paths,
+                        &lookup_path));
+
+        ASSERT_EQ(strv_length(paths), 10u);
+        FOREACH_ARGUMENT(entry, duplicate_high, real, local_unit, broken, max_template, regular, concrete)
+                ASSERT_TRUE(strv_contains(paths, entry));
+        FOREACH_ARGUMENT(
+                        entry,
+                        duplicate_low,
+                        template,
+                        long_template,
+                        other_template,
+                        alias,
+                        masked,
+                        runtime_masked)
+                ASSERT_FALSE(strv_contains(paths, entry));
+
+        ASSERT_OK(path_extract_filename(template, &template_name));
+
+        const char *template_instance_path = NULL, *long_instance_path = NULL, *other_instance_path = NULL;
+        STRV_FOREACH(candidate_path, paths) {
+                _cleanup_free_ char *candidate_template = NULL;
+                const char *name = last_path_component(*candidate_path);
+
+                if (!unit_name_is_valid(name, UNIT_NAME_INSTANCE))
+                        continue;
+
+                ASSERT_OK(unit_name_template(name, &candidate_template));
+                if (streq(candidate_template, template_name) && !path_equal(*candidate_path, concrete))
+                        template_instance_path = *candidate_path;
+                else if (streq(candidate_template, long_name))
+                        long_instance_path = *candidate_path;
+                else if (streq(candidate_template, other_name))
+                        other_instance_path = *candidate_path;
+        }
+
+        ASSERT_NOT_NULL(template_instance_path);
+        ASSERT_NOT_NULL(long_instance_path);
+        ASSERT_NOT_NULL(other_instance_path);
+
+        _cleanup_free_ char *template_instance = NULL, *long_instance = NULL, *other_instance = NULL;
+        ASSERT_EQ(unit_name_to_instance(last_path_component(template_instance_path), &template_instance),
+                  UNIT_NAME_INSTANCE);
+        ASSERT_EQ(unit_name_to_instance(last_path_component(long_instance_path), &long_instance),
+                  UNIT_NAME_INSTANCE);
+        ASSERT_EQ(unit_name_to_instance(last_path_component(other_instance_path), &other_instance),
+                  UNIT_NAME_INSTANCE);
+        ASSERT_TRUE(unit_instance_is_valid(template_instance));
+        ASSERT_FALSE(STR_IN_SET(template_instance, "a", "b"));
+        ASSERT_EQ(strlen(long_instance), 1u);
+        ASSERT_EQ(strlen(other_instance), 1u);
+        ASSERT_FALSE(streq(long_instance, other_instance));
+        ASSERT_EQ(strlen(last_path_component(long_instance_path)), (size_t) UNIT_NAME_MAX - 1);
+        ASSERT_EQ(strlen(last_path_component(other_instance_path)), (size_t) UNIT_NAME_MAX - 1);
+
+        ASSERT_NOT_NULL(strchr(tmp, ':'));
+        ASSERT_TRUE(strv_contains(lookup_path, high));
+        ASSERT_TRUE(strv_contains(lookup_path, local));
+        ASSERT_TRUE(strv_contains(lookup_path, low));
+
+        const VerifyUnitsParameters parameters = {
+                .filenames = paths,
+                .runtime_scope = RUNTIME_SCOPE_SYSTEM,
+                .recursive_errors = RECURSIVE_ERRORS_YES,
+                .root = tmp,
+                .instance = "test_instance",
+                .lookup_path_override = lookup_path,
+                .suppress_output = true,
+        };
+
+        r = verify_units(&parameters, &result);
+        if (manager_errno_skip_test(r)) {
+                log_notice_errno(r, "Skipping verification, manager startup failed: %m");
+                return;
+        }
+        ASSERT_OK(r);
+
+        bool found_invalid_template = false, found_uninstantiable_template = false;
+        FOREACH_ARRAY(diagnostic, result.diagnostics, result.n_diagnostics) {
+                if (streq_ptr(diagnostic->unit, last_path_component(template_instance_path)) &&
+                    streq_ptr(diagnostic->configuration_file, template) &&
+                    streq_ptr(diagnostic->message_id, SD_MESSAGE_INVALID_CONFIGURATION_STR)) {
+                        found_invalid_template = true;
+                        continue;
+                }
+
+                if (!diagnostic->unit &&
+                    streq_ptr(diagnostic->configuration_file, max_template) &&
+                    startswith(diagnostic->message, "Failed to prepare filename "))
+                        found_uninstantiable_template = true;
+        }
+        ASSERT_TRUE(found_invalid_template);
+        ASSERT_TRUE(found_uninstantiable_template);
+}
+
+TEST(scan_lookup_path_override) {
+        _cleanup_(verify_units_result_done) VerifyUnitsResult result = {};
+        _cleanup_(rm_rf_physical_and_freep) char *tmp = NULL;
+        _cleanup_strv_free_ char **paths = NULL, **lookup_path = NULL;
+        _cleanup_free_ char *control = NULL, *low = NULL, *main = NULL, *shadow = NULL, *mask = NULL;
+        int r;
+
+        ASSERT_OK(mkdtemp_malloc("/tmp/test-analyze-verify-varlink-path.XXXXXX", &tmp));
+        control = ASSERT_NOT_NULL(path_join(tmp, "/run/systemd/system.control"));
+        low = ASSERT_NOT_NULL(path_join(tmp, SYSTEM_DATA_UNIT_DIR));
+        main = ASSERT_NOT_NULL(path_join(low, "main.target"));
+        shadow = ASSERT_NOT_NULL(path_join(low, "shadowed.target"));
+        mask = ASSERT_NOT_NULL(path_join(control, "shadowed.target"));
+
+        ASSERT_OK(write_string_file(
+                        main,
+                        "[Unit]\nRequires=shadowed.target\n",
+                        WRITE_STRING_FILE_CREATE|WRITE_STRING_FILE_MKDIR_0755));
+        ASSERT_OK(write_string_file(shadow, "[Unit]\n", WRITE_STRING_FILE_CREATE));
+        ASSERT_OK(mkdir_p(control, 0755));
+        ASSERT_OK_ERRNO(symlink("/dev/null", mask));
+
+        ASSERT_OK(verify_varlink_collect_unit_files(
+                        RUNTIME_SCOPE_SYSTEM,
+                        tmp,
+                        &paths,
+                        &lookup_path));
+        ASSERT_TRUE(strv_equal(paths, STRV_MAKE(main)));
+        ASSERT_TRUE(strv_contains(lookup_path, control));
+        ASSERT_TRUE(strv_contains(lookup_path, low));
+
+        const VerifyUnitsParameters parameters = {
+                .filenames = paths,
+                .runtime_scope = RUNTIME_SCOPE_SYSTEM,
+                .recursive_errors = RECURSIVE_ERRORS_YES,
+                .root = tmp,
+                .instance = "test_instance",
+                .lookup_path_override = lookup_path,
+                .suppress_output = true,
+        };
+
+        r = verify_units(&parameters, &result);
+        if (manager_errno_skip_test(r)) {
+                log_notice_errno(r, "Skipping verification, manager startup failed: %m");
+                return;
+        }
+        ASSERT_OK(r);
+        ASSERT_LT(result.legacy_status, 0);
+}
+
+DEFINE_TEST_MAIN(LOG_INFO);

--- a/src/analyze/test-verify.c
+++ b/src/analyze/test-verify.c
@@ -2,17 +2,17 @@
 
 #include <stdlib.h>
 
-#include "analyze.h"
+#include "sd-messages.h"
+
 #include "analyze-verify-util.h"
 #include "execute.h"
 #include "fileio.h"
 #include "path-util.h"
 #include "rm-rf.h"
 #include "string-util.h"
+#include "strv.h"
 #include "tests.h"
 #include "tmpfile-util.h"
-
-const char *arg_instance = "test_instance";
 
 TEST(verify_nonexistent) {
         /* Negative cases */
@@ -52,17 +52,305 @@ TEST(verify_set_unit_path) {
         _cleanup_free_ char *old_saved = getenv("SYSTEMD_UNIT_PATH") ? strdup(getenv("SYSTEMD_UNIT_PATH")) : NULL;
         ASSERT_TRUE(old_saved || !getenv("SYSTEMD_UNIT_PATH"));
 
-        test_verify_set_unit_path_one(NULL, ":");
+        test_verify_set_unit_path_one(/* old= */ NULL, ":");
         test_verify_set_unit_path_one("", "");
         test_verify_set_unit_path_one(":", ":");
         test_verify_set_unit_path_one("/foo:", ":/foo:");
-        test_verify_set_unit_path_one(":foo", NULL);
-        test_verify_set_unit_path_one("/foo::/bar", NULL);
+        test_verify_set_unit_path_one(":foo", /* expected= */ NULL);
+        test_verify_set_unit_path_one("/foo::/bar", /* expected= */ NULL);
 
         if (old_saved)
                 ASSERT_OK_ERRNO(setenv("SYSTEMD_UNIT_PATH", old_saved, 1));
         else
                 ASSERT_OK_ERRNO(unsetenv("SYSTEMD_UNIT_PATH"));
+}
+
+TEST(verify_units_restores_unit_path) {
+        _cleanup_(rm_rf_physical_and_freep) char *tmp = NULL;
+        _cleanup_free_ char *first = NULL, *second = NULL;
+        const bool had_unit_path = getenv("SYSTEMD_UNIT_PATH");
+        _cleanup_free_ char *old_unit_path = had_unit_path ? strdup(getenv("SYSTEMD_UNIT_PATH")) : NULL;
+        char *filenames[2] = {};
+        char *filename;
+        int r;
+
+        ASSERT_TRUE(old_unit_path || !had_unit_path);
+        ASSERT_OK(mkdtemp_malloc("/tmp/test-verify-restore.XXXXXX", &tmp));
+        first = ASSERT_NOT_NULL(path_join(tmp, "first.service"));
+        second = ASSERT_NOT_NULL(path_join(tmp, "second.service"));
+        ASSERT_OK(write_string_file(first, "[Unit]\n", WRITE_STRING_FILE_CREATE));
+        ASSERT_OK(write_string_file(second, "[Unit]\n", WRITE_STRING_FILE_CREATE));
+
+        ASSERT_OK_ERRNO(setenv("SYSTEMD_UNIT_PATH", ":", /* overwrite= */ true));
+
+        VerifyUnitsParameters parameters = {
+                .filenames = filenames,
+                .runtime_scope = RUNTIME_SCOPE_SYSTEM,
+                .recursive_errors = RECURSIVE_ERRORS_NO,
+                .instance = "test_instance",
+                .suppress_output = true,
+        };
+
+        FOREACH_ARGUMENT(filename, first, second) {
+                _cleanup_(verify_units_result_done) VerifyUnitsResult result = {};
+
+                filenames[0] = filename;
+                r = verify_units(&parameters, &result);
+                ASSERT_STREQ(getenv("SYSTEMD_UNIT_PATH"), ":");
+                if (manager_errno_skip_test(r)) {
+                        log_notice_errno(r, "Skipping test, manager startup failed: %m");
+                        break;
+                }
+                ASSERT_OK(r);
+        }
+
+        if (had_unit_path)
+                ASSERT_OK_ERRNO(setenv("SYSTEMD_UNIT_PATH", old_unit_path, /* overwrite= */ true));
+        else
+                ASSERT_OK_ERRNO(unsetenv("SYSTEMD_UNIT_PATH"));
+}
+
+TEST(verify_units_empty) {
+        _cleanup_(verify_units_result_done) VerifyUnitsResult result = {};
+
+        ASSERT_OK(verify_units(&(VerifyUnitsParameters) {}, &result));
+        ASSERT_OK(result.legacy_status);
+        ASSERT_EQ(result.n_diagnostics, 0u);
+}
+
+static VerifyDiagnostic* find_diagnostic(
+                VerifyUnitsResult *result,
+                const char *unit,
+                const char *configuration_file,
+                const char *message_id) {
+
+        FOREACH_ARRAY(diagnostic, result->diagnostics, result->n_diagnostics)
+                if (streq_ptr(diagnostic->unit, unit) &&
+                    streq_ptr(diagnostic->configuration_file, configuration_file) &&
+                    streq_ptr(diagnostic->message_id, message_id))
+                        return diagnostic;
+
+        return NULL;
+}
+
+static VerifyDiagnostic* find_diagnostic_by_message_id(
+                VerifyUnitsResult *result,
+                const char *message_id) {
+
+        FOREACH_ARRAY(diagnostic, result->diagnostics, result->n_diagnostics)
+                if (streq_ptr(diagnostic->message_id, message_id))
+                        return diagnostic;
+
+        return NULL;
+}
+
+TEST(verify_units_result) {
+        _cleanup_(verify_units_result_done) VerifyUnitsResult result = {};
+        _cleanup_(rm_rf_physical_and_freep) char *tmp = NULL;
+        _cleanup_free_ char *bad = NULL, *invalid = NULL, *load_error = NULL, *missing = NULL, *parse = NULL;
+        char *filenames[3];
+        int r;
+
+        ASSERT_OK(mkdtemp_malloc("/tmp/test-verify.XXXXXX", &tmp));
+        bad = ASSERT_NOT_NULL(path_join(tmp, "bad.service"));
+        invalid = ASSERT_NOT_NULL(path_join(tmp, "invalid"));
+        load_error = ASSERT_NOT_NULL(path_join(tmp, "load-error.service"));
+        missing = ASSERT_NOT_NULL(path_join(tmp, "missing.service"));
+        parse = ASSERT_NOT_NULL(path_join(tmp, "parse.service"));
+        ASSERT_OK(write_string_file(
+                        bad,
+                        "[Unit]\nUnknownSetting=yes\n[Service]\nExecStart=/bin/true\n",
+                        WRITE_STRING_FILE_CREATE));
+        ASSERT_OK(write_string_file(load_error, "[Service]\n", WRITE_STRING_FILE_CREATE));
+        ASSERT_OK(write_string_file(
+                        parse,
+                        "[Service]\nRemainAfterExit=invalid\nExecStart=/bin/true\n",
+                        WRITE_STRING_FILE_CREATE));
+
+        VerifyUnitsParameters parameters = {
+                .filenames = filenames,
+                .runtime_scope = RUNTIME_SCOPE_SYSTEM,
+                .recursive_errors = _RECURSIVE_ERRORS_INVALID,
+                .instance = "test_instance",
+                .suppress_output = true,
+        };
+
+        filenames[0] = bad;
+        filenames[1] = NULL;
+        filenames[2] = NULL;
+
+        r = verify_units(&parameters, &result);
+        if (manager_errno_skip_test(r)) {
+                log_notice_errno(r, "Skipping test, manager startup failed: %m");
+                return;
+        }
+        ASSERT_OK(r);
+        ASSERT_EQ(result.legacy_status, 0);
+
+        VerifyDiagnostic *diagnostic = ASSERT_NOT_NULL(find_diagnostic(
+                        &result, "bad.service", bad, SD_MESSAGE_INVALID_CONFIGURATION_STR));
+        ASSERT_STREQ(diagnostic->configuration_file, bad);
+        ASSERT_EQ(diagnostic->configuration_line, 2u);
+
+        verify_units_result_done(&result);
+        parameters.recursive_errors = RECURSIVE_ERRORS_NO;
+        ASSERT_OK(verify_units(&parameters, &result));
+        ASSERT_ERROR(result.legacy_status, ENOTRECOVERABLE);
+
+        /* Diagnostics and recursive error handling must not depend on the selected log verbosity. The
+         * unknown-key path is gated by log_syntax_enabled(), while parse errors call log_syntax_internal()
+         * directly, so keep both cases covered. */
+        int old_max_level = log_set_max_level(LOG_ERR);
+
+        verify_units_result_done(&result);
+        parameters.suppress_output = false;
+        ASSERT_OK(verify_units(&parameters, &result));
+        ASSERT_ERROR(result.legacy_status, ENOTRECOVERABLE);
+        ASSERT_NOT_NULL(find_diagnostic(
+                        &result, "bad.service", bad, SD_MESSAGE_INVALID_CONFIGURATION_STR));
+
+        verify_units_result_done(&result);
+        filenames[0] = parse;
+        ASSERT_OK(verify_units(&parameters, &result));
+        ASSERT_ERROR(result.legacy_status, ENOTRECOVERABLE);
+        ASSERT_NOT_NULL(find_diagnostic(
+                        &result, "parse.service", parse, SD_MESSAGE_INVALID_CONFIGURATION_STR));
+
+        log_set_max_level(old_max_level);
+        parameters.suppress_output = true;
+
+        verify_units_result_done(&result);
+        filenames[0] = load_error;
+        ASSERT_OK(verify_units(&parameters, &result));
+        ASSERT_LT(result.legacy_status, 0);
+        diagnostic = ASSERT_NOT_NULL(find_diagnostic(
+                        &result, "load-error.service", load_error, /* message_id= */ NULL));
+        ASSERT_STREQ(diagnostic->configuration_file, load_error);
+
+        verify_units_result_done(&result);
+        filenames[0] = missing;
+        ASSERT_OK(verify_units(&parameters, &result));
+        ASSERT_LT(result.legacy_status, 0);
+        diagnostic = ASSERT_NOT_NULL(find_diagnostic(
+                        &result, "missing.service", missing, /* message_id= */ NULL));
+        ASSERT_STREQ(diagnostic->configuration_file, missing);
+
+        verify_units_result_done(&result);
+        filenames[0] = invalid;
+        ASSERT_OK(verify_units(&parameters, &result));
+        ASSERT_ERROR(result.legacy_status, EINVAL);
+        diagnostic = ASSERT_NOT_NULL(find_diagnostic(
+                        &result, /* unit= */ NULL, invalid, /* message_id= */ NULL));
+        ASSERT_STREQ(diagnostic->configuration_file, invalid);
+}
+
+TEST(verify_units_cycles) {
+        _cleanup_(verify_units_result_done) VerifyUnitsResult result = {};
+        _cleanup_free_ char *unit_dir = NULL, *unbreakable = NULL, *breakable = NULL;
+        VerifyDiagnostic *diagnostic;
+        char *filenames[2];
+        int r;
+
+        ASSERT_OK(get_testdata_dir("test-engine", &unit_dir));
+        unbreakable = ASSERT_NOT_NULL(path_join(unit_dir, "d.service"));
+        breakable = ASSERT_NOT_NULL(path_join(unit_dir, "e.service"));
+
+        VerifyUnitsParameters parameters = {
+                .filenames = filenames,
+                .runtime_scope = RUNTIME_SCOPE_SYSTEM,
+                .recursive_errors = RECURSIVE_ERRORS_YES,
+                .instance = "test_instance",
+                .suppress_output = true,
+        };
+
+        filenames[0] = unbreakable;
+        filenames[1] = NULL;
+
+        r = verify_units(&parameters, &result);
+        if (manager_errno_skip_test(r)) {
+                log_notice_errno(r, "Skipping test, manager startup failed: %m");
+                return;
+        }
+        ASSERT_OK(r);
+        ASSERT_LT(result.legacy_status, 0);
+        diagnostic = ASSERT_NOT_NULL(find_diagnostic_by_message_id(
+                        &result, SD_MESSAGE_UNIT_ORDERING_CYCLE_STR));
+        ASSERT_NOT_NULL(diagnostic->unit);
+        ASSERT_TRUE(STR_IN_SET(diagnostic->unit, "a.service", "b.service", "d.service"));
+        diagnostic = ASSERT_NOT_NULL(find_diagnostic_by_message_id(
+                        &result, SD_MESSAGE_CANT_BREAK_ORDERING_CYCLE_STR));
+        ASSERT_NOT_NULL(diagnostic->unit);
+        ASSERT_TRUE(STR_IN_SET(diagnostic->unit, "a.service", "b.service", "d.service"));
+
+        verify_units_result_done(&result);
+        filenames[0] = breakable;
+
+        ASSERT_OK(verify_units(&parameters, &result));
+        ASSERT_OK(result.legacy_status);
+        diagnostic = ASSERT_NOT_NULL(find_diagnostic_by_message_id(
+                        &result, SD_MESSAGE_UNIT_ORDERING_CYCLE_STR));
+        ASSERT_NOT_NULL(diagnostic->unit);
+        ASSERT_TRUE(STR_IN_SET(diagnostic->unit, "a.service", "b.service", "e.service"));
+        diagnostic = ASSERT_NOT_NULL(find_diagnostic_by_message_id(
+                        &result, SD_MESSAGE_DELETING_JOB_BECAUSE_ORDERING_CYCLE_STR));
+        ASSERT_NOT_NULL(diagnostic->unit);
+        ASSERT_TRUE(STR_IN_SET(diagnostic->unit, "a.service", "b.service", "e.service"));
+}
+
+TEST(verify_units_manager_diagnostics) {
+        _cleanup_(verify_units_result_done) VerifyUnitsResult result = {};
+        _cleanup_(rm_rf_physical_and_freep) char *tmp = NULL;
+        _cleanup_free_ char *service = NULL;
+        char *filenames[2];
+        int r;
+
+        ASSERT_OK(mkdtemp_malloc("/tmp/test-verify-diagnostics.XXXXXX", &tmp));
+        service = ASSERT_NOT_NULL(path_join(tmp, "diagnostics.service"));
+        ASSERT_OK(write_string_file(
+                        service,
+                        "[Service]\n"
+                        "Type=oneshot\n"
+                        "RuntimeMaxSec=1s\n"
+                        "User=unsafe@name\n"
+                        "User=nobody\n"
+                        "ExecStart=true\n",
+                        WRITE_STRING_FILE_CREATE));
+
+        VerifyUnitsParameters parameters = {
+                .filenames = filenames,
+                .runtime_scope = RUNTIME_SCOPE_SYSTEM,
+                .recursive_errors = RECURSIVE_ERRORS_YES,
+                .instance = "test_instance",
+                .suppress_output = true,
+        };
+
+        filenames[0] = service;
+        filenames[1] = NULL;
+
+        r = verify_units(&parameters, &result);
+        if (manager_errno_skip_test(r)) {
+                log_notice_errno(r, "Skipping test, manager startup failed: %m");
+                return;
+        }
+        ASSERT_OK(r);
+        ASSERT_OK(result.legacy_status);
+
+        bool found = false;
+        FOREACH_ARRAY(diagnostic, result.diagnostics, result.n_diagnostics)
+                if (streq_ptr(diagnostic->unit, "diagnostics.service") &&
+                    strstr(diagnostic->message, "RuntimeMaxSec=")) {
+                        found = true;
+                        break;
+                }
+        ASSERT_TRUE(found);
+        ASSERT_NOT_NULL(find_diagnostic(
+                        &result, "diagnostics.service", service,
+                        SD_MESSAGE_UNSAFE_USER_NAME_STR));
+        ASSERT_NOT_NULL(find_diagnostic(
+                        &result,
+                        "diagnostics.service",
+                        service,
+                        SD_MESSAGE_NOBODY_USER_UNSUITABLE_STR));
 }
 
 DEFINE_TEST_MAIN(LOG_DEBUG);

--- a/src/basic/log.c
+++ b/src/basic/log.c
@@ -1421,6 +1421,11 @@ int log_get_max_level(void) {
         return log_max_level;
 }
 
+bool log_syntax_enabled(int level) {
+        return LOG_PRI(level) <= log_max_level ||
+                (log_syntax_callback && LOG_PRI(level) <= LOG_INFO);
+}
+
 int log_get_target_max_level(LogTarget target) {
         assert(target >= 0);
         assert(target < _LOG_TARGET_SINGLE_MAX);
@@ -1564,11 +1569,12 @@ int log_syntax_internal(
 
         PROTECT_ERRNO;
 
-        if (log_syntax_callback)
-                log_syntax_callback(unit, level, log_syntax_callback_userdata);
+        assert(format);
 
-        if (_likely_(LOG_PRI(level) > log_max_level) ||
-            log_target == LOG_TARGET_NULL)
+        bool callback_enabled = log_syntax_callback && LOG_PRI(level) <= LOG_INFO;
+
+        if (!callback_enabled &&
+            (_likely_(LOG_PRI(level) > log_max_level) || log_target == LOG_TARGET_NULL))
                 return -ERRNO_VALUE(error);
 
         char buffer[LINE_MAX];
@@ -1580,6 +1586,21 @@ int log_syntax_internal(
         va_start(ap, format);
         (void) vsnprintf(buffer, sizeof buffer, format, ap);
         va_end(ap);
+
+        if (callback_enabled)
+                log_syntax_callback(
+                                &(LogSyntaxRecord) {
+                                        .priority = LOG_PRI(level),
+                                        .message = buffer,
+                                        .unit = unit,
+                                        .config_file = config_file,
+                                        .config_line = config_line,
+                                },
+                                log_syntax_callback_userdata);
+
+        if (_likely_(LOG_PRI(level) > log_max_level) ||
+            log_target == LOG_TARGET_NULL)
+                return -ERRNO_VALUE(error);
 
         if (unit)
                 unit_fmt = getpid_cached() == 1 ? "UNIT=%s" : "USER_UNIT=%s";

--- a/src/basic/log.h
+++ b/src/basic/log.h
@@ -22,6 +22,14 @@ typedef enum LogTarget{
         _LOG_TARGET_INVALID = -EINVAL,
 } LogTarget;
 
+typedef struct LogSyntaxRecord {
+        int priority;
+        const char *message;
+        const char *unit;
+        const char *config_file;
+        unsigned config_line;
+} LogSyntaxRecord;
+
 /* This log level disables logging completely. It can only be passed to log_set_max_level() and cannot be
  * used as a regular log level. */
 #define LOG_NULL (LOG_EMERG - 1)
@@ -31,13 +39,12 @@ assert_cc(LOG_NULL == -1);
 #define IS_SYNTHETIC_ERRNO(val)             (((val) >> 30) == 1)
 #define ERRNO_VALUE(val)                    (ABS(val) & ~(1 << 30))
 
-/* The callback function to be invoked when syntax warnings are seen
- * in the unit files. */
-typedef void (*log_syntax_callback_t)(const char *unit, int level, void *userdata);
+/* The record and its strings are borrowed and only valid for the duration of the callback. */
+typedef void (*log_syntax_callback_t)(const LogSyntaxRecord *record, void *userdata);
 void set_log_syntax_callback(log_syntax_callback_t cb, void *userdata);
 
 static inline void clear_log_syntax_callback(dummy_t *dummy) {
-          set_log_syntax_callback(/* cb= */ NULL, /* userdata= */ NULL);
+        set_log_syntax_callback(/* cb= */ NULL, /* userdata= */ NULL);
 }
 
 DECLARE_STRING_TABLE_LOOKUP(log_target, LogTarget);
@@ -50,6 +57,7 @@ void log_settle_target(void);
 int log_set_max_level(int level);
 int log_set_max_level_from_string(const char *e);
 int log_get_max_level(void) _pure_;
+bool log_syntax_enabled(int level) _pure_;
 int log_get_target_max_level(LogTarget target);
 int log_max_levels_to_string(int level, char **ret);
 
@@ -365,7 +373,7 @@ int log_syntax_parse_error_internal(
 #define log_syntax(unit, level, config_file, config_line, error, ...)   \
         ({                                                              \
                 int _level = (level), _e = (error);                     \
-                (log_get_max_level() >= LOG_PRI(_level))                \
+                log_syntax_enabled(_level)                              \
                         ? log_syntax_internal(unit, _level, config_file, config_line, _e, PROJECT_FILE, __LINE__, __func__, __VA_ARGS__) \
                         : -ERRNO_VALUE(_e);                             \
         })
@@ -373,7 +381,7 @@ int log_syntax_parse_error_internal(
 #define log_syntax_invalid_utf8(unit, level, config_file, config_line, rvalue) \
         ({                                                              \
                 int _level = (level);                                   \
-                (log_get_max_level() >= LOG_PRI(_level))                \
+                log_syntax_enabled(_level)                              \
                         ? log_syntax_invalid_utf8_internal(unit, _level, config_file, config_line, PROJECT_FILE, __LINE__, __func__, rvalue) \
                         : -EINVAL;                                      \
         })

--- a/src/core/load-fragment.c
+++ b/src/core/load-fragment.c
@@ -2547,6 +2547,43 @@ int config_parse_service_timeout_abort(
         return 0;
 }
 
+_printf_(6, 7)
+static void dispatch_user_group_diagnostic(
+                const Unit *u,
+                const char *unit,
+                const char *filename,
+                unsigned line,
+                const char *message_id,
+                const char *format, ...) {
+
+        assert(u);
+        assert(u->manager);
+        assert(unit);
+        assert(filename);
+        assert(message_id);
+        assert(format);
+
+        if (!u->manager->test_run_diagnostic_callback)
+                return;
+
+        char buffer[LINE_MAX];
+        PROTECT_ERRNO;
+        va_list ap;
+
+        va_start(ap, format);
+        (void) vsnprintf(buffer, sizeof buffer, format, ap);
+        va_end(ap);
+
+        manager_dispatch_test_run_diagnostic(u->manager, &(ManagerDiagnostic) {
+                        .priority = LOG_NOTICE,
+                        .message = buffer,
+                        .unit = unit,
+                        .configuration_file = filename,
+                        .configuration_line = line,
+                        .message_id = message_id,
+                });
+}
+
 int config_parse_user_group_compat(
                 const char *unit,
                 const char *filename,
@@ -2584,7 +2621,28 @@ int config_parse_user_group_compat(
                 return -ENOEXEC;
         }
 
-        if (strstr(lvalue, "User") && streq(k, NOBODY_USER_NAME))
+        if (u->manager->test_run_diagnostic_callback &&
+            !valid_user_group_name(k, VALID_USER_ALLOW_NUMERIC))
+                dispatch_user_group_diagnostic(
+                                u,
+                                unit,
+                                filename,
+                                line,
+                                SD_MESSAGE_UNSAFE_USER_NAME_STR,
+                                "Accepting user/group name '%s', which does not match strict "
+                                "user/group name rules.",
+                                k);
+
+        if (strstr(lvalue, "User") && streq(k, NOBODY_USER_NAME)) {
+                dispatch_user_group_diagnostic(
+                                u,
+                                unit,
+                                filename,
+                                line,
+                                SD_MESSAGE_NOBODY_USER_UNSUITABLE_STR,
+                                "Special user %s configured, this is not safe!",
+                                k);
+
                 log_struct(LOG_NOTICE,
                            LOG_MESSAGE("%s:%u: Special user %s configured, this is not safe!", filename, line, k),
                            LOG_MESSAGE_ID(SD_MESSAGE_NOBODY_USER_UNSUITABLE_STR),
@@ -2592,6 +2650,7 @@ int config_parse_user_group_compat(
                            LOG_ITEM("OFFENDING_USER=%s", k),
                            LOG_ITEM("CONFIG_FILE=%s", filename),
                            LOG_ITEM("CONFIG_LINE=%u", line));
+        }
 
         return free_and_replace(*user, k);
 }
@@ -2644,6 +2703,18 @@ int config_parse_user_group_strv_compat(
                         log_syntax(unit, LOG_ERR, filename, line, 0, "Invalid user/group name or numeric ID: %s", k);
                         return -ENOEXEC;
                 }
+
+                if (u->manager->test_run_diagnostic_callback &&
+                    !valid_user_group_name(k, VALID_USER_ALLOW_NUMERIC))
+                        dispatch_user_group_diagnostic(
+                                        u,
+                                        unit,
+                                        filename,
+                                        line,
+                                        SD_MESSAGE_UNSAFE_USER_NAME_STR,
+                                        "Accepting user/group name '%s', which does not match strict "
+                                        "user/group name rules.",
+                                        k);
 
                 r = strv_push(users, k);
                 if (r < 0)

--- a/src/core/manager.c
+++ b/src/core/manager.c
@@ -1088,6 +1088,19 @@ int manager_new(RuntimeScope runtime_scope, ManagerTestRunFlags test_run_flags, 
         return 0;
 }
 
+void manager_dispatch_test_run_diagnostic(Manager *m, const ManagerDiagnostic *record) {
+        assert(m);
+        assert(record);
+        assert(record->message);
+
+        if (!m->test_run_diagnostic_callback)
+                return;
+
+        PROTECT_ERRNO;
+
+        m->test_run_diagnostic_callback(record, m->test_run_diagnostic_userdata);
+}
+
 static int manager_setup_notify(Manager *m) {
         int r;
 

--- a/src/core/manager.h
+++ b/src/core/manager.h
@@ -148,6 +148,18 @@ typedef enum ManagerTestRunFlags {
 
 assert_cc((MANAGER_TEST_FULL & UINT8_MAX) == MANAGER_TEST_FULL);
 
+typedef struct ManagerDiagnostic {
+        int priority;
+        const char *message;
+        const char *unit;
+        const char *configuration_file;
+        unsigned configuration_line;
+        const char *message_id;
+} ManagerDiagnostic;
+
+/* The record and its strings are borrowed and only valid for the duration of the callback. */
+typedef void (*ManagerDiagnosticCallback)(const ManagerDiagnostic *record, void *userdata);
+
 /* Various defaults for unit file settings. */
 typedef struct UnitDefaults {
         ExecOutput std_output, std_error;
@@ -415,6 +427,9 @@ typedef struct Manager {
 
         ManagerTestRunFlags test_run_flags;
 
+        ManagerDiagnosticCallback test_run_diagnostic_callback;
+        void *test_run_diagnostic_userdata;
+
         /* If non-zero, exit with the following value when the systemd
          * process terminate. Useful for containers: systemd-nspawn could get
          * the return value. */
@@ -572,6 +587,8 @@ usec_t manager_default_timeout(RuntimeScope scope);
 int manager_new(RuntimeScope scope, ManagerTestRunFlags test_run_flags, Manager **ret);
 Manager* manager_free(Manager *m);
 DEFINE_TRIVIAL_CLEANUP_FUNC(Manager*, manager_free);
+
+void manager_dispatch_test_run_diagnostic(Manager *m, const ManagerDiagnostic *record);
 
 /* One entry parsed out of the upstream "systemd-fdstore-mapping" memfd. Pairs the numeric index from the
  * JSON map to the (unit-id, original fdname) the fd was originally stored as. */

--- a/src/core/transaction.c
+++ b/src/core/transaction.c
@@ -22,6 +22,37 @@ static bool job_matters_to_anchor(Job *job);
 static void transaction_unlink_job(Transaction *tr, Job *j, bool delete_dependencies);
 static void transaction_find_jobs_that_matter_to_anchor(Transaction *tr, unsigned generation);
 
+_printf_(4, 5)
+static void transaction_dispatch_diagnostic(
+                const Job *j,
+                int priority,
+                const char *message_id,
+                const char *format, ...) {
+
+        assert(j);
+        assert(j->manager);
+        assert(message_id);
+        assert(format);
+
+        if (!j->manager->test_run_diagnostic_callback)
+                return;
+
+        char buffer[LINE_MAX];
+        PROTECT_ERRNO;
+        va_list ap;
+
+        va_start(ap, format);
+        (void) vsnprintf(buffer, sizeof buffer, format, ap);
+        va_end(ap);
+
+        manager_dispatch_test_run_diagnostic(j->manager, &(ManagerDiagnostic) {
+                        .priority = priority,
+                        .message = buffer,
+                        .unit = j->unit->id,
+                        .message_id = message_id,
+                });
+}
+
 static void transaction_delete_job(Transaction *tr, Job *j, bool delete_dependencies) {
         assert(tr);
         assert(j);
@@ -468,11 +499,19 @@ static int transaction_verify_order_one(Transaction *tr, Job *j, Job *from, unsi
                 }
 
                 /* logging for j not k here to provide a consistent narrative */
-                if (cycle_path_text)
+                if (cycle_path_text) {
+                        transaction_dispatch_diagnostic(
+                                        j,
+                                        LOG_ERR,
+                                        SD_MESSAGE_UNIT_ORDERING_CYCLE_STR,
+                                        "%s",
+                                        cycle_path_text);
+
                         log_struct(LOG_ERR,
                                    LOG_UNIT_MESSAGE(j->unit, "%s", cycle_path_text),
                                    LOG_MESSAGE_ID(SD_MESSAGE_UNIT_ORDERING_CYCLE_STR),
                                    LOG_ITEM("%s", strempty(unit_ids)));
+                }
 
                 if (set_size(j->manager->transactions_with_cycle) >= CYCLIC_TRANSACTIONS_MAX)
                         log_warning("Too many transactions with ordering cycle, suppressing record.");
@@ -487,6 +526,16 @@ static int transaction_verify_order_one(Transaction *tr, Job *j, Job *from, unsi
                 if (delete) {
                         const char *status;
                         /* logging for j not k here to provide a consistent narrative */
+                        transaction_dispatch_diagnostic(
+                                        j,
+                                        LOG_WARNING,
+                                        SD_MESSAGE_DELETING_JOB_BECAUSE_ORDERING_CYCLE_STR,
+                                        "Job %s/%s deleted to break ordering cycle starting with %s/%s",
+                                        delete->unit->id,
+                                        job_type_to_string(delete->type),
+                                        j->unit->id,
+                                        job_type_to_string(j->type));
+
                         log_struct(LOG_WARNING,
                                    LOG_UNIT_MESSAGE(j->unit,
                                                     "Job %s/%s deleted to break ordering cycle starting with %s/%s",
@@ -510,6 +559,14 @@ static int transaction_verify_order_one(Transaction *tr, Job *j, Job *from, unsi
                         transaction_delete_unit(tr, delete->unit);
                         return -EAGAIN;
                 }
+
+                transaction_dispatch_diagnostic(
+                                j,
+                                LOG_ERR,
+                                SD_MESSAGE_CANT_BREAK_ORDERING_CYCLE_STR,
+                                "Unable to break cycle starting with %s/%s",
+                                j->unit->id,
+                                job_type_to_string(j->type));
 
                 log_struct(LOG_ERR,
                            LOG_UNIT_MESSAGE(j->unit, "Unable to break cycle starting with %s/%s",

--- a/src/core/unit.c
+++ b/src/core/unit.c
@@ -1776,25 +1776,136 @@ fail:
         return log_unit_debug_errno(u, r, "Failed to load configuration: %m");
 }
 
+_printf_(7, 0)
+static int log_unit_internalv(
+                const Unit *u,
+                int level,
+                int error,
+                const char *file,
+                int line,
+                const char *func,
+                const char *format,
+                bool check_unit_log_level,
+                va_list ap) {
+
+        PROTECT_ERRNO;
+
+        assert(u);
+        assert(unit_test_run_diagnostic_enabled(u));
+        assert(LOG_PRI(level) <= LOG_INFO);
+        assert(format);
+
+        char buffer[LINE_MAX];
+        va_list aq;
+
+        errno = ERRNO_VALUE(error);
+
+        va_copy(aq, ap);
+        (void) vsnprintf(buffer, sizeof buffer, format, aq);
+        va_end(aq);
+
+        manager_dispatch_test_run_diagnostic(u->manager, &(ManagerDiagnostic) {
+                        .priority = LOG_PRI(level),
+                        .message = buffer,
+                        .unit = u->id,
+        });
+
+        if (check_unit_log_level && !unit_log_level_test(u, level))
+                return -ERRNO_VALUE(error);
+
+        return log_object_internalv(
+                        level,
+                        error,
+                        file,
+                        line,
+                        func,
+                        unit_log_field(u),
+                        u->id,
+                        unit_invocation_log_field(u),
+                        u->invocation_id_string,
+                        format,
+                        ap);
+}
+
+bool unit_test_run_diagnostic_enabled(const Unit *u) {
+        return u && u->manager && u->manager->test_run_diagnostic_callback;
+}
+
+int log_unit_internal(
+                const Unit *u,
+                int level,
+                int error,
+                const char *file,
+                int line,
+                const char *func,
+                const char *format, ...) {
+
+        va_list ap;
+        int r;
+
+        va_start(ap, format);
+        r = log_unit_internalv(
+                        u,
+                        level,
+                        error,
+                        file,
+                        line,
+                        func,
+                        format,
+                        /* check_unit_log_level= */ false,
+                        ap);
+        va_end(ap);
+
+        return r;
+}
+
 _printf_(7, 8)
-static int log_unit_internal(void *userdata, int level, int error, const char *file, int line, const char *func, const char *format, ...) {
+static int log_unit_condition_internal(
+                void *userdata,
+                int level,
+                int error,
+                const char *file,
+                int line,
+                const char *func,
+                const char *format, ...) {
+
         Unit *u = userdata;
         va_list ap;
         int r;
 
-        if (u && !unit_log_level_test(u, level))
+        bool diagnostic_enabled =
+                _unlikely_(u && LOG_PRI(level) <= LOG_WARNING && unit_test_run_diagnostic_enabled(u));
+
+        if (u && !diagnostic_enabled && !unit_log_level_test(u, level))
                 return -ERRNO_VALUE(error);
 
         va_start(ap, format);
-        if (u)
-                r = log_object_internalv(level, error, file, line, func,
-                                         unit_log_field(u),
-                                         u->id,
-                                         unit_invocation_log_field(u),
-                                         u->invocation_id_string,
-                                         format, ap);
+        if (diagnostic_enabled)
+                r = log_unit_internalv(
+                                u,
+                                level,
+                                error,
+                                file,
+                                line,
+                                func,
+                                format,
+                                /* check_unit_log_level= */ true,
+                                ap);
+        else if (u)
+                r = log_object_internalv(
+                                level,
+                                error,
+                                file,
+                                line,
+                                func,
+                                unit_log_field(u),
+                                u->id,
+                                unit_invocation_log_field(u),
+                                u->invocation_id_string,
+                                format,
+                                ap);
         else
-                r = log_internalv(level, error,  file, line, func, format, ap);
+                r = log_internalv(level, error, file, line, func, format, ap);
         va_end(ap);
 
         return r;
@@ -1817,7 +1928,7 @@ static bool unit_test_condition(Unit *u) {
                                 u->conditions,
                                 env,
                                 condition_type_to_string,
-                                log_unit_internal,
+                                log_unit_condition_internal,
                                 u);
 
         unit_add_to_dbus_queue(u);
@@ -1841,7 +1952,7 @@ static bool unit_test_assert(Unit *u) {
                                 u->asserts,
                                 env,
                                 assert_type_to_string,
-                                log_unit_internal,
+                                log_unit_condition_internal,
                                 u);
 
         unit_add_to_dbus_queue(u);

--- a/src/core/unit.h
+++ b/src/core/unit.h
@@ -1103,6 +1103,16 @@ int unit_compare_priority(Unit *a, Unit *b);
 
 const char* unit_log_field(const Unit *u);
 const char* unit_invocation_log_field(const Unit *u);
+bool unit_test_run_diagnostic_enabled(const Unit *u);
+
+int log_unit_internal(
+                const Unit *u,
+                int level,
+                int error,
+                const char *file,
+                int line,
+                const char *func,
+                const char *format, ...) _printf_(7, 8);
 
 DECLARE_STRING_TABLE_LOOKUP(unit_mount_dependency_type, UnitMountDependencyType);
 UnitDependency unit_mount_dependency_type_to_dependency_type(UnitMountDependencyType t) _pure_;
@@ -1129,8 +1139,14 @@ unsigned unit_normalize_markers(unsigned existing_markers, unsigned new_markers)
                 const ExecContext *_c = _u ? unit_get_exec_context(_u) : NULL; \
                 LOG_CONTEXT_PUSH_IOV(_c ? _c->log_extra_fields : NULL,  \
                                      _c ? _c->n_log_extra_fields : 0);  \
-                _u ? log_object_internal(_l, error, PROJECT_FILE, __LINE__, __func__,  unit_log_field(_u), _u->id, unit_invocation_log_field(_u), _u->invocation_id_string, ##__VA_ARGS__) : \
-                     log_internal(_l, error, PROJECT_FILE, __LINE__, __func__, ##__VA_ARGS__); \
+                _unlikely_(_u && LOG_PRI(_l) <= LOG_INFO && unit_test_run_diagnostic_enabled(_u)) \
+                        ? log_unit_internal(_u, _l, error, PROJECT_FILE, __LINE__, __func__, ##__VA_ARGS__) \
+                        : _u ? log_object_internal(                    \
+                                          _l, error, PROJECT_FILE, __LINE__, __func__, \
+                                          unit_log_field(_u), _u->id, \
+                                          unit_invocation_log_field(_u), _u->invocation_id_string, \
+                                          ##__VA_ARGS__)               \
+                             : log_internal(_l, error, PROJECT_FILE, __LINE__, __func__, ##__VA_ARGS__); \
         })
 
 #define log_unit_full_errno(unit, level, error, ...) \

--- a/src/libsystemd/sd-varlink/test-varlink-idl.c
+++ b/src/libsystemd/sd-varlink/test-varlink-idl.c
@@ -18,6 +18,7 @@
 #include "test-varlink-idl-util.h"
 #include "varlink-idl-util.h"
 #include "varlink-io.systemd.h"
+#include "varlink-io.systemd.Analyze.h"
 #include "varlink-io.systemd.AskPassword.h"
 #include "varlink-io.systemd.BootControl.h"
 #include "varlink-io.systemd.Credentials.h"
@@ -198,6 +199,7 @@ static void test_parse_format_one(const sd_varlink_interface *iface) {
 TEST(parse_format) {
         const sd_varlink_interface* const list[] = {
                 &vl_interface_io_systemd,
+                &vl_interface_io_systemd_Analyze,
                 &vl_interface_io_systemd_AskPassword,
                 &vl_interface_io_systemd_BootControl,
                 &vl_interface_io_systemd_Credentials,

--- a/src/shared/meson.build
+++ b/src/shared/meson.build
@@ -222,6 +222,7 @@ shared_sources = files(
         'userdb-dropin.c',
         'userdb.c',
         'varlink-idl-common.c',
+        'varlink-io.systemd.Analyze.c',
         'varlink-io.systemd.AskPassword.c',
         'varlink-io.systemd.BootControl.c',
         'varlink-io.systemd.Credentials.c',

--- a/src/shared/varlink-io.systemd.Analyze.c
+++ b/src/shared/varlink-io.systemd.Analyze.c
@@ -1,0 +1,49 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include "varlink-io.systemd.Analyze.h"
+
+static SD_VARLINK_DEFINE_STRUCT_TYPE(
+                Diagnostic,
+                SD_VARLINK_FIELD_COMMENT(
+                                "Diagnostic severity. Current values are 'error', 'warning', 'notice', "
+                                "and 'info'; clients must accept additional values."),
+                SD_VARLINK_DEFINE_FIELD(severity, SD_VARLINK_STRING, 0),
+                SD_VARLINK_FIELD_COMMENT(
+                                "Human-readable diagnostic text. This text is not a stable identifier and "
+                                "must not be matched by programs."),
+                SD_VARLINK_DEFINE_FIELD(message, SD_VARLINK_STRING, 0),
+                SD_VARLINK_FIELD_COMMENT("Unit associated with the diagnostic, if known."),
+                SD_VARLINK_DEFINE_FIELD(unit, SD_VARLINK_STRING, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("Configuration file associated with the diagnostic, if known."),
+                SD_VARLINK_DEFINE_FIELD(configurationFile, SD_VARLINK_STRING, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("One-based line number in configurationFile, if known."),
+                SD_VARLINK_DEFINE_FIELD(configurationLine, SD_VARLINK_INT, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT(
+                                "Stable systemd MESSAGE_ID associated with the diagnostic, if one was "
+                                "emitted."),
+                SD_VARLINK_DEFINE_FIELD(messageId, SD_VARLINK_STRING, SD_VARLINK_NULLABLE));
+
+static SD_VARLINK_DEFINE_METHOD(
+                Verify,
+                SD_VARLINK_FIELD_COMMENT(
+                                "Absolute, normalized unit file paths to verify. If unset, null, or empty, "
+                                "all effective non-alias, unmasked unit-file entries selected by this "
+                                "endpoint's lookup path are verified."),
+                SD_VARLINK_DEFINE_INPUT(unitFiles, SD_VARLINK_STRING, SD_VARLINK_ARRAY|SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT(
+                                "Diagnostics in verification order. An empty array means no findings; "
+                                "verification findings are returned as successful method replies."),
+                SD_VARLINK_DEFINE_OUTPUT_BY_TYPE(diagnostics, Diagnostic, SD_VARLINK_ARRAY));
+
+SD_VARLINK_DEFINE_INTERFACE(
+                io_systemd_Analyze,
+                "io.systemd.Analyze",
+                SD_VARLINK_INTERFACE_COMMENT(
+                                "Offline unit-file analysis APIs. The endpoint determines whether the "
+                                "system or user unit lookup path is used."),
+                SD_VARLINK_SYMBOL_COMMENT("A structured unit-file verification diagnostic."),
+                &vl_type_Diagnostic,
+                SD_VARLINK_SYMBOL_COMMENT(
+                                "Verify selected unit files, or the effective non-alias, unmasked entries "
+                                "selected by the lookup path when no selection is supplied."),
+                &vl_method_Verify);

--- a/src/shared/varlink-io.systemd.Analyze.h
+++ b/src/shared/varlink-io.systemd.Analyze.h
@@ -1,0 +1,6 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#pragma once
+
+#include "sd-varlink-idl.h"
+
+extern const sd_varlink_interface vl_interface_io_systemd_Analyze;

--- a/src/test/test-load-fragment.c
+++ b/src/test/test-load-fragment.c
@@ -92,10 +92,12 @@ static void check_execcommand(ExecCommand *c,
         ASSERT_EQ(FLAGS_SET(c->flags, EXEC_COMMAND_IGNORE_FAILURE), ignore);
 }
 
-static void count_syntax_warnings(_unused_ const char *unit, int level, void *userdata) {
+static void count_syntax_warnings(const LogSyntaxRecord *record, void *userdata) {
         unsigned *n_syntax_warnings = ASSERT_PTR(userdata);
 
-        if (level <= LOG_WARNING)
+        assert(record);
+
+        if (record->priority <= LOG_WARNING)
                 (*n_syntax_warnings)++;
 }
 

--- a/src/test/test-log.c
+++ b/src/test/test-log.c
@@ -340,6 +340,107 @@ static void test_log_prefix(void) {
         test_log_syntax();
 }
 
+typedef struct LogSyntaxCallbackTestContext {
+        int expected_priority;
+        const char *expected_message;
+        const char *expected_unit;
+        const char *expected_config_file;
+        unsigned expected_config_line;
+        unsigned n_calls;
+} LogSyntaxCallbackTestContext;
+
+static void log_syntax_test_callback(const LogSyntaxRecord *record, void *userdata) {
+        LogSyntaxCallbackTestContext *ctx = ASSERT_PTR(userdata);
+
+        assert_se(record);
+        assert_se(record->priority == ctx->expected_priority);
+        assert_se(streq_ptr(record->message, ctx->expected_message));
+        assert_se(streq_ptr(record->unit, ctx->expected_unit));
+        assert_se(streq_ptr(record->config_file, ctx->expected_config_file));
+        assert_se(record->config_line == ctx->expected_config_line);
+
+        ctx->n_calls++;
+}
+
+TEST(log_syntax_callback) {
+        LogSyntaxCallbackTestContext ctx = {
+                .expected_priority = LOG_WARNING,
+                .expected_message = "bad setting 1",
+                .expected_unit = "typed.service",
+                .expected_config_file = "/tmp/typed.service",
+                .expected_config_line = 23,
+        };
+        LogTarget old_target = log_get_target();
+        int old_max_level = log_set_max_level(LOG_ERR);
+        unsigned ordinary_format_calls = 0, syntax_format_calls = 0;
+
+        log_set_target(LOG_TARGET_NULL);
+        ASSERT_FALSE(log_syntax_enabled(LOG_WARNING));
+
+        {
+                _unused_ _cleanup_(clear_log_syntax_callback) dummy_t dummy;
+
+                set_log_syntax_callback(log_syntax_test_callback, &ctx);
+                ASSERT_TRUE(log_syntax_enabled(LOG_INFO));
+                ASSERT_FALSE(log_syntax_enabled(LOG_DEBUG));
+
+                log_info("ordinary log %u", ++ordinary_format_calls);
+                ASSERT_EQ(ordinary_format_calls, 0u);
+
+                ASSERT_ERROR(log_syntax(
+                                     "typed.service",
+                                     LOG_DAEMON|LOG_WARNING,
+                                     "/tmp/typed.service",
+                                     23,
+                                     EINVAL,
+                                     "bad setting %u",
+                                     ++syntax_format_calls),
+                             EINVAL);
+                ASSERT_EQ(ctx.n_calls, 1u);
+                ASSERT_EQ(syntax_format_calls, 1u);
+
+                ctx = (LogSyntaxCallbackTestContext) {
+                        .expected_priority = LOG_WARNING,
+                        .expected_message = "optional metadata 2",
+                };
+                ASSERT_ERROR(log_syntax(
+                                     NULL, LOG_WARNING, NULL, 0, EINVAL,
+                                     "optional metadata %u", ++syntax_format_calls),
+                             EINVAL);
+                ASSERT_EQ(ctx.n_calls, 1u);
+
+                ctx = (LogSyntaxCallbackTestContext) {
+                        .expected_priority = LOG_INFO,
+                        .expected_message = "info syntax 3",
+                };
+                ASSERT_ERROR(log_syntax(
+                                     NULL, LOG_INFO, NULL, 0, EINVAL,
+                                     "info syntax %u", ++syntax_format_calls),
+                             EINVAL);
+                ASSERT_EQ(ctx.n_calls, 1u);
+
+                ctx = (LogSyntaxCallbackTestContext) {
+                        .expected_priority = LOG_DEBUG,
+                };
+                ASSERT_ERROR(log_syntax(
+                                     NULL, LOG_DEBUG, NULL, 0, EINVAL,
+                                     "debug syntax %u", ++syntax_format_calls),
+                             EINVAL);
+                ASSERT_EQ(ctx.n_calls, 0u);
+                ASSERT_EQ(syntax_format_calls, 3u);
+        }
+
+        ASSERT_FALSE(log_syntax_enabled(LOG_WARNING));
+        ASSERT_ERROR(log_syntax(
+                             NULL, LOG_WARNING, NULL, 0, EINVAL,
+                             "filtered syntax %u", ++syntax_format_calls),
+                     EINVAL);
+        ASSERT_EQ(syntax_format_calls, 3u);
+
+        log_set_target(old_target);
+        log_set_max_level(old_max_level);
+}
+
 TEST(log_target) {
         for (int target = 0; target < _LOG_TARGET_MAX; target++) {
                 log_set_target(target);

--- a/test/units/TEST-65-ANALYZE.sh
+++ b/test/units/TEST-65-ANALYZE.sh
@@ -520,6 +520,164 @@ systemd-analyze verify "${TESTDATA}/loopy2.service"
 systemd-analyze verify "${TESTDATA}/loopy3.service"
 systemd-analyze verify "${TESTDATA}/loopy4.service"
 
+ANALYZE_SOCKET=/run/systemd/io.systemd.Analyze
+ANALYZE_METHOD=io.systemd.Analyze.Verify
+ANALYZE_FIRST_FILE=/tmp/analyze-varlink-first/analyze-varlink-first.service
+ANALYZE_LATER_FILE=/tmp/analyze-varlink-later/analyze-varlink-later.service
+ANALYZE_DEPENDENCY=analyze-varlink-dependency.service
+SYSTEM_ANALYZE_SCOPE_FILE=/run/systemd/system/analyze-varlink-system-scope.service
+testuser_uid="$(id -u testuser)"
+testuser_gid="$(id -g testuser)"
+USER_ANALYZE_DIR="/run/user/$testuser_uid/systemd/user"
+USER_ANALYZE_SCOPE_FILE="$USER_ANALYZE_DIR/analyze-varlink-user-scope.service"
+USER_ANALYZE_SOCKET="/run/user/$testuser_uid/systemd/io.systemd.Analyze"
+
+install_user_analyze_scope_file() {
+    install -d -o "$testuser_uid" -g "$testuser_gid" "$USER_ANALYZE_DIR"
+    cat <<EOF >"$USER_ANALYZE_SCOPE_FILE"
+[Unit]
+UserScopeMarker=yes
+
+[Service]
+ExecStart=/bin/true
+EOF
+    chown "$testuser_uid:$testuser_gid" "$USER_ANALYZE_SCOPE_FILE"
+}
+
+ANALYZE_FIRST="$(jq -cn --arg unit_file "$ANALYZE_FIRST_FILE" '{unitFiles:[$unit_file]}')"
+ANALYZE_LATER="$(jq -cn --arg unit_file "$ANALYZE_LATER_FILE" '{unitFiles:[$unit_file]}')"
+
+# Both units require the same dependency, which exists only in the first unit's directory.
+mkdir -p "${ANALYZE_FIRST_FILE%/*}" "${ANALYZE_LATER_FILE%/*}"
+
+cat <<EOF >"$ANALYZE_FIRST_FILE"
+[Unit]
+Requires=$ANALYZE_DEPENDENCY
+
+[Service]
+ExecStart=/bin/true
+EOF
+
+cat <<EOF >"${ANALYZE_FIRST_FILE%/*}/$ANALYZE_DEPENDENCY"
+[Service]
+ExecStart=/bin/true
+EOF
+
+cat <<EOF >"$ANALYZE_LATER_FILE"
+[Unit]
+Requires=$ANALYZE_DEPENDENCY
+
+[Service]
+ExecStart=/bin/true
+EOF
+
+cat <<EOF >"$SYSTEM_ANALYZE_SCOPE_FILE"
+[Unit]
+SystemScopeMarker=yes
+
+[Service]
+ExecStart=/bin/true
+EOF
+
+install_user_analyze_scope_file
+
+systemctl start systemd-analyze.socket
+[[ ! -e /run/varlink/registry/io.systemd.Analyze ]]
+
+expect_analyze_invalid_parameter() {
+    local output
+
+    output="$(varlinkctl call --graceful=org.varlink.service.InvalidParameter \
+        "$ANALYZE_SOCKET" "$ANALYZE_METHOD" "$1")"
+    jq -e '.parameter == "unitFiles"' <<<"$output" >/dev/null
+}
+
+expect_analyze_invalid_parameter '{"unitFiles":["relative.service"]}'
+expect_analyze_invalid_parameter \
+    '{"unitFiles":["/tmp/../tmp/analyze-varlink-first/analyze-varlink-first.service"]}'
+
+analyze_reply="$(varlinkctl call -j "$ANALYZE_SOCKET" "$ANALYZE_METHOD" '{}')"
+jq -e '
+        (.diagnostics | type == "array") and
+        any(.diagnostics[]; .configurationFile == $system_file) and
+        all(.diagnostics[]; .configurationFile != $user_file)
+' --arg system_file "$SYSTEM_ANALYZE_SCOPE_FILE" \
+  --arg user_file "$USER_ANALYZE_SCOPE_FILE" \
+  <<<"$analyze_reply"
+
+ANALYZE_REQUESTS=/tmp/analyze-varlink-requests
+ANALYZE_REPLIES=/tmp/analyze-varlink-replies
+
+# Keep both calls on one connection to check request-local path isolation.
+{
+    jq -jcn --arg method "$ANALYZE_METHOD" --argjson parameters "$ANALYZE_FIRST" \
+        '{method:$method, parameters:$parameters}'
+    printf '\0'
+    jq -jcn --arg method "$ANALYZE_METHOD" --argjson parameters "$ANALYZE_LATER" \
+        '{method:$method, parameters:$parameters}'
+    printf '\0'
+} >"$ANALYZE_REQUESTS"
+
+socat -t 10 - "UNIX-CONNECT:$ANALYZE_SOCKET" <"$ANALYZE_REQUESTS" >"$ANALYZE_REPLIES"
+tr '\0' '\n' <"$ANALYZE_REPLIES" >"$ANALYZE_REPLIES.lines"
+mapfile -t analyze_replies <"$ANALYZE_REPLIES.lines"
+assert_eq "${#analyze_replies[@]}" "2"
+jq -e '
+        .error == null and
+        (.parameters.diagnostics | type == "array") and
+        (.parameters.diagnostics | length == 0)
+' <<<"${analyze_replies[0]}"
+jq -e '
+        .error == null and
+        (.parameters.diagnostics | type == "array") and
+        any(
+                .parameters.diagnostics[];
+                .severity == "error" and (.message | contains($dependency))
+        )
+' --arg dependency "$ANALYZE_DEPENDENCY" <<<"${analyze_replies[1]}"
+
+systemctl start "user@$testuser_uid.service"
+install_user_analyze_scope_file
+runas testuser systemctl --user start systemd-analyze.socket
+[[ ! -e "/run/user/$testuser_uid/varlink/registry/io.systemd.Analyze" ]]
+
+analyze_reply="$(runas testuser varlinkctl call -j \
+    "$USER_ANALYZE_SOCKET" "$ANALYZE_METHOD" '{}')"
+jq -e '
+        (.diagnostics | type == "array") and
+        any(.diagnostics[]; .configurationFile == $user_file) and
+        all(.diagnostics[]; .configurationFile != $system_file)
+' --arg user_file "$USER_ANALYZE_SCOPE_FILE" \
+  --arg system_file "$SYSTEM_ANALYZE_SCOPE_FILE" \
+  <<<"$analyze_reply"
+
+(! runas testuser varlinkctl call "$ANALYZE_SOCKET" "$ANALYZE_METHOD" '{}')
+(! runas nobody varlinkctl call "$USER_ANALYZE_SOCKET" "$ANALYZE_METHOD" "$ANALYZE_FIRST")
+
+analyze_reply="$(varlinkctl call -j \
+    "$USER_ANALYZE_SOCKET" "$ANALYZE_METHOD" "$ANALYZE_FIRST")"
+assert_eq "$(jq -r '.diagnostics | length' <<<"$analyze_reply")" "0"
+
+wait_for_analyze_instances() {
+    local -a systemctl_command=("$@")
+    local output
+
+    for _ in {1..60}; do
+        output="$("${systemctl_command[@]}" list-units \
+            --plain --no-legend "systemd-analyze@*.service")"
+        if [[ -z "$output" ]]; then
+            return 0
+        fi
+        sleep .5
+    done
+
+    printf '%s\n' "$output"
+    return 1
+}
+
+wait_for_analyze_instances systemctl
+wait_for_analyze_instances runas testuser systemctl --user
+
 # Added an additional "INVALID_ID" id to the .json to verify that nothing breaks when input is malformed
 # The PrivateNetwork id description and weight was changed to verify that 'security' is actually reading in
 # values from the .json file when required. The default weight for "PrivateNetwork" is 2500, and the new weight

--- a/units/meson.build
+++ b/units/meson.build
@@ -262,6 +262,11 @@ units = [
         { 'file' : 'system-update-pre.target' },
         { 'file' : 'system-update.target' },
         {
+          'file' : 'systemd-analyze.socket',
+          'symlinks' : ['sockets.target.wants/'],
+        },
+        { 'file' : 'systemd-analyze@.service.in' },
+        {
           'file' : 'systemd-ask-password.socket',
           'symlinks' : ['sockets.target.wants/']
         },

--- a/units/systemd-analyze.socket
+++ b/units/systemd-analyze.socket
@@ -1,0 +1,24 @@
+#  SPDX-License-Identifier: LGPL-2.1-or-later
+#
+#  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+
+[Unit]
+Description=Unit File Verification Socket
+DefaultDependencies=no
+Before=sockets.target
+
+[Socket]
+ListenStream=/run/systemd/io.systemd.Analyze
+FileDescriptorName=varlink
+SocketMode=0644
+Accept=yes
+MaxConnectionsPerSource=16
+RemoveOnStop=yes
+XAttrEntryPoint=user.varlink=entrypoint
+XAttrListen=user.varlink=listen
+XAttrAccept=user.varlink=server

--- a/units/systemd-analyze@.service.in
+++ b/units/systemd-analyze@.service.in
@@ -1,0 +1,24 @@
+#  SPDX-License-Identifier: LGPL-2.1-or-later
+#
+#  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+
+[Unit]
+Description=Unit File Verification Service
+DefaultDependencies=no
+Conflicts=shutdown.target
+Before=shutdown.target
+CollectMode=inactive-or-failed
+
+[Service]
+ExecStart={{LIBEXECDIR}}/systemd-analyze-verify --system
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+NoNewPrivileges=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+SystemCallArchitectures=native

--- a/units/user/meson.build
+++ b/units/user/meson.build
@@ -51,6 +51,11 @@ units = [
         { 'file' : 'sockets.target' },
         { 'file' : 'sound.target' },
         {
+          'file' : 'systemd-analyze.socket',
+          'symlinks' : ['sockets.target.wants/'],
+        },
+        { 'file' : 'systemd-analyze@.service.in' },
+        {
           'file' : 'systemd-ask-password.socket',
           'symlinks' : ['sockets.target.wants/']
         },

--- a/units/user/systemd-analyze.socket
+++ b/units/user/systemd-analyze.socket
@@ -1,0 +1,22 @@
+#  SPDX-License-Identifier: LGPL-2.1-or-later
+#
+#  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+
+[Unit]
+Description=Unit File Verification Socket
+
+[Socket]
+ListenStream=%t/systemd/io.systemd.Analyze
+FileDescriptorName=varlink
+SocketMode=0600
+Accept=yes
+MaxConnectionsPerSource=16
+RemoveOnStop=yes
+XAttrEntryPoint=user.varlink=entrypoint
+XAttrListen=user.varlink=listen
+XAttrAccept=user.varlink=server

--- a/units/user/systemd-analyze@.service.in
+++ b/units/user/systemd-analyze@.service.in
@@ -1,0 +1,21 @@
+#  SPDX-License-Identifier: LGPL-2.1-or-later
+#
+#  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+
+[Unit]
+Description=Unit File Verification Service
+CollectMode=inactive-or-failed
+
+[Service]
+ExecStart={{LIBEXECDIR}}/systemd-analyze-verify --user
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+NoNewPrivileges=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+SystemCallArchitectures=native


### PR DESCRIPTION
`systemd-analyze verify` currently exposes diagnostics through human-oriented
output, so callers that verify unit files must spawn the CLI and parse stderr.

Add `io.systemd.Analyze.Verify`, served by a small socket-activated helper. The
method accepts an optional list of normalized absolute unit-file paths. When the
list is omitted, null, or empty, it verifies the effective non-alias, unmasked
unit-file entries selected by the endpoint's lookup path. Results contain flat,
structured diagnostics with severity, message, unit, configuration file and
line, and message ID where available.

Refactor the existing verifier to return owned diagnostics separately from the
legacy CLI status. Extend the existing syntax callback with the metadata needed
for parser findings, and add an opt-in callback on the temporary test Manager for
unit validation and ordering-cycle findings. Normal manager operation and normal
logging remain unchanged when those callbacks are not installed.

Install separate system and user sockets so scope follows the endpoint and user
lookup paths are evaluated in the correct environment. `Accept=yes` gives each
connection an isolated worker; the system endpoint accepts root and the user
endpoint accepts root or its owner. Generator, manual-page, alternate-root, and
scope controls are intentionally not exposed by the initial API.

The sockets are deliberately not published through the Varlink registry because
registered interfaces may be exported through bridges that obscure the original
client credentials. Clients use the fixed system or user socket path directly.

The helper is built independently of whether the public `systemd-analyze` binary
is installed, while the CLI continues to use the same verification engine and
retains its existing command-line behavior.

Fixes #42211
