### PR TITLE
hwdb: mark Lenovo ThinkPad X1 Tablet Gen 3 touchpad as internal

### DIFF
--- a/hwdb.d/70-touchpad.hwdb
+++ b/hwdb.d/70-touchpad.hwdb
@@ -54,6 +54,15 @@ touchpad:bluetooth:v17efp60fa:*
  ID_INPUT_TOUCHPAD_INTEGRATION=internal
 
 ###########################################################
+# Lenovo ThinkPad X1 Tablet Thin Keyboard Gen 3 (17EF:60B5)
+###########################################################
+# The USB port is reported as removable by firmware, so 65-integration.rules
+# classifies the touchpad as external and libinput skips disable-while-typing.
+# The touchpad is physically integrated; mark it internal to enable DWT.
+touchpad:usb:v17efp60b5:name:Chicony ThinkPad X1 Tablet Thin Keyboard Gen 3:*
+ ID_INPUT_TOUCHPAD_INTEGRATION=internal
+
+###########################################################
 # Microsoft Surface Type Cover
 ###########################################################
 # The USB port is reported as removable by firmware, so 65-integration.rules


### PR DESCRIPTION
Similar to d13c07ecd8 and 373a4020d5, 65-integration.rules sets ID_INPUT_TOUCHPAD_INTEGRATION=external, and libinput skips disable-while-typing (DWT) for the device.

The touchpad is integrated into a detachable keyboard which isn't usable on other devices so it should be marked as internal. This enables palm detection and DWT.