### PR TITLE
core: apply UnsetEnvironment= after command line expansion

### DIFF
--- a/man/systemd.exec.xml
+++ b/man/systemd.exec.xml
@@ -3366,7 +3366,9 @@ SystemCallErrorNumber=EPERM</programlisting>
         assignments made through <varname>Environment=</varname> or <varname>EnvironmentFile=</varname>, inherited from
         the system manager's global set of environment variables, inherited via <varname>PassEnvironment=</varname>,
         set by the service manager itself (such as <varname>$NOTIFY_SOCKET</varname> and such), or set by a PAM module
-        (in case <varname>PAMName=</varname> is used).</para>
+        (in case <varname>PAMName=</varname> is used). Note that variable expansion in the command lines of
+        <varname>ExecStart=</varname> and friends is not affected by this option, as it happens before the
+        unsetting is applied.</para>
 
         <para>See "Environment Variables in Spawned Processes" below for a description of how those
         settings combine to form the inherited environment. See <citerefentry
@@ -4165,7 +4167,9 @@ StandardInputData=V2XigLJyZSBubyBzdHJhbmdlcnMgdG8gbG92ZQpZb3Uga25vdyB0aGUgcnVsZX
     <para>If the same environment variable is set by multiple of these sources, the later source — according
     to the order of the list above — wins. Note that as the final step all variables listed in
     <varname>UnsetEnvironment=</varname> are removed from the compiled environment variable list, immediately
-    before it is passed to the executed process.</para>
+    before it is passed to the executed process. This unsetting happens after variable expansion in
+    the command lines of <varname>ExecStart=</varname> and friends is performed, hence command line
+    expansion is not affected by <varname>UnsetEnvironment=</varname>.</para>
 
     <para>The general philosophy is to expose a small curated list of environment variables to processes.
     Services started by the system manager (PID 1) will be started, without additional service-specific

--- a/src/core/exec-invoke.c
+++ b/src/core/exec-invoke.c
@@ -6665,18 +6665,6 @@ int exec_invoke(
 #endif
         }
 
-        if (!strv_isempty(context->unset_environment)) {
-                char **ee = NULL;
-
-                ee = strv_env_delete(accum_env, 1, context->unset_environment);
-                if (!ee) {
-                        *exit_status = EXIT_MEMORY;
-                        return log_oom();
-                }
-
-                strv_free_and_replace(accum_env, ee);
-        }
-
         _cleanup_strv_free_ char **replaced_argv = NULL, **argv_via_shell = NULL;
         char **final_argv = FLAGS_SET(command->flags, EXEC_COMMAND_VIA_SHELL) ? strv_skip(command->argv, 1) : command->argv;
 
@@ -6699,6 +6687,21 @@ int exec_invoke(
                         _cleanup_free_ char *jb = strv_join(bad_variables, ", ");
                         log_warning("Invalid environment variable name evaluates to an empty string: %s", strna(jb));
                 }
+        }
+
+        /* Apply UnsetEnvironment= after the command line has been expanded, so that the variables it
+         * removes are still available for expansion. Only the environment block passed to the executed
+         * process is affected, not the expansion. */
+        if (!strv_isempty(context->unset_environment)) {
+                char **ee = NULL;
+
+                ee = strv_env_delete(accum_env, 1, context->unset_environment);
+                if (!ee) {
+                        *exit_status = EXIT_MEMORY;
+                        return log_oom();
+                }
+
+                strv_free_and_replace(accum_env, ee);
         }
 
         if (FLAGS_SET(command->flags, EXEC_COMMAND_VIA_SHELL)) {

--- a/test/test-execute/exec-unsetenvironment.service
+++ b/test/test-execute/exec-unsetenvironment.service
@@ -3,7 +3,9 @@
 Description=Test for UnsetEnvironment
 
 [Service]
-ExecStart=bash -x -c 'test "$$FOO" = "bar" && test "$${QUUX-X}" = "X" && test "$$VAR3" = "value3" && test "$${VAR4-X}" = "X" && test "$$VAR5" = "value5" && test "$${X%b-X}" = "X"'
+# Variable expansion in the command line is done by the service manager before UnsetEnvironment= is
+# applied, so $VAR6 is expanded, but the variable is not part of the environment of the executed bash.
+ExecStart=bash -x -c 'test "$$FOO" = "bar" && test "$${QUUX-X}" = "X" && test "$$VAR3" = "value3" && test "$${VAR4-X}" = "X" && test "$$VAR5" = "value5" && test "$${X%b-X}" = "X" && test "$$1" = "value6" && test "$${VAR6-X}" = "X"' x $VAR6
 Type=oneshot
-Environment=FOO=bar QUUX=waldo VAR3=value3 VAR4=value4 VAR5=value5 X%b=%U
-UnsetEnvironment=QUUX=waldo VAR3=somethingelse VAR4 X%b=%U
+Environment=FOO=bar QUUX=waldo VAR3=value3 VAR4=value4 VAR5=value5 X%b=%U VAR6=value6
+UnsetEnvironment=QUUX=waldo VAR3=somethingelse VAR4 X%b=%U VAR6


### PR DESCRIPTION
`UnsetEnvironment=` was applied to the environment block before the command line was expanded. The expansion looks the variables up in that same block, so anything listed in `UnsetEnvironment=` was already gone when `` in `ExecStart=` and friends was resolved, and a whole-word `` reference was dropped from the command line altogether.

Apply the unsetting after the expansion instead, as the last modification of the environment block, right before it is passed to the executed process. The command line then sees the full environment, and the variables are still removed from what the process receives. Nothing else is changed.

This is a behaviour clarification rather than a documentation fix: the docs only ever specified the ordering within the environment block compilation, not when command line variables are resolved. Document the new ordering in both the `UnsetEnvironment=` description and the "Environment Variables in Spawned Processes" section.

Extend the `exec-unsetenvironment` test: the whole-word `` argument must be expanded into a positional parameter for the shell, while `${VAR6-X}` must evaluate to `X` in the executed process. The extended test fails on unpatched code and passes with this change.

Fixes: #43343
