### PR TITLE
hwdb: add quirks for Lenovo ThinkBook 16p G5 IRX

### DIFF
--- a/hwdb.d/60-keyboard.hwdb
+++ b/hwdb.d/60-keyboard.hwdb
@@ -1162,6 +1162,11 @@ evdev:atkbd:dmi:bvn*:bvr*:svnLENOVO:pn21SQ*:pvrThinkBook142-in-1G5IAU:*
  KEYBOARD_KEY_ae=!volumedown
  KEYBOARD_KEY_b0=!volumeup
 
+# Lenovo ThinkBook 16p G5 IRX
+evdev:atkbd:dmi:bvn*:bvr*:bd*:svnLENOVO:pn21N5*:pvrThinkBook16pG5IRX:*
+ KEYBOARD_KEY_a1=!calc
+ KEYBOARD_KEY_d7=unknown                                # Fn+F4 mic mute, also emitted by "Ideapad extra buttons", ignore
+
 evdev:atkbd:dmi:*:svnLENOVO:*:pvrLenovoYoga300-11IBR:*
  KEYBOARD_KEY_62=unknown                                # Touchpad on, also emitted by "Ideapad extra buttons", ignore
  KEYBOARD_KEY_63=unknown                                # Touchpad off, also emitted by "Ideapad extra buttons", ignore


### PR DESCRIPTION
The calculator key (Fn + numpad =) emits a press event but never a release, leaving KEY_CALC permanently held down. Desktop environments then repeatedly spawn the calculator.

Before:
  MSC_SCAN a1 / KEY_CALC value 1
  (no release for the remaining 24s of the capture)

After:
  MSC_SCAN a1 / KEY_CALC value 1
  MSC_SCAN a1 / KEY_CALC value 0   (14us later)

Scancode 0xd7 (Fn+F4) is an atkbd echo of the mic mute key that ideapad-laptop already reports as KEY_MICMUTE with a proper press/release pair. Mapping it to unknown silences the repeated "Unknown key pressed" kernel messages without affecting the working key.

Tested on Fedora 44, kernel 7.1.10, BIOS P5CN31WW.