### PR TITLE
core: include parallelism ratio in resource usage log message

### DIFF
--- a/src/core/unit.c
+++ b/src/core/unit.c
@@ -46,6 +46,7 @@
 #include "mountpoint-util.h"
 #include "netlink-internal.h"
 #include "path-util.h"
+#include "percent-util.h"
 #include "process-util.h"
 #include "quota-util.h"
 #include "rm-rf.h"
@@ -2441,6 +2442,8 @@ static int unit_log_resources(Unit *u) {
 
         (void) unit_get_cpu_usage(u, &cpu_nsec);
         if (cpu_nsec != NSEC_INFINITY) {
+                usec_t cpu_usec = cpu_nsec / NSEC_PER_USEC;
+
                 /* Format the CPU time for inclusion in the structured log message */
                 if (asprintf(&t, "CPU_USAGE_NSEC=%" PRIu64, cpu_nsec) < 0)
                         return log_oom();
@@ -2452,15 +2455,31 @@ static int unit_log_resources(Unit *u) {
                         usec_t wall_clock_usec = usec_sub_unsigned(u->inactive_enter_timestamp.monotonic, u->inactive_exit_timestamp.monotonic);
                         if (strextendf_with_separator(&message, ", ",
                                                       "Consumed %s CPU time over %s wall clock time",
-                                                      FORMAT_TIMESPAN(cpu_nsec / NSEC_PER_USEC, USEC_PER_MSEC),
+                                                      FORMAT_TIMESPAN(cpu_usec, USEC_PER_MSEC),
                                                       FORMAT_TIMESPAN(wall_clock_usec, USEC_PER_MSEC)) < 0)
                                 return log_oom();
-                } else {
-                        if (strextendf_with_separator(&message, ", ",
-                                                      "Consumed %s CPU time",
-                                                      FORMAT_TIMESPAN(cpu_nsec / NSEC_PER_USEC, USEC_PER_MSEC)) < 0)
-                                return log_oom();
-                }
+
+                        if (timestamp_is_set(wall_clock_usec)) {
+                                uint64_t q = cpu_usec / wall_clock_usec, r = cpu_usec % wall_clock_usec;
+                                uint64_t cpu_permyriad = q * 10000U +
+                                                (r * 10000U + wall_clock_usec / 2) / wall_clock_usec;
+
+                                if (cpu_permyriad >= 1000U) {
+                                        uint64_t cpu_pct = q * 100U +
+                                                        (r * 100U + wall_clock_usec / 2) / wall_clock_usec;
+                                        if (strextendf(&message, " (%" PRIu64 "%% CPU)", cpu_pct) < 0)
+                                                return log_oom();
+                                } else if (cpu_permyriad > 0)
+                                        if (strextendf(&message,
+                                                       " (" PERMYRIAD_AS_PERCENT_FORMAT_STR " CPU)",
+                                                       PERMYRIAD_AS_PERCENT_FORMAT_VAL((int) cpu_permyriad)) <
+                                            0)
+                                                return log_oom();
+                        }
+                } else if (strextendf_with_separator(&message, ", ",
+                                                     "Consumed %s CPU time",
+                                                     FORMAT_TIMESPAN(cpu_usec, USEC_PER_MSEC)) < 0)
+                        return log_oom();
 
                 log_level = raise_level(log_level,
                                         cpu_nsec > MENTIONWORTHY_CPU_NSEC,


### PR DESCRIPTION
When logging CPU time consumed over wall clock time, append the ratio (parallelism multiplier) between the two to provide a clear indicator of how much concurrent CPU usage occurred.

For example, this changes
  Consumed X CPU time over Y wall clock time
to
  Consumed X CPU time over Y wall clock time (N.NNx)