### PR TITLE
hostname-setup: re-derive the default hostname after switch-root

### DIFF
--- a/src/hostname/hostnamed.c
+++ b/src/hostname/hostnamed.c
@@ -801,7 +801,7 @@ static int context_update_kernel_hostname(
 
         /* ... and the ultimate fallback */
         } else {
-                hn = _hn_free = get_default_hostname();
+                hn = _hn_free = get_default_hostname_or_fallback();
                 if (!hn)
                         return log_oom();
 
@@ -1069,7 +1069,7 @@ static int property_get_hostname(
                 if (r != -ENXIO)
                         return r;
 
-                hn = get_default_hostname();
+                hn = get_default_hostname_or_fallback();
                 if (!hn)
                         return -ENOMEM;
         }
@@ -1104,7 +1104,7 @@ static int property_get_default_hostname(
 
         _cleanup_free_ char *hn = NULL;
 
-        hn = get_default_hostname();
+        hn = get_default_hostname_or_fallback();
         if (!hn)
                 return log_oom();
 
@@ -1964,7 +1964,7 @@ static int build_describe_response(Context *c, bool privileged, sd_json_variant 
         context_read_os_release(c);
         context_determine_hostname_source(c);
 
-        dhn = get_default_hostname();
+        dhn = get_default_hostname_or_fallback();
         if (!dhn)
                 return log_oom();
 

--- a/src/resolve/resolved-manager.c
+++ b/src/resolve/resolved-manager.c
@@ -440,7 +440,7 @@ static char* fallback_hostname(void) {
          * to be "localhost" even if that's the default hostname. In this case, let's revert to "linux"
          * instead. */
 
-        _cleanup_free_ char *n = get_default_hostname();
+        _cleanup_free_ char *n = get_default_hostname_or_fallback();
         if (!n)
                 return NULL;
 

--- a/src/shared/hostname-setup.c
+++ b/src/shared/hostname-setup.c
@@ -263,7 +263,7 @@ int hostname_setup(bool really) {
                 if (enoent)
                         log_info("No hostname configured, using default hostname.");
 
-                hn = get_default_hostname();
+                hn = get_default_hostname_or_fallback();
                 if (!hn)
                         return log_oom();
 
@@ -518,27 +518,41 @@ int hostname_substitute_wildcards(const char *name, char **ret) {
         return 0;
 }
 
-char* get_default_hostname(void) {
+int get_default_hostname(char **ret) {
         int r;
+
+        assert(ret);
 
         _cleanup_free_ char *h = get_default_hostname_raw();
         if (!h)
-                return NULL;
+                return -ENOMEM;
 
         _cleanup_free_ char *substituted = NULL;
         r = hostname_substitute_wildcards(h, &substituted);
-        if (r < 0) {
-                log_debug_errno(r, "Failed to substitute wildcards in hostname, falling back to built-in name: %m");
-                return strdup(FALLBACK_HOSTNAME);
-        }
+        if (r < 0)
+                return log_debug_errno(r, "Failed to substitute wildcards in hostname '%s': %m", h);
 
         /* Each token expands to a whole word, so the concrete name may exceed the length limit. */
-        if (!hostname_is_valid(substituted, VALID_HOSTNAME_TRAILING_DOT)) {
-                log_debug("Substituted hostname '%s' is invalid, falling back to built-in name.", substituted);
+        if (!hostname_is_valid(substituted, VALID_HOSTNAME_TRAILING_DOT))
+                return log_debug_errno(SYNTHETIC_ERRNO(EINVAL),
+                                       "Substituted hostname '%s' is invalid.", substituted);
+
+        *ret = TAKE_PTR(substituted);
+        return 0;
+}
+
+char* get_default_hostname_or_fallback(void) {
+        _cleanup_free_ char *h = NULL;
+
+        int r = get_default_hostname(&h);
+        if (r == -ENOMEM)
+                return NULL;
+        if (r < 0) {
+                log_debug_errno(r, "Falling back to built-in hostname: %m");
                 return strdup(FALLBACK_HOSTNAME);
         }
 
-        return TAKE_PTR(substituted);
+        return TAKE_PTR(h);
 }
 
 int gethostname_full(GetHostnameFlags flags, char **ret) {
@@ -558,7 +572,7 @@ int gethostname_full(GetHostnameFlags flags, char **ret) {
                 if (!FLAGS_SET(flags, GET_HOSTNAME_FALLBACK_DEFAULT))
                         return -ENXIO;
 
-                s = fallback = get_default_hostname();
+                s = fallback = get_default_hostname_or_fallback();
                 if (!s)
                         return -ENOMEM;
 

--- a/src/shared/hostname-setup.c
+++ b/src/shared/hostname-setup.c
@@ -205,6 +205,10 @@ int read_etc_hostname(const char *path, bool substitute_wildcards, char **ret) {
         return read_etc_hostname_stream(f, substitute_wildcards, ret);
 }
 
+static const char* run_default_hostname_path(void) {
+        return secure_getenv("SYSTEMD_RUN_DEFAULT_HOSTNAME_PATH") ?: "/run/systemd/default-hostname";
+}
+
 void hostname_update_source_hint(const char *hostname, HostnameSource source) {
         int r;
 
@@ -214,13 +218,15 @@ void hostname_update_source_hint(const char *hostname, HostnameSource source) {
          * notice if somebody sets the hostname directly (not going through hostnamed).
          */
 
+        const char *path = run_default_hostname_path();
+
         if (source == HOSTNAME_DEFAULT) {
-                r = write_string_file("/run/systemd/default-hostname", hostname,
+                r = write_string_file(path, hostname,
                                       WRITE_STRING_FILE_CREATE | WRITE_STRING_FILE_ATOMIC);
                 if (r < 0)
-                        log_warning_errno(r, "Failed to create \"/run/systemd/default-hostname\", ignoring: %m");
+                        log_warning_errno(r, "Failed to create \"%s\", ignoring: %m", path);
         } else
-                (void) unlink_or_warn("/run/systemd/default-hostname");
+                (void) unlink_or_warn(path);
 }
 
 int hostname_setup(bool really) {
@@ -250,22 +256,48 @@ int hostname_setup(bool really) {
         }
 
         if (!hn) {
-                /* Don't override the hostname if it is already set and not explicitly configured */
-
+                /* Don't override the hostname if it is already set and not explicitly configured. However,
+                 * update it if it was set by us in the initrd, so that '?' and '$' patterns are derived from
+                 * the real machine ID, not from the random one of the initrd. */
                 r = gethostname_full(GET_HOSTNAME_ALLOW_LOCALHOST, &hn);
                 if (r == -ENOMEM)
                         return log_oom();
                 if (r >= 0) {
-                        log_debug("No hostname configured, leaving existing hostname <%s> in place.", hn);
-                        goto finish;
-                }
+                        _cleanup_free_ char *default_hostname = NULL;
 
-                if (enoent)
+                        const char *path = run_default_hostname_path();
+
+                        r = read_one_line_file(path, &default_hostname);
+                        if (r < 0 && r != -ENOENT)
+                                log_warning_errno(r, "Failed to read \"%s\", ignoring: %m", path);
+
+                        if (!streq_ptr(default_hostname, hn)) {
+                                log_debug("No hostname configured, leaving existing hostname <%s> in place.",
+                                          hn);
+                                goto finish;
+                        }
+
+                        log_debug("Existing hostname <%s> matches the default we recorded earlier, re-deriving it.",
+                                  hn);
+
+                        /* Now re-derive the hostname but only use it on success, otherwise keep the old */
+                        _cleanup_free_ char *rederived = NULL;
+                        r = get_default_hostname(&rederived);
+                        if (r < 0) {
+                                log_warning_errno(r, "Failed to re-derive default hostname, leaving existing hostname <%s> in place: %m",
+                                                  hn);
+                                goto finish;
+                        }
+
+                        free_and_replace(hn, rederived);
+                } else if (enoent)
                         log_info("No hostname configured, using default hostname.");
 
-                hn = get_default_hostname_or_fallback();
-                if (!hn)
-                        return log_oom();
+                if (!hn) {
+                        hn = get_default_hostname_or_fallback();
+                        if (!hn)
+                                return log_oom();
+                }
 
                 source = HOSTNAME_DEFAULT;
         }

--- a/src/shared/hostname-setup.h
+++ b/src/shared/hostname-setup.h
@@ -24,7 +24,10 @@ int hostname_setup(bool really);
 
 int hostname_substitute_wildcards(const char *name, char **ret);
 
-char* get_default_hostname(void);
+/* Returns the default hostname with '?'/'$' wildcards expanded, or a negative errno if the expansion
+ * fails. get_default_hostname_or_fallback() hides such failures behind FALLBACK_HOSTNAME instead. */
+int get_default_hostname(char **ret);
+char* get_default_hostname_or_fallback(void);
 
 typedef enum GetHostnameFlags {
         GET_HOSTNAME_ALLOW_LOCALHOST  = 1 << 0, /* accepts "localhost" or friends. */

--- a/src/test/test-hostname-setup.c
+++ b/src/test/test-hostname-setup.c
@@ -183,9 +183,9 @@ TEST(default_hostname) {
                 exit(EXIT_FAILURE);
         }
 
-        _cleanup_free_ char *n = get_default_hostname();
+        _cleanup_free_ char *n = get_default_hostname_or_fallback();
         ASSERT_NOT_NULL(n);
-        log_info("get_default_hostname: \"%s\"", n);
+        log_info("get_default_hostname_or_fallback: \"%s\"", n);
         ASSERT_TRUE(hostname_is_valid(n, /* flags= */ 0));
 
         _cleanup_free_ char *m = get_default_hostname_raw();

--- a/src/test/test-hostname-setup.c
+++ b/src/test/test-hostname-setup.c
@@ -136,6 +136,69 @@ TEST(hostname_substitute_wildcards_words) {
         ASSERT_OK(unsetenv("SYSTEMD_HOSTNAME_WORDLIST_PATH"));
 }
 
+TEST(hostname_setup_rederive_default) {
+        int r;
+
+        /* hostname_setup() only re-derives the hostname if it is the default we recorded ourselves
+         * earlier. Check that we do so in that case, and leave the hostname alone in every other. */
+
+        if (geteuid() != 0)
+                return (void) log_tests_skipped("Not privileged");
+
+        r = sd_id128_get_machine(NULL);
+        if (ERRNO_IS_NEG_MACHINE_ID_UNSET(r))
+                return (void) log_tests_skipped_errno(r, "skipping re-derive hostname tests, no machine ID defined");
+
+        _cleanup_(rm_rf_physical_and_freep) char *d = NULL;
+        ASSERT_OK(mkdtemp_malloc("/tmp/hostname-hint.XXXXXX", &d));
+
+        _cleanup_free_ char *hint = ASSERT_PTR(path_join(d, "default-hostname"));
+        ASSERT_OK(setenv("SYSTEMD_RUN_DEFAULT_HOSTNAME_PATH", hint, /* overwrite= */ true));
+        ASSERT_OK(setenv("SYSTEMD_DEFAULT_HOSTNAME", "test-????", /* overwrite= */ true));
+        ASSERT_OK(setenv("SYSTEMD_PROC_CMDLINE", "", /* overwrite= */ true));
+
+        /* We apply the hostname for real, so do it in a UTS namespace of our own. */
+        r = ASSERT_OK(pidref_safe_fork("(test-rederive)", FORK_LOG|FORK_WAIT|FORK_DEATHSIG_SIGKILL, /* ret= */ NULL));
+        if (r == 0) {
+                _cleanup_free_ char *h = NULL;
+
+                ASSERT_OK_ERRNO(unshare(CLONE_NEWUTS));
+
+                /* No hint at all: the hostname is not ours, leave it alone. */
+                ASSERT_OK(sethostname_idempotent("no-hint"));
+                ASSERT_OK(hostname_setup(/* really= */ true));
+                ASSERT_NOT_NULL(h = gethostname_malloc());
+                ASSERT_STREQ(h, "no-hint");
+                h = mfree(h);
+
+                /* Hint holds some other name: somebody else set the current one, leave it alone. */
+                ASSERT_OK(write_string_file(hint, "some-other-name", WRITE_STRING_FILE_CREATE));
+                ASSERT_OK(sethostname_idempotent("stale-hint"));
+                ASSERT_OK(hostname_setup(/* really= */ true));
+                ASSERT_NOT_NULL(h = gethostname_malloc());
+                ASSERT_STREQ(h, "stale-hint");
+                h = mfree(h);
+
+                /* Hint matches the current hostname: it is the default we set earlier, re-derive it. */
+                ASSERT_OK(sethostname_idempotent("ours-dead"));
+                ASSERT_OK(write_string_file(hint, "ours-dead", WRITE_STRING_FILE_CREATE));
+                ASSERT_OK(hostname_setup(/* really= */ true));
+                ASSERT_NOT_NULL(h = gethostname_malloc());
+                ASSERT_EQ(fnmatch("test-????", h, /* flags= */ 0), 0);
+
+                /* ... and the hint is updated to the name we just applied. */
+                _cleanup_free_ char *recorded = NULL;
+                ASSERT_OK(read_one_line_file(hint, &recorded));
+                ASSERT_STREQ(recorded, h);
+
+                _exit(EXIT_SUCCESS);
+        }
+
+        ASSERT_OK(unsetenv("SYSTEMD_PROC_CMDLINE"));
+        ASSERT_OK(unsetenv("SYSTEMD_DEFAULT_HOSTNAME"));
+        ASSERT_OK(unsetenv("SYSTEMD_RUN_DEFAULT_HOSTNAME_PATH"));
+}
+
 TEST(hostname_setup_cmdline_wildcards) {
         _cleanup_(rm_rf_physical_and_freep) char *d = NULL;
         int r;
@@ -259,4 +322,13 @@ TEST(pidref_gethostname_full) {
         ASSERT_STREQ(s, original_short);
 }
 
-DEFINE_TEST_MAIN(LOG_DEBUG);
+static int intro(void) {
+        /* hostname_setup() consults /etc/hostname before falling back to the default hostname, so point it
+         * at a path that does not exist: otherwise which branch these tests take depends on whether the host
+         * running them happens to have that file. */
+        ASSERT_OK(setenv("SYSTEMD_ETC_HOSTNAME", "/tmp/test-hostname-setup-no-such-file", /* overwrite= */ true));
+
+        return EXIT_SUCCESS;
+}
+
+DEFINE_TEST_MAIN_WITH_INTRO(LOG_DEBUG, intro);


### PR DESCRIPTION
When the new $ hostname pattern (but also ?) [1] is used in DEFAULT_HOSTNAME= the initrd already expands them, but from the random machine ID it just generated, and sets the result as the hostname.

When the "real" machine ID is available after switch-root nothing updates the hostname: PID 1 sees it as already set and leaves it in place, so the machine comes up with a different name on every boot. So this commit tweaks hostname_setup() to check whether the current hostname is the default we set ourselves earlier (recorded in /run/systemd/default-hostname) and if so re-derive it, so that the patterns are evaluated against the stable machine ID. A hostname set by anyone else is still left alone.

Its a bit hard to write an automatic test with the current framework (at least I couldn't find a nice way) so I did:
```
cat > ~/devel/systemd/systemd/mkosi/mkosi.local.conf <<'EOF'
[Distribution]
Distribution=fedora
Release=rawhide

[Content]
Hostname=test-????
RemoveFiles=/etc/hostname
EOF

cat > ~/devel/systemd/systemd/mkosi/mkosi.initrd.conf/mkosi.local.conf <<'EOF'
[Content]
RemoveFiles=/etc/hostname
EOF

mkosi -f genkey
mkosi -f build

mkosi vm (twice)
```
With the patch I see a stable `test-1ec3` accross two reboots for transient hostname, without the I see `test-93d0` first and then `test-264f`.

Please double check this carefully, the hostname setup is quite complex - I am pretty sure I got this right though. 

[1] https://github.com/systemd/systemd/pull/42566