### PR TITLE
hwdb: add calibration override for AYANEO Flip KB/DS touchscreen

### DIFF
--- a/hwdb.d/60-evdev.hwdb
+++ b/hwdb.d/60-evdev.hwdb
@@ -432,6 +432,19 @@ evdev:name:Atmel maXTouch Touch*:dmi:bvn*:bvr*:bd*:svnGOOGLE:pnSamus:*
 evdev:input:b0018v27C6p01E9*
  EVDEV_ABS_18=0:255:0:0
 
+# Goodix Capacitive TouchScreen (AYANEO Flip KB / Flip DS, main display)
+# The touch controller reports an invalid/garbage calibration range at boot
+# (observed ABS_X max as high as 65343, ABS_Y max as low as 256) due to
+# unreliable I2C communication during early boot. Override with the correct
+# panel resolution. The Flip DS is mostly identical to the Flip KB apart
+# from a second screen replacing the keyboard.
+evdev:name:Goodix Capacitive TouchScreen:dmi:*svnAYANEO:*pnFLIPKB**
+evdev:name:Goodix Capacitive TouchScreen:dmi:*svnAYANEO:*pnFLIPDS**
+ EVDEV_ABS_00=0:1199:0:0:0
+ EVDEV_ABS_01=0:1919:0:0:0
+ EVDEV_ABS_35=0:1199:0:0:0
+ EVDEV_ABS_36=0:1919:0:0:0
+
 #########################################
 # Granite Devices Simucube wheel bases
 #########################################


### PR DESCRIPTION
The Goodix Capacitive TouchScreen on the AYANEO Flip KB reports an invalid calibration range during boot, due to unreliable I2C communication with the touch controller early in the boot sequence. Observed values include ABS_X max as high as 65343 and ABS_Y max as low as 256, far outside the panel's actual resolution.

Confirmed on real hardware across multiple cold boots that the controller never reports a correct calibration on its own, including after forcing driver re-probes via unbind/bind. This overrides the axis ranges with the panel's real resolution (1200x1920).

Also covers the Flip DS, mostly identical to the Flip KB apart from a second screen replacing the keyboard. Not independently verified on Flip DS hardware, but consistent with a community report of the same Y-axis maximum (1919) for that model's main display: https://universal-blue.discourse.group/t/ayaneo-flip-kb-almost-perfect-just-a-few-quirks/9039/3

Note: the panel is also mounted rotated relative to the raw sensor axes; this entry only fixes the calibration range, not rotation (most desktop environments handle touch rotation automatically when the display output is rotated, independent of this).

Tested with `systemd-hwdb --strict update` and `systemd-hwdb query` against the device's real modalias.
