### PR TITLE
journal: Log the error that made a journal file unusable

### DIFF
--- a/src/shared/journal-file-util.c
+++ b/src/shared/journal-file-util.c
@@ -530,7 +530,7 @@ int journal_file_open_reliably(
                 return r;
 
         /* The file is corrupted. Rotate it away and try it again (but only once) */
-        log_warning_errno(r, "File %s corrupted or uncleanly shut down, renaming and replacing.", fname);
+        log_warning_errno(r, "File %s corrupted or uncleanly shut down, renaming and replacing: %m", fname);
 
         /* The file is corrupted. Try opening it read-only as the template before rotating to inherit its
          * sequence number and ID. */


### PR DESCRIPTION
journal_file_open_reliably() recovers from nine distinct errors, but the warning it emits names none of them:

    systemd-journald[47980]: File /var/log/journal/95790226b8d0779f4b4797314ca986d4/user-7736.journal corrupted or uncleanly shut down, renaming and replacing.

So an administrator cannot tell an unclean journald shutdown (-EBUSY) from real corruption (-EBADMSG), an incompatible feature flag (-EPROTONOSUPPORT) or a failing disk (-EIO) — all of which reach this line. The reason is known at this point, but only reachable through the log_debug_errno() calls in journal_file_verify_header(), which are off by default and gone by the time the warning is noticed.

Append %m so the error is part of the message. It now reads

    File /run/log/journal/…/user-7736.journal corrupted or uncleanly shut down, renaming and replacing: Device or resource busy

for a file left online by an unclean journald exit, and

  … renaming and replacing: No data available

for a truncated one.