### PR TITLE
vmspawn: put the ephemeral overlay next to the image

### DIFF
--- a/man/systemd-vmspawn.xml
+++ b/man/systemd-vmspawn.xml
@@ -109,9 +109,20 @@
           <term><option>--ephemeral</option></term>
 
           <listitem><para>If specified, the VM is run with a temporary snapshot of its file system that is removed
-          immediately when the VM terminates. Only works with <option>--image=</option> currently.
+          immediately when the VM terminates.</para>
 
-          Note that <option>--ephemeral</option> will not work with <option>--extra-drive=</option>.</para>
+          <para>For <option>--directory=</option> the snapshot is a btrfs snapshot of the directory, or a
+          copy of it if the file system does not support snapshots, made next to the directory, or inside
+          it if it is a mount point.</para>
+
+          <para>For <option>--image=</option> the snapshot is an unnamed temporary file created next to the
+          resolved image. If the image is not a regular file, its directory is unavailable, or its file
+          system is memory-backed, the directory selected by <varname>$TMPDIR</varname>,
+          <varname>$TEMP</varname>, or <varname>$TMP</varname> is used instead, defaulting to
+          <filename>/var/tmp/</filename>. Memory-backed directories are refused.</para>
+
+          <para>Note that <option>--ephemeral</option> will not work with
+          <option>--extra-drive=</option>.</para>
 
           <xi:include href="version-info.xml" xpointer="v260"/></listitem>
         </varlistentry>

--- a/src/vmspawn/vmspawn.c
+++ b/src/vmspawn/vmspawn.c
@@ -26,6 +26,7 @@
 #include "bus-locator.h"
 #include "bus-util.h"
 #include "capability-util.h"
+#include "chase.h"
 #include "common-signal.h"
 #include "copy.h"
 #include "discover-image.h"
@@ -53,7 +54,6 @@
 #include "machine-credential.h"
 #include "machine-register.h"
 #include "main-func.h"
-#include "memfd-util.h"
 #include "mkdir.h"
 #include "namespace-util.h"
 #include "netif-util.h"
@@ -2318,10 +2318,9 @@ static int resolve_disk_driver(DiskType dt, const char *filename, DriveInfo *inf
         return 0;
 }
 
-static int prepare_primary_drive(const char *runtime_dir, DriveInfos *drives) {
+static int prepare_primary_drive(DriveInfos *drives) {
         int r;
 
-        assert(runtime_dir);
         assert(drives);
 
         if (!arg_image)
@@ -2342,9 +2341,11 @@ static int prepare_primary_drive(const char *runtime_dir, DriveInfos *drives) {
 
         int open_flags = ((arg_ephemeral || FLAGS_SET(d->flags, QMP_DRIVE_READ_ONLY)) ? O_RDONLY : O_RDWR) | O_CLOEXEC | O_NOCTTY;
 
-        _cleanup_close_ int image_fd = open(arg_image, open_flags);
+        _cleanup_free_ char *image_path = NULL;
+        _cleanup_close_ int image_fd = chase_and_open(arg_image, /* root= */ NULL, /* chase_flags= */ 0,
+                                                      open_flags, &image_path);
         if (image_fd < 0)
-                return log_error_errno(errno, "Failed to open '%s': %m", arg_image);
+                return log_error_errno(image_fd, "Failed to open '%s': %m", arg_image);
 
         struct stat st;
         if (fstat(image_fd, &st) < 0)
@@ -2369,16 +2370,59 @@ static int prepare_primary_drive(const char *runtime_dir, DriveInfos *drives) {
          * as qcow2 via blockdev-create, so no filesystem path is needed.
          * Skip for read-only drives (e.g. CDROM) where overlays are not meaningful. */
         if (arg_ephemeral && !FLAGS_SET(d->flags, QMP_DRIVE_READ_ONLY)) {
-                _cleanup_close_ int overlay_fd = open(runtime_dir, O_TMPFILE | O_RDWR | O_CLOEXEC, 0600);
-                if (overlay_fd < 0) {
-                        if (!ERRNO_IS_NOT_SUPPORTED(errno))
-                                return log_error_errno(errno, "Failed to create ephemeral overlay in '%s': %m", runtime_dir);
-
-                        /* Fallback to memfd if O_TMPFILE is not supported */
-                        overlay_fd = memfd_new("vmspawn-overlay");
-                        if (overlay_fd < 0)
-                                return log_error_errno(overlay_fd, "Failed to create ephemeral overlay via memfd: %m");
+                /* Prefer the image's file system, except for block devices and memory-backed file systems. */
+                _cleanup_free_ char *image_dir = NULL;
+                if (S_ISREG(st.st_mode)) {
+                        r = path_extract_directory(image_path, &image_dir);
+                        if (r < 0)
+                                log_debug_errno(r, "Failed to determine directory of '%s', ignoring: %m", arg_image);
                 }
+
+                const char *var_tmp;
+                r = var_tmp_dir(&var_tmp);
+                if (r < 0)
+                        return log_error_errno(r, "Failed to determine directory for large temporary files: %m");
+
+                _cleanup_close_ int overlay_fd = -EBADF;
+                const char *overlay_dir;
+                int overlay_error = -EOPNOTSUPP;
+                FOREACH_ARGUMENT(overlay_dir, image_dir, var_tmp) {
+                        if (!overlay_dir)
+                                continue;
+
+                        _cleanup_close_ int fd = open(overlay_dir, O_TMPFILE|O_RDWR|O_CLOEXEC, 0600);
+                        if (fd < 0) {
+                                overlay_error = -errno;
+                                log_debug_errno(errno,
+                                                "Failed to create ephemeral overlay in '%s', trying next directory: %m",
+                                                overlay_dir);
+                                continue;
+                        }
+
+                        r = fd_is_temporary_fs(fd);
+                        if (r < 0) {
+                                overlay_error = r;
+                                log_debug_errno(r,
+                                                "Failed to determine backing filesystem of '%s', trying next directory: %m",
+                                                overlay_dir);
+                                continue;
+                        }
+                        if (r > 0) {
+                                overlay_error = -EOPNOTSUPP;
+                                log_debug("Ephemeral overlay directory '%s' is backed by memory, trying next directory.",
+                                          overlay_dir);
+                                continue;
+                        }
+
+                        overlay_fd = TAKE_FD(fd);
+                        break;
+                }
+                if (overlay_fd < 0)
+                        return log_error_errno(overlay_error,
+                                               "Failed to create ephemeral overlay on non-memory-backed storage: %m");
+
+                log_debug("Created ephemeral overlay in '%s'.", overlay_dir);
+
                 d->overlay_fd = TAKE_FD(overlay_fd);
                 d->flags |= QMP_DRIVE_NO_FLUSH;
                 d->grow_to = arg_grow_image;
@@ -2479,10 +2523,9 @@ static int assign_pcie_ports(MachineConfig *c) {
         return 0;
 }
 
-static int prepare_device_info(const char *runtime_dir, MachineConfig *c) {
+static int prepare_device_info(MachineConfig *c) {
         int r;
 
-        assert(runtime_dir);
         assert(c);
 
         DriveInfos *drives = &c->drives;
@@ -2493,7 +2536,7 @@ static int prepare_device_info(const char *runtime_dir, MachineConfig *c) {
         if (!drives->drives)
                 return log_oom();
 
-        r = prepare_primary_drive(runtime_dir, drives);
+        r = prepare_primary_drive(drives);
         if (r < 0)
                 return r;
 
@@ -3823,7 +3866,7 @@ static int run_virtual_machine(int kvm_device_fd, int vhost_device_fd) {
         child_pty = safe_close(child_pty);
         bridge_fds[1] = safe_close(bridge_fds[1]);
 
-        r = prepare_device_info(runtime_dir, &config);
+        r = prepare_device_info(&config);
         if (r < 0)
                 return r;
 

--- a/test/units/TEST-87-AUX-UTILS-VM.vmspawn-drives.sh
+++ b/test/units/TEST-87-AUX-UTILS-VM.vmspawn-drives.sh
@@ -34,6 +34,17 @@ if ! command -v mke2fs >/dev/null 2>&1; then
     exit 77
 fi
 
+# Overlay location tests need both disk-backed and memory-backed storage.
+if [[ "$(stat --file-system --format=%T /var/tmp)" == tmpfs ]]; then
+    echo "/var/tmp is backed by memory, cannot tell the overlay locations apart, skipping"
+    exit 77
+fi
+
+if [[ ! -d /dev/shm ]]; then
+    echo "/dev/shm not available, skipping"
+    exit 77
+fi
+
 # Find a kernel for direct boot
 KERNEL=""
 for k in /usr/lib/modules/"$(uname -r)"/vmlinuz /boot/vmlinuz-"$(uname -r)" /boot/vmlinuz; do
@@ -49,8 +60,6 @@ if [[ -z "$KERNEL" ]]; then
 fi
 echo "Using kernel: $KERNEL"
 
-WORKDIR="$(mktemp -d)"
-
 at_exit() {
     set +e
     for m in "${MACHINE_MULTI:-}" "${MACHINE_EPHEMERAL:-}" "${MACHINE_GROW:-}"; do
@@ -63,9 +72,13 @@ at_exit() {
     [[ -n "${VMSPAWN_MULTI_PID:-}" ]] && kill "$VMSPAWN_MULTI_PID" 2>/dev/null && wait "$VMSPAWN_MULTI_PID" 2>/dev/null
     [[ -n "${VMSPAWN_EPHEMERAL_PID:-}" ]] && kill "$VMSPAWN_EPHEMERAL_PID" 2>/dev/null && wait "$VMSPAWN_EPHEMERAL_PID" 2>/dev/null
     [[ -n "${VMSPAWN_GROW_PID:-}" ]] && kill "$VMSPAWN_GROW_PID" 2>/dev/null && wait "$VMSPAWN_GROW_PID" 2>/dev/null
-    rm -rf "$WORKDIR"
+    rm -rf "${WORKDIR:-}" "${SHMDIR:-}"
 }
 trap at_exit EXIT
+
+# Keep the image on disk-backed storage and use /dev/shm for tmpfs cases.
+WORKDIR="$(mktemp -d -p /var/tmp)"
+SHMDIR="$(mktemp -d -p /dev/shm)"
 
 # Create a minimal root filesystem directory, then bake it into a raw ext4 image.
 # The guest doesn't need to fully boot — 'sleep infinity' keeps QEMU alive for QMP testing.
@@ -82,6 +95,27 @@ mke2fs -t ext4 -q -d "$WORKDIR/rootfs" "$WORKDIR/root.raw"
 # Create extra raw drive images (different sizes to be distinguishable)
 truncate -s 64M "$WORKDIR/extra1.raw"
 truncate -s 32M "$WORKDIR/extra2.raw"
+
+# Print QEMU's overlay fd if it points into the requested directory.
+find_overlay_fd() {
+    local machine="$1" dir="$2" log="$3" pid fd target
+
+    pid="$(varlinkctl call /run/systemd/machine/io.systemd.Machine \
+        io.systemd.Machine.List "{\"name\":\"$machine\"}" | jq -r '.leader.pid')"
+
+    for fd in /proc/"$pid"/fd/*; do
+        target="$(readlink "$fd" 2>/dev/null)" || continue
+        # An O_TMPFILE is reported as "<dir>/#<inode> (deleted)".
+        [[ "$target" == "$dir"/#*" (deleted)" ]] || continue
+        echo "$fd"
+        return 0
+    done
+
+    echo "No ephemeral overlay found in '$dir', QEMU has these files open:" >&2
+    ls -l /proc/"$pid"/fd >&2 || :
+    cat "$log" >&2
+    return 1
+}
 
 # --- Test 1: Multi-drive setup (root + 2 extra drives) ---
 # Verifies that --image with multiple --extra-drive flags works with the async
@@ -136,11 +170,15 @@ echo "Multi-drive VM terminated cleanly"
 # device_add. If any step fails, the root drive is never attached and the kernel
 # panics — vmspawn exits without registering.
 
+# Exercise the large temporary-file directory fallback with an image on tmpfs.
+cp --sparse=always "$WORKDIR/root.raw" "$SHMDIR/root.raw"
+mkdir -p "$WORKDIR/large-tmp"
+
 MACHINE_EPHEMERAL="test-vmspawn-ephemeral-$$"
-systemd-vmspawn \
+TMPDIR="$WORKDIR/large-tmp" systemd-vmspawn \
     --machine="$MACHINE_EPHEMERAL" \
     --ram=256M \
-    --image="$WORKDIR/root.raw" \
+    --image="$SHMDIR/root.raw" \
     --ephemeral \
     --linux="$KERNEL" \
     --tpm=no \
@@ -167,6 +205,9 @@ if grep -E '(add-fd|blockdev-add|blockdev-create|device_add|getfd|netdev_add|cha
 fi
 echo "No QMP device setup errors in ephemeral log"
 
+find_overlay_fd "$MACHINE_EPHEMERAL" "$WORKDIR/large-tmp" "$WORKDIR/vmspawn-ephemeral.log" >/dev/null
+echo "Ephemeral overlay is in \$TMPDIR"
+
 machinectl terminate "$MACHINE_EPHEMERAL"
 timeout 10 bash -c "while machinectl status '$MACHINE_EPHEMERAL' &>/dev/null; do sleep .5; done"
 timeout 10 bash -c "while kill -0 '$VMSPAWN_EPHEMERAL_PID' 2>/dev/null; do sleep .5; done"
@@ -177,6 +218,9 @@ echo "Ephemeral VM terminated cleanly"
 # image passed to --image= is opened read-only and has to come out of the run
 # at its original size.
 
+# Resolve the image symlink before selecting the overlay directory.
+ln -s "$WORKDIR/root.raw" "$SHMDIR/root-link.raw"
+
 MACHINE_GROW="test-vmspawn-grow-$$"
 GROW_SIZE=$((512 * 1024 * 1024))
 IMAGE_SIZE="$(stat -c %s "$WORKDIR/root.raw")"
@@ -184,7 +228,7 @@ IMAGE_SIZE="$(stat -c %s "$WORKDIR/root.raw")"
 systemd-vmspawn \
     --machine="$MACHINE_GROW" \
     --ram=256M \
-    --image="$WORKDIR/root.raw" \
+    --image="$SHMDIR/root-link.raw" \
     --ephemeral \
     --grow-image="$GROW_SIZE" \
     --linux="$KERNEL" \
@@ -200,21 +244,12 @@ echo "Grown ephemeral machine '$MACHINE_GROW' registered with machined"
 assert_eq "$(stat -c %s "$WORKDIR/root.raw")" "$IMAGE_SIZE"
 echo "Image passed to --image= was left at its original size"
 
-# The overlay is unlinked, so QEMU's fd is the only way to reach it. vmspawn
-# registers QEMU itself as the machine leader, so machined knows its PID.
-QEMU_PID="$(varlinkctl call /run/systemd/machine/io.systemd.Machine \
-    io.systemd.Machine.List "{\"name\":\"$MACHINE_GROW\"}" | jq -r '.leader.pid')"
-
-OVERLAY=""
-for fd in /proc/"$QEMU_PID"/fd/*; do
-    target="$(readlink "$fd" 2>/dev/null)" || continue
-    # O_TMPFILE in the runtime directory, or the memfd fallback.
-    [[ "$target" == */vmspawn/"$MACHINE_GROW"/#* || "$target" == /memfd:vmspawn-overlay* ]] || continue
-    OVERLAY="$fd"
-    break
-done
-assert_neq "$OVERLAY" ""
-echo "Ephemeral overlay is QEMU fd ${OVERLAY##*/}"
+OVERLAY="$(find_overlay_fd "$MACHINE_GROW" "$WORKDIR" "$WORKDIR/vmspawn-grow.log")"
+if grep "backed by memory" "$WORKDIR/vmspawn-grow.log" >/dev/null; then
+    cat "$WORKDIR/vmspawn-grow.log"
+    exit 1
+fi
+echo "Ephemeral overlay was created next to the image and is QEMU fd ${OVERLAY##*/}"
 
 # qcow2 header: the magic, followed by the virtual size as a big endian u64 at
 # offset 24. Read it out of the header directly, qemu-img may not be installed.
@@ -226,5 +261,22 @@ machinectl terminate "$MACHINE_GROW"
 timeout 10 bash -c "while machinectl status '$MACHINE_GROW' &>/dev/null; do sleep .5; done"
 timeout 10 bash -c "while kill -0 '$VMSPAWN_GROW_PID' 2>/dev/null; do sleep .5; done"
 echo "Grown ephemeral VM terminated cleanly"
+
+# --- Test 4: Refuse memory-backed overlays ---
+if TMPDIR="$SHMDIR" systemd-vmspawn \
+    --machine="test-vmspawn-shm-$$" \
+    --ram=256M \
+    --image="$SHMDIR/root.raw" \
+    --ephemeral \
+    --linux="$KERNEL" \
+    --tpm=no \
+    --console=headless \
+    root=/dev/vda rw \
+    &>"$WORKDIR/vmspawn-shm.log"; then
+    cat "$WORKDIR/vmspawn-shm.log"
+    exit 1
+fi
+grep "Failed to create ephemeral overlay on non-memory-backed storage" "$WORKDIR/vmspawn-shm.log" >/dev/null
+echo "Memory backed ephemeral overlay was refused"
 
 echo "All vmspawn drive setup tests passed"


### PR DESCRIPTION
The overlay absorbs every write the guest makes, and we created it in the
runtime directory, with a memfd as fallback. Both put it in the one place it
must not go: the runtime directory is a tmpfs, so the overlay competes with the
guest for the very memory the VM runs in, and an ephemeral guest that writes a
few gigabytes takes the host down with it.

Create it next to the image instead, which is where nspawn puts its ephemeral
copy as well, and where there is known to be room for data of this size. For
images we cannot write next to, such as those on a read-only filesystem, fall
back to $TMPDIR, or /var/tmp, which is also where QEMU puts the overlays for
its own -snapshot mode. Block devices are skipped, as /dev is a tmpfs and thus
no better than that fallback. Failing to find a directory is rare enough to
report as an error rather than to quietly resort to memory again.

Document where the snapshot ends up, and look for it next to the image in
TEST-87.
