### PR TITLE
machine-id-setup: add --force to regenerate the machine ID

### DIFF
--- a/man/systemd-machine-id-setup.xml
+++ b/man/systemd-machine-id-setup.xml
@@ -144,6 +144,21 @@
         <xi:include href="version-info.xml" xpointer="v231"/></listitem>
       </varlistentry>
 
+      <varlistentry>
+        <term><option>--force</option></term>
+
+        <listitem><para>Replace the machine ID even if <filename>/etc/machine-id</filename> already holds
+        a valid one, or the <literal>uninitialized</literal> marker. The new ID is always taken from the
+        random pool. May not be combined with <option>--commit</option>.</para>
+
+        <para>Requires <option>--root=</option> or <option>--image=</option>: this is for giving a fresh
+        identity to an offline image, so that systems installed by cloning it do not all share the ID baked
+        into it. Changing the machine ID of a running system is not supported, as it is cached by everything
+        that has read it, PID 1 included.</para>
+
+        <xi:include href="version-info.xml" xpointer="v262"/></listitem>
+      </varlistentry>
+
       <xi:include href="standard-options.xml" xpointer="help" />
       <xi:include href="standard-options.xml" xpointer="version" />
     </variablelist>

--- a/src/machine-id-setup/machine-id-setup-main.c
+++ b/src/machine-id-setup/machine-id-setup-main.c
@@ -22,6 +22,7 @@ static char *arg_root = NULL;
 static char *arg_image = NULL;
 static bool arg_commit = false;
 static bool arg_print = false;
+static bool arg_force = false;
 static ImagePolicy *arg_image_policy = NULL;
 
 STATIC_DESTRUCTOR_REGISTER(arg_root, freep);
@@ -80,6 +81,10 @@ static int parse_argv(int argc, char *argv[]) {
                         arg_print = true;
                         break;
 
+                OPTION_LONG("force", NULL, "Replace machine ID of an offline image"):
+                        arg_force = true;
+                        break;
+
                 OPTION_COMMON_INTROSPECT_CLI:
                         return introspect_cli(SD_JSON_FORMAT_OFF);
                 }
@@ -90,6 +95,12 @@ static int parse_argv(int argc, char *argv[]) {
 
         if (arg_image && arg_root)
                 return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "Please specify either --root= or --image=, the combination of both is not supported.");
+
+        if (arg_force && arg_commit)
+                return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "Please specify either --commit or --force, the combination of both is not supported.");
+
+        if (arg_force && !arg_root && !arg_image)
+                return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "--force requires --root= or --image=, changing the machine ID of a running system is not supported.");
 
         return 1;
 }
@@ -148,13 +159,14 @@ static int run(int argc, char *argv[]) {
                 if (arg_print)
                         puts(SD_ID128_TO_STRING(id));
 
-        } else if (id128_get_machine(arg_root, NULL) == -ENOPKG) {
+        } else if (!arg_force && id128_get_machine(arg_root, NULL) == -ENOPKG) {
                 if (arg_print)
                         puts("uninitialized");
         } else {
                 sd_id128_t id;
 
-                r = machine_id_setup(arg_root, SD_ID128_NULL, /* flags= */ 0, &id);
+                r = machine_id_setup(arg_root, SD_ID128_NULL,
+                                     arg_force ? MACHINE_ID_SETUP_FORCE_NEW : 0, &id);
                 if (r < 0)
                         return r;
 

--- a/src/shared/machine-id-setup.c
+++ b/src/shared/machine-id-setup.c
@@ -196,6 +196,20 @@ int machine_id_setup(const char *root, sd_id128_t machine_id, MachineIdSetupFlag
                 }
         }
 
+        if (FLAGS_SET(flags, MACHINE_ID_SETUP_FORCE_NEW)) {
+                /* Don't look at the ID in place, and don't go through acquire_machine_id() either: on a
+                 * clone every source it consults would just hand back the ID we are replacing. */
+
+                if (!writable)
+                        return log_error_errno(SYNTHETIC_ERRNO(EROFS), "%s is not writable.", etc_machine_id);
+
+                r = sd_id128_randomize(&machine_id);
+                if (r < 0)
+                        return log_error_errno(r, "Failed to generate randomized machine ID: %m");
+
+                log_info("Generating new machine ID from random generator.");
+        }
+
         /* A we got a valid machine ID argument, that's what counts */
         if (sd_id128_is_null(machine_id) || FLAGS_SET(flags, MACHINE_ID_SETUP_FORCE_FIRMWARE)) {
 

--- a/src/shared/machine-id-setup.h
+++ b/src/shared/machine-id-setup.h
@@ -8,6 +8,7 @@
 typedef enum MachineIdSetupFlags {
         MACHINE_ID_SETUP_FORCE_TRANSIENT = 1 << 0,
         MACHINE_ID_SETUP_FORCE_FIRMWARE  = 1 << 1,
+        MACHINE_ID_SETUP_FORCE_NEW       = 1 << 2,
 } MachineIdSetupFlags;
 
 int machine_id_commit(const char *root);

--- a/test/units/TEST-74-AUX-UTILS.machine-id-setup.sh
+++ b/test/units/TEST-74-AUX-UTILS.machine-id-setup.sh
@@ -90,6 +90,35 @@ testcase_transient_symlink() {
     diff "$root/persist/etc/machine-id" "$root/run/machine-id"
 }
 
+testcase_force() {
+    local root old id
+
+    root="$(mktemp -d)"
+    trap "root_cleanup $root" RETURN
+    root_mock "$root"
+
+    # A valid ID gets replaced, and so does the "uninitialized" marker
+    old="$(systemd-machine-id-setup --print --root "$root")"
+    id="$(systemd-machine-id-setup --print --force --root "$root")"
+    [[ "$id" != "$old" ]]
+    diff <(echo "$id") "$root/etc/machine-id"
+
+    echo uninitialized >"$root/etc/machine-id"
+    id="$(systemd-machine-id-setup --print --force --root "$root")"
+    [[ "$id" != "uninitialized" ]]
+
+    # Refuse a read-only tree instead of falling back to a transient ID
+    mount -o remount,ro "$root"
+    mount -t tmpfs tmpfs "$root/run"
+    (! systemd-machine-id-setup --force --root "$root")
+    umount "$root/run"
+    mount -o remount,rw "$root"
+
+    # Offline images only
+    (! systemd-machine-id-setup --force)
+    (! systemd-machine-id-setup --force --commit --root "$root")
+}
+
 # Check if we correctly processed the invalid machine ID we set up in the respective
 # test.sh file
 systemctl --state=failed --no-legend --no-pager | tee /failed


### PR DESCRIPTION
So far systemd-machine-id-setup would only ever *initialize* the machine ID: if /etc/machine-id already carried a valid ID, the tool was a no-op. Assigning a new identity to a system thus required manually removing /etc/machine-id (and typically /var/lib/dbus/machine-id) first, which is easy to get wrong — most notably when a disk image or VM is cloned, where every clone otherwise keeps the machine ID baked into the image.

Add a --force switch for that, backed by a new MACHINE_ID_SETUP_FORCE_NEW flag. Contrary to the regular code path it does not look at the ID currently stored, and it deliberately bypasses acquire_machine_id() altogether: every source the latter consults (/run/machine-id, the D-Bus machine ID, the system.machine_id credential, the container/VM UUID) would on a cloned system just hand back the very ID we are supposed to replace. The new ID is therefore always taken from the random pool.

--force also overrides the "uninitialized" special case, so that an image that was provisioned with a first-boot marker can be given a real ID right away. It cannot be combined with --commit, as the two contradict each other.

While at it, document the whole cloned-system workflow in machine-id(5), including the caveats that a reboot is needed and that neither /var/lib/dbus/machine-id nor identifiers already derived from the old ID are updated along the way.