### PR TITLE
journal: obtain Manager object from varlink server

### DIFF
--- a/src/journal/journald-varlink.c
+++ b/src/journal/journald-varlink.c
@@ -24,7 +24,7 @@ void sync_req_varlink_reply(SyncReq *req) {
 
         /* Disconnect the SyncReq from the Varlink connection object, and free it */
         _cleanup_(sd_varlink_unrefp) sd_varlink *vl = TAKE_PTR(req->link);
-        sd_varlink_set_userdata(vl, req->manager); /* reinstall manager object */
+        sd_varlink_set_userdata(vl, NULL);
         req = sync_req_free(req);
 
         r = sd_varlink_reply(vl, NULL);
@@ -44,11 +44,10 @@ static int vl_method_synchronize(sd_varlink *link, sd_json_variant *parameters, 
 
         assert(link);
 
-        /* Here, userdata may not be a pointer to the Manager object. Obtain the manager from the server. */
         Manager *m = ASSERT_PTR(sd_varlink_server_get_userdata(sd_varlink_get_server(link)));
 
         /* The varlink connection already requested to sync journals. Refusing. */
-        if (sd_varlink_get_userdata(link) != m)
+        if (sd_varlink_get_userdata(link))
                 return -EBUSY;
 
         r = sd_varlink_dispatch(link, parameters, dispatch_table, &offline);
@@ -87,10 +86,11 @@ static int vl_method_synchronize(sd_varlink *link, sd_json_variant *parameters, 
 }
 
 static int vl_method_rotate(sd_varlink *link, sd_json_variant *parameters, sd_varlink_method_flags_t flags, void *userdata) {
-        Manager *m = ASSERT_PTR(userdata);
         int r;
 
         assert(link);
+
+        Manager *m = ASSERT_PTR(sd_varlink_server_get_userdata(sd_varlink_get_server(link)));
 
         r = sd_varlink_dispatch(link, parameters, /* dispatch_table= */ NULL, /* userdata= */ NULL);
         if (r != 0)
@@ -108,10 +108,11 @@ static int vl_method_rotate(sd_varlink *link, sd_json_variant *parameters, sd_va
 }
 
 static int vl_method_flush_to_var(sd_varlink *link, sd_json_variant *parameters, sd_varlink_method_flags_t flags, void *userdata) {
-        Manager *m = ASSERT_PTR(userdata);
         int r;
 
         assert(link);
+
+        Manager *m = ASSERT_PTR(sd_varlink_server_get_userdata(sd_varlink_get_server(link)));
 
         r = sd_varlink_dispatch(link, parameters, /* dispatch_table= */ NULL, /* userdata= */ NULL);
         if (r != 0)
@@ -132,10 +133,11 @@ static int vl_method_flush_to_var(sd_varlink *link, sd_json_variant *parameters,
 }
 
 static int vl_method_relinquish_var(sd_varlink *link, sd_json_variant *parameters, sd_varlink_method_flags_t flags, void *userdata) {
-        Manager *m = ASSERT_PTR(userdata);
         int r;
 
         assert(link);
+
+        Manager *m = ASSERT_PTR(sd_varlink_server_get_userdata(sd_varlink_get_server(link)));
 
         r = sd_varlink_dispatch(link, parameters, /* dispatch_table= */ NULL, /* userdata= */ NULL);
         if (r != 0)
@@ -172,15 +174,7 @@ static void vl_disconnect(sd_varlink_server *server, sd_varlink *link, void *use
         assert(server);
         assert(link);
 
-        void *u = sd_varlink_get_userdata(link);
-        if (u != m) {
-                /* If this is a Varlink connection that does not have the Manager object as userdata, then
-                 * it has a SyncReq object instead. Let's finish it. */
-
-                SyncReq *req = u;
-                sd_varlink_set_userdata(link, m); /* reinstall the manager object */
-                sync_req_free(req);
-        }
+        sync_req_free(sd_varlink_set_userdata(link, NULL));
 
         (void) manager_start_or_stop_idle_timer(m); /* maybe we are idle now */
 }
@@ -192,7 +186,7 @@ int manager_open_varlink(Manager *m, const char *socket, int fd) {
 
         r = varlink_server_new(
                         &m->varlink_server,
-                        SD_VARLINK_SERVER_ACCOUNT_UID|SD_VARLINK_SERVER_INHERIT_USERDATA,
+                        SD_VARLINK_SERVER_ACCOUNT_UID,
                         m);
         if (r < 0)
                 return log_error_errno(r, "Failed to allocate varlink server object: %m");


### PR DESCRIPTION
Previously, if a synchronization operation was requested, and not finished yet, the userdata passed to each vl_method function was not a pointer to Manager object.

So, when there is a method that sets a custom userdata, we should not inherit the userdata set to the sd_varlink_server to sd_varlink.

Let's drop SD_VARLINK_SERVER_INHERIT_USERDATA flag from the server, and always obtain the Manager object from the server.

Follow-up for c2806a8c1d6b775fb73516ef62b9f66e7cc00310.

This must be merged before #42861, as it trying to revert the commit c2806a8c1d6b775fb73516ef62b9f66e7cc00310.
But the commit c2806a8c1d6b775fb73516ef62b9f66e7cc00310 and this are important for backport (and #42861 should not be backported). To make it easy to backport to stable branch, this must be merged earlier.