### PR TITLE
oomd: fix OOMPolicy=stop not work

### DIFF
--- a/src/core/cgroup.c
+++ b/src/core/cgroup.c
@@ -2155,6 +2155,11 @@ static int unit_update_cgroup(
                                             "Failed to get cgroup ID of cgroup %s, ignoring: %m", cgroup_full_path);
         }
 
+        if (crt->cgroup_id != cgroup_id) {
+                crt->oom_kill_last = 0;
+                crt->managed_oom_kill_last = 0;
+        }
+
         crt->cgroup_id = cgroup_id;
 
         /* Start watching it */


### PR DESCRIPTION
1. When the first OOM occurs, systemd changes the value of oom_kill_last to 1.
2. When the service is restarted, the value of oom_kill_last may not be changed because systemd changes the value of oom_kill_last only when detecting that the value of memory.events changes.
3. If the second OOM occurs quickly, the value of memory.events of the service may have been changed to 1 when systemd processes the OOM event. As a result, the value of increased is false and the service status is abnormal. 
When we remove the inotify listener for the unit, we also reset oom_kill_last to avoid leaving behind information form the previous OOM event. 
Fix #43439