### PR TITLE
test: use socat for oomd prekill hooks

### DIFF
--- a/test/units/TEST-55-OOMD.sh
+++ b/test/units/TEST-55-OOMD.sh
@@ -519,7 +519,7 @@ EOF
 
     # one hook
     mkdir -p /run/systemd/oomd.prekill.hook/
-    ncat --recv-only -kUl /run/systemd/oomd.prekill.hook/althook >/tmp/oomd_event.json &
+    socat -u UNIX-LISTEN:/run/systemd/oomd.prekill.hook/althook STDOUT >/tmp/oomd_event.json &
     ! systemctl start --wait TEST-55-OOMD-testbloat.service || exit 1
     [[ $(jq -r .method </tmp/oomd_event.json) = 'io.systemd.oom.Prekill.Notify' ]]
 
@@ -527,7 +527,7 @@ EOF
 
     # many hooks
     for i in {1..4}; do
-        ncat --recv-only -kUl "/run/systemd/oomd.prekill.hook/althook$i" >"/tmp/oomd_event$i.json" &
+        socat -u "UNIX-LISTEN:/run/systemd/oomd.prekill.hook/althook$i" STDOUT >"/tmp/oomd_event$i.json" &
     done
 
     ! systemctl start --wait TEST-55-OOMD-testbloat.service || exit 1


### PR DESCRIPTION
Arch rolling now ships Nmap 7.991, which contains Nmap commit b408fc2, titled "Ignore stdin with recv-only"[1].

That change omits stdin from the Ncat descriptor list in recv-only mode. For a Unix listener, the listening socket is then its sole descriptor. Ncat enters its listen loop only when that list has more than one descriptor or a connection already exists, so it exits immediately after bind and leaves the socket pathname behind.

systemd-oomd sees that stale pathname, tries to invoke the hook, and gets ECONNREFUSED. The notification output therefore remains empty and the jq assertion fails. The problem is visible in trunk's CI failures[2].

Use socat for these one-way Unix listeners. It remains in accept while waiting for the hook and is already installed in integration images.

[1] https://github.com/nmap/nmap/commit/b408fc243ce26da7ca497595833c14ce36a5e1a4
[2] https://github.com/systemd/systemd/actions/runs/32622985037/job/97153925154