### PR TITLE
core: fix integer truncation checks

### DIFF
--- a/src/core/dbus-socket.c
+++ b/src/core/dbus-socket.c
@@ -159,11 +159,11 @@ const sd_bus_vtable bus_socket_vtable[] = {
 };
 
 static bool check_size_t_truncation(uint64_t t) {
-        return (size_t) t == t;
+        return t <= SIZE_MAX;
 }
 
 static bool check_long_truncation(int64_t t) {
-        return (int64_t) (long) t == t;
+        return t <= LONG_MAX && t >= LONG_MIN;
 }
 
 static const char* socket_protocol_to_string(int32_t i) {

--- a/src/shared/conf-parser.c
+++ b/src/shared/conf-parser.c
@@ -992,7 +992,7 @@ int config_parse_iec_size(
         assert(rvalue);
 
         r = parse_size(rvalue, 1024, &v);
-        if (r >= 0 && (uint64_t) (size_t) v != v)
+        if (r >= 0 && v > SIZE_MAX)
                 r = -ERANGE;
         if (r < 0)
                 return log_syntax_parse_error(unit, filename, line, r, lvalue, rvalue);


### PR DESCRIPTION
Follow-up for 78238fd7c9bcdc4272c4aa22930424a2febf6768.