### PR TITLE
cryptsetup: don't wait for udev when no PKCS#11 token is enrolled

### DIFF
--- a/src/cryptsetup/cryptsetup.c
+++ b/src/cryptsetup/cryptsetup.c
@@ -1743,6 +1743,9 @@ static int attach_luks_or_plain_or_bitlk_by_pkcs11(
         if (arg_pkcs11_uri_auto) {
                 if (!use_libcryptsetup_plugin) {
                         r = find_pkcs11_auto_data(cd, &discovered_uri, &discovered_key, &discovered_key_size, &rsa_padding, &keyslot);
+                        if (ERRNO_IS_NOT_SUPPORTED(r))
+                                return log_debug_errno(SYNTHETIC_ERRNO(EAGAIN),
+                                                       "PKCS#11 token support not available, falling back to traditional unlocking.");
                         if (IN_SET(r, -ENOTUNIQ, -ENXIO))
                                 return log_debug_errno(SYNTHETIC_ERRNO(EAGAIN),
                                                        "Automatic PKCS#11 metadata discovery was not possible because missing or not unique, falling back to traditional unlocking.");
@@ -1765,7 +1768,7 @@ static int attach_luks_or_plain_or_bitlk_by_pkcs11(
                 return log_oom();
 
         for (;;) {
-                if (use_libcryptsetup_plugin && arg_pkcs11_uri_auto)
+                if (use_libcryptsetup_plugin && arg_pkcs11_uri_auto) {
                         r = attach_luks2_by_pkcs11_via_plugin(
                                         cd,
                                         name,
@@ -1773,7 +1776,14 @@ static int attach_luks_or_plain_or_bitlk_by_pkcs11(
                                         until,
                                         "cryptsetup.pkcs11-pin",
                                         flags);
-                else {
+                        if (r >= 0)
+                                return 0;
+                        /* EAGAIN means: token enrolled, but not currently present */
+                        if (r == -ENOENT) /* nothing enrolled, or the enrolled key object could not be
+                                           * found on the token: nothing to wait for, fall back right away */
+                                return log_debug_errno(SYNTHETIC_ERRNO(EAGAIN),
+                                                       "No PKCS#11 metadata enrolled in LUKS2 header, or referenced key not found on token, falling back to traditional unlocking.");
+                } else {
                         r = decrypt_pkcs11_key(
                                         name,
                                         friendly,
@@ -1788,8 +1798,20 @@ static int attach_luks_or_plain_or_bitlk_by_pkcs11(
                                 break;
                 }
 
-                if (r != -EAGAIN) /* EAGAIN means: token not found */
+                /* Don't mangle errors that mean the user actively cancelled the PIN prompt, that we're out
+                 * of memory, or that indicate the token was found but PIN acquisition itself failed
+                 * (timeout, no interactive/cached answer available, headless with no cached answer, or the
+                 * PIN was wrong/locked): propagate those verbatim instead of silently falling back and
+                 * re-prompting. This mirrors how the FIDO2 code path (acquire_fido2_key()) treats the same
+                 * set of errors from its own PIN prompt. */
+                if (ERRNO_IS_NEG_RESOURCE(r) ||
+                    IN_SET(r, -ECANCELED, -EINTR, -ETIME, -EUNATCH, -ENOEXEC, -ENOPKG, -EPERM))
                         return r;
+
+                if (r != -EAGAIN) /* EAGAIN means: token not found */
+                        return log_notice_errno(SYNTHETIC_ERRNO(EAGAIN),
+                                                "PKCS#11 operation failed, falling back to traditional unlocking: %s",
+                                                STRERROR(r));
 
                 if (!monitor) {
                         /* We didn't find the token. In this case, watch for it via udev. Let's

--- a/test/units/TEST-24-CRYPTSETUP.sh
+++ b/test/units/TEST-24-CRYPTSETUP.sh
@@ -184,6 +184,8 @@ empty1               $IMAGE_EMPTY    -                               headless=1,
 # This one expects the key to be under /{etc,run}/cryptsetup-keys.d/empty_nokey.key
 empty_nokey          $IMAGE_EMPTY    -                               headless=1
 empty_pkcs11_auto    $IMAGE_EMPTY    -                               headless=1,pkcs11-uri=auto
+# No PKCS#11 token enrolled at all: should fall back to the empty passphrase instead of failing or stalling
+empty_pkcs11_none    $IMAGE_EMPTY    -                               headless=1,pkcs11-uri=auto,try-empty-password=1
 
 detached             $IMAGE_DETACHED $IMAGE_DETACHED_KEYFILE         headless=1,header=$IMAGE_DETACHED_HEADER,keyfile-offset=32,keyfile-size=16
 detached_store0      $IMAGE_DETACHED $IMAGE_DETACHED_KEYFILE         headless=1,header=/header:LABEL=header_store,keyfile-offset=32,keyfile-size=16
@@ -227,6 +229,21 @@ cryptsetup_start_and_check -f empty_nokey
 mkdir -p /run/cryptsetup-keys.d
 cp "$IMAGE_EMPTY_KEYFILE" /run/cryptsetup-keys.d/empty_nokey.key
 cryptsetup_start_and_check empty_nokey
+
+# pkcs11-uri=auto with no PKCS#11 token enrolled must fall back to traditional
+# unlocking (not fail outright, and not wait on a udev token monitor).
+# Exercise both the libcryptsetup token module path and the plugin-less
+# fallback path explicitly, since the error handling differs between them.
+for mod in 1 0; do
+    systemctl set-environment SYSTEMD_CRYPTSETUP_USE_TOKEN_MODULE="$mod"
+    SECONDS=0
+    cryptsetup_start_and_check empty_pkcs11_none
+    # The fallback should be immediate. If we ended up waiting on the udev
+    # token monitor instead of falling back right away, this would block
+    # until the device timeout elapses instead.
+    [[ "$SECONDS" -lt 30 ]]
+done
+systemctl unset-environment SYSTEMD_CRYPTSETUP_USE_TOKEN_MODULE
 
 if [[ -d /usr/lib/softhsm/tokens ]]; then
     # Test unlocking with a PKCS#11 token


### PR DESCRIPTION
crypt_activate_by_token_pin() returns -ENOENT when the LUKS2 header has no systemd-pkcs11 token at all, as opposed to -EAGAIN which means a token is enrolled but the hardware isn't currently present. Since the enrolled/not-enrolled case can never be resolved by waiting for a udev event, treat it the same way attach_luks_or_plain_or_bitlk_by_tpm2() already treats a missing TPM2 token: return right away and fall back to the next unlocking method, instead of stalling for up to 30secs

Fixes [43528](https://github.com/systemd/systemd/issues/43528)