### PR TITLE
hwdb: add Acer Nitro ANV15-52 NitroSense button

### DIFF
--- a/hwdb.d/60-keyboard.hwdb
+++ b/hwdb.d/60-keyboard.hwdb
@@ -254,6 +254,10 @@ evdev:atkbd:dmi:bvn*:bvr*:bd*:svnAcer*:pnNitro*ANV*15-51:pvr*
  KEYBOARD_KEY_66=micmute                                # Microphone mute button
  KEYBOARD_KEY_f5=prog1                                  # NitroSense button
 
+# Nitro ANV15-52
+evdev:atkbd:dmi:bvn*:bvr*:bd*:svnAcer*:pnNitro*ANV*15-52:pvr*
+ KEYBOARD_KEY_f5=prog1                                  # NitroSense button
+
 ###########################################################
 # Alienware
 ###########################################################


### PR DESCRIPTION
The Acer Nitro V 15 (**ANV15-52**) has the same dedicated NitroSense button as its sibling ANV15-51, and it emits the same atkbd scancode `0xf5`. #38415 added the mapping for the ANV15-51; this adds the equivalent entry for the ANV15-52 so the button is usable out of the box (as `prog1`).

**Hardware** (DMI modalias):

```
dmi:bvnINSYDECorp.:bvrV1.31:bd06/27/2025:br1.31:efr1.7:svnAcer:pnNitroANV15-52:pvrV1.31:rvnRPL:rnSportage_RTH:rvrV1.31:cvnAcer:ct10:cvrChassisVersion:sku0000000000000000:pfaAcerNitroV15:
```

**Evidence** — evdev capture on "AT Translated Set 2 keyboard" while pressing the NitroSense button (3 presses):

```
EV_MSC scan=0xf5
EV_KEY code=425 value=1   # KEY_PRESENTATION, via the generic Acer f5 rule
EV_MSC scan=0xf5
EV_KEY code=425 value=0
(×3)
```

Without a model-specific entry the button currently falls through to the generic Acer rule (`KEYBOARD_KEY_f5=presentation`); this maps it to `prog1`, consistent with the other Nitro models in the file (AN515-47, AN515-58, AN517-54, ANV15-51).

Unlike the ANV15-51 entry, no `66=micmute` line is included — I only verified the NitroSense button on this unit.
