### PR TITLE
nspawn: set ping group range for userns containers

### DIFF
--- a/src/nspawn/nspawn.c
+++ b/src/nspawn/nspawn.c
@@ -3264,6 +3264,16 @@ static int patch_sysctl(void) {
 
         flags = effective_clone_ns_flags();
 
+        if (FLAGS_SET(flags, CLONE_NEWUSER|CLONE_NEWNET) && !arg_network_namespace_path) {
+                /* Follow the system-wide default from sysctl.d/50-default.conf, but clamp it to the
+                 * groups mapped into the container's user namespace. */
+                r = sysctl_writef("net/ipv4/ping_group_range", "0 " GID_FMT,
+                                 MIN(arg_uid_range - 1, (gid_t) INT32_MAX));
+                if (r < 0)
+                        log_warning_errno(r,
+                                          "Failed to set sysctl 'net.ipv4.ping_group_range', ignoring: %m");
+        }
+
         STRV_FOREACH_PAIR(k, v, arg_sysctl) {
                 bool good = false;
 

--- a/test/units/TEST-13-NSPAWN.nspawn.sh
+++ b/test/units/TEST-13-NSPAWN.nspawn.sh
@@ -1211,6 +1211,26 @@ matrix_run_one() {
     return 0
 }
 
+testcase_ping_group_range() {
+    local range root
+
+    if [[ "$IS_USERNS_SUPPORTED" == "no" ]]; then
+        echo "Skipping user namespace test..."
+        return 0
+    fi
+
+    root="$(mktemp -d /var/lib/machines/TEST-13-NSPAWN.ping-group-range.XXX)"
+    create_dummy_container "$root"
+    trap 'rm -fr "$root"' RETURN ERR
+
+    range="$(systemd-nspawn --pipe --register=no \
+                            --directory="$root" \
+                            --private-network \
+                            --private-users=pick \
+                            cat /proc/sys/net/ipv4/ping_group_range)"
+    assert_eq "${range//[[:space:]]/ }" "0 65535"
+}
+
 testcase_api_vfs() {
     local api_vfs_writable
 


### PR DESCRIPTION
Fixes #41603.

When nspawn creates both a private user namespace and a private network namespace, `net.ipv4.ping_group_range` may exclude the container's groups.

Initialize the range using the mapped GIDs, capped at `INT32_MAX`, following the system-wide default from `sysctl.d/50-default.conf`. Treat write failures as non-fatal warnings, and leave network namespaces supplied through `--network-namespace-path=` untouched.

A standalone TEST-13 regression reads `ping_group_range` inside a container created with `--private-network --private-users=pick` and checks the expected `0 65535` range. It uses existing tools in the minimal container image; no image configuration changes or additional packages are needed.

Validation:

- `git diff --check` passed.
- Syntax check of the added Bash test function passed.
- Build and runtime validation for this revision: pending PR CI.
