### PR TITLE
pam_systemd: fix invalid class when logging in as root through ssh

### DIFF
--- a/src/login/pam_systemd.c
+++ b/src/login/pam_systemd.c
@@ -964,8 +964,6 @@ static void session_context_mangle(
                 /* ssh has been setting PAM_TTY to "ssh" (for the same reason as cron does this, see above. For further
                  * details look for "PAM_TTY_KLUDGE" in the openssh sources). */
                 c->type = "tty";
-                if (isempty(c->class))
-                        c->class = "user";
                 c->tty = NULL; /* This one is particularly sad, as this means that ssh sessions — even though
                                * usually associated with a pty — won't be tracked by their tty in
                                * logind. This is because ssh does the PAM session registration early for new


### PR DESCRIPTION
This fixes an issue where class was set to "user" even for root user when logging in through ssh, preventing early logins until systemd-user-sessions.service is active (because root session scope was getting `After=systemd-user-sessions.service` stanza).

Without the fix:

~~~
$ ssh root@localhost
# echo $XDG_SESSION_CLASS
user
~~~

With the fix:

~~~
$ ssh root@localhost
# echo $XDG_SESSION_CLASS
user-early
~~~

Minimal Reproducer:

1. Create a drop-in delaying the start of `systemd-user-sessions.service`

   ~~~
   # mkdir /etc/systemd/system/systemd-user-sessions.service.d
   # echo -e "[Service]\nExecStartPre=/bin/sleep 5m" > /etc/systemd/system/systemd-user-sessions.service.d/delay.conf
   ~~~

2. Reboot

3. Try logging in as root through ssh

   ~~~
   $ ssh root@vm-fedora
   ~~~

Expected outcome:

   Login occurs immediately

Actual outcome (without the fix):

   Hang on prompt until `pam_systemd` times out after 2 minutes