### PR TITLE
logind: preserve scheduled shutdown on failure

### DIFF
--- a/src/login/logind-dbus.c
+++ b/src/login/logind-dbus.c
@@ -2327,7 +2327,11 @@ static int method_do_shutdown_or_sleep(
                                          handle_action_to_string(m->delayed_action->handle),
                                          handle_action_to_string(a->handle));
 
-        /* reset case we're shorting a scheduled shutdown */
+        r = bus_manager_shutdown_or_sleep_now_or_later(m, a, error);
+        if (r < 0)
+                return r;
+
+        /* Reset in case we're short-circuiting a scheduled shutdown. */
         m->unlink_nologin = false;
         manager_reset_scheduled_shutdown(m);
 
@@ -2335,10 +2339,6 @@ static int method_do_shutdown_or_sleep(
         m->scheduled_shutdown_action = action;
 
         (void) setup_wall_message_timer(m, message);
-
-        r = bus_manager_shutdown_or_sleep_now_or_later(m, a, error);
-        if (r < 0)
-                return r;
 
         return sd_bus_reply_method_return(message, NULL);
 }

--- a/src/login/logind-varlink.c
+++ b/src/login/logind-varlink.c
@@ -820,15 +820,6 @@ static int manager_do_shutdown_action(sd_varlink *link, sd_json_variant *paramet
         if (m->delayed_action)
                 return sd_varlink_error(link, "io.systemd.Shutdown.AlreadyInProgress", /* parameters= */ NULL);
 
-        /* Reset in case we're short-circuiting a scheduled shutdown */
-        m->unlink_nologin = false;
-        manager_reset_scheduled_shutdown(m);
-
-        m->scheduled_shutdown_timeout = 0;
-        m->scheduled_shutdown_action = action;
-
-        (void) setup_wall_message_timer(m, link);
-
         _cleanup_(sd_bus_error_free) sd_bus_error error = SD_BUS_ERROR_NULL;
         r = bus_manager_shutdown_or_sleep_now_or_later(m, a, &error);
         if (r < 0) {
@@ -837,6 +828,15 @@ static int manager_do_shutdown_action(sd_varlink *link, sd_json_variant *paramet
                                   bus_error_message(&error, r));
                 return sd_varlink_error_errno(link, r);
         }
+
+        /* Reset in case we're short-circuiting a scheduled shutdown. */
+        m->unlink_nologin = false;
+        manager_reset_scheduled_shutdown(m);
+
+        m->scheduled_shutdown_timeout = 0;
+        m->scheduled_shutdown_action = action;
+
+        (void) setup_wall_message_timer(m, link);
 
         return sd_varlink_reply(link, NULL);
 }


### PR DESCRIPTION
Do not discard an existing scheduled shutdown until the new action has been accepted. Keep failed D-Bus and Varlink requests from cancelling the pending shutdown.

Follow-up for: 5ed73478e1b1560274038ef30ec6f89022b4d8f6