### PR TITLE
homed: add thin-backed and hardware-wrapped LUKS homes

### DIFF
--- a/docs/USER_RECORD.md
+++ b/docs/USER_RECORD.md
@@ -861,7 +861,13 @@ and `perMachine` sections:
 
 `blobDirectory`, `imagePath`, `homeDirectory`, `partitionUuid`, `luksUuid`,
 `fileSystemUuid`, `uid`, `gid`, `storage`, `fileSystemType`, `luksCipher`,
-`luksCipherMode`, `luksVolumeKeySize`.
+`luksCipherMode`, `luksKeyType`, `luksIntegrity`, `luksVolumeKeySize`.
+
+`luksIntegrity` records the integrity profile authenticated by the local binding. The value
+`hmac(sha256)` identifies hardware-wrapped, thin-backed homes using journaled dm-integrity with an
+internal HMAC over filesystem plaintext. dm-integrity is above dm-inlinecrypt, so the lower inline-encryption
+layer encrypts both the data and dm-integrity metadata. The field is omitted for raw-key homes and for
+hardware-wrapped homes created before this profile was introduced.
 
 ## Fields in the `status` section
 

--- a/man/homed.conf.xml
+++ b/man/homed.conf.xml
@@ -80,6 +80,75 @@
         <xi:include href="version-info.xml" xpointer="v246"/></listitem>
       </varlistentry>
 
+      <varlistentry>
+        <term><varname>ThinPool=</varname></term>
+        <listitem><para>Configures an already active raw device-mapper thin pool used for newly created LUKS
+        home areas that do not specify an explicit image path. The value must be an absolute path to a block
+        device containing exactly one <literal>thin-pool</literal> target, for example
+        <filename>/dev/mapper/homes</filename>. Such homes use ext4. If no <varname>diskSize</varname> is
+        specified, the logical size is derived from the active pool's data size, rounded down to the normal
+        home-disk alignment and limited to the supported size range. An explicit <varname>diskSize</varname>
+        remains authoritative. Resizing and automatic space rebalancing are disabled for these fixed logical
+        devices.</para>
+
+        <para>The pool must be dedicated exclusively to <command>systemd-homed</command>. Its DM UUID must
+        be nonempty and must not use the <literal>LVM-</literal> namespace. Mixing homed's 24-bit thin-device
+        IDs with another volume manager can cause ID collisions and data loss. The pool must be writable,
+        use <literal>error_if_no_space</literal>, and pass discards through. Failed, read-only, exhausted, or
+        <literal>needs_check</literal> pools are rejected and their homes remain inactive.</para>
+
+        <para><command>systemd-homed</command> allocates, activates, and deletes thin devices, and records the
+        pool generation UUID and numeric device ID in the machine-specific user-record binding. It maintains
+        a durable, locked allocator state synchronized with the pool transaction ID and never reuses IDs
+        within a pool generation. If that state is lost after the pool has been modified, the transaction ID
+        mismatch is treated as unsafe and the pool is refused rather than restarting allocation at zero.
+        Formatting, initial activation, offline <command>thin_check</command>, repair, and backing-device
+        growth remain platform responsibilities. There is no unattended repair; a corrupt pool must be taken
+        offline and checked or repaired by the administrator before retrying.</para>
+
+        <xi:include href="version-info.xml" xpointer="v262"/></listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term><varname>HardwareWrappedKeys=</varname></term>
+        <listitem><para>Takes a boolean and defaults to false. When enabled, newly created thin-backed
+        LUKS/ext4 homes use a hardware-wrapped inline-encryption key. The complete block stack and storage
+        controller must support hardware-wrapped key generation, software-secret derivation, ephemeral-key
+        preparation, inline AES-256-XTS encryption through <literal>dm-inlinecrypt</literal>, and journaled
+        <literal>dm-integrity</literal> provisioning. The resulting stack is ext4 over
+        <literal>dm-integrity</literal>, <literal>dm-inlinecrypt</literal>, and the raw dm-thin device. Integrity
+        uses an internal <literal>hmac(sha256)</literal> over filesystem plaintext with 4096-byte sectors,
+        32-byte tags, colocated metadata, and a fixed 32 MiB journal. The lower inline-encryption layer
+        encrypts the data, integrity tags, superblock, and journal. An explicit
+        <literal>yes</literal> fails creation if any required component is unavailable; it never falls back
+        to a raw volume key. Existing wrapped homes remain usable when this setting is later disabled. This
+        is intentionally a system-wide creation policy; no per-user <command>homectl</command> override is
+        provided. New raw-key homes continue to use the unversioned identity-token format for compatibility,
+        while version 2 is reserved for the authenticated hardware-wrapped-key envelope.</para>
+
+        <para>The wrapped key is tied to the storage hardware's wrapping identity. A LUKS header backup and
+        the user's password are not sufficient for recovery after incompatible storage-controller or
+        motherboard replacement. Keep normal LUKS header and dm-thin metadata backups for repair, but also keep an
+        independent encrypted file-level backup. Migrate a home while the source hardware is available by
+        unlocking it and copying its files into a newly created home on the destination; copying only the thin
+        thin device or LUKS header to hardware with a different wrapping identity is not a migration method.</para>
+
+        <para>Password, recovery-key, PKCS#11, and FIDO2 enrollment changes update normal LUKS2 keyslots while
+        retaining the same wrapped data key. Online LUKS reencryption and data-key rotation are not supported
+        for this profile. Locking a newly created wrapped home requires cryptsetup, a
+        <literal>dm-inlinecrypt</literal> target version 1.1 or newer, and a <literal>dm-integrity</literal>
+        target version 1.15 or newer with suspended <literal>key wipe</literal>/<literal>key set</literal>
+        support. Older stacks return an unsupported-operation error without leaving only one layer resumed;
+        full deactivation remains supported and evicts both active keys.</para>
+
+        <para>Each protected home permanently reserves approximately 32 MiB for the integrity journal, in
+        addition to dm-integrity tags and filesystem blocks provisioned in the thin pool. Size thin-pool data
+        and metadata capacity for this overhead. Homes created before integrity support retain their existing
+        layout and do not acquire this reservation automatically.</para>
+
+        <xi:include href="version-info.xml" xpointer="v262"/></listitem>
+      </varlistentry>
+
     </variablelist>
   </refsect1>
 

--- a/src/home/home-util.c
+++ b/src/home/home-util.c
@@ -6,12 +6,15 @@
 
 #include "alloc-util.h"
 #include "dns-domain.h"
+#include "errno-util.h"
 #include "fd-util.h"
+#include "fs-util.h"
 #include "hash-funcs.h"
 #include "home-util.h"
 #include "path-util.h"
 #include "string-util.h"
 #include "strv.h"
+#include "sync-util.h"
 #include "user-record.h"
 #include "user-util.h"
 
@@ -151,4 +154,80 @@ const char* home_record_dir(void) {
 
 const char* home_system_blob_dir(void) {
         return secure_getenv("SYSTEMD_HOME_SYSTEM_BLOB_DIR") ?: "/var/cache/systemd/home/";
+}
+
+int home_record_commit_pending(const char *user_name) {
+        const char *final, *pending;
+        int r;
+
+        assert(user_name);
+
+        pending = strjoina(home_record_dir(), "/", user_name, HOME_RECORD_PENDING_SUFFIX);
+        final = strjoina(home_record_dir(), "/", user_name, HOME_RECORD_SUFFIX);
+
+        r = rename_noreplace(AT_FDCWD, pending, AT_FDCWD, final);
+        if (r < 0)
+                return r;
+
+        return fsync_parent_at(AT_FDCWD, final);
+}
+
+int home_record_cancel_pending(const char *user_name) {
+        _cleanup_close_ int dir_fd = -EBADF;
+        _cleanup_free_ char *intent = NULL, *pending = NULL;
+        bool removed = false;
+        int ret = 0, r;
+
+        assert(user_name);
+
+        dir_fd = open(home_record_dir(), O_RDONLY|O_DIRECTORY|O_CLOEXEC);
+        if (dir_fd < 0)
+                return errno == ENOENT ? 0 : -errno;
+
+        pending = strjoin(user_name, HOME_RECORD_PENDING_SUFFIX);
+        intent = strjoin(user_name, HOME_RECORD_THIN_INTENT_SUFFIX);
+        if (!pending || !intent)
+                return -ENOMEM;
+
+        r = RET_NERRNO(unlinkat(dir_fd, pending, 0));
+        if (r == -ENOENT)
+                r = 0;
+        else if (r >= 0)
+                removed = true;
+        RET_GATHER(ret, r);
+
+        r = RET_NERRNO(unlinkat(dir_fd, intent, 0));
+        if (r == -ENOENT)
+                r = 0;
+        else if (r >= 0)
+                removed = true;
+        RET_GATHER(ret, r);
+
+        if (removed)
+                RET_GATHER(ret, RET_NERRNO(fsync(dir_fd)));
+
+        return ret;
+}
+
+int home_record_has_pending(const char *user_name) {
+        const char *intent, *pending;
+        int r;
+
+        assert(user_name);
+
+        pending = strjoina(home_record_dir(), "/", user_name, HOME_RECORD_PENDING_SUFFIX);
+        r = access_nofollow(pending, F_OK);
+        if (r >= 0)
+                return 1;
+        if (r != -ENOENT)
+                return r;
+
+        intent = strjoina(home_record_dir(), "/", user_name, HOME_RECORD_THIN_INTENT_SUFFIX);
+        r = access_nofollow(intent, F_OK);
+        if (r >= 0)
+                return 1;
+        if (r != -ENOENT)
+                return r;
+
+        return 0;
 }

--- a/src/home/home-util.h
+++ b/src/home/home-util.h
@@ -19,6 +19,10 @@
  * rebalancing. */
 #define USER_DISK_SIZE_DEFAULT_PERCENT ((unsigned) ((100 * REBALANCE_WEIGHT_DEFAULT) / (REBALANCE_WEIGHT_DEFAULT + REBALANCE_WEIGHT_BACKING)))
 
+#define HOME_RECORD_SUFFIX ".identity"
+#define HOME_RECORD_PENDING_SUFFIX HOME_RECORD_SUFFIX ".pending"
+#define HOME_RECORD_THIN_INTENT_SUFFIX HOME_RECORD_SUFFIX ".thin-intent"
+
 extern const struct hash_ops blob_fd_hash_ops;
 
 bool suitable_user_name(const char *name);
@@ -40,3 +44,6 @@ int bus_message_append_secret(sd_bus_message *m, UserRecord *secret);
 
 const char* home_record_dir(void);
 const char* home_system_blob_dir(void);
+int home_record_commit_pending(const char *user_name);
+int home_record_cancel_pending(const char *user_name);
+int home_record_has_pending(const char *user_name);

--- a/src/home/homectl.c
+++ b/src/home/homectl.c
@@ -473,6 +473,10 @@ static int handle_generic_user_record_error(
                 return log_error_errno(SYNTHETIC_ERRNO(ETOOMANYREFS),
                                        "Too frequent login attempts for user %s, try again later.", user_name);
 
+        else if (!arg_ask_password)
+                return log_error_errno(ret, "Operation on home %s failed: %s", user_name,
+                                       bus_error_message(error, ret));
+
         else if (sd_bus_error_has_name(error, BUS_ERROR_BAD_PASSWORD)) {
 
                 if (!strv_isempty(hr->password))

--- a/src/home/homed-conf.c
+++ b/src/home/homed-conf.c
@@ -3,6 +3,7 @@
 #include "conf-parser.h"
 #include "home-util.h"
 #include "homed-conf.h"
+#include "path-util.h"
 #include "string-util.h"
 #include "user-record.h"
 
@@ -19,6 +20,36 @@ int manager_parse_config_file(Manager *m) {
 }
 
 DEFINE_CONFIG_PARSE_ENUM(config_parse_default_storage, user_storage, UserStorage);
+
+int config_parse_thin_pool(
+                const char *unit,
+                const char *filename,
+                unsigned line,
+                const char *section,
+                unsigned section_line,
+                const char *lvalue,
+                int ltype,
+                const char *rvalue,
+                void *data,
+                void *userdata) {
+
+        char **pool = ASSERT_PTR(data);
+
+        assert(rvalue);
+
+        if (isempty(rvalue)) {
+                *pool = mfree(*pool);
+                return 0;
+        }
+
+        if (!path_is_absolute(rvalue) || !path_is_normalized(rvalue)) {
+                log_syntax(unit, LOG_WARNING, filename, line, 0,
+                           "Thin pool must be specified as an absolute normalized device path, ignoring: %s", rvalue);
+                return 0;
+        }
+
+        return free_and_strdup_warn(pool, rvalue);
+}
 
 int config_parse_default_file_system_type(
                 const char *unit,

--- a/src/home/homed-conf.h
+++ b/src/home/homed-conf.h
@@ -9,3 +9,4 @@ const struct ConfigPerfItem* homed_gperf_lookup(const char *str, GPERF_LEN_TYPE 
 
 CONFIG_PARSER_PROTOTYPE(config_parse_default_storage);
 CONFIG_PARSER_PROTOTYPE(config_parse_default_file_system_type);
+CONFIG_PARSER_PROTOTYPE(config_parse_thin_pool);

--- a/src/home/homed-gperf.gperf
+++ b/src/home/homed-gperf.gperf
@@ -22,3 +22,5 @@ struct ConfigPerfItem;
 %%
 Home.DefaultStorage,        config_parse_default_storage,          0, offsetof(Manager, default_storage)
 Home.DefaultFileSystemType, config_parse_default_file_system_type, 0, offsetof(Manager, default_file_system_type)
+Home.ThinPool,              config_parse_thin_pool,                 0, offsetof(Manager, thin_pool)
+Home.HardwareWrappedKeys,   config_parse_bool,                      0, offsetof(Manager, hardware_wrapped_keys)

--- a/src/home/homed-home.c
+++ b/src/home/homed-home.c
@@ -41,6 +41,7 @@
 #include "stat-util.h"
 #include "string-table.h"
 #include "strv.h"
+#include "sync-util.h"
 #include "time-util.h"
 #include "uid-classification.h"
 #include "user-record.h"
@@ -336,44 +337,43 @@ int home_set_record(Home *h, UserRecord *hr) {
 }
 
 int home_save_record(Home *h) {
-        _cleanup_(sd_json_variant_unrefp) sd_json_variant *v = NULL;
-        _cleanup_free_ char *text = NULL;
         const char *fn;
-        int r;
 
         assert(h);
-
-        v = sd_json_variant_ref(h->record->json);
-        r = sd_json_variant_normalize(&v);
-        if (r < 0)
-                log_warning_errno(r, "User record could not be normalized.");
-
-        r = sd_json_variant_format(v, SD_JSON_FORMAT_PRETTY|SD_JSON_FORMAT_NEWLINE, &text);
-        if (r < 0)
-                return r;
 
         (void) mkdir("/var/lib/systemd/", 0755);
         (void) mkdir(home_record_dir(), 0700);
 
-        fn = strjoina(home_record_dir(), "/", h->user_name, ".identity");
-
-        r = write_string_file(fn, text, WRITE_STRING_FILE_ATOMIC|WRITE_STRING_FILE_CREATE|WRITE_STRING_FILE_MODE_0600|WRITE_STRING_FILE_SYNC);
-        if (r < 0)
-                return r;
-
-        return 0;
+        fn = strjoina(home_record_dir(), "/", h->user_name, HOME_RECORD_SUFFIX);
+        return user_record_save(h->record, fn);
 }
 
 int home_unlink_record(Home *h) {
         _cleanup_free_ char *blob = NULL;
         const char *fn;
+        bool removed = false;
         int r;
 
         assert(h);
 
-        fn = strjoina(home_record_dir(), "/", h->user_name, ".identity");
-        if (unlink(fn) < 0 && errno != ENOENT)
-                return -errno;
+        /* Recovery records must be removed and the directory synchronized before the committed identity is
+         * unlinked. Otherwise a crash in between could resurrect a deliberately removed home. */
+        r = home_record_cancel_pending(h->user_name);
+        if (r < 0)
+                return r;
+
+        fn = strjoina(home_record_dir(), "/", h->user_name, HOME_RECORD_SUFFIX);
+        if (unlink(fn) < 0) {
+                if (errno != ENOENT)
+                        return -errno;
+        } else
+                removed = true;
+
+        if (removed) {
+                r = fsync_path_at(AT_FDCWD, home_record_dir());
+                if (r < 0)
+                        return r;
+        }
 
         fn = strjoina("/run/systemd/home/", h->user_name, ".ref");
         if (unlink(fn) < 0 && errno != ENOENT)
@@ -942,21 +942,35 @@ fail:
 }
 
 static void home_create_finish(Home *h, int ret, UserRecord *hr) {
+        _cleanup_(sd_bus_error_free) sd_bus_error error = SD_BUS_ERROR_NULL;
         int r;
 
         assert(h);
         assert(h->state == HOME_CREATING);
 
         if (ret < 0) {
-                _cleanup_(sd_bus_error_free) sd_bus_error error = SD_BUS_ERROR_NULL;
-
                 (void) convert_worker_errno(h, ret, &error);
                 log_error_errno(ret, "Operation on %s failed: %m", h->user_name);
                 h->current_operation = operation_result_unref(h->current_operation, ret, &error);
 
                 if (h->unregister_on_failure) {
-                        (void) home_unlink_record(h);
+                        Manager *m = h->manager;
+
+                        r = home_record_has_pending(h->user_name);
+                        if (r == 0)
+                                (void) home_unlink_record(h);
+                        else if (r < 0)
+                                log_warning_errno(r,
+                                                  "Failed to check for a thin-volume recovery record, "
+                                                  "preserving files: %m");
+                        else
+                                log_notice("Preserving thin-volume recovery record after failed creation of '%s'.",
+                                           h->user_name);
+
                         h = home_free(h);
+
+                        if (r != 0)
+                                (void) manager_recover_records(m);
                         return;
                 }
 
@@ -966,13 +980,32 @@ static void home_create_finish(Home *h, int ret, UserRecord *hr) {
 
         if (hr) {
                 r = home_set_record(h, hr);
-                if (r < 0)
-                        log_warning_errno(r, "Failed to update home record, ignoring: %m");
+                if (r < 0) {
+                        log_error_errno(r, "Failed to update home record: %m");
+                        sd_bus_error_set(&error, SD_BUS_ERROR_FAILED, "Failed to cache the created home record");
+                        goto fail;
+                }
         }
 
-        r = home_save_record(h);
-        if (r < 0)
-                log_warning_errno(r, "Failed to save record to disk, ignoring: %m");
+        if (h->record->thin_pool_uuid) {
+                r = home_record_commit_pending(h->user_name);
+                if (r >= 0) {
+                        int q;
+
+                        q = home_record_cancel_pending(h->user_name);
+                        if (q < 0)
+                                log_warning_errno(q,
+                                                  "Failed to remove stale thin-volume recovery record, ignoring: %m");
+                }
+        } else
+                r = home_save_record(h);
+        if (r < 0) {
+                log_error_errno(r, "Failed to commit created home record: %m");
+                sd_bus_error_set(&error, SD_BUS_ERROR_FAILED, "Failed to commit the created home record");
+                goto fail;
+        }
+
+        h->unregister_on_failure = false;
 
         log_debug("Creation of %s completed.", h->user_name);
 
@@ -980,6 +1013,14 @@ static void home_create_finish(Home *h, int ret, UserRecord *hr) {
         home_set_state(h, _HOME_STATE_INVALID);
 
         (void) manager_schedule_rebalance(h->manager, /* immediately= */ true);
+        return;
+
+fail:
+        /* The storage has already been fully created at this point. A thin home's pending record is deliberately
+         * retained for recovery, and the in-memory object remains registered to prevent a colliding retry. */
+        h->unregister_on_failure = false;
+        h->current_operation = operation_result_unref(h->current_operation, r, &error);
+        home_set_state(h, _HOME_STATE_INVALID);
 }
 
 static void home_change_finish(Home *h, int ret, UserRecord *hr) {
@@ -1414,6 +1455,18 @@ static int home_start_work(
                                 log_error_errno(errno, "Failed to set $SYSTEMD_HOME_DEFAULT_FILE_SYSTEM_TYPE: %m");
                                 _exit(EXIT_FAILURE);
                         }
+
+                if (h->manager->thin_pool)
+                        if (setenv("SYSTEMD_HOME_THIN_POOL", h->manager->thin_pool, 1) < 0) {
+                                log_error_errno(errno, "Failed to set $SYSTEMD_HOME_THIN_POOL: %m");
+                                _exit(EXIT_FAILURE);
+                        }
+
+                if (setenv("SYSTEMD_HOME_HARDWARE_WRAPPED_KEYS",
+                           one_zero(h->manager->hardware_wrapped_keys), 1) < 0) {
+                        log_error_errno(errno, "Failed to set $SYSTEMD_HOME_HARDWARE_WRAPPED_KEYS: %m");
+                        _exit(EXIT_FAILURE);
+                }
 
                 if (setenv("SYSTEMD_HOMEWORK_UPDATE_OFFLINE", one_zero(FLAGS_SET(flags, SD_HOMED_UPDATE_OFFLINE)), 1) < 0) {
                         log_error_errno(errno, "Failed to set $SYSTEMD_HOMEWORK_UPDATE_OFFLINE: %m");
@@ -2215,6 +2268,18 @@ int home_unlock(Home *h, UserRecord *secret, sd_bus_error *error) {
         return home_unlock_internal(h, secret, HOME_UNLOCKING, error);
 }
 
+static int home_test_image_path(Home *h) {
+        int r;
+
+        assert(h);
+
+        r = user_record_test_image_path(h->record);
+        if (r == USER_TEST_ABSENT && h->record->thin_pool_uuid)
+                return USER_TEST_MAYBE; /* Inactive activation-skipped LVs intentionally have no devlinks. */
+
+        return r;
+}
+
 HomeState home_get_state(Home *h) {
         int r;
         assert(h);
@@ -2229,7 +2294,7 @@ HomeState home_get_state(Home *h) {
                 return h->retry_deactivate_event_source ? HOME_LINGERING : HOME_ACTIVE;
 
         /* And if we see the image being gone, we report this as absent */
-        r = user_record_test_image_path(h->record);
+        r = home_test_image_path(h);
         if (r == USER_TEST_ABSENT)
                 return HOME_ABSENT;
         if (r == USER_TEST_DIRTY)
@@ -2356,7 +2421,10 @@ static int home_get_disk_status_luks(
 
         assert(h);
 
-        if (state != HOME_ABSENT) {
+        if (h->record->thin_pool_uuid && h->record->disk_size != UINT64_MAX)
+                disk_ceiling = disk_size = h->record->disk_size;
+
+        if (state != HOME_ABSENT && (!h->record->thin_pool_uuid || HOME_STATE_IS_ACTIVE(state))) {
                 const char *ip;
 
                 ip = user_record_image_path(h->record);
@@ -3311,7 +3379,7 @@ int home_auto_login(Home *h, char ***ret_seats) {
                  * We filter out users marked for auto-login in we know for sure their home directory is
                  * absent. */
 
-                if (user_record_test_image_path(h->record) != USER_TEST_ABSENT) {
+                if (home_test_image_path(h) != USER_TEST_ABSENT) {
                         seat2 = strdup("seat0");
                         if (!seat2)
                                 return -ENOMEM;

--- a/src/home/homed-manager-bus.c
+++ b/src/home/homed-manager-bus.c
@@ -23,6 +23,7 @@
 #include "homed-manager.h"
 #include "homed-manager-bus.h"
 #include "homed-operation.h"
+#include "homework-thin.h"
 #include "log.h"
 #include "path-util.h"
 #include "set.h"
@@ -394,6 +395,23 @@ static int validate_and_allocate_home(Manager *m, UserRecord *hr, Hashmap *blobs
         if (r < 0)
                 return r;
 
+        r = home_record_has_pending(hr->user_name);
+        if (r < 0)
+                return r;
+        if (r > 0) {
+                /* Recovery may have retained an intent while its thin pool was unavailable during early
+                 * boot. A create retry is also an opportunity to recover it after the pool appeared. */
+                (void) manager_recover_records(m);
+
+                r = home_record_has_pending(hr->user_name);
+                if (r < 0)
+                        return r;
+        }
+        if (r > 0)
+                return sd_bus_error_setf(error, BUS_ERROR_USER_NAME_EXISTS,
+                                         "Recovery of an earlier home creation for %s is still pending, refusing.",
+                                         hr->user_name);
+
         r = check_for_conflicts(m, hr->user_name, error);
         if (r < 0)
                 return r;
@@ -491,6 +509,39 @@ static int validate_and_allocate_home(Manager *m, UserRecord *hr, Hashmap *blobs
         return r;
 }
 
+static int prepare_thin_home_record(Manager *m, UserRecord *hr, sd_bus_error *error) {
+        uint64_t backing_size, size;
+        int r;
+
+        assert(m);
+        assert(hr);
+
+        if (!m->thin_pool ||
+            hr->image_path ||
+            hr->disk_size != UINT64_MAX ||
+            !(hr->storage < 0 || hr->storage == USER_LUKS))
+                return 0;
+
+        if (FLAGS_SET(hr->mask, USER_RECORD_SIGNATURE))
+                return sd_bus_error_setf(
+                                error,
+                                BUS_ERROR_HOME_RECORD_SIGNED,
+                                "Signed thin-backed record for %s lacks an explicit disk size.",
+                                hr->user_name);
+
+        r = home_thin_pool_default_size(m->thin_pool, &size, &backing_size);
+        if (r < 0)
+                return sd_bus_error_set_errnof(error, r, "Failed to determine default thin-volume size: %m");
+
+        r = user_record_set_disk_size(hr, size);
+        if (r < 0)
+                return sd_bus_error_set_errnof(error, r, "Failed to record derived thin-volume size: %m");
+
+        log_info("Selected default thin-volume size %s from %s of currently backed capacity in %s.",
+                 FORMAT_BYTES(size), FORMAT_BYTES(backing_size), m->thin_pool);
+        return 1;
+}
+
 static int method_register_home(
                 sd_bus_message *message,
                 void *userdata,
@@ -579,6 +630,7 @@ static int method_unregister_home(sd_bus_message *message, void *userdata, sd_bu
 static int method_create_home(sd_bus_message *message, void *userdata, sd_bus_error *error) {
         _cleanup_(user_record_unrefp) UserRecord *hr = NULL;
         _cleanup_hashmap_free_ Hashmap *blobs = NULL;
+        sd_id128_t uuid;
         uint64_t flags = 0;
         Manager *m = ASSERT_PTR(userdata);
         Home *h;
@@ -612,6 +664,22 @@ static int method_create_home(sd_bus_message *message, void *userdata, sd_bus_er
                 return r;
         if (r == 0)
                 return 1; /* Will call us back */
+
+        if (sd_id128_is_null(hr->uuid) && !FLAGS_SET(hr->mask, USER_RECORD_SIGNATURE)) {
+                r = sd_id128_randomize(&uuid);
+                if (r < 0)
+                        return r;
+
+                r = sd_json_variant_set_field_uuid(&hr->json, "uuid", uuid);
+                if (r < 0)
+                        return r;
+
+                hr->uuid = uuid;
+        }
+
+        r = prepare_thin_home_record(m, hr, error);
+        if (r < 0)
+                return r;
 
         r = validate_and_allocate_home(m, hr, blobs, &h, error);
         if (r < 0)

--- a/src/home/homed-manager.c
+++ b/src/home/homed-manager.c
@@ -40,6 +40,7 @@
 #include "homed-manager-bus.h"
 #include "homed-operation.h"
 #include "homed-varlink.h"
+#include "homework-thin.h"
 #include "logarithm.h"
 #include "mkdir.h"
 #include "notify-recv.h"
@@ -321,6 +322,7 @@ Manager* manager_free(Manager *m) {
         free(m->userdb_service);
 
         free(m->default_file_system_type);
+        free(m->thin_pool);
 
         return mfree(m);
 }
@@ -378,21 +380,24 @@ int manager_verify_user_record(Manager *m, UserRecord *hr) {
         return -ENOKEY;
 }
 
-static int manager_add_home_by_record(
+static int manager_load_home_record(
                 Manager *m,
                 const char *name,
                 int dir_fd,
-                const char *fname) {
+                const char *fname,
+                bool remove_empty,
+                UserRecord **ret_record,
+                int *ret_signed) {
 
         _cleanup_(sd_json_variant_unrefp) sd_json_variant *v = NULL;
         _cleanup_(user_record_unrefp) UserRecord *hr = NULL;
         int r, is_signed;
         struct stat st;
-        Home *h;
 
         assert(m);
         assert(name);
         assert(fname);
+        assert(ret_record);
 
         if (fstatat(dir_fd, fname, &st, 0) < 0)
                 return log_error_errno(errno, "Failed to stat identity record %s: %m", fname);
@@ -402,16 +407,26 @@ static int manager_add_home_by_record(
                 return 0;
         }
 
-        if (st.st_size == 0)
+        if (st.st_size == 0) {
+                if (!remove_empty)
+                        return log_error_errno(SYNTHETIC_ERRNO(EBADMSG),
+                                               "Recovery record '%s' is empty, preserving it.", fname);
+
                 goto unlink_this_file;
+        }
 
         unsigned line = 0, column = 0;
         r = sd_json_parse_file_at(/* f= */ NULL, dir_fd, fname, SD_JSON_PARSE_MUST_BE_OBJECT|SD_JSON_PARSE_SENSITIVE, &v, &line, &column);
         if (r < 0)
                 return log_error_errno(r, "Failed to parse identity record at %s:%u:%u: %m", fname, line, column);
 
-        if (sd_json_variant_is_blank_object(v))
+        if (sd_json_variant_is_blank_object(v)) {
+                if (!remove_empty)
+                        return log_error_errno(SYNTHETIC_ERRNO(EBADMSG),
+                                               "Recovery record '%s' is blank, preserving it.", fname);
+
                 goto unlink_this_file;
+        }
 
         hr = user_record_new();
         if (!hr)
@@ -447,6 +462,43 @@ static int manager_add_home_by_record(
                 return log_error_errno(is_signed, "Failed to verify signature of user record in %s: %m", fname);
         }
 
+        *ret_record = TAKE_PTR(hr);
+        if (ret_signed)
+                *ret_signed = is_signed;
+        return 1;
+
+unlink_this_file:
+        /* If this is an empty file, then let's just remove it. An empty file is not useful in any case, and
+         * apparently xfs likes to leave empty files around when not unmounted cleanly (see
+         * https://github.com/systemd/systemd/issues/15178 for example). Note that we don't delete non-empty
+         * files even if they are invalid, because that's just too risky, we might delete data the user still
+         * needs. But empty files are never useful, hence let's just remove them. */
+
+        if (unlinkat(dir_fd, fname, 0) < 0)
+                return log_error_errno(errno, "Failed to remove empty user record file %s: %m", fname);
+
+        log_notice("Discovered empty user record file %s/%s, removed automatically.", home_record_dir(), fname);
+        return 0;
+}
+
+static int manager_add_home_by_record(
+                Manager *m,
+                const char *name,
+                int dir_fd,
+                const char *fname) {
+
+        _cleanup_(user_record_unrefp) UserRecord *hr = NULL;
+        Home *h;
+        int is_signed, r;
+
+        assert(m);
+        assert(name);
+        assert(fname);
+
+        r = manager_load_home_record(m, name, dir_fd, fname, /* remove_empty= */ true, &hr, &is_signed);
+        if (r <= 0)
+                return r;
+
         h = hashmap_get(m->homes_by_name, name);
         if (h) {
                 r = home_set_record(h, hr);
@@ -470,19 +522,6 @@ static int manager_add_home_by_record(
         h->signed_locally = is_signed == USER_RECORD_SIGNED_EXCLUSIVE;
 
         return 1;
-
-unlink_this_file:
-        /* If this is an empty file, then let's just remove it. An empty file is not useful in any case, and
-         * apparently xfs likes to leave empty files around when not unmounted cleanly (see
-         * https://github.com/systemd/systemd/issues/15178 for example). Note that we don't delete non-empty
-         * files even if they are invalid, because that's just too risky, we might delete data the user still
-         * needs. But empty files are never useful, hence let's just remove them. */
-
-        if (unlinkat(dir_fd, fname, 0) < 0)
-                return log_error_errno(errno, "Failed to remove empty user record file %s: %m", fname);
-
-        log_notice("Discovered empty user record file %s/%s, removed automatically.", home_record_dir(), fname);
-        return 0;
 }
 
 static int manager_enumerate_records(Manager *m) {
@@ -517,6 +556,275 @@ static int manager_enumerate_records(Manager *m) {
         }
 
         return 0;
+}
+
+static int manager_unlink_recovery_record(int dir_fd, const char *fname) {
+        int r;
+
+        assert(dir_fd >= 0);
+        assert(fname);
+
+        if (unlinkat(dir_fd, fname, 0) < 0) {
+                if (errno == ENOENT)
+                        return 0;
+
+                return -errno;
+        }
+
+        r = fsync_path_at(dir_fd, NULL);
+        if (r < 0)
+                return r;
+
+        return 1;
+}
+
+static int manager_recover_pending_records(Manager *m) {
+        _cleanup_closedir_ DIR *d = NULL;
+
+        assert(m);
+
+        d = opendir(home_record_dir());
+        if (!d)
+                return log_full_errno(errno == ENOENT ? LOG_DEBUG : LOG_ERR, errno,
+                                      "Failed to open %s: %m", home_record_dir());
+
+        FOREACH_DIRENT(de, d, return log_error_errno(errno, "Failed to read record directory: %m")) {
+                _cleanup_free_ char *final = NULL, *n = NULL;
+                const char *e;
+                int r;
+
+                if (!dirent_is_file(de))
+                        continue;
+
+                e = endswith(de->d_name, HOME_RECORD_PENDING_SUFFIX);
+                if (!e)
+                        continue;
+
+                n = strndup(de->d_name, e - de->d_name);
+                if (!n)
+                        return log_oom();
+                if (!suitable_user_name(n))
+                        continue;
+
+                final = strjoin(n, HOME_RECORD_SUFFIX);
+                if (!final)
+                        return log_oom();
+
+                if (faccessat(dirfd(d), final, F_OK, AT_SYMLINK_NOFOLLOW) >= 0) {
+                        r = manager_add_home_by_record(m, n, dirfd(d), final);
+                        if (r > 0) {
+                                r = manager_unlink_recovery_record(dirfd(d), de->d_name);
+                                if (r < 0)
+                                        log_warning_errno(r,
+                                                          "Failed to remove stale pending home record '%s', "
+                                                          "ignoring: %m",
+                                                          de->d_name);
+                                continue;
+                        }
+                        if (r < 0)
+                                continue;
+
+                        /* Empty records are removed by manager_add_home_by_record(). If it left some other
+                         * non-regular entry in place, do not replace it automatically. */
+                        if (faccessat(dirfd(d), final, F_OK, AT_SYMLINK_NOFOLLOW) >= 0)
+                                continue;
+                        if (errno != ENOENT) {
+                                log_warning_errno(errno,
+                                                  "Failed to retest committed home record '%s', skipping: %m",
+                                                  final);
+                                continue;
+                        }
+                } else if (errno != ENOENT) {
+                        log_warning_errno(errno, "Failed to test for committed home record '%s', skipping: %m", final);
+                        continue;
+                }
+
+                r = manager_add_home_by_record(m, n, dirfd(d), de->d_name);
+                if (r <= 0)
+                        continue;
+
+                r = home_record_commit_pending(n);
+                if (r < 0) {
+                        log_error_errno(r, "Failed to commit pending home record '%s': %m", de->d_name);
+                        continue;
+                }
+
+                log_notice("Recovered pending home record for '%s'.", n);
+        }
+
+        return 0;
+}
+
+static int manager_record_protects_thin_intent(
+                Manager *m,
+                const char *name,
+                int dir_fd,
+                const char *fname,
+                UserRecord *intent) {
+
+        _cleanup_(user_record_unrefp) UserRecord *record = NULL;
+        int r;
+
+        assert(m);
+        assert(name);
+        assert(dir_fd >= 0);
+        assert(fname);
+        assert(intent);
+
+        if (faccessat(dir_fd, fname, F_OK, AT_SYMLINK_NOFOLLOW) < 0)
+                return errno == ENOENT ? 0 : -errno;
+
+        r = manager_load_home_record(
+                        m,
+                        name,
+                        dir_fd,
+                        fname,
+                        /* remove_empty= */ true,
+                        &record,
+                        /* ret_signed= */ NULL);
+        if (r < 0)
+                return r;
+        if (r == 0) {
+                /* manager_load_home_record() removes empty regular files, but leaves other file types alone. */
+                if (faccessat(dir_fd, fname, F_OK, AT_SYMLINK_NOFOLLOW) >= 0)
+                        return -EBUSY;
+                return errno == ENOENT ? 0 : -errno;
+        }
+
+        if (!sd_id128_equal(record->uuid, intent->uuid) ||
+            !record->thin_pool_uuid || record->thin_device_id == UINT32_MAX)
+                return false;
+
+        if (intent->thin_pool_uuid &&
+            (!streq(record->thin_pool_uuid, intent->thin_pool_uuid) ||
+             record->thin_device_id != intent->thin_device_id))
+                return false;
+
+        if (!m->thin_pool)
+                return -ENXIO;
+
+        r = home_thin_volume_commit_path(record, m->thin_pool);
+        if (r < 0)
+                return r;
+
+        return true;
+}
+
+static int manager_recover_thin_volume_intents(Manager *m) {
+        _cleanup_closedir_ DIR *d = NULL;
+
+        assert(m);
+
+        d = opendir(home_record_dir());
+        if (!d)
+                return log_full_errno(errno == ENOENT ? LOG_DEBUG : LOG_ERR, errno,
+                                      "Failed to open %s: %m", home_record_dir());
+
+        FOREACH_DIRENT(de, d, return log_error_errno(errno, "Failed to read record directory: %m")) {
+                _cleanup_(user_record_unrefp) UserRecord *intent = NULL;
+                _cleanup_free_ char *final = NULL, *n = NULL, *pending = NULL;
+                const char *e;
+                int r;
+
+                if (!dirent_is_file(de))
+                        continue;
+
+                e = endswith(de->d_name, HOME_RECORD_THIN_INTENT_SUFFIX);
+                if (!e)
+                        continue;
+
+                n = strndup(de->d_name, e - de->d_name);
+                if (!n)
+                        return log_oom();
+                if (!suitable_user_name(n))
+                        continue;
+
+                r = manager_load_home_record(
+                                m,
+                                n,
+                                dirfd(d),
+                                de->d_name,
+                                /* remove_empty= */ false,
+                                &intent,
+                                /* ret_signed= */ NULL);
+                if (r <= 0)
+                        continue;
+
+                final = strjoin(n, HOME_RECORD_SUFFIX);
+                pending = strjoin(n, HOME_RECORD_PENDING_SUFFIX);
+                if (!final || !pending)
+                        return log_oom();
+
+                r = manager_record_protects_thin_intent(m, n, dirfd(d), final, intent);
+                if (r < 0) {
+                        log_warning_errno(r,
+                                          "Unable to determine whether '%s' supersedes thin-volume intent '%s', "
+                                          "preserving intent: %m",
+                                          final,
+                                          de->d_name);
+                        continue;
+                }
+                if (r == 0) {
+                        r = manager_record_protects_thin_intent(m, n, dirfd(d), pending, intent);
+                        if (r < 0) {
+                                log_warning_errno(r,
+                                                  "Unable to determine whether '%s' supersedes thin-volume intent '%s', "
+                                                  "preserving intent: %m",
+                                                  pending,
+                                                  de->d_name);
+                                continue;
+                        }
+                }
+
+                if (r == 0) {
+                        if (!m->thin_pool) {
+                                log_error("Cannot recover thin-volume intent '%s' without ThinPool= configured, preserving intent.",
+                                          de->d_name);
+                                continue;
+                        }
+
+                        r = home_thin_volume_remove_incomplete(intent, m->thin_pool);
+                        if (r < 0) {
+                                log_error_errno(r,
+                                                "Failed to recover thin-volume intent '%s', preserving intent: %m",
+                                                de->d_name);
+                                continue;
+                        }
+                }
+
+                r = manager_unlink_recovery_record(dirfd(d), de->d_name);
+                if (r < 0) {
+                        log_warning_errno(r,
+                                          "Failed to remove recovered thin-volume intent '%s', ignoring: %m",
+                                          de->d_name);
+                        continue;
+                }
+
+                log_notice("Recovered thin-volume creation intent for '%s'.", n);
+        }
+
+        return 0;
+}
+
+int manager_recover_records(Manager *m) {
+        int ret, r;
+
+        assert(m);
+
+        ret = 0;
+        if (m->thin_pool) {
+                r = home_thin_pool_recover(m->thin_pool);
+                if (r < 0)
+                        log_error_errno(r, "Failed to recover dm-thin allocator state: %m");
+                RET_GATHER(ret, r);
+        }
+
+        r = manager_recover_pending_records(m);
+        RET_GATHER(ret, r);
+        r = manager_recover_thin_volume_intents(m);
+        RET_GATHER(ret, r);
+
+        return ret;
 }
 
 static int search_quota(uid_t uid, const char *exclude_quota_path) {
@@ -842,6 +1150,7 @@ int manager_augment_record_with_uid(
                         SD_ID128_NULL,
                         SD_ID128_NULL,
                         SD_ID128_NULL,
+                        NULL,
                         NULL,
                         NULL,
                         UINT64_MAX,
@@ -1572,6 +1881,7 @@ int manager_startup(Manager *m) {
         manager_watch_home(m);
         (void) manager_watch_devices(m);
 
+        (void) manager_recover_records(m);
         (void) manager_enumerate_records(m);
         (void) manager_enumerate_images(m);
         (void) manager_enumerate_devices(m);

--- a/src/home/homed-manager.h
+++ b/src/home/homed-manager.h
@@ -30,6 +30,8 @@ typedef struct Manager {
         bool scan_slash_home;
         UserStorage default_storage;
         char *default_file_system_type;
+        char *thin_pool;
+        bool hardware_wrapped_keys;
 
         sd_event_source *inotify_event_source;
 
@@ -66,6 +68,7 @@ Manager* manager_free(Manager *m);
 DEFINE_TRIVIAL_CLEANUP_FUNC(Manager*, manager_free);
 
 int manager_startup(Manager *m);
+int manager_recover_records(Manager *m);
 
 int manager_augment_record_with_uid(Manager *m, UserRecord *hr);
 

--- a/src/home/homed.conf
+++ b/src/home/homed.conf
@@ -19,3 +19,5 @@
 [Home]
 #DefaultStorage=
 #DefaultFileSystemType=btrfs
+#ThinPool=
+#HardwareWrappedKeys=no

--- a/src/home/homework-cifs.c
+++ b/src/home/homework-cifs.c
@@ -247,6 +247,7 @@ int home_create_cifs(UserRecord *h, HomeSetup *setup, UserRecord **ret_home) {
                         SD_ID128_NULL,
                         NULL,
                         NULL,
+                        NULL,
                         UINT64_MAX,
                         NULL,
                         NULL,

--- a/src/home/homework-directory.c
+++ b/src/home/homework-directory.c
@@ -243,6 +243,7 @@ int home_create_directory_or_subvolume(UserRecord *h, HomeSetup *setup, UserReco
                         SD_ID128_NULL,
                         NULL,
                         NULL,
+                        NULL,
                         UINT64_MAX,
                         NULL,
                         NULL,

--- a/src/home/homework-fscrypt.c
+++ b/src/home/homework-fscrypt.c
@@ -1385,6 +1385,7 @@ int home_create_fscrypt(
                         SD_ID128_NULL,
                         NULL,
                         NULL,
+                        NULL,
                         UINT64_MAX,
                         NULL,
                         NULL,

--- a/src/home/homework-luks-token.c
+++ b/src/home/homework-luks-token.c
@@ -1,0 +1,431 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include <openssl/evp.h>
+
+#include "sd-id128.h"
+#include "sd-json.h"
+
+#include "alloc-util.h"
+#include "crypto-util.h"
+#include "errno-util.h"
+#include "homework-luks-token.h"
+#include "iovec-util.h"
+#include "memory-util.h"
+#include "string-util.h"
+
+#define HOME_LUKS_TOKEN_V2_CIPHER "aes-256-gcm"
+#define HOME_LUKS_TOKEN_V2_KDF "hkdf-sha256"
+
+static const uint8_t home_luks_token_v2_hkdf_info[] =
+        "systemd-homed identity-token v2";
+static const uint8_t home_luks_token_v2_aad[] =
+        "type=systemd-homed\0"
+        "version=2\0"
+        "cipher=" HOME_LUKS_TOKEN_V2_CIPHER "\0"
+        "kdf=" HOME_LUKS_TOKEN_V2_KDF "\0";
+
+int home_luks_token_encrypt_legacy(
+                const void *plaintext,
+                size_t plaintext_size,
+                const EVP_CIPHER *cipher,
+                const void *volume_key,
+                size_t volume_key_size,
+                const void *iv,
+                size_t iv_size,
+                char **ret) {
+
+        _cleanup_(EVP_CIPHER_CTX_freep) EVP_CIPHER_CTX *context = NULL;
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *token = NULL;
+        _cleanup_(erase_and_freep) void *ciphertext = NULL;
+        int encrypted_size_out1 = 0, encrypted_size_out2 = 0;
+        size_t ciphertext_size;
+        int r;
+
+        assert(plaintext);
+        assert(plaintext_size > 0);
+        assert(cipher);
+        assert(volume_key);
+        assert(ret);
+
+        if (plaintext_size > INT_MAX || volume_key_size != (size_t) sym_EVP_CIPHER_get_key_length(cipher) ||
+            iv_size != (size_t) sym_EVP_CIPHER_get_iv_length(cipher) || (iv_size > 0 && !iv))
+                return -EINVAL;
+
+        if (__builtin_add_overflow(plaintext_size,
+                                   (size_t) sym_EVP_CIPHER_get_block_size(cipher),
+                                   &ciphertext_size))
+                return -EOVERFLOW;
+
+        context = sym_EVP_CIPHER_CTX_new();
+        if (!context)
+                return -ENOMEM;
+
+        if (sym_EVP_EncryptInit_ex(context, cipher, NULL, volume_key, iv) != 1)
+                return -EINVAL;
+
+        ciphertext = malloc(ciphertext_size);
+        if (!ciphertext)
+                return -ENOMEM;
+
+        if (sym_EVP_EncryptUpdate(context, ciphertext, &encrypted_size_out1,
+                                  plaintext, (int) plaintext_size) != 1)
+                return -EINVAL;
+        if (sym_EVP_EncryptFinal_ex(context,
+                                    (uint8_t*) ciphertext + encrypted_size_out1,
+                                    &encrypted_size_out2) != 1)
+                return -EINVAL;
+
+        assert((size_t) encrypted_size_out1 + (size_t) encrypted_size_out2 <= ciphertext_size);
+        ciphertext_size = (size_t) encrypted_size_out1 + (size_t) encrypted_size_out2;
+
+        r = sd_json_buildo(
+                        &token,
+                        SD_JSON_BUILD_PAIR_STRING("type", "systemd-homed"),
+                        SD_JSON_BUILD_PAIR("keyslots", SD_JSON_BUILD_EMPTY_ARRAY),
+                        SD_JSON_BUILD_PAIR("record", SD_JSON_BUILD_BASE64(ciphertext, ciphertext_size)),
+                        SD_JSON_BUILD_PAIR("iv", SD_JSON_BUILD_BASE64(iv, iv_size)));
+        if (r < 0)
+                return r;
+
+        return sd_json_variant_format(token, 0, ret);
+}
+
+int home_luks_token_decrypt_legacy(
+                sd_json_variant *token,
+                const EVP_CIPHER *cipher,
+                const void *volume_key,
+                size_t volume_key_size,
+                void **ret_plaintext,
+                size_t *ret_plaintext_size) {
+
+        _cleanup_(EVP_CIPHER_CTX_freep) EVP_CIPHER_CTX *context = NULL;
+        _cleanup_free_ void *ciphertext = NULL, *iv = NULL;
+        _cleanup_(erase_and_freep) void *plaintext = NULL;
+        int decrypted_size_out1 = 0, decrypted_size_out2 = 0;
+        size_t ciphertext_size, iv_size, plaintext_size;
+        sd_json_variant *field;
+        int r;
+
+        assert(token);
+        assert(cipher);
+        assert(volume_key);
+        assert(ret_plaintext);
+        assert(ret_plaintext_size);
+
+        *ret_plaintext = NULL;
+        *ret_plaintext_size = 0;
+
+        if (volume_key_size != (size_t) sym_EVP_CIPHER_get_key_length(cipher))
+                return -EINVAL;
+
+        field = sd_json_variant_by_key(token, "type");
+        if (!field || !streq_ptr(sd_json_variant_string(field), "systemd-homed"))
+                return -EINVAL;
+        if (sd_json_variant_by_key(token, "version"))
+                return -EINVAL;
+
+        field = sd_json_variant_by_key(token, "record");
+        if (!field)
+                return -EINVAL;
+        r = sd_json_variant_unbase64(field, &ciphertext, &ciphertext_size);
+        if (r < 0 || ciphertext_size == 0 || ciphertext_size > INT_MAX)
+                return -EINVAL;
+
+        field = sd_json_variant_by_key(token, "iv");
+        if (!field)
+                return -EINVAL;
+        r = sd_json_variant_unbase64(field, &iv, &iv_size);
+        if (r < 0 || iv_size != (size_t) sym_EVP_CIPHER_get_iv_length(cipher))
+                return -EINVAL;
+
+        context = sym_EVP_CIPHER_CTX_new();
+        if (!context)
+                return -ENOMEM;
+        if (sym_EVP_DecryptInit_ex(context, cipher, NULL, volume_key, iv) != 1)
+                return -EINVAL;
+
+        if (__builtin_add_overflow(ciphertext_size,
+                                   (size_t) sym_EVP_CIPHER_get_block_size(cipher),
+                                   &plaintext_size) ||
+            __builtin_add_overflow(plaintext_size, 1U, &plaintext_size))
+                return -EOVERFLOW;
+
+        plaintext = malloc(plaintext_size);
+        if (!plaintext)
+                return -ENOMEM;
+
+        if (sym_EVP_DecryptUpdate(context, plaintext, &decrypted_size_out1,
+                                  ciphertext, (int) ciphertext_size) != 1)
+                return -EINVAL;
+        if (sym_EVP_DecryptFinal_ex(context,
+                                    (uint8_t*) plaintext + decrypted_size_out1,
+                                    &decrypted_size_out2) != 1)
+                return -EBADMSG;
+
+        assert((size_t) decrypted_size_out1 + (size_t) decrypted_size_out2 < plaintext_size);
+        plaintext_size = (size_t) decrypted_size_out1 + (size_t) decrypted_size_out2;
+        ((uint8_t*) plaintext)[plaintext_size] = 0;
+
+        *ret_plaintext = TAKE_PTR(plaintext);
+        *ret_plaintext_size = plaintext_size;
+        return 0;
+}
+
+static int home_luks_token_v2_derive_key(
+                const void *software_secret,
+                size_t software_secret_size,
+                sd_id128_t luks_uuid,
+                struct iovec *ret) {
+
+        assert(software_secret);
+        assert(software_secret_size > 0);
+        assert(ret);
+
+        return kdf_hkdf_sha256(
+                        &IOVEC_MAKE((void*) software_secret, software_secret_size),
+                        &IOVEC_MAKE(luks_uuid.bytes, sizeof(luks_uuid.bytes)),
+                        &IOVEC_MAKE((void*) home_luks_token_v2_hkdf_info,
+                                    sizeof(home_luks_token_v2_hkdf_info) - 1),
+                        HOME_LUKS_TOKEN_V2_KEY_SIZE,
+                        ret);
+}
+
+static int home_luks_token_v2_add_aad(EVP_CIPHER_CTX *context, bool encrypt, sd_id128_t luks_uuid) {
+        int added;
+
+        assert(context);
+
+        if (encrypt) {
+                if (sym_EVP_EncryptUpdate(context, NULL, &added,
+                                          home_luks_token_v2_aad,
+                                          (int) sizeof(home_luks_token_v2_aad)) != 1)
+                        return -EINVAL;
+                if (sym_EVP_EncryptUpdate(context, NULL, &added,
+                                          luks_uuid.bytes,
+                                          (int) sizeof(luks_uuid.bytes)) != 1)
+                        return -EINVAL;
+        } else {
+                if (sym_EVP_DecryptUpdate(context, NULL, &added,
+                                          home_luks_token_v2_aad,
+                                          (int) sizeof(home_luks_token_v2_aad)) != 1)
+                        return -EINVAL;
+                if (sym_EVP_DecryptUpdate(context, NULL, &added,
+                                          luks_uuid.bytes,
+                                          (int) sizeof(luks_uuid.bytes)) != 1)
+                        return -EINVAL;
+        }
+
+        return 0;
+}
+
+int home_luks_token_encrypt_v2(
+                const void *plaintext,
+                size_t plaintext_size,
+                const void *software_secret,
+                size_t software_secret_size,
+                const char *luks_uuid,
+                const uint8_t iv[static HOME_LUKS_TOKEN_V2_IV_SIZE],
+                char **ret) {
+
+        _cleanup_(EVP_CIPHER_CTX_freep) EVP_CIPHER_CTX *context = NULL;
+        _cleanup_(iovec_done_erase) struct iovec key = {};
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *token = NULL;
+        _cleanup_(erase_and_freep) void *ciphertext = NULL;
+        uint8_t tag[HOME_LUKS_TOKEN_V2_TAG_SIZE] = {};
+        int encrypted_size_out1 = 0, encrypted_size_out2 = 0;
+        size_t ciphertext_size;
+        sd_id128_t uuid;
+        const EVP_CIPHER *cipher;
+        int r;
+
+        assert(plaintext);
+        assert(plaintext_size > 0);
+        assert(software_secret);
+        assert(software_secret_size == HOME_LUKS_TOKEN_V2_KEY_SIZE);
+        assert(luks_uuid);
+        assert(iv);
+        assert(ret);
+
+        if (plaintext_size > INT_MAX)
+                return -E2BIG;
+
+        CLEANUP_ERASE(tag);
+
+        r = sd_id128_from_string(luks_uuid, &uuid);
+        if (r < 0)
+                return -EINVAL;
+
+        r = home_luks_token_v2_derive_key(software_secret, software_secret_size, uuid, &key);
+        if (r < 0)
+                return r;
+
+        context = sym_EVP_CIPHER_CTX_new();
+        if (!context)
+                return -ENOMEM;
+
+        assert_se(cipher = sym_EVP_aes_256_gcm());
+        if (sym_EVP_EncryptInit_ex(context, cipher, NULL, NULL, NULL) != 1)
+                return -EINVAL;
+        if (sym_EVP_CIPHER_CTX_ctrl(context, EVP_CTRL_GCM_SET_IVLEN,
+                                    HOME_LUKS_TOKEN_V2_IV_SIZE, NULL) != 1)
+                return -EINVAL;
+        if (sym_EVP_EncryptInit_ex(context, NULL, NULL, key.iov_base, iv) != 1)
+                return -EINVAL;
+
+        r = home_luks_token_v2_add_aad(context, true, uuid);
+        if (r < 0)
+                return r;
+
+        if (__builtin_add_overflow(plaintext_size,
+                                   (size_t) sym_EVP_CIPHER_get_block_size(cipher),
+                                   &ciphertext_size))
+                return -EOVERFLOW;
+
+        ciphertext = malloc(ciphertext_size);
+        if (!ciphertext)
+                return -ENOMEM;
+
+        if (sym_EVP_EncryptUpdate(context, ciphertext, &encrypted_size_out1,
+                                  plaintext, (int) plaintext_size) != 1)
+                return -EINVAL;
+        if (sym_EVP_EncryptFinal_ex(context,
+                                    (uint8_t*) ciphertext + encrypted_size_out1,
+                                    &encrypted_size_out2) != 1)
+                return -EINVAL;
+
+        assert((size_t) encrypted_size_out1 + (size_t) encrypted_size_out2 <= ciphertext_size);
+        ciphertext_size = (size_t) encrypted_size_out1 + (size_t) encrypted_size_out2;
+
+        if (sym_EVP_CIPHER_CTX_ctrl(context, EVP_CTRL_GCM_GET_TAG,
+                                    (int) sizeof(tag), tag) != 1)
+                return -EINVAL;
+
+        r = sd_json_buildo(
+                        &token,
+                        SD_JSON_BUILD_PAIR_STRING("type", "systemd-homed"),
+                        SD_JSON_BUILD_PAIR("keyslots", SD_JSON_BUILD_EMPTY_ARRAY),
+                        SD_JSON_BUILD_PAIR_UNSIGNED("version", 2),
+                        SD_JSON_BUILD_PAIR_STRING("cipher", HOME_LUKS_TOKEN_V2_CIPHER),
+                        SD_JSON_BUILD_PAIR_STRING("kdf", HOME_LUKS_TOKEN_V2_KDF),
+                        SD_JSON_BUILD_PAIR("iv", SD_JSON_BUILD_BASE64(iv, HOME_LUKS_TOKEN_V2_IV_SIZE)),
+                        SD_JSON_BUILD_PAIR("tag", SD_JSON_BUILD_BASE64(tag, sizeof(tag))),
+                        SD_JSON_BUILD_PAIR("ciphertext", SD_JSON_BUILD_BASE64(ciphertext, ciphertext_size)));
+        if (r < 0)
+                return r;
+
+        return sd_json_variant_format(token, 0, ret);
+}
+
+int home_luks_token_decrypt_v2(
+                sd_json_variant *token,
+                const void *software_secret,
+                size_t software_secret_size,
+                const char *luks_uuid,
+                void **ret_plaintext,
+                size_t *ret_plaintext_size) {
+
+        _cleanup_(EVP_CIPHER_CTX_freep) EVP_CIPHER_CTX *context = NULL;
+        _cleanup_(iovec_done_erase) struct iovec key = {};
+        _cleanup_free_ void *ciphertext = NULL, *iv = NULL, *tag = NULL;
+        _cleanup_(erase_and_freep) void *plaintext = NULL;
+        sd_json_variant *field;
+        size_t ciphertext_size, iv_size, plaintext_size, tag_size;
+        int decrypted_size_out1 = 0, decrypted_size_out2 = 0;
+        sd_id128_t uuid;
+        const EVP_CIPHER *cipher;
+        int r;
+
+        assert(token);
+        assert(software_secret);
+        assert(software_secret_size == HOME_LUKS_TOKEN_V2_KEY_SIZE);
+        assert(luks_uuid);
+        assert(ret_plaintext);
+        assert(ret_plaintext_size);
+
+        *ret_plaintext = NULL;
+        *ret_plaintext_size = 0;
+
+        field = sd_json_variant_by_key(token, "type");
+        if (!field || !streq_ptr(sd_json_variant_string(field), "systemd-homed"))
+                return -EINVAL;
+        field = sd_json_variant_by_key(token, "version");
+        if (!sd_json_variant_is_unsigned(field) || sd_json_variant_unsigned(field) != 2)
+                return -EINVAL;
+        field = sd_json_variant_by_key(token, "cipher");
+        if (!field || !streq_ptr(sd_json_variant_string(field), HOME_LUKS_TOKEN_V2_CIPHER))
+                return -EINVAL;
+        field = sd_json_variant_by_key(token, "kdf");
+        if (!field || !streq_ptr(sd_json_variant_string(field), HOME_LUKS_TOKEN_V2_KDF))
+                return -EINVAL;
+
+        field = sd_json_variant_by_key(token, "iv");
+        if (!field)
+                return -EINVAL;
+        r = sd_json_variant_unbase64(field, &iv, &iv_size);
+        if (r < 0 || iv_size != HOME_LUKS_TOKEN_V2_IV_SIZE)
+                return -EINVAL;
+        field = sd_json_variant_by_key(token, "tag");
+        if (!field)
+                return -EINVAL;
+        r = sd_json_variant_unbase64(field, &tag, &tag_size);
+        if (r < 0 || tag_size != HOME_LUKS_TOKEN_V2_TAG_SIZE)
+                return -EINVAL;
+        field = sd_json_variant_by_key(token, "ciphertext");
+        if (!field)
+                return -EINVAL;
+        r = sd_json_variant_unbase64(field, &ciphertext, &ciphertext_size);
+        if (r < 0 || ciphertext_size == 0 || ciphertext_size > INT_MAX)
+                return -EINVAL;
+
+        r = sd_id128_from_string(luks_uuid, &uuid);
+        if (r < 0)
+                return -EINVAL;
+
+        r = home_luks_token_v2_derive_key(software_secret, software_secret_size, uuid, &key);
+        if (r < 0)
+                return r;
+
+        context = sym_EVP_CIPHER_CTX_new();
+        if (!context)
+                return -ENOMEM;
+
+        assert_se(cipher = sym_EVP_aes_256_gcm());
+        if (sym_EVP_DecryptInit_ex(context, cipher, NULL, NULL, NULL) != 1)
+                return -EINVAL;
+        if (sym_EVP_CIPHER_CTX_ctrl(context, EVP_CTRL_GCM_SET_IVLEN, (int) iv_size, NULL) != 1)
+                return -EINVAL;
+        if (sym_EVP_DecryptInit_ex(context, NULL, NULL, key.iov_base, iv) != 1)
+                return -EINVAL;
+
+        r = home_luks_token_v2_add_aad(context, false, uuid);
+        if (r < 0)
+                return r;
+
+        if (__builtin_add_overflow(ciphertext_size,
+                                   (size_t) sym_EVP_CIPHER_get_block_size(cipher),
+                                   &plaintext_size))
+                return -EOVERFLOW;
+
+        plaintext = malloc(plaintext_size);
+        if (!plaintext)
+                return -ENOMEM;
+
+        if (sym_EVP_DecryptUpdate(context, plaintext, &decrypted_size_out1,
+                                  ciphertext, (int) ciphertext_size) != 1)
+                return -EINVAL;
+
+        if (sym_EVP_CIPHER_CTX_ctrl(context, EVP_CTRL_GCM_SET_TAG, (int) tag_size, tag) != 1)
+                return -EINVAL;
+        if (sym_EVP_DecryptFinal_ex(context,
+                                    (uint8_t*) plaintext + decrypted_size_out1,
+                                    &decrypted_size_out2) != 1)
+                return -EBADMSG;
+
+        assert((size_t) decrypted_size_out1 + (size_t) decrypted_size_out2 <= plaintext_size);
+        plaintext_size = (size_t) decrypted_size_out1 + (size_t) decrypted_size_out2;
+        ((uint8_t*) plaintext)[plaintext_size] = 0;
+
+        *ret_plaintext = TAKE_PTR(plaintext);
+        *ret_plaintext_size = plaintext_size;
+        return 0;
+}

--- a/src/home/homework-luks-token.h
+++ b/src/home/homework-luks-token.h
@@ -1,0 +1,48 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <openssl/evp.h>
+
+#include "forward.h"
+
+#define HOME_LUKS_TOKEN_V2_IV_SIZE 12U
+#define HOME_LUKS_TOKEN_V2_TAG_SIZE 16U
+#define HOME_LUKS_TOKEN_V2_KEY_SIZE 32U
+
+int home_luks_token_encrypt_legacy(
+                const void *plaintext,
+                size_t plaintext_size,
+                const EVP_CIPHER *cipher,
+                const void *volume_key,
+                size_t volume_key_size,
+                const void *iv,
+                size_t iv_size,
+                char **ret);
+
+int home_luks_token_decrypt_legacy(
+                sd_json_variant *token,
+                const EVP_CIPHER *cipher,
+                const void *volume_key,
+                size_t volume_key_size,
+                void **ret_plaintext,
+                size_t *ret_plaintext_size);
+
+int home_luks_token_encrypt_v2(
+                const void *plaintext,
+                size_t plaintext_size,
+                const void *software_secret,
+                size_t software_secret_size,
+                const char *luks_uuid,
+                const uint8_t iv[static HOME_LUKS_TOKEN_V2_IV_SIZE],
+                char **ret);
+
+int home_luks_token_decrypt_v2(
+                sd_json_variant *token,
+                const void *software_secret,
+                size_t software_secret_size,
+                const char *luks_uuid,
+                void **ret_plaintext,
+                size_t *ret_plaintext_size);

--- a/src/home/homework-luks.c
+++ b/src/home/homework-luks.c
@@ -40,8 +40,10 @@
 #include "homework.h"
 #include "homework-blob.h"
 #include "homework-luks.h"
+#include "homework-luks-token.h"
 #include "homework-mount.h"
 #include "homework-password-cache.h"
+#include "homework-thin.h"
 #include "io-util.h"
 #include "json-util.h"
 #include "keyring-util.h"
@@ -49,6 +51,7 @@
 #include "memory-util.h"
 #include "mkdir.h"
 #include "mkfs-util.h"
+#include "mountpoint-util.h"
 #include "parse-util.h"
 #include "path-util.h"
 #include "pidref.h"
@@ -70,6 +73,12 @@
  * partitions to that too. In the worst case we'll waste 1 MiB per partition that way, but I think I can live
  * with that. */
 #define DISK_SIZE_ROUND_DOWN(x) ((x) & ~(U64_MB - 1))
+
+#define HOME_LUKS_INTEGRITY_ALGORITHM "hmac(sha256)"
+#define HOME_LUKS_INTEGRITY_KEY_SIZE 32U
+#define HOME_LUKS_INTEGRITY_TAG_SIZE 32U
+#define HOME_LUKS_INTEGRITY_SECTOR_SIZE 4096U
+#define HOME_LUKS_INTEGRITY_JOURNAL_SIZE (UINT64_C(32) * U64_MB)
 
 /* Rounds up to the nearest 1 MiB boundary. Returns UINT64_MAX on overflow */
 #define DISK_SIZE_ROUND_UP(x)                                           \
@@ -401,6 +410,7 @@ static int luks_setup(
                 sd_id128_t uuid,
                 const char *cipher,
                 const char *cipher_mode,
+                const char *key_type,
                 uint64_t volume_key_size,
                 const PasswordCache *cache,
                 bool discard,
@@ -415,7 +425,7 @@ static int luks_setup(
         _cleanup_(erase_and_freep) void *vk = NULL;
         sd_id128_t p;
         size_t vks;
-        int r;
+        int encryption_type, r;
 
         assert(h);
         assert(node);
@@ -431,6 +441,11 @@ static int luks_setup(
         r = sym_crypt_load(cd, CRYPT_LUKS2, NULL);
         if (r < 0)
                 return log_error_errno(r, "Failed to load LUKS superblock: %m");
+
+        encryption_type = sym_crypt_get_hw_encryption_type(cd);
+        if (encryption_type < 0)
+                return log_error_errno(encryption_type,
+                                       "Failed to determine LUKS hardware-encryption type: %m");
 
         r = sym_crypt_get_volume_key_size(cd);
         if (r <= 0)
@@ -460,7 +475,47 @@ static int luks_setup(
         if (cipher_mode && !streq_ptr(cipher_mode, sym_crypt_get_cipher_mode(cd)))
                 return log_error_errno(SYNTHETIC_ERRNO(EMEDIUMTYPE), "LUKS superblock declares wrong cipher mode.");
 
-        if (volume_key_size != UINT64_MAX && vks != volume_key_size)
+        const char *actual_key_type = encryption_type == CRYPT_INLINE_HW_WRAPPED ? "hw-wrapped" : "raw";
+        if (key_type && !streq(key_type, actual_key_type))
+                return log_error_errno(SYNTHETIC_ERRNO(EMEDIUMTYPE),
+                                       "LUKS superblock key type '%s' does not match record binding '%s'.",
+                                       actual_key_type, key_type);
+
+        struct crypt_params_integrity integrity = {};
+        r = sym_crypt_get_integrity_info(cd, &integrity);
+        if (r < 0)
+                return log_error_errno(r, "Failed to determine LUKS integrity profile: %m");
+
+        const char *actual_integrity = NULL;
+        if (encryption_type == CRYPT_INLINE_HW_WRAPPED && integrity.integrity) {
+                if (integrity.journal_size != HOME_LUKS_INTEGRITY_JOURNAL_SIZE ||
+                    integrity.journal_watermark != 0 ||
+                    integrity.journal_commit_time != 0 ||
+                    integrity.interleave_sectors != 0 ||
+                    integrity.tag_size != HOME_LUKS_INTEGRITY_TAG_SIZE ||
+                    integrity.sector_size != HOME_LUKS_INTEGRITY_SECTOR_SIZE ||
+                    integrity.buffer_sectors != 0 ||
+                    !streq(integrity.integrity, HOME_LUKS_INTEGRITY_ALGORITHM) ||
+                    integrity.integrity_key_size != HOME_LUKS_INTEGRITY_KEY_SIZE ||
+                    integrity.journal_integrity ||
+                    integrity.journal_integrity_key ||
+                    integrity.journal_integrity_key_size != 0 ||
+                    integrity.journal_crypt ||
+                    integrity.journal_crypt_key ||
+                    integrity.journal_crypt_key_size != 0)
+                        return log_error_errno(SYNTHETIC_ERRNO(EMEDIUMTYPE),
+                                               "LUKS superblock declares an unsupported hardware-wrapped integrity profile.");
+
+                actual_integrity = HOME_LUKS_INTEGRITY_ALGORITHM;
+        }
+
+        if (!streq_ptr(actual_integrity, h->luks_integrity))
+                return log_error_errno(SYNTHETIC_ERRNO(EMEDIUMTYPE),
+                                       "LUKS superblock integrity profile '%s' does not match record binding '%s'.",
+                                       strna(actual_integrity), strna(h->luks_integrity));
+
+        if (encryption_type != CRYPT_INLINE_HW_WRAPPED &&
+            volume_key_size != UINT64_MAX && vks != volume_key_size)
                 return log_error_errno(SYNTHETIC_ERRNO(EMEDIUMTYPE), "LUKS superblock declares wrong volume key size.");
 
         vk = malloc(vks);
@@ -477,7 +532,7 @@ static int luks_setup(
                         cd,
                         dm_name,
                         vk, vks,
-                        discard ? CRYPT_ACTIVATE_ALLOW_DISCARDS : 0);
+                        (discard || h->luks_integrity) ? CRYPT_ACTIVATE_ALLOW_DISCARDS : 0);
         if (r < 0)
                 return log_error_errno(r, "Failed to unlock LUKS superblock: %m");
 
@@ -849,31 +904,109 @@ static int crypt_device_to_evp_cipher(struct crypt_device *cd, const EVP_CIPHER 
         return 0;
 }
 
+static int luks_validate_decrypted_home_record(
+                UserRecord *h,
+                PasswordCache *cache,
+                char *decrypted,
+                size_t decrypted_size,
+                UserRecord **ret_luks_home_record) {
+
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *record = NULL;
+        _cleanup_(user_record_unrefp) UserRecord *lhr = NULL;
+        int r;
+
+        assert(h);
+        assert(decrypted);
+        assert(ret_luks_home_record);
+
+        if (memchr(decrypted, 0, decrypted_size))
+                return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "Inner NUL byte in JSON record, refusing.");
+
+        decrypted[decrypted_size] = 0;
+
+        r = sd_json_parse(decrypted, SD_JSON_PARSE_MUST_BE_OBJECT|SD_JSON_PARSE_SENSITIVE,
+                          &record, NULL, NULL);
+        if (r < 0)
+                return log_error_errno(r, "Failed to parse decrypted JSON record, refusing.");
+
+        lhr = user_record_new();
+        if (!lhr)
+                return log_oom();
+
+        r = user_record_load(lhr, record, USER_RECORD_LOAD_EMBEDDED|USER_RECORD_PERMISSIVE);
+        if (r < 0)
+                return log_error_errno(r, "Failed to parse user record: %m");
+
+        if (!user_record_compatible(h, lhr))
+                return log_error_errno(SYNTHETIC_ERRNO(EREMCHG),
+                                       "LUKS home record not compatible with host record, refusing.");
+
+        r = user_record_authenticate(lhr, h, cache, /* strict_verify= */ true);
+        if (r < 0)
+                return r;
+        assert(r > 0);
+
+        *ret_luks_home_record = TAKE_PTR(lhr);
+        return 0;
+}
+
+static int luks_token_decrypt_legacy(
+                struct crypt_device *cd,
+                sd_json_variant *token,
+                const void *volume_key,
+                char **ret_decrypted,
+                size_t *ret_decrypted_size) {
+
+        const EVP_CIPHER *cipher;
+        int r;
+
+        assert(cd);
+        assert(token);
+        assert(volume_key);
+        assert(ret_decrypted);
+        assert(ret_decrypted_size);
+
+        r = crypt_device_to_evp_cipher(cd, &cipher);
+        if (r < 0)
+                return r;
+
+        return home_luks_token_decrypt_legacy(
+                        token,
+                        cipher,
+                        volume_key,
+                        (size_t) sym_EVP_CIPHER_get_key_length(cipher),
+                        (void**) ret_decrypted,
+                        ret_decrypted_size);
+}
+
 static int luks_validate_home_record(
                 struct crypt_device *cd,
                 UserRecord *h,
                 const void *volume_key,
+                size_t volume_key_size,
                 PasswordCache *cache,
                 UserRecord **ret_luks_home_record) {
 
-        int r;
+        int encryption_type, r;
 
         assert(cd);
         assert(h);
+        assert(volume_key);
+        assert(volume_key_size > 0);
         assert(ret_luks_home_record);
 
+        encryption_type = sym_crypt_get_hw_encryption_type(cd);
+        if (encryption_type < 0)
+                return log_error_errno(encryption_type, "Failed to determine LUKS hardware-encryption type: %m");
+
         for (int token = 0; token < sym_crypt_token_max(CRYPT_LUKS2); token++) {
-                _cleanup_(sd_json_variant_unrefp) sd_json_variant *v = NULL, *rr = NULL;
-                _cleanup_(EVP_CIPHER_CTX_freep) EVP_CIPHER_CTX *context = NULL;
-                _cleanup_(user_record_unrefp) UserRecord *lhr = NULL;
-                _cleanup_free_ void *encrypted = NULL, *iv = NULL;
-                size_t decrypted_size, encrypted_size, iv_size;
-                int decrypted_size_out1, decrypted_size_out2;
-                _cleanup_free_ char *decrypted = NULL;
+                _cleanup_(sd_json_variant_unrefp) sd_json_variant *v = NULL;
+                _cleanup_(crypt_safe_freep) void *software_secret = NULL;
+                _cleanup_(erase_and_freep) char *decrypted = NULL;
+                size_t decrypted_size, software_secret_size = 0;
                 const char *text, *type;
                 crypt_token_info state;
-                sd_json_variant *jr, *jiv;
-                const EVP_CIPHER *cc;
+                sd_json_variant *version;
 
                 state = sym_crypt_token_status(cd, token, &type);
                 if (state == CRYPT_TOKEN_INACTIVE) /* First unconfigured token, give up */
@@ -895,95 +1028,66 @@ static int luks_validate_home_record(
                 if (r < 0)
                         return log_error_errno(r, "Failed to parse LUKS token JSON data %u:%u: %m", line, column);
 
-                jr = sd_json_variant_by_key(v, "record");
-                if (!jr)
-                        return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "LUKS token lacks 'record' field.");
-                jiv = sd_json_variant_by_key(v, "iv");
-                if (!jiv)
-                        return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "LUKS token lacks 'iv' field.");
+                version = sd_json_variant_by_key(v, "version");
+                if (!version) {
+                        if (encryption_type == CRYPT_INLINE_HW_WRAPPED)
+                                return log_error_errno(SYNTHETIC_ERRNO(EMEDIUMTYPE),
+                                                       "Hardware-wrapped LUKS home uses a legacy identity token, refusing.");
 
-                r = sd_json_variant_unbase64(jr, &encrypted, &encrypted_size);
+                        r = luks_token_decrypt_legacy(cd, v, volume_key, &decrypted, &decrypted_size);
+                } else {
+                        if (!sd_json_variant_is_unsigned(version) || sd_json_variant_unsigned(version) != 2)
+                                return log_error_errno(SYNTHETIC_ERRNO(EOPNOTSUPP),
+                                                       "Unsupported LUKS identity-token version.");
+                        if (encryption_type != CRYPT_INLINE_HW_WRAPPED)
+                                return log_error_errno(SYNTHETIC_ERRNO(EMEDIUMTYPE),
+                                                       "Version-2 identity token requires a hardware-wrapped LUKS home.");
+
+                        r = sym_crypt_hw_wrapped_key_derive_secret(
+                                        cd,
+                                        volume_key,
+                                        volume_key_size,
+                                        (char**) &software_secret,
+                                        &software_secret_size);
+                        if (r < 0)
+                                return log_error_errno(r, "Failed to derive LUKS identity-token secret: %m");
+                        if (software_secret_size != CRYPT_HW_WRAPPED_KEY_SW_SECRET_SIZE)
+                                return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
+                                                       "LUKS identity-token secret has an invalid size.");
+
+                        const char *uuid = sym_crypt_get_uuid(cd);
+                        if (!uuid)
+                                return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
+                                                       "Hardware-wrapped LUKS home lacks a UUID.");
+
+                        r = home_luks_token_decrypt_v2(
+                                        v,
+                                        software_secret,
+                                        software_secret_size,
+                                        uuid,
+                                        (void**) &decrypted,
+                                        &decrypted_size);
+                }
                 if (r < 0)
-                        return log_error_errno(r, "Failed to base64 decode record: %m");
+                        return log_error_errno(r, "Failed to decrypt LUKS identity token: %m");
 
-                r = sd_json_variant_unbase64(jiv, &iv, &iv_size);
-                if (r < 0)
-                        return log_error_errno(r, "Failed to base64 decode IV: %m");
-
-                r = crypt_device_to_evp_cipher(cd, &cc);
-                if (r < 0)
-                        return r;
-                if (iv_size > INT_MAX || sym_EVP_CIPHER_get_iv_length(cc) != (int) iv_size)
-                        return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "IV size doesn't match.");
-
-                context = sym_EVP_CIPHER_CTX_new();
-                if (!context)
-                        return log_oom();
-
-                if (sym_EVP_DecryptInit_ex(context, cc, NULL, volume_key, iv) != 1)
-                        return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "Failed to initialize decryption context.");
-
-                decrypted_size = encrypted_size + sym_EVP_CIPHER_get_key_length(cc) * 2;
-                decrypted = new(char, decrypted_size);
-                if (!decrypted)
-                        return log_oom();
-
-                if (sym_EVP_DecryptUpdate(context, (uint8_t*) decrypted, &decrypted_size_out1, encrypted, encrypted_size) != 1)
-                        return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "Failed to decrypt JSON record.");
-
-                assert((size_t) decrypted_size_out1 <= decrypted_size);
-
-                if (sym_EVP_DecryptFinal_ex(context, (uint8_t*) decrypted + decrypted_size_out1, &decrypted_size_out2) != 1)
-                        return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "Failed to finish decryption of JSON record.");
-
-                assert((size_t) decrypted_size_out1 + (size_t) decrypted_size_out2 < decrypted_size);
-                decrypted_size = (size_t) decrypted_size_out1 + (size_t) decrypted_size_out2;
-
-                if (memchr(decrypted, 0, decrypted_size))
-                        return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "Inner NUL byte in JSON record, refusing.");
-
-                decrypted[decrypted_size] = 0;
-
-                r = sd_json_parse(decrypted, SD_JSON_PARSE_MUST_BE_OBJECT|SD_JSON_PARSE_SENSITIVE, &rr, NULL, NULL);
-                if (r < 0)
-                        return log_error_errno(r, "Failed to parse decrypted JSON record, refusing.");
-
-                lhr = user_record_new();
-                if (!lhr)
-                        return log_oom();
-
-                r = user_record_load(lhr, rr, USER_RECORD_LOAD_EMBEDDED|USER_RECORD_PERMISSIVE);
-                if (r < 0)
-                        return log_error_errno(r, "Failed to parse user record: %m");
-
-                if (!user_record_compatible(h, lhr))
-                        return log_error_errno(SYNTHETIC_ERRNO(EREMCHG), "LUKS home record not compatible with host record, refusing.");
-
-                r = user_record_authenticate(lhr, h, cache, /* strict_verify= */ true);
-                if (r < 0)
-                        return r;
-                assert(r > 0); /* Insist that a password was verified */
-
-                *ret_luks_home_record = TAKE_PTR(lhr);
-                return 0;
+                return luks_validate_decrypted_home_record(
+                                h, cache, decrypted, decrypted_size, ret_luks_home_record);
         }
 
         return log_error_errno(SYNTHETIC_ERRNO(EBADMSG), "Couldn't find home record in LUKS2 header, refusing.");
 }
 
-static int format_luks_token_text(
+static int format_luks_token_text_legacy(
                 struct crypt_device *cd,
                 UserRecord *hr,
                 const void *volume_key,
                 char **ret) {
 
-        int r, encrypted_size_out1 = 0, encrypted_size_out2 = 0, iv_size, key_size;
-        _cleanup_(EVP_CIPHER_CTX_freep) EVP_CIPHER_CTX *context = NULL;
-        _cleanup_(sd_json_variant_unrefp) sd_json_variant *v = NULL;
-        _cleanup_free_ void *iv = NULL, *encrypted = NULL;
-        size_t text_length, encrypted_size;
-        _cleanup_free_ char *text = NULL;
+        _cleanup_free_ void *iv = NULL;
+        _cleanup_(erase_and_freep) char *text = NULL;
         const EVP_CIPHER *cc;
+        int iv_size, r;
 
         assert(cd);
         assert(hr);
@@ -994,7 +1098,6 @@ static int format_luks_token_text(
         if (r < 0)
                 return r;
 
-        key_size = sym_EVP_CIPHER_get_key_length(cc);
         iv_size = sym_EVP_CIPHER_get_iv_length(cc);
 
         if (iv_size > 0) {
@@ -1007,46 +1110,87 @@ static int format_luks_token_text(
                         return log_error_errno(r, "Failed to generate IV: %m");
         }
 
-        context = sym_EVP_CIPHER_CTX_new();
-        if (!context)
-                return log_oom();
-
-        if (sym_EVP_EncryptInit_ex(context, cc, NULL, volume_key, iv) != 1)
-                return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "Failed to initialize encryption context.");
-
         r = sd_json_variant_format(hr->json, 0, &text);
         if (r < 0)
                 return log_error_errno(r, "Failed to format user record for LUKS: %m");
 
-        text_length = strlen(text);
-        encrypted_size = text_length + 2*key_size - 1;
-
-        encrypted = malloc(encrypted_size);
-        if (!encrypted)
-                return log_oom();
-
-        if (sym_EVP_EncryptUpdate(context, encrypted, &encrypted_size_out1, (uint8_t*) text, text_length) != 1)
-                return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "Failed to encrypt JSON record.");
-
-        assert((size_t) encrypted_size_out1 <= encrypted_size);
-
-        if (sym_EVP_EncryptFinal_ex(context, (uint8_t*) encrypted + encrypted_size_out1, &encrypted_size_out2) != 1)
-                return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "Failed to finish encryption of JSON record.");
-
-        assert((size_t) encrypted_size_out1 + (size_t) encrypted_size_out2 <= encrypted_size);
-
-        r = sd_json_buildo(
-                        &v,
-                        SD_JSON_BUILD_PAIR("type", JSON_BUILD_CONST_STRING("systemd-homed")),
-                        SD_JSON_BUILD_PAIR("keyslots", SD_JSON_BUILD_EMPTY_ARRAY),
-                        SD_JSON_BUILD_PAIR("record", SD_JSON_BUILD_BASE64(encrypted, encrypted_size_out1 + encrypted_size_out2)),
-                        SD_JSON_BUILD_PAIR("iv", SD_JSON_BUILD_BASE64(iv, iv_size)));
-        if (r < 0)
-                return log_error_errno(r, "Failed to prepare LUKS JSON token object: %m");
-
-        r = sd_json_variant_format(v, 0, ret);
+        r = home_luks_token_encrypt_legacy(
+                        text,
+                        strlen(text),
+                        cc,
+                        volume_key,
+                        (size_t) sym_EVP_CIPHER_get_key_length(cc),
+                        iv,
+                        (size_t) iv_size,
+                        ret);
         if (r < 0)
                 return log_error_errno(r, "Failed to format encrypted user record for LUKS: %m");
+
+        return 0;
+}
+
+static int format_luks_token_text(
+                struct crypt_device *cd,
+                UserRecord *hr,
+                const void *volume_key,
+                size_t volume_key_size,
+                char **ret) {
+
+        _cleanup_(crypt_safe_freep) void *software_secret = NULL;
+        _cleanup_(erase_and_freep) char *plaintext = NULL;
+        uint8_t iv[HOME_LUKS_TOKEN_V2_IV_SIZE];
+        size_t software_secret_size = 0;
+        int encryption_type, r;
+
+        assert(cd);
+        assert(hr);
+        assert(volume_key);
+        assert(volume_key_size > 0);
+        assert(ret);
+
+        encryption_type = sym_crypt_get_hw_encryption_type(cd);
+        if (encryption_type < 0)
+                return encryption_type;
+        if (encryption_type != CRYPT_INLINE_HW_WRAPPED)
+                return format_luks_token_text_legacy(cd, hr, volume_key, ret);
+
+        CLEANUP_ERASE(iv);
+
+        r = sym_crypt_hw_wrapped_key_derive_secret(
+                        cd,
+                        volume_key,
+                        volume_key_size,
+                        (char**) &software_secret,
+                        &software_secret_size);
+        if (r < 0)
+                return log_error_errno(r, "Failed to derive LUKS identity-token secret: %m");
+        if (software_secret_size != CRYPT_HW_WRAPPED_KEY_SW_SECRET_SIZE)
+                return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
+                                       "LUKS identity-token secret has an invalid size.");
+
+        r = sd_json_variant_format(hr->json, 0, &plaintext);
+        if (r < 0)
+                return log_error_errno(r, "Failed to format user record for LUKS: %m");
+
+        r = crypto_random_bytes(iv, sizeof(iv));
+        if (r < 0)
+                return log_error_errno(r, "Failed to generate LUKS identity-token IV: %m");
+
+        const char *uuid = sym_crypt_get_uuid(cd);
+        if (!uuid)
+                return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
+                                       "Hardware-wrapped LUKS home lacks a UUID.");
+
+        r = home_luks_token_encrypt_v2(
+                        plaintext,
+                        strlen(plaintext),
+                        software_secret,
+                        software_secret_size,
+                        uuid,
+                        iv,
+                        ret);
+        if (r < 0)
+                return log_error_errno(r, "Failed to encrypt LUKS identity token: %m");
 
         return 0;
 }
@@ -1084,7 +1228,8 @@ int home_store_header_identity_luks(
                 return 0;
         }
 
-        r = format_luks_token_text(setup->crypt_device, header_home, setup->volume_key, &text);
+        r = format_luks_token_text(setup->crypt_device, header_home,
+                                   setup->volume_key, setup->volume_key_size, &text);
         if (r < 0)
                 return r;
 
@@ -1234,6 +1379,33 @@ static int lock_image_fd(int image_fd, const char *ip) {
         return 0;
 }
 
+static int luks_mount_options(UserRecord *h, const char *fstype, char **ret) {
+        _cleanup_free_ char *options = NULL;
+        int r;
+
+        assert(h);
+        assert(fstype);
+        assert(ret);
+
+        if (h->luks_extra_mount_options) {
+                options = strdup(h->luks_extra_mount_options);
+                if (!options)
+                        return -ENOMEM;
+        }
+
+        if (h->thin_pool_uuid && streq(fstype, "ext4")) {
+                r = mount_option_supported(fstype, "provision", NULL);
+                if (r > 0)
+                        if (!strextend_with_separator(&options, ",", "provision"))
+                                return -ENOMEM;
+                if (r < 0)
+                        log_debug_errno(r, "Unable to determine whether ext4 supports the 'provision' mount option, not enabling it: %m");
+        }
+
+        *ret = TAKE_PTR(options);
+        return 0;
+}
+
 static int open_image_file(
                 UserRecord *h,
                 const char *force_image_path,
@@ -1325,7 +1497,8 @@ int home_setup_luks(
                 }
 
                 if (ret_luks_home) {
-                        r = luks_validate_home_record(setup->crypt_device, h, volume_key, cache, &luks_home);
+                        r = luks_validate_home_record(setup->crypt_device, h, volume_key,
+                                                      volume_key_size, cache, &luks_home);
                         if (r < 0)
                                 return r;
                 }
@@ -1398,7 +1571,7 @@ int home_setup_luks(
                                 return log_error_errno(errno, "Failed to open home directory: %m");
                 }
         } else {
-                _cleanup_free_ char *fstype = NULL, *subdir = NULL;
+                _cleanup_free_ char *fstype = NULL, *mount_options = NULL, *subdir = NULL;
                 const char *ip;
 
                 /* When we aren't reopening the home directory we are allocating it fresh, hence the relevant
@@ -1465,6 +1638,7 @@ int home_setup_luks(
                                h->luks_uuid,
                                h->luks_cipher,
                                h->luks_cipher_mode,
+                               h->luks_key_type,
                                h->luks_volume_key_size,
                                cache,
                                user_record_luks_discard(h) || user_record_luks_offline_discard(h),
@@ -1479,7 +1653,8 @@ int home_setup_luks(
                 setup->undo_dm = true;
 
                 if (ret_luks_home) {
-                        r = luks_validate_home_record(setup->crypt_device, h, volume_key, cache, &luks_home);
+                        r = luks_validate_home_record(setup->crypt_device, h, volume_key,
+                                                      volume_key_size, cache, &luks_home);
                         if (r < 0)
                                 return r;
                 }
@@ -1492,7 +1667,11 @@ int home_setup_luks(
                 if (r < 0)
                         return r;
 
-                r = home_unshare_and_mount(setup->dm_node, fstype, user_record_luks_discard(h), user_record_mount_flags(h), h->luks_extra_mount_options);
+                r = luks_mount_options(h, fstype, &mount_options);
+                if (r < 0)
+                        return r;
+
+                r = home_unshare_and_mount(setup->dm_node, fstype, user_record_luks_discard(h), user_record_mount_flags(h), mount_options);
                 if (r < 0)
                         return r;
 
@@ -1660,6 +1839,7 @@ int home_activate_luks(
                 log_warning_errno(r, "Failed to relinquish DM device, ignoring: %m");
 
         setup->undo_dm = false;
+        setup->deactivate_thin_volume = false;
         setup->do_offline_fallocate = false;
         setup->do_mark_clean = false;
         setup->do_drop_caches = false;
@@ -1781,14 +1961,24 @@ static int luks_format(
                 char **effective_passwords,
                 bool discard,
                 uint64_t sector_size,
+                bool hardware_wrapped_keys,
                 UserRecord *hr,
                 struct crypt_device **ret) {
 
         _cleanup_(user_record_unrefp) UserRecord *reduced = NULL;
         _cleanup_(crypt_freep) struct crypt_device *cd = NULL;
-        _cleanup_(erase_and_freep) void *volume_key = NULL;
+        _cleanup_(erase_and_freep) void *raw_volume_key = NULL;
+        _cleanup_(crypt_safe_freep) void *wrapped_key = NULL;
         struct crypt_pbkdf_type good_pbkdf, minimal_pbkdf;
+        const struct crypt_params_integrity integrity_params = {
+                .journal_size = HOME_LUKS_INTEGRITY_JOURNAL_SIZE,
+                .tag_size = HOME_LUKS_INTEGRITY_TAG_SIZE,
+                .sector_size = HOME_LUKS_INTEGRITY_SECTOR_SIZE,
+                .integrity = HOME_LUKS_INTEGRITY_ALGORITHM,
+                .integrity_key_size = HOME_LUKS_INTEGRITY_KEY_SIZE,
+        };
         _cleanup_free_ char *text = NULL;
+        const void *volume_key;
         size_t volume_key_size;
         int slot = 0, r;
 
@@ -1807,14 +1997,31 @@ static int luks_format(
          * can't extract the volume key from the library again, but we need it in order to encrypt the JSON
          * record. Hence, let's generate it on our own, so that we can keep track of it. */
 
-        volume_key_size = user_record_luks_volume_key_size(hr);
-        volume_key = malloc(volume_key_size);
-        if (!volume_key)
-                return log_oom();
+        if (hardware_wrapped_keys) {
+                r = sym_crypt_hw_wrapped_key_generate(
+                                cd,
+                                (char**) &wrapped_key,
+                                &volume_key_size);
+                if (r < 0)
+                        return log_error_errno(r,
+                                               "Failed to generate hardware-wrapped LUKS volume key: %m");
+                if (volume_key_size == 0)
+                        return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
+                                               "Generated hardware-wrapped LUKS volume key is empty.");
 
-        r = crypto_random_bytes(volume_key, volume_key_size);
-        if (r < 0)
-                return log_error_errno(r, "Failed to generate volume key: %m");
+                volume_key = wrapped_key;
+        } else {
+                volume_key_size = user_record_luks_volume_key_size(hr);
+                raw_volume_key = malloc(volume_key_size);
+                if (!raw_volume_key)
+                        return log_oom();
+
+                r = crypto_random_bytes(raw_volume_key, volume_key_size);
+                if (r < 0)
+                        return log_error_errno(r, "Failed to generate volume key: %m");
+
+                volume_key = raw_volume_key;
+        }
 
         /* Increase the metadata space to 4M, the largest LUKS2 supports */
         r = sym_crypt_set_metadata_size(cd, 4096U*1024U, 0);
@@ -1824,20 +2031,34 @@ static int luks_format(
         build_good_pbkdf(&good_pbkdf, hr);
         build_minimal_pbkdf(&minimal_pbkdf, hr);
 
-        r = sym_crypt_format(
-                        cd,
-                        CRYPT_LUKS2,
-                        user_record_luks_cipher(hr),
-                        user_record_luks_cipher_mode(hr),
-                        SD_ID128_TO_UUID_STRING(uuid),
-                        volume_key,
-                        volume_key_size,
-                        &(struct crypt_params_luks2) {
-                                .label = label,
-                                .subsystem = "systemd-home",
-                                .sector_size = sector_size, /* sector-size of 0 is auto for libcryptsetup */
-                                .pbkdf = &good_pbkdf,
-                        });
+        struct crypt_params_luks2 params = {
+                .label = label,
+                .subsystem = "systemd-home",
+                .sector_size = hardware_wrapped_keys ? HOME_LUKS_INTEGRITY_SECTOR_SIZE : sector_size,
+                .integrity = hardware_wrapped_keys ? HOME_LUKS_INTEGRITY_ALGORITHM : NULL,
+                .integrity_params = hardware_wrapped_keys ? &integrity_params : NULL,
+                .pbkdf = &good_pbkdf,
+        };
+
+        if (hardware_wrapped_keys)
+                r = sym_crypt_format_luks2_hw_wrapped(
+                                cd,
+                                user_record_luks_cipher(hr),
+                                user_record_luks_cipher_mode(hr),
+                                SD_ID128_TO_UUID_STRING(uuid),
+                                volume_key,
+                                volume_key_size,
+                                &params);
+        else
+                r = sym_crypt_format(
+                                cd,
+                                CRYPT_LUKS2,
+                                user_record_luks_cipher(hr),
+                                user_record_luks_cipher_mode(hr),
+                                SD_ID128_TO_UUID_STRING(uuid),
+                                volume_key,
+                                volume_key_size,
+                                &params);
         if (r < 0)
                 return log_error_errno(r, "Failed to format LUKS image: %m");
 
@@ -1869,22 +2090,11 @@ static int luks_format(
                 slot++;
         }
 
-        r = sym_crypt_activate_by_volume_key(
-                        cd,
-                        dm_name,
-                        volume_key,
-                        volume_key_size,
-                        discard ? CRYPT_ACTIVATE_ALLOW_DISCARDS : 0);
-        if (r < 0)
-                return log_error_errno(r, "Failed to activate LUKS superblock: %m");
-
-        log_info("LUKS activation by volume key succeeded.");
-
         r = user_record_clone(hr, USER_RECORD_EXTRACT_EMBEDDED|USER_RECORD_PERMISSIVE, &reduced);
         if (r < 0)
                 return log_error_errno(r, "Failed to prepare home record for LUKS: %m");
 
-        r = format_luks_token_text(cd, reduced, volume_key, &text);
+        r = format_luks_token_text(cd, reduced, volume_key, volume_key_size, &text);
         if (r < 0)
                 return r;
 
@@ -1893,6 +2103,17 @@ static int luks_format(
                 return log_error_errno(r, "Failed to set LUKS JSON token: %m");
 
         log_info("Writing user record as LUKS token completed.");
+
+        r = sym_crypt_activate_by_volume_key(
+                        cd,
+                        dm_name,
+                        volume_key,
+                        volume_key_size,
+                        (discard || hardware_wrapped_keys) ? CRYPT_ACTIVATE_ALLOW_DISCARDS : 0);
+        if (r < 0)
+                return log_error_errno(r, "Failed to activate LUKS superblock: %m");
+
+        log_info("LUKS activation by volume key succeeded.");
 
         if (ret)
                 *ret = TAKE_PTR(cd);
@@ -2192,7 +2413,7 @@ int home_create_luks(
                 char **effective_passwords,
                 UserRecord **ret_home) {
 
-        _cleanup_free_ char *subdir = NULL, *disk_uuid_path = NULL;
+        _cleanup_free_ char *subdir = NULL, *disk_uuid_path = NULL, *mount_options = NULL;
         uint64_t encrypted_size, image_sector_size, luks_sector_size,
                 host_size = 0, partition_offset = 0, partition_size = 0; /* Unnecessary initialization to appease gcc */
         _cleanup_(user_record_unrefp) UserRecord *new_home = NULL;
@@ -2201,6 +2422,7 @@ int home_create_luks(
         const char *fstype, *ip;
         struct statfs sfs;
         struct stat st;
+        bool hardware_wrapped_keys;
         int r;
         _cleanup_strv_free_ char **extra_mkfs_options = NULL;
 
@@ -2218,6 +2440,21 @@ int home_create_luks(
         r = dlopen_cryptsetup(LOG_DEBUG);
         if (r < 0)
                 return r;
+
+        r = getenv_bool("SYSTEMD_HOME_HARDWARE_WRAPPED_KEYS");
+        if (r < 0 && r != -ENXIO)
+                return log_error_errno(r, "Failed to parse hardware-wrapped key creation policy: %m");
+        hardware_wrapped_keys = r > 0;
+
+        if (hardware_wrapped_keys &&
+            (!h->thin_pool_uuid || !setup->thin_volume_path || !streq(user_record_file_system_type(h), "ext4")))
+                return log_error_errno(SYNTHETIC_ERRNO(EOPNOTSUPP),
+                                       "Hardware-wrapped keys require a thin-backed LUKS/ext4 home.");
+
+        if (hardware_wrapped_keys && h->luks_sector_size != UINT64_MAX &&
+            user_record_luks_sector_size(h) != HOME_LUKS_INTEGRITY_SECTOR_SIZE)
+                return log_error_errno(SYNTHETIC_ERRNO(EOPNOTSUPP),
+                                       "Hardware-wrapped keys require a 4096-byte LUKS sector size.");
 
         assert_se(ip = user_record_image_path(h));
 
@@ -2383,6 +2620,8 @@ int home_create_luks(
                 } else
                         image_sector_size = luks_sector_size = user_record_luks_sector_size(h);
         }
+        if (hardware_wrapped_keys)
+                luks_sector_size = HOME_LUKS_INTEGRITY_SECTOR_SIZE;
         r = make_partition_table(
                         setup->image_fd,
                         image_sector_size,
@@ -2402,25 +2641,46 @@ int home_create_luks(
         /* Ensure we don't create a loop device over block device as it leads to huge overhead for discard operations
          * if the device does not support discard_zeroes_data */
         if (S_ISBLK(st.st_mode)) {
-                _cleanup_free_ char *partition_path = NULL;
+                _cleanup_free_ char *mapped_path = NULL, *partition_path = NULL;
+                const char *open_path;
+
                 assert(!sd_id128_is_null(partition_uuid));
-                if (asprintf(&partition_path, "/dev/disk/by-partuuid/" SD_ID128_UUID_FORMAT_STR, SD_ID128_FORMAT_VAL(partition_uuid)) < 0)
-                        return log_oom();
+
+                if (setup->thin_volume_path) {
+                        r = home_thin_volume_map_partition(
+                                        h,
+                                        setup->image_fd,
+                                        partition_offset,
+                                        partition_size,
+                                        &mapped_path);
+                        if (r < 0)
+                                return log_error_errno(r, "Failed to map thin-volume home partition: %m");
+
+                        open_path = mapped_path;
+                } else {
+                        if (asprintf(&partition_path,
+                                     "/dev/disk/by-partuuid/" SD_ID128_UUID_FORMAT_STR,
+                                     SD_ID128_FORMAT_VAL(partition_uuid)) < 0)
+                                return log_oom();
+
+                        open_path = partition_path;
+                }
 
                 /* Release the lock, so that udev can find the partition */
                 setup->image_fd = safe_close(setup->image_fd);
-                (void) wait_for_devlink(partition_path);
+                if (partition_path)
+                        (void) wait_for_devlink(partition_path);
                 setup->image_fd = open_image_file(h, ip, &st);
                 if (setup->image_fd < 0)
                         return setup->image_fd;
 
                 r = loop_device_open_from_path(
-                                partition_path,
+                                open_path,
                                 O_RDWR,
                                 LOCK_EX,
                                 &setup->loop);
                 if (r < 0)
-                        return log_error_errno(r, "Failed to open newly written partition device: %s", partition_path);
+                        return log_error_errno(r, "Failed to open newly written partition device: %s", open_path);
         } else {
                 r = loop_device_make(
                                 setup->image_fd,
@@ -2449,6 +2709,7 @@ int home_create_luks(
                         effective_passwords,
                         user_record_luks_discard(h) || user_record_luks_offline_discard(h),
                         luks_sector_size,
+                        hardware_wrapped_keys,
                         h,
                         &setup->crypt_device);
         if (r < 0)
@@ -2481,7 +2742,11 @@ int home_create_luks(
 
         log_info("Formatting file system completed.");
 
-        r = home_unshare_and_mount(setup->dm_node, fstype, user_record_luks_discard(h), user_record_mount_flags(h), h->luks_extra_mount_options);
+        r = luks_mount_options(h, fstype, &mount_options);
+        if (r < 0)
+                return r;
+
+        r = home_unshare_and_mount(setup->dm_node, fstype, user_record_luks_discard(h), user_record_mount_flags(h), mount_options);
         if (r < 0)
                 return r;
 
@@ -2534,6 +2799,7 @@ int home_create_luks(
                         fs_uuid,
                         sym_crypt_get_cipher(setup->crypt_device),
                         sym_crypt_get_cipher_mode(setup->crypt_device),
+                        luks_key_type_convert(setup->crypt_device),
                         luks_volume_key_size_convert(setup->crypt_device),
                         fstype,
                         NULL,
@@ -2541,6 +2807,12 @@ int home_create_luks(
                         (gid_t) h->uid);
         if (r < 0)
                 return log_error_errno(r, "Failed to add binding to record: %m");
+
+        if (hardware_wrapped_keys) {
+                r = user_record_set_luks_integrity_binding(new_home, HOME_LUKS_INTEGRITY_ALGORITHM);
+                if (r < 0)
+                        return log_error_errno(r, "Failed to add LUKS integrity binding to record: %m");
+        }
 
         if (user_record_luks_offline_discard(h)) {
                 r = run_fitrim(setup->root_fd);
@@ -3071,6 +3343,7 @@ static int resize_fs_loop(
                 uint64_t new_fs_size,
                 uint64_t *ret_fs_size) {
 
+        _cleanup_free_ char *mount_options = NULL;
         uint64_t current_fs_size;
         unsigned n_iterations = 0;
         int r;
@@ -3078,6 +3351,10 @@ static int resize_fs_loop(
         assert(h);
         assert(setup);
         assert(setup->root_fd >= 0);
+
+        r = luks_mount_options(h, "ext4", &mount_options);
+        if (r < 0)
+                return r;
 
         /* A bisection loop trying to find the closest size to what the user asked for. (Well, we bisect like
          * this only when we *shrink* the fs — if we grow the fs there's no need to bisect.) */
@@ -3106,7 +3383,7 @@ static int resize_fs_loop(
                         /* If we hit a disk space issue and are shrinking the fs, then maybe it helps to
                          * increase the image size. */
                 } else {
-                        r = ext4_offline_resize_fs(setup, try_fs_size, user_record_luks_discard(h), user_record_mount_flags(h), h->luks_extra_mount_options);
+                        r = ext4_offline_resize_fs(setup, try_fs_size, user_record_luks_discard(h), user_record_mount_flags(h), mount_options);
                         if (r < 0)
                                 return r;
 
@@ -3837,7 +4114,7 @@ rollback:
 
 int home_lock_luks(UserRecord *h, HomeSetup *setup) {
         const char *p;
-        int r;
+        int encryption_type, r;
 
         assert(h);
         assert(setup);
@@ -3860,8 +4137,13 @@ int home_lock_luks(UserRecord *h, HomeSetup *setup) {
         /* Note that we don't invoke FIFREEZE here, it appears libcryptsetup/device-mapper already does that on its own for us */
 
         r = sym_crypt_suspend(setup->crypt_device, setup->dm_name);
-        if (r < 0)
+        if (r < 0) {
+                encryption_type = sym_crypt_get_hw_encryption_type(setup->crypt_device);
+                if (r == -ENOTSUP && encryption_type == CRYPT_INLINE_HW_WRAPPED)
+                        return log_error_errno(r,
+                                               "Locking a hardware-wrapped home requires dm-inlinecrypt key wipe/set support.");
                 return log_error_errno(r, "Failed to suspend cryptsetup device: %s: %m", setup->dm_node);
+        }
 
         log_info("LUKS device suspended.");
         return 0;
@@ -4073,9 +4355,27 @@ uint64_t luks_volume_key_size_convert(struct crypt_device *cd) {
 
         /* Convert the "int" to uint64_t, which we usually use for byte sizes stored on disk. */
 
+        k = sym_crypt_get_hw_encryption_type(cd);
+        if (k == CRYPT_INLINE_HW_WRAPPED)
+                return UINT64_MAX;
+        if (k < 0)
+                return UINT64_MAX;
+
         k = sym_crypt_get_volume_key_size(cd);
         if (k <= 0)
                 return UINT64_MAX;
 
         return (uint64_t) k;
+}
+
+const char* luks_key_type_convert(struct crypt_device *cd) {
+        int k;
+
+        assert(cd);
+
+        k = sym_crypt_get_hw_encryption_type(cd);
+        if (k < 0)
+                return NULL;
+
+        return k == CRYPT_INLINE_HW_WRAPPED ? "hw-wrapped" : "raw";
 }

--- a/src/home/homework-luks.h
+++ b/src/home/homework-luks.h
@@ -25,6 +25,7 @@ int home_unlock_luks(UserRecord *h, HomeSetup *setup, const PasswordCache *cache
 int home_auto_shrink_luks(UserRecord *h, HomeSetup *setup, PasswordCache *cache);
 
 uint64_t luks_volume_key_size_convert(struct crypt_device *cd);
+const char* luks_key_type_convert(struct crypt_device *cd);
 
 int run_fitrim(int root_fd);
 int run_fallocate(int backing_fd, const struct stat *st);

--- a/src/home/homework-thin.c
+++ b/src/home/homework-thin.c
@@ -1,0 +1,1371 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include <fcntl.h>
+#include <inttypes.h>
+#include <sys/file.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "alloc-util.h"
+#include "blkid-util.h"
+#include "blockdev-util.h"
+#include "dm-util.h"
+#include "errno-util.h"
+#include "extract-word.h"
+#include "fd-util.h"
+#include "fileio.h"
+#include "gpt.h"
+#include "home-util.h"
+#include "homework-thin.h"
+#include "json-util.h"
+#include "log.h"
+#include "parse-util.h"
+#include "path-util.h"
+#include "string-util.h"
+#include "strv.h"
+#include "time-util.h"
+#include "udev-util.h"
+#include "user-record.h"
+#include "user-record-util.h"
+
+#define HOME_THIN_DEVICE_ID_MAX ((UINT32_C(1) << 24) - 1U)
+#define DISK_SIZE_ROUND_DOWN(x) ((x) & ~(U64_MB - 1))
+
+typedef struct ThinPoolInfo {
+        DmDeviceInfo device;
+        char *name, *path;
+        HomeThinPoolStatus status;
+} ThinPoolInfo;
+
+static void thin_pool_info_done(ThinPoolInfo *info) {
+        if (!info)
+                return;
+
+        free(info->name);
+        free(info->path);
+}
+
+int home_thin_volume_make_path(UserRecord *h, const char *pool, char **ret_path, char **ret_name) {
+        _cleanup_free_ char *name = NULL, *path = NULL;
+
+        assert(h);
+        assert(pool);
+        assert(ret_path);
+        assert(ret_name);
+
+        if (!path_is_absolute(pool) || !path_is_normalized(pool))
+                return -EINVAL;
+        if (sd_id128_is_null(h->uuid))
+                return -EINVAL;
+
+        if (asprintf(&name, "homed-" SD_ID128_FORMAT_STR, SD_ID128_FORMAT_VAL(h->uuid)) < 0)
+                return -ENOMEM;
+
+        path = path_join("/dev/mapper", name);
+        if (!path)
+                return -ENOMEM;
+
+        *ret_path = TAKE_PTR(path);
+        *ret_name = TAKE_PTR(name);
+        return 0;
+}
+
+static int thin_volume_partition_name_from_path(const char *path, char **ret) {
+        _cleanup_free_ char *name = NULL, *volume = NULL;
+        int r;
+
+        assert(path);
+        assert(ret);
+
+        r = path_extract_filename(path, &volume);
+        if (r < 0)
+                return r;
+        if (!startswith(volume, "homed-") || strlen(volume) != STRLEN("homed-") + 32)
+                return -EINVAL;
+
+        name = strjoin(volume, "-part1");
+        if (!name)
+                return -ENOMEM;
+
+        *ret = TAKE_PTR(name);
+        return 0;
+}
+
+static int thin_volume_unmap_partition(const char *volume_path) {
+        _cleanup_free_ char *name = NULL;
+        usec_t until;
+        int r;
+
+        assert(volume_path);
+
+        r = thin_volume_partition_name_from_path(volume_path, &name);
+        if (r < 0)
+                return r;
+
+        until = usec_add(now(CLOCK_MONOTONIC), 2 * USEC_PER_SEC);
+        for (;;) {
+                r = dm_remove_device(name);
+                if (r != -EBUSY || now(CLOCK_MONOTONIC) >= until)
+                        return r;
+
+                (void) usleep_safe(50 * USEC_PER_MSEC);
+        }
+}
+
+int home_thin_volume_map_partition(
+                UserRecord *h,
+                int volume_fd,
+                uint64_t offset,
+                uint64_t size,
+                char **ret_path) {
+
+        _cleanup_free_ char *name = NULL, *node = NULL, *uuid = NULL;
+        uint64_t volume_size;
+        struct stat st;
+        int r;
+
+        assert(h);
+        assert(volume_fd >= 0);
+        assert(ret_path);
+
+        if (sd_id128_is_null(h->uuid))
+                return -EINVAL;
+        if (offset % 512U != 0 || size == 0 || size % 512U != 0)
+                return -EINVAL;
+
+        if (fstat(volume_fd, &st) < 0)
+                return -errno;
+        if (!S_ISBLK(st.st_mode))
+                return -ENOTBLK;
+
+        r = blockdev_get_device_size(volume_fd, &volume_size);
+        if (r < 0)
+                return r;
+        if (offset > volume_size || size > volume_size - offset)
+                return -ERANGE;
+
+        if (asprintf(&name,
+                     "homed-" SD_ID128_FORMAT_STR "-part1",
+                     SD_ID128_FORMAT_VAL(h->uuid)) < 0)
+                return -ENOMEM;
+
+        uuid = strjoin("HOMED-PART1-", SD_ID128_TO_STRING(h->uuid));
+        node = path_join("/dev/mapper", name);
+        if (!uuid || !node)
+                return -ENOMEM;
+
+        r = dm_create_linear(name, uuid, st.st_rdev, offset, size);
+        if (r < 0)
+                return r;
+
+        r = device_wait_for_devlink(node, "block", 45 * USEC_PER_SEC, /* ret= */ NULL);
+        if (r < 0) {
+                (void) dm_remove_device(name);
+                return r;
+        }
+
+        *ret_path = TAKE_PTR(node);
+        return 1;
+}
+
+static int thin_volume_find_partition(UserRecord *h, int fd, uint64_t *ret_offset, uint64_t *ret_size) {
+#if HAVE_BLKID
+        _cleanup_(blkid_free_probep) blkid_probe b = NULL;
+        const char *pttype = NULL;
+        blkid_partlist partitions;
+        int n, r;
+
+        assert(h);
+        assert(fd >= 0);
+        assert(ret_offset);
+        assert(ret_size);
+
+        if (sd_id128_is_null(h->partition_uuid))
+                return -ENXIO;
+
+        r = dlopen_libblkid(LOG_DEBUG);
+        if (r < 0)
+                return r;
+
+        b = sym_blkid_new_probe();
+        if (!b)
+                return -ENOMEM;
+
+        errno = 0;
+        r = sym_blkid_probe_set_device(b, fd, /* off= */ 0, /* size= */ 0);
+        if (r != 0)
+                return errno_or_else(ENOMEM);
+
+        (void) sym_blkid_probe_enable_partitions(b, 1);
+        (void) sym_blkid_probe_set_partitions_flags(b, BLKID_PARTS_ENTRY_DETAILS);
+
+        errno = 0;
+        r = sym_blkid_do_safeprobe(b);
+        if (r == _BLKID_SAFEPROBE_ERROR)
+                return errno_or_else(EIO);
+        if (IN_SET(r, _BLKID_SAFEPROBE_AMBIGUOUS, _BLKID_SAFEPROBE_NOT_FOUND))
+                return -ENOPKG;
+
+        assert(r == _BLKID_SAFEPROBE_FOUND);
+
+        (void) sym_blkid_probe_lookup_value(b, "PTTYPE", &pttype, /* len= */ NULL);
+        if (!streq_ptr(pttype, "gpt"))
+                return -ENOPKG;
+
+        errno = 0;
+        partitions = sym_blkid_probe_get_partitions(b);
+        if (!partitions)
+                return errno_or_else(ENOMEM);
+
+        errno = 0;
+        n = sym_blkid_partlist_numof_partitions(partitions);
+        if (n < 0)
+                return errno_or_else(EIO);
+
+        for (int i = 0; i < n; i++) {
+                sd_id128_t uuid;
+                blkid_loff_t offset, size;
+                blkid_partition partition;
+
+                errno = 0;
+                partition = sym_blkid_partlist_get_partition(partitions, i);
+                if (!partition)
+                        return errno_or_else(EIO);
+
+                if (sd_id128_string_equal(
+                                    sym_blkid_partition_get_type_string(partition),
+                                    SD_GPT_USER_HOME) <= 0)
+                        continue;
+
+                r = blkid_partition_get_uuid_id128(partition, &uuid);
+                if (r < 0 || !sd_id128_equal(uuid, h->partition_uuid))
+                        continue;
+
+                offset = sym_blkid_partition_get_start(partition);
+                size = sym_blkid_partition_get_size(partition);
+                if (offset < 0 || (uint64_t) offset > UINT64_MAX / 512U)
+                        return -EINVAL;
+                if (size <= 0 || (uint64_t) size > UINT64_MAX / 512U)
+                        return -EINVAL;
+
+                *ret_offset = (uint64_t) offset * 512U;
+                *ret_size = (uint64_t) size * 512U;
+                return 1;
+        }
+
+        return -ENOPKG;
+#else
+        return -EOPNOTSUPP;
+#endif
+}
+
+typedef enum ThinOperation {
+        THIN_OPERATION_NONE,
+        THIN_OPERATION_CREATE,
+        THIN_OPERATION_DELETE,
+        _THIN_OPERATION_MAX,
+        _THIN_OPERATION_INVALID = -EINVAL,
+} ThinOperation;
+
+typedef struct ThinPoolState {
+        char *pool_uuid;
+        uint32_t next_device_id;
+        uint64_t transaction_id;
+        ThinOperation operation;
+        sd_id128_t home_uuid;
+        uint32_t device_id;
+        uint64_t operation_transaction_id;
+} ThinPoolState;
+
+static void thin_pool_state_done(ThinPoolState *state) {
+        if (!state)
+                return;
+
+        free(state->pool_uuid);
+}
+
+static const char* thin_operation_to_string(ThinOperation operation) {
+        static const char * const table[_THIN_OPERATION_MAX] = {
+                [THIN_OPERATION_NONE] = "none",
+                [THIN_OPERATION_CREATE] = "create",
+                [THIN_OPERATION_DELETE] = "delete",
+        };
+
+        if (operation < 0 || operation >= _THIN_OPERATION_MAX)
+                return NULL;
+        return table[operation];
+}
+
+static int thin_operation_from_string(const char *s) {
+        assert(s);
+
+        for (ThinOperation operation = 0; operation < _THIN_OPERATION_MAX; operation++)
+                if (streq(s, thin_operation_to_string(operation)))
+                        return operation;
+
+        return -EINVAL;
+}
+
+static int parse_fraction(const char *s, uint64_t *ret_used, uint64_t *ret_total) {
+        _cleanup_free_ char *used = NULL;
+        const char *slash;
+        uint64_t u, t;
+        int r;
+
+        assert(s);
+        assert(ret_used);
+        assert(ret_total);
+
+        slash = strchr(s, '/');
+        if (!slash || slash == s || isempty(slash + 1) || strchr(slash + 1, '/'))
+                return -EINVAL;
+
+        used = strndup(s, slash - s);
+        if (!used)
+                return -ENOMEM;
+
+        r = safe_atou64(used, &u);
+        if (r < 0)
+                return r;
+        r = safe_atou64(slash + 1, &t);
+        if (r < 0)
+                return r;
+        if (t == 0 || u > t)
+                return -ERANGE;
+
+        *ret_used = u;
+        *ret_total = t;
+        return 0;
+}
+
+int home_thin_pool_parse_status(const char *status, HomeThinPoolStatus *ret) {
+        _cleanup_strv_free_ char **fields = NULL;
+        int r;
+
+        assert(status);
+        assert(ret);
+
+        if (streq(status, "Fail"))
+                return -EIO;
+
+        fields = strv_split(status, WHITESPACE);
+        if (!fields)
+                return -ENOMEM;
+        if (strv_length(fields) < 8)
+                return -EBADMSG;
+
+        r = safe_atou64(fields[0], &ret->transaction_id);
+        if (r < 0)
+                return r;
+        r = parse_fraction(fields[1], &ret->used_metadata, &ret->total_metadata);
+        if (r < 0)
+                return r;
+        r = parse_fraction(fields[2], &ret->used_data, &ret->total_data);
+        if (r < 0)
+                return r;
+
+        if (!streq(fields[4], "rw"))
+                return streq(fields[4], "ro") ? -EROFS : -ENOSPC;
+        if (!streq(fields[5], "discard_passdown"))
+                return -EOPNOTSUPP;
+        if (!streq(fields[6], "error_if_no_space"))
+                return -EOPNOTSUPP;
+        if (!streq(fields[7], "-"))
+                return streq(fields[7], "needs_check") ? -EUCLEAN : -EBADMSG;
+
+        return 0;
+}
+
+int home_thin_pool_validate_table(const char *parameters) {
+        _cleanup_free_ char *copy = NULL;
+        const char *p;
+        unsigned n_features;
+        int r;
+
+        assert(parameters);
+
+        copy = strdup(parameters);
+        if (!copy)
+                return -ENOMEM;
+        p = copy;
+
+        for (unsigned i = 0; i < 4; i++) {
+                _cleanup_free_ char *word = NULL;
+
+                r = extract_first_word(&p, &word, NULL, 0);
+                if (r <= 0)
+                        return -EBADMSG;
+        }
+
+        _cleanup_free_ char *count = NULL;
+        r = extract_first_word(&p, &count, NULL, 0);
+        if (r == 0)
+                return -EOPNOTSUPP; /* error_if_no_space is mandatory. */
+        if (r < 0)
+                return r;
+        r = safe_atou(count, &n_features);
+        if (r < 0)
+                return r;
+
+        bool error_if_no_space = false;
+        for (unsigned i = 0; i < n_features; i++) {
+                _cleanup_free_ char *feature = NULL;
+
+                r = extract_first_word(&p, &feature, NULL, 0);
+                if (r <= 0)
+                        return -EBADMSG;
+
+                if (streq(feature, "error_if_no_space"))
+                        error_if_no_space = true;
+                else if (STR_IN_SET(feature, "read_only", "ignore_discard", "no_discard_passdown"))
+                        return -EOPNOTSUPP;
+        }
+        if (!error_if_no_space)
+                return -EOPNOTSUPP;
+        if (!isempty(p))
+                return -EBADMSG;
+
+        return 0;
+}
+
+static int thin_pool_query(const char *path, ThinPoolInfo *ret) {
+        _cleanup_(dm_target_info_done) DmTargetInfo status = {}, table = {};
+        _cleanup_(thin_pool_info_done) ThinPoolInfo info = {};
+        int r;
+
+        assert(path);
+        assert(ret);
+
+        if (!path_is_absolute(path) || !path_is_normalized(path))
+                return -EINVAL;
+
+        r = dm_device_info_from_path(path, &info.device);
+        if (r < 0)
+                return log_error_errno(r, "Failed to query configured thin pool %s: %m", path);
+        if (isempty(info.device.uuid))
+                return log_error_errno(SYNTHETIC_ERRNO(ENXIO),
+                                       "Configured thin pool %s has no DM UUID, refusing.", path);
+        if (startswith(info.device.uuid, "LVM-"))
+                return log_error_errno(SYNTHETIC_ERRNO(EREMCHG),
+                                       "Configured thin pool %s is owned by LVM, refusing.", path);
+        if (FLAGS_SET(info.device.flags, DM_READONLY_FLAG))
+                return log_error_errno(SYNTHETIC_ERRNO(EROFS),
+                                       "Configured thin pool %s is read-only, refusing.", path);
+        if (info.device.target_count != 1)
+                return log_error_errno(SYNTHETIC_ERRNO(ENOTUNIQ),
+                                       "Configured thin pool %s does not contain exactly one target.", path);
+
+        info.name = strdup(info.device.name);
+        info.path = strdup(path);
+        if (!info.name || !info.path)
+                return -ENOMEM;
+
+        r = dm_device_query_target(info.name, true, &table);
+        if (r < 0)
+                return r;
+        if (!streq(table.type, "thin-pool") || table.start != 0)
+                return log_error_errno(SYNTHETIC_ERRNO(ENOTTY),
+                                       "Configured device %s is not a whole-device thin pool.", path);
+        r = home_thin_pool_validate_table(table.parameters);
+        if (r < 0)
+                return log_error_errno(r, "Thin pool %s has unsupported table options: %m", path);
+
+        r = dm_device_query_target(info.name, false, &status);
+        if (r < 0)
+                return r;
+        if (!streq(status.type, "thin-pool") || status.start != 0 || status.length != table.length)
+                return -EREMCHG;
+        r = home_thin_pool_parse_status(status.parameters, &info.status);
+        if (r < 0)
+                return log_error_errno(r, "Thin pool %s is not healthy and writable: %m", path);
+
+        if (info.status.used_metadata == info.status.total_metadata ||
+            info.status.used_data == info.status.total_data)
+                return log_error_errno(SYNTHETIC_ERRNO(ENOSPC), "Thin pool %s is exhausted.", path);
+        if (info.status.used_metadata >= info.status.total_metadata - info.status.total_metadata / 5U)
+                log_warning("Thin pool %s metadata usage is at least 80%%.", path);
+        if (info.status.used_data >= info.status.total_data - info.status.total_data / 5U)
+                log_warning("Thin pool %s data usage is at least 80%%.", path);
+
+        *ret = TAKE_STRUCT(info);
+        return 0;
+}
+
+int home_thin_pool_validate(const char *pool_path) {
+        _cleanup_(thin_pool_info_done) ThinPoolInfo pool = {};
+
+        assert(pool_path);
+
+        return thin_pool_query(pool_path, &pool);
+}
+
+int home_thin_pool_default_size(const char *pool, uint64_t *ret_size, uint64_t *ret_backing_size) {
+        _cleanup_(dm_target_info_done) DmTargetInfo table = {};
+        _cleanup_(thin_pool_info_done) ThinPoolInfo info = {};
+        uint64_t size;
+        int r;
+
+        assert(pool);
+        assert(ret_size);
+
+        r = thin_pool_query(pool, &info);
+        if (r < 0)
+                return r;
+        r = dm_device_query_target(info.name, true, &table);
+        if (r < 0)
+                return r;
+        if (table.length > UINT64_MAX / 512U)
+                return -EOVERFLOW;
+
+        size = DISK_SIZE_ROUND_DOWN(MIN(table.length * 512U, USER_DISK_SIZE_MAX));
+        if (size < USER_DISK_SIZE_MIN)
+                return -ENOSPC;
+
+        *ret_size = size;
+        if (ret_backing_size)
+                *ret_backing_size = table.length * 512U;
+        return 0;
+}
+
+static char* thin_pool_state_path(void) {
+        return path_join(home_record_dir(), ".thin-pool-state");
+}
+
+static char* thin_pool_lock_path(void) {
+        return path_join(home_record_dir(), ".thin-pool-state.lock");
+}
+
+static int thin_pool_state_load(ThinPoolState *ret) {
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *v = NULL;
+        _cleanup_free_ char *operation = NULL, *path = NULL, *text = NULL;
+        ThinPoolState state = {
+                .next_device_id = UINT32_MAX,
+                .operation = _THIN_OPERATION_INVALID,
+                .device_id = UINT32_MAX,
+        };
+        int r;
+
+        static const sd_json_dispatch_field table[] = {
+                { "poolUuid",               SD_JSON_VARIANT_STRING,        sd_json_dispatch_string, offsetof(ThinPoolState, pool_uuid),                SD_JSON_MANDATORY },
+                { "nextDeviceId",           _SD_JSON_VARIANT_TYPE_INVALID, sd_json_dispatch_uint32, offsetof(ThinPoolState, next_device_id),            SD_JSON_MANDATORY },
+                { "transactionId",          _SD_JSON_VARIANT_TYPE_INVALID, sd_json_dispatch_uint64, offsetof(ThinPoolState, transaction_id),             SD_JSON_MANDATORY },
+                { "operation",              SD_JSON_VARIANT_STRING,        NULL,                    0,                                                   SD_JSON_MANDATORY },
+                { "homeUuid",               SD_JSON_VARIANT_STRING,        sd_json_dispatch_id128,  offsetof(ThinPoolState, home_uuid),                 0 },
+                { "deviceId",               _SD_JSON_VARIANT_TYPE_INVALID, sd_json_dispatch_uint32, offsetof(ThinPoolState, device_id),                 0 },
+                { "operationTransactionId", _SD_JSON_VARIANT_TYPE_INVALID, sd_json_dispatch_uint64, offsetof(ThinPoolState, operation_transaction_id), 0 },
+                {},
+        };
+
+        assert(ret);
+
+        path = thin_pool_state_path();
+        if (!path)
+                return -ENOMEM;
+
+        r = read_full_file(path, &text, NULL);
+        if (r < 0)
+                return r;
+        r = sd_json_parse(text, SD_JSON_PARSE_MUST_BE_OBJECT, &v, NULL, NULL);
+        if (r < 0)
+                return r;
+        r = sd_json_dispatch(v, table, SD_JSON_LOG, &state);
+        if (r < 0)
+                return r;
+
+        sd_json_variant *o = sd_json_variant_by_key(v, "operation");
+        if (!o || !sd_json_variant_is_string(o))
+                return -EBADMSG;
+        operation = strdup(sd_json_variant_string(o));
+        if (!operation)
+                return -ENOMEM;
+        state.operation = thin_operation_from_string(operation);
+        if (state.operation < 0)
+                return state.operation;
+        if (state.next_device_id > HOME_THIN_DEVICE_ID_MAX + 1U)
+                return -ERANGE;
+        if (state.operation != THIN_OPERATION_NONE &&
+            (sd_id128_is_null(state.home_uuid) || state.device_id > HOME_THIN_DEVICE_ID_MAX))
+                return -EBADMSG;
+
+        *ret = TAKE_STRUCT(state);
+        return 0;
+}
+
+static int thin_pool_state_save(const ThinPoolState *state) {
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *v = NULL;
+        _cleanup_free_ char *path = NULL, *text = NULL;
+        int r;
+
+        assert(state);
+        assert(state->pool_uuid);
+
+        r = sd_json_buildo(
+                        &v,
+                        SD_JSON_BUILD_PAIR_STRING("poolUuid", state->pool_uuid),
+                        SD_JSON_BUILD_PAIR_UNSIGNED("nextDeviceId", state->next_device_id),
+                        SD_JSON_BUILD_PAIR_UNSIGNED("transactionId", state->transaction_id),
+                        SD_JSON_BUILD_PAIR_STRING("operation", thin_operation_to_string(state->operation)),
+                        SD_JSON_BUILD_PAIR_CONDITION(
+                                        state->operation != THIN_OPERATION_NONE,
+                                        "homeUuid", SD_JSON_BUILD_ID128(state->home_uuid)),
+                        SD_JSON_BUILD_PAIR_CONDITION(
+                                        state->operation != THIN_OPERATION_NONE,
+                                        "deviceId", SD_JSON_BUILD_UNSIGNED(state->device_id)),
+                        SD_JSON_BUILD_PAIR_CONDITION(
+                                        state->operation != THIN_OPERATION_NONE,
+                                        "operationTransactionId",
+                                        SD_JSON_BUILD_UNSIGNED(state->operation_transaction_id)));
+        if (r < 0)
+                return r;
+        r = sd_json_variant_format(v, SD_JSON_FORMAT_PRETTY|SD_JSON_FORMAT_NEWLINE, &text);
+        if (r < 0)
+                return r;
+
+        path = thin_pool_state_path();
+        if (!path)
+                return -ENOMEM;
+
+        return write_string_file(
+                        path, text,
+                        WRITE_STRING_FILE_CREATE|WRITE_STRING_FILE_ATOMIC|WRITE_STRING_FILE_SYNC|
+                        WRITE_STRING_FILE_MODE_0600|WRITE_STRING_FILE_MKDIR_0755);
+}
+
+static int thin_pool_lock(int *ret_fd) {
+        _cleanup_close_ int fd = -EBADF;
+        _cleanup_free_ char *path = NULL;
+
+        assert(ret_fd);
+
+        path = thin_pool_lock_path();
+        if (!path)
+                return -ENOMEM;
+
+        fd = open(path, O_RDWR|O_CREAT|O_CLOEXEC|O_NOFOLLOW, 0600);
+        if (fd < 0)
+                return -errno;
+        if (flock(fd, LOCK_EX) < 0)
+                return -errno;
+
+        *ret_fd = TAKE_FD(fd);
+        return 0;
+}
+
+static int thin_pool_state_acquire(
+                const char *path,
+                ThinPoolInfo *ret_pool,
+                ThinPoolState *ret,
+                int *ret_lock_fd) {
+
+        _cleanup_(thin_pool_info_done) ThinPoolInfo pool = {};
+        _cleanup_(thin_pool_state_done) ThinPoolState state = {};
+        _cleanup_close_ int lock_fd = -EBADF;
+        int r;
+
+        assert(path);
+        assert(ret_pool);
+        assert(ret);
+        assert(ret_lock_fd);
+
+        r = thin_pool_lock(&lock_fd);
+        if (r < 0)
+                return r;
+
+        r = thin_pool_query(path, &pool);
+        if (r < 0)
+                return r;
+
+        r = thin_pool_state_load(&state);
+        if (r == -ENOENT) {
+                /* Once homed has modified a pool it always advances the transaction ID. Thus a missing
+                 * allocator file is safe to initialize only for an untouched pool; otherwise starting at
+                 * device ID zero could collide with an existing home. */
+                if (pool.status.transaction_id != 0)
+                        return -ENODATA;
+
+                state = (ThinPoolState) {
+                        .pool_uuid = strdup(pool.device.uuid),
+                        .next_device_id = 0,
+                        .transaction_id = pool.status.transaction_id,
+                        .operation = THIN_OPERATION_NONE,
+                        .device_id = UINT32_MAX,
+                };
+                if (!state.pool_uuid)
+                        return -ENOMEM;
+                r = thin_pool_state_save(&state);
+        }
+        if (r < 0)
+                return r;
+        if (!streq(state.pool_uuid, pool.device.uuid))
+                return -ESTALE;
+        if (state.operation == THIN_OPERATION_NONE && state.transaction_id != pool.status.transaction_id)
+                return -EREMCHG;
+        if (state.operation != THIN_OPERATION_NONE &&
+            pool.status.transaction_id != state.operation_transaction_id &&
+            pool.status.transaction_id != state.operation_transaction_id + 1U)
+                return -EREMCHG;
+
+        *ret_pool = TAKE_STRUCT(pool);
+        *ret = TAKE_STRUCT(state);
+        *ret_lock_fd = TAKE_FD(lock_fd);
+        return 0;
+}
+
+static int thin_pool_advance_transaction(const ThinPoolInfo *pool, uint64_t old_id) {
+        _cleanup_free_ char *message = NULL;
+
+        assert(pool);
+
+        if (old_id == UINT64_MAX)
+                return -EOVERFLOW;
+        if (asprintf(&message, "set_transaction_id %" PRIu64 " %" PRIu64, old_id, old_id + 1U) < 0)
+                return -ENOMEM;
+
+        return dm_target_message(pool->name, 0, message);
+}
+
+static int thin_volume_validate_mapping(
+                UserRecord *h,
+                const ThinPoolInfo *pool,
+                char **ret_path);
+
+static int thin_volume_create_mapping(
+                UserRecord *h,
+                const ThinPoolInfo *pool,
+                uint32_t device_id,
+                uint64_t size,
+                char **ret_path,
+                char **ret_name) {
+
+        _cleanup_free_ char *name = NULL, *parameters = NULL, *path = NULL, *uuid = NULL;
+        int r;
+
+        assert(h);
+        assert(pool);
+        assert(device_id <= HOME_THIN_DEVICE_ID_MAX);
+        assert(size > 0 && size % 512U == 0);
+
+        r = home_thin_volume_make_path(h, pool->path, &path, &name);
+        if (r < 0)
+                return r;
+        if (asprintf(&parameters, "%u:%u %" PRIu32,
+                     major(pool->device.devnum), minor(pool->device.devnum), device_id) < 0)
+                return -ENOMEM;
+        uuid = strjoin("HOMED-THIN-", SD_ID128_TO_STRING(h->uuid));
+        if (!uuid)
+                return -ENOMEM;
+
+        r = dm_create_device(name, uuid, 0, size / 512U, "thin", parameters);
+        if (r == -EEXIST) {
+                r = thin_volume_validate_mapping(h, pool, NULL);
+                if (r <= 0)
+                        return r < 0 ? r : -EREMCHG;
+        } else if (r < 0)
+                return r;
+        else
+                r = device_wait_for_devlink(path, "block", 45 * USEC_PER_SEC, NULL);
+        if (r < 0) {
+                (void) dm_remove_device(name);
+                return r;
+        }
+
+        if (ret_path)
+                *ret_path = TAKE_PTR(path);
+        if (ret_name)
+                *ret_name = TAKE_PTR(name);
+        return 1;
+}
+
+static int thin_pool_send_device_message(const ThinPoolInfo *pool, const char *verb, uint32_t device_id) {
+        _cleanup_free_ char *message = NULL;
+
+        assert(pool);
+        assert(verb);
+        assert(device_id <= HOME_THIN_DEVICE_ID_MAX);
+
+        if (asprintf(&message, "%s %" PRIu32, verb, device_id) < 0)
+                return -ENOMEM;
+
+        return dm_target_message(pool->name, 0, message);
+}
+
+static int thin_pool_confirm_transaction(const char *path, uint64_t expected) {
+        _cleanup_(thin_pool_info_done) ThinPoolInfo pool = {};
+        int r;
+
+        assert(path);
+
+        r = thin_pool_query(path, &pool);
+        if (r < 0)
+                return r;
+
+        return pool.status.transaction_id == expected ? 0 : -EREMCHG;
+}
+
+int home_thin_pool_recover(const char *pool_path) {
+        _cleanup_(thin_pool_info_done) ThinPoolInfo pool = {};
+        _cleanup_(thin_pool_state_done) ThinPoolState state = {};
+        _cleanup_close_ int lock_fd = -EBADF;
+        int r;
+
+        assert(pool_path);
+
+        r = thin_pool_state_acquire(pool_path, &pool, &state, &lock_fd);
+        if (r < 0)
+                return r;
+        if (state.operation != THIN_OPERATION_DELETE)
+                return 0;
+
+        if (pool.status.transaction_id == state.operation_transaction_id) {
+                r = thin_pool_send_device_message(&pool, "delete", state.device_id);
+                if (r < 0 && r != -ENODATA)
+                        return r;
+
+                r = thin_pool_advance_transaction(&pool, pool.status.transaction_id);
+                if (r < 0)
+                        return r;
+                r = thin_pool_confirm_transaction(pool_path, pool.status.transaction_id + 1U);
+                if (r < 0)
+                        return r;
+
+                pool.status.transaction_id++;
+        }
+
+        assert(pool.status.transaction_id == state.operation_transaction_id + 1U);
+        state.transaction_id = pool.status.transaction_id;
+        state.operation = THIN_OPERATION_NONE;
+        state.home_uuid = SD_ID128_NULL;
+        state.device_id = UINT32_MAX;
+        state.operation_transaction_id = 0;
+
+        r = thin_pool_state_save(&state);
+        if (r < 0)
+                return r;
+
+        log_notice("Recovered interrupted dm-thin deletion transaction.");
+        return 1;
+}
+
+int home_thin_volume_allocate(
+                UserRecord *h,
+                const char *pool_path,
+                char **ret_pool_uuid,
+                uint32_t *ret_device_id) {
+
+        _cleanup_(thin_pool_info_done) ThinPoolInfo pool = {};
+        _cleanup_(thin_pool_state_done) ThinPoolState state = {};
+        _cleanup_close_ int lock_fd = -EBADF;
+        uint32_t device_id;
+        int r;
+
+        assert(h);
+        assert(pool_path);
+        assert(ret_pool_uuid);
+        assert(ret_device_id);
+
+        if (sd_id128_is_null(h->uuid))
+                return -EINVAL;
+
+        r = thin_pool_state_acquire(pool_path, &pool, &state, &lock_fd);
+        if (r < 0)
+                return r;
+        if (state.operation != THIN_OPERATION_NONE)
+                return -EBUSY;
+        if (state.next_device_id > HOME_THIN_DEVICE_ID_MAX)
+                return -ENOSPC;
+
+        device_id = state.next_device_id++;
+        state.operation = THIN_OPERATION_CREATE;
+        state.home_uuid = h->uuid;
+        state.device_id = device_id;
+        state.operation_transaction_id = pool.status.transaction_id;
+
+        r = thin_pool_state_save(&state);
+        if (r < 0)
+                return r;
+
+        *ret_pool_uuid = strdup(pool.device.uuid);
+        if (!*ret_pool_uuid)
+                return -ENOMEM;
+        *ret_device_id = device_id;
+        return 1;
+}
+
+static int thin_volume_validate_binding(UserRecord *h, const ThinPoolInfo *pool) {
+        assert(h);
+        assert(pool);
+
+        if (!h->thin_pool_uuid && h->thin_device_id == UINT32_MAX)
+                return 0;
+        if (!h->thin_pool_uuid || h->thin_device_id > HOME_THIN_DEVICE_ID_MAX)
+                return -EBADMSG;
+        if (user_record_storage(h) != USER_LUKS)
+                return -EBADMSG;
+        if (h->disk_size == UINT64_MAX || h->disk_size == 0 || h->disk_size % 512U != 0)
+                return -EBADMSG;
+        if (!streq(h->thin_pool_uuid, pool->device.uuid))
+                return -ESTALE;
+
+        return 1;
+}
+
+static int thin_volume_validate_mapping(
+                UserRecord *h,
+                const ThinPoolInfo *pool,
+                char **ret_path) {
+
+        _cleanup_(dm_target_info_done) DmTargetInfo target = {};
+        _cleanup_free_ char *expected_uuid = NULL, *name = NULL, *path = NULL;
+        DmDeviceInfo device;
+        unsigned pool_major, pool_minor, device_id;
+        int consumed = 0, r;
+
+        assert(h);
+        assert(pool);
+
+        r = home_thin_volume_make_path(h, pool->path, &path, &name);
+        if (r < 0)
+                return r;
+        r = dm_device_info_from_path(path, &device);
+        if (r == -ENOENT)
+                return 0;
+        if (r < 0)
+                return r;
+
+        expected_uuid = strjoin("HOMED-THIN-", SD_ID128_TO_STRING(h->uuid));
+        if (!expected_uuid)
+                return -ENOMEM;
+        if (!streq(device.name, name) || !streq(device.uuid, expected_uuid) ||
+            FLAGS_SET(device.flags, DM_READONLY_FLAG) || device.target_count != 1)
+                return -EREMCHG;
+
+        r = dm_device_query_target(name, true, &target);
+        if (r < 0)
+                return r;
+        if (!streq(target.type, "thin") || target.start != 0 || target.length != h->disk_size / 512U ||
+            sscanf(target.parameters, "%u:%u %u %n", &pool_major, &pool_minor, &device_id, &consumed) != 3 ||
+            consumed <= 0 || !isempty(target.parameters + consumed) ||
+            makedev(pool_major, pool_minor) != pool->device.devnum || device_id != h->thin_device_id)
+                return -EREMCHG;
+
+        if (ret_path)
+                *ret_path = TAKE_PTR(path);
+        return 1;
+}
+
+int home_thin_volume_create(
+                UserRecord *h,
+                const char *pool_path,
+                uint64_t size,
+                sd_id128_t creation_id,
+                char **ret_path,
+                char **ret_name) {
+
+        _cleanup_(thin_pool_info_done) ThinPoolInfo pool = {};
+        _cleanup_(thin_pool_state_done) ThinPoolState state = {};
+        _cleanup_close_ int lock_fd = -EBADF;
+        int r;
+
+        assert(h);
+        assert(pool_path);
+        assert(size > 0 && size % 512U == 0);
+        assert(!sd_id128_is_null(creation_id));
+        assert(ret_path);
+        assert(ret_name);
+
+        r = thin_pool_state_acquire(pool_path, &pool, &state, &lock_fd);
+        if (r < 0)
+                return r;
+        r = thin_volume_validate_binding(h, &pool);
+        if (r <= 0)
+                return r < 0 ? r : -EBADMSG;
+        if (state.operation != THIN_OPERATION_CREATE ||
+            !sd_id128_equal(state.home_uuid, h->uuid) || state.device_id != h->thin_device_id)
+                return -EREMCHG;
+        if (pool.status.transaction_id != state.operation_transaction_id)
+                return -EALREADY;
+
+        r = thin_pool_send_device_message(&pool, "create_thin", h->thin_device_id);
+        if (r < 0)
+                return log_error_errno(r, "Failed to allocate dm-thin device ID %" PRIu32 ": %m",
+                                       h->thin_device_id);
+        r = thin_pool_advance_transaction(&pool, pool.status.transaction_id);
+        if (r < 0)
+                return log_error_errno(r, "Failed to advance dm-thin transaction: %m");
+        r = thin_pool_confirm_transaction(pool_path, pool.status.transaction_id + 1U);
+        if (r < 0)
+                return r;
+
+        state.transaction_id = ++pool.status.transaction_id;
+        r = thin_pool_state_save(&state);
+        if (r < 0)
+                return r;
+
+        r = thin_volume_create_mapping(h, &pool, h->thin_device_id, size, ret_path, ret_name);
+        if (r < 0)
+                return log_error_errno(r, "Failed to activate new dm-thin home device: %m");
+
+        return 1;
+}
+
+int home_thin_volume_commit_path(UserRecord *h, const char *pool_path) {
+        _cleanup_(thin_pool_info_done) ThinPoolInfo pool = {};
+        _cleanup_(thin_pool_state_done) ThinPoolState state = {};
+        _cleanup_close_ int lock_fd = -EBADF;
+        int r;
+
+        assert(h);
+        assert(pool_path);
+        r = thin_pool_state_acquire(pool_path, &pool, &state, &lock_fd);
+        if (r < 0)
+                return r;
+        r = thin_volume_validate_binding(h, &pool);
+        if (r <= 0)
+                return r < 0 ? r : -EBADMSG;
+        if (state.operation == THIN_OPERATION_NONE)
+                return 0;
+        if (state.operation != THIN_OPERATION_CREATE ||
+            !sd_id128_equal(state.home_uuid, h->uuid) || state.device_id != h->thin_device_id ||
+            pool.status.transaction_id != state.operation_transaction_id + 1U)
+                return -EREMCHG;
+
+        state.operation = THIN_OPERATION_NONE;
+        state.home_uuid = SD_ID128_NULL;
+        state.device_id = UINT32_MAX;
+        state.operation_transaction_id = 0;
+        return thin_pool_state_save(&state);
+}
+
+int home_thin_volume_commit(UserRecord *h) {
+        const char *pool_path;
+
+        assert(h);
+
+        pool_path = secure_getenv("SYSTEMD_HOME_THIN_POOL");
+        if (!pool_path)
+                return -ENXIO;
+
+        return home_thin_volume_commit_path(h, pool_path);
+}
+
+int home_thin_volume_activate(UserRecord *h, bool already_active, char **ret_path) {
+        _cleanup_(thin_pool_info_done) ThinPoolInfo pool = {};
+        _cleanup_(thin_pool_state_done) ThinPoolState state = {};
+        _cleanup_close_ int fd = -EBADF;
+        _cleanup_close_ int lock_fd = -EBADF;
+        _cleanup_free_ char *mapping = NULL, *path = NULL;
+        const char *image_path, *pool_path;
+        uint64_t offset, size;
+        int r;
+
+        assert(h);
+
+        if (!h->thin_pool_uuid && h->thin_device_id == UINT32_MAX)
+                return 0;
+        pool_path = secure_getenv("SYSTEMD_HOME_THIN_POOL");
+        if (!pool_path)
+                return -ENXIO;
+        r = thin_pool_state_acquire(pool_path, &pool, &state, &lock_fd);
+        if (r < 0)
+                return r;
+        lock_fd = safe_close(lock_fd);
+        r = thin_volume_validate_binding(h, &pool);
+        if (r <= 0)
+                return r;
+        r = thin_volume_validate_mapping(h, &pool, &path);
+        if (r < 0)
+                return r;
+        if (r == 0) {
+                r = thin_volume_create_mapping(h, &pool, h->thin_device_id, h->disk_size, &path, NULL);
+                if (r < 0)
+                        return r;
+        }
+
+        if (already_active) {
+                if (ret_path)
+                        *ret_path = TAKE_PTR(path);
+                return 1;
+        }
+
+        image_path = user_record_image_path(h);
+        if (!image_path || path_equal(image_path, path))
+                return -EBADMSG;
+        fd = open(path, O_RDONLY|O_CLOEXEC|O_NONBLOCK|O_NOCTTY);
+        if (fd < 0)
+                return -errno;
+        r = thin_volume_find_partition(h, fd, &offset, &size);
+        if (r < 0)
+                goto fail;
+        r = thin_volume_unmap_partition(path);
+        if (r < 0)
+                goto fail;
+        r = home_thin_volume_map_partition(h, fd, offset, size, &mapping);
+        if (r < 0)
+                goto fail;
+        r = device_wait_for_devlink(image_path, "block", 45 * USEC_PER_SEC, NULL);
+        if (r < 0)
+                goto fail;
+
+        if (ret_path)
+                *ret_path = TAKE_PTR(path);
+        return 1;
+
+fail:
+        (void) home_thin_volume_deactivate_path(path);
+        return r;
+}
+
+int home_thin_volume_exists(UserRecord *h) {
+        _cleanup_(thin_pool_info_done) ThinPoolInfo pool = {};
+        _cleanup_(thin_pool_state_done) ThinPoolState state = {};
+        _cleanup_close_ int lock_fd = -EBADF;
+        const char *pool_path;
+        int r;
+
+        assert(h);
+
+        if (!h->thin_pool_uuid && h->thin_device_id == UINT32_MAX)
+                return 0;
+        pool_path = secure_getenv("SYSTEMD_HOME_THIN_POOL");
+        if (!pool_path)
+                return -ENXIO;
+        r = thin_pool_state_acquire(pool_path, &pool, &state, &lock_fd);
+        if (r < 0)
+                return r;
+        lock_fd = safe_close(lock_fd);
+        r = thin_volume_validate_binding(h, &pool);
+        if (r <= 0)
+                return r;
+        r = thin_volume_validate_mapping(h, &pool, NULL);
+        if (r != 0)
+                return r;
+
+        _cleanup_free_ char *name = NULL, *path = NULL;
+        r = home_thin_volume_make_path(h, pool_path, &path, &name);
+        if (r < 0)
+                return r;
+        r = thin_volume_create_mapping(h, &pool, h->thin_device_id, h->disk_size, NULL, NULL);
+        if (r < 0)
+                return ERRNO_IS_NEG_DEVICE_ABSENT(r) ? 0 : r;
+        (void) dm_remove_device(name);
+        return 1;
+}
+
+int home_thin_volume_deactivate_path(const char *path) {
+        _cleanup_free_ char *name = NULL;
+        int r;
+
+        assert(path);
+
+        r = thin_volume_unmap_partition(path);
+        if (r < 0)
+                return r;
+        r = path_extract_filename(path, &name);
+        if (r < 0)
+                return r;
+        r = dm_remove_device(name);
+        if (r < 0)
+                return r;
+        return 1;
+}
+
+int home_thin_volume_deactivate(UserRecord *h) {
+        _cleanup_free_ char *name = NULL, *path = NULL;
+        const char *pool_path;
+        int r;
+
+        assert(h);
+
+        if (!h->thin_pool_uuid && h->thin_device_id == UINT32_MAX)
+                return 0;
+        pool_path = secure_getenv("SYSTEMD_HOME_THIN_POOL");
+        if (!pool_path)
+                return -ENXIO;
+        r = home_thin_volume_make_path(h, pool_path, &path, &name);
+        if (r < 0)
+                return r;
+        return home_thin_volume_deactivate_path(path);
+}
+
+static int thin_volume_delete(UserRecord *h, const char *pool_path) {
+        _cleanup_(thin_pool_info_done) ThinPoolInfo pool = {};
+        _cleanup_(thin_pool_state_done) ThinPoolState state = {};
+        _cleanup_close_ int lock_fd = -EBADF;
+        ThinOperation previous_operation;
+        uint64_t previous_transaction;
+        int r;
+
+        assert(h);
+        assert(pool_path);
+        r = thin_pool_state_acquire(pool_path, &pool, &state, &lock_fd);
+        if (r < 0)
+                return r;
+        r = thin_volume_validate_binding(h, &pool);
+        if (r <= 0)
+                return r;
+
+        previous_operation = state.operation;
+        previous_transaction = state.operation_transaction_id;
+        if (state.operation == THIN_OPERATION_DELETE &&
+            sd_id128_equal(state.home_uuid, h->uuid) && state.device_id == h->thin_device_id &&
+            pool.status.transaction_id == state.operation_transaction_id + 1U) {
+                state.transaction_id = pool.status.transaction_id;
+                state.operation = THIN_OPERATION_NONE;
+                state.home_uuid = SD_ID128_NULL;
+                state.device_id = UINT32_MAX;
+                state.operation_transaction_id = 0;
+                return thin_pool_state_save(&state);
+        }
+        if (state.operation != THIN_OPERATION_NONE &&
+            !((state.operation == THIN_OPERATION_CREATE || state.operation == THIN_OPERATION_DELETE) &&
+              sd_id128_equal(state.home_uuid, h->uuid) && state.device_id == h->thin_device_id))
+                return -EBUSY;
+
+        state.operation = THIN_OPERATION_DELETE;
+        state.home_uuid = h->uuid;
+        state.device_id = h->thin_device_id;
+        state.operation_transaction_id = pool.status.transaction_id;
+        r = thin_pool_state_save(&state);
+        if (r < 0)
+                return r;
+
+        r = thin_pool_send_device_message(&pool, "delete", h->thin_device_id);
+        if (r < 0 && r != -ENODATA)
+                return r;
+        if (r == -ENODATA && previous_operation == THIN_OPERATION_CREATE &&
+            pool.status.transaction_id == previous_transaction) {
+                state.operation = THIN_OPERATION_NONE;
+                state.home_uuid = SD_ID128_NULL;
+                state.device_id = UINT32_MAX;
+                state.operation_transaction_id = 0;
+                return thin_pool_state_save(&state);
+        }
+        r = thin_pool_advance_transaction(&pool, pool.status.transaction_id);
+        if (r < 0)
+                return r;
+        r = thin_pool_confirm_transaction(pool_path, pool.status.transaction_id + 1U);
+        if (r < 0)
+                return r;
+
+        state.transaction_id = pool.status.transaction_id + 1U;
+        state.operation = THIN_OPERATION_NONE;
+        state.home_uuid = SD_ID128_NULL;
+        state.device_id = UINT32_MAX;
+        state.operation_transaction_id = 0;
+        return thin_pool_state_save(&state);
+}
+
+int home_thin_volume_remove(UserRecord *h) {
+        _cleanup_free_ char *name = NULL, *path = NULL;
+        const char *pool_path;
+        int r;
+
+        assert(h);
+
+        if (!h->thin_pool_uuid && h->thin_device_id == UINT32_MAX)
+                return 0;
+
+        pool_path = secure_getenv("SYSTEMD_HOME_THIN_POOL");
+        if (!pool_path)
+                return -ENXIO;
+        r = home_thin_volume_make_path(h, pool_path, &path, &name);
+        if (r < 0)
+                return r;
+        r = home_thin_volume_deactivate_path(path);
+        if (r < 0 && r != -ENXIO)
+                return r;
+        r = thin_volume_delete(h, pool_path);
+        if (r < 0)
+                return r;
+
+        log_info("Removed dm-thin home device ID %" PRIu32 ".", h->thin_device_id);
+        return 1;
+}
+
+int home_thin_volume_remove_incomplete(UserRecord *h, const char *pool_path) {
+        _cleanup_(thin_pool_info_done) ThinPoolInfo pool = {};
+        _cleanup_(thin_pool_state_done) ThinPoolState state = {};
+        _cleanup_close_ int lock_fd = -EBADF;
+        int r;
+
+        assert(h);
+        assert(pool_path);
+
+        if (!h->thin_pool_uuid || h->thin_device_id == UINT32_MAX) {
+                r = thin_pool_state_acquire(pool_path, &pool, &state, &lock_fd);
+                if (r < 0)
+                        return r;
+                if (state.operation != THIN_OPERATION_CREATE ||
+                    !sd_id128_equal(state.home_uuid, h->uuid))
+                        return 0;
+
+                h->thin_pool_uuid = strdup(pool.device.uuid);
+                if (!h->thin_pool_uuid)
+                        return -ENOMEM;
+                h->thin_device_id = state.device_id;
+                lock_fd = safe_close(lock_fd);
+        }
+
+        _cleanup_free_ char *name = NULL, *path = NULL;
+        r = home_thin_volume_make_path(h, pool_path, &path, &name);
+        if (r < 0)
+                return r;
+        r = home_thin_volume_deactivate_path(path);
+        if (r < 0 && r != -ENXIO)
+                return r;
+        return thin_volume_delete(h, pool_path);
+}
+
+int home_thin_volume_remove_created(const char *path) {
+        _cleanup_(dm_target_info_done) DmTargetInfo target = {};
+        _cleanup_(user_record_unrefp) UserRecord *h = NULL;
+        _cleanup_free_ char *name = NULL;
+        DmDeviceInfo device;
+        unsigned pool_major, pool_minor, device_id;
+        sd_id128_t home_uuid;
+        int r;
+
+        assert(path);
+
+        r = dm_device_info_from_path(path, &device);
+        if (r < 0)
+                return r;
+        if (!startswith(device.uuid, "HOMED-THIN-") ||
+            sd_id128_from_string(device.uuid + STRLEN("HOMED-THIN-"), &home_uuid) < 0)
+                return -EREMCHG;
+        r = path_extract_filename(path, &name);
+        if (r < 0)
+                return r;
+        r = dm_device_query_target(name, true, &target);
+        if (r < 0)
+                return r;
+        if (!streq(target.type, "thin") ||
+            sscanf(target.parameters, "%u:%u %u", &pool_major, &pool_minor, &device_id) != 3 ||
+            device_id > HOME_THIN_DEVICE_ID_MAX)
+                return -EREMCHG;
+
+        h = user_record_new();
+        if (!h)
+                return -ENOMEM;
+        h->uuid = home_uuid;
+        h->storage = USER_LUKS;
+        h->thin_device_id = device_id;
+
+        const char *pool_path = secure_getenv("SYSTEMD_HOME_THIN_POOL");
+        if (!pool_path)
+                return -ENXIO;
+        _cleanup_(thin_pool_info_done) ThinPoolInfo pool = {};
+        r = thin_pool_query(pool_path, &pool);
+        if (r < 0)
+                return r;
+        if (makedev(pool_major, pool_minor) != pool.device.devnum)
+                return -EREMCHG;
+        h->thin_pool_uuid = strdup(pool.device.uuid);
+        if (!h->thin_pool_uuid)
+                return -ENOMEM;
+
+        r = home_thin_volume_deactivate_path(path);
+        if (r < 0)
+                return r;
+        return thin_volume_delete(h, pool_path);
+}

--- a/src/home/homework-thin.h
+++ b/src/home/homework-thin.h
@@ -1,0 +1,43 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#pragma once
+
+#include <stdint.h>
+
+#include "forward.h"
+
+typedef struct HomeThinPoolStatus {
+        uint64_t transaction_id;
+        uint64_t used_metadata, total_metadata;
+        uint64_t used_data, total_data;
+} HomeThinPoolStatus;
+
+int home_thin_pool_parse_status(const char *status, HomeThinPoolStatus *ret);
+int home_thin_pool_validate_table(const char *parameters);
+int home_thin_pool_validate(const char *pool_path);
+int home_thin_pool_recover(const char *pool_path);
+
+int home_thin_pool_default_size(const char *pool, uint64_t *ret_size, uint64_t *ret_backing_size);
+int home_thin_volume_make_path(UserRecord *h, const char *pool, char **ret_path, char **ret_name);
+int home_thin_volume_allocate(
+                UserRecord *h,
+                const char *pool,
+                char **ret_pool_uuid,
+                uint32_t *ret_device_id);
+int home_thin_volume_create(
+                UserRecord *h,
+                const char *pool,
+                uint64_t size,
+                sd_id128_t creation_id,
+                char **ret_path,
+                char **ret_name);
+int home_thin_volume_commit(UserRecord *h);
+int home_thin_volume_commit_path(UserRecord *h, const char *pool_path);
+
+int home_thin_volume_map_partition(UserRecord *h, int volume_fd, uint64_t offset, uint64_t size, char **ret_path);
+int home_thin_volume_activate(UserRecord *h, bool already_active, char **ret_path);
+int home_thin_volume_exists(UserRecord *h);
+int home_thin_volume_deactivate(UserRecord *h);
+int home_thin_volume_deactivate_path(const char *path);
+int home_thin_volume_remove(UserRecord *h);
+int home_thin_volume_remove_incomplete(UserRecord *h, const char *pool_path);
+int home_thin_volume_remove_created(const char *path);

--- a/src/home/homework.c
+++ b/src/home/homework.c
@@ -12,6 +12,7 @@
 #include "chase.h"
 #include "chown-recursive.h"
 #include "copy.h"
+#include "coredump-util.h"
 #include "cryptsetup-util.h"
 #include "dlopen-note.h"
 #include "env-util.h"
@@ -33,6 +34,7 @@
 #include "homework-fscrypt.h"
 #include "homework-luks.h"
 #include "homework-mount.h"
+#include "homework-thin.h"
 #include "json-util.h"
 #include "libcrypt-util.h"
 #include "loop-util.h"
@@ -407,7 +409,45 @@ static int keyring_flush(UserRecord *h) {
         return keyring_unlink(serial);
 }
 
+static int home_prepare_thin_volume(UserRecord *h, bool already_active, HomeSetup *setup) {
+        int r;
+
+        assert(h);
+        assert(setup);
+
+        if (setup->thin_volume_path)
+                return 0;
+
+        r = home_thin_volume_activate(h, already_active, &setup->thin_volume_path);
+        if (r < 0)
+                return r;
+        if (r > 0 && !already_active)
+                setup->deactivate_thin_volume = true;
+
+        return r;
+}
+
+static int unlink_record_file(const char *path) {
+        int r;
+
+        assert(path);
+
+        if (unlink(path) < 0) {
+                if (errno == ENOENT)
+                        return 0;
+
+                return -errno;
+        }
+
+        r = fsync_path_at(AT_FDCWD, home_record_dir());
+        if (r < 0)
+                return r;
+
+        return 1;
+}
+
 int home_setup_done(HomeSetup *setup) {
+        bool remove_thin_volume_intent;
         int r = 0, q;
 
         assert(setup);
@@ -475,6 +515,45 @@ int home_setup_done(HomeSetup *setup) {
 
         setup->loop = loop_device_unref(setup->loop);
 
+        remove_thin_volume_intent = setup->thin_volume_record_saved;
+
+        if (setup->deactivate_thin_volume && !setup->undo_thin_volume) {
+                assert(setup->thin_volume_path);
+
+                q = home_thin_volume_deactivate_path(setup->thin_volume_path);
+                if (q < 0 && r >= 0)
+                        r = q;
+
+                setup->deactivate_thin_volume = false;
+        }
+
+        if (setup->undo_thin_volume) {
+                assert(setup->thin_volume_path);
+
+                q = home_thin_volume_remove_created(setup->thin_volume_path);
+                if (q < 0) {
+                        log_debug_errno(q, "Failed to roll back thin volume %s: %m", setup->thin_volume_path);
+                        if (r >= 0)
+                                r = q;
+                } else
+                        remove_thin_volume_intent = true;
+
+                setup->undo_thin_volume = false;
+        }
+        setup->thin_volume_path = mfree(setup->thin_volume_path);
+
+        if (remove_thin_volume_intent && setup->thin_volume_intent_path) {
+                q = unlink_record_file(setup->thin_volume_intent_path);
+                if (q < 0) {
+                        log_debug_errno(q,
+                                        "Failed to remove thin-volume intent '%s': %m",
+                                        setup->thin_volume_intent_path);
+                        if (r >= 0)
+                                r = q;
+                }
+        }
+        setup->thin_volume_intent_path = mfree(setup->thin_volume_intent_path);
+
         setup->volume_key = erase_and_free(setup->volume_key);
         setup->volume_key_size = 0;
 
@@ -507,6 +586,10 @@ int home_setup(
 
         if (!FLAGS_SET(flags, HOME_SETUP_ALREADY_ACTIVATED)) /* If we set up the directory, we should also drop caches once we are done */
                 setup->do_drop_caches = setup->do_drop_caches || user_record_drop_caches(h);
+
+        r = home_prepare_thin_volume(h, FLAGS_SET(flags, HOME_SETUP_ALREADY_ACTIVATED), setup);
+        if (r < 0)
+                return r;
 
         switch (user_record_storage(h)) {
 
@@ -794,6 +877,7 @@ int home_extend_embedded_identity(UserRecord *h, UserRecord *used, HomeSetup *se
                         setup->found_fs_uuid,
                         setup->crypt_device ? sym_crypt_get_cipher(setup->crypt_device) : NULL,
                         setup->crypt_device ? sym_crypt_get_cipher_mode(setup->crypt_device) : NULL,
+                        setup->crypt_device ? luks_key_type_convert(setup->crypt_device) : NULL,
                         setup->crypt_device ? luks_volume_key_size_convert(setup->crypt_device) : UINT64_MAX,
                         file_system_type_fd(setup->root_fd),
                         user_record_home_directory(used),
@@ -937,11 +1021,17 @@ static int home_activate(UserRecord *h, UserRecord **ret_home) {
         if (r == USER_TEST_MOUNTED)
                 return log_error_errno(SYNTHETIC_ERRNO(EALREADY), "Home directory %s is already mounted, refusing.", user_record_home_directory(h));
 
-        r = user_record_test_image_path_and_warn(h);
+        r = home_prepare_thin_volume(h, /* already_active= */ false, &setup);
         if (r < 0)
                 return r;
-        if (r == USER_TEST_ABSENT)
-                return log_error_errno(SYNTHETIC_ERRNO(ENETUNREACH), "Image path %s is missing, refusing.", user_record_image_path(h));
+
+        if (!h->thin_pool_uuid) {
+                r = user_record_test_image_path_and_warn(h);
+                if (r < 0)
+                        return r;
+                if (r == USER_TEST_ABSENT)
+                        return log_error_errno(SYNTHETIC_ERRNO(ENETUNREACH), "Image path %s is missing, refusing.", user_record_image_path(h));
+        }
 
         switch (user_record_storage(h)) {
 
@@ -1050,6 +1140,12 @@ static int home_deactivate(UserRecord *h, bool force) {
 
         if (user_record_storage(h) == USER_LUKS) {
                 r = home_deactivate_luks(h, &setup);
+                if (r < 0)
+                        return r;
+                if (r > 0)
+                        done = true;
+
+                r = home_thin_volume_deactivate(h);
                 if (r < 0)
                         return r;
                 if (r > 0)
@@ -1360,13 +1456,66 @@ static int determine_default_storage(UserStorage *ret) {
         return 0;
 }
 
+static int home_save_pending_record(UserRecord *h) {
+        const char *path;
+
+        assert(h);
+        assert(h->user_name);
+
+        (void) mkdir("/var/lib/systemd/", 0755);
+        (void) mkdir(home_record_dir(), 0700);
+
+        path = strjoina(home_record_dir(), "/", h->user_name, HOME_RECORD_PENDING_SUFFIX);
+        return user_record_save(h, path);
+}
+
+static int home_save_thin_volume_intent(UserRecord *h, char **ret_path, sd_id128_t *ret_creation_id) {
+        _cleanup_(user_record_unrefp) UserRecord *masked = NULL;
+        _cleanup_free_ char *path = NULL;
+        sd_id128_t creation_id;
+        int r;
+
+        assert(h);
+        assert(h->user_name);
+        assert(ret_path);
+        assert(ret_creation_id);
+
+        r = user_record_clone(h, USER_RECORD_LOAD_MASK_SECRET|USER_RECORD_PERMISSIVE, &masked);
+        if (r < 0)
+                return r;
+
+        r = sd_id128_randomize(&creation_id);
+        if (r < 0)
+                return r;
+
+        r = user_record_set_thin_volume_creation_id(masked, creation_id);
+        if (r < 0)
+                return r;
+
+        (void) mkdir("/var/lib/systemd/", 0755);
+        (void) mkdir(home_record_dir(), 0700);
+
+        path = strjoin(home_record_dir(), "/", h->user_name, HOME_RECORD_THIN_INTENT_SUFFIX);
+        if (!path)
+                return -ENOMEM;
+
+        r = user_record_save(masked, path);
+        if (r < 0)
+                return r;
+
+        *ret_path = TAKE_PTR(path);
+        *ret_creation_id = creation_id;
+        return 0;
+}
+
 static int home_create(UserRecord *h, Hashmap *blobs, UserRecord **ret_home) {
         _cleanup_strv_free_erase_ char **effective_passwords = NULL;
         _cleanup_(home_setup_done) HomeSetup setup = HOME_SETUP_INIT;
         _cleanup_(user_record_unrefp) UserRecord *new_home = NULL;
         _cleanup_(password_cache_free) PasswordCache cache = {};
         UserStorage new_storage = _USER_STORAGE_INVALID;
-        const char *new_fs = NULL;
+        const char *new_fs = NULL, *thin_pool;
+        bool hardware_wrapped_keys;
         int r;
 
         assert(h);
@@ -1393,10 +1542,17 @@ static int home_create(UserRecord *h, Hashmap *blobs, UserRecord **ret_home) {
                         return r;
         }
 
+        thin_pool = secure_getenv("SYSTEMD_HOME_THIN_POOL");
+
+        r = getenv_bool("SYSTEMD_HOME_HARDWARE_WRAPPED_KEYS");
+        if (r < 0 && r != -ENXIO)
+                return log_error_errno(r, "Failed to parse hardware-wrapped key creation policy: %m");
+        hardware_wrapped_keys = r > 0;
+
         if ((h->storage == USER_LUKS ||
              (h->storage < 0 && new_storage == USER_LUKS)) &&
             !h->file_system_type)
-                new_fs = getenv("SYSTEMD_HOME_DEFAULT_FILE_SYSTEM_TYPE");
+                new_fs = thin_pool && !h->image_path ? "ext4" : getenv("SYSTEMD_HOME_DEFAULT_FILE_SYSTEM_TYPE");
 
         if (new_storage >= 0 || new_fs) {
                 r = user_record_add_binding(
@@ -1408,6 +1564,7 @@ static int home_create(UserRecord *h, Hashmap *blobs, UserRecord **ret_home) {
                                 SD_ID128_NULL,
                                 NULL,
                                 NULL,
+                                NULL,
                                 UINT64_MAX,
                                 new_fs,
                                 NULL,
@@ -1417,11 +1574,99 @@ static int home_create(UserRecord *h, Hashmap *blobs, UserRecord **ret_home) {
                         return log_error_errno(r, "Failed to change storage type to LUKS: %m");
         }
 
+        if (hardware_wrapped_keys &&
+            (!thin_pool || user_record_storage(h) != USER_LUKS || h->image_path ||
+             !streq(user_record_file_system_type(h), "ext4")))
+                return log_error_errno(
+                                SYNTHETIC_ERRNO(EOPNOTSUPP),
+                                "Hardware-wrapped keys require a thin-backed LUKS/ext4 home without an explicit image path.");
+
         r = user_record_test_image_path_and_warn(h);
         if (r < 0)
                 return r;
         if (!IN_SET(r, USER_TEST_ABSENT, USER_TEST_UNDEFINED, USER_TEST_MAYBE))
                 return log_error_errno(SYNTHETIC_ERRNO(EEXIST), "Image path %s already exists, refusing.", user_record_image_path(h));
+
+        if (thin_pool &&
+            user_record_storage(h) == USER_LUKS &&
+            !h->image_path) {
+                _cleanup_free_ char *created_name = NULL, *created_path = NULL, *pool_uuid = NULL, *thin_name = NULL;
+                sd_id128_t creation_id;
+                uint32_t device_id;
+                uint64_t size;
+
+                if (!streq(user_record_file_system_type(h), "ext4"))
+                        return log_error_errno(SYNTHETIC_ERRNO(EPROTONOSUPPORT),
+                                               "Thin-provisioned homes require the ext4 file system.");
+
+                if (h->disk_size == UINT64_MAX)
+                        return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
+                                               "Thin-provisioned home lacks a manager-selected disk size.");
+
+                size = h->disk_size;
+
+                if (size < USER_DISK_SIZE_MIN || size > USER_DISK_SIZE_MAX)
+                        return log_error_errno(SYNTHETIC_ERRNO(ERANGE),
+                                               "Thin-volume size is outside the supported range.");
+
+                /* Reject a foreign or unhealthy pool before persisting the identity-side recovery
+                 * intent. Once that file exists, every subsequent failure must be treated as potentially
+                 * following an allocator-state mutation and hence recovered durably. */
+                r = home_thin_pool_validate(thin_pool);
+                if (r < 0)
+                        return r;
+
+                r = home_thin_volume_make_path(h, thin_pool, &setup.thin_volume_path, &thin_name);
+                if (r < 0)
+                        return log_error_errno(r, "Failed to determine thin-volume name: %m");
+
+                r = user_record_add_binding(
+                                h,
+                                USER_LUKS,
+                                setup.thin_volume_path,
+                                SD_ID128_NULL,
+                                SD_ID128_NULL,
+                                SD_ID128_NULL,
+                                NULL,
+                                NULL,
+                                NULL,
+                                UINT64_MAX,
+                                NULL,
+                                NULL,
+                                UID_INVALID,
+                                GID_INVALID);
+                if (r < 0)
+                        return log_error_errno(r, "Failed to bind home to thin volume: %m");
+
+                r = home_save_thin_volume_intent(h, &setup.thin_volume_intent_path, &creation_id);
+                if (r < 0)
+                        return log_error_errno(r, "Failed to save thin-volume intent: %m");
+
+                r = home_thin_volume_allocate(h, thin_pool, &pool_uuid, &device_id);
+                if (r < 0)
+                        return log_error_errno(r, "Failed to allocate a dm-thin device ID: %m");
+
+                r = user_record_add_thin_pool_binding(h, pool_uuid, device_id);
+                if (r < 0)
+                        return log_error_errno(r, "Failed to record thin-volume intent binding: %m");
+
+                r = home_thin_volume_create(
+                                h,
+                                thin_pool,
+                                size,
+                                creation_id,
+                                &created_path,
+                                &created_name);
+                if (r < 0)
+                        return r;
+                setup.undo_thin_volume = true;
+                setup.deactivate_thin_volume = true;
+
+                if (!path_equal(created_path, setup.thin_volume_path) || !streq(created_name, thin_name))
+                        return log_error_errno(SYNTHETIC_ERRNO(EREMCHG),
+                                               "Created thin volume does not match its intent.");
+
+        }
 
         r = home_apply_new_blob_dir(h, blobs);
         if (r < 0)
@@ -1453,6 +1698,32 @@ static int home_create(UserRecord *h, Hashmap *blobs, UserRecord **ret_home) {
         if (r < 0)
                 return r;
 
+        if (setup.undo_thin_volume) {
+                /* The manager cannot acknowledge the record until after this worker exits. Persist the complete
+                 * machine binding first, so that either the manager can commit it or the next manager instance
+                 * can recover it. Only then is the dm-thin device no longer owned by the rollback cleanup. */
+                assert(new_home);
+
+                r = home_save_pending_record(new_home);
+                if (r < 0)
+                        return log_error_errno(r, "Failed to save pending thin-volume record: %m");
+
+                r = home_thin_volume_commit(new_home);
+                if (r < 0) {
+                        int q;
+
+                        q = unlink_record_file(
+                                        strjoina(home_record_dir(), "/", new_home->user_name, HOME_RECORD_PENDING_SUFFIX));
+                        if (q < 0)
+                                log_warning_errno(q, "Failed to remove uncommitted pending home record, ignoring: %m");
+
+                        return log_error_errno(r, "Failed to commit dm-thin allocator state: %m");
+                }
+
+                setup.thin_volume_record_saved = true;
+                setup.undo_thin_volume = false;
+        }
+
         if (user_record_equal(h, new_home)) {
                 *ret_home = NULL;
                 return 0;
@@ -1463,6 +1734,7 @@ static int home_create(UserRecord *h, Hashmap *blobs, UserRecord **ret_home) {
 }
 
 static int home_remove(UserRecord *h) {
+        _cleanup_(home_setup_done) HomeSetup setup = HOME_SETUP_INIT;
         bool deleted = false;
         const char *ip, *hd;
         int r;
@@ -1473,6 +1745,15 @@ static int home_remove(UserRecord *h) {
                 return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "User record lacks user name, refusing.");
         if (!IN_SET(user_record_storage(h), USER_LUKS, USER_DIRECTORY, USER_SUBVOLUME, USER_FSCRYPT, USER_CIFS))
                 return log_error_errno(SYNTHETIC_ERRNO(ENOTTY), "Removing home directories of type '%s' currently not supported.", user_storage_to_string(user_record_storage(h)));
+
+        r = home_thin_volume_exists(h);
+        if (r < 0)
+                return log_error_errno(r, "Failed to determine whether the thin volume exists: %m");
+        if (r > 0) {
+                r = home_prepare_thin_volume(h, /* already_active= */ false, &setup);
+                if (r < 0)
+                        return r;
+        }
 
         hd = user_record_home_directory(h);
 
@@ -1558,6 +1839,14 @@ static int home_remove(UserRecord *h) {
                 assert_not_reached();
         }
 
+        r = home_thin_volume_remove(h);
+        if (r < 0)
+                return r;
+        if (r > 0) {
+                deleted = true;
+                setup.deactivate_thin_volume = false;
+        }
+
         if (hd) {
                 if (rmdir(hd) < 0) {
                         if (errno != ENOENT)
@@ -1610,11 +1899,17 @@ static int home_validate_update(UserRecord *h, HomeSetup *setup, HomeSetupFlags 
 
         has_mount = r == USER_TEST_MOUNTED;
 
-        r = user_record_test_image_path_and_warn(h);
+        r = home_prepare_thin_volume(h, has_mount, setup);
         if (r < 0)
                 return r;
-        if (r == USER_TEST_ABSENT)
-                return log_error_errno(SYNTHETIC_ERRNO(ENETUNREACH), "Image path %s does not exist", user_record_image_path(h));
+
+        if (!h->thin_pool_uuid) {
+                r = user_record_test_image_path_and_warn(h);
+                if (r < 0)
+                        return r;
+                if (r == USER_TEST_ABSENT)
+                        return log_error_errno(SYNTHETIC_ERRNO(ENETUNREACH), "Image path %s does not exist", user_record_image_path(h));
+        }
 
         switch (user_record_storage(h)) {
 
@@ -1739,6 +2034,9 @@ static int home_resize(UserRecord *h, UserRecord **ret) {
 
         if (h->disk_size == UINT64_MAX)
                 return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "No target size specified, refusing.");
+        if (h->thin_pool_uuid)
+                return log_error_errno(SYNTHETIC_ERRNO(EOPNOTSUPP),
+                                       "Thin-provisioned homes have a fixed virtual disk size.");
 
         password_cache_load_keyring(h, &cache);
 
@@ -2018,6 +2316,10 @@ static int run(int argc, char *argv[]) {
         start = now(CLOCK_MONOTONIC);
 
         log_setup();
+
+        /* The worker handles passwords, volume keys, and decrypted identity records. Never write
+         * them to a core dump. */
+        disable_coredumps();
 
         umask(0022);
 

--- a/src/home/homework.h
+++ b/src/home/homework.h
@@ -57,6 +57,12 @@ typedef struct HomeSetup {
         char *mount_suffix;           /* The directory to use as home dir is this path below /run/systemd/user-home-mount */
 
         char *temporary_image_path;
+
+        char *thin_volume_path;
+        char *thin_volume_intent_path;
+        bool undo_thin_volume:1;
+        bool deactivate_thin_volume:1;
+        bool thin_volume_record_saved:1;
 } HomeSetup;
 
 #define HOME_SETUP_INIT                                 \

--- a/src/home/meson.build
+++ b/src/home/meson.build
@@ -14,6 +14,7 @@ systemd_homed_sources = files(
         'homed-operation.c',
         'homed-varlink.c',
         'homed.c',
+        'homework-thin.c',
         'user-record-sign.c',
 )
 systemd_homed_export_sources = files(
@@ -30,10 +31,12 @@ systemd_homework_sources = files(
         'homework-fido2.c',
         'homework-fscrypt.c',
         'homework-luks.c',
+        'homework-luks-token.c',
         'homework-mount.c',
         'homework-password-cache.c',
         'homework-pkcs11.c',
         'homework-quota.c',
+        'homework-thin.c',
 )
 
 homed_gperf_c = custom_target(
@@ -67,7 +70,10 @@ executables += [
                 'dbus' : true,
                 'sources' : systemd_homed_sources,
                 'export' : systemd_homed_export_sources,
-                'dependencies' : libopenssl_cflags,
+                'dependencies' : [
+                        libblkid_cflags,
+                        libopenssl_cflags,
+                ],
         },
         libexec_template + {
                 'name' : 'systemd-homework',
@@ -102,6 +108,17 @@ executables += [
         test_template + {
                 'sources' : files('test-homed-regression-31896.c'),
                 'type' : 'manual',
+        },
+        test_template + {
+                'sources' : files('test-home-util.c'),
+                'import' : ['systemd-homed'],
+        },
+        test_template + {
+                'sources' : files(
+                        'test-homework-luks-token.c',
+                        'homework-luks-token.c',
+                ),
+                'dependencies' : libopenssl_cflags,
         },
 ]
 

--- a/src/home/test-home-util.c
+++ b/src/home/test-home-util.c
@@ -1,0 +1,134 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include "sd-id128.h"
+#include "sd-json.h"
+
+#include "errno-util.h"
+#include "fileio.h"
+#include "home-util.h"
+#include "id128-util.h"
+#include "path-util.h"
+#include "rm-rf.h"
+#include "tests.h"
+#include "tmpfile-util.h"
+#include "user-record.h"
+#include "user-record-util.h"
+
+TEST(record_commit_pending) {
+        _cleanup_(rm_rf_physical_and_freep) char *d = NULL;
+        _cleanup_free_ char *contents = NULL, *final = NULL, *intent = NULL, *pending = NULL;
+
+        ASSERT_OK(mkdtemp_malloc(NULL, &d));
+        ASSERT_OK_ERRNO(setenv("SYSTEMD_HOME_RECORD_DIR", d, /* overwrite= */ true));
+
+        pending = path_join(d, "alice" HOME_RECORD_PENDING_SUFFIX);
+        intent = path_join(d, "alice" HOME_RECORD_THIN_INTENT_SUFFIX);
+        final = path_join(d, "alice" HOME_RECORD_SUFFIX);
+        ASSERT_NOT_NULL(pending);
+        ASSERT_NOT_NULL(intent);
+        ASSERT_NOT_NULL(final);
+
+        ASSERT_OK(write_string_file(pending, "pending", WRITE_STRING_FILE_CREATE));
+        ASSERT_OK(home_record_commit_pending("alice"));
+        ASSERT_OK_ERRNO(access(final, F_OK));
+        ASSERT_ERROR_ERRNO(access(pending, F_OK), ENOENT);
+
+        ASSERT_OK(read_full_file(final, &contents, /* ret_size= */ NULL));
+        ASSERT_STREQ(contents, "pending\n");
+
+        ASSERT_OK(write_string_file(pending, "new", WRITE_STRING_FILE_CREATE));
+        ASSERT_ERROR(home_record_commit_pending("alice"), EEXIST);
+
+        ASSERT_OK(write_string_file(intent, "intent", WRITE_STRING_FILE_CREATE));
+        ASSERT_EQ(home_record_has_pending("alice"), 1);
+        ASSERT_OK(home_record_cancel_pending("alice"));
+        ASSERT_ERROR_ERRNO(access(pending, F_OK), ENOENT);
+        ASSERT_ERROR_ERRNO(access(intent, F_OK), ENOENT);
+        ASSERT_EQ(home_record_has_pending("alice"), 0);
+
+        contents = mfree(contents);
+        ASSERT_OK(read_full_file(final, &contents, /* ret_size= */ NULL));
+        ASSERT_STREQ(contents, "pending\n");
+}
+
+TEST(incomplete_thin_binding) {
+        _cleanup_(user_record_unrefp) UserRecord *clone = NULL, *u = NULL;
+        sd_id128_t creation_id = SD_ID128_MAKE(51,df,0b,4b,c3,b0,4c,97,80,e2,99,b9,8c,a3,73,b8),
+                loaded_creation_id, mid;
+        int r;
+
+        r = sd_id128_get_machine(&mid);
+        if (ERRNO_IS_NEG_MACHINE_ID_UNSET(r))
+                return (void) log_tests_skipped("/etc/machine-id missing");
+        ASSERT_OK(r);
+
+        ASSERT_OK(user_record_build(
+                        &u,
+                        SD_JSON_BUILD_OBJECT(
+                                        SD_JSON_BUILD_PAIR_STRING("disposition", "regular"),
+                                        SD_JSON_BUILD_PAIR_STRING("userName", "alice"),
+                                        SD_JSON_BUILD_PAIR_OBJECT(
+                                                        "binding",
+                                                        SD_JSON_BUILD_PAIR_OBJECT(
+                                                                        SD_ID128_TO_STRING(mid),
+                                                                        SD_JSON_BUILD_PAIR_STRING("storage", "luks"),
+                                                                        SD_JSON_BUILD_PAIR_STRING("luksKeyType", "hw-wrapped"),
+                                                                        SD_JSON_BUILD_PAIR_STRING(
+                                                                                        "imagePath",
+                                                                                        "/dev/homes/homed-alice"))))));
+
+        ASSERT_OK(user_record_add_thin_pool_binding(u, "HOMED-POOL-test", 42));
+        ASSERT_STREQ(u->thin_pool_uuid, "HOMED-POOL-test");
+        ASSERT_EQ(u->thin_device_id, 42U);
+        ASSERT_STREQ(u->luks_key_type, "hw-wrapped");
+        ASSERT_NULL(u->luks_integrity);
+
+        ASSERT_OK(user_record_set_thin_volume_creation_id(u, creation_id));
+        ASSERT_OK(user_record_get_thin_volume_creation_id(u, &loaded_creation_id));
+        ASSERT_EQ_ID128(loaded_creation_id, creation_id);
+
+        ASSERT_OK(user_record_clone(u, USER_RECORD_LOAD_MASK_SECRET|USER_RECORD_PERMISSIVE, &clone));
+        ASSERT_STREQ(clone->thin_pool_uuid, "HOMED-POOL-test");
+        ASSERT_EQ(clone->thin_device_id, 42U);
+        ASSERT_STREQ(clone->luks_key_type, "hw-wrapped");
+        ASSERT_NULL(clone->luks_integrity);
+        ASSERT_OK(user_record_get_thin_volume_creation_id(clone, &loaded_creation_id));
+        ASSERT_EQ_ID128(loaded_creation_id, creation_id);
+}
+
+TEST(protected_thin_binding) {
+        _cleanup_(user_record_unrefp) UserRecord *clone = NULL, *u = NULL;
+        sd_id128_t mid;
+        int r;
+
+        r = sd_id128_get_machine(&mid);
+        if (ERRNO_IS_NEG_MACHINE_ID_UNSET(r))
+                return (void) log_tests_skipped("/etc/machine-id missing");
+        ASSERT_OK(r);
+
+        ASSERT_OK(user_record_build(
+                        &u,
+                        SD_JSON_BUILD_OBJECT(
+                                        SD_JSON_BUILD_PAIR_STRING("disposition", "regular"),
+                                        SD_JSON_BUILD_PAIR_STRING("userName", "alice"),
+                                        SD_JSON_BUILD_PAIR_OBJECT(
+                                                        "binding",
+                                                        SD_JSON_BUILD_PAIR_OBJECT(
+                                                                        SD_ID128_TO_STRING(mid),
+                                                                        SD_JSON_BUILD_PAIR_STRING("storage", "luks"),
+                                                                        SD_JSON_BUILD_PAIR_STRING("luksKeyType", "hw-wrapped"),
+                                                                        SD_JSON_BUILD_PAIR_STRING(
+                                                                                        "imagePath",
+                                                                                        "/dev/homes/homed-alice"))))));
+
+        ASSERT_OK(user_record_set_luks_integrity_binding(u, "hmac(sha256)"));
+        ASSERT_STREQ(u->luks_integrity, "hmac(sha256)");
+
+        ASSERT_OK(user_record_clone(u, USER_RECORD_LOAD_MASK_SECRET|USER_RECORD_PERMISSIVE, &clone));
+        ASSERT_STREQ(clone->luks_integrity, "hmac(sha256)");
+
+        ASSERT_OK(user_record_set_luks_integrity_binding(clone, NULL));
+        ASSERT_NULL(clone->luks_integrity);
+}
+
+DEFINE_TEST_MAIN(LOG_INFO);

--- a/src/home/test-homework-luks-token.c
+++ b/src/home/test-homework-luks-token.c
@@ -1,0 +1,189 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include "sd-json.h"
+
+#include "alloc-util.h"
+#include "crypto-util.h"
+#include "homework-luks-token.h"
+#include "memory-util.h"
+#include "strv.h"
+#include "tests.h"
+
+static const uint8_t test_secret[HOME_LUKS_TOKEN_V2_KEY_SIZE] = {
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+        0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+        0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+        0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
+};
+static const uint8_t test_iv[HOME_LUKS_TOKEN_V2_IV_SIZE] = {
+        0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5,
+        0xa6, 0xa7, 0xa8, 0xa9, 0xaa, 0xab,
+};
+static const char test_uuid[] = "01234567-89ab-cdef-0123-456789abcdef";
+static const char test_plaintext[] = "{\"userName\":\"alice\",\"uid\":1000}";
+
+static sd_json_variant* parse_token(const char *text);
+
+TEST(legacy_roundtrip) {
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *token = NULL;
+        _cleanup_free_ char *text = NULL;
+        _cleanup_(erase_and_freep) void *plaintext = NULL;
+        uint8_t iv[16], volume_key[64];
+        const EVP_CIPHER *cipher;
+        size_t plaintext_size = 0;
+
+        for (size_t i = 0; i < sizeof(volume_key); i++)
+                volume_key[i] = (uint8_t) i;
+        for (size_t i = 0; i < sizeof(iv); i++)
+                iv[i] = (uint8_t) (0x80U + i);
+
+        ASSERT_OK(dlopen_libcrypto(LOG_DEBUG));
+        ASSERT_NOT_NULL(cipher = sym_EVP_get_cipherbyname("aes-256-xts"));
+        ASSERT_OK(home_luks_token_encrypt_legacy(
+                          test_plaintext,
+                          strlen(test_plaintext),
+                          cipher,
+                          volume_key,
+                          sizeof(volume_key),
+                          iv,
+                          sizeof(iv),
+                          &text));
+
+        token = parse_token(text);
+        ASSERT_NULL(sd_json_variant_by_key(token, "version"));
+        ASSERT_NOT_NULL(sd_json_variant_by_key(token, "record"));
+        ASSERT_NOT_NULL(sd_json_variant_by_key(token, "iv"));
+
+        ASSERT_OK(home_luks_token_decrypt_legacy(
+                          token,
+                          cipher,
+                          volume_key,
+                          sizeof(volume_key),
+                          &plaintext,
+                          &plaintext_size));
+        ASSERT_EQ(plaintext_size, strlen(test_plaintext));
+        ASSERT_EQ(memcmp(plaintext, test_plaintext, plaintext_size), 0);
+
+        ASSERT_OK(sd_json_variant_set_field_unsigned(&token, "version", 2));
+        plaintext = erase_and_free(plaintext);
+        ASSERT_ERROR(home_luks_token_decrypt_legacy(
+                             token,
+                             cipher,
+                             volume_key,
+                             sizeof(volume_key),
+                             &plaintext,
+                             &plaintext_size), EINVAL);
+}
+
+static sd_json_variant* parse_token(const char *text) {
+        sd_json_variant *token = NULL;
+
+        ASSERT_OK(sd_json_parse(text, SD_JSON_PARSE_MUST_BE_OBJECT|SD_JSON_PARSE_SENSITIVE,
+                                &token, NULL, NULL));
+        return token;
+}
+
+static void assert_decrypts(sd_json_variant *token) {
+        _cleanup_(erase_and_freep) void *plaintext = NULL;
+        size_t plaintext_size = 0;
+
+        ASSERT_OK(home_luks_token_decrypt_v2(
+                          token,
+                          test_secret,
+                          sizeof(test_secret),
+                          test_uuid,
+                          &plaintext,
+                          &plaintext_size));
+        ASSERT_EQ(plaintext_size, strlen(test_plaintext));
+        ASSERT_EQ(memcmp(plaintext, test_plaintext, plaintext_size), 0);
+}
+
+static void corrupt_binary_field(sd_json_variant **token, const char *name, bool truncate) {
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *encoded = NULL;
+        _cleanup_free_ void *data = NULL;
+        size_t size;
+
+        ASSERT_OK(sd_json_variant_unbase64(sd_json_variant_by_key(*token, name), &data, &size));
+        ASSERT_GT(size, 1U);
+        if (truncate)
+                size--;
+        else
+                ((uint8_t*) data)[0] ^= 1U;
+
+        ASSERT_OK(sd_json_variant_new_base64(&encoded, data, size));
+        ASSERT_OK(sd_json_variant_set_field(token, name, encoded));
+}
+
+TEST(v2_roundtrip_and_fail_closed) {
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *token = NULL;
+        _cleanup_free_ char *text = NULL, *text_again = NULL;
+        _cleanup_(erase_and_freep) void *plaintext = NULL;
+        uint8_t wrong_secret[sizeof(test_secret)];
+        size_t plaintext_size = 0;
+
+        ASSERT_OK(home_luks_token_encrypt_v2(
+                          test_plaintext,
+                          strlen(test_plaintext),
+                          test_secret,
+                          sizeof(test_secret),
+                          test_uuid,
+                          test_iv,
+                          &text));
+        ASSERT_OK(home_luks_token_encrypt_v2(
+                          test_plaintext,
+                          strlen(test_plaintext),
+                          test_secret,
+                          sizeof(test_secret),
+                          test_uuid,
+                          test_iv,
+                          &text_again));
+        ASSERT_STREQ(text, text_again);
+
+        token = parse_token(text);
+        ASSERT_EQ(sd_json_variant_unsigned(sd_json_variant_by_key(token, "version")), 2U);
+        ASSERT_STREQ(sd_json_variant_string(sd_json_variant_by_key(token, "cipher")), "aes-256-gcm");
+        ASSERT_STREQ(sd_json_variant_string(sd_json_variant_by_key(token, "kdf")), "hkdf-sha256");
+        assert_decrypts(token);
+
+        memcpy(wrong_secret, test_secret, sizeof(wrong_secret));
+        wrong_secret[0] ^= 1U;
+        ASSERT_ERROR(home_luks_token_decrypt_v2(
+                             token, wrong_secret, sizeof(wrong_secret), test_uuid,
+                             &plaintext, &plaintext_size), EBADMSG);
+        ASSERT_ERROR(home_luks_token_decrypt_v2(
+                             token, test_secret, sizeof(test_secret),
+                             "fedcba98-7654-3210-fedc-ba9876543210",
+                             &plaintext, &plaintext_size), EBADMSG);
+
+        token = sd_json_variant_unref(token);
+        token = parse_token(text);
+        ASSERT_OK(sd_json_variant_set_field_string(&token, "cipher", "aes-128-gcm"));
+        ASSERT_ERROR(home_luks_token_decrypt_v2(
+                             token, test_secret, sizeof(test_secret), test_uuid,
+                             &plaintext, &plaintext_size), EINVAL);
+
+        token = sd_json_variant_unref(token);
+        token = parse_token(text);
+        ASSERT_OK(sd_json_variant_set_field_unsigned(&token, "version", 3));
+        ASSERT_ERROR(home_luks_token_decrypt_v2(
+                             token, test_secret, sizeof(test_secret), test_uuid,
+                             &plaintext, &plaintext_size), EINVAL);
+
+        FOREACH_STRING(field, "iv", "tag", "ciphertext") {
+                token = sd_json_variant_unref(token);
+                token = parse_token(text);
+                corrupt_binary_field(&token, field, false);
+                ASSERT_ERROR(home_luks_token_decrypt_v2(
+                                     token, test_secret, sizeof(test_secret), test_uuid,
+                                     &plaintext, &plaintext_size), EBADMSG);
+        }
+
+        token = sd_json_variant_unref(token);
+        token = parse_token(text);
+        corrupt_binary_field(&token, "ciphertext", true);
+        ASSERT_ERROR(home_luks_token_decrypt_v2(
+                             token, test_secret, sizeof(test_secret), test_uuid,
+                             &plaintext, &plaintext_size), EBADMSG);
+}
+
+DEFINE_TEST_MAIN(LOG_INFO);

--- a/src/home/user-record-util.c
+++ b/src/home/user-record-util.c
@@ -9,6 +9,7 @@
 #include "alloc-util.h"
 #include "errno-util.h"
 #include "fd-util.h"
+#include "fileio.h"
 #include "group-record.h"
 #include "hashmap.h"
 #include "home-util.h"
@@ -26,6 +27,29 @@
 #include "user-record.h"
 #include "user-record-util.h"
 #include "user-util.h"
+
+int user_record_save(UserRecord *h, const char *path) {
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *v = NULL;
+        _cleanup_free_ char *text = NULL;
+        int r;
+
+        assert(h);
+        assert(path);
+
+        v = sd_json_variant_ref(h->json);
+        r = sd_json_variant_normalize(&v);
+        if (r < 0)
+                log_debug_errno(r, "User record could not be normalized, ignoring: %m");
+
+        r = sd_json_variant_format(v, SD_JSON_FORMAT_PRETTY|SD_JSON_FORMAT_NEWLINE, &text);
+        if (r < 0)
+                return r;
+
+        return write_string_file(
+                        path,
+                        text,
+                        WRITE_STRING_FILE_ATOMIC|WRITE_STRING_FILE_CREATE|WRITE_STRING_FILE_MODE_0600|WRITE_STRING_FILE_SYNC);
+}
 
 int user_record_synthesize(
                 UserRecord *h,
@@ -289,6 +313,7 @@ int user_record_add_binding(
                 sd_id128_t fs_uuid,
                 const char *luks_cipher,
                 const char *luks_cipher_mode,
+                const char *luks_key_type,
                 uint64_t luks_volume_key_size,
                 const char *file_system_type,
                 const char *home_directory,
@@ -296,7 +321,8 @@ int user_record_add_binding(
                 gid_t gid) {
 
         _cleanup_(sd_json_variant_unrefp) sd_json_variant *new_binding_entry = NULL, *binding = NULL;
-        _cleanup_free_ char *blob = NULL, *ip = NULL, *hd = NULL, *ip_auto = NULL, *lc = NULL, *lcm = NULL, *fst = NULL;
+        _cleanup_free_ char *blob = NULL, *ip = NULL, *hd = NULL, *ip_auto = NULL, *lc = NULL, *lcm = NULL,
+                *lkt = NULL, *fst = NULL;
         sd_id128_t mid;
         int r;
 
@@ -347,6 +373,12 @@ int user_record_add_binding(
                         return -ENOMEM;
         }
 
+        if (luks_key_type) {
+                lkt = strdup(luks_key_type);
+                if (!lkt)
+                        return -ENOMEM;
+        }
+
         r = sd_json_buildo(
                         &new_binding_entry,
                         SD_JSON_BUILD_PAIR_STRING("blobDirectory", blob),
@@ -356,6 +388,7 @@ int user_record_add_binding(
                         SD_JSON_BUILD_PAIR_CONDITION(!sd_id128_is_null(fs_uuid), "fileSystemUuid", SD_JSON_BUILD_STRING(SD_ID128_TO_UUID_STRING(fs_uuid))),
                         SD_JSON_BUILD_PAIR_CONDITION(!!luks_cipher, "luksCipher", SD_JSON_BUILD_STRING(luks_cipher)),
                         SD_JSON_BUILD_PAIR_CONDITION(!!luks_cipher_mode, "luksCipherMode", SD_JSON_BUILD_STRING(luks_cipher_mode)),
+                        SD_JSON_BUILD_PAIR_CONDITION(!!luks_key_type, "luksKeyType", SD_JSON_BUILD_STRING(luks_key_type)),
                         SD_JSON_BUILD_PAIR_CONDITION(luks_volume_key_size != UINT64_MAX, "luksVolumeKeySize", SD_JSON_BUILD_UNSIGNED(luks_volume_key_size)),
                         SD_JSON_BUILD_PAIR_CONDITION(!!file_system_type, "fileSystemType", SD_JSON_BUILD_STRING(file_system_type)),
                         SD_JSON_BUILD_PAIR_CONDITION(!!home_directory, "homeDirectory", SD_JSON_BUILD_STRING(home_directory)),
@@ -411,6 +444,8 @@ int user_record_add_binding(
                 free_and_replace(h->luks_cipher, lc);
         if (lcm)
                 free_and_replace(h->luks_cipher_mode, lcm);
+        if (lkt)
+                free_and_replace(h->luks_key_type, lkt);
         if (luks_volume_key_size != UINT64_MAX)
                 h->luks_volume_key_size = luks_volume_key_size;
 
@@ -426,6 +461,180 @@ int user_record_add_binding(
 
         h->mask |= USER_RECORD_BINDING;
         return 1;
+}
+
+int user_record_add_thin_pool_binding(
+                UserRecord *h,
+                const char *pool_uuid,
+                uint32_t device_id) {
+
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *entry = NULL, *binding = NULL;
+        _cleanup_free_ char *u = NULL;
+        sd_id128_t mid;
+        int r;
+
+        assert(h);
+        assert(pool_uuid);
+        assert(device_id < UINT32_C(1) << 24);
+
+        if (!h->json)
+                return -EUNATCH;
+
+        u = strdup(pool_uuid);
+        if (!u)
+                return -ENOMEM;
+
+        r = sd_id128_get_machine(&mid);
+        if (r < 0)
+                return r;
+
+        binding = sd_json_variant_ref(sd_json_variant_by_key(h->json, "binding"));
+        if (!binding)
+                return -ENXIO;
+
+        entry = sd_json_variant_ref(sd_json_variant_by_key(binding, SD_ID128_TO_STRING(mid)));
+        if (!entry)
+                return -ENXIO;
+
+        r = sd_json_variant_set_field_string(&entry, "thinPoolUuid", pool_uuid);
+        if (r < 0)
+                return r;
+        r = sd_json_variant_set_field_unsigned(&entry, "thinDeviceId", device_id);
+        if (r < 0)
+                return r;
+
+        r = sd_json_variant_set_field(&binding, SD_ID128_TO_STRING(mid), entry);
+        if (r < 0)
+                return r;
+        r = sd_json_variant_set_field(&h->json, "binding", binding);
+        if (r < 0)
+                return r;
+
+        free_and_replace(h->thin_pool_uuid, u);
+        h->thin_device_id = device_id;
+        h->mask |= USER_RECORD_BINDING;
+        return 1;
+}
+
+int user_record_set_luks_integrity_binding(UserRecord *h, const char *integrity) {
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *entry = NULL, *binding = NULL;
+        _cleanup_free_ char *copy = NULL;
+        sd_id128_t mid;
+        int r;
+
+        assert(h);
+
+        if (!h->json)
+                return -EUNATCH;
+
+        if (integrity) {
+                copy = strdup(integrity);
+                if (!copy)
+                        return -ENOMEM;
+        }
+
+        r = sd_id128_get_machine(&mid);
+        if (r < 0)
+                return r;
+
+        binding = sd_json_variant_ref(sd_json_variant_by_key(h->json, "binding"));
+        if (!binding)
+                return -ENXIO;
+
+        entry = sd_json_variant_ref(sd_json_variant_by_key(binding, SD_ID128_TO_STRING(mid)));
+        if (!entry)
+                return -ENXIO;
+
+        if (integrity)
+                r = sd_json_variant_set_field_string(&entry, "luksIntegrity", integrity);
+        else
+                r = sd_json_variant_filter(&entry, STRV_MAKE("luksIntegrity"));
+        if (r < 0)
+                return r;
+
+        r = sd_json_variant_set_field(&binding, SD_ID128_TO_STRING(mid), entry);
+        if (r < 0)
+                return r;
+        r = sd_json_variant_set_field(&h->json, "binding", binding);
+        if (r < 0)
+                return r;
+
+        free_and_replace(h->luks_integrity, copy);
+        h->mask |= USER_RECORD_BINDING;
+        return 1;
+}
+
+int user_record_set_thin_volume_creation_id(UserRecord *h, sd_id128_t creation_id) {
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *binding = NULL, *entry = NULL;
+        sd_id128_t mid;
+        int r;
+
+        assert(h);
+        assert(!sd_id128_is_null(creation_id));
+
+        if (!h->json)
+                return -EUNATCH;
+
+        r = sd_id128_get_machine(&mid);
+        if (r < 0)
+                return r;
+
+        binding = sd_json_variant_ref(sd_json_variant_by_key(h->json, "binding"));
+        if (!binding)
+                return -ENXIO;
+
+        entry = sd_json_variant_ref(sd_json_variant_by_key(binding, SD_ID128_TO_STRING(mid)));
+        if (!entry)
+                return -ENXIO;
+
+        r = sd_json_variant_set_field_id128(&entry, HOMEWORK_THIN_CREATION_ID_FIELD, creation_id);
+        if (r < 0)
+                return r;
+
+        r = sd_json_variant_set_field(&binding, SD_ID128_TO_STRING(mid), entry);
+        if (r < 0)
+                return r;
+        r = sd_json_variant_set_field(&h->json, "binding", binding);
+        if (r < 0)
+                return r;
+
+        h->mask |= USER_RECORD_BINDING;
+        return 1;
+}
+
+int user_record_get_thin_volume_creation_id(UserRecord *h, sd_id128_t *ret_creation_id) {
+        sd_json_variant *binding, *entry, *v;
+        sd_id128_t creation_id, mid;
+        int r;
+
+        assert(h);
+        assert(h->json);
+        assert(ret_creation_id);
+
+        r = sd_id128_get_machine(&mid);
+        if (r < 0)
+                return r;
+
+        binding = sd_json_variant_by_key(h->json, "binding");
+        if (!binding)
+                return -ENXIO;
+
+        entry = sd_json_variant_by_key(binding, SD_ID128_TO_STRING(mid));
+        if (!entry)
+                return -ENXIO;
+
+        v = sd_json_variant_by_key(entry, HOMEWORK_THIN_CREATION_ID_FIELD);
+        if (!v)
+                return -EBADMSG;
+
+        r = sd_json_dispatch_id128(HOMEWORK_THIN_CREATION_ID_FIELD, v, SD_JSON_STRICT, &creation_id);
+        if (r < 0)
+                return r;
+        if (sd_id128_is_null(creation_id))
+                return -EBADMSG;
+
+        *ret_creation_id = creation_id;
+        return 0;
 }
 
 int user_record_test_home_directory(UserRecord *h) {
@@ -1355,7 +1564,8 @@ int user_record_is_supported(UserRecord *hr, sd_bus_error *error) {
                 return sd_bus_error_set(error, SD_BUS_ERROR_INVALID_ARGS, "Cannot manage custom blob directories.");
         }
 
-        if (sd_json_variant_by_key(hr->json, HOMEWORK_BLOB_FDMAP_FIELD))
+        if (sd_json_variant_by_key(hr->json, HOMEWORK_BLOB_FDMAP_FIELD) ||
+            sd_json_variant_by_key(hr->json, HOMEWORK_THIN_CREATION_ID_FIELD))
                 return sd_bus_error_set(error, SD_BUS_ERROR_INVALID_ARGS, "User record contains unsafe internal fields.");
 
         return 0;

--- a/src/home/user-record-util.h
+++ b/src/home/user-record-util.h
@@ -7,6 +7,7 @@
  * reduce the chance of collision with a field any legitimate user record may ever
  * want to set. */
 #define HOMEWORK_BLOB_FDMAP_FIELD "__systemd_homework_internal_blob_fdmap"
+#define HOMEWORK_THIN_CREATION_ID_FIELD "__systemd_homework_internal_thin_creation_id"
 
 int user_record_synthesize(UserRecord *h, const char *user_name, const char *realm, const char *image_path, UserStorage storage, uid_t uid, gid_t gid);
 int group_record_synthesize(GroupRecord *g, UserRecord *h);
@@ -26,7 +27,12 @@ enum { /* return values */
 };
 
 int user_record_reconcile(UserRecord *host, UserRecord *embedded, UserReconcileMode mode, UserRecord **ret);
-int user_record_add_binding(UserRecord *h, UserStorage storage, const char *image_path, sd_id128_t partition_uuid, sd_id128_t luks_uuid, sd_id128_t fs_uuid, const char *luks_cipher, const char *luks_cipher_mode, uint64_t luks_volume_key_size, const char *file_system_type, const char *home_directory, uid_t uid, gid_t gid);
+int user_record_save(UserRecord *h, const char *path);
+int user_record_add_binding(UserRecord *h, UserStorage storage, const char *image_path, sd_id128_t partition_uuid, sd_id128_t luks_uuid, sd_id128_t fs_uuid, const char *luks_cipher, const char *luks_cipher_mode, const char *luks_key_type, uint64_t luks_volume_key_size, const char *file_system_type, const char *home_directory, uid_t uid, gid_t gid);
+int user_record_set_luks_integrity_binding(UserRecord *h, const char *integrity);
+int user_record_add_thin_pool_binding(UserRecord *h, const char *pool_uuid, uint32_t device_id);
+int user_record_set_thin_volume_creation_id(UserRecord *h, sd_id128_t creation_id);
+int user_record_get_thin_volume_creation_id(UserRecord *h, sd_id128_t *ret_creation_id);
 
 /* Results of the two test functions below. */
 enum {

--- a/src/repart/repart.c
+++ b/src/repart/repart.c
@@ -5100,6 +5100,37 @@ static BlockPartition* block_partition_free(BlockPartition *p) {
 
 DEFINE_TRIVIAL_CLEANUP_FUNC(BlockPartition*, block_partition_free);
 
+static int block_partition_matches(int fd, uint64_t offset, uint64_t size) {
+        char sysfs[STRLEN("/sys/dev/block/:/start") + 2*DECIMAL_STR_MAX(dev_t) + 1];
+        _cleanup_free_ char *value = NULL;
+        uint64_t start, device_size;
+        struct stat st;
+        int r;
+
+        assert(fd >= 0);
+
+        if (fstat(fd, &st) < 0)
+                return -errno;
+        if (!S_ISBLK(st.st_mode))
+                return -ENOTBLK;
+
+        xsprintf(sysfs, "/sys/dev/block/" DEVNUM_FORMAT_STR "/start", DEVNUM_FORMAT_VAL(st.st_rdev));
+        r = read_one_line_file(sysfs, &value);
+        if (r < 0)
+                return r;
+        r = safe_atou64(value, &start);
+        if (r < 0)
+                return r;
+        if (start > UINT64_MAX / 512U)
+                return -EOVERFLOW;
+
+        r = blockdev_get_device_size(fd, &device_size);
+        if (r < 0)
+                return r;
+
+        return start * 512U == offset && device_size == size;
+}
+
 typedef struct {
         LoopDevice *loop;
         BlockPartition *block_partition;
@@ -5248,6 +5279,7 @@ static int partition_target_prepare(
                         _cleanup_close_ int dev_fd = -EBADF;
                         _cleanup_free_ char *part_node = NULL;
                         _cleanup_(block_partition_freep) BlockPartition *b = NULL;
+                        bool added = false;
                         int nr;
 
                         /* blkpg takes int for partition numbers */
@@ -5268,27 +5300,48 @@ static int partition_target_prepare(
                                   p->offset, NATURAL_ALIGNMENT(p->offset),
                                   size, NATURAL_ALIGNMENT(size));
                         r = block_device_add_partition(whole_fd, nr, p->offset, size);
-                        if (r < 0)
+                        if (r == -EBUSY)
+                                log_debug_errno(r, "Kernel was quicker than us in adding partition '%s'.", part_node);
+                        else if (r < 0)
                                 return log_error_errno(r, "Failed to create new partition '%s': %m", part_node);
+                        else
+                                added = true;
 
                         context->needs_rescan = true;
 
                         dev_fd = open(part_node, O_RDWR|O_CLOEXEC|O_NOCTTY);
                         if (dev_fd < 0) {
                                 r = -errno;
+                                if (added) {
+                                        int q = block_device_remove_partition(whole_fd, nr);
+                                        if (q < 0)
+                                                log_warning_errno(q, "Error while removing block device partition '%s', ignoring: %m", part_node);
+                                }
+                                return log_error_errno(r, "Failed to open new partition '%s': %m", part_node);
+                        }
+
+                        r = block_partition_matches(dev_fd, p->offset, size);
+                        if (r <= 0 && added) {
                                 int q = block_device_remove_partition(whole_fd, nr);
                                 if (q < 0)
                                         log_warning_errno(q, "Error while removing block device partition '%s', ignoring: %m", part_node);
-                                return log_error_errno(r, "Failed to open new partition '%s': %m", part_node);
                         }
+                        if (r < 0)
+                                return log_error_errno(r, "Failed to verify new partition '%s': %m", part_node);
+                        if (r == 0)
+                                return log_error_errno(SYNTHETIC_ERRNO(ERANGE),
+                                                       "New partition '%s' does not match the requested offset and size.",
+                                                       part_node);
 
                         /* No need to flock for udev, the whole disk fd is already locked. */
 
                         b = new(BlockPartition, 1);
                         if (!b) {
-                                r = block_device_remove_partition(whole_fd, nr);
-                                if (r < 0)
-                                        log_warning_errno(r, "Error while removing block device partition '%s', ignoring: %m", part_node);
+                                if (added) {
+                                        r = block_device_remove_partition(whole_fd, nr);
+                                        if (r < 0)
+                                                log_warning_errno(r, "Error while removing block device partition '%s', ignoring: %m", part_node);
+                                }
 
                                 return log_oom();
                         }

--- a/src/shared/cryptsetup-util.c
+++ b/src/shared/cryptsetup-util.c
@@ -23,6 +23,17 @@ DLSYM_PROTOTYPE(crypt_activate_by_volume_key) = NULL;
 DLSYM_PROTOTYPE(crypt_deactivate) = NULL;
 DLSYM_PROTOTYPE(crypt_deactivate_by_name) = NULL;
 DLSYM_PROTOTYPE(crypt_format) = NULL;
+static int missing_crypt_format_luks2_hw_wrapped(
+                struct crypt_device *cd,
+                const char *cipher,
+                const char *cipher_mode,
+                const char *uuid,
+                const char *wrapped_key,
+                size_t wrapped_key_size,
+                struct crypt_params_luks2 *params) {
+        return -EOPNOTSUPP;
+}
+DLSYM_PROTOTYPE(crypt_format_luks2_hw_wrapped) = missing_crypt_format_luks2_hw_wrapped;
 DLSYM_PROTOTYPE(crypt_free) = NULL;
 DLSYM_PROTOTYPE(crypt_get_cipher) = NULL;
 DLSYM_PROTOTYPE(crypt_get_cipher_mode) = NULL;
@@ -80,6 +91,46 @@ DLSYM_PROTOTYPE(crypt_volume_key_get) = NULL;
 DLSYM_PROTOTYPE(crypt_volume_key_keyring) = NULL;
 DLSYM_PROTOTYPE(crypt_wipe) = NULL;
 DLSYM_PROTOTYPE(crypt_get_integrity_info) = NULL;
+static int missing_crypt_get_hw_encryption_type(struct crypt_device *cd) {
+        return CRYPT_SW_ONLY;
+}
+DLSYM_PROTOTYPE(crypt_get_hw_encryption_type) = missing_crypt_get_hw_encryption_type;
+static int missing_crypt_hw_wrapped_key_generate(
+                struct crypt_device *cd,
+                char **wrapped_key,
+                size_t *wrapped_key_size) {
+        return -EOPNOTSUPP;
+}
+DLSYM_PROTOTYPE(crypt_hw_wrapped_key_generate) = missing_crypt_hw_wrapped_key_generate;
+static int missing_crypt_hw_wrapped_key_derive_secret(
+                struct crypt_device *cd,
+                const char *wrapped_key,
+                size_t wrapped_key_size,
+                char **secret,
+                size_t *secret_size) {
+        return -EOPNOTSUPP;
+}
+DLSYM_PROTOTYPE(crypt_hw_wrapped_key_derive_secret) = missing_crypt_hw_wrapped_key_derive_secret;
+DLSYM_PROTOTYPE(crypt_safe_free) = NULL;
+
+unsigned cryptsetup_hw_wrapped_key_capabilities(void) {
+        unsigned capabilities = 0;
+
+        if (sym_crypt_format_luks2_hw_wrapped != missing_crypt_format_luks2_hw_wrapped)
+                capabilities |= CRYPTSETUP_HW_WRAPPED_FORMAT;
+        if (sym_crypt_get_hw_encryption_type != missing_crypt_get_hw_encryption_type)
+                capabilities |= CRYPTSETUP_HW_ENCRYPTION_TYPE;
+        if (sym_crypt_hw_wrapped_key_generate != missing_crypt_hw_wrapped_key_generate)
+                capabilities |= CRYPTSETUP_HW_WRAPPED_GENERATE;
+        if (sym_crypt_hw_wrapped_key_derive_secret != missing_crypt_hw_wrapped_key_derive_secret)
+                capabilities |= CRYPTSETUP_HW_WRAPPED_DERIVE_SECRET;
+
+        return capabilities;
+}
+
+bool cryptsetup_has_hw_wrapped_key_support(void) {
+        return cryptsetup_hw_wrapped_key_capabilities() == _CRYPTSETUP_HW_WRAPPED_ALL;
+}
 
 static void cryptsetup_log_glue(int level, const char *msg, void *usrptr) {
 
@@ -319,6 +370,7 @@ int dlopen_cryptsetup(int log_level) {
                         DLSYM_ARG(crypt_reencrypt_run),
                         DLSYM_ARG(crypt_resize),
                         DLSYM_ARG(crypt_resume_by_volume_key),
+                        DLSYM_ARG(crypt_safe_free),
                         DLSYM_ARG(crypt_set_data_device),
                         DLSYM_ARG(crypt_set_data_offset),
                         DLSYM_ARG(crypt_set_debug_level),
@@ -344,6 +396,10 @@ int dlopen_cryptsetup(int log_level) {
          * symbol unconditionally. */
         DLSYM_OPTIONAL(cryptsetup_dl, crypt_set_keyring_to_link);
         DLSYM_OPTIONAL(cryptsetup_dl, crypt_token_set_external_path);
+        DLSYM_OPTIONAL(cryptsetup_dl, crypt_format_luks2_hw_wrapped);
+        DLSYM_OPTIONAL(cryptsetup_dl, crypt_get_hw_encryption_type);
+        DLSYM_OPTIONAL(cryptsetup_dl, crypt_hw_wrapped_key_generate);
+        DLSYM_OPTIONAL(cryptsetup_dl, crypt_hw_wrapped_key_derive_secret);
 
         /* Redirect the default logging calls of libcryptsetup to our own logging infra. (Note that
          * libcryptsetup also maintains per-"struct crypt_device" log functions, which we'll also set

--- a/src/shared/cryptsetup-util.h
+++ b/src/shared/cryptsetup-util.h
@@ -22,8 +22,32 @@ extern int crypt_set_keyring_to_link(struct crypt_device *cd,
                                      const char *key_type_desc,
                                      const char *keyring_to_link_vk);
 extern int crypt_token_set_external_path(const char *path);
+extern int crypt_format_luks2_hw_wrapped(struct crypt_device *cd,
+                                         const char *cipher,
+                                         const char *cipher_mode,
+                                         const char *uuid,
+                                         const char *wrapped_key,
+                                         size_t wrapped_key_size,
+                                         struct crypt_params_luks2 *params);
+extern int crypt_get_hw_encryption_type(struct crypt_device *cd);
+extern int crypt_hw_wrapped_key_generate(struct crypt_device *cd,
+                                         char **wrapped_key,
+                                         size_t *wrapped_key_size);
+extern int crypt_hw_wrapped_key_derive_secret(struct crypt_device *cd,
+                                              const char *wrapped_key,
+                                              size_t wrapped_key_size,
+                                              char **secret,
+                                              size_t *secret_size);
 /* NOLINTEND(readability-redundant-declaration) */
 REENABLE_WARNING;
+
+#ifndef CRYPT_INLINE_HW_WRAPPED
+#define CRYPT_INLINE_HW_WRAPPED INT16_C(3)
+#endif
+
+#ifndef CRYPT_HW_WRAPPED_KEY_SW_SECRET_SIZE
+#define CRYPT_HW_WRAPPED_KEY_SW_SECRET_SIZE 32U
+#endif
 
 extern DLSYM_PROTOTYPE(crypt_activate_by_passphrase);
 extern DLSYM_PROTOTYPE(crypt_activate_by_signed_key);
@@ -32,6 +56,7 @@ extern DLSYM_PROTOTYPE(crypt_activate_by_volume_key);
 extern DLSYM_PROTOTYPE(crypt_deactivate);
 extern DLSYM_PROTOTYPE(crypt_deactivate_by_name);
 extern DLSYM_PROTOTYPE(crypt_format);
+extern DLSYM_PROTOTYPE(crypt_format_luks2_hw_wrapped);
 extern DLSYM_PROTOTYPE(crypt_free);
 extern DLSYM_PROTOTYPE(crypt_get_cipher);
 extern DLSYM_PROTOTYPE(crypt_get_cipher_mode);
@@ -78,10 +103,15 @@ extern DLSYM_PROTOTYPE(crypt_volume_key_get);
 extern DLSYM_PROTOTYPE(crypt_volume_key_keyring);
 extern DLSYM_PROTOTYPE(crypt_wipe);
 extern DLSYM_PROTOTYPE(crypt_get_integrity_info);
+extern DLSYM_PROTOTYPE(crypt_get_hw_encryption_type);
+extern DLSYM_PROTOTYPE(crypt_hw_wrapped_key_generate);
+extern DLSYM_PROTOTYPE(crypt_hw_wrapped_key_derive_secret);
+extern DLSYM_PROTOTYPE(crypt_safe_free);
 
 /* Be careful, these work with dlopen_cryptsetup(), that is, they call sym_crypt_free() instead of
  * crypt_free() and hence depend on dlopen_cryptsetup() having been called. */
 DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_RENAME(struct crypt_device *, sym_crypt_free, crypt_freep, NULL);
+DEFINE_TRIVIAL_CLEANUP_FUNC_FULL_RENAME(void *, sym_crypt_safe_free, crypt_safe_freep, NULL);
 #define crypt_free_and_replace(a, b)                    \
         free_and_replace_full(a, b, sym_crypt_free)
 
@@ -100,6 +130,17 @@ int cryptsetup_get_volume_key_id(struct crypt_device *cd, const char *volume_nam
 #endif
 
 int dlopen_cryptsetup(int log_level) _dlopen_loader_;
+
+typedef enum CryptsetupHwWrappedKeyCapability {
+        CRYPTSETUP_HW_WRAPPED_FORMAT        = 1U << 0,
+        CRYPTSETUP_HW_ENCRYPTION_TYPE       = 1U << 1,
+        CRYPTSETUP_HW_WRAPPED_GENERATE      = 1U << 2,
+        CRYPTSETUP_HW_WRAPPED_DERIVE_SECRET = 1U << 3,
+        _CRYPTSETUP_HW_WRAPPED_ALL          = (1U << 4) - 1,
+} CryptsetupHwWrappedKeyCapability;
+
+unsigned cryptsetup_hw_wrapped_key_capabilities(void);
+bool cryptsetup_has_hw_wrapped_key_support(void);
 
 int cryptsetup_get_keyslot_from_token(sd_json_variant *v);
 

--- a/src/shared/dm-util.c
+++ b/src/shared/dm-util.c
@@ -1,12 +1,318 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
 #include <fcntl.h>
+#include <inttypes.h>
 #include <linux/dm-ioctl.h>
 #include <sys/ioctl.h>
+#include <sys/sysmacros.h>
 
+#include "alloc-util.h"
 #include "dm-util.h"
+#include "errno-util.h"
 #include "fd-util.h"
+#include "memory-util.h"
+#include "stat-util.h"
 #include "string-util.h"
+
+/* The upper half of dm_ioctl.event_nr carries udev flags. Keep this in sync with
+ * DM_UDEV_PRIMARY_SOURCE_FLAG and DM_UDEV_FLAGS_SHIFT from libdevmapper.h. We use the raw kernel API
+ * here, hence libdevmapper cannot add the flag for us. */
+#define DM_UDEV_PRIMARY_SOURCE_EVENT UINT32_C(0x00400000)
+
+static int dm_ioctl_run(int fd, unsigned long request, struct dm_ioctl *dm, size_t size) {
+        assert(fd >= 0);
+        assert(dm);
+        assert(size >= sizeof(*dm));
+        assert(size <= UINT32_MAX);
+
+        dm->version[0] = DM_VERSION_MAJOR;
+        dm->version[1] = DM_VERSION_MINOR;
+        dm->version[2] = DM_VERSION_PATCHLEVEL;
+        dm->data_size = size;
+
+        return RET_NERRNO(ioctl(fd, request, dm));
+}
+
+static int dm_remove_device_fd(int fd, const char *name) {
+        struct dm_ioctl dm = {
+                .event_nr = DM_UDEV_PRIMARY_SOURCE_EVENT,
+        };
+        int r;
+
+        assert(fd >= 0);
+        assert(name);
+
+        if (strlen(name) >= sizeof(dm.name))
+                return -ENAMETOOLONG;
+
+        strncpy_exact(dm.name, name, sizeof(dm.name));
+
+        r = dm_ioctl_run(fd, DM_DEV_REMOVE, &dm, sizeof(dm));
+        if (r == -ENXIO)
+                return 0;
+
+        return r;
+}
+
+void dm_target_info_done(DmTargetInfo *info) {
+        if (!info)
+                return;
+
+        free(info->parameters);
+}
+
+int dm_device_info(dev_t devnum, DmDeviceInfo *ret) {
+        _cleanup_close_ int fd = -EBADF;
+        struct dm_ioctl dm = {
+                .dev = devnum,
+        };
+        int r;
+
+        assert(major(devnum) > 0);
+        assert(ret);
+
+        fd = open("/dev/mapper/control", O_RDWR|O_CLOEXEC);
+        if (fd < 0)
+                return -errno;
+
+        r = dm_ioctl_run(fd, DM_DEV_STATUS, &dm, sizeof(dm));
+        if (r < 0)
+                return r;
+
+        *ret = (DmDeviceInfo) {
+                .devnum = dm.dev,
+                .flags = dm.flags,
+                .target_count = dm.target_count,
+        };
+        strncpy_exact(ret->name, dm.name, sizeof(ret->name));
+        strncpy_exact(ret->uuid, dm.uuid, sizeof(ret->uuid));
+        return 0;
+}
+
+int dm_device_info_from_path(const char *path, DmDeviceInfo *ret) {
+        struct stat st;
+
+        assert(path);
+        assert(ret);
+
+        if (stat(path, &st) < 0)
+                return -errno;
+        if (!S_ISBLK(st.st_mode))
+                return -ENOTBLK;
+
+        return dm_device_info(st.st_rdev, ret);
+}
+
+int dm_device_query_target(const char *name, bool table, DmTargetInfo *ret) {
+        _cleanup_close_ int fd = -EBADF;
+        _cleanup_free_ struct dm_ioctl *dm = NULL;
+        size_t size = 16U * 1024U;
+        int r;
+
+        assert(name);
+        assert(ret);
+
+        if (strlen(name) >= DM_NAME_LEN)
+                return -ENAMETOOLONG;
+
+        fd = open("/dev/mapper/control", O_RDWR|O_CLOEXEC);
+        if (fd < 0)
+                return -errno;
+
+        for (;;) {
+                dm = malloc0(size);
+                if (!dm)
+                        return -ENOMEM;
+
+                dm->data_start = ALIGN8(sizeof(*dm));
+                strncpy_exact(dm->name, name, sizeof(dm->name));
+
+                if (table)
+                        dm->flags |= DM_STATUS_TABLE_FLAG;
+
+                r = dm_ioctl_run(fd, DM_TABLE_STATUS, dm, size);
+                if (r < 0)
+                        return r;
+                if (!FLAGS_SET(dm->flags, DM_BUFFER_FULL_FLAG))
+                        break;
+                if (size > UINT32_MAX / 2U)
+                        return -E2BIG;
+
+                dm = mfree(dm);
+                size *= 2U;
+        }
+
+        if (dm->target_count != 1)
+                return -ENOTUNIQ;
+        if (dm->data_size > size || dm->data_start > dm->data_size ||
+            dm->data_size - dm->data_start < sizeof(struct dm_target_spec))
+                return -EBADMSG;
+
+        struct dm_target_spec *spec = CAST_ALIGN_PTR(struct dm_target_spec, (uint8_t*) dm + dm->data_start);
+        /* For DM_TABLE_STATUS, data_size ends immediately after the final parameter string's NUL,
+         * while next is rounded up to the alignment of the hypothetical next target. Thus, next can
+         * legitimately point past data_size for the final target. Since we require exactly one target,
+         * use the returned data size to delimit its parameters and only verify that next stays within
+         * the allocation. */
+        size_t record_size = dm->data_size - dm->data_start;
+        if (record_size < sizeof(*spec) + 1U ||
+            (spec->next != 0 && (spec->next < record_size || spec->next > size - dm->data_start)))
+                return -EBADMSG;
+
+        const char *p = (char*) spec + sizeof(*spec);
+        size_t n = record_size - sizeof(*spec);
+        if (!memchr(p, 0, n))
+                return -EBADMSG;
+
+        char *parameters = strdup(p);
+        if (!parameters)
+                return -ENOMEM;
+
+        *ret = (DmTargetInfo) {
+                .start = spec->sector_start,
+                .length = spec->length,
+                .parameters = parameters,
+        };
+        strncpy_exact(ret->type, spec->target_type, sizeof(ret->type));
+        return 0;
+}
+
+int dm_create_device(
+                const char *name,
+                const char *uuid,
+                uint64_t start,
+                uint64_t length,
+                const char *target_type,
+                const char *parameters) {
+
+        _cleanup_close_ int fd = -EBADF;
+        _cleanup_free_ struct dm_ioctl *table = NULL;
+        size_t parameters_size, table_size, target_size;
+        struct dm_target_spec *target;
+        struct dm_ioctl create = {};
+        int r;
+
+        assert(name);
+        assert(uuid);
+        assert(length > 0);
+        assert(target_type);
+        assert(parameters);
+
+        if (strlen(name) >= sizeof(create.name) || strlen(uuid) >= sizeof(create.uuid) ||
+            strlen(target_type) >= DM_MAX_TYPE_NAME)
+                return -ENAMETOOLONG;
+
+        fd = open("/dev/mapper/control", O_RDWR|O_CLOEXEC);
+        if (fd < 0)
+                return -errno;
+
+        strncpy_exact(create.name, name, sizeof(create.name));
+        strncpy_exact(create.uuid, uuid, sizeof(create.uuid));
+        r = dm_ioctl_run(fd, DM_DEV_CREATE, &create, sizeof(create));
+        if (r < 0)
+                return r;
+
+        parameters_size = strlen(parameters);
+        target_size = sizeof(struct dm_target_spec);
+        table_size = ALIGN8(sizeof(struct dm_ioctl));
+        if (!ADD_SAFE(&parameters_size, parameters_size, 1U) ||
+            !ADD_SAFE(&target_size, target_size, parameters_size)) {
+                r = -EOVERFLOW;
+                goto fail;
+        }
+        target_size = ALIGN8(target_size);
+        if (target_size == SIZE_MAX || !ADD_SAFE(&table_size, table_size, target_size) ||
+            table_size > UINT32_MAX) {
+                r = -EOVERFLOW;
+                goto fail;
+        }
+
+        table = malloc0(table_size);
+        if (!table) {
+                r = -ENOMEM;
+                goto fail;
+        }
+        table->data_start = ALIGN8(sizeof(*table));
+        table->target_count = 1;
+        strncpy_exact(table->name, name, sizeof(table->name));
+
+        target = CAST_ALIGN_PTR(struct dm_target_spec, (uint8_t*) table + table->data_start);
+        *target = (struct dm_target_spec) {
+                .sector_start = start,
+                .length = length,
+                .next = target_size,
+        };
+        strncpy_exact(target->target_type, target_type, sizeof(target->target_type));
+        memcpy((uint8_t*) target + sizeof(*target), parameters, parameters_size);
+
+        r = dm_ioctl_run(fd, DM_TABLE_LOAD, table, table_size);
+        if (r < 0)
+                goto fail;
+
+        r = dm_suspend_device(name, false);
+        if (r < 0)
+                goto fail;
+
+        return 0;
+
+fail:
+        (void) dm_remove_device_fd(fd, name);
+        return r;
+}
+
+int dm_suspend_device(const char *name, bool suspend) {
+        _cleanup_close_ int fd = -EBADF;
+        struct dm_ioctl dm = {
+                .event_nr = DM_UDEV_PRIMARY_SOURCE_EVENT,
+                .flags = suspend ? DM_SUSPEND_FLAG : 0,
+        };
+
+        assert(name);
+
+        if (strlen(name) >= sizeof(dm.name))
+                return -ENAMETOOLONG;
+        strncpy_exact(dm.name, name, sizeof(dm.name));
+
+        fd = open("/dev/mapper/control", O_RDWR|O_CLOEXEC);
+        if (fd < 0)
+                return -errno;
+
+        return dm_ioctl_run(fd, DM_DEV_SUSPEND, &dm, sizeof(dm));
+}
+
+int dm_target_message(const char *name, uint64_t sector, const char *message) {
+        _cleanup_close_ int fd = -EBADF;
+        _cleanup_free_ struct dm_ioctl *dm = NULL;
+        struct dm_target_msg *msg;
+        size_t size;
+
+        assert(name);
+        assert(message);
+
+        if (strlen(name) >= DM_NAME_LEN)
+                return -ENAMETOOLONG;
+
+        size = ALIGN8(sizeof(struct dm_ioctl));
+        if (!ADD_SAFE(&size, size, offsetof(struct dm_target_msg, message)) ||
+            !ADD_SAFE(&size, size, strlen(message)) ||
+            !ADD_SAFE(&size, size, 1U) || size > UINT32_MAX)
+                return -E2BIG;
+
+        dm = malloc0(size);
+        if (!dm)
+                return -ENOMEM;
+        dm->data_start = ALIGN8(sizeof(*dm));
+        strncpy_exact(dm->name, name, sizeof(dm->name));
+        msg = CAST_ALIGN_PTR(struct dm_target_msg, (uint8_t*) dm + dm->data_start);
+        msg->sector = sector;
+        strcpy(msg->message, message);
+
+        fd = open("/dev/mapper/control", O_RDWR|O_CLOEXEC);
+        if (fd < 0)
+                return -errno;
+
+        return dm_ioctl_run(fd, DM_TARGET_MSG, dm, size);
+}
 
 int dm_deferred_remove_cancel(const char *name) {
         _cleanup_close_ int fd = -EBADF;
@@ -50,4 +356,116 @@ int dm_deferred_remove_cancel(const char *name) {
                 return -errno;
 
         return 0;
+}
+
+int dm_create_linear(
+                const char *name,
+                const char *uuid,
+                dev_t devnum,
+                uint64_t offset,
+                uint64_t size) {
+
+        _cleanup_close_ int fd = -EBADF;
+        _cleanup_free_ struct dm_ioctl *table = NULL;
+        _cleanup_free_ char *params = NULL;
+        size_t params_size, table_size, target_size;
+        struct dm_target_spec *target;
+        struct dm_ioctl create = {};
+        int r;
+
+        assert(name);
+        assert(uuid);
+        assert(major(devnum) > 0);
+        assert(offset % 512U == 0);
+        assert(size > 0 && size % 512U == 0);
+
+        if (strlen(name) >= sizeof(create.name) || strlen(uuid) >= sizeof(create.uuid))
+                return -ENAMETOOLONG;
+
+        fd = open("/dev/mapper/control", O_RDWR|O_CLOEXEC);
+        if (fd < 0)
+                return -errno;
+
+        strncpy_exact(create.name, name, sizeof(create.name));
+        strncpy_exact(create.uuid, uuid, sizeof(create.uuid));
+
+        r = dm_ioctl_run(fd, DM_DEV_CREATE, &create, sizeof(create));
+        if (r < 0)
+                return r;
+
+        if (asprintf(&params,
+                     "%u:%u %" PRIu64,
+                     major(devnum),
+                     minor(devnum),
+                     offset / 512U) < 0) {
+                r = -ENOMEM;
+                goto fail;
+        }
+
+        params_size = strlen(params) + 1;
+        target_size = sizeof(struct dm_target_spec);
+        if (!ADD_SAFE(&target_size, target_size, params_size)) {
+                r = -EOVERFLOW;
+                goto fail;
+        }
+        target_size = ALIGN8(target_size);
+
+        table_size = ALIGN8(sizeof(struct dm_ioctl));
+        if (target_size == SIZE_MAX ||
+            !ADD_SAFE(&table_size, table_size, target_size) ||
+            table_size > UINT32_MAX) {
+                r = -EOVERFLOW;
+                goto fail;
+        }
+
+        table = malloc0(table_size);
+        if (!table) {
+                r = -ENOMEM;
+                goto fail;
+        }
+
+        *table = (struct dm_ioctl) {
+                .data_start = ALIGN8(sizeof(struct dm_ioctl)),
+                .target_count = 1,
+        };
+        strncpy_exact(table->name, name, sizeof(table->name));
+
+        target = CAST_ALIGN_PTR(struct dm_target_spec, (uint8_t*) table + table->data_start);
+        *target = (struct dm_target_spec) {
+                .length = size / 512U,
+                .next = target_size,
+        };
+        strncpy_exact(target->target_type, "linear", sizeof(target->target_type));
+        memcpy((uint8_t*) target + sizeof(*target), params, params_size);
+
+        r = dm_ioctl_run(fd, DM_TABLE_LOAD, table, table_size);
+        if (r < 0)
+                goto fail;
+
+        struct dm_ioctl resume = {
+                .event_nr = DM_UDEV_PRIMARY_SOURCE_EVENT,
+        };
+        strncpy_exact(resume.name, name, sizeof(resume.name));
+
+        r = dm_ioctl_run(fd, DM_DEV_SUSPEND, &resume, sizeof(resume));
+        if (r < 0)
+                goto fail;
+
+        return 0;
+
+fail:
+        (void) dm_remove_device_fd(fd, name);
+        return r;
+}
+
+int dm_remove_device(const char *name) {
+        _cleanup_close_ int fd = -EBADF;
+
+        assert(name);
+
+        fd = open("/dev/mapper/control", O_RDWR|O_CLOEXEC);
+        if (fd < 0)
+                return -errno;
+
+        return dm_remove_device_fd(fd, name);
 }

--- a/src/shared/dm-util.h
+++ b/src/shared/dm-util.h
@@ -1,4 +1,46 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 #pragma once
 
+#include <linux/dm-ioctl.h>
+
+#include "forward.h"
+
+typedef struct DmDeviceInfo {
+        char name[DM_NAME_LEN];
+        char uuid[DM_UUID_LEN];
+        dev_t devnum;
+        uint32_t flags;
+        uint32_t target_count;
+} DmDeviceInfo;
+
+typedef struct DmTargetInfo {
+        uint64_t start;
+        uint64_t length;
+        char type[DM_MAX_TYPE_NAME];
+        char *parameters;
+} DmTargetInfo;
+
+void dm_target_info_done(DmTargetInfo *info);
+
+int dm_device_info(dev_t devnum, DmDeviceInfo *ret);
+int dm_device_info_from_path(const char *path, DmDeviceInfo *ret);
+int dm_device_query_target(const char *name, bool table, DmTargetInfo *ret);
+int dm_create_device(
+                const char *name,
+                const char *uuid,
+                uint64_t start,
+                uint64_t length,
+                const char *target,
+                const char *parameters);
+int dm_target_message(const char *name, uint64_t sector, const char *message);
+int dm_suspend_device(const char *name, bool suspend);
+
 int dm_deferred_remove_cancel(const char *name);
+
+int dm_create_linear(
+                const char *name,
+                const char *uuid,
+                dev_t devnum,
+                uint64_t offset,
+                uint64_t size);
+int dm_remove_device(const char *name);

--- a/src/shared/user-record-show.c
+++ b/src/shared/user-record-show.c
@@ -442,6 +442,10 @@ void user_record_show(UserRecord *hr, bool show_full_group_info) {
                         printf(" LUKS Cipher: %s\n", hr->luks_cipher);
                 if (hr->luks_cipher_mode)
                         printf(" Cipher Mode: %s\n", hr->luks_cipher_mode);
+                if (hr->luks_key_type)
+                        printf("    Key Type: %s\n", hr->luks_key_type);
+                if (hr->luks_integrity)
+                        printf("   Integrity: %s\n", hr->luks_integrity);
                 if (hr->luks_volume_key_size != UINT64_MAX)
                         printf("  Volume Key: %" PRIu64 "bit\n", hr->luks_volume_key_size * 8);
 

--- a/src/shared/user-record.c
+++ b/src/shared/user-record.c
@@ -51,6 +51,7 @@ UserRecord* user_record_new(void) {
                 .storage = _USER_STORAGE_INVALID,
                 .access_mode = MODE_INVALID,
                 .disk_size = UINT64_MAX,
+                .thin_device_id = UINT32_MAX,
                 .disk_size_relative = UINT64_MAX,
                 .tasks_max = UINT64_MAX,
                 .memory_high = UINT64_MAX,
@@ -193,8 +194,11 @@ static UserRecord* user_record_free(UserRecord *h) {
         strv_free(h->capability_ambient_set);
 
         free(h->file_system_type);
+        free(h->thin_pool_uuid);
         free(h->luks_cipher);
         free(h->luks_cipher_mode);
+        free(h->luks_key_type);
+        free(h->luks_integrity);
         free(h->luks_pbkdf_hash_algorithm);
         free(h->luks_pbkdf_type);
         free(h->luks_extra_mount_options);
@@ -1052,6 +1056,26 @@ static int dispatch_privileged(const char *name, sd_json_variant *variant, sd_js
         return sd_json_dispatch(variant, privileged_dispatch_table, flags, userdata);
 }
 
+static int json_dispatch_thin_device_id(
+                const char *field,
+                sd_json_variant *value,
+                sd_json_dispatch_flags_t dispatch_flags,
+                void *target) {
+
+        uint32_t id;
+        int r;
+
+        r = sd_json_dispatch_uint32(field, value, dispatch_flags, &id);
+        if (r < 0)
+                return r;
+        if (id >= UINT32_C(1) << 24)
+                return json_log(value, dispatch_flags, SYNTHETIC_ERRNO(ERANGE),
+                                "JSON field '%s' is not a valid 24-bit dm-thin device ID.", field);
+
+        *(uint32_t*) target = id;
+        return 0;
+}
+
 static int dispatch_binding(const char *name, sd_json_variant *variant, sd_json_dispatch_flags_t flags, void *userdata) {
 
         static const sd_json_dispatch_field binding_dispatch_table[] = {
@@ -1061,12 +1085,16 @@ static int dispatch_binding(const char *name, sd_json_variant *variant, sd_json_
                 { "partitionUuid",     SD_JSON_VARIANT_STRING,        sd_json_dispatch_id128,       offsetof(UserRecord, partition_uuid),       0              },
                 { "luksUuid",          SD_JSON_VARIANT_STRING,        sd_json_dispatch_id128,       offsetof(UserRecord, luks_uuid),            0              },
                 { "fileSystemUuid",    SD_JSON_VARIANT_STRING,        sd_json_dispatch_id128,       offsetof(UserRecord, file_system_uuid),     0              },
+                { "thinPoolUuid",      SD_JSON_VARIANT_STRING,        sd_json_dispatch_string,      offsetof(UserRecord, thin_pool_uuid),       SD_JSON_STRICT },
+                { "thinDeviceId",      _SD_JSON_VARIANT_TYPE_INVALID, json_dispatch_thin_device_id, offsetof(UserRecord, thin_device_id),       SD_JSON_STRICT },
                 { "uid",               SD_JSON_VARIANT_UNSIGNED,      sd_json_dispatch_uid_gid,     offsetof(UserRecord, uid),                  0              },
                 { "gid",               SD_JSON_VARIANT_UNSIGNED,      sd_json_dispatch_uid_gid,     offsetof(UserRecord, gid),                  0              },
                 { "storage",           SD_JSON_VARIANT_STRING,        json_dispatch_user_storage,   offsetof(UserRecord, storage),              0              },
                 { "fileSystemType",    SD_JSON_VARIANT_STRING,        sd_json_dispatch_string,      offsetof(UserRecord, file_system_type),     SD_JSON_STRICT },
                 { "luksCipher",        SD_JSON_VARIANT_STRING,        sd_json_dispatch_string,      offsetof(UserRecord, luks_cipher),          SD_JSON_STRICT },
                 { "luksCipherMode",    SD_JSON_VARIANT_STRING,        sd_json_dispatch_string,      offsetof(UserRecord, luks_cipher_mode),     SD_JSON_STRICT },
+                { "luksKeyType",       SD_JSON_VARIANT_STRING,        sd_json_dispatch_string,      offsetof(UserRecord, luks_key_type),        SD_JSON_STRICT },
+                { "luksIntegrity",     SD_JSON_VARIANT_STRING,        sd_json_dispatch_string,      offsetof(UserRecord, luks_integrity),       SD_JSON_STRICT },
                 { "luksVolumeKeySize", _SD_JSON_VARIANT_TYPE_INVALID, sd_json_dispatch_uint64,      offsetof(UserRecord, luks_volume_key_size), 0              },
                 {},
         };
@@ -2175,6 +2203,9 @@ bool user_record_drop_caches(UserRecord *h) {
 AutoResizeMode user_record_auto_resize_mode(UserRecord *h) {
         assert(h);
 
+        if (h->thin_pool_uuid)
+                return AUTO_RESIZE_OFF;
+
         if (h->auto_resize_mode >= 0)
                 return h->auto_resize_mode;
 
@@ -2183,6 +2214,9 @@ AutoResizeMode user_record_auto_resize_mode(UserRecord *h) {
 
 uint64_t user_record_rebalance_weight(UserRecord *h) {
         assert(h);
+
+        if (h->thin_pool_uuid)
+                return REBALANCE_WEIGHT_OFF;
 
         if (h->rebalance_weight == REBALANCE_WEIGHT_UNSET)
                 return REBALANCE_WEIGHT_DEFAULT;

--- a/src/shared/user-record.h
+++ b/src/shared/user-record.h
@@ -342,10 +342,16 @@ typedef struct UserRecord {
         sd_id128_t luks_uuid;
         sd_id128_t file_system_uuid;
 
+        /* Raw dm-thin backing, recorded in the machine-specific binding. */
+        char *thin_pool_uuid;
+        uint32_t thin_device_id;
+
         int luks_discard;
         int luks_offline_discard;
         char *luks_cipher;
         char *luks_cipher_mode;
+        char *luks_key_type;
+        char *luks_integrity;
         uint64_t luks_volume_key_size;
         char *luks_pbkdf_hash_algorithm;
         char *luks_pbkdf_type;

--- a/src/test/meson.build
+++ b/src/test/meson.build
@@ -247,6 +247,17 @@ common_test_dependencies = [
 
 executables += [
         test_template + {
+                'name' : 'test-homework-thin',
+                'sources' : files(
+                        '../home/home-util.c',
+                        '../home/homework-thin.c',
+                        '../home/user-record-util.c',
+                        'test-homework-thin.c',
+                ),
+                'include_directories' : [include_directories('../home'), includes],
+                'dependencies' : libblkid_cflags,
+        },
+        test_template + {
                 'sources' : files('test-acl-util.c'),
                 'conditions' : ['HAVE_ACL'],
                 'dependencies' : libacl_cflags,

--- a/src/test/test-dlopen-so.c
+++ b/src/test/test-dlopen-so.c
@@ -51,6 +51,27 @@ static int run(int argc, char **argv) {
         ASSERT_DLOPEN(dlopen_bzip2, HAVE_BZIP2);
         ASSERT_DLOPEN(dlopen_bpf, HAVE_LIBBPF);
         ASSERT_DLOPEN(dlopen_cryptsetup, HAVE_LIBCRYPTSETUP);
+        if (HAVE_LIBCRYPTSETUP && !cryptsetup_has_hw_wrapped_key_support()) {
+                unsigned capabilities = cryptsetup_hw_wrapped_key_capabilities();
+                char *p = NULL;
+                size_t n = 0;
+
+                /* An older libcryptsetup must keep the ordinary required symbol set loadable while
+                 * wrapped-only entry points fail through their typed compatibility stubs. */
+                if (!FLAGS_SET(capabilities, CRYPTSETUP_HW_WRAPPED_FORMAT))
+                        ASSERT_ERROR(sym_crypt_format_luks2_hw_wrapped(
+                                             NULL, NULL, NULL, NULL, NULL, 0, NULL),
+                                     EOPNOTSUPP);
+                if (!FLAGS_SET(capabilities, CRYPTSETUP_HW_ENCRYPTION_TYPE))
+                        ASSERT_EQ(sym_crypt_get_hw_encryption_type(NULL), CRYPT_SW_ONLY);
+                if (!FLAGS_SET(capabilities, CRYPTSETUP_HW_WRAPPED_GENERATE))
+                        ASSERT_ERROR(sym_crypt_hw_wrapped_key_generate(NULL, &p, &n), EOPNOTSUPP);
+                if (!FLAGS_SET(capabilities, CRYPTSETUP_HW_WRAPPED_DERIVE_SECRET))
+                        ASSERT_ERROR(sym_crypt_hw_wrapped_key_derive_secret(NULL, NULL, 0, &p, &n),
+                                     EOPNOTSUPP);
+                ASSERT_NULL(p);
+                ASSERT_EQ(n, 0U);
+        }
         ASSERT_DLOPEN(dlopen_curl, HAVE_LIBCURL);
         ASSERT_DLOPEN(dlopen_dw, HAVE_ELFUTILS);
         ASSERT_DLOPEN(dlopen_elf, HAVE_ELFUTILS);

--- a/src/test/test-homework-thin.c
+++ b/src/test/test-homework-thin.c
@@ -1,0 +1,44 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include "homework-thin.h"
+#include "tests.h"
+
+TEST(pool_status) {
+        HomeThinPoolStatus status;
+
+        ASSERT_OK(home_thin_pool_parse_status(
+                        "7 2/1024 8/4096 - rw discard_passdown error_if_no_space - 16",
+                        &status));
+        ASSERT_EQ(status.transaction_id, 7U);
+        ASSERT_EQ(status.used_metadata, 2U);
+        ASSERT_EQ(status.total_metadata, 1024U);
+        ASSERT_EQ(status.used_data, 8U);
+        ASSERT_EQ(status.total_data, 4096U);
+
+        ASSERT_ERROR(home_thin_pool_parse_status("Fail", &status), EIO);
+        ASSERT_ERROR(home_thin_pool_parse_status(
+                             "7 2/1024 8/4096 - ro discard_passdown error_if_no_space - 16", &status),
+                     EROFS);
+        ASSERT_ERROR(home_thin_pool_parse_status(
+                             "7 2/1024 8/4096 - rw no_discard_passdown error_if_no_space - 16", &status),
+                     EOPNOTSUPP);
+        ASSERT_ERROR(home_thin_pool_parse_status(
+                             "7 2/1024 8/4096 - rw discard_passdown queue_if_no_space - 16", &status),
+                     EOPNOTSUPP);
+        ASSERT_ERROR(home_thin_pool_parse_status(
+                             "7 2/1024 8/4096 - rw discard_passdown error_if_no_space needs_check 16", &status),
+                     EUCLEAN);
+}
+
+TEST(pool_table) {
+        ASSERT_OK(home_thin_pool_validate_table("253:0 253:1 512 128 1 error_if_no_space"));
+        ASSERT_OK(home_thin_pool_validate_table(
+                        "253:0 253:1 512 128 2 skip_block_zeroing error_if_no_space"));
+        ASSERT_ERROR(home_thin_pool_validate_table("253:0 253:1 512 128"), EOPNOTSUPP);
+        ASSERT_ERROR(home_thin_pool_validate_table("253:0 253:1 512 128 1 read_only"), EOPNOTSUPP);
+        ASSERT_ERROR(home_thin_pool_validate_table(
+                             "253:0 253:1 512 128 2 error_if_no_space no_discard_passdown"),
+                     EOPNOTSUPP);
+}
+
+DEFINE_TEST_MAIN(LOG_DEBUG);

--- a/src/test/test-user-record.c
+++ b/src/test/test-user-record.c
@@ -109,6 +109,48 @@ TEST(shell_validation) {
         ASSERT_STREQ(user_record_shell(u), "/bin/zsh");
 }
 
+TEST(thin_pool_binding) {
+        _cleanup_(user_record_unrefp) UserRecord *u = NULL;
+        sd_id128_t mid;
+        int r;
+
+        r = sd_id128_get_machine(&mid);
+        if (ERRNO_IS_NEG_MACHINE_ID_UNSET(r))
+                return (void) log_tests_skipped("/etc/machine-id missing");
+        ASSERT_OK(r);
+
+        USER(&u,
+             SD_JSON_BUILD_PAIR_STRING("userName", "test"),
+             SD_JSON_BUILD_PAIR_OBJECT(
+                             "binding",
+                             SD_JSON_BUILD_PAIR_OBJECT(
+                                             SD_ID128_TO_STRING(mid),
+                                             SD_JSON_BUILD_PAIR_STRING("storage", "luks"),
+                                             SD_JSON_BUILD_PAIR_STRING("imagePath", "/dev/homes/homed-test"),
+                                             SD_JSON_BUILD_PAIR_STRING("thinPoolUuid", "HOMED-POOL-test"),
+                                             SD_JSON_BUILD_PAIR_UNSIGNED("thinDeviceId", 42))));
+
+        ASSERT_STREQ(u->thin_pool_uuid, "HOMED-POOL-test");
+        ASSERT_EQ(u->thin_device_id, 42U);
+        ASSERT_EQ(user_record_auto_resize_mode(u), AUTO_RESIZE_OFF);
+        ASSERT_EQ(user_record_rebalance_weight(u), REBALANCE_WEIGHT_OFF);
+
+        u = user_record_unref(u);
+        ASSERT_ERROR(user_record_build(
+                             &u,
+                             SD_JSON_BUILD_OBJECT(
+                                             SD_JSON_BUILD_PAIR_STRING("disposition", "regular"),
+                                             SD_JSON_BUILD_PAIR_STRING("userName", "test"),
+                                             SD_JSON_BUILD_PAIR_OBJECT(
+                                                             "binding",
+                                                             SD_JSON_BUILD_PAIR_OBJECT(
+                                                                             SD_ID128_TO_STRING(mid),
+                                                                             SD_JSON_BUILD_PAIR_STRING("thinPoolUuid", "HOMED-POOL-test"),
+                                                                             SD_JSON_BUILD_PAIR_UNSIGNED("thinDeviceId", UINT32_C(1) << 24))))),
+                     ERANGE);
+        ASSERT_NULL(u);
+}
+
 TEST(self_changes) {
         _cleanup_(user_record_unrefp) UserRecord *curr = NULL, *new = NULL;
 

--- a/test/fuzz/fuzz-user-record/full-featured.json
+++ b/test/fuzz/fuzz-user-record/full-featured.json
@@ -193,12 +193,16 @@
             "partitionUuid": "41f9ce04-c827-4b74-a981-c669f93eb4dc",
             "luksUuid": "e63581ba-79fb-4226-b9de-1888393f7573",
             "fileSystemUuid": "758e88c8-5851-4a2a-b88f-e7474279c111",
+            "thinPoolUuid": "HOMED-POOL-test",
+            "thinDeviceId": 42,
             "uid": 60001,
             "gid": 60001,
             "storage": "luks",
             "fileSystemType": "ext4",
             "luksCipher": "aes",
             "luksCipherMode": "xts-plain64",
+            "luksKeyType": "hw-wrapped",
+            "luksIntegrity": "hmac(sha256)",
             "luksVolumeKeySize": 64
         }
     },

--- a/test/units/TEST-46-HOMED.sh
+++ b/test/units/TEST-46-HOMED.sh
@@ -1177,4 +1177,185 @@ EOF
     homectl remove idgrouptest2
 }
 
+testcase_thin_volume() {
+    local metadata_backing="/var/tmp/homed-thin-metadata-$$.img"
+    local data_backing="/var/tmp/homed-thin-data-$$.img"
+    local config=/run/systemd/homed.conf.d/90-test-thin.conf
+    local metadata_loop="" data_loop=""
+    local pool_name="homed-test-pool-$$"
+    local pool="/dev/mapper/$pool_name"
+    local pool_uuid="HOMED-POOL-test-$$"
+    local default_user=thin-default-user password=thin-test-password user=thin-user second=thin-user-2
+    local data_sectors=$((768 * 1024 * 1024 / 512))
+
+    for command in awk cryptsetup dd dmsetup findmnt fstrim jq losetup modprobe truncate; do
+        if ! command -v "$command" >/dev/null; then
+            echo "Skipping thin-volume test: $command is not installed"
+            return 0
+        fi
+    done
+    modprobe dm-thin-pool ||:
+    if ! dmsetup targets | awk '$1 == "thin-pool" { found = 1 } END { exit !found }'; then
+        echo "Skipping thin-volume test: dm-thin-pool is unavailable"
+        return 0
+    fi
+
+    thin_cleanup() {
+        set +e
+        homectl deactivate "$second"
+        homectl remove "$second"
+        homectl deactivate "$default_user"
+        homectl remove "$default_user"
+        homectl deactivate "$user"
+        homectl remove "$user"
+        homectl remove thin-policy-test
+        rm -f "$config"
+        systemctl restart systemd-homed.service
+        dmsetup remove --retry "$pool_name"
+        if [[ -n "$metadata_loop" ]]; then
+            losetup --detach "$metadata_loop"
+        fi
+        if [[ -n "$data_loop" ]]; then
+            losetup --detach "$data_loop"
+        fi
+        rm -f /var/lib/systemd/home/.thin-pool-state /var/lib/systemd/home/.thin-pool-state.lock \
+            /run/homed-thin-state-backup-$$
+        rm -f "$metadata_backing" "$data_backing"
+    }
+    trap thin_cleanup EXIT
+
+    truncate --size=16M "$metadata_backing"
+    truncate --size=768M "$data_backing"
+    metadata_loop="$(losetup --find --show "$metadata_backing")"
+    data_loop="$(losetup --find --show "$data_backing")"
+    dd if=/dev/zero of="$metadata_loop" bs=4096 count=1 conv=fsync
+    rm -f /var/lib/systemd/home/.thin-pool-state /var/lib/systemd/home/.thin-pool-state.lock
+    dmsetup create "$pool_name" --uuid "LVM-test-pool-$$" --table \
+        "0 $data_sectors thin-pool $metadata_loop $data_loop 512 128 1 error_if_no_space"
+
+    mkdir -p "$(dirname "$config")"
+    cat >"$config" <<EOF
+[Home]
+DefaultStorage=luks
+ThinPool=$pool
+HardwareWrappedKeys=no
+EOF
+    systemctl restart systemd-homed.service
+
+    # Raw ownership is mandatory; accepting an LVM UUID would make the numeric ID namespace ambiguous.
+    (! NEWPASSWORD="$password" homectl create thin-policy-test \
+        --storage=luks --fs-type=ext4 --disk-size=300M \
+        --luks-pbkdf-type=pbkdf2 --luks-pbkdf-time-cost=1ms)
+    (! homectl inspect thin-policy-test)
+    dmsetup remove --retry "$pool_name"
+    dmsetup create "$pool_name" --uuid "$pool_uuid" --table \
+        "0 $data_sectors thin-pool $metadata_loop $data_loop 512 128 1 error_if_no_space"
+    systemctl restart systemd-homed.service
+
+    # queue_if_no_space is rejected before any device ID is allocated.
+    dmsetup suspend "$pool_name"
+    dmsetup reload "$pool_name" --table \
+        "0 $data_sectors thin-pool $metadata_loop $data_loop 512 128 0"
+    dmsetup resume "$pool_name"
+    (! NEWPASSWORD="$password" homectl create thin-policy-test \
+        --storage=luks --fs-type=ext4 --disk-size=300M \
+        --luks-pbkdf-type=pbkdf2 --luks-pbkdf-time-cost=1ms)
+    (! homectl inspect thin-policy-test)
+    dmsetup suspend "$pool_name"
+    dmsetup reload "$pool_name" --table \
+        "0 $data_sectors thin-pool $metadata_loop $data_loop 512 128 1 error_if_no_space"
+    dmsetup resume "$pool_name"
+
+    local machine_id default_record default_size default_mapping default_device_id
+    machine_id="$(cat /etc/machine-id)"
+    default_size=$((data_sectors * 512 / 1048576 * 1048576))
+    NEWPASSWORD="$password" homectl create "$default_user" \
+        --luks-pbkdf-type=pbkdf2 --luks-pbkdf-time-cost=1ms
+    default_record="$(homectl inspect --json=short "$default_user")"
+    default_device_id="$(jq -er --arg m "$machine_id" '.binding[$m].thinDeviceId' <<<"$default_record")"
+    [[ "$(jq -er --arg m "$machine_id" \
+        '.perMachine[] | select(.matchMachineId | if type == "array" then index($m) else . == $m end) | .diskSize' \
+        <<<"$default_record")" == "$default_size" ]]
+    default_mapping="homed-$(jq -er '.uuid | gsub("-"; "")' <<<"$default_record")"
+    PASSWORD="$password" homectl activate "$default_user"
+    [[ "$(dmsetup table "$default_mapping" | awk 'NR == 1 { print $3 }')" == thin ]]
+    homectl deactivate "$default_user"
+    homectl remove "$default_user"
+
+    NEWPASSWORD="$password" homectl create "$user" \
+        --storage=luks --fs-type=ext4 --disk-size=800M \
+        --luks-pbkdf-type=pbkdf2 --luks-pbkdf-time-cost=1ms
+
+    local record record_uuid device_id image_path mapping usage_before usage_after
+    record="$(homectl inspect --json=short "$user")"
+    record_uuid="$(jq -er '.uuid' <<<"$record")"
+    mapping="homed-${record_uuid//-/}"
+    device_id="$(jq -er --arg m "$machine_id" '.binding[$m].thinDeviceId' <<<"$record")"
+    (( device_id > default_device_id ))
+    image_path="$(jq -er --arg m "$machine_id" '.binding[$m].imagePath' <<<"$record")"
+    [[ "$(jq -er --arg m "$machine_id" '.binding[$m].thinPoolUuid' <<<"$record")" == "$pool_uuid" ]]
+    [[ "$(jq -er --arg m "$machine_id" '.binding[$m].storage' <<<"$record")" == luks ]]
+
+    PASSWORD="$password" homectl activate "$user"
+    [[ "$(dmsetup table "$mapping" | awk 'NR == 1 { print $3 }')" == thin ]]
+    dmsetup table "$mapping" | grep -w "$device_id"
+    dd if=/dev/zero of="/home/$user/discard-me" bs=1M count=64 conv=fsync
+    echo persistent >"/home/$user/persistent"
+    sync
+    usage_before="$(dmsetup status "$pool_name" | awk '{ print $6 }')"
+    rm "/home/$user/discard-me"
+    usage_after="$usage_before"
+    for _ in {1..10}; do
+        fstrim "/home/$user"
+        sync
+        usage_after="$(dmsetup status "$pool_name" | awk '{ print $6 }')"
+        if awk -F '[/ ]' -v before="$usage_before" -v after="$usage_after" \
+            'BEGIN { split(before, b, "/"); split(after, a, "/"); exit !(a[1] < b[1]) }'; then
+            break
+        fi
+        sleep 0.2
+    done
+    awk -v before="$usage_before" -v after="$usage_after" \
+        'BEGIN { split(before, b, "/"); split(after, a, "/"); exit !(a[1] < b[1]) }'
+
+    homectl deactivate "$user"
+
+    # Losing the durable allocator must not silently restart allocation at device ID zero.
+    cp /var/lib/systemd/home/.thin-pool-state /run/homed-thin-state-backup-$$
+    rm /var/lib/systemd/home/.thin-pool-state
+    systemctl restart systemd-homed.service
+    (! PASSWORD="$password" homectl activate "$user")
+    cp /run/homed-thin-state-backup-$$ /var/lib/systemd/home/.thin-pool-state
+    rm /run/homed-thin-state-backup-$$
+
+    # The record and allocator are tied to the pool generation UUID, not merely its backing devices.
+    dmsetup remove --retry "$pool_name"
+    dmsetup create "$pool_name" --uuid "HOMED-POOL-wrong-$$" --table \
+        "0 $data_sectors thin-pool $metadata_loop $data_loop 512 128 1 error_if_no_space"
+    systemctl restart systemd-homed.service
+    (! PASSWORD="$password" homectl activate "$user")
+    dmsetup remove --retry "$pool_name"
+    dmsetup create "$pool_name" --uuid "$pool_uuid" --table \
+        "0 $data_sectors thin-pool $metadata_loop $data_loop 512 128 1 error_if_no_space"
+    systemctl restart systemd-homed.service
+    PASSWORD="$password" homectl activate "$user"
+    grep -Fx persistent "/home/$user/persistent"
+
+    NEWPASSWORD="$password" homectl create "$second" \
+        --storage=luks --fs-type=ext4 --disk-size=300M \
+        --luks-pbkdf-type=pbkdf2 --luks-pbkdf-time-cost=1ms
+    PASSWORD="$password" homectl activate "$second"
+    dd if=/dev/zero of="/home/$user/concurrent" bs=1M count=32 conv=fsync
+    dd if=/dev/zero of="/home/$second/concurrent" bs=1M count=32 conv=fsync
+
+    homectl deactivate "$second"
+    homectl remove "$second"
+    homectl deactivate "$user"
+    homectl remove "$user"
+    (! dmsetup info "$mapping")
+
+    trap - EXIT
+    thin_cleanup
+}
+
 run_testcases

--- a/test/units/TEST-46-HOMED.sh
+++ b/test/units/TEST-46-HOMED.sh
@@ -44,9 +44,13 @@ FSTYPE="$(stat --file-system --format "%T" /)"
 
 systemctl start systemd-homed.service systemd-userdbd.socket
 
-# Create a tmpfs to use as backing store for the home dir. That way we can enforce a size limit nicely.
+# Create a tmpfs to use as backing store for the normal test.  The persistent
+# wrapped-key lane keeps /home on the root image so its identity record survives
+# all three QEMU processes.
 mkdir -p /home
-mount -t tmpfs tmpfs /home -o size=290M
+if [[ -z "${SYSTEMD_TEST_HW_WRAPPED_PHASE:-}" ]]; then
+    mount -t tmpfs tmpfs /home -o size=290M
+fi
 
 # Make sure systemd-homed takes notice of the overmounted /home/
 systemctl kill -sUSR1 systemd-homed
@@ -1356,6 +1360,242 @@ EOF
 
     trap - EXIT
     thin_cleanup
+}
+
+testcase_hw_wrapped_multiboot() {
+    if [[ -z "${SYSTEMD_TEST_HW_WRAPPED_PHASE:-}" ]]; then
+        echo "Skipping hardware-wrapped multiboot lane without SYSTEMD_TEST_HW_WRAPPED_PHASE"
+        return 0
+    fi
+
+    local phase="${SYSTEMD_TEST_HW_WRAPPED_PHASE:?set SYSTEMD_TEST_HW_WRAPPED_PHASE to 1, 2, or 3}"
+    local device="${SYSTEMD_TEST_HW_WRAPPED_DEVICE:?set SYSTEMD_TEST_HW_WRAPPED_DEVICE to the dedicated UFS block device}"
+    local config=/run/systemd/homed.conf.d/90-test-hw-wrapped.conf
+    local state_dir=/var/lib/systemd/tests/homed-hw-wrapped
+    local state_file="$state_dir/state"
+    local pool_name=homed-hw-pool pool=/dev/mapper/homed-hw-pool user=wrapped-persistent-user luks_uuid
+    local metadata_device data_device pool_uuid data_sectors
+    local image_path=
+    local password=wrapped-initial-password rotated=wrapped-rotated-password
+
+    for command in awk blockdev cryptsetup dd dmsetup findmnt fstrim jq lsblk sfdisk sha256sum udevadm; do
+        command -v "$command" >/dev/null
+    done
+    device="$(realpath -e "$device")"
+    [[ -b "$device" ]]
+    [[ "$phase" =~ ^[123]$ ]]
+
+    mkdir -p "$(dirname "$config")" "$state_dir"
+    cat >"$config" <<EOF
+[Home]
+ThinPool=$pool
+HardwareWrappedKeys=yes
+EOF
+
+    hw_open_image() {
+        local partition partition_node start sector_size count
+
+        if [[ ! -b "/dev/mapper/$thin_mapping" ]]; then
+            dmsetup create "$thin_mapping" --uuid "HOMED-THIN-${home_uuid//-/}" --table \
+                "0 $((2 * 1024 * 1024 * 1024 / 512)) thin $pool $thin_device_id"
+        fi
+        partition="$(sfdisk --json "/dev/mapper/$thin_mapping")"
+        start="$(jq -er '.partitiontable.partitions[0].start' <<<"$partition")"
+        partition_node="$(jq -er '.partitiontable.partitions[0].node' <<<"$partition")"
+        sector_size="$(jq -er '.partitiontable.sectorsize' <<<"$partition")"
+        (( sector_size > 0 && 32 * 1024 * 1024 % sector_size == 0 ))
+        count=$((32 * 1024 * 1024 / sector_size))
+        image_path=/run/homed-hw-wrapped-header.raw
+        dd if="/dev/mapper/$thin_mapping" of="$image_path" bs="$sector_size" skip="$start" count="$count" iflag=fullblock status=none
+        udevadm settle
+        if [[ -b "$partition_node" ]]; then
+            dmsetup remove --retry "$partition_node"
+        fi
+        dmsetup remove --retry "$thin_mapping"
+        [[ -f "$image_path" ]]
+        [[ "$(cryptsetup luksUUID "$image_path")" == "$luks_uuid" ]]
+    }
+
+    hw_close_image() {
+        rm -f "$image_path"
+        image_path=
+    }
+
+    if [[ "$phase" == 1 ]]; then
+        printf 'label: gpt\n,32M,L\n,,L\n' | sfdisk --wipe=always "$device"
+        udevadm settle
+        mapfile -t pool_partitions < <(lsblk --json --paths --output PATH,TYPE "$device" |
+            jq -er '.blockdevices[0].children[] | select(.type == "part") | .path')
+        [[ "${#pool_partitions[@]}" == 2 ]]
+        metadata_device="${pool_partitions[0]}"
+        data_device="${pool_partitions[1]}"
+        dd if=/dev/zero of="$metadata_device" bs=4096 count=1 conv=fsync
+    else
+        [[ -s "$state_file" ]]
+        # shellcheck source=/dev/null
+        source "$state_file"
+    fi
+
+    if [[ -z "${metadata_device:-}" || -z "${data_device:-}" ]]; then
+        mapfile -t pool_partitions < <(lsblk --json --paths --output PATH,TYPE "$device" |
+            jq -er '.blockdevices[0].children[] | select(.type == "part") | .path')
+        metadata_device="${pool_partitions[0]}"
+        data_device="${pool_partitions[1]}"
+    fi
+    pool_uuid="HOMED-POOL-$(lsblk --noheadings --raw --output PARTUUID "$metadata_device")-$(lsblk --noheadings --raw --output PARTUUID "$data_device")"
+    data_sectors="$(blockdev --getsz "$data_device")"
+    dmsetup create "$pool_name" --uuid "$pool_uuid" --table \
+        "0 $data_sectors thin-pool $metadata_device $data_device 512 128 1 error_if_no_space"
+
+    systemctl restart systemd-homed.service
+
+    hw_dm_child() {
+        dmsetup deps --options devname --noheadings "$1" |
+            sed -n 's/.*(\([^()]\+\)).*/\1/p'
+    }
+
+    hw_assert_metadata() {
+        local image_path="$1" metadata
+
+        metadata="$(cryptsetup luksDump --dump-json-metadata "$image_path")"
+        [[ "$(jq -r '.segments."0".key_type' <<<"$metadata")" == hw-wrapped ]]
+        jq -e '.config.requirements.mandatory | index("hw-wrapped-key")' <<<"$metadata"
+        jq -e '.config.requirements.mandatory | index("hw-wrapped-key-integrity")' <<<"$metadata"
+    }
+
+    hw_assert_topology() {
+        local source top inline linear thin table mount_options
+
+        source="$(findmnt --noheadings --output SOURCE --target "/home/$user" | xargs)"
+        source="${source%%\[*}"
+        top="$(dmsetup info --columns --noheadings --options name "$source" | xargs)"
+        [[ "$(dmsetup table "$top" | awk 'NR == 1 { print $3 }')" == integrity ]]
+        inline="$(hw_dm_child "$top")"
+        [[ -n "$inline" ]]
+        [[ "$(dmsetup table "$inline" | awk 'NR == 1 { print $3 }')" == inlinecrypt ]]
+        table="$(dmsetup table "$inline")"
+        grep -w 'keytype:hw-wrapped' <<<"$table"
+        ! grep -Eq '(^|[[:space:]])[[:xdigit:]]{64,}([[:space:]]|$)' <<<"$table"
+        linear="$(hw_dm_child "$inline")"
+        [[ "$(dmsetup table "$linear" | awk 'NR == 1 { print $3 }')" == linear ]]
+        thin="$(hw_dm_child "$linear")"
+        [[ "$(dmsetup table "$thin" | awk 'NR == 1 { print $3 }')" == thin ]]
+        mount_options="$(findmnt --noheadings --output OPTIONS --target "/home/$user")"
+        grep -w provision <<<"${mount_options//,/ }"
+        grep -w nodelalloc <<<"${mount_options//,/ }"
+    }
+
+    hw_assert_allocation_and_trim() {
+        local before allocated trimmed
+
+        before="$(dmsetup status "$pool_name" | awk '{ print $6 }')"
+        dd if=/dev/zero of="/home/$user/discard-me" bs=1M count=16 conv=fsync
+        allocated="$(dmsetup status "$pool_name" | awk '{ print $6 }')"
+        awk -v before="$before" -v after="$allocated" \
+            'BEGIN { split(before, b, "/"); split(after, a, "/"); exit !(a[1] > b[1]) }'
+        rm "/home/$user/discard-me"
+        trimmed="$allocated"
+        for _ in {1..20}; do
+            fstrim "/home/$user"
+            sync
+            trimmed="$(dmsetup status "$pool_name" | awk '{ print $6 }')"
+            if awk -v before="$allocated" -v after="$trimmed" \
+                'BEGIN { split(before, b, "/"); split(after, a, "/"); exit !(a[1] < b[1]) }'; then
+                break
+            fi
+            sleep 0.2
+        done
+        awk -v before="$allocated" -v after="$trimmed" \
+            'BEGIN { split(before, b, "/"); split(after, a, "/"); exit !(a[1] < b[1]) }'
+    }
+
+    hw_header_hash() {
+        dd if="$1" bs=1M count=32 status=none | sha256sum | awk '{ print $1 }'
+    }
+
+    case "$phase" in
+        1)
+            local machine_id record header_hash
+
+            NEWPASSWORD="$password" homectl create "$user" \
+                --storage=luks --fs-type=ext4 --disk-size=2G \
+                --luks-pbkdf-type=pbkdf2 --luks-pbkdf-time-cost=1ms
+            machine_id="$(cat /etc/machine-id)"
+            record="$(homectl inspect --json=short "$user")"
+            [[ "$(jq -er --arg m "$machine_id" '.binding[$m].luksKeyType' <<<"$record")" == hw-wrapped ]]
+            [[ "$(jq -er --arg m "$machine_id" '.binding[$m].luksIntegrity' <<<"$record")" == 'hmac(sha256)' ]]
+            home_uuid="$(jq -er '.uuid' <<<"$record")"
+            thin_mapping="homed-${home_uuid//-/}"
+            thin_device_id="$(jq -er --arg m "$machine_id" '.binding[$m].thinDeviceId' <<<"$record")"
+            [[ "$(jq -er --arg m "$machine_id" '.binding[$m].thinPoolUuid' <<<"$record")" == "$pool_uuid" ]]
+            luks_uuid="$(jq -er --arg m "$machine_id" '.binding[$m].luksUuid' <<<"$record")"
+            hw_open_image
+            hw_assert_metadata "$image_path"
+            hw_close_image
+
+            PASSWORD="$password" homectl activate "$user"
+            hw_assert_topology
+            printf '%s\n' 'persistent-wrapped-home-marker-7bcce8ef' >"/home/$user/persistent"
+            sync
+            hw_assert_allocation_and_trim
+            homectl lock "$user"
+            dmsetup info "home-$user" | grep -w SUSPENDED
+            # The private lower mapping may lose its userspace name while a
+            # deferred removal is pending. Unlock must still find it through
+            # the upper mapping's device dependency.
+            if ! PASSWORD="$password" homectl unlock "$user"; then
+                journalctl --boot --no-pager --unit systemd-homed.service
+                return 1
+            fi
+            PASSWORD="$password" NEWPASSWORD="$rotated" homectl passwd "$user"
+            homectl deactivate "$user"
+            hw_open_image
+            header_hash="$(hw_header_hash "$image_path")"
+            hw_close_image
+            printf 'metadata_device=%q\ndata_device=%q\nhome_uuid=%q\nthin_mapping=%q\nthin_device_id=%q\nluks_uuid=%q\nheader_hash=%q\n' \
+                "$metadata_device" "$data_device" "$home_uuid" "$thin_mapping" "$thin_device_id" \
+                "$luks_uuid" "$header_hash" >"$state_file"
+            printf 'HOMED_HW_WRAPPED_PHASE_1_PASS thin_device_id=%s\n' "$thin_device_id"
+            ;;
+        2)
+            hw_open_image
+            [[ "$(hw_header_hash "$image_path")" == "$header_hash" ]]
+            hw_close_image
+            if PASSWORD="$rotated" homectl activate "$user"; then
+                echo "Wrapped home activated under the wrong hardware identity" >&2
+                return 1
+            fi
+            hw_open_image
+            [[ "$(hw_header_hash "$image_path")" == "$header_hash" ]]
+            hw_close_image
+            homectl inspect "$user" | grep -w inactive
+            [[ ! -e "/home/$user/persistent" ]]
+            ! dmsetup message "$pool_name" 0 "create_thin $thin_device_id"
+            printf 'HOMED_HW_WRAPPED_PHASE_2_PASS thin_device_id=%s\n' "$thin_device_id"
+            ;;
+        3)
+            hw_open_image
+            hw_assert_metadata "$image_path"
+            hw_close_image
+            if PASSWORD=definitely-wrong homectl --no-ask-password activate "$user"; then
+                echo "Wrapped home activated with the wrong password" >&2
+                return 1
+            fi
+            PASSWORD="$rotated" homectl activate "$user"
+            grep -Fx 'persistent-wrapped-home-marker-7bcce8ef' "/home/$user/persistent"
+            hw_assert_topology
+            hw_assert_allocation_and_trim
+            homectl deactivate "$user"
+            homectl remove "$user"
+            ! dmsetup create "$thin_mapping" --table \
+                "0 $((2 * 1024 * 1024 * 1024 / 512)) thin $pool $thin_device_id"
+            dmsetup remove "$thin_mapping" || :
+            rm -f "$state_file"
+            dmsetup remove --retry "$pool_name"
+            rm -f /var/lib/systemd/home/.thin-pool-state /var/lib/systemd/home/.thin-pool-state.lock
+            printf 'HOMED_HW_WRAPPED_PHASE_3_PASS thin_device_id=%s\n' "$thin_device_id"
+            ;;
+    esac
 }
 
 run_testcases


### PR DESCRIPTION
This PR requires work across multiple projects, but I figured I would send it upstream for review sooner rather than later as requested by @poettering.

This series adds LVM thin-pool-backed LUKS homes and optional hardware-wrapped encryption keys to systemd-homed.

ThinPool= selects an administrator-managed LVM thin pool for new LUKS/ext4 homes. homed creates a tagged per-user thin LV, records and validates its immutable LVM identity, enables discard and ext4 provisioning, and handles incomplete creation through pending records and startup
recovery. Pool sizing, monitoring, and repair remain administrator responsibilities.

HardwareWrappedKeys= optionally creates thin-backed homes using a hardware-wrapped AES-256-XTS key. The resulting stack is:

```
ext4
  └─ dm-integrity: journaled hmac(sha256)
       └─ dm-inlinecrypt: hardware-wrapped AES-256-XTS key
            └─ linear partition mapping
                 └─ LVM thin volume
                      └─ administrator-managed thin pool
```

The raw encryption key remains within the storage hardware. A separately derived software secret protects the homed identity token using AES-256-GCM and provides the key for journaled hmac(sha256) integrity. Creation fails rather than falling back to a raw key when the required support is unavailable. Existing password, recovery-key, PKCS#11, and FIDO2 enrollment continues to use normal LUKS2 keyslots.

The final commit fixes a systemd-repart race encountered with these block-backed homes: the kernel may create a partition before BLKPG_ADD_PARTITION, causing EBUSY. Repart now accepts the existing partition only after verifying its geometry and avoids removing a kernel-created device during cleanup.

This was tested end-to-end with the companion branches:

- cryptsetup (https://github.com/chergert/cryptsetup), main
- Linux (https://github.com/chergert/linux), master
- QEMU (https://github.com/chergert/qemu), ufs-inline-crypto
- edk2 (tianocore) (https://github.com/chergert/edk2), master

Testing covers thin-volume creation, recovery, activation, discard, removal, the integrity/inlinecrypt topology, lock/unlock, password rotation, persistence across reboot, failure under a different hardware wrapping identity, and successful recovery when the original identity is restored.
