### PR TITLE
resolve: add io.systemd.Resolve.Monitor.{FlushCaches,ResetServerFeatures}

### DIFF
--- a/src/resolve/resolvectl.c
+++ b/src/resolve/resolvectl.c
@@ -1969,19 +1969,20 @@ static int verb_reset_statistics(int argc, char *argv[], uintptr_t _data, void *
 VERB(verb_flush_caches, "flush-caches", NULL, VERB_ANY, 1, 0,
      "Flush all local DNS caches");
 static int verb_flush_caches(int argc, char *argv[], uintptr_t _data, void *userdata) {
-        _cleanup_(sd_bus_flush_close_unrefp) sd_bus *bus = NULL;
-        _cleanup_(sd_bus_error_free) sd_bus_error error = SD_BUS_ERROR_NULL;
         int r;
 
-        r = acquire_bus(&bus);
-        if (r < 0)
-                return r;
+        (void) polkit_agent_open_if_enabled(BUS_TRANSPORT_LOCAL, arg_ask_password);
 
-        r = bus_call_method(bus, bus_resolve_mgr, "FlushCaches", &error, NULL, NULL);
+        _cleanup_(sd_varlink_unrefp) sd_varlink *vl = NULL;
+        r = sd_varlink_connect_address(&vl, "/run/systemd/resolve/io.systemd.Resolve.Monitor");
         if (r < 0)
-                return log_error_errno(r, "Failed to flush caches: %s", bus_error_message(&error, r));
+                return log_error_errno(r, "Failed to connect to /run/systemd/resolve/io.systemd.Resolve.Monitor: %m");
 
-        return 0;
+        return varlink_callbo_and_log(
+                        vl,
+                        "io.systemd.Resolve.Monitor.FlushCaches",
+                        /* reply= */ NULL,
+                        SD_JSON_BUILD_PAIR_BOOLEAN("allowInteractiveAuthentication", arg_ask_password));
 }
 
 VERB(verb_reset_server_features, "reset-server-features", NULL, VERB_ANY, 1, 0,

--- a/src/resolve/resolvectl.c
+++ b/src/resolve/resolvectl.c
@@ -1988,19 +1988,20 @@ static int verb_flush_caches(int argc, char *argv[], uintptr_t _data, void *user
 VERB(verb_reset_server_features, "reset-server-features", NULL, VERB_ANY, 1, 0,
      "Forget learnt DNS server feature levels");
 static int verb_reset_server_features(int argc, char *argv[], uintptr_t _data, void *userdata) {
-        _cleanup_(sd_bus_flush_close_unrefp) sd_bus *bus = NULL;
-        _cleanup_(sd_bus_error_free) sd_bus_error error = SD_BUS_ERROR_NULL;
         int r;
 
-        r = acquire_bus(&bus);
-        if (r < 0)
-                return r;
+        (void) polkit_agent_open_if_enabled(BUS_TRANSPORT_LOCAL, arg_ask_password);
 
-        r = bus_call_method(bus, bus_resolve_mgr, "ResetServerFeatures", &error, NULL, NULL);
+        _cleanup_(sd_varlink_unrefp) sd_varlink *vl = NULL;
+        r = sd_varlink_connect_address(&vl, "/run/systemd/resolve/io.systemd.Resolve.Monitor");
         if (r < 0)
-                return log_error_errno(r, "Failed to reset server features: %s", bus_error_message(&error, r));
+                return log_error_errno(r, "Failed to connect to /run/systemd/resolve/io.systemd.Resolve.Monitor: %m");
 
-        return 0;
+        return varlink_callbo_and_log(
+                        vl,
+                        "io.systemd.Resolve.Monitor.ResetServerFeatures",
+                        /* reply= */ NULL,
+                        SD_JSON_BUILD_PAIR_BOOLEAN("allowInteractiveAuthentication", arg_ask_password));
 }
 
 static int print_question(char prefix, const char *color, sd_json_variant *question) {

--- a/src/resolve/resolved-varlink.c
+++ b/src/resolve/resolved-varlink.c
@@ -1381,6 +1381,19 @@ static int vl_method_reset_statistics(sd_varlink *link, sd_json_variant *paramet
         return sd_varlink_replyb(link, SD_JSON_BUILD_EMPTY_OBJECT);
 }
 
+static int vl_method_flush_caches(sd_varlink *link, sd_json_variant *parameters, sd_varlink_method_flags_t flags, void *userdata) {
+        Manager *m = ASSERT_PTR(sd_varlink_get_userdata(ASSERT_PTR(link)));
+        int r;
+
+        r = verify_polkit(link, parameters, "org.freedesktop.resolve1.flush-caches");
+        if (r <= 0)
+                return r;
+
+        manager_flush_caches(m, LOG_INFO);
+
+        return sd_varlink_reply(link, NULL);
+}
+
 static int vl_method_subscribe_dns_configuration(sd_varlink *link, sd_json_variant *parameters, sd_varlink_method_flags_t flags, void *userdata) {
         Manager *m = ASSERT_PTR(sd_varlink_get_userdata(ASSERT_PTR(link)));
         int r;
@@ -1464,7 +1477,8 @@ static int varlink_monitor_server_init(Manager *m) {
                         "io.systemd.Resolve.Monitor.DumpServerState", vl_method_dump_server_state,
                         "io.systemd.Resolve.Monitor.DumpStatistics", vl_method_dump_statistics,
                         "io.systemd.Resolve.Monitor.ResetStatistics", vl_method_reset_statistics,
-                        "io.systemd.Resolve.Monitor.SubscribeDNSConfiguration", vl_method_subscribe_dns_configuration);
+                        "io.systemd.Resolve.Monitor.SubscribeDNSConfiguration", vl_method_subscribe_dns_configuration,
+                        "io.systemd.Resolve.Monitor.FlushCaches", vl_method_flush_caches);
         if (r < 0)
                 return log_error_errno(r, "Failed to register varlink methods: %m");
 

--- a/src/resolve/resolved-varlink.c
+++ b/src/resolve/resolved-varlink.c
@@ -1394,6 +1394,20 @@ static int vl_method_flush_caches(sd_varlink *link, sd_json_variant *parameters,
         return sd_varlink_reply(link, NULL);
 }
 
+static int vl_method_reset_server_features(sd_varlink *link, sd_json_variant *parameters, sd_varlink_method_flags_t flags, void *userdata) {
+        Manager *m = ASSERT_PTR(sd_varlink_get_userdata(ASSERT_PTR(link)));
+        int r;
+
+        r = verify_polkit(link, parameters, "org.freedesktop.resolve1.reset-server-features");
+        if (r <= 0)
+                return r;
+
+        (void) dns_stream_disconnect_all(m);
+        manager_reset_server_features(m);
+
+        return sd_varlink_reply(link, NULL);
+}
+
 static int vl_method_subscribe_dns_configuration(sd_varlink *link, sd_json_variant *parameters, sd_varlink_method_flags_t flags, void *userdata) {
         Manager *m = ASSERT_PTR(sd_varlink_get_userdata(ASSERT_PTR(link)));
         int r;
@@ -1478,7 +1492,8 @@ static int varlink_monitor_server_init(Manager *m) {
                         "io.systemd.Resolve.Monitor.DumpStatistics", vl_method_dump_statistics,
                         "io.systemd.Resolve.Monitor.ResetStatistics", vl_method_reset_statistics,
                         "io.systemd.Resolve.Monitor.SubscribeDNSConfiguration", vl_method_subscribe_dns_configuration,
-                        "io.systemd.Resolve.Monitor.FlushCaches", vl_method_flush_caches);
+                        "io.systemd.Resolve.Monitor.FlushCaches", vl_method_flush_caches,
+                        "io.systemd.Resolve.Monitor.ResetServerFeatures", vl_method_reset_server_features);
         if (r < 0)
                 return log_error_errno(r, "Failed to register varlink methods: %m");
 

--- a/src/shared/varlink-io.systemd.Resolve.Monitor.c
+++ b/src/shared/varlink-io.systemd.Resolve.Monitor.c
@@ -137,6 +137,10 @@ static SD_VARLINK_DEFINE_METHOD(
                 FlushCaches,
                 VARLINK_DEFINE_POLKIT_INPUT);
 
+static SD_VARLINK_DEFINE_METHOD(
+                ResetServerFeatures,
+                VARLINK_DEFINE_POLKIT_INPUT);
+
 SD_VARLINK_DEFINE_INTERFACE(
                 io_systemd_Resolve_Monitor,
                 "io.systemd.Resolve.Monitor",
@@ -170,4 +174,6 @@ SD_VARLINK_DEFINE_INTERFACE(
                 SD_VARLINK_SYMBOL_COMMENT("Sends the complete global and per-link DNS configurations when any changes are made to them. The current configurations are given immediately when this method is invoked."),
                 &vl_method_SubscribeDNSConfiguration,
                 SD_VARLINK_SYMBOL_COMMENT("Flushes all DNS resource record caches the service maintains locally."),
-                &vl_method_FlushCaches);
+                &vl_method_FlushCaches,
+                SD_VARLINK_SYMBOL_COMMENT("Flushes all feature level information the resolver learnt about specific servers, and ensures that the server feature probing logic is started from the beginning with the next look-up request."),
+                &vl_method_ResetServerFeatures);

--- a/src/shared/varlink-io.systemd.Resolve.Monitor.c
+++ b/src/shared/varlink-io.systemd.Resolve.Monitor.c
@@ -133,6 +133,10 @@ static SD_VARLINK_DEFINE_METHOD_FULL(
                 SD_VARLINK_FIELD_COMMENT("The current global and per-interface DNS configurations"),
                 SD_VARLINK_DEFINE_OUTPUT_BY_TYPE(configuration, DNSConfiguration, SD_VARLINK_ARRAY));
 
+static SD_VARLINK_DEFINE_METHOD(
+                FlushCaches,
+                VARLINK_DEFINE_POLKIT_INPUT);
+
 SD_VARLINK_DEFINE_INTERFACE(
                 io_systemd_Resolve_Monitor,
                 "io.systemd.Resolve.Monitor",
@@ -164,4 +168,6 @@ SD_VARLINK_DEFINE_INTERFACE(
                 SD_VARLINK_SYMBOL_COMMENT("Encapsulates a DNS scope specification."),
                 &vl_type_DNSScope,
                 SD_VARLINK_SYMBOL_COMMENT("Sends the complete global and per-link DNS configurations when any changes are made to them. The current configurations are given immediately when this method is invoked."),
-                &vl_method_SubscribeDNSConfiguration);
+                &vl_method_SubscribeDNSConfiguration,
+                SD_VARLINK_SYMBOL_COMMENT("Flushes all DNS resource record caches the service maintains locally."),
+                &vl_method_FlushCaches);


### PR DESCRIPTION
Some miscellaneous varlink migration for resolved (https://github.com/systemd/systemd/pull/43183 handles the rest of the API that resolvectl needs).

These seem to fit better with the io.systemd.Resolve.Monitor interface, so add them to that.