### PR TITLE
creds: typo fix in the Credentials.NullKeyNotAllowed description

### DIFF
--- a/src/shared/creds-util.c
+++ b/src/shared/creds-util.c
@@ -1970,7 +1970,7 @@ static const CredentialsVarlinkError credentials_varlink_error_table[] = {
         { "io.systemd.Credentials.NoSuchUser",             ESRCH,        "No such user." },
         { "io.systemd.Credentials.BadScope",               EMEDIUMTYPE,  "Scope mismatch." },
         { "io.systemd.Credentials.CantFindPCRSignature",   EHOSTDOWN,    "PCR signature required for decryption, but could not be found." },
-        { "io.systemd.Credentials.NullKeyNotAllowed",      EHWPOISON,    "The key was encrypted with a null key, but that's now allowed during decryption." },
+        { "io.systemd.Credentials.NullKeyNotAllowed",      EHWPOISON,    "The key was encrypted with a null key, but that's not allowed during decryption." },
         { "io.systemd.Credentials.KeyBelongsToOtherTPM",   EREMOTE,      "The TPM integrity check for this key failed, key probably belongs to another TPM, or was corrupted." },
         { "io.systemd.Credentials.TPMInDictionaryLockout", ENOLCK,       "The TPM is in dictionary lockout mode, cannot operate." },
         { "io.systemd.Credentials.UnexpectedPCRState" ,    EUCLEAN,      "Unexpected TPM PCR state of the system." },

--- a/src/shared/varlink-io.systemd.Credentials.c
+++ b/src/shared/varlink-io.systemd.Credentials.c
@@ -105,7 +105,7 @@ SD_VARLINK_DEFINE_INTERFACE(
                 &vl_error_BadScope,
                 SD_VARLINK_SYMBOL_COMMENT("PCR signature required for decryption, but not found."),
                 &vl_error_CantFindPCRSignature,
-                SD_VARLINK_SYMBOL_COMMENT("The key was encrypted with a null key, but that's now allowed during decryption."),
+                SD_VARLINK_SYMBOL_COMMENT("The key was encrypted with a null key, but that's not allowed during decryption."),
                 &vl_error_NullKeyNotAllowed,
                 SD_VARLINK_SYMBOL_COMMENT("The TPM integrity check for this key failed, key probably belongs to another TPM, or was corrupted."),
                 &vl_error_KeyBelongsToOtherTPM,


### PR DESCRIPTION
There is small (but confusing) typo in the description of the `io.systemd.Credentials.NullKeyNotAllowed` error. This commit fixes it.