### PR TITLE
ci: don't run the review agent outside the workspace

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -175,8 +175,6 @@ jobs:
         run: |
           rm -rf claude-review-work
           mkdir claude-review-work
-          rm -rf /tmp/claude-review-sandbox
-          mkdir /tmp/claude-review-sandbox
 
       - name: Download PR context
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -227,7 +225,6 @@ jobs:
 
       - name: Run Claude Code review
         timeout-minutes: 50
-        working-directory: /tmp/claude-review-sandbox
         env:
           CLAUDE_CODE_USE_BEDROCK: "1"
           CLAUDE_CODE_USE_MANTLE: "1"


### PR DESCRIPTION
Running the review step from /tmp/claude-review-sandbox put the directory the
review result has to be written to outside the agent's working directory. The
Write tool refuses to touch anything outside that directory, no matter what the
permission rules say, so every attempt to write review-result.json was denied.
Runs only passed because the agent fell back to writing the file from a
sandboxed shell command instead, and the last one hit the 50 minute step
timeout before it got that far, leaving nothing for the post job to upload.

The separate working directory bought little on top of the write allow rule,
which already confines the agent to claude-review-work/, so drop it and run in
the workspace again.
