### PR TITLE
sd-journal: skip over empty journal files instead of failing the open

### DIFF
--- a/man/sd_journal_open.xml
+++ b/man/sd_journal_open.xml
@@ -147,15 +147,26 @@
 
     <para><function>sd_journal_open_files()</function> is similar to <function>sd_journal_open()</function> but takes a
     <constant>NULL</constant>-terminated list of file paths to open.  All files will be opened and interleaved
-    automatically. This call also takes a flags argument, but it must be passed as 0 as no flags are currently
-    understood for this call. Please note that in the case of a live journal, this function is only useful for
-    debugging, because individual journal files can be rotated at any moment, and the opening of specific files is
-    inherently racy.</para>
+    automatically. The only flag accepted by this call is <constant>SD_JOURNAL_ASSUME_IMMUTABLE</constant>, which
+    declares that the listed files will not change while they are in use. Please note that in the case of a live
+    journal, this function is only useful for debugging, because individual journal files can be rotated at any
+    moment, and the opening of specific files is inherently racy. When
+    <constant>SD_JOURNAL_ASSUME_IMMUTABLE</constant> is specified, empty journal files are skipped, as if they had not
+    been listed: journal files are created empty and acquire their header shortly after creation, hence an empty
+    journal file carries no data yet, and never will for a caller that treats it as immutable. Waiting for changes is
+    not available under the flag anyway: <function>sd_journal_get_fd()</function> and related calls fail with
+    <constant>-EUNATCH</constant>. A skipped file stays
+    out of the file set for the lifetime of the journal object, and if all listed files are skipped the call still
+    succeeds and returns a journal object without entries. Without the flag, an empty journal file makes the call fail
+    with <constant>-ENODATA</constant>.</para>
 
     <para><function>sd_journal_open_files_fd()</function> is similar to <function>sd_journal_open_files()</function>
     but takes an array of open file descriptors that must reference journal files, instead of an array of file system
-    paths. Pass the array of file descriptors as second argument, and the number of array entries in the third. The
-    flags parameter must be passed as 0.</para>
+    paths. Pass the array of file descriptors as second argument, and the number of array entries in the third. This
+    call accepts the same flags as <function>sd_journal_open_files()</function>, but never skips empty files, since a
+    skipped file descriptor would neither be taken over by the journal object nor reported back to the caller: a
+    zero-length file makes the call fail with <constant>-ENODATA</constant>, even when
+    <constant>SD_JOURNAL_ASSUME_IMMUTABLE</constant> is specified.</para>
 
     <para><varname>sd_journal</varname> objects cannot be used in the
     child after a fork. Functions which take a journal object as an

--- a/src/libsystemd/sd-journal/journal-file.c
+++ b/src/libsystemd/sd-journal/journal-file.c
@@ -542,6 +542,7 @@ static bool hash_table_is_valid(uint64_t offset, uint64_t size, uint64_t header_
 
 static int journal_file_verify_header(JournalFile *f) {
         uint64_t arena_size, header_size;
+        int r;
 
         assert(f);
         assert(f->header);
@@ -583,6 +584,14 @@ static int journal_file_verify_header(JournalFile *f) {
 
         if (UINT64_MAX - header_size < arena_size)
                 return -ENODATA;
+
+        /* The writer grows the file before it updates arena_size, hence refresh possibly stale stat data
+         * before judging (#41992). */
+        if (header_size + arena_size > (uint64_t) f->last_stat.st_size) {
+                r = journal_file_fstat(f);
+                if (r < 0)
+                        return r;
+        }
 
         uint64_t file_size = (uint64_t) f->last_stat.st_size;
 
@@ -714,7 +723,6 @@ static int journal_file_verify_header(JournalFile *f) {
         if (journal_file_writable(f)) {
                 sd_id128_t machine_id;
                 uint8_t state;
-                int r;
 
                 r = sd_id128_get_machine(&machine_id);
                 if (ERRNO_IS_NEG_MACHINE_ID_UNSET(r)) /* Gracefully handle the machine ID not being initialized yet */

--- a/src/libsystemd/sd-journal/journal-file.c
+++ b/src/libsystemd/sd-journal/journal-file.c
@@ -524,17 +524,18 @@ static bool offset_is_valid(uint64_t offset, uint64_t header_size, uint64_t tail
         return true;
 }
 
-static bool hash_table_is_valid(uint64_t offset, uint64_t size, uint64_t header_size, uint64_t arena_size, uint64_t tail_object_offset) {
+static bool hash_table_is_valid(uint64_t offset, uint64_t size, uint64_t header_size, uint64_t arena_size) {
         if ((offset == 0) != (size == 0))
                 return false;
         if (offset == 0)
                 return true;
         if (offset <= offsetof(Object, hash_table.items))
                 return false;
-        offset -= offsetof(Object, hash_table.items);
-        if (!offset_is_valid(offset, header_size, tail_object_offset))
+        if (!offset_is_valid(offset - offsetof(Object, hash_table.items), header_size, header_size + arena_size))
                 return false;
-        assert(offset <= header_size + arena_size);
+        /* The item span itself must lie inside the arena, not just the object start. */
+        if (offset > header_size + arena_size)
+                return false;
         if (size > header_size + arena_size - offset)
                 return false;
         return true;
@@ -597,7 +598,6 @@ static int journal_file_verify_header(JournalFile *f) {
 
         /* Probably an unclean shutdown where the header was written, but the arena data was not. On write we
          * should ask the caller to rotate, but on read, we can still work it out with bounds checks. */
-        bool truncated = false;
         if (header_size + arena_size > file_size) {
                 if (journal_file_writable(f))
                         return -ENODATA;
@@ -614,15 +614,33 @@ static int journal_file_verify_header(JournalFile *f) {
                           arena_size,
                           file_size);
                 arena_size = available - header_size;
-                truncated = true;
         }
 
+        /* The hash table descriptors are set up once, when the file is created, hence cannot be observed
+         * torn, and they are the one thing the object accessors do not revalidate:
+         * journal_file_map_data_hash_table() and journal_file_map_field_hash_table() map whatever they
+         * denote. Check them for every open. */
+        if (!hash_table_is_valid(le64toh(f->header->data_hash_table_offset),
+                                 le64toh(f->header->data_hash_table_size),
+                                 header_size, arena_size))
+                return -ENODATA;
+
+        if (!hash_table_is_valid(le64toh(f->header->field_hash_table_offset),
+                                 le64toh(f->header->field_hash_table_size),
+                                 header_size, arena_size))
+                return -ENODATA;
+
+        /* The remaining checks relate fields the writer updates one at a time, without locks, as it
+         * appends. A reader racing an append can load a torn pair, e.g. a tail_entry_offset pointing past
+         * the tail_object_offset loaded a moment earlier, and would fail spuriously here (#40053). The
+         * state field cannot say whether the file is settled: journald moves a live file to STATE_OFFLINE
+         * on sync and back on the next append, and a crashed writer leaves STATE_ONLINE behind for good.
+         * Hence enforce these relations only on writable opens; readers revalidate every offset against
+         * the file size at access time anyway. */
+        if (!journal_file_writable(f))
+                return 0;
+
         uint64_t tail_object_offset = le64toh(f->header->tail_object_offset);
-        if (truncated)
-                /* The tail may be in the lost region, so cap it at the last possible object header start. */
-                tail_object_offset = MIN(
-                                tail_object_offset,
-                                header_size + arena_size - offsetof(ObjectHeader, payload));
         if (!offset_is_valid(tail_object_offset, header_size, UINT64_MAX))
                 return -ENODATA;
         if (header_size + arena_size < tail_object_offset)
@@ -630,21 +648,11 @@ static int journal_file_verify_header(JournalFile *f) {
         if (header_size + arena_size - tail_object_offset < offsetof(ObjectHeader, payload))
                 return -ENODATA;
 
-        if (!hash_table_is_valid(le64toh(f->header->data_hash_table_offset),
-                                 le64toh(f->header->data_hash_table_size),
-                                 header_size, arena_size, tail_object_offset))
-                return -ENODATA;
-
-        if (!hash_table_is_valid(le64toh(f->header->field_hash_table_offset),
-                                 le64toh(f->header->field_hash_table_size),
-                                 header_size, arena_size, tail_object_offset))
-                return -ENODATA;
-
         uint64_t entry_array_offset = le64toh(f->header->entry_array_offset);
         if (!offset_is_valid(entry_array_offset, header_size, tail_object_offset))
                 return -ENODATA;
 
-        if (!truncated && JOURNAL_HEADER_CONTAINS(f->header, tail_entry_array_offset)) {
+        if (JOURNAL_HEADER_CONTAINS(f->header, tail_entry_array_offset)) {
                 uint32_t offset = le32toh(f->header->tail_entry_array_offset);
                 uint32_t n = le32toh(f->header->tail_entry_array_n_entries);
 
@@ -661,7 +669,7 @@ static int journal_file_verify_header(JournalFile *f) {
                         return -ENODATA;
         }
 
-        if (!truncated && JOURNAL_HEADER_CONTAINS(f->header, tail_entry_offset)) {
+        if (JOURNAL_HEADER_CONTAINS(f->header, tail_entry_offset)) {
                 uint64_t offset = le64toh(f->header->tail_entry_offset);
 
                 if (!offset_is_valid(offset, header_size, tail_object_offset))
@@ -693,7 +701,7 @@ static int journal_file_verify_header(JournalFile *f) {
 
         /* Verify number of objects */
         uint64_t n_objects = le64toh(f->header->n_objects);
-        if (!truncated && n_objects > arena_size / offsetof(ObjectHeader, payload))
+        if (n_objects > arena_size / offsetof(ObjectHeader, payload))
                 return -ENODATA;
 
         uint64_t n_entries = le64toh(f->header->n_entries);
@@ -720,36 +728,32 @@ static int journal_file_verify_header(JournalFile *f) {
             le32toh(f->header->tail_entry_array_n_entries) > n_entries)
                 return -ENODATA;
 
-        if (journal_file_writable(f)) {
-                sd_id128_t machine_id;
-                uint8_t state;
+        sd_id128_t machine_id;
+        r = sd_id128_get_machine(&machine_id);
+        if (ERRNO_IS_NEG_MACHINE_ID_UNSET(r)) /* Gracefully handle the machine ID not being initialized yet */
+                machine_id = SD_ID128_NULL;
+        else if (r < 0)
+                return r;
 
-                r = sd_id128_get_machine(&machine_id);
-                if (ERRNO_IS_NEG_MACHINE_ID_UNSET(r)) /* Gracefully handle the machine ID not being initialized yet */
-                        machine_id = SD_ID128_NULL;
-                else if (r < 0)
-                        return r;
+        if (!sd_id128_equal(machine_id, f->header->machine_id))
+                return log_debug_errno(SYNTHETIC_ERRNO(EHOSTDOWN),
+                                       "Trying to open journal file from different host for writing, refusing.");
 
-                if (!sd_id128_equal(machine_id, f->header->machine_id))
-                        return log_debug_errno(SYNTHETIC_ERRNO(EHOSTDOWN),
-                                               "Trying to open journal file from different host for writing, refusing.");
+        uint8_t state = f->header->state;
 
-                state = f->header->state;
+        if (state == STATE_ARCHIVED)
+                return -ESHUTDOWN; /* Already archived */
+        if (state == STATE_ONLINE)
+                return log_debug_errno(SYNTHETIC_ERRNO(EBUSY),
+                                       "Journal file %s is already online. Assuming unclean closing.",
+                                       f->path);
+        if (state != STATE_OFFLINE)
+                return log_debug_errno(SYNTHETIC_ERRNO(EBUSY),
+                                       "Journal file %s has unknown state %i.",
+                                       f->path, state);
 
-                if (state == STATE_ARCHIVED)
-                        return -ESHUTDOWN; /* Already archived */
-                if (state == STATE_ONLINE)
-                        return log_debug_errno(SYNTHETIC_ERRNO(EBUSY),
-                                               "Journal file %s is already online. Assuming unclean closing.",
-                                               f->path);
-                if (state != STATE_OFFLINE)
-                        return log_debug_errno(SYNTHETIC_ERRNO(EBUSY),
-                                               "Journal file %s has unknown state %i.",
-                                               f->path, state);
-
-                if (f->header->field_hash_table_size == 0 || f->header->data_hash_table_size == 0)
-                        return -EBADMSG;
-        }
+        if (f->header->field_hash_table_size == 0 || f->header->data_hash_table_size == 0)
+                return -EBADMSG;
 
         return 0;
 }

--- a/src/libsystemd/sd-journal/sd-journal.c
+++ b/src/libsystemd/sd-journal/sd-journal.c
@@ -2689,11 +2689,16 @@ static int journal_file_read_tail_timestamp(sd_journal *j, JournalFile *f) {
                  * recent entry timestamps from the header. It's equally good. Unfortunately though, in old
                  * versions of the journal the boot ID in the header doesn't have to match the monotonic
                  * timestamp of the header. Let's check the header flag that indicates whether this strictly
-                 * matches first hence, before using the data. */
+                 * matches first hence, before using the data. The timestamps must also be valid: a
+                 * read-only open does not validate them, hence check here, at use. */
 
-                if (JOURNAL_HEADER_TAIL_ENTRY_BOOT_ID(f->header) && f->header->state == STATE_ARCHIVED) {
-                        mo = le64toh(f->header->tail_entry_monotonic);
-                        rt = le64toh(f->header->tail_entry_realtime);
+                uint64_t header_mo = le64toh(READ_NOW(f->header->tail_entry_monotonic)),
+                         header_rt = le64toh(READ_NOW(f->header->tail_entry_realtime));
+
+                if (JOURNAL_HEADER_TAIL_ENTRY_BOOT_ID(f->header) && f->header->state == STATE_ARCHIVED &&
+                    VALID_MONOTONIC(header_mo) && VALID_REALTIME(header_rt)) {
+                        mo = header_mo;
+                        rt = header_rt;
                         id = f->header->tail_entry_boot_id;
                         offset = UINT64_MAX;
                 } else {

--- a/src/libsystemd/sd-journal/sd-journal.c
+++ b/src/libsystemd/sd-journal/sd-journal.c
@@ -1671,6 +1671,26 @@ static int add_any_file(
                 }
         }
 
+        if (our_fd >= 0 && st.st_size == 0 && FLAGS_SET(j->flags, SD_JOURNAL_ASSUME_IMMUTABLE)) {
+                /* Journal writers create journal files empty at their final name, and write the header in
+                 * a second step. Hence an empty journal file is likely one we caught right at the time of
+                 * its creation, before its header was written, and carries no data yet. Skip it, as if it
+                 * didn't exist yet, instead of failing the whole open with -ENODATA, but record the skip
+                 * in the error map so that callers can still report the file. Do this only when the
+                 * caller declared it won't wait for changes: without SD_JOURNAL_ASSUME_IMMUTABLE the
+                 * caller may wait for the file to become readable, but a file skipped here would never be
+                 * picked up again once sd_journal_open_files() has marked the file set as final, so keep
+                 * the hard error there (for watched directories the enumeration ignores the error, and
+                 * inotify retries once the header has been written). Also do this only for files we
+                 * opened ourselves by path: for a caller provided fd skipping the file would leave the
+                 * fd's ownership in limbo, neither taken by us nor reported back. */
+                log_debug("Journal file %s is empty, likely being created right now, skipping.", path);
+                r = journal_put_error(j, -ENODATA, path);
+                if (r < 0)
+                        return r;
+                return 0;
+        }
+
         if (ordered_hashmap_size(j->files) >= JOURNAL_FILES_MAX) {
                 r = log_debug_errno(SYNTHETIC_ERRNO(ETOOMANYREFS),
                                     "Too many open journal files, not adding %s.", path ?: "fd");

--- a/src/libsystemd/sd-journal/test-journal-init.c
+++ b/src/libsystemd/sd-journal/test-journal-init.c
@@ -1,17 +1,88 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
+#include <fcntl.h>
 #include <stdlib.h>
 #include <unistd.h>
 
 #include "sd-journal.h"
 
+#include "alloc-util.h"
 #include "chattr-util.h"
+#include "fd-util.h"
+#include "hashmap.h"
+#include "iovec-util.h"
+#include "journal-file-util.h"
 #include "journal-internal.h"
 #include "log.h"
 #include "parse-util.h"
+#include "path-util.h"
 #include "process-util.h"
 #include "rm-rf.h"
 #include "tests.h"
+
+static void test_tail_timestamp_archived_fallback(void) {
+        _cleanup_(mmap_cache_unrefp) MMapCache *m = NULL;
+        _cleanup_close_ int fd = -EBADF;
+        _cleanup_free_ char *path = NULL;
+        dual_timestamp ts = {};
+        sd_journal *j;
+        JournalFile *f;
+        le64_t v;
+        uint8_t state;
+        char t[] = "/var/tmp/journal-tail-XXXXXX";
+
+        /* An archived file's tail entry timestamps are not validated on a read-only open, so the
+         * header fallback in journal_file_read_tail_timestamp() must validate them at use, and read
+         * the last entry instead when they are invalid. */
+
+        ASSERT_NOT_NULL(mkdtemp(t));
+        (void) chattr_path(t, FS_NOCOW_FL, FS_NOCOW_FL);
+        ASSERT_NOT_NULL(path = path_join(t, "test.journal"));
+
+        ASSERT_NOT_NULL(m = mmap_cache_new());
+        ASSERT_OK_ZERO(journal_file_open(
+                        -EBADF, path, O_RDWR|O_CREAT, JOURNAL_COMPRESS, 0666, UINT64_MAX,
+                        /* metrics= */ NULL, m, /* template= */ NULL, &f));
+
+        for (unsigned i = 0; i < 5; i++) {
+                struct iovec iovec = IOVEC_MAKE_STRING("LINE=x");
+                ts.monotonic = 100 + i;
+                ts.realtime = 1000 + i;
+                ASSERT_OK_ZERO(journal_file_append_entry(
+                                f, &ts, /* boot_id= */ NULL, &iovec, 1,
+                                /* seqnum= */ NULL, /* seqnum_id= */ NULL,
+                                /* ret_object= */ NULL, /* ret_offset= */ NULL));
+        }
+
+        (void) journal_file_offline_close(f);
+
+        /* The fallback requires an archived file whose tail_entry_offset does not resolve to an
+         * entry object: point it at the first object after the header, which is a hash table, and
+         * make tail_entry_realtime invalid. */
+        ASSERT_OK_ERRNO(fd = open(path, O_RDWR|O_CLOEXEC));
+        state = STATE_ARCHIVED;
+        ASSERT_OK_EQ_ERRNO(pwrite(fd, &state, sizeof(state), offsetof(Header, state)),
+                           (ssize_t) sizeof(state));
+        ASSERT_OK_EQ_ERRNO(pread(fd, &v, sizeof(v), offsetof(Header, header_size)),
+                           (ssize_t) sizeof(v));
+        ASSERT_OK_EQ_ERRNO(pwrite(fd, &v, sizeof(v), offsetof(Header, tail_entry_offset)),
+                           (ssize_t) sizeof(v));
+        v = htole64(UINT64_MAX);
+        ASSERT_OK_EQ_ERRNO(pwrite(fd, &v, sizeof(v), offsetof(Header, tail_entry_realtime)),
+                           (ssize_t) sizeof(v));
+
+        ASSERT_OK_ZERO(sd_journal_open_files(&j, (const char**) STRV_MAKE(path), 0));
+        ASSERT_OK(sd_journal_next(j));
+
+        /* The newest-entry cache must hold the last entry's timestamps, not the doctored header
+         * value. */
+        ASSERT_NOT_NULL(f = ordered_hashmap_first(j->files));
+        ASSERT_EQ(f->newest_realtime_usec, UINT64_C(1004));
+        ASSERT_EQ(f->newest_monotonic_usec, UINT64_C(104));
+
+        sd_journal_close(j);
+        ASSERT_OK(rm_rf(t, REMOVE_ROOT|REMOVE_PHYSICAL));
+}
 
 int main(int argc, char *argv[]) {
         sd_journal *j;
@@ -61,6 +132,8 @@ int main(int argc, char *argv[]) {
         }
 
         ASSERT_OK(rm_rf(t, REMOVE_ROOT|REMOVE_PHYSICAL));
+
+        test_tail_timestamp_archived_fallback();
 
         return 0;
 }

--- a/src/libsystemd/sd-journal/test-journal-init.c
+++ b/src/libsystemd/sd-journal/test-journal-init.c
@@ -2,6 +2,7 @@
 
 #include <fcntl.h>
 #include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
 
 #include "sd-journal.h"
@@ -19,6 +20,96 @@
 #include "process-util.h"
 #include "rm-rf.h"
 #include "tests.h"
+#include "time-util.h"
+
+static void test_open_files_incomplete_header(const char *root) {
+        _cleanup_(mmap_cache_unrefp) MMapCache *m = NULL;
+        _cleanup_free_ char *empty = NULL, *truncated = NULL, *garbage = NULL, *valid = NULL;
+        _cleanup_close_ int fd = -EBADF;
+        struct iovec iovec = IOVEC_MAKE_STRING("MESSAGE=hello");
+        sd_journal *j = NULL;
+        JournalFile *vf;
+        dual_timestamp ts;
+        char buf[300];
+
+        /* Journal writers create journal files empty at their final name, and write the header in a
+         * second step. With SD_JOURNAL_ASSUME_IMMUTABLE the caller declared it won't wait for changes,
+         * hence opening such a nascent file shall succeed, skip the file, and record the skip in the
+         * error map. Without the flag the caller may wait for the file to become readable, but
+         * sd_journal_open_files() pins the file set, so a file skipped at open time would be ignored
+         * forever: the open shall keep failing instead. A file with an incomplete or invalid header
+         * shall keep reporting an error in any case. */
+
+        ASSERT_NOT_NULL(empty = path_join(root, "empty.journal"));
+        ASSERT_OK_ERRNO(fd = open(empty, O_CREAT|O_WRONLY|O_CLOEXEC, 0644));
+        fd = safe_close(fd);
+
+        ASSERT_OK_ZERO(sd_journal_open_files(&j, (const char**) STRV_MAKE(empty), SD_JOURNAL_ASSUME_IMMUTABLE));
+        ASSERT_TRUE(ordered_hashmap_isempty(j->files));
+        ASSERT_TRUE(hashmap_contains(j->errors, INT_TO_PTR(-ENODATA)));
+        ASSERT_OK_ZERO(sd_journal_seek_head(j));
+        ASSERT_OK_ZERO(sd_journal_next(j));
+        sd_journal_close(j);
+        j = NULL;
+
+        ASSERT_ERROR(sd_journal_open_files(&j, (const char**) STRV_MAKE(empty), 0), ENODATA);
+        ASSERT_NULL(j);
+
+        /* An empty file among valid ones is skipped, and doesn't affect the valid ones. */
+        ASSERT_NOT_NULL(m = mmap_cache_new());
+        ASSERT_NOT_NULL(valid = path_join(root, "valid.journal"));
+        ASSERT_OK_ZERO(journal_file_open(-EBADF, valid, O_RDWR|O_CREAT, JOURNAL_COMPRESS, 0644, UINT64_MAX,
+                                         /* metrics= */ NULL, m, /* template= */ NULL, &vf));
+        dual_timestamp_now(&ts);
+        ASSERT_OK_ZERO(journal_file_append_entry(vf, &ts, /* boot_id= */ NULL, &iovec, 1,
+                                                 /* seqnum= */ NULL, /* seqnum_id= */ NULL,
+                                                 /* ret_object= */ NULL, /* ret_offset= */ NULL));
+        (void) journal_file_offline_close(vf);
+
+        ASSERT_OK_ZERO(sd_journal_open_files(&j, (const char**) STRV_MAKE(empty, valid), SD_JOURNAL_ASSUME_IMMUTABLE));
+        ASSERT_EQ(ordered_hashmap_size(j->files), 1u);
+        ASSERT_TRUE(hashmap_contains(j->errors, INT_TO_PTR(-ENODATA)));
+        ASSERT_OK_ZERO(sd_journal_seek_head(j));
+        ASSERT_EQ(sd_journal_next(j), 1);
+        ASSERT_OK_ZERO(sd_journal_next(j));
+        sd_journal_close(j);
+        j = NULL;
+
+        ASSERT_ERROR(sd_journal_open_files(&j, (const char**) STRV_MAKE(empty, valid), 0), ENODATA);
+        ASSERT_NULL(j);
+
+        /* For caller provided fds the error is kept even with SD_JOURNAL_ASSUME_IMMUTABLE, since
+         * skipping the file would leave the fd's ownership in limbo. The fd shall remain open, as for
+         * any other failure. */
+        ASSERT_OK_ERRNO(fd = open(empty, O_RDONLY|O_CLOEXEC));
+        ASSERT_ERROR(sd_journal_open_files_fd(&j, (int[]) { fd }, 1, SD_JOURNAL_ASSUME_IMMUTABLE), ENODATA);
+        ASSERT_NULL(j);
+        ASSERT_OK_ERRNO(fcntl(fd, F_GETFD));
+        fd = safe_close(fd);
+
+        /* Only a zero size file counts as nascent: a nonzero file shorter than the header lost data to
+         * truncation, and keeps failing even with SD_JOURNAL_ASSUME_IMMUTABLE. */
+        ASSERT_NOT_NULL(truncated = path_join(root, "truncated.journal"));
+        ASSERT_OK_ERRNO(fd = open(truncated, O_CREAT|O_WRONLY|O_CLOEXEC, 0644));
+        ASSERT_EQ(write(fd, "x", 1), (ssize_t) 1);
+        fd = safe_close(fd);
+
+        ASSERT_ERROR(sd_journal_open_files(&j, (const char**) STRV_MAKE(truncated), SD_JOURNAL_ASSUME_IMMUTABLE), ENODATA);
+        ASSERT_NULL(j);
+        ASSERT_ERROR(sd_journal_open_files(&j, (const char**) STRV_MAKE(truncated), 0), ENODATA);
+        ASSERT_NULL(j);
+
+        ASSERT_NOT_NULL(garbage = path_join(root, "garbage.journal"));
+        ASSERT_OK_ERRNO(fd = open(garbage, O_CREAT|O_WRONLY|O_CLOEXEC, 0644));
+        memset(buf, 'x', sizeof(buf));
+        ASSERT_EQ(write(fd, buf, sizeof(buf)), (ssize_t) sizeof(buf));
+        fd = safe_close(fd);
+
+        ASSERT_ERROR(sd_journal_open_files(&j, (const char**) STRV_MAKE(garbage), SD_JOURNAL_ASSUME_IMMUTABLE), EBADMSG);
+        ASSERT_NULL(j);
+        ASSERT_ERROR(sd_journal_open_files(&j, (const char**) STRV_MAKE(garbage), 0), EBADMSG);
+        ASSERT_NULL(j);
+}
 
 static void test_tail_timestamp_archived_fallback(void) {
         _cleanup_(mmap_cache_unrefp) MMapCache *m = NULL;
@@ -130,6 +221,8 @@ int main(int argc, char *argv[]) {
                 ASSERT_RETURN_EXPECTED(ASSERT_ERROR(sd_journal_open_directory(&j, t, SD_JOURNAL_LOCAL_ONLY), EINVAL));
                 ASSERT_NULL(j);
         }
+
+        test_open_files_incomplete_header(t);
 
         ASSERT_OK(rm_rf(t, REMOVE_ROOT|REMOVE_PHYSICAL));
 

--- a/src/libsystemd/sd-journal/test-journal.c
+++ b/src/libsystemd/sd-journal/test-journal.c
@@ -5,6 +5,7 @@
 
 #include "argv-util.h"
 #include "chattr-util.h"
+#include "fd-util.h"
 #include "iovec-util.h"
 #include "journal-authenticate.h"
 #include "journal-file-util.h"
@@ -579,6 +580,141 @@ TEST(recover_truncated_hash_chain) {
                 test_recover_truncated_hash_chain_one(/* field= */ true, /* zeroed_tail= */ false);
                 test_recover_truncated_hash_chain_one(/* field= */ true, /* zeroed_tail= */ true);
         }
+}
+
+TEST(verify_header_torn) {
+        _cleanup_(mmap_cache_unrefp) MMapCache *m = NULL;
+        _cleanup_close_ int fd = -EBADF;
+        dual_timestamp ts;
+        JournalFile *f;
+        Object *o;
+        le64_t tail_object_offset_le = 0, tail_entry_offset_le, data_hash_table_offset_le = 0,
+                header_size_le = 0, arena_size_le = 0, data_hash_table_size_le = 0, oversized_le;
+        uint8_t state;
+        uint64_t p, c;
+        usec_t from, to;
+        int r;
+        char t[] = "/var/tmp/journal-XXXXXX";
+
+        /* A live writer updates the tail offsets and counters of an append one at a time, so a reader
+         * racing it can load a mutually inconsistent snapshot of them, e.g. a tail_entry_offset past the
+         * tail_object_offset it loaded a moment earlier (#40053). A read-only open must tolerate that and
+         * still find the entries; a writable open must keep refusing it; and damage to the hash table
+         * descriptors, which no append ever touches, must keep being refused even read-only. */
+
+        ASSERT_NOT_NULL(m = mmap_cache_new());
+        mkdtemp_chdir_chattr(t);
+
+        ASSERT_OK_ZERO(journal_file_open(
+                        -EBADF, "test.journal", O_RDWR|O_CREAT, JOURNAL_COMPRESS, 0666, UINT64_MAX,
+                        /* metrics= */ NULL, m, /* template= */ NULL, &f));
+        dual_timestamp_now(&ts);
+
+        for (unsigned i = 0; i < 10; i++) {
+                struct iovec iovec = IOVEC_MAKE_STRING("LINE=x");
+                ts.realtime = i + 1;
+                ASSERT_OK_ZERO(journal_file_append_entry(
+                                f, &ts, /* boot_id= */ NULL, &iovec, 1,
+                                /* seqnum= */ NULL, /* seqnum_id= */ NULL,
+                                /* ret_object= */ NULL, /* ret_offset= */ NULL));
+        }
+
+        (void) journal_file_offline_close(f);
+
+        /* Emulate the torn snapshot: point tail_entry_offset past tail_object_offset. */
+        ASSERT_OK_ERRNO(fd = open("test.journal", O_RDWR|O_CLOEXEC));
+        ASSERT_OK_EQ_ERRNO(pread(fd, &tail_object_offset_le, sizeof(tail_object_offset_le),
+                                 offsetof(Header, tail_object_offset)),
+                           (ssize_t) sizeof(tail_object_offset_le));
+        tail_entry_offset_le = htole64(le64toh(tail_object_offset_le) + 16);
+        ASSERT_OK_EQ_ERRNO(pwrite(fd, &tail_entry_offset_le, sizeof(tail_entry_offset_le),
+                                  offsetof(Header, tail_entry_offset)),
+                           (ssize_t) sizeof(tail_entry_offset_le));
+
+        /* The relaxation must not depend on the state byte: a crashed writer leaves STATE_ONLINE behind,
+         * and journald flips a live file to STATE_OFFLINE on sync, so neither value proves anything. */
+        ASSERT_OK_ZERO(journal_file_open(
+                        -EBADF, "test.journal", O_RDONLY, JOURNAL_COMPRESS, 0666, UINT64_MAX,
+                        /* metrics= */ NULL, m, /* template= */ NULL, &f));
+        (void) journal_file_close(f);
+
+        state = STATE_ONLINE;
+        ASSERT_OK_EQ_ERRNO(pwrite(fd, &state, sizeof(state), offsetof(Header, state)),
+                           (ssize_t) sizeof(state));
+
+        /* A writable open must keep refusing the inconsistency, before it ever gets to the state check
+         * (EBUSY), i.e. writable opens stay strict. */
+        ASSERT_ERROR(journal_file_open(
+                        -EBADF, "test.journal", O_RDWR, JOURNAL_COMPRESS, 0666, UINT64_MAX,
+                        /* metrics= */ NULL, m, /* template= */ NULL, &f), ENODATA);
+
+        /* A read-only open must succeed, and the entries must be reachable: iteration goes through the
+         * entry array, not through the torn tail_entry_offset. */
+        ASSERT_OK_ZERO(journal_file_open(
+                        -EBADF, "test.journal", O_RDONLY, JOURNAL_COMPRESS, 0666, UINT64_MAX,
+                        /* metrics= */ NULL, m, /* template= */ NULL, &f));
+
+        c = 0;
+        p = 0;
+        while ((r = journal_file_next_entry(f, p, DIRECTION_DOWN, &o, &p)) > 0) {
+                c++;
+                ASSERT_EQ(le64toh(o->entry.seqnum), c);
+        }
+        ASSERT_OK_ZERO(r);
+        ASSERT_EQ(c, UINT64_C(10));
+
+        ASSERT_EQ(journal_file_get_cutoff_realtime_usec(f, &from, &to), 1);
+        ASSERT_EQ(from, UINT64_C(1));
+        ASSERT_EQ(to, UINT64_C(10));
+
+        (void) journal_file_close(f);
+
+        /* The whole item span must lie inside the arena: a size that keeps the object start in bounds
+         * but runs the items offsetof(Object, hash_table.items) bytes past header_size + arena_size
+         * must be refused. */
+        ASSERT_OK_EQ_ERRNO(pread(fd, &header_size_le, sizeof(header_size_le),
+                                 offsetof(Header, header_size)),
+                           (ssize_t) sizeof(header_size_le));
+        ASSERT_OK_EQ_ERRNO(pread(fd, &arena_size_le, sizeof(arena_size_le),
+                                 offsetof(Header, arena_size)),
+                           (ssize_t) sizeof(arena_size_le));
+        ASSERT_OK_EQ_ERRNO(pread(fd, &data_hash_table_offset_le, sizeof(data_hash_table_offset_le),
+                                 offsetof(Header, data_hash_table_offset)),
+                           (ssize_t) sizeof(data_hash_table_offset_le));
+        ASSERT_OK_EQ_ERRNO(pread(fd, &data_hash_table_size_le, sizeof(data_hash_table_size_le),
+                                 offsetof(Header, data_hash_table_size)),
+                           (ssize_t) sizeof(data_hash_table_size_le));
+
+        oversized_le = htole64(le64toh(header_size_le) + le64toh(arena_size_le) -
+                               (le64toh(data_hash_table_offset_le) - offsetof(Object, hash_table.items)));
+        ASSERT_OK_EQ_ERRNO(pwrite(fd, &oversized_le, sizeof(oversized_le),
+                                  offsetof(Header, data_hash_table_size)),
+                           (ssize_t) sizeof(oversized_le));
+
+        ASSERT_ERROR(journal_file_open(
+                        -EBADF, "test.journal", O_RDONLY, JOURNAL_COMPRESS, 0666, UINT64_MAX,
+                        /* metrics= */ NULL, m, /* template= */ NULL, &f), ENODATA);
+
+        ASSERT_OK_EQ_ERRNO(pwrite(fd, &data_hash_table_size_le, sizeof(data_hash_table_size_le),
+                                  offsetof(Header, data_hash_table_size)),
+                           (ssize_t) sizeof(data_hash_table_size_le));
+
+        /* The hash table descriptors are written only at file creation, so they cannot be observed torn,
+         * and a read-only open of an online file must keep validating them: point the data hash table
+         * into the header and expect refusal. */
+        data_hash_table_offset_le = htole64(ALIGN64(sizeof(Header) / 2));
+        ASSERT_OK_EQ_ERRNO(pwrite(fd, &data_hash_table_offset_le, sizeof(data_hash_table_offset_le),
+                                  offsetof(Header, data_hash_table_offset)),
+                           (ssize_t) sizeof(data_hash_table_offset_le));
+
+        ASSERT_ERROR(journal_file_open(
+                        -EBADF, "test.journal", O_RDONLY, JOURNAL_COMPRESS, 0666, UINT64_MAX,
+                        /* metrics= */ NULL, m, /* template= */ NULL, &f), ENODATA);
+
+        if (arg_keep)
+                log_info("Not removing %s", t);
+        else
+                ASSERT_OK(rm_rf(t, REMOVE_ROOT | REMOVE_PHYSICAL));
 }
 
 static int intro(void) {

--- a/src/shared/journal-util.c
+++ b/src/shared/journal-util.c
@@ -124,7 +124,7 @@ int journal_access_check_and_warn(sd_journal *j, bool quiet, bool want_other_use
                         continue;
 
                 case ENODATA:
-                        log_warning_errno(err, "Journal file %s is truncated, ignoring file.", path);
+                        log_warning_errno(err, "Journal file %s is truncated or empty, ignoring file.", path);
                         break;
 
                 case EPROTONOSUPPORT:


### PR DESCRIPTION
journalctl --file fails with "Failed to open files: No data available" when it catches a journal file that exists but has no header yet. The writer creates the file empty at its final name and writes the header a moment later; rotation runs the same sequence after renaming the old file away. In the #40053 stress setup this is the last remaining failure class: 2 of 595,375 opens in 300 seconds, both with a file size of zero at open time.

add_any_file() now skips an empty file it opened by path, but only when the caller passed SD_JOURNAL_ASSUME_IMMUTABLE, and it records the skip via journal_put_error(), so journalctl reports "Journal file ... is truncated or empty, ignoring file." instead of failing the whole open. Under that flag no waiting is possible anyway (sd_journal_get_fd() refuses with -EUNATCH), so a file skipped for the lifetime of the object costs nothing. Without the flag the open keeps failing with -ENODATA: those callers (journalctl --follow, journal-gatewayd, journal-upload) can wait for the file, and a file skipped here would never be picked up again once sd_journal_open_files() has marked the file set final. Only st_size == 0 qualifies, so a one-byte file still fails with ENODATA and a garbage file with EBADMSG, and caller-provided fds keep the error too, since skipping one would leave its ownership unclear.

The writer-side alternative, a temporary name renamed into place after the header write, was rejected: it changes the inotify event sequence, can leave stray temp files after a crash, does not help with files from existing writers, and readers polling across a rotation see a longer window in which the file is missing entirely. sd_journal_open(3) documents the skip, its lifetime, and that sd_journal_open_files_fd() never skips.

Verified with tests in test-journal-init.c covering an empty file alone, an empty file next to a valid one, a one-byte file, a garbage file and the fd entrypoint, each with and without the flag, and a 120 s stress rerun: 36,037 opens, zero failures. Based on #43467 since it modifies the same function; only the last commit is new.