### PR TITLE
ukify: fix cleaning up a temporary file

### DIFF
--- a/src/ukify/ukify.py
+++ b/src/ukify/ukify.py
@@ -1369,8 +1369,10 @@ def make_uki(opts: UkifyConfig) -> None:
                 print(f'{linux} is not a valid PE file and cannot be decompressed either', file=sys.stderr)
             else:
                 print(f'{linux} is compressed and cannot be loaded by UEFI, decompressing', file=sys.stderr)
-                linux = Path(tempfile.NamedTemporaryFile(prefix='linux-decompressed').name)
-                linux.write_bytes(decompressed)
+                linux_decompressed = tempfile.NamedTemporaryFile(prefix='linux-decompressed')
+                linux_decompressed.write(decompressed)
+                linux_decompressed.flush()
+                linux = Path(linux_decompressed.name)
 
     if linux and sign_args_present:
         assert opts.signtool is not None


### PR DESCRIPTION
... prefixed with name `linux-decompressed`.

Current code does not hold a reference to object returned from `tempfile.NamedTemporaryFile()`. This would cause the object to be immediately garbage collected and the temporary file is deleted. A new file is created with `linux.write_bytes()` which never gets cleaned up. Keeping a reference to this object would automatically clean up the temporary file when `make_uki()` function returns.

Found by AISLE in partnership with Red Hat