### PR TITLE
pid1: count transaction jobs for slice hard limit

### DIFF
--- a/src/core/transaction.c
+++ b/src/core/transaction.c
@@ -11,7 +11,6 @@
 #include "hash-funcs.h"
 #include "manager.h"
 #include "set.h"
-#include "slice.h"
 #include "string-util.h"
 #include "strv.h"
 #include "transaction.h"
@@ -1089,16 +1088,6 @@ int transaction_add_job_and_dependencies(
                 return sd_bus_error_setf(e, BUS_ERROR_JOB_TYPE_NOT_APPLICABLE,
                                          "Job type %s is not applicable for unit %s.",
                                          job_type_to_string(type), unit->id);
-
-        if (type == JOB_START) {
-                /* The hard concurrency limit for slice units we already enforce when a job is enqueued. */
-                Slice *slice = SLICE(UNIT_GET_SLICE(unit));
-                if (slice && slice_concurrency_hard_max_reached(slice, unit))
-                        return sd_bus_error_setf(
-                                        e, BUS_ERROR_CONCURRENCY_LIMIT_REACHED,
-                                        "Concurrency limit of the slice unit '%s' (or any of its parents) the unit '%s' is contained in has been reached, refusing start job.",
-                                        UNIT(slice)->id, unit->id);
-        }
 
         /* First add the job. */
         job = transaction_add_one_job(tr, type, unit, &is_new);

--- a/test/units/TEST-07-PID1.concurrency.sh
+++ b/test/units/TEST-07-PID1.concurrency.sh
@@ -93,6 +93,80 @@ systemctl stop sleepforever1@b.service
 systemctl stop sleepforever1@c.service
 systemctl stop sleepforever1@d.service
 
+# Hard limits should allow a batch that exactly fits...
+cat >/run/systemd/system/concurrency-bug-fit.slice <<EOF
+[Slice]
+ConcurrencyHardMax=2
+EOF
+
+cat >/run/systemd/system/concurrency-bug-fit@.service <<EOF
+[Service]
+Slice=concurrency-bug-fit.slice
+ExecStart=sleep infinity
+EOF
+
+cat >/run/systemd/system/concurrency-bug-fit.target <<EOF
+[Unit]
+Wants=concurrency-bug-fit@a.service concurrency-bug-fit@b.service
+EOF
+
+systemctl daemon-reload
+
+systemctl --no-block start concurrency-bug-fit.target
+echo "fit exit=$?"
+
+sleep 2
+
+fit_a_state=$(systemctl is-active concurrency-bug-fit@a.service || :)
+fit_b_state=$(systemctl is-active concurrency-bug-fit@b.service || :)
+test "$(printf '%s\n%s\n' "$fit_a_state" "$fit_b_state" | grep -c '^active$')" -eq 2
+
+systemctl stop concurrency-bug-fit.target 'concurrency-bug-fit@*.service' concurrency-bug-fit.slice ||:
+systemctl reset-failed concurrency-bug-fit.target 'concurrency-bug-fit@*.service' concurrency-bug-fit.slice ||:
+
+rm /run/systemd/system/concurrency-bug-fit.slice
+rm /run/systemd/system/concurrency-bug-fit@.service
+rm /run/systemd/system/concurrency-bug-fit.target
+
+# ...and let only the overflow unit miss out.
+cat >/run/systemd/system/concurrency-bug-over.slice <<EOF
+[Slice]
+ConcurrencyHardMax=2
+EOF
+
+cat >/run/systemd/system/concurrency-bug-over@.service <<EOF
+[Service]
+Slice=concurrency-bug-over.slice
+ExecStart=sleep infinity
+EOF
+
+cat >/run/systemd/system/concurrency-bug-over.target <<EOF
+[Unit]
+Wants=concurrency-bug-over@a.service concurrency-bug-over@b.service concurrency-bug-over@c.service
+EOF
+
+systemctl daemon-reload
+
+systemctl --no-block start concurrency-bug-over.target
+echo "over exit=$?"
+
+sleep 2
+
+over_a_state=$(systemctl is-active concurrency-bug-over@a.service || :)
+over_b_state=$(systemctl is-active concurrency-bug-over@b.service || :)
+over_c_state=$(systemctl is-active concurrency-bug-over@c.service || :)
+test "$(printf '%s\n%s\n%s\n' "$over_a_state" "$over_b_state" "$over_c_state" | grep -c '^active$')" -eq 2
+test "$(printf '%s\n%s\n%s\n' "$over_a_state" "$over_b_state" "$over_c_state" | grep -c '^inactive$')" -eq 1
+
+systemctl stop concurrency-bug-over.target 'concurrency-bug-over@*.service' concurrency-bug-over.slice ||:
+systemctl reset-failed concurrency-bug-over.target 'concurrency-bug-over@*.service' concurrency-bug-over.slice ||:
+
+rm /run/systemd/system/concurrency-bug-over.slice
+rm /run/systemd/system/concurrency-bug-over@.service
+rm /run/systemd/system/concurrency-bug-over.target
+
+systemctl daemon-reload
+
 # Now go for some nesting
 systemctl start sleepforever2@a.service
 systemctl is-active sleepforever2@a.service


### PR DESCRIPTION
ConcurrencyHardMax= should keep rejecting only the unit that exceeds the limit, not the whole transaction. The hard-limit check stays in unit_start(), so overflow jobs fail individually at dispatch.

Follow-up for: https://github.com/systemd/systemd/commit/9ca16f6f18543754e6dc1eeb54af474468e228ff