### PR TITLE
resolved: add RR overrides from credentials and cmdline

### DIFF
--- a/man/kernel-command-line.xml
+++ b/man/kernel-command-line.xml
@@ -620,6 +620,19 @@
       </varlistentry>
 
       <varlistentry>
+        <term><varname>systemd.resolved.rr=</varname></term>
+        <listitem>
+          <para>Select a file containing local DNS resource records for
+          <citerefentry><refentrytitle>systemd-resolved.service</refentrytitle><manvolnum>8</manvolnum></citerefentry>.
+          May be specified more than once. See
+          <citerefentry><refentrytitle>systemd.rr</refentrytitle><manvolnum>5</manvolnum></citerefentry>
+          for details.</para>
+
+          <xi:include href="version-info.xml" xpointer="v262"/>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
         <term><varname>resume=</varname></term>
         <term><varname>resumeflags=</varname></term>
 

--- a/man/systemd-resolved.service.xml
+++ b/man/systemd-resolved.service.xml
@@ -139,7 +139,9 @@
       <citerefentry><refentrytitle>systemd.rr</refentrytitle><manvolnum>5</manvolnum></citerefentry> for
       details. Support for this may be disabled with <varname>ReadStaticRecords=no</varname>, see
       <citerefentry><refentrytitle>resolved.conf</refentrytitle><manvolnum>5</manvolnum></citerefentry>.
-      </para></listitem>
+      Records from the <varname>network.rr</varname> credential and files selected with
+      <varname>systemd.resolved.rr=</varname> take precedence over these records and are intended for
+      temporary or image-specific redirection.</para></listitem>
 
       <listitem><para>The mappings defined in <filename>/etc/hosts</filename> are resolved to their
       configured addresses and back, but they will not affect lookups for non-address types (like MX).
@@ -466,13 +468,25 @@ search foobar.com barbar.com
 
         <xi:include href="version-info.xml" xpointer="v253"/></listitem>
       </varlistentry>
+      <varlistentry>
+        <term><varname>network.rr</varname></term>
+
+        <listitem><para>Contains one DNS RR object or an array of DNS RR objects in the JSON format described
+        in
+        <citerefentry><refentrytitle>systemd.rr</refentrytitle><manvolnum>5</manvolnum></citerefentry>.
+        These records take precedence over the static records read from the filesystem. This credential is
+        independent of the <varname>network.dns</varname> and <varname>network.search_domains</varname>
+        credentials.</para>
+
+        <xi:include href="version-info.xml" xpointer="v262"/></listitem>
+      </varlistentry>
     </variablelist>
   </refsect1>
 
   <refsect1>
     <title>Kernel Command Line</title>
 
-    <para><command>systemd-resolved</command> also honours two kernel command line options:</para>
+    <para><command>systemd-resolved</command> also honours the following kernel command line options:</para>
 
     <variablelist class='kernel-commandline-options'>
       <varlistentry>
@@ -489,6 +503,18 @@ search foobar.com barbar.com
         configuration.</para>
 
         <xi:include href="version-info.xml" xpointer="v253"/></listitem>
+      </varlistentry>
+      <varlistentry>
+        <term><varname>systemd.resolved.rr=</varname></term>
+
+        <listitem><para>Specifies an absolute path to a file containing DNS records in the JSON format
+        described in
+        <citerefentry><refentrytitle>systemd.rr</refentrytitle><manvolnum>5</manvolnum></citerefentry>.
+        May be specified more than once. Records read from these files take precedence over records from the
+        static record directories and from the <varname>network.rr</varname> credential. This is useful for
+        selecting an alternative set of service endpoints from a boot loader entry.</para>
+
+        <xi:include href="version-info.xml" xpointer="v262"/></listitem>
       </varlistentry>
     </variablelist>
   </refsect1>

--- a/man/systemd.rr.xml
+++ b/man/systemd.rr.xml
@@ -59,6 +59,16 @@
     <para>This JSON serialization of DNS RRs matches the one returned by <command>resolvectl</command>.</para>
 
     <para>Currently no other RR types are supported.</para>
+
+    <para>For temporary or image-specific overrides, the same JSON format may be supplied in the
+    <varname>network.rr</varname> service credential, or in a file selected with the
+    <varname>systemd.resolved.rr=</varname> kernel command line option. Records supplied through either of
+    these mechanisms take precedence over records from the directories listed above. The kernel command line
+    option may be specified more than once.</para>
+
+    <para>These records affect DNS resolution only. They do not change the hostname in a URL, the HTTP
+    <literal>Host</literal> header, or the TLS SNI name. In particular, a redirected HTTPS service must still
+    accept the original hostname and provide a certificate valid for it.</para>
   </refsect1>
 
   <refsect1>

--- a/man/systemd.system-credentials.xml
+++ b/man/systemd.system-credentials.xml
@@ -180,6 +180,19 @@
       </varlistentry>
 
       <varlistentry>
+        <term><varname>network.rr</varname></term>
+        <listitem>
+          <para>Static DNS resource records in the JSON format described in
+          <citerefentry><refentrytitle>systemd.rr</refentrytitle><manvolnum>5</manvolnum></citerefentry>.
+          Read by
+          <citerefentry><refentrytitle>systemd-resolved.service</refentrytitle><manvolnum>8</manvolnum></citerefentry>
+          and applied with higher priority than records read from the static record directories.</para>
+
+          <xi:include href="version-info.xml" xpointer="v262"/>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
         <term><varname>network.conf.*</varname></term>
         <term><varname>network.link.*</varname></term>
         <term><varname>network.netdev.*</varname></term>

--- a/src/resolve/meson.build
+++ b/src/resolve/meson.build
@@ -124,6 +124,9 @@ executables += [
                 'sources' : files('test-resolved-etc-hosts.c'),
         },
         resolve_test_template + {
+                'sources' : files('test-resolved-static-records.c'),
+        },
+        resolve_test_template + {
                 'sources' : files('test-resolved-packet.c'),
         },
         resolve_test_template + {

--- a/src/resolve/resolved-conf.c
+++ b/src/resolve/resolved-conf.c
@@ -6,6 +6,7 @@
 #include "dns-type.h"
 #include "extract-word.h"
 #include "ordered-set.h"
+#include "path-util.h"
 #include "proc-cmdline.h"
 #include "resolved-conf.h"
 #include "resolved-dns-cache.h"
@@ -16,6 +17,7 @@
 #include "set.h"
 #include "socket-netlink.h"
 #include "string-util.h"
+#include "strv.h"
 
 DEFINE_CONFIG_PARSE_ENUM(config_parse_dns_stub_listener_mode, dns_stub_listener_mode, DnsStubListenerMode);
 
@@ -251,6 +253,20 @@ static int proc_cmdline_callback(const char *key, const char *value, void *data)
                         log_warning_errno(r, "Failed to parse credential provided search domain string '%s', ignoring.", value);
 
                 info->manager->read_resolv_conf = false;
+
+        } else if (streq(key, "systemd.resolved.rr")) {
+
+                if (proc_cmdline_value_missing(key, value))
+                        return 0;
+
+                if (!path_is_absolute(value)) {
+                        log_warning("Ignoring relative path in systemd.resolved.rr=: %s", value);
+                        return 0;
+                }
+
+                r = strv_extend(&info->manager->static_record_override_paths, value);
+                if (r < 0)
+                        return log_oom();
         }
 
         return 0;

--- a/src/resolve/resolved-dns-query.c
+++ b/src/resolve/resolved-dns-query.c
@@ -920,7 +920,14 @@ static int dns_query_try_static_records(DnsQuery *q) {
                 return 0;
 
         _cleanup_(dns_answer_unrefp) DnsAnswer *answer = NULL;
-        r = manager_static_records_lookup(
+        r = manager_static_record_overrides_lookup(
+                        q->manager,
+                        q->question_bypass ? q->question_bypass->question : q->question_utf8,
+                        &answer);
+        if (r < 0)
+                return r;
+        if (r == 0)
+                r = manager_static_records_lookup(
                         q->manager,
                         q->question_bypass ? q->question_bypass->question : q->question_utf8,
                         &answer);

--- a/src/resolve/resolved-manager.c
+++ b/src/resolve/resolved-manager.c
@@ -55,6 +55,7 @@
 #include "set.h"
 #include "socket-util.h"
 #include "string-util.h"
+#include "strv.h"
 #include "time-util.h"
 #include "varlink-util.h"
 
@@ -645,6 +646,7 @@ static void manager_set_defaults(Manager *m) {
                 m->cache_max[p] = DEFAULT_CACHE_MAX;
         m->stale_retention_usec = 0;
         m->refuse_record_types = set_free(m->refuse_record_types);
+        m->static_record_override_paths = strv_free(m->static_record_override_paths);
         m->resolv_conf_stat = (struct stat) {};
 }
 
@@ -871,6 +873,7 @@ Manager* manager_free(Manager *m) {
 #endif
 
         set_free(m->refuse_record_types);
+        strv_free(m->static_record_override_paths);
         hashmap_free(m->links);
         hashmap_free(m->dns_transactions);
 

--- a/src/resolve/resolved-manager.h
+++ b/src/resolve/resolved-manager.h
@@ -126,9 +126,12 @@ typedef struct Manager {
 
         /* Data from {/etc,/run,/usr/local/lib,/usr/lib}/systemd/resolve/static.d/ */
         Hashmap *static_records;
+        Hashmap *static_record_overrides;
+        char **static_record_override_paths;
         usec_t static_records_last;
         Set *static_records_stat;
         bool read_static_records;
+        bool static_records_loaded;
 
         /* List of refused DNS Record Types */
         Set *refuse_record_types;

--- a/src/resolve/resolved-static-records.c
+++ b/src/resolve/resolved-static-records.c
@@ -5,6 +5,7 @@
 #include "alloc-util.h"
 #include "conf-files.h"
 #include "constants.h"
+#include "creds-util.h"
 #include "dns-answer.h"
 #include "dns-domain.h"
 #include "dns-question.h"
@@ -13,10 +14,13 @@
 #include "hashmap.h"
 #include "json-util.h"
 #include "log.h"
+#include "path-util.h"
 #include "resolved-manager.h"
 #include "resolved-static-records.h"
 #include "set.h"
 #include "stat-util.h"
+#include "string-util.h"
+#include "strv.h"
 
 /* This implements a mechanism to extend what systemd-resolved resolves locally, via .rr drop-ins in
  * {/etc,/run,/usr/local/lib,/usr/lib}/systemd/resolve/static.d/. These files are in JSON format, and are RR
@@ -45,7 +49,7 @@ DEFINE_PRIVATE_HASH_OPS_WITH_VALUE_DESTRUCTOR(
                 DnsAnswer,
                 dns_answer_unref);
 
-static int load_static_record_file_item(sd_json_variant *rj, Hashmap **records) {
+static int load_static_record_file_item(sd_json_variant *rj, const char *source, Hashmap **records) {
         int r;
 
         assert(records);
@@ -53,14 +57,14 @@ static int load_static_record_file_item(sd_json_variant *rj, Hashmap **records) 
         _cleanup_(dns_resource_record_unrefp) DnsResourceRecord *rr = NULL;
         r = dns_resource_record_from_json(rj, &rr);
         if (r < 0)
-                return log_error_errno(r, "Failed to parse DNS record from JSON: %m");
+                return log_error_errno(r, "Failed to parse DNS record from %s: %m", source);
 
         _cleanup_(dns_answer_unrefp) DnsAnswer *a =
                 hashmap_remove(*records, dns_resource_key_name(rr->key));
 
         r = dns_answer_add_extend_full(&a, rr, /* ifindex= */ 0, DNS_ANSWER_AUTHENTICATED, /* rrsig= */ NULL, /* until= */ USEC_INFINITY);
         if (r < 0)
-                return log_error_errno(r, "Failed to append RR to DNS answer: %m");
+                return log_error_errno(r, "Failed to append RR from %s to DNS answer: %m", source);
 
         DnsAnswerItem *item = ASSERT_PTR(ordered_set_first(a->items));
 
@@ -72,6 +76,113 @@ static int load_static_record_file_item(sd_json_variant *rj, Hashmap **records) 
 
         log_debug("Added static resource record: %s", dns_resource_record_to_string(rr));
         return 1;
+}
+
+static int load_static_record_json(sd_json_variant *j, const char *source, Hashmap **records) {
+        assert(j);
+        assert(source);
+        assert(records);
+
+        if (sd_json_variant_is_array(j)) {
+                sd_json_variant *i;
+                int ret = 0;
+
+                JSON_VARIANT_ARRAY_FOREACH(i, j)
+                        RET_GATHER(ret, load_static_record_file_item(i, source, records));
+                return ret;
+        }
+
+        if (sd_json_variant_is_object(j))
+                return load_static_record_file_item(j, source, records);
+
+        log_warning("JSON source %s contains neither array nor object, skipping.", source);
+        return 0;
+}
+
+static int merge_static_record_overrides(Hashmap **records, Hashmap *source) {
+        DnsAnswer *a;
+        int r;
+
+        assert(records);
+
+        HASHMAP_FOREACH(a, source) {
+                DnsAnswerItem *item = ASSERT_PTR(ordered_set_first(a->items));
+                const char *name = dns_resource_key_name(item->rr->key);
+                _cleanup_(dns_answer_unrefp) DnsAnswer *copy = dns_answer_ref(a);
+
+                dns_answer_unref(hashmap_remove(*records, name));
+
+                r = hashmap_ensure_put(records, &answer_by_name_hash_ops, name, copy);
+                if (r < 0)
+                        return r;
+
+                TAKE_PTR(copy);
+        }
+
+        return 0;
+}
+
+static int add_static_record_stat(Set **stats, const struct stat *st) {
+        assert(stats);
+        assert(st);
+
+        _cleanup_free_ struct stat *copy = memdup(st, sizeof(*st));
+        if (!copy)
+                return log_oom();
+
+        if (set_ensure_consume(stats, &inode_unmodified_hash_ops, TAKE_PTR(copy)) < 0)
+                return log_oom();
+
+        return 0;
+}
+
+static int get_static_record_credential_path(char **ret) {
+        _cleanup_free_ char *path = NULL;
+        const char *dir;
+        int r;
+
+        assert(ret);
+
+        r = get_credentials_dir(&dir);
+        if (r < 0)
+                return r;
+
+        path = path_join(dir, "network.rr");
+        if (!path)
+                return log_oom();
+
+        *ret = TAKE_PTR(path);
+        return 0;
+}
+
+static int static_record_source_stat(
+                const char *path,
+                Set *old_stats,
+                size_t *ret_n_stats,
+                bool *ret_changed) {
+
+        struct stat st;
+        int r;
+
+        assert(path);
+        assert(ret_n_stats);
+        assert(ret_changed);
+
+        if (stat(path, &st) < 0) {
+                r = -errno;
+                if (r == -ENOENT)
+                        return 0;
+
+                log_debug_errno(r, "Failed to stat static DNS record source '%s', assuming it changed: %m", path);
+                *ret_changed = true;
+                return 0;
+        }
+
+        (*ret_n_stats)++;
+        if (!old_stats || !set_contains(old_stats, &st))
+                *ret_changed = true;
+
+        return 0;
 }
 
 static int load_static_record_file(const ConfFile *cf, Hashmap **records, Set **stats) {
@@ -87,12 +198,9 @@ static int load_static_record_file(const ConfFile *cf, Hashmap **records, Set **
         if (set_contains(*stats, &cf->st))
                 return 0;
 
-        _cleanup_free_ struct stat *st_copy = memdup(&cf->st, sizeof(cf->st));
-        if (!st_copy)
-                return log_oom();
-
-        if (set_ensure_consume(stats, &inode_unmodified_hash_ops, TAKE_PTR(st_copy)) < 0)
-                return log_oom();
+        r = add_static_record_stat(stats, &cf->st);
+        if (r < 0)
+                return r;
 
         _cleanup_(sd_json_variant_unrefp) sd_json_variant *j = NULL;
         unsigned line = 0, column = 0;
@@ -105,23 +213,111 @@ static int load_static_record_file(const ConfFile *cf, Hashmap **records, Set **
                 return 0;
         }
 
-        if (sd_json_variant_is_array(j)) {
-                sd_json_variant *i;
-                int ret = 0;
-                JSON_VARIANT_ARRAY_FOREACH(i, j)
-                        RET_GATHER(ret, load_static_record_file_item(i, records));
-                if (ret < 0)
-                        return ret;
-        } else if (sd_json_variant_is_object(j)) {
-                r = load_static_record_file_item(j, records);
-                if (r < 0)
-                        return r;
-        } else {
-                log_warning("JSON file '%s' contains neither array nor object, skipping.", cf->result);
+        return load_static_record_json(j, cf->result, records);
+}
+
+static int load_static_record_path(const char *path, Hashmap **records, Set **stats) {
+        _cleanup_(hashmap_freep) Hashmap *source = NULL;
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *j = NULL;
+        struct stat st;
+        unsigned line = 0, column = 0;
+        int r;
+
+        assert(path);
+        assert(records);
+        assert(stats);
+
+        if (stat(path, &st) < 0) {
+                r = -errno;
+                log_warning_errno(r, "Failed to stat static DNS record file '%s', skipping: %m", path);
                 return 0;
         }
 
-        return 1;
+        r = add_static_record_stat(stats, &st);
+        if (r < 0)
+                return r;
+
+        r = sd_json_parse_file(
+                        /* f= */ NULL,
+                        path,
+                        /* flags= */ 0,
+                        &j,
+                        &line,
+                        &column);
+        if (r < 0) {
+                if (line > 0)
+                        log_syntax(/* unit= */ NULL, LOG_WARNING, path, line, r, "Failed to parse JSON, skipping: %m");
+                else
+                        log_warning_errno(r, "Failed to parse JSON file '%s', skipping: %m", path);
+                return 0;
+        }
+
+        r = load_static_record_json(j, path, &source);
+        if (r < 0)
+                return r;
+
+        return merge_static_record_overrides(records, source);
+}
+
+static int load_static_record_credential(Hashmap **records, Set **stats) {
+        _cleanup_(hashmap_freep) Hashmap *source = NULL;
+        _cleanup_free_ char *path = NULL;
+        _cleanup_free_ void *data = NULL;
+        _cleanup_free_ char *text = NULL;
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *j = NULL;
+        struct stat st;
+        size_t size;
+        unsigned line = 0, column = 0;
+        int r;
+
+        assert(records);
+        assert(stats);
+
+        r = get_static_record_credential_path(&path);
+        if (IN_SET(r, -ENXIO, -ENOENT))
+                return 0;
+        if (r < 0)
+                return log_warning_errno(r, "Failed to determine credential network.rr path, ignoring: %m");
+
+        if (stat(path, &st) < 0) {
+                r = -errno;
+                if (r != -ENOENT)
+                        log_warning_errno(r, "Failed to stat credential network.rr, ignoring: %m");
+                return 0;
+        }
+
+        r = add_static_record_stat(stats, &st);
+        if (r < 0)
+                return r;
+
+        r = read_credential("network.rr", &data, &size);
+        if (IN_SET(r, -ENXIO, -ENOENT))
+                return 0;
+        if (r < 0)
+                return log_warning_errno(r, "Failed to read credential network.rr, ignoring: %m");
+
+        if (memchr(data, 0, size))
+                return log_warning_errno(SYNTHETIC_ERRNO(EINVAL), "Credential network.rr contains NUL bytes, ignoring.");
+
+        text = memdup_suffix0(data, size);
+        if (!text)
+                return log_oom();
+
+        r = sd_json_parse_with_source(text, "credential network.rr", /* flags= */ 0, &j, &line, &column);
+        if (r < 0) {
+                if (line > 0)
+                        log_syntax(/* unit= */ NULL, LOG_WARNING, "credential network.rr", line, r,
+                                   "Failed to parse JSON, skipping: %m");
+                else
+                        log_warning_errno(r, "Failed to parse credential network.rr, skipping: %m");
+                return 0;
+        }
+
+        r = load_static_record_json(j, "credential network.rr", &source);
+        if (r < 0)
+                return r;
+
+        return merge_static_record_overrides(records, source);
 }
 
 static int manager_static_records_read(Manager *m) {
@@ -152,17 +348,30 @@ static int manager_static_records_read(Manager *m) {
 
         /* Let's suppress reloads if nothing changed. For that keep the set of inodes from the previous
          * reload around, and see if there are any changes on them. */
-        bool reload;
-        if (set_size(m->static_records_stat) != n_files)
-                reload = true;
-        else {
-                reload = false;
+        bool reload = !m->static_records_loaded;
+        size_t n_stats = n_files;
+        if (!reload)
                 FOREACH_ARRAY(f, files, n_files)
                         if (!set_contains(m->static_records_stat, &(*f)->st)) {
                                 reload = true;
                                 break;
                         }
-        }
+
+        _cleanup_free_ char *credential_path = NULL;
+        if (get_static_record_credential_path(&credential_path) >= 0)
+                (void) static_record_source_stat(credential_path,
+                                                  m->static_records_loaded ? m->static_records_stat : NULL,
+                                                  &n_stats,
+                                                  &reload);
+
+        STRV_FOREACH(path, m->static_record_override_paths)
+                (void) static_record_source_stat(*path,
+                                                  m->static_records_loaded ? m->static_records_stat : NULL,
+                                                  &n_stats,
+                                                  &reload);
+
+        if (m->static_records_loaded && set_size(m->static_records_stat) != n_stats)
+                reload = true;
 
         if (!reload) {
                 log_debug("No static record files changed, not re-reading.");
@@ -170,15 +379,23 @@ static int manager_static_records_read(Manager *m) {
         }
 
         _cleanup_(hashmap_freep) Hashmap *records = NULL;
+        _cleanup_(hashmap_freep) Hashmap *overrides = NULL;
         _cleanup_(set_freep) Set *stats = NULL;
         FOREACH_ARRAY(f, files, n_files)
                 (void) load_static_record_file(*f, &records, &stats);
 
+        (void) load_static_record_credential(&overrides, &stats);
+        STRV_FOREACH(path, m->static_record_override_paths)
+                (void) load_static_record_path(*path, &overrides, &stats);
+
         hashmap_free(m->static_records);
         m->static_records = TAKE_PTR(records);
+        hashmap_free(m->static_record_overrides);
+        m->static_record_overrides = TAKE_PTR(overrides);
 
         set_free(m->static_records_stat);
         m->static_records_stat = TAKE_PTR(stats);
+        m->static_records_loaded = true;
 
         return 0;
 }
@@ -210,9 +427,38 @@ int manager_static_records_lookup(Manager *m, DnsQuestion *q, DnsAnswer **answer
         return 1;
 }
 
+int manager_static_record_overrides_lookup(Manager *m, DnsQuestion *q, DnsAnswer **answer) {
+        int r;
+
+        assert(m);
+        assert(q);
+        assert(answer);
+
+        if (!m->read_static_records)
+                return 0;
+
+        (void) manager_static_records_read(m);
+
+        const char *n = dns_question_first_name(q);
+        if (!n)
+                return 0;
+
+        DnsAnswer *f = hashmap_get(m->static_record_overrides, n);
+        if (!f)
+                return 0;
+
+        r = dns_answer_extend(answer, f);
+        if (r < 0)
+                return r;
+
+        return 1;
+}
+
 void manager_static_records_flush(Manager *m) {
         assert(m);
 
         m->static_records = hashmap_free(m->static_records);
+        m->static_record_overrides = hashmap_free(m->static_record_overrides);
         m->static_records_stat = set_free(m->static_records_stat);
+        m->static_records_loaded = false;
 }

--- a/src/resolve/resolved-static-records.h
+++ b/src/resolve/resolved-static-records.h
@@ -5,3 +5,4 @@
 
 void manager_static_records_flush(Manager *m);
 int manager_static_records_lookup(Manager *m, DnsQuestion* q, DnsAnswer **answer);
+int manager_static_record_overrides_lookup(Manager *m, DnsQuestion* q, DnsAnswer **answer);

--- a/src/resolve/test-resolved-static-records.c
+++ b/src/resolve/test-resolved-static-records.c
@@ -1,0 +1,96 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include <endian.h>
+
+#include "sd-event.h"
+
+#include "alloc-util.h"
+#include "dns-answer.h"
+#include "dns-question.h"
+#include "dns-rr.h"
+#include "fd-util.h"
+#include "fileio.h"
+#include "ordered-set.h"
+#include "path-util.h"
+#include "resolved-manager.h"
+#include "resolved-static-records.h"
+#include "rm-rf.h"
+#include "strv.h"
+#include "tests.h"
+#include "tmpfile-util.h"
+
+static void assert_override_address(Manager *manager, const char *name, uint32_t address) {
+        _cleanup_(dns_question_unrefp) DnsQuestion *question = NULL;
+        _cleanup_(dns_answer_unrefp) DnsAnswer *answer = NULL;
+        DnsResourceKey *key;
+        DnsResourceRecord *rr;
+
+        ASSERT_NOT_NULL(question = dns_question_new(1));
+        ASSERT_NOT_NULL(key = dns_resource_key_new(DNS_CLASS_IN, DNS_TYPE_A, name));
+        ASSERT_OK(dns_question_add(question, key, 0));
+        dns_resource_key_unref(key);
+
+        ASSERT_OK(manager_static_record_overrides_lookup(manager, question, &answer));
+        ASSERT_EQ(dns_answer_size(answer), 1u);
+
+        DnsAnswerItem *item = ASSERT_PTR(ordered_set_first(answer->items));
+        rr = item->rr;
+        ASSERT_EQ(rr->key->type, DNS_TYPE_A);
+        ASSERT_EQ(rr->a.in_addr.s_addr, htobe32(address));
+}
+
+TEST(static_record_overrides) {
+        _cleanup_(rm_rf_physical_and_freep) char *credential_dir = NULL;
+        _cleanup_free_ char *credential_path = NULL;
+        _cleanup_(sd_event_unrefp) sd_event *event = NULL;
+        _cleanup_(strv_freep) char **paths = NULL;
+        _cleanup_(unlink_tempfilep) char path[] = "/tmp/test-resolved-static-records.XXXXXX";
+        const char *old_credential_dir;
+        _cleanup_free_ char *saved_credential_dir = NULL;
+        Manager manager = {};
+        int fd;
+
+        old_credential_dir = getenv("CREDENTIALS_DIRECTORY");
+        if (old_credential_dir)
+                ASSERT_NOT_NULL(saved_credential_dir = strdup(old_credential_dir));
+
+        ASSERT_OK(mkdtemp_malloc(NULL, &credential_dir));
+        ASSERT_OK_ERRNO(setenv("CREDENTIALS_DIRECTORY", credential_dir, true));
+
+        ASSERT_NOT_NULL(credential_path = path_join(credential_dir, "network.rr"));
+        ASSERT_OK(write_string_file(
+                              credential_path,
+                              "{ \"key\": { \"name\": \"rr-override.waldo\", \"type\": 1 }, "
+                              "\"address\": [ 5, 6, 7, 8 ] }",
+                              WRITE_STRING_FILE_CREATE|WRITE_STRING_FILE_AVOID_NEWLINE));
+
+        ASSERT_OK(fd = mkostemp_safe(path));
+        safe_close(fd);
+        ASSERT_OK(write_string_file(
+                              path,
+                              "{ \"key\": { \"name\": \"rr-override.waldo\", \"type\": 1 }, "
+                              "\"address\": [ 1, 2, 3, 4 ] }",
+                              WRITE_STRING_FILE_TRUNCATE|WRITE_STRING_FILE_AVOID_NEWLINE));
+
+        ASSERT_OK(sd_event_new(&event));
+        ASSERT_NOT_NULL(paths = strv_new(path));
+
+        manager = (Manager) {
+                .event = event,
+                .read_static_records = true,
+                .static_records_last = USEC_INFINITY,
+                .static_record_override_paths = TAKE_PTR(paths),
+        };
+
+        assert_override_address(&manager, "rr-override.waldo", 0x01020304);
+
+        manager_static_records_flush(&manager);
+        strv_free(manager.static_record_override_paths);
+
+        if (saved_credential_dir)
+                ASSERT_OK_ERRNO(setenv("CREDENTIALS_DIRECTORY", saved_credential_dir, true));
+        else
+                ASSERT_OK_ERRNO(unsetenv("CREDENTIALS_DIRECTORY"));
+}
+
+DEFINE_TEST_MAIN(LOG_DEBUG);

--- a/units/systemd-resolved.service.in
+++ b/units/systemd-resolved.service.in
@@ -53,6 +53,7 @@ Type=notify-reload
 User=systemd-resolve
 ImportCredential=network.dns
 ImportCredential=network.search_domains
+ImportCredential=network.rr
 {{SERVICE_WATCHDOG}}
 
 [Install]


### PR DESCRIPTION
1. Add a shared override layer for static DNS RR answers in
   systemd-resolved, while keeping the existing .rr drop-ins.

2. Load network.rr from system credentials and
   systemd.resolved.rr= from the kernel command line.

3. Apply override RR sets before normal static records so redirected
   names win deterministically.

4. Track source changes, update the docs, and add tests for the new
   lookup path and precedence.

Closes: #43456