### PR TITLE
nspawn: set PATH early in inner_child()

### DIFF
--- a/src/nspawn/nspawn.c
+++ b/src/nspawn/nspawn.c
@@ -3368,7 +3368,7 @@ static int inner_child(
                 NULL, /* LANG */
                 NULL
         };
-        const char *exec_target;
+        const char *exec_target, *dollar_path;
         _cleanup_strv_free_ char **env_use = NULL;
         int r, which_failed;
 
@@ -3387,6 +3387,20 @@ static int inner_child(
         assert(fd_inner_socket >= 0);
 
         log_debug("Inner child is initializing.");
+
+        /* Reset the environment here to prevent accidentlly leaking variables from the host when running
+         * programs from the container before executing the payload. */
+        if (clearenv() < 0)
+                return log_error_errno(errno, "Failed to clear environment: %m");
+
+        /* Use the user supplied search $PATH if there is one, or DEFAULT_PATH_COMPAT if not to search the
+         * payload binary (or any spawned binaries executed in the meantime). */
+        dollar_path = strv_env_get(arg_setenv, "PATH");
+        if (!dollar_path)
+                dollar_path = DEFAULT_PATH_COMPAT;
+
+        if (setenv("PATH", dollar_path, 1) < 0)
+                return log_error_errno(errno, "Failed to update $PATH: %m");
 
         if (arg_userns_mode != USER_NAMESPACE_NO) {
                 /* Tell the parent, that it now can write the UID map. */
@@ -3717,18 +3731,7 @@ static int inner_child(
 
                 exec_target = "/usr/lib/systemd/systemd, /lib/systemd/systemd, /sbin/init";
         } else if (!strv_isempty(arg_parameters)) {
-                const char *dollar_path;
-
                 exec_target = arg_parameters[0];
-
-                /* Use the user supplied search $PATH if there is one, or DEFAULT_PATH_COMPAT if not to search the
-                 * binary. */
-                dollar_path = strv_env_get(env_use, "PATH");
-                if (dollar_path) {
-                        if (setenv("PATH", dollar_path, 1) < 0)
-                                return log_error_errno(errno, "Failed to update $PATH: %m");
-                }
-
                 execvpe(arg_parameters[0], arg_parameters, env_use);
         } else {
                 if (!arg_chdir)


### PR DESCRIPTION
Commit 5b193a8e233f ("meson: read more progs from PATH") mistakenly assumed that PATH would have already been set to DEFAULT_PATH_COMPAT when spawn_getent() is called [1], but that's not true - the PATH is still unchanged at this point, so the caller's PATH is now used to resolve the getent binary, even though the child is already running in the pivoted root.

Moreover, that commit also assumed that the whole environment has already been reset at that point, and thus switched to calling getent with execlp() instead of execle() + an explicit empty environment, so the guest getent binary actually now runs with the full environment leaked from the host.

There is a similar faulty assumption in the
`!strv_isempty(arg_parameters)` branch at the end of inner_child(), although here it doesn't lead to a bug. The code checks if PATH is set in env_use and sets it in the current environment to that value if it is. But the PATH variable will be always set to something in env_use, so the !dollar_path branch is just dead code and the comment is misleading.

Fix all these issues (and prevent future similar ones) by setting up a minimal environment always and early in inner_child(), containing only PATH set to the user-specified value or DEFAULT_PATH_COMPAT if it's not set. Since at this point env_use is not yet constructed, use PATH from arg_setenv or DEFAULT_PATH_COMPAT if not set there. The only other source for env_use (os_release_pairs) is not expected to contain the PATH variable.

[1] https://github.com/systemd/systemd/pull/40674#discussion_r2810099862

Fixes 5b193a8e233fecd6af00d5aa6a781a5ef3dd8571
Related: https://github.com/NixOS/nixpkgs/issues/510036