### PR TITLE
test: synchronize with prekill hook listeners in TEST-55-OOMD

### DIFF
--- a/test/units/TEST-55-OOMD.sh
+++ b/test/units/TEST-55-OOMD.sh
@@ -505,6 +505,59 @@ EOF
     systemctl reload systemd-oomd.service
 }
 
+PREKILL_LISTENER_PIDS=()
+
+start_prekill_listener() {
+    local sock="${1:?}" output="${2:?}"
+    local pid
+
+    # Pre-create the capture file: the forked cat opens it only on the first connection.
+    : >"$output"
+
+    pid=$(systemd-notify --fork -- systemd-socket-activate --accept --inetd -l "$sock" -- sh -c "cat >>'$output'")
+    PREKILL_LISTENER_PIDS+=("$pid")
+}
+
+check_prekill_notification() {
+    local output="${1:?}" rc=0
+
+    # shellcheck disable=SC2002
+    cat "$output" | tr -d '\0' |
+        jq -se 'length > 0 and all(.[]; .method == "io.systemd.oom.Prekill.Notify")' >/dev/null || rc=$?
+    if [[ $rc -eq 0 ]]; then
+        return 0
+    fi
+
+    if [[ $rc -eq 1 ]]; then
+        echo >&2 "FAIL: no valid notification captured in $output:"
+    else
+        echo >&2 "FAIL: parsing $output failed with status $rc:"
+    fi
+    cat -v "$output" >&2
+    ls -la /run/systemd/oomd.prekill.hook/ >&2
+    return 1
+}
+
+kill_prekill_listeners() {
+    local pid
+
+    for pid in "${PREKILL_LISTENER_PIDS[@]}"; do
+        kill "$pid" 2>/dev/null || :
+    done
+    PREKILL_LISTENER_PIDS=()
+}
+
+prekill_hook_at_exit() {
+    # Uniformly non-fatal: the handler inherits set -e, and a failing cleanup step would both
+    # skip the rest of the cleanup and rewrite the testcase's exit status.
+    set +e
+
+    kill_prekill_listeners
+    rm -rf /run/systemd/oomd.prekill.hook/ /tmp/oomd_event*.json
+    rm -f /run/systemd/oomd.conf.d/99-oomd-prekill-test.conf
+    systemctl reload systemd-oomd.service
+}
+
 testcase_prekill_hook() {
     [[ "$STRESS_NG_BROKEN" == "1" ]] && { echo "stress-ng is broken on this host, skipping ${FUNCNAME[0]}"; return 0; }
 
@@ -513,27 +566,35 @@ testcase_prekill_hook() {
 PrekillHookTimeoutSec=3s
 EOF
 
+    # run_testcases runs each testcase in a subshell, so this also fires on a mid-testcase abort.
+    trap prekill_hook_at_exit EXIT
+
     # no hooks
     systemctl reload systemd-oomd.service
     ! systemctl start --wait TEST-55-OOMD-testbloat.service || exit 1
 
     # one hook
     mkdir -p /run/systemd/oomd.prekill.hook/
-    socat -u UNIX-LISTEN:/run/systemd/oomd.prekill.hook/althook STDOUT >/tmp/oomd_event.json &
+    start_prekill_listener /run/systemd/oomd.prekill.hook/althook /tmp/oomd_event.json
     ! systemctl start --wait TEST-55-OOMD-testbloat.service || exit 1
-    [[ $(jq -r .method </tmp/oomd_event.json) = 'io.systemd.oom.Prekill.Notify' ]]
+    check_prekill_notification /tmp/oomd_event.json
 
+    # The socket file survives the kill, and oomd would still notify it in the next phase.
+    kill_prekill_listeners
     rm -f /run/systemd/oomd.prekill.hook/* /tmp/oomd_event.json
 
     # many hooks
     for i in {1..4}; do
-        socat -u "UNIX-LISTEN:/run/systemd/oomd.prekill.hook/althook$i" STDOUT >"/tmp/oomd_event$i.json" &
+        start_prekill_listener "/run/systemd/oomd.prekill.hook/althook$i" "/tmp/oomd_event$i.json"
     done
 
     ! systemctl start --wait TEST-55-OOMD-testbloat.service || exit 1
-    for j in /tmp/oomd_event*.json; do
-        [[ $(jq -r .method <"$j") = 'io.systemd.oom.Prekill.Notify' ]]
+
+    local rc=0
+    for i in {1..4}; do
+        check_prekill_notification "/tmp/oomd_event$i.json" || rc=1
     done
+    assert_eq "$rc" "0"
 }
 
 run_testcases


### PR DESCRIPTION
testcase_prekill_hook forks each hook listener into the background and starts the memory hog on the very next line. systemd-oomd checks the hook sockets only at kill time and skips a non-connectible socket as stale, so a listener that is not accepting yet becomes a failed jq assertion on an empty capture file, with nothing in the artifacts to explain why. CI hit this on arch: the trigger there was Ncat 7.991 exiting right after bind, fixed by 5e96efc8df switching to socat, but the fork-to-connect race is independent of the listener tool.

Following Ivan's suggestion, each listener now starts as `systemd-notify --fork -- systemd-socket-activate --accept --inetd`, which returns only once the socket is listening, or fails loudly if the listener dies first. An immediate connect after it returned succeeded in all 130 tries; against a plain background fork it was refused in 34 of 100 tries idle and 100 of 100 under load.

The assertion reads only the capture file and tolerates more than one frame, since the listener accepts for the whole phase and oomd connects once per kill. Cleanup runs from a prekill_hook_at_exit() EXIT trap, so a mid-phase abort cannot leak a bound socket or the shortened PrekillHookTimeoutSec= into later testcases. Rebased onto current main; measurements and details are in the commit message.