### PR TITLE
meson: drop deprecated options

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,10 @@ CHANGES WITH 262:
 
         Feature Removals and Incompatible Changes:
 
+        * Meson options '-Dlibiptc=' (deprecated in v259), '-Dlibidn=',
+          '-Drc-local=', '-Dsysvinit-path=', and '-Dsysvrcnd-path=' (deprecated
+          in v260) have been removed.
+
         * Services of Type=notify-reload are now required to catch or block
           ReloadSignal= when they send READY=1. If they do neither at that
           point, the service fails to start with a protocol error. Previously,

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -46,13 +46,6 @@ option('standalone-binaries', type : 'string',
 option('build-static', type : 'boolean', value : false,
        description : 'build static versions of supported binaries')
 
-option('sysvinit-path', type : 'string', value : '/etc/init.d', deprecated : true,
-       description : 'This option is deprecated and will be removed in a future release')
-option('sysvrcnd-path', type : 'string', value : '/etc/rc.d', deprecated : true,
-       description : 'This option is deprecated and will be removed in a future release')
-option('rc-local', type : 'string', value : '/etc/rc.local', deprecated : true,
-       description : 'This option is deprecated and will be removed in a future release')
-
 option('initrd', type : 'boolean',
        description : 'install services for use when running systemd in initrd')
 option('compat-mutable-uid-boundaries', type : 'boolean', value : false,
@@ -462,10 +455,6 @@ option('idn', type : 'boolean',
        description : 'use IDN when printing hostnames')
 option('libidn2', type : 'feature', deprecated : { 'true' : 'enabled', 'false' : 'disabled' },
        description : 'libidn2 support')
-option('libidn', type : 'feature', deprecated : true,
-       description : 'This option is deprecated and will be removed in a future release')
-option('libiptc', type : 'feature', deprecated : true,
-       description : 'This option is deprecated and will be removed in a future release')
 option('qrencode', type : 'feature', deprecated : { 'true' : 'enabled', 'false' : 'disabled' },
        description : 'libqrencode support')
 option('gcrypt', type : 'feature', deprecated : { 'true' : 'enabled', 'false' : 'disabled' },

--- a/mkosi/mkosi.pkgenv/mkosi.conf.d/debian-ubuntu.conf
+++ b/mkosi/mkosi.pkgenv/mkosi.conf.d/debian-ubuntu.conf
@@ -9,5 +9,5 @@ Environment=
         GIT_URL=https://salsa.debian.org/systemd-team/systemd.git
         GIT_SUBDIR=debian
         GIT_BRANCH=debian/master
-        GIT_COMMIT=56402b2bde258999a8f01a8b04465fde9242d6a1
+        GIT_COMMIT=9badaae1c4c08db447b4e409784688f32d3f04f3
         PKG_SUBDIR=debian


### PR DESCRIPTION
The meson option -Dlibiptc= was deprecated in v259. Other options were deprecated in v260.