### PR TITLE
verbs: fix typo

### DIFF
--- a/src/shared/verbs.c
+++ b/src/shared/verbs.c
@@ -453,7 +453,7 @@ static int print_wrapped(const char *text, bool abstract) {
         if (r < 0)
                 return r;
 
-        /* Seperate this block from the previous input. */
+        /* Separate this block from the previous input. */
         putchar('\n');
 
         STRV_FOREACH(line, lines2)


### PR DESCRIPTION
Found by Fossies.

Follow-up for 7ea090f41b389cb9448b4f1f81fe866a3cd27cb7.