### PR TITLE
clonesetup-generator: set IgnoreOnIsolate=yes on generated units

### DIFF
--- a/src/clonesetup/clonesetup-generator.c
+++ b/src/clonesetup/clonesetup-generator.c
@@ -112,6 +112,7 @@ static int generate_clone_units(
                 "Description=Create dm-clone device %1$s\n"
                 "Documentation=man:clonetab(5) man:systemd-clonesetup(8) man:systemd-clonesetup-generator(8)\n"
                 "DefaultDependencies=no\n"
+                "IgnoreOnIsolate=yes\n"
                 "BindsTo=%2$s %3$s %4$s\n"
                 "After=%2$s %3$s %4$s systemd-udevd-kernel.socket\n"
                 "Before=blockdev@%5$s.target clonesetup.target shutdown.target\n"


### PR DESCRIPTION
If /sysroot is mounted in the initrd on a cloned device, initrd-cleanup.service will stop this unit (via `systemctl isolate initrd-switch-root.target`).

cryptsetup-generator, veritysetup-generator and integritysetup-generator all set "IgnoreOnIsolate=yes" on their generated units for this reason.