### PR TITLE
nspawn: do not let Private=yes override --network-veth

### DIFF
--- a/src/nspawn/nspawn-settings.c
+++ b/src/nspawn/nspawn-settings.c
@@ -193,13 +193,22 @@ bool settings_private_network(Settings *s) {
                 s->network_veth_extra;
 }
 
-bool settings_network_veth(Settings *s) {
+int settings_network_veth(Settings *s) {
         assert(s);
 
-        return
-                s->network_veth > 0 ||
-                s->network_bridge ||
-                s->network_zone;
+        /* Bridge= and Zone= imply VirtualEthernet=yes. */
+        if (s->network_bridge || s->network_zone)
+                return 1;
+
+        /* Honor VirtualEthernet= setting if specified. */
+        if (s->network_veth >= 0)
+                return s->network_veth;
+
+        /* Private=yes does not override an inherited VirtualEthernet= setting. */
+        if (s->private_network > 0 && !s->network_namespace_path)
+                return -1;
+
+        return 0;
 }
 
 bool settings_network_configured(Settings *s) {

--- a/src/nspawn/nspawn-settings.h
+++ b/src/nspawn/nspawn-settings.h
@@ -245,7 +245,7 @@ Settings *settings_new(void);
 int settings_load(FILE *f, const char *path, Settings **ret);
 Settings* settings_free(Settings *s);
 
-bool settings_network_veth(Settings *s);
+int settings_network_veth(Settings *s);
 bool settings_private_network(Settings *s);
 bool settings_network_configured(Settings *s);
 

--- a/src/nspawn/nspawn.c
+++ b/src/nspawn/nspawn.c
@@ -4896,16 +4896,20 @@ static int merge_settings(Settings *settings, const char *path) {
                 if (!arg_settings_trusted)
                         log_warning("Ignoring network settings, file %s is not trusted.", path);
                 else {
-                        arg_network_veth = settings_network_veth(settings);
+                        int veth = settings_network_veth(settings);
+
                         arg_private_network = settings_private_network(settings);
+
+                        if (veth >= 0) {
+                                arg_network_veth = veth > 0;
+                                free_and_replace(arg_network_bridge, settings->network_bridge);
+                                free_and_replace(arg_network_zone, settings->network_zone);
+                        }
 
                         strv_free_and_replace(arg_network_interfaces, settings->network_interfaces);
                         strv_free_and_replace(arg_network_macvlan, settings->network_macvlan);
                         strv_free_and_replace(arg_network_ipvlan, settings->network_ipvlan);
                         strv_free_and_replace(arg_network_veth_extra, settings->network_veth_extra);
-
-                        free_and_replace(arg_network_bridge, settings->network_bridge);
-                        free_and_replace(arg_network_zone, settings->network_zone);
 
                         free_and_replace(arg_network_namespace_path, settings->network_namespace_path);
                 }

--- a/src/nspawn/test-nspawn-tables.c
+++ b/src/nspawn/test-nspawn-tables.c
@@ -4,11 +4,34 @@
 #include "test-tables.h"
 #include "tests.h"
 
-int main(int argc, char **argv) {
-        test_setup_logging(LOG_DEBUG);
+TEST(settings_network_veth) {
+        struct {
+                const char *name;
+                Settings settings;
+                int expected;
+        } cases[] = {
+                { "unset",          { .private_network = -1, .network_veth = -1 },  0 },
+                { "private-no",     { .private_network =  0, .network_veth = -1 },  0 },
+                { "private-yes",    { .private_network =  1, .network_veth = -1 }, -1 },
+                { "private-path",   { .private_network =  1, .network_veth = -1,
+                                        .network_namespace_path = (char*) "/run/netns/test" }, 0 },
+                { "veth-no",        { .private_network = -1, .network_veth =  0 },  0 },
+                { "veth-yes",       { .private_network = -1, .network_veth =  1 },  1 },
+                { "bridge-veth-no", { .private_network = -1, .network_veth =  0,
+                                        .network_bridge = (char*) "br0" }, 1 },
+                { "zone",           { .private_network = -1, .network_veth = -1,
+                                        .network_zone = (char*) "vz-test" }, 1 },
+        };
 
+        FOREACH_ELEMENT(c, cases) {
+                log_info("/* %s */", c->name);
+                ASSERT_EQ(settings_network_veth(&c->settings), c->expected);
+        }
+}
+
+TEST(tables) {
         test_table(ResolvConfMode, resolv_conf_mode, RESOLV_CONF_MODE);
         test_table(TimezoneMode, timezone_mode, TIMEZONE_MODE);
-
-        return 0;
 }
+
+DEFINE_TEST_MAIN(LOG_DEBUG);

--- a/test/units/TEST-13-NSPAWN.nspawn.sh
+++ b/test/units/TEST-13-NSPAWN.nspawn.sh
@@ -609,6 +609,24 @@ EOF
         systemd-nspawn --directory="$root" bash -xec '[[ "$(hostname)" == private-users ]]'
     done
 
+    # Private=yes must not override --network-veth when VirtualEthernet= is unspecified.
+    # (https://github.com/systemd/systemd/issues/12313#issuecomment-681116926).
+    cat >"/run/systemd/nspawn/$container.nspawn" <<EOF
+[Exec]
+PrivateUsers=no
+
+[Files]
+${COVERAGE_BUILD_DIR:+"Bind=$COVERAGE_BUILD_DIR"}
+
+[Network]
+Private=yes
+EOF
+    systemd-nspawn --register=no \
+                   --directory="$root" \
+                   --network-veth \
+                   --settings=override \
+                   bash -xec 'ip link show dev host0'
+
     rm -fr "$root" "/run/systemd/nspawn/$container.nspawn"
 }
 


### PR DESCRIPTION
With --settings=override, merge_settings() currently replaces the command-line network configuration whenever the .nspawn file contains any network setting. In particular, Private=yes causes an unspecified VirtualEthernet= to be treated as false, overriding --network-veth. The container gets a private network namespace and CAP_NET_ADMIN, but host0 is not created.

Keep the primary veth decision tristate: return -1 when VirtualEthernet= is unspecified, honor an explicit yes or no, and continue to let Bridge= and Zone= imply yes. Compute the merged private network state before moving fields out of Settings, and replace individual link settings only when the file specifies them.

This preserves command-line veth and extra-link settings with Private=yes. Private=no and NamespacePath= still clear incompatible inherited links, while VirtualEthernet=no disables the primary veth and its Bridge= or Zone= configuration without removing independent extra links.

Add table coverage for all VirtualEthernet= states with Bridge= and Zone=, together with integration tests for Private=yes, VirtualEthernet=no, zone cleanup, and NamespacePath= precedence.

Fixes #12313