### PR TITLE
tmpfiles: set /var/log mode to 0775 to allow ACL usage

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -956,9 +956,6 @@ endif
 # Do not use set_quoted() here, so that the value is available as an integer.
 conf.set('TTY_MODE', tty_mode)
 
-var_log_mode = get_option('var-log-mode')
-conf.set_quoted('VAR_LOG_MODE', var_log_mode)
-
 kill_user_processes = get_option('default-kill-user-processes')
 conf.set10('KILL_USER_PROCESSES', kill_user_processes)
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -358,10 +358,6 @@ option('group-render-mode', type : 'string', value : '0666',
        description : 'Access mode for devices owned by render group (e.g. /dev/dri/renderD*, /dev/kfd).')
 option('tty-mode', type : 'string', value : '0600',
        description : 'Access mode for tty/pts device nodes.')
-option('var-log-mode', type : 'combo',
-       description : 'Access mode for /var/log directory.',
-       choices : ['0755', '0775'],
-       value : '0755')
 option('default-kill-user-processes', type : 'boolean',
        description : 'the default value for KillUserProcesses= setting')
 option('gshadow', type : 'boolean',

--- a/tmpfiles.d/var.conf.in
+++ b/tmpfiles.d/var.conf.in
@@ -11,7 +11,7 @@ q /var 0755 - - -
 
 L /var/run - - - - ../run
 
-d /var/log 0755 - - -
+d /var/log 0775 - - -
 {% if ENABLE_UTMP %}
 f /var/log/wtmp 0664 root utmp -
 f /var/log/btmp 0660 root utmp -

--- a/tmpfiles.d/var.conf.in
+++ b/tmpfiles.d/var.conf.in
@@ -11,7 +11,7 @@ q /var 0755 - - -
 
 L /var/run - - - - ../run
 
-d /var/log {{VAR_LOG_MODE}} - - -
+d /var/log 0755 - - -
 {% if ENABLE_UTMP %}
 f /var/log/wtmp 0664 root utmp -
 f /var/log/btmp 0660 root utmp -


### PR DESCRIPTION
Follow-up for #43140.