### PR TITLE
hwdb: stop lid open toggling airplane mode on HP ENVY x360 Convertible 13

### DIFF
--- a/hwdb.d/60-keyboard.hwdb
+++ b/hwdb.d/60-keyboard.hwdb
@@ -714,6 +714,7 @@ evdev:atkbd:dmi:bvn*:bvr*:bd*:svnHP*:pnHPSpectrex360Convertible13*:*
 # ENVY x360 13
 evdev:atkbd:dmi:bvn*:bvr*:bd*:svnHP*:pnHPENVYx360Convertible13*:*
  KEYBOARD_KEY_82=micmute                                # Microphone mute button
+ KEYBOARD_KEY_d7=unknown                                # EC emits e057 on every lid open
 
 # Spectre x360 16 2022
 evdev:name:Intel HID events:dmi:bvn*:bvr*:bd*:svnHP*:pn*HP[sS][pP][eE][cC][tT][rR][eE]*x3602-in-1*:*


### PR DESCRIPTION
The embedded controller on the HP ENVY x360 Convertible 13 emits atkbd scancode `e057` on
every lid open. The generic HP block maps it to `KEY_WLAN`, which desktop environments bind
to the airplane-mode action, so opening the lid switches off every radio. There is no
physical key on this machine that emits `e057`; it only ever arrives from the lid.

The same quirk already exists for the Pavilion Gaming 15-dk1 and the Spectre x360 13. This
model was never added to it.

The property goes in the existing `ENVY x360 13` record rather than in the Spectre `d7`
block, because that block would need a match line the file already carries at `:715`, and
`parse-hwdb` rejects duplicates.

The record is shared with `pnHPSpectrex360Convertible13*`, which already receives
`d7=unknown` from the broader glob at `:709`, so nothing changes there.

### Verification

`parse_hwdb.py` passes. Match count is unchanged at 425 and properties go from 1153 to
1154, confirming no record was added.

I compiled both revisions into separate roots and queried them with the modalias from
#43494. I do not have this hardware; the hardware confirmation is the reporter's.

```
-KEYBOARD_KEY_d7=wlan
+KEYBOARD_KEY_d7=unknown
 KEYBOARD_KEY_82=micmute   (unchanged)
```

Querying a Spectre modalias returns identical output before and after.

`e058` fires on lid close but carries no keycode in the generic HP block, so it is already
inert and is left alone.

### Scope

Matched `13*` because `13-bd0xxx` is what the reporter can evidence. Happy to widen to
`pnHPENVYx360Convertible*` if you prefer.

### Credit

@RobinRichardRajan did the analysis in #43494. The evtest capture showing `KEY_WLAN`
arriving 0.4ms ahead of `SW_LID`, the DMI modalias, and the pointer to the existing Pavilion
and Spectre entries are all his. The verification above relies on that capture, since I do
not have the hardware.
