### PR TITLE
hwdb: mark Hangsheng R75 QMK as not a joystick

### DIFF
--- a/hwdb.d/60-input-id.hwdb
+++ b/hwdb.d/60-input-id.hwdb
@@ -77,6 +77,10 @@ id-input:modalias:input:b0003v1781p0898*
  ID_INPUT_ACCELEROMETER=
  ID_INPUT_JOYSTICK=1
 
+# Hangsheng R75 QMK
+id-input:modalias:input:b0003v342DpE483*
+ ID_INPUT_JOYSTICK=0
+
 # XP-PEN STAR 06
 id-input:modalias:input:b0003v28bdp0078*
  ID_INPUT_TABLET=1


### PR DESCRIPTION
The Hangsheng R75 QMK keyboard (USB 342d:e483) exposes a System
Control interface with ABS capabilities. input_id consequently
classifies the interface as a joystick and sets
ID_INPUT_JOYSTICK=1.

This makes desktop environments such as KDE Plasma expose the
keyboard as a game controller.

Setting ID_INPUT_JOYSTICK=0 for this device fixes the classification
while preserving its keyboard, consumer control and system control
functionality.

The quirk was tested locally using an equivalent entry under
/etc/udev/hwdb.d/. The hwdb parser and hwdb compilation tests pass.

Affected modalias:

    input:b0003v342DpE483e0111-e0,1,3,4,k74,8A,8B,8E,8F,94,AE,E3,F8,161,164,198,1B6,24E,24F,ra10,11,28,m4,lsfw