### PR TITLE
hwdb: label Lenovo ThinkPad X1 Tablet Gen 3 trackpoint as pointing stick

### DIFF
--- a/hwdb.d/60-input-id.hwdb
+++ b/hwdb.d/60-input-id.hwdb
@@ -114,6 +114,10 @@ id-input:modalias:input:b0003v068Ep00F2*
 id-input:modalias:input:b0003v04D9p0407e0111-e0,1,2,4*
  ID_INPUT_POINTINGSTICK=1
 
+# Lenovo ThinkPad X1 Tablet Gen 3 TrackPoint
+id-input:modalias:input:b0003v17EFp60B5e0111-e0,1,2,4,k110,111,112*
+ ID_INPUT_POINTINGSTICK=1
+
 # ASRock LED Controller
 id-input:modalias:input:b0003v26CEp01A2*
  ID_INPUT_JOYSTICK=


### PR DESCRIPTION
The trackpoint of the ThinkPad X1 Tablet Gen 3 detachable keyboard (USB 17EF:60B5) lives in the same HID interface as the touchpad, which is bound to hid-multitouch. The kernel never sets INPUT_PROP_POINTING_STICK for it, so input_id classifies the trackpoint as a plain mouse.

Mark it as a pointing stick so libinput applies trackpoint acceleration instead of the mouse acceleration profile.

The interface also exposes a second mouse node without a middle button; the modal match keys on the button set (k110,111,112) to select only the trackpoint node and leave the touchpad and the other mouse node untouched.