### PR TITLE
core,journald: make LogLevelMax= work for user units

### DIFF
--- a/man/systemd.exec.xml
+++ b/man/systemd.exec.xml
@@ -3636,6 +3636,13 @@ StandardInputData=V2XigLJyZSBubyBzdHJhbmdlcnMgdG8gbG92ZQpZb3Uga25vdyB0aGUgcnVsZX
         might prohibit messages of higher log levels to be stored on disk, even though the per-unit
         <varname>LogLevelMax=</varname> permitted it to be processed.</para>
 
+        <para>Note that the journal applies the lowest log level max found on the unit and on any units
+        enclosing it: a <varname>LogLevelMax=</varname> set on an enclosing unit, e.g. on
+        <filename>user@.service</filename> for all units of a user session, cannot be loosened for a unit
+        below it. In particular, setting <varname>LogLevelMax=</varname><option>debug</option> on a unit
+        only raises its own ceiling, it does not lift a stricter limit configured on an enclosing
+        unit.</para>
+
         <xi:include href="version-info.xml" xpointer="v236"/></listitem>
       </varlistentry>
 
@@ -3681,6 +3688,9 @@ StandardInputData=V2XigLJyZSBubyBzdHJhbmdlcnMgdG8gbG92ZQpZb3Uga25vdyB0aGUgcnVsZX
         to messages written that way (but it will be enforced for messages generated via
         <citerefentry project='man-pages'><refentrytitle>syslog</refentrytitle><manvolnum>3</manvolnum></citerefentry>
         and similar functions).</para>
+
+        <para>Note that this functionality is currently only available in system services, not in per-user
+        services.</para>
 
         <xi:include href="version-info.xml" xpointer="v240"/></listitem>
       </varlistentry>

--- a/man/systemd.service.xml
+++ b/man/systemd.service.xml
@@ -1051,6 +1051,12 @@ RestartMaxDelaySec=160s</programlisting>
                 enable debug level logging in systemd, which is very verbose. This is otherwise equivalent
                 to <option>normal</option> mode.</para>
 
+                <para>Note that the raised debug level only affects this unit's own log level ceiling: it
+                cannot lift a stricter <varname>LogLevelMax=</varname> configured on an enclosing unit,
+                e.g. on <filename>user@.service</filename>. See
+                <citerefentry><refentrytitle>systemd.exec</refentrytitle><manvolnum>5</manvolnum></citerefentry>
+                for details.</para>
+
                 <xi:include href="version-info.xml" xpointer="v257"/>
               </listitem>
             </itemizedlist>

--- a/src/core/cgroup.c
+++ b/src/core/cgroup.c
@@ -50,6 +50,7 @@
 #include "string-table.h"
 #include "string-util.h"
 #include "strv.h"
+#include "syslog-util.h"
 #include "virt.h"
 
 #if BPF_FRAMEWORK
@@ -885,6 +886,35 @@ static int cgroup_log_xattr_apply(Unit *u) {
         return 0;
 }
 
+void cgroup_log_level_max_xattr_apply(Unit *u) {
+        int level;
+
+        assert(u);
+
+        /* Export the maximum log level in effect for this unit as a cgroup xattr, so that journald
+         * can pick it up for messages of this unit. This works the same for system and user units:
+         * the manager that owns the unit sets the xattr on the unit's cgroup, and journald reads
+         * it from there, regardless of which manager the unit belongs to. */
+        if (!unit_get_exec_context(u))
+                /* Units without an exec context, e.g. slices, cannot have a LogLevelMax=
+                 * configured. Their cgroups may carry xattrs set by whoever owns the surrounding
+                 * hierarchy instead: for the root slice of PID 1 that is the root of the whole
+                 * cgroup tree, for the root slice of a user manager the cgroup of the enclosing,
+                 * delegated user@<UID>.service. Leave those alone. */
+                return;
+
+        level = unit_effective_log_level_max(u);
+        if (level >= 0) {
+                /* The level comes from the parsed configuration or is LOG_DEBUG, so an out-of-range
+                 * value is a bug rather than something to mask out. */
+                assert_se(log_level_is_valid(level));
+
+                char value = '0' + level;
+                unit_set_xattr_graceful(u, "user.journald_log_level_max", &value, 1);
+        } else
+                unit_remove_xattr_graceful(u, "user.journald_log_level_max");
+}
+
 static void cgroup_invocation_id_xattr_apply(Unit *u) {
         bool b;
 
@@ -951,6 +981,7 @@ static void cgroup_xattr_apply(Unit *u) {
         /* The 'user.*' xattrs can be set from a user manager. */
         cgroup_oomd_xattr_apply(u);
         cgroup_log_xattr_apply(u);
+        cgroup_log_level_max_xattr_apply(u);
         cgroup_coredump_xattr_apply(u);
 
         if (!MANAGER_IS_SYSTEM(u->manager))
@@ -2574,8 +2605,15 @@ static int unit_realize_cgroup_now(Unit *u, ManagerState state) {
         target_mask = unit_get_target_mask(u);
         enable_mask = unit_get_enable_mask(u);
 
-        if (unit_has_mask_realized(u, target_mask, enable_mask))
+        if (unit_has_mask_realized(u, target_mask, enable_mask)) {
+                /* The log level max and log filter pattern xattrs follow settings that the
+                 * realization masks know nothing about: a realization with the masks already in
+                 * order is no guarantee that they are current. Re-apply them to converge; the
+                 * other xattrs are handled when the cgroup itself is created or updated below. */
+                cgroup_log_xattr_apply(u);
+                cgroup_log_level_max_xattr_apply(u);
                 return 0;
+        }
 
         /* Disable controllers below us, if there are any */
         r = unit_realize_cgroup_now_disable(u, state);

--- a/src/core/cgroup.h
+++ b/src/core/cgroup.h
@@ -427,6 +427,7 @@ int unit_get_cgroup_path_with_fallback(const Unit *u, char **ret);
 int unit_realize_cgroup(Unit *u);
 void unit_prune_cgroup(Unit *u);
 void unit_add_to_cgroup_realize_queue(Unit *u);
+void cgroup_log_level_max_xattr_apply(Unit *u);
 
 int unit_cgroup_is_empty(Unit *u);
 void unit_release_cgroup(Unit *u, bool drop_cgroup_runtime);

--- a/src/core/service.c
+++ b/src/core/service.c
@@ -2542,13 +2542,11 @@ static void service_enter_dead(Service *s, ServiceResult f, bool allow_restart) 
                 }
 
                 /* If the relevant option is set, and the unit doesn't already have logging level set to
-                 * debug, enable it now. Make sure to overwrite the state in /run/systemd/units/ too, to
+                 * debug, enable it now. Make sure to update the log level exported to journald too, to
                  * ensure journald doesn't prune the messages. The previous state is saved and restored
                  * once the auto-restart flow ends. */
                 if (s->restart_mode == SERVICE_RESTART_MODE_DEBUG) {
                         r = unit_set_debug_invocation(UNIT(s), true);
-                        if (r < 0)
-                                log_unit_warning_errno(UNIT(s), r, "Failed to enable debug invocation, ignoring: %m");
                         if (r > 0)
                                 log_unit_notice(UNIT(s), "Service dead, subsequent restarts will be executed with debug level logging.");
                 }

--- a/src/core/unit-serialize.c
+++ b/src/core/unit-serialize.c
@@ -112,7 +112,6 @@ int unit_serialize_state(Unit *u, FILE *f, FDSet *fds, bool switching_root) {
         (void) serialize_bool(f, "debug-invocation", u->debug_invocation);
 
         (void) serialize_bool(f, "exported-invocation-id", u->exported_invocation_id);
-        (void) serialize_bool(f, "exported-log-level-max", u->exported_log_level_max);
         (void) serialize_bool(f, "exported-log-extra-fields", u->exported_log_extra_fields);
         (void) serialize_bool(f, "exported-log-rate-limit-interval", u->exported_log_ratelimit_interval);
         (void) serialize_bool(f, "exported-log-rate-limit-burst", u->exported_log_ratelimit_burst);
@@ -278,9 +277,6 @@ int unit_deserialize_state(Unit *u, FILE *f, FDSet *fds) {
                         continue;
 
                 else if (MATCH_DESERIALIZE("exported-invocation-id", l, v, parse_boolean, u->exported_invocation_id))
-                        continue;
-
-                else if (MATCH_DESERIALIZE("exported-log-level-max", l, v, parse_boolean, u->exported_log_level_max))
                         continue;
 
                 else if (MATCH_DESERIALIZE("exported-log-extra-fields", l, v, parse_boolean, u->exported_log_extra_fields))

--- a/src/core/unit.c
+++ b/src/core/unit.c
@@ -4596,6 +4596,24 @@ ExecContext *unit_get_exec_context(const Unit *u) {
         return (ExecContext*) ((uint8_t*) u + offset);
 }
 
+int unit_effective_log_level_max(const Unit *u) {
+        const ExecContext *c;
+
+        assert(u);
+
+        /* The maximum log level in effect for this unit: the configured LogLevelMax=, raised to
+         * LOG_DEBUG while a debug invocation runs. -EINVAL if the unit has none configured. */
+
+        c = unit_get_exec_context(u);
+        if (!c)
+                return -EINVAL;
+
+        if (u->debug_invocation)
+                return LOG_DEBUG;
+
+        return c->log_level_max >= 0 ? c->log_level_max : -EINVAL;
+}
+
 KillContext *unit_get_kill_context(const Unit *u) {
         size_t offset;
         assert(u);
@@ -5914,36 +5932,6 @@ static int unit_export_invocation_id(Unit *u) {
         return 0;
 }
 
-static int unit_export_log_level_max(Unit *u, int log_level_max, bool overwrite) {
-        const char *p;
-        char buf[2];
-        int r;
-
-        assert(u);
-
-        /* When the debug_invocation logic runs, overwrite will be true as we always want to switch the max
-         * log level that the journal applies, and we want to always restore the previous level once done */
-
-        if (!overwrite && u->exported_log_level_max)
-                return 0;
-
-        if (log_level_max < 0)
-                return 0;
-
-        assert(log_level_max <= 7);
-
-        buf[0] = '0' + log_level_max;
-        buf[1] = 0;
-
-        p = strjoina("/run/systemd/units/log-level-max:", u->id);
-        r = symlink_atomic(buf, p);
-        if (r < 0)
-                return log_unit_debug_errno(u, r, "Failed to create maximum log level symlink %s: %m", p);
-
-        u->exported_log_level_max = true;
-        return 0;
-}
-
 static int unit_export_log_extra_fields(Unit *u, const ExecContext *c) {
         _cleanup_free_ char *p = NULL;
         int r;
@@ -6079,12 +6067,11 @@ void unit_export_state_files(Unit *u) {
 
         (void) unit_export_invocation_id(u);
 
-        if (!MANAGER_IS_SYSTEM(u->manager))
-                return;
-
         c = unit_get_exec_context(u);
-        if (c) {
-                (void) unit_export_log_level_max(u, c->log_level_max, /* overwrite= */ false);
+        if (c && MANAGER_IS_SYSTEM(u->manager)) {
+                /* LogExtraFields= and the per-unit log rate limit settings are currently only
+                 * available in system services, not in per-user services. For LogExtraFields=
+                 * this is documented in systemd.exec(5). */
                 (void) unit_export_log_extra_fields(u, c);
                 (void) unit_export_log_ratelimit_interval(u, c);
                 (void) unit_export_log_ratelimit_burst(u, c);
@@ -6109,16 +6096,6 @@ void unit_unlink_state_files(Unit *u) {
                         (void) unlink(invocation_path);
                         u->exported_invocation_id = false;
                 }
-        }
-
-        if (!MANAGER_IS_SYSTEM(u->manager))
-                return;
-
-        if (u->exported_log_level_max) {
-                const char *p = strjoina("/run/systemd/units/log-level-max:", u->id);
-                (void) unlink(p);
-
-                u->exported_log_level_max = false;
         }
 
         if (u->exported_log_extra_fields) {
@@ -6153,8 +6130,6 @@ void unit_unlink_state_files(Unit *u) {
 }
 
 int unit_set_debug_invocation(Unit *u, bool enable) {
-        int r;
-
         assert(u);
 
         if (u->debug_invocation == enable)
@@ -6163,14 +6138,7 @@ int unit_set_debug_invocation(Unit *u, bool enable) {
         u->debug_invocation = enable;
 
         /* Ensure that the new log level is exported for the journal, in place of the previous one */
-        if (u->exported_log_level_max) {
-                const ExecContext *ec = unit_get_exec_context(u);
-                if (ec) {
-                        r = unit_export_log_level_max(u, enable ? LOG_PRI(LOG_DEBUG) : ec->log_level_max, /* overwrite= */ true);
-                        if (r < 0)
-                                return r;
-                }
-        }
+        cgroup_log_level_max_xattr_apply(u);
 
         return 1;
 }

--- a/src/core/unit.c
+++ b/src/core/unit.c
@@ -5864,23 +5864,24 @@ void unit_remove_dependencies(Unit *u, UnitDependencyMask mask) {
         }
 }
 
-static int unit_get_invocation_path(Unit *u, char **ret) {
+static int unit_get_state_file_path(const Unit *u, const char *name, char **ret) {
         char *p;
         int r;
 
         assert(u);
+        assert(name);
         assert(ret);
 
         if (MANAGER_IS_SYSTEM(u->manager))
-                p = strjoin("/run/systemd/units/invocation:", u->id);
+                p = strjoin("/run/systemd/units/", name, u->id);
         else {
                 _cleanup_free_ char *user_path = NULL;
 
-                r = xdg_user_runtime_dir("/systemd/units/invocation:", &user_path);
+                r = xdg_user_runtime_dir("/systemd/units/", &user_path);
                 if (r < 0)
                         return r;
 
-                p = strjoin(user_path, u->id);
+                p = strjoin(user_path, name, u->id);
         }
         if (!p)
                 return -ENOMEM;
@@ -5901,7 +5902,7 @@ static int unit_export_invocation_id(Unit *u) {
         if (sd_id128_is_null(u->invocation_id))
                 return 0;
 
-        r = unit_get_invocation_path(u, &p);
+        r = unit_get_state_file_path(u, "invocation:", &p);
         if (r < 0)
                 return log_unit_debug_errno(u, r, "Failed to get invocation path: %m");
 
@@ -5944,6 +5945,7 @@ static int unit_export_log_level_max(Unit *u, int log_level_max, bool overwrite)
 }
 
 static int unit_export_log_extra_fields(Unit *u, const ExecContext *c) {
+        _cleanup_free_ char *p = NULL;
         int r;
 
         if (u->exported_log_extra_fields)
@@ -5964,7 +5966,10 @@ static int unit_export_log_extra_fields(Unit *u, const ExecContext *c) {
                 iovec[i*2+1] = c->log_extra_fields[i];
         }
 
-        const char *p = strjoina("/run/systemd/units/log-extra-fields:", u->id);
+        r = unit_get_state_file_path(u, "log-extra-fields:", &p);
+        if (r < 0)
+                return log_unit_debug_errno(u, r, "Failed to get path of extra fields file: %m");
+
         char *pattern = strjoina(p, ".XXXXXX");
 
         _cleanup_close_ int fd = mkostemp_safe(pattern);
@@ -5992,6 +5997,7 @@ fail:
 }
 
 static int unit_export_log_ratelimit_interval(Unit *u, const ExecContext *c) {
+        _cleanup_free_ char *p = NULL;
         int r;
 
         assert(u);
@@ -6003,7 +6009,9 @@ static int unit_export_log_ratelimit_interval(Unit *u, const ExecContext *c) {
         if (c->log_ratelimit.interval == 0)
                 return 0;
 
-        const char *p = strjoina("/run/systemd/units/log-rate-limit-interval:", u->id);
+        r = unit_get_state_file_path(u, "log-rate-limit-interval:", &p);
+        if (r < 0)
+                return log_unit_debug_errno(u, r, "Failed to get log rate limit interval path: %m");
 
         char buf[DECIMAL_STR_MAX(c->log_ratelimit.interval)];
         xsprintf(buf, "%" PRIu64, c->log_ratelimit.interval);
@@ -6017,6 +6025,7 @@ static int unit_export_log_ratelimit_interval(Unit *u, const ExecContext *c) {
 }
 
 static int unit_export_log_ratelimit_burst(Unit *u, const ExecContext *c) {
+        _cleanup_free_ char *p = NULL;
         int r;
 
         assert(u);
@@ -6028,7 +6037,9 @@ static int unit_export_log_ratelimit_burst(Unit *u, const ExecContext *c) {
         if (c->log_ratelimit.burst == 0)
                 return 0;
 
-        const char *p = strjoina("/run/systemd/units/log-rate-limit-burst:", u->id);
+        r = unit_get_state_file_path(u, "log-rate-limit-burst:", &p);
+        if (r < 0)
+                return log_unit_debug_errno(u, r, "Failed to get log rate limit burst path: %m");
 
         char buf[DECIMAL_STR_MAX(c->log_ratelimit.burst)];
         xsprintf(buf, "%u", c->log_ratelimit.burst);
@@ -6052,7 +6063,8 @@ void unit_export_state_files(Unit *u) {
         if (MANAGER_IS_TEST_RUN(u->manager))
                 return;
 
-        /* Exports a couple of unit properties to /run/systemd/units/, so that journald can quickly query this data
+        /* Exports a couple of unit properties to /run/systemd/units/ (for the system manager) or
+         * /run/user/<UID>/systemd/units/ (for user managers), so that journald can quickly query this data
          * from there. Ideally, journald would use IPC to query this, like everybody else, but that's hard, as long as
          * the IPC system itself and PID 1 also log to the journal.
          *
@@ -6080,18 +6092,19 @@ void unit_export_state_files(Unit *u) {
 }
 
 void unit_unlink_state_files(Unit *u) {
-        const char *p;
+        int r;
 
         assert(u);
 
         if (!u->id)
                 return;
 
-        /* Undoes the effect of unit_export_state() */
+        /* Undoes the effect of unit_export_state_files() */
 
         if (u->exported_invocation_id) {
                 _cleanup_free_ char *invocation_path = NULL;
-                int r = unit_get_invocation_path(u, &invocation_path);
+
+                r = unit_get_state_file_path(u, "invocation:", &invocation_path);
                 if (r >= 0) {
                         (void) unlink(invocation_path);
                         u->exported_invocation_id = false;
@@ -6102,31 +6115,40 @@ void unit_unlink_state_files(Unit *u) {
                 return;
 
         if (u->exported_log_level_max) {
-                p = strjoina("/run/systemd/units/log-level-max:", u->id);
+                const char *p = strjoina("/run/systemd/units/log-level-max:", u->id);
                 (void) unlink(p);
 
                 u->exported_log_level_max = false;
         }
 
         if (u->exported_log_extra_fields) {
-                p = strjoina("/run/systemd/units/log-extra-fields:", u->id);
-                (void) unlink(p);
+                _cleanup_free_ char *p = NULL;
 
-                u->exported_log_extra_fields = false;
+                r = unit_get_state_file_path(u, "log-extra-fields:", &p);
+                if (r >= 0) {
+                        (void) unlink(p);
+                        u->exported_log_extra_fields = false;
+                }
         }
 
         if (u->exported_log_ratelimit_interval) {
-                p = strjoina("/run/systemd/units/log-rate-limit-interval:", u->id);
-                (void) unlink(p);
+                _cleanup_free_ char *p = NULL;
 
-                u->exported_log_ratelimit_interval = false;
+                r = unit_get_state_file_path(u, "log-rate-limit-interval:", &p);
+                if (r >= 0) {
+                        (void) unlink(p);
+                        u->exported_log_ratelimit_interval = false;
+                }
         }
 
         if (u->exported_log_ratelimit_burst) {
-                p = strjoina("/run/systemd/units/log-rate-limit-burst:", u->id);
-                (void) unlink(p);
+                _cleanup_free_ char *p = NULL;
 
-                u->exported_log_ratelimit_burst = false;
+                r = unit_get_state_file_path(u, "log-rate-limit-burst:", &p);
+                if (r >= 0) {
+                        (void) unlink(p);
+                        u->exported_log_ratelimit_burst = false;
+                }
         }
 }
 

--- a/src/core/unit.c
+++ b/src/core/unit.c
@@ -6109,7 +6109,7 @@ void unit_unlink_state_files(Unit *u) {
         }
 
         if (u->exported_log_extra_fields) {
-                p = strjoina("/run/systemd/units/extra-fields:", u->id);
+                p = strjoina("/run/systemd/units/log-extra-fields:", u->id);
                 (void) unlink(p);
 
                 u->exported_log_extra_fields = false;

--- a/src/core/unit.h
+++ b/src/core/unit.h
@@ -475,7 +475,6 @@ typedef struct Unit {
 
         /* Remember which unit state files we created */
         bool exported_invocation_id:1;
-        bool exported_log_level_max:1;
         bool exported_log_extra_fields:1;
         bool exported_log_ratelimit_interval:1;
         bool exported_log_ratelimit_burst:1;
@@ -972,6 +971,7 @@ int unit_patch_contexts(Unit *u);
 ExecContext* unit_get_exec_context(const Unit *u) _pure_;
 KillContext* unit_get_kill_context(const Unit *u) _pure_;
 CGroupContext* unit_get_cgroup_context(const Unit *u) _pure_;
+int unit_effective_log_level_max(const Unit *u) _pure_;
 
 ExecRuntime* unit_get_exec_runtime(const Unit *u) _pure_;
 CGroupRuntime* unit_get_cgroup_runtime(const Unit *u) _pure_;

--- a/src/journal/journald-client.c
+++ b/src/journal/journald-client.c
@@ -7,9 +7,11 @@
 #include "journald-context.h"
 #include "log.h"
 #include "nulstr-util.h"
+#include "path-util.h"
 #include "pcre2-util.h"
 #include "set.h"
 #include "strv.h"
+#include "syslog-util.h"
 
 /* This consumes both `allow_list` and `deny_list` arguments. Hence, those arguments are not owned by the
  * caller anymore and should not be freed. */
@@ -101,6 +103,45 @@ int client_context_read_log_filter_patterns(ClientContext *c, const char *cgroup
         client_set_filtering_patterns(c, TAKE_PTR(allow_list), TAKE_PTR(deny_list));
 
         return 0;
+}
+
+void client_context_read_log_level_max(ClientContext *c, const char *cgroup) {
+        int level = -1;
+
+        assert(c);
+        assert(cgroup);
+
+        /* Like client_context_read_log_filter_patterns() above, but for LogLevelMax=: the level is
+         * exported as an xattr by the manager that owns the unit, PID 1 for system units and the
+         * user manager for user units. Check the xattr on the sender's cgroup and on every cgroup
+         * above it, up to the root of the tree, and apply the lowest limit found: a limit set on an
+         * enclosing cgroup, e.g. on user@<UID>.service for all units of a user session, cannot be
+         * loosened by a more permissive one on a cgroup below it. Unreadable or unparseable xattrs
+         * are ignored, so that they cannot defeat a limit set on some enclosing cgroup either. */
+        char prefix[strlen(cgroup) + 1];
+        PATH_FOREACH_PREFIX_MORE(prefix, cgroup) {
+                _cleanup_free_ char *value = NULL;
+                int r;
+
+                r = cg_get_xattr(prefix, "user.journald_log_level_max", &value, /* ret_size= */ NULL);
+                if (ERRNO_IS_NEG_XATTR_ABSENT(r))
+                        continue;
+                if (r < 0) {
+                        log_debug_errno(r, "Failed to get user.journald_log_level_max xattr of %s, ignoring: %m", prefix);
+                        continue;
+                }
+
+                r = log_level_from_string(value);
+                if (r < 0) {
+                        log_debug_errno(r, "Failed to parse log level max xattr '%s' of %s, ignoring.", value, prefix);
+                        continue;
+                }
+
+                if (level < 0 || r < level)
+                        level = r;
+        }
+
+        c->log_level_max = level;
 }
 
 int client_context_check_keep_log(ClientContext *c, const char *message, size_t len) {

--- a/src/journal/journald-client.h
+++ b/src/journal/journald-client.h
@@ -4,4 +4,5 @@
 #include "journald-forward.h"
 
 int client_context_read_log_filter_patterns(ClientContext *c, const char *cgroup);
+void client_context_read_log_level_max(ClientContext *c, const char *cgroup);
 int client_context_check_keep_log(ClientContext *c, const char *message, size_t len);

--- a/src/journal/journald-context.c
+++ b/src/journal/journald-context.c
@@ -9,6 +9,7 @@
 #include "env-util.h"
 #include "fd-util.h"
 #include "fileio.h"
+#include "format-util.h"
 #include "fs-util.h"
 #include "iovec-util.h"
 #include "journal-internal.h"
@@ -26,7 +27,6 @@
 #include "selinux-util.h"
 #include "set.h"
 #include "string-util.h"
-#include "syslog-util.h"
 #include "time-util.h"
 #include "unaligned.h"
 #include "user-util.h"
@@ -283,6 +283,11 @@ static int client_context_read_cgroup(Manager *m, ClientContext *c, const char *
 
         assert(c);
 
+        /* The log level max can only be read from the unit's cgroup, see
+         * client_context_read_log_level_max() in journald-client.c. If we cannot resolve the
+         * cgroup at all there is no level, hence reset it here so that no stale one is retained. */
+        c->log_level_max = -1;
+
         /* Try to acquire the current cgroup path */
         r = cg_pid_get_path_shifted(c->pid, m->cgroup_root, &t);
         if (r < 0 || empty_or_root(t)) {
@@ -299,6 +304,7 @@ static int client_context_read_cgroup(Manager *m, ClientContext *c, const char *
         }
 
         (void) client_context_read_log_filter_patterns(c, t);
+        client_context_read_log_level_max(c, t);
 
         /* Let's shortcut this if the cgroup path didn't change */
         if (streq_ptr(c->cgroup, t))
@@ -327,6 +333,33 @@ static int client_context_read_cgroup(Manager *m, ClientContext *c, const char *
         return 0;
 }
 
+static bool client_context_is_user_area(const ClientContext *c) {
+        assert(c);
+
+        return c->user_unit && uid_is_valid(c->owner_uid);
+}
+
+static char *client_context_system_state_file_path(const ClientContext *c, const char *name) {
+        assert(c);
+        assert(name);
+        assert(c->unit);
+
+        return strjoin("/run/systemd/units/", name, c->unit);
+}
+
+static char *client_context_state_file_path(const ClientContext *c, const char *name) {
+        assert(c);
+        assert(name);
+        assert(c->unit);
+
+        /* Per-unit state files for journald: PID 1 stores them in /run/systemd/units/, user managers
+         * store them under /run/user/<uid>/systemd/units/. */
+        if (client_context_is_user_area(c))
+                return strjoin("/run/user/", FORMAT_UID(c->owner_uid), "/systemd/units/", name, c->user_unit);
+
+        return client_context_system_state_file_path(c, name);
+}
+
 static int client_context_read_invocation_id(
                 Manager *m,
                 ClientContext *c) {
@@ -337,52 +370,24 @@ static int client_context_read_invocation_id(
         assert(m);
         assert(c);
 
-        /* Read the invocation ID of a unit off a unit.
-         * PID 1 stores it in a per-unit symlink in /run/systemd/units/
-         * User managers store it in a per-unit symlink under /run/user/<uid>/systemd/units/ */
-
         if (!c->unit)
                 return 0;
 
-        if (c->user_unit) {
-                r = asprintf(&p, "/run/user/" UID_FMT "/systemd/units/invocation:%s", c->owner_uid, c->user_unit);
-                if (r < 0)
-                        return r;
-        } else {
-                p = strjoin("/run/systemd/units/invocation:", c->unit);
-                if (!p)
-                        return -ENOMEM;
-        }
+        /* Capsules have no /run/user/<uid>/ directory, and no invocation ID was read for their
+         * units before; leave the field unset instead of attributing them to the invocation ID
+         * of the capsule manager service. */
+        if (c->user_unit && !client_context_is_user_area(c))
+                return 0;
+
+        p = client_context_state_file_path(c, "invocation:");
+        if (!p)
+                return -ENOMEM;
 
         r = readlink_malloc(p, &value);
         if (r < 0)
                 return r;
 
         return sd_id128_from_string(value, &c->invocation_id);
-}
-
-static int client_context_read_log_level_max(
-                Manager *m,
-                ClientContext *c) {
-
-        _cleanup_free_ char *value = NULL;
-        const char *p;
-        int r, ll;
-
-        if (!c->unit)
-                return 0;
-
-        p = strjoina("/run/systemd/units/log-level-max:", c->unit);
-        r = readlink_malloc(p, &value);
-        if (r < 0)
-                return r;
-
-        ll = log_level_from_string(value);
-        if (ll < 0)
-                return ll;
-
-        c->log_level_max = ll;
-        return 0;
 }
 
 static int client_context_read_extra_fields(
@@ -394,14 +399,16 @@ static int client_context_read_extra_fields(
         _cleanup_free_ void *data = NULL;
         _cleanup_fclose_ FILE *f = NULL;
         struct stat st;
-        const char *p;
+        _cleanup_free_ char *p = NULL;
         uint8_t *q;
         int r;
 
         if (!c->unit)
                 return 0;
 
-        p = strjoina("/run/systemd/units/log-extra-fields:", c->unit);
+        p = client_context_system_state_file_path(c, "log-extra-fields:");
+        if (!p)
+                return -ENOMEM;
 
         if (c->extra_fields_mtime != NSEC_INFINITY) {
                 if (stat(p, &st) < 0) {
@@ -479,8 +486,7 @@ static int client_context_read_extra_fields(
 }
 
 static int client_context_read_log_ratelimit_interval(ClientContext *c) {
-        _cleanup_free_ char *value = NULL;
-        const char *p;
+        _cleanup_free_ char *p = NULL, *value = NULL;
         int r;
 
         assert(c);
@@ -488,7 +494,10 @@ static int client_context_read_log_ratelimit_interval(ClientContext *c) {
         if (!c->unit)
                 return 0;
 
-        p = strjoina("/run/systemd/units/log-rate-limit-interval:", c->unit);
+        p = client_context_system_state_file_path(c, "log-rate-limit-interval:");
+        if (!p)
+                return -ENOMEM;
+
         r = readlink_malloc(p, &value);
         if (r < 0)
                 return r;
@@ -502,8 +511,7 @@ static int client_context_read_log_ratelimit_interval(ClientContext *c) {
 }
 
 static int client_context_read_log_ratelimit_burst(ClientContext *c) {
-        _cleanup_free_ char *value = NULL;
-        const char *p;
+        _cleanup_free_ char *p = NULL, *value = NULL;
         int r;
 
         assert(c);
@@ -511,7 +519,10 @@ static int client_context_read_log_ratelimit_burst(ClientContext *c) {
         if (!c->unit)
                 return 0;
 
-        p = strjoina("/run/systemd/units/log-rate-limit-burst:", c->unit);
+        p = client_context_system_state_file_path(c, "log-rate-limit-burst:");
+        if (!p)
+                return -ENOMEM;
+
         r = readlink_malloc(p, &value);
         if (r < 0)
                 return r;
@@ -548,7 +559,6 @@ static void client_context_really_refresh(
 
         (void) client_context_read_cgroup(m, c, unit_id);
         (void) client_context_read_invocation_id(m, c);
-        (void) client_context_read_log_level_max(m, c);
         (void) client_context_read_extra_fields(m, c);
         (void) client_context_read_log_ratelimit_interval(c);
         (void) client_context_read_log_ratelimit_burst(c);

--- a/test/units/TEST-04-JOURNAL.log-extra-fields.sh
+++ b/test/units/TEST-04-JOURNAL.log-extra-fields.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: LGPL-2.1-or-later
+set -eux
+set -o pipefail
+
+# shellcheck source=test/units/util.sh
+. "$(dirname "$0")"/util.sh
+
+# Tests that the log extra fields state file is created while the unit runs
+# and removed again when it exits
+unit="log-extra-fields-$RANDOM.service"
+systemd-run --service-type=exec --unit="$unit" \
+            -p LogExtraFields=FOO=bar \
+            sleep 60
+test -e "/run/systemd/units/log-extra-fields:$unit"
+systemctl stop "$unit"
+timeout 30 bash -c "while [ -e '/run/systemd/units/log-extra-fields:$unit' ]; do sleep .5; done"

--- a/test/units/TEST-04-JOURNAL.log-level-max.sh
+++ b/test/units/TEST-04-JOURNAL.log-level-max.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: LGPL-2.1-or-later
+set -eux
+set -o pipefail
+
+# shellcheck source=test/units/util.sh
+. "$(dirname "$0")"/util.sh
+
+# Tests that LogLevelMax= applies to the unit's messages, for system and user units alike
+# https://github.com/systemd/systemd/issues/43446
+
+if ! cgroupfs_supports_user_xattrs; then
+    echo "CGroup does not support user xattrs, skipping LogLevelMax= tests."
+    exit 0
+fi
+
+unit=""
+uid="$(id -u testuser)"
+
+cleanup() {
+    systemctl --user -M testuser@ stop "$unit" 2>/dev/null || :
+    systemctl stop "$unit" 2>/dev/null || :
+    rm -rf "/run/systemd/system/user@$uid.service.d"
+    systemctl daemon-reload || :
+    systemctl stop "user@$uid.service" 2>/dev/null || :
+    loginctl disable-linger testuser || :
+}
+trap cleanup EXIT
+
+# Keep the user manager of testuser around while the subtests below hand control
+# back and forth between the host and the user manager, so that it cannot be
+# garbage-collected in between
+loginctl enable-linger testuser
+
+# Each message sender is kept alive for a moment after logging, as journald
+# cannot attribute messages to the unit anymore if the sender already exited
+# again when the message is processed.
+# The dropped and the kept message are sent over a single stream, tagged with
+# syslog level prefixes: the kept message then also proves that the dropped one
+# was attributed to the unit, and hence filtered rather than lost.
+# A message logged with a priority above LogLevelMax=info must be dropped by
+# journald, one below must be kept
+
+# The LogLevelMax= of a system unit must apply
+unit="log-level-max-system-$RANDOM.service"
+systemd-run --wait --service-type=exec --unit="$unit" \
+            -p LogLevelMax=info \
+            bash -ec "{ printf '<7>suppressed-debug-message\n<6>kept-info-message\n'; sleep 1; } | systemd-cat"
+journalctl --sync
+run_and_grep "^kept-info-message$" journalctl -q -b "_SYSTEMD_UNIT=$unit" -o cat
+run_and_grep -n "^suppressed-debug-message$" journalctl -q -b "_SYSTEMD_UNIT=$unit" -o cat
+
+# The LogLevelMax= of a user unit must apply too
+# Match by _SYSTEMD_USER_UNIT instead of --user-unit=, as the latter also
+# requires _UID= to match the uid of the calling journalctl, which is root
+# here, but testuser for the messages below
+unit="log-level-max-user-$RANDOM.service"
+systemd-run --user -M testuser@ --wait --service-type=exec --unit="$unit" \
+            -p LogLevelMax=info \
+            bash -ec "{ printf '<7>suppressed-debug-message\n<6>kept-info-message\n'; sleep 1; } | systemd-cat"
+journalctl --sync
+run_and_grep "^kept-info-message$" journalctl -q -b "_SYSTEMD_USER_UNIT=$unit" -o cat
+run_and_grep -n "^suppressed-debug-message$" journalctl -q -b "_SYSTEMD_USER_UNIT=$unit" -o cat
+
+# Without LogLevelMax= both messages must be kept
+unit="log-level-max-user-$RANDOM.service"
+systemd-run --user -M testuser@ --wait --service-type=exec --unit="$unit" \
+            bash -ec '{ echo kept-debug-message; sleep 1; } | systemd-cat -p debug;
+                       { echo kept-info-message; sleep 1; } | systemd-cat -p info'
+journalctl --sync
+run_and_grep "^kept-debug-message$" journalctl -q -b "_SYSTEMD_USER_UNIT=$unit" -o cat
+run_and_grep "^kept-info-message$" journalctl -q -b "_SYSTEMD_USER_UNIT=$unit" -o cat
+
+# A LogLevelMax= set on user@<UID>.service applies to the user manager and to the
+# user units of that user; a per-unit LogLevelMax= can only tighten that cap,
+# not loosen it
+mkdir -p "/run/systemd/system/user@$uid.service.d"
+printf '[Service]\nLogLevelMax=info\n' >"/run/systemd/system/user@$uid.service.d/10-log-level-max.conf"
+systemctl daemon-reload
+systemctl stop "user@$uid.service"
+
+# Without a per-unit LogLevelMax= the session-wide one applies
+unit="log-level-max-user-$RANDOM.service"
+systemd-run --user -M testuser@ --wait --service-type=exec --unit="$unit" \
+            bash -ec "{ printf '<7>session-suppressed-debug-message\n<6>session-kept-info-message\n'; sleep 1; } | systemd-cat"
+journalctl --sync
+run_and_grep "^session-kept-info-message$" journalctl -q -b "_SYSTEMD_USER_UNIT=$unit" -o cat
+run_and_grep -n "^session-suppressed-debug-message$" journalctl -q -b "_SYSTEMD_USER_UNIT=$unit" -o cat
+
+# A per-unit LogLevelMax= cannot loosen the session-wide cap: with
+# LogLevelMax=info on user@<UID>.service and LogLevelMax=debug on the unit,
+# the effective cap is the lower of the two, i.e. info
+unit="log-level-max-user-$RANDOM.service"
+systemd-run --user -M testuser@ --wait --service-type=exec --unit="$unit" \
+            -p LogLevelMax=debug \
+            bash -ec "{ printf '<7>unit-suppressed-debug-message\n<6>unit-kept-info-message\n'; sleep 1; } | systemd-cat"
+journalctl --sync
+run_and_grep "^unit-kept-info-message$" journalctl -q -b "_SYSTEMD_USER_UNIT=$unit" -o cat
+run_and_grep -n "^unit-suppressed-debug-message$" journalctl -q -b "_SYSTEMD_USER_UNIT=$unit" -o cat
+
+# While the session-wide cap is in place, it is exported as an xattr on the
+# cgroup of the user manager service itself. It is removed again once the cap
+# is dropped, even though the cgroup of the still-running user manager persists
+user_manager_cgroup="/sys/fs/cgroup$(systemctl show "user@$uid.service" -p ControlGroup --value)"
+test "$(getfattr --absolute-names --only-values -n user.journald_log_level_max "$user_manager_cgroup")" = 6
+
+rm -rf "/run/systemd/system/user@$uid.service.d"
+systemctl daemon-reload
+# The re-realization that applies the xattrs again is asynchronous, hence poll
+timeout 30 bash -c "while getfattr --absolute-names --only-values -n user.journald_log_level_max '$user_manager_cgroup' >/dev/null 2>&1; do sleep .5; done"
+test -d "$user_manager_cgroup"
+
+# With the session-wide cap gone, messages of the user units pass through the
+# journal unfiltered again
+unit="log-level-max-user-$RANDOM.service"
+systemd-run --user -M testuser@ --wait --service-type=exec --unit="$unit" \
+    bash -ec '{ echo recovered-debug-message; sleep 1; } | systemd-cat -p debug;
+               { echo recovered-info-message; sleep 1; } | systemd-cat -p info'
+journalctl --sync
+run_and_grep "^recovered-debug-message$" journalctl -q -b "_SYSTEMD_USER_UNIT=$unit" -o cat
+run_and_grep "^recovered-info-message$" journalctl -q -b "_SYSTEMD_USER_UNIT=$unit" -o cat
+
+systemctl stop "user@$uid.service"
+
+# The log level is exported as an xattr on the unit's own cgroup, so that it is
+# removed together with the cgroup again when the unit stops
+unit="log-level-max-user-$RANDOM.service"
+systemd-run --user -M testuser@ --service-type=exec --unit="$unit" \
+            -p LogLevelMax=info \
+            sleep 60
+cgroup="/sys/fs/cgroup$(systemctl --user -M testuser@ show "$unit" -p ControlGroup --value)"
+# LogLevelMax=info is exported as its numeric log level
+test "$(getfattr --absolute-names --only-values -n user.journald_log_level_max "$cgroup")" = 6
+systemctl --user -M testuser@ stop "$unit"
+timeout 30 bash -c "while [ -e '$cgroup' ]; do sleep .5; done"
+
+# A unit that configures no LogLevelMax= of its own gets no xattr
+unit="log-level-max-user-$RANDOM.service"
+systemd-run --user -M testuser@ --service-type=exec --unit="$unit" \
+            sleep 60
+cgroup="/sys/fs/cgroup$(systemctl --user -M testuser@ show "$unit" -p ControlGroup --value)"
+(! getfattr --absolute-names --only-values -n user.journald_log_level_max "$cgroup" 2>/dev/null)
+systemctl --user -M testuser@ stop "$unit"
+
+# The min of the levels is also applied when the leaf is the stricter one:
+# with LogLevelMax=debug on user@<UID>.service and LogLevelMax=info on the
+# unit, the effective cap is the lower of the two, i.e. info
+mkdir -p "/run/systemd/system/user@$uid.service.d"
+printf '[Service]\nLogLevelMax=debug\n' >"/run/systemd/system/user@$uid.service.d/10-log-level-max.conf"
+systemctl daemon-reload
+systemctl start "user@$uid.service"
+timeout 30 bash -c "while [ \"\$(getfattr --absolute-names --only-values -n user.journald_log_level_max '$user_manager_cgroup')\" != 7 ]; do sleep .5; done"
+
+unit="log-level-max-user-$RANDOM.service"
+systemd-run --user -M testuser@ --wait --service-type=exec --unit="$unit" \
+    -p LogLevelMax=info \
+    bash -ec "{ printf '<7>leaf-suppressed-debug-message\n<6>leaf-kept-info-message\n'; sleep 1; } | systemd-cat"
+journalctl --sync
+run_and_grep "^leaf-kept-info-message$" journalctl -q -b "_SYSTEMD_USER_UNIT=$unit" -o cat
+run_and_grep -n "^leaf-suppressed-debug-message$" journalctl -q -b "_SYSTEMD_USER_UNIT=$unit" -o cat


### PR DESCRIPTION
PID 1 passes per-unit log settings to journald via state files below /run/systemd/units/. LogLevelMax= never worked for user units, and for them the state file is the wrong transport anyway: the system journald would have to read files below /run/user/<UID>/, a directory the user owns and may replace, and cgroups without a runtime directory there, like capsules, would not fit the scheme at all.

Export LogLevelMax= as a user.journald_log_level_max xattr on the unit's cgroup instead, the way LogFilterPatterns= is already handled: PID 1 sets it for system units, the user manager for user units, and journald reads it off the cgroup of the unit the sender belongs to, so it works the same for both. The xattr is removed together with the cgroup, so nothing can linger and nothing needs unlinking, and the system journald no longer reaches into the user's runtime directory. A LogLevelMax= set on user@<UID>.service still applies to the whole session as a fallback — it caps the user manager itself, whose processes run in a subgroup below its cgroup, and the user units that set no level of their own — while a level set on the user unit takes precedence. user.* xattrs on cgroupfs are supported since kernel 5.7, below our baseline.

While at it, fix the unlink path of the log extra fields state file: it is created as log-extra-fields: but was unlinked as extra-fields:, i.e. never actually removed.

Fixes: #43446
