### PR TITLE
tree-wide: format man page references as foo(1)

### DIFF
--- a/src/ac-power/ac-power.c
+++ b/src/ac-power/ac-power.c
@@ -19,7 +19,7 @@ static enum {
 COMMAND(
         "systemd-ac-power\0",
         "Report whether we are connected to an external power source.",
-        .man_pages = "systemd-ac-power.1\0",
+        .man_pages = "systemd-ac-power(1)\0",
 );
 
 static int parse_argv(int argc, char *argv[]) {

--- a/src/analyze/analyze.c
+++ b/src/analyze/analyze.c
@@ -199,7 +199,7 @@ static int verb_transient_settings(int argc, char *argv[], uintptr_t _data, void
 COMMAND(
         "systemd-analyze\0",
         "Profile systemd, show unit dependencies, check unit files.",
-        .man_pages = "systemd-analyze.1\0",
+        .man_pages = "systemd-analyze(1)\0",
         .pager_flags = &arg_pager_flags,
 );
 

--- a/src/ask-password/ask-password.c
+++ b/src/ask-password/ask-password.c
@@ -40,7 +40,7 @@ COMMAND(
         "systemd-ask-password\0",
         "Query the user for a passphrase, via the TTY or a UI agent.",
         .argspec = "MESSAGE\0",
-        .man_pages = "systemd-ask-password.1\0",
+        .man_pages = "systemd-ask-password(1)\0",
 );
 
 static int parse_argv(int argc, char *argv[]) {

--- a/src/backlight/backlight.c
+++ b/src/backlight/backlight.c
@@ -26,7 +26,7 @@ COMMAND(
         "systemd-backlight\0",
         "Save and restore backlight brightness at shutdown and boot.",
         .argspec = "COMMAND [backlight|leds]:DEVICE\0",
-        .man_pages = "systemd-backlight.8\0",
+        .man_pages = "systemd-backlight(8)\0",
 );
 
 static int has_multiple_graphics_cards(void) {

--- a/src/battery-check/battery-check.c
+++ b/src/battery-check/battery-check.c
@@ -29,7 +29,7 @@ static bool arg_doit = true;
 COMMAND(
         "systemd-battery-check\0",
         "Check battery level to see whether there's enough charge.",
-        .man_pages = "systemd-battery-check.8\0",
+        .man_pages = "systemd-battery-check(8)\0",
 );
 
 static int plymouth_send_message(const char *mode, const char *message) {

--- a/src/binfmt/binfmt.c
+++ b/src/binfmt/binfmt.c
@@ -30,7 +30,7 @@ COMMAND(
         "systemd-binfmt\0",
         "Register binary formats with the kernel.",
         .argspec = "[CONFIGURATION FILE…]\0",
-        .man_pages = "systemd-binfmt.service.8\0",
+        .man_pages = "systemd-binfmt.service(8)\0",
         .pager_flags = &arg_pager_flags,
 );
 

--- a/src/bless-boot/bless-boot.c
+++ b/src/bless-boot/bless-boot.c
@@ -30,7 +30,7 @@ STATIC_DESTRUCTOR_REGISTER(arg_path, strv_freep);
 COMMAND(
         "systemd-bless-boot\0",
         "Mark the boot process as good or bad.",
-        .man_pages = "systemd-bless-boot.service.8\0",
+        .man_pages = "systemd-bless-boot.service(8)\0",
 );
 
 typedef enum Status {

--- a/src/bless-boot/boot-check-no-failures.c
+++ b/src/bless-boot/boot-check-no-failures.c
@@ -12,7 +12,7 @@
 COMMAND(
         "systemd-boot-check-no-failures\0",
         "Verify system operational state.",
-        .man_pages = "systemd-boot-check-no-failures.service.8\0",
+        .man_pages = "systemd-boot-check-no-failures.service(8)\0",
 );
 
 static int parse_argv(int argc, char *argv[]) {

--- a/src/bootctl/bootctl.c
+++ b/src/bootctl/bootctl.c
@@ -110,7 +110,7 @@ STATIC_DESTRUCTOR_REGISTER(arg_extras, strv_freep);
 COMMAND(
         "bootctl\0",
         "Control EFI firmware boot settings and manage boot loader.",
-        .man_pages = "bootctl.1\0",
+        .man_pages = "bootctl(1)\0",
         .pager_flags = &arg_pager_flags,
 );
 

--- a/src/busctl/busctl.c
+++ b/src/busctl/busctl.c
@@ -78,7 +78,7 @@ STATIC_DESTRUCTOR_REGISTER(arg_matches, strv_freep);
 COMMAND(
         "busctl\0",
         "Introspect the D-Bus IPC bus.",
-        .man_pages = "busctl.1\0",
+        .man_pages = "busctl(1)\0",
         .pager_flags = &arg_pager_flags,
         .flags = COMMAND_HELP_SEPARATE,  /* the verb table is very wide */
 );

--- a/src/cgls/cgls.c
+++ b/src/cgls/cgls.c
@@ -41,7 +41,7 @@ COMMAND(
         "systemd-cgls\0",
         "Recursively show control group contents.",
         .argspec = "[CGROUP…]\0" "--unit|--user-unit UNIT…\0",
-        .man_pages = "systemd-cgls.1\0",
+        .man_pages = "systemd-cgls(1)\0",
         .pager_flags = &arg_pager_flags,
 );
 

--- a/src/cgtop/cgtop.c
+++ b/src/cgtop/cgtop.c
@@ -94,7 +94,7 @@ COMMAND(
         "systemd-cgtop\0",
         "Show top control groups by their resource usage.",
         .argspec = "[CGROUP]\0",
-        .man_pages = "systemd-cgtop.1\0",
+        .man_pages = "systemd-cgtop(1)\0",
 );
 
 static const char *order_table[_ORDER_MAX] = {

--- a/src/clonesetup/clonesetup.c
+++ b/src/clonesetup/clonesetup.c
@@ -24,7 +24,7 @@
 COMMAND(
         "systemd-clonesetup\0",
         "Add or remove a dm-clone device.",
-        .man_pages = "systemd-clonesetup.8\0",
+        .man_pages = "systemd-clonesetup(8)\0",
 );
 
 static int parse_clone_options(const char *options, uint64_t *ret_region_size_bytes) {

--- a/src/core/executor.c
+++ b/src/core/executor.c
@@ -33,7 +33,7 @@ STATIC_DESTRUCTOR_REGISTER(arg_serialization, fclosep);
 COMMAND(
         "systemd-executor\0",
         "Sandbox and execute processes.",
-        .man_pages = "systemd.1\0",
+        .man_pages = "systemd(1)\0",
         .option_namespace = "systemd-executor",
 );
 

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -1042,7 +1042,7 @@ static int redirect_telinit(char *argv[], char **args) {
 COMMAND(
         "systemd\0",
         "Start and monitor system and user services.",
-        .man_pages = "systemd.1\0",
+        .man_pages = "systemd(1)\0",
         .option_namespace = "systemd",
         .pager_flags = &arg_pager_flags,
 );

--- a/src/coredump/coredumpctl.c
+++ b/src/coredump/coredumpctl.c
@@ -63,7 +63,7 @@ STATIC_DESTRUCTOR_REGISTER(arg_image_policy, image_policy_freep);
 COMMAND(
         "coredumpctl\0",
         "List or retrieve coredumps from the journal.",
-        .man_pages = "coredumpctl.1\0",
+        .man_pages = "coredumpctl(1)\0",
         .pager_flags = &arg_pager_flags,
 );
 

--- a/src/creds/creds.c
+++ b/src/creds/creds.c
@@ -81,7 +81,7 @@ STATIC_DESTRUCTOR_REGISTER(arg_tpm2_signature, freep);
 COMMAND(
         "systemd-creds\0",
         "Display and process credentials.",
-        .man_pages = "systemd-creds.1\0",
+        .man_pages = "systemd-creds(1)\0",
         .pager_flags = &arg_pager_flags,
 );
 

--- a/src/cryptenroll/cryptenroll.c
+++ b/src/cryptenroll/cryptenroll.c
@@ -122,7 +122,7 @@ COMMAND(
         "systemd-cryptenroll\0",
         "Enroll a security token or authentication credential to a LUKS volume.",
         .argspec = "[BLOCK-DEVICE]\0",
-        .man_pages = "systemd-cryptenroll.1\0",
+        .man_pages = "systemd-cryptenroll(1)\0",
         .pager_flags = &arg_pager_flags,
 );
 

--- a/src/cryptsetup/cryptsetup.c
+++ b/src/cryptsetup/cryptsetup.c
@@ -145,7 +145,7 @@ STATIC_DESTRUCTOR_REGISTER(arg_fixate_volume_key, freep);
 COMMAND(
         "systemd-cryptsetup\0",
         "Attach or detach an encrypted block device.",
-        .man_pages = "systemd-cryptsetup.8\0",
+        .man_pages = "systemd-cryptsetup(8)\0",
 );
 
 static const char* const passphrase_type_table[_PASSPHRASE_TYPE_MAX] = {

--- a/src/delta/delta.c
+++ b/src/delta/delta.c
@@ -71,7 +71,7 @@ COMMAND(
         "systemd-delta\0",
         "Find overridden configuration files.",
         .argspec = "[SUFFIX…]\0",
-        .man_pages = "systemd-delta.1\0",
+        .man_pages = "systemd-delta(1)\0",
         .pager_flags = &arg_pager_flags,
 );
 

--- a/src/detect-virt/detect-virt.c
+++ b/src/detect-virt/detect-virt.c
@@ -24,7 +24,7 @@ static enum {
 COMMAND(
         "systemd-detect-virt\0",
         "Detect execution in a virtualized environment.",
-        .man_pages = "systemd-detect-virt.1\0",
+        .man_pages = "systemd-detect-virt(1)\0",
 );
 
 static int parse_argv(int argc, char *argv[]) {

--- a/src/dissect/dissect.c
+++ b/src/dissect/dissect.c
@@ -139,7 +139,7 @@ COMMAND(
                "--discover\0"
                "--validate IMAGE\0"
                "--shift IMAGE UIDBASE\0",
-        .man_pages = "systemd-dissect.1\0",
+        .man_pages = "systemd-dissect(1)\0",
         .option_namespace = "systemd-dissect",
         .pager_flags = &arg_pager_flags,
 );
@@ -715,7 +715,7 @@ static int parse_argv(int argc, char *argv[]) {
 COMMAND(
         "mount.ddi\0",
         "External helper for mount.8 to mount Discoverable Disk Images (DDIs).",
-        .man_pages = "systemd-dissect.1\0",
+        .man_pages = "systemd-dissect(1)\0",
         .option_namespace = "mount.ddi",
 );
 

--- a/src/escape/escape-tool.c
+++ b/src/escape/escape-tool.c
@@ -31,7 +31,7 @@ COMMAND(
         "systemd-escape\0",
         "Escape strings for usage in systemd unit names.",
         .argspec = "STRING…\0" "--stdin\0",
-        .man_pages = "systemd-escape.1\0",
+        .man_pages = "systemd-escape(1)\0",
 );
 
 static int parse_argv(int argc, char *argv[], char ***ret_args) {

--- a/src/factory-reset/factory-reset-tool.c
+++ b/src/factory-reset/factory-reset-tool.c
@@ -25,7 +25,7 @@ static bool arg_varlink = false;
 COMMAND(
         "systemd-factory-reset\0",
         "Query, request, or cancel a factory reset operation.",
-        .man_pages = "systemd-factory-reset.8\0",
+        .man_pages = "systemd-factory-reset(8)\0",
 );
 
 static int parse_argv(int argc, char *argv[], char ***ret_args) {

--- a/src/firstboot/firstboot.c
+++ b/src/firstboot/firstboot.c
@@ -112,7 +112,7 @@ STATIC_DESTRUCTOR_REGISTER(arg_label_context, mac_label_context_freep);
 COMMAND(
         "systemd-firstboot\0",
         "Configure basic settings of the system.",
-        .man_pages = "systemd-firstboot.1\0",
+        .man_pages = "systemd-firstboot(1)\0",
 );
 
 static bool welcome_done = false;

--- a/src/growfs/growfs.c
+++ b/src/growfs/growfs.c
@@ -30,7 +30,7 @@ COMMAND(
         "systemd-growfs\0",
         "Grow filesystem or encrypted payload to device size.",
         .argspec = "MOUNTPOINT\0",
-        .man_pages = "systemd-growfs@.service.8\0",
+        .man_pages = "systemd-growfs@.service(8)\0",
 );
 
 #if HAVE_LIBCRYPTSETUP

--- a/src/hibernate-resume/hibernate-resume.c
+++ b/src/hibernate-resume/hibernate-resume.c
@@ -28,7 +28,7 @@ COMMAND(
         .argspec =
                 "[DEVICE [OFFSET]]\0"
                 "--clear\0",
-        .man_pages = "systemd-hibernate-resume.8\0",
+        .man_pages = "systemd-hibernate-resume(8)\0",
 );
 
 static int parse_argv(int argc, char *argv[], char ***ret_args) {

--- a/src/home/homectl.c
+++ b/src/home/homectl.c
@@ -185,7 +185,7 @@ static int acquire_bus(sd_bus **bus) {
 COMMAND(
         "homectl\0",
         "Create, manipulate or inspect home directories.",
-        .man_pages = "homectl.1\0",
+        .man_pages = "homectl(1)\0",
         .pager_flags = &arg_pager_flags,
         .flags = COMMAND_HELP_SEPARATE,  /* the option table is very wide */
 );

--- a/src/home/homed.c
+++ b/src/home/homed.c
@@ -18,7 +18,7 @@
 COMMAND(
         "systemd-homed\0",
         "Create, remove, change or inspect home areas.",
-        .man_pages = "systemd-homed.service.8\0",
+        .man_pages = "systemd-homed.service(8)\0",
         .option_namespace = "service",
         .option_groups =
                 "Options\0"

--- a/src/hostname/hostnamectl.c
+++ b/src/hostname/hostnamectl.c
@@ -43,7 +43,7 @@ static sd_json_format_flags_t arg_json_format_flags = SD_JSON_FORMAT_OFF;
 COMMAND(
         "hostnamectl\0",
         "Query or change system hostname.",
-        .man_pages = "hostnamectl.1\0",
+        .man_pages = "hostnamectl(1)\0",
 );
 
 typedef struct StatusInfo {

--- a/src/hostname/hostnamed.c
+++ b/src/hostname/hostnamed.c
@@ -2666,7 +2666,7 @@ static bool context_check_idle(void *userdata) {
 COMMAND(
         "systemd-hostnamed\0",
         "Manage the system hostname and related metadata.",
-        .man_pages = "systemd-hostnamed.service.8\0",
+        .man_pages = "systemd-hostnamed.service(8)\0",
         .option_namespace = "service",
         .option_groups =
                 "Options\0"

--- a/src/hwdb/hwdb.c
+++ b/src/hwdb/hwdb.c
@@ -17,7 +17,7 @@ static bool arg_strict = false;
 COMMAND(
         "systemd-hwdb\0",
         "Update or query the hardware database.",
-        .man_pages = "systemd-hwdb.8\0",
+        .man_pages = "systemd-hwdb(8)\0",
 );
 
 VERB(verb_query, "query", "MODALIAS", 2, 2, 0,

--- a/src/id128/id128.c
+++ b/src/id128/id128.c
@@ -28,7 +28,7 @@ static sd_json_format_flags_t arg_json_format_flags = SD_JSON_FORMAT_OFF;
 COMMAND(
         "systemd-id128\0",
         "Generate and print 128-bit identifiers.",
-        .man_pages = "systemd-id128.1\0",
+        .man_pages = "systemd-id128(1)\0",
         .pager_flags = &arg_pager_flags,
 );
 

--- a/src/imds/imds-tool.c
+++ b/src/imds/imds-tool.c
@@ -55,7 +55,7 @@ COMMAND(
         "systemd-imds\0",
         "IMDS data acquisition.",
         .argspec = "[KEY]\0",
-        .man_pages = "systemd-imds.1\0",
+        .man_pages = "systemd-imds(1)\0",
 );
 
 static int parse_argv(int argc, char *argv[]) {

--- a/src/imds/imdsd.c
+++ b/src/imds/imdsd.c
@@ -143,7 +143,7 @@ COMMAND(
         "systemd-imdsd\0",
         "Low-level IMDS data acquisition.",
         .argspec = "KEY\0",
-        .man_pages = "systemd-imdsd@.service.8\0",
+        .man_pages = "systemd-imdsd@.service(8)\0",
 );
 
 typedef struct Context Context;

--- a/src/import/importctl.c
+++ b/src/import/importctl.c
@@ -51,7 +51,7 @@ static RuntimeScope arg_runtime_scope = RUNTIME_SCOPE_SYSTEM;
 COMMAND(
         "importctl\0",
         "Download, import or export disk images.",
-        .man_pages = "importctl.1\0",
+        .man_pages = "importctl(1)\0",
         .pager_flags = &arg_pager_flags,
 );
 

--- a/src/import/importd.c
+++ b/src/import/importd.c
@@ -2084,7 +2084,7 @@ static void manager_parse_env(Manager *m) {
 COMMAND(
         "systemd-importd\0",
         "Import and export VM and container images.",
-        .man_pages = "systemd-importd.service.8\0",
+        .man_pages = "systemd-importd.service(8)\0",
         .option_namespace = "service",
         .option_groups =
                 "Options\0"

--- a/src/integritysetup/integritysetup.c
+++ b/src/integritysetup/integritysetup.c
@@ -44,7 +44,7 @@ DEFINE_PRIVATE_STRING_TABLE_LOOKUP_TO_STRING(dm_integrity_algorithm, IntegrityAl
 COMMAND(
         "systemd-integritysetup\0",
         "Attach or detach an integrity protected block device.",
-        .man_pages = "systemd-integritysetup@.service.8\0",
+        .man_pages = "systemd-integritysetup@.service(8)\0",
 );
 
 static int load_key_file(

--- a/src/journal-remote/journal-gatewayd.c
+++ b/src/journal-remote/journal-gatewayd.c
@@ -55,7 +55,7 @@ STATIC_DESTRUCTOR_REGISTER(arg_file, strv_freep);
 COMMAND(
         "systemd-journal-gatewayd\0",
         "Serve journal events over HTTP.",
-        .man_pages = "systemd-journal-gatewayd.service.8\0",
+        .man_pages = "systemd-journal-gatewayd.service(8)\0",
 );
 
 typedef struct RequestMeta {

--- a/src/journal-remote/journal-remote-main.c
+++ b/src/journal-remote/journal-remote-main.c
@@ -88,7 +88,7 @@ COMMAND(
         "Write external journal events to journal files.",
         .argspec = "[{FILE|-}…]\0",
         .footer = "Note: file descriptors from sd_listen_fds() will be consumed, too.",
-        .man_pages = "systemd-journal-remote.service.8\0",
+        .man_pages = "systemd-journal-remote.service(8)\0",
 );
 
 static const char* const journal_write_split_mode_table[_JOURNAL_WRITE_SPLIT_MAX] = {

--- a/src/journal-remote/journal-upload.c
+++ b/src/journal-remote/journal-upload.c
@@ -81,7 +81,7 @@ COMMAND(
         "systemd-journal-upload\0",
         "Upload journal events to a remote server.",
         .argspec = "[-u URL] [{FILE|-}…]\0",
-        .man_pages = "systemd-journal-upload.service.8\0",
+        .man_pages = "systemd-journal-upload.service(8)\0",
 );
 
 static void close_fd_input(Uploader *u);

--- a/src/journal/bsod.c
+++ b/src/journal/bsod.c
@@ -33,7 +33,7 @@ COMMAND(
         "systemd-bsod\0",
         "Filter the journal to fetch the first message from the current boot with an emergency "
         "log level and display it as a string and a QR code.",
-        .man_pages = "systemd-bsod.8\0",
+        .man_pages = "systemd-bsod(8)\0",
 );
 
 static int acquire_first_emergency_log_message(char **ret) {

--- a/src/journal/cat.c
+++ b/src/journal/cat.c
@@ -29,7 +29,7 @@ COMMAND(
         "systemd-cat\0",
         "Execute process with stdout/stderr connected to the journal.",
         .argspec = "[COMMAND…]\0",
-        .man_pages = "systemd-cat.1\0",
+        .man_pages = "systemd-cat(1)\0",
 );
 
 static int parse_argv(int argc, char *argv[], char ***ret_args) {

--- a/src/journal/journalctl.c
+++ b/src/journal/journalctl.c
@@ -146,7 +146,7 @@ COMMAND(
         "journalctl\0",
         "Query the journal.",
         .argspec = "[MATCH…]\0",
-        .man_pages = "journalctl.1\0",
+        .man_pages = "journalctl(1)\0",
         .option_namespace = "journalctl",
         .pager_flags = &arg_pager_flags,
 );

--- a/src/kernel-install/kernel-install.c
+++ b/src/kernel-install/kernel-install.c
@@ -70,7 +70,7 @@ COMMAND(
         .footer = "This program may also be invoked as 'installkernel':\n"
                   "  installkernel [OPTION…] VERSION VMLINUZ [MAP] [INSTALLATION-DIR]\n"
                   "(The optional arguments are passed by kernel build system, but ignored.)",
-        .man_pages = "kernel-install.8\0",
+        .man_pages = "kernel-install(8)\0",
         .pager_flags = &arg_pager_flags,
         .flags = COMMAND_HELP_SEPARATE,  /* the verb table is very wide */
 );
@@ -1729,7 +1729,7 @@ COMMAND(
         "Add and remove kernel and initrd images to and from the boot partition.",
         .argspec = "VERSION VMLINUZ [MAP] [INSTALLATION-DIR]\0",
         .footer = "This is a compat interface intended only to be called from kernel Makefiles.",
-        .man_pages = "kernel-install.8\0",
+        .man_pages = "kernel-install(8)\0",
         .pager_flags = &arg_pager_flags,
 );
 

--- a/src/keyutil/keyutil.c
+++ b/src/keyutil/keyutil.c
@@ -39,7 +39,7 @@ STATIC_DESTRUCTOR_REGISTER(arg_output, freep);
 COMMAND(
         "systemd-keyutil\0",
         "Perform various operations on private keys and certificates.",
-        .man_pages = "systemd-keyutil.1\0",
+        .man_pages = "systemd-keyutil(1)\0",
 );
 
 VERB_COMMON_HELP_AUTO_HIDDEN();

--- a/src/locale/localectl.c
+++ b/src/locale/localectl.c
@@ -40,7 +40,7 @@ static bool arg_full = false;
 COMMAND(
         "localectl\0",
         "Query or change system locale and keyboard settings.",
-        .man_pages = "localectl.1\0",
+        .man_pages = "localectl(1)\0",
         .pager_flags = &arg_pager_flags,
 );
 

--- a/src/locale/localed.c
+++ b/src/locale/localed.c
@@ -631,7 +631,7 @@ static bool context_check_idle(void *userdata) {
 COMMAND(
         "systemd-localed\0",
         "Manage system locale settings and key mappings.",
-        .man_pages = "systemd-localed.service.8\0",
+        .man_pages = "systemd-localed.service(8)\0",
         .option_namespace = "service",
         .option_groups =
                 "Options\0"

--- a/src/login/inhibit.c
+++ b/src/login/inhibit.c
@@ -51,7 +51,7 @@ COMMAND(
         .argspec =
                 "COMMAND…\0"
                 "--list\0",
-        .man_pages = "systemd-inhibit.1\0",
+        .man_pages = "systemd-inhibit(1)\0",
         .pager_flags = &arg_pager_flags,
 );
 

--- a/src/login/loginctl.c
+++ b/src/login/loginctl.c
@@ -58,7 +58,7 @@ STATIC_DESTRUCTOR_REGISTER(arg_property, strv_freep);
 COMMAND(
         "loginctl\0",
         "Send control commands to or query the login manager.",
-        .man_pages = "loginctl.1\0",
+        .man_pages = "loginctl(1)\0",
         .pager_flags = &arg_pager_flags,
 );
 

--- a/src/login/logind.c
+++ b/src/login/logind.c
@@ -1351,7 +1351,7 @@ static int manager_run(Manager *m) {
 COMMAND(
         "systemd-logind\0",
         "Manage user logins and devices and privileged operations.",
-        .man_pages = "systemd-logind.service.8\0",
+        .man_pages = "systemd-logind.service(8)\0",
         .option_namespace = "service",
         .option_groups =
                 "Options\0"

--- a/src/machine-id-setup/machine-id-setup-main.c
+++ b/src/machine-id-setup/machine-id-setup-main.c
@@ -31,7 +31,7 @@ STATIC_DESTRUCTOR_REGISTER(arg_image_policy, image_policy_freep);
 COMMAND(
         "systemd-machine-id-setup\0",
         "Initialize /etc/machine-id from a random source.",
-        .man_pages = "systemd-machine-id-setup.1\0",
+        .man_pages = "systemd-machine-id-setup(1)\0",
 );
 
 static int parse_argv(int argc, char *argv[]) {

--- a/src/machine/machinectl.c
+++ b/src/machine/machinectl.c
@@ -119,7 +119,7 @@ STATIC_DESTRUCTOR_REGISTER(arg_setenv, strv_freep);
 COMMAND(
         "machinectl\0",
         "Send control commands to or query the virtual machine and container registration manager.",
-        .man_pages = "machinectl.1\0",
+        .man_pages = "machinectl(1)\0",
         .pager_flags = &arg_pager_flags,
 );
 

--- a/src/machine/machined.c
+++ b/src/machine/machined.c
@@ -347,7 +347,7 @@ static bool check_idle(void *userdata) {
 COMMAND(
         "systemd-machined\0",
         "Manage registrations of local VMs and containers.",
-        .man_pages = "systemd-machined.service.8\0",
+        .man_pages = "systemd-machined.service(8)\0",
         .option_namespace = "service",
         .option_groups =
                 "Options\0"

--- a/src/measure/measure-tool.c
+++ b/src/measure/measure-tool.c
@@ -68,7 +68,7 @@ STATIC_DESTRUCTOR_REGISTER(arg_sections, free_sections);
 COMMAND(
         "systemd-measure\0",
         "Pre-calculate and sign PCR hash for a unified kernel image (UKI).",
-        .man_pages = "systemd-measure.1\0",
+        .man_pages = "systemd-measure(1)\0",
         .pager_flags = &arg_pager_flags,
 );
 

--- a/src/modules-load/modules-load.c
+++ b/src/modules-load/modules-load.c
@@ -40,7 +40,7 @@ COMMAND(
         "systemd-modules-load\0",
         "Load statically configured kernel modules.",
         .argspec = "[CONFIGURATION FILE…]\0",
-        .man_pages = "systemd-modules-load.service.8\0",
+        .man_pages = "systemd-modules-load.service(8)\0",
 );
 
 static int modules_list_append_suffix(OrderedSet **module_set, char *modp) {

--- a/src/mount/mount-tool.c
+++ b/src/mount/mount-tool.c
@@ -97,7 +97,7 @@ COMMAND(
         .option_groups =
                 "Common options\0"
                 "Mount options\0",
-        .man_pages = "systemd-mount.1\0",
+        .man_pages = "systemd-mount(1)\0",
         .flags = COMMAND_VERBS_SHARED,
         .pager_flags = &arg_pager_flags,
 );
@@ -108,7 +108,7 @@ COMMAND(
                 "WHAT|WHERE…\0",
         .option_groups =
                 "Common options\0",
-        .man_pages = "systemd-mount.1\0",
+        .man_pages = "systemd-mount(1)\0",
         .flags = COMMAND_VERBS_SHARED,
         .pager_flags = &arg_pager_flags,
 );

--- a/src/mstack/mstack-tool.c
+++ b/src/mstack/mstack-tool.c
@@ -49,7 +49,7 @@ COMMAND(
                 "WHAT\0"
                 "--mount WHAT WHERE\0"
                 "--umount WHERE\0",
-        .man_pages = "systemd-mstack.1\0",
+        .man_pages = "systemd-mstack(1)\0",
         .option_namespace = "systemd-mstack",
         .pager_flags = &arg_pager_flags,
 );
@@ -191,7 +191,7 @@ static int parse_argv(int argc, char *argv[]) {
 COMMAND(
         "mount.mstack\0",
         "External helper for mount.8 to mount mount stacks.",
-        .man_pages = "systemd-mstack.1\0",
+        .man_pages = "systemd-mstack(1)\0",
         .option_namespace = "mount.mstack",
 );
 

--- a/src/mute-console/mute-console.c
+++ b/src/mute-console/mute-console.c
@@ -30,7 +30,7 @@ static bool arg_varlink = false;
 COMMAND(
         "systemd-mute-console\0",
         "Mute status output to the console.",
-        .man_pages = "systemd-mute-console.1\0",
+        .man_pages = "systemd-mute-console(1)\0",
 );
 
 static int parse_argv(int argc, char *argv[]) {

--- a/src/network/generator/network-generator-main.c
+++ b/src/network/generator/network-generator-main.c
@@ -30,7 +30,7 @@ COMMAND(
         "systemd-network-generator\0",
         "Generate network configuration from the kernel command line.",
         .argspec = "[-- KERNEL_CMDLINE]\0",
-        .man_pages = "systemd-network-generator.service.8\0",
+        .man_pages = "systemd-network-generator.service(8)\0",
 );
 
 static int network_save(Network *network, const char *dest_dir) {

--- a/src/network/networkctl.c
+++ b/src/network/networkctl.c
@@ -41,7 +41,7 @@ STATIC_DESTRUCTOR_REGISTER(arg_drop_in, freep);
 COMMAND(
         "networkctl\0",
         "Query and control the networking subsystem.",
-        .man_pages = "networkctl.1\0",
+        .man_pages = "networkctl(1)\0",
         .pager_flags = &arg_pager_flags,
 );
 

--- a/src/network/networkd.c
+++ b/src/network/networkd.c
@@ -24,7 +24,7 @@
 COMMAND(
         "systemd-networkd\0",
         "Manage and configure network devices, create virtual network devices.",
-        .man_pages = "systemd-networkd.service.8\0",
+        .man_pages = "systemd-networkd.service(8)\0",
         .option_namespace = "service",
         .option_groups =
                 "Options\0"

--- a/src/network/wait-online/wait-online.c
+++ b/src/network/wait-online/wait-online.c
@@ -33,7 +33,7 @@ STATIC_DESTRUCTOR_REGISTER(arg_ignore, strv_freep);
 COMMAND(
         "systemd-networkd-wait-online\0",
         "Block until network is configured.",
-        .man_pages = "systemd-networkd-wait-online.service.8\0",
+        .man_pages = "systemd-networkd-wait-online.service(8)\0",
 );
 
 static int parse_interface_with_operstate_range(const char *str) {

--- a/src/notify/notify.c
+++ b/src/notify/notify.c
@@ -62,7 +62,7 @@ COMMAND(
                 "[VARIABLE=VALUE…]\0"
                 "--exec [VARIABLE=VALUE…] ; -- CMDLINE…\0"
                 "--fork -- CMDLINE…\0",
-        .man_pages = "systemd-notify.1\0",
+        .man_pages = "systemd-notify(1)\0",
 );
 
 static int get_manager_pid(PidRef *ret) {

--- a/src/nspawn/nspawn.c
+++ b/src/nspawn/nspawn.c
@@ -322,7 +322,7 @@ COMMAND(
         "systemd-nspawn\0",
         "Spawn a command or OS in a lightweight container.",
         .argspec = "[PATH] [ARGUMENTS…]\0",
-        .man_pages = "systemd-nspawn.1\0",
+        .man_pages = "systemd-nspawn(1)\0",
         .pager_flags = &arg_pager_flags,
 );
 

--- a/src/oom/oomctl.c
+++ b/src/oom/oomctl.c
@@ -17,7 +17,7 @@ static PagerFlags arg_pager_flags = 0;
 COMMAND(
         "oomctl\0",
         "Manage or inspect the userspace OOM killer.",
-        .man_pages = "oomctl.1\0",
+        .man_pages = "oomctl(1)\0",
         .pager_flags = &arg_pager_flags,
 );
 

--- a/src/oom/oomd.c
+++ b/src/oom/oomd.c
@@ -24,7 +24,7 @@ static bool arg_dry_run = false;
 COMMAND(
         "systemd-oomd\0",
         "Run the userspace out-of-memory (OOM) killer.",
-        .man_pages = "systemd-oomd.8\0",
+        .man_pages = "systemd-oomd(8)\0",
 );
 
 static int parse_argv(int argc, char *argv[]) {

--- a/src/path/path-tool.c
+++ b/src/path/path-tool.c
@@ -24,7 +24,7 @@ COMMAND(
         "systemd-path\0",
         "Show system and user paths.",
         .argspec = "[NAME…]\0",
-        .man_pages = "systemd-path.1\0",
+        .man_pages = "systemd-path(1)\0",
         .pager_flags = &arg_pager_flags,
 );
 

--- a/src/pcrextend/pcrextend.c
+++ b/src/pcrextend/pcrextend.c
@@ -52,7 +52,7 @@ COMMAND(
                 "--machine-id\0"
                 "--product-id\0"
                 "--login=UID|USER\0",
-        .man_pages = "systemd-pcrextend.8\0",
+        .man_pages = "systemd-pcrextend(8)\0",
 );
 
 #define EXTENSION_STRING_SAFE_LIMIT 1024

--- a/src/pcrlock/pcrlock.c
+++ b/src/pcrlock/pcrlock.c
@@ -106,7 +106,7 @@ STATIC_DESTRUCTOR_REGISTER(arg_entry_token, freep);
 COMMAND(
         "systemd-pcrlock\0",
         "Manage a TPM2 PCR lock.",
-        .man_pages = "systemd-pcrlock.8\0",
+        .man_pages = "systemd-pcrlock(8)\0",
         .pager_flags = &arg_pager_flags,
 );
 

--- a/src/portable/portablectl.c
+++ b/src/portable/portablectl.c
@@ -54,7 +54,7 @@ STATIC_DESTRUCTOR_REGISTER(arg_extension_images, strv_freep);
 COMMAND(
         "portablectl\0",
         "Attach or detach portable services in the local system.",
-        .man_pages = "portablectl.1\0",
+        .man_pages = "portablectl(1)\0",
         .pager_flags = &arg_pager_flags,
 );
 

--- a/src/portable/portabled.c
+++ b/src/portable/portabled.c
@@ -143,7 +143,7 @@ static bool check_idle(void *userdata) {
 COMMAND(
         "systemd-portabled\0",
         "Manage registrations of portable images.",
-        .man_pages = "systemd-portabled.service.8\0",
+        .man_pages = "systemd-portabled.service(8)\0",
         .option_namespace = "service",
         .option_groups =
                 "Options\0"

--- a/src/ptyfwd/ptyfwd-tool.c
+++ b/src/ptyfwd/ptyfwd-tool.c
@@ -31,7 +31,7 @@ COMMAND(
         "systemd-pty-forward\0",
         "Run command with a custom terminal background color or title.",
         .argspec = "COMMAND…\0",
-        .man_pages = "systemd-pty-forward.1\0",
+        .man_pages = "systemd-pty-forward(1)\0",
 );
 
 static int parse_argv(int argc, char *argv[], char ***remaining_args) {

--- a/src/random-seed/random-seed-tool.c
+++ b/src/random-seed/random-seed-tool.c
@@ -46,7 +46,7 @@ static SeedAction arg_action = _ACTION_INVALID;
 COMMAND(
         "systemd-random-seed\0",
         "Load and save the system random seed at boot and shutdown.",
-        .man_pages = "systemd-random-seed.8\0",
+        .man_pages = "systemd-random-seed(8)\0",
 );
 
 static CreditEntropy may_credit(int seed_fd) {

--- a/src/repart/repart.c
+++ b/src/repart/repart.c
@@ -252,7 +252,7 @@ COMMAND(
         "systemd-repart\0",
         "Grow and add partitions to a partition table, and generate disk images (DDIs).",
         .argspec = "[DEVICE]\0",
-        .man_pages = "systemd-repart.8\0",
+        .man_pages = "systemd-repart(8)\0",
         .pager_flags = &arg_pager_flags,
 );
 

--- a/src/report/report-files-server.c
+++ b/src/report/report-files-server.c
@@ -14,7 +14,7 @@
 COMMAND(
         "systemd-report-files\0",
         "Report the contents of files as system report metrics.",
-        .man_pages = "systemd-report-files@.service.8\0",
+        .man_pages = "systemd-report-files@.service(8)\0",
 );
 
 static int vl_server(void) {

--- a/src/report/report-sign-plain.c
+++ b/src/report/report-sign-plain.c
@@ -30,7 +30,7 @@
 COMMAND(
         "systemd-report-sign-plain\0",
         "Sign system reports with a local software key.",
-        .man_pages = "systemd-report-sign-plain@.service.8\0",
+        .man_pages = "systemd-report-sign-plain@.service(8)\0",
 );
 
 #define REPORT_SIGN_PLAIN_DIR         "/var/lib/systemd/report.sign.plain"

--- a/src/report/report-sign-tsm.c
+++ b/src/report/report-sign-tsm.c
@@ -19,7 +19,7 @@ COMMAND(
         "systemd-report-sign-tsm\0",
         "Get an attestation report via configfs Trusted Security Module (TSM) "
         "that includes the hash of the system report.",
-        .man_pages = "systemd-report-sign-tsm@.service.8\0",
+        .man_pages = "systemd-report-sign-tsm@.service(8)\0",
 );
 
 typedef struct SignParameters {

--- a/src/report/report.c
+++ b/src/report/report.c
@@ -58,7 +58,7 @@ STATIC_DESTRUCTOR_REGISTER(arg_extra_headers, strv_freep);
 COMMAND(
         "systemd-report\0",
         "Acquire metrics from local sources.",
-        .man_pages = "systemd-report.1\0",
+        .man_pages = "systemd-report(1)\0",
         .pager_flags = &arg_pager_flags,
 );
 

--- a/src/resolve/resolvconf-compat.c
+++ b/src/resolve/resolvconf-compat.c
@@ -24,7 +24,7 @@ typedef enum LookupType  {
 COMMAND(
         "resolvconf\0",
         "Register DNS server and domain configuration with systemd-resolved.",
-        .man_pages = "resolvectl.1\0",
+        .man_pages = "resolvectl(1)\0",
         .argspec = "-a INTERFACE <FILE\0"
                    "-d INTERFACE\0",
         .footer =

--- a/src/resolve/resolvectl.c
+++ b/src/resolve/resolvectl.c
@@ -100,7 +100,7 @@ COMMAND(
         "resolvectl\0",
         "Send control commands to the network name resolution manager, or "
         "resolve domain names, IPv4 and IPv6 addresses, DNS records, and services.",
-        .man_pages = "resolvectl.1\0",
+        .man_pages = "resolvectl(1)\0",
         .option_namespace = "resolvectl",
         .pager_flags = &arg_pager_flags,
 );
@@ -3251,7 +3251,7 @@ VERB_COMMON_HELP_AUTO_PROGRAM_HIDDEN("resolvectl");
 COMMAND(
         "systemd-resolve\0",
         "This command is deprecated. Use resolvectl.1 instead.",
-        .man_pages = "resolvectl.1\0",
+        .man_pages = "resolvectl(1)\0",
         .option_namespace = "systemd-resolve",
         .pager_flags = &arg_pager_flags,
 );

--- a/src/resolve/resolved.c
+++ b/src/resolve/resolved.c
@@ -24,7 +24,7 @@
 COMMAND(
         "systemd-resolved\0",
         "Provide name resolution with caching using DNS, mDNS, LLMNR.",
-        .man_pages = "systemd-resolved.service.8\0",
+        .man_pages = "systemd-resolved.service(8)\0",
         .option_namespace = "service",
         .option_groups =
                 "Options\0"

--- a/src/run/run.c
+++ b/src/run/run.c
@@ -148,7 +148,7 @@ COMMAND(
         "systemd-run\0",
         "Run the specified command in a transient scope or service.",
         .argspec = "COMMAND [ARGUMENTS…]\0",
-        .man_pages = "systemd-run.1\0",
+        .man_pages = "systemd-run(1)\0",
         .option_namespace = "systemd-run",
         .pager_flags = &arg_pager_flags,
 );
@@ -758,7 +758,7 @@ COMMAND(
         "run0\0",
         "Elevate privileges interactively.",
         .argspec = "COMMAND [ARGUMENTS…]\0",
-        .man_pages = "run0.1\0",
+        .man_pages = "run0(1)\0",
         .option_namespace = "run0",
         .pager_flags = &arg_pager_flags,
 );

--- a/src/sbsign/sbsign.c
+++ b/src/sbsign/sbsign.c
@@ -49,7 +49,7 @@ STATIC_DESTRUCTOR_REGISTER(arg_signed_data_signature, freep);
 COMMAND(
         "systemd-sbsign\0",
         "Sign PE binaries for EFI Secure Boot.",
-        .man_pages = "systemd-sbsign.1\0",
+        .man_pages = "systemd-sbsign(1)\0",
 );
 
 VERB_COMMON_HELP_AUTO_HIDDEN();

--- a/src/shutdown/shutdown.c
+++ b/src/shutdown/shutdown.c
@@ -66,7 +66,7 @@ COMMAND(
         "systemd-shutdown\0",
         "Execute the final phase of system shutdown.",
         .argspec = "reboot|poweroff|halt|kexec|exit\0",
-        .man_pages = "systemd-shutdown.8\0",
+        .man_pages = "systemd-shutdown(8)\0",
 );
 
 static int parse_argv(int argc, char *argv[]) {

--- a/src/sleep/sleep.c
+++ b/src/sleep/sleep.c
@@ -48,7 +48,7 @@
 COMMAND(
         "systemd-sleep\0",
         "Suspend the system, hibernate the system, or both.",
-        .man_pages = "systemd-suspend.service.8\0",
+        .man_pages = "systemd-suspend.service(8)\0",
 );
 
 #if ENABLE_EFI

--- a/src/socket-activate/socket-activate.c
+++ b/src/socket-activate/socket-activate.c
@@ -40,7 +40,7 @@ COMMAND(
         "Listen on sockets and launch child on connection.",
         .argspec = "COMMAND…\0",
         .footer = "Note: file descriptors from sd_listen_fds() will be passed through.",
-        .man_pages = "systemd-socket-activate.1\0",
+        .man_pages = "systemd-socket-activate(1)\0",
 );
 
 static int add_epoll(int epoll_fd, int fd) {

--- a/src/socket-proxy/socket-proxyd.c
+++ b/src/socket-proxy/socket-proxyd.c
@@ -56,7 +56,7 @@ COMMAND(
                 "HOST:PORT\0"
                 "SOCKET\0",
         .footer = "See systemd.time(7) for the --exit-idle-time= time span format.",
-        .man_pages = "systemd-socket-proxyd.8\0",
+        .man_pages = "systemd-socket-proxyd(8)\0",
 );
 
 typedef struct Context {

--- a/src/ssh-generator/ssh-issue.c
+++ b/src/ssh-generator/ssh-issue.c
@@ -28,7 +28,7 @@ STATIC_DESTRUCTOR_REGISTER(arg_issue_path, freep);
 COMMAND(
         "systemd-ssh-issue\0",
         "Create or remove the /run/issue.d/ file announcing the SSH VSOCK address.",
-        .man_pages = "systemd-ssh-issue.1\0",
+        .man_pages = "systemd-ssh-issue(1)\0",
 );
 
 static int acquire_cid(unsigned *ret_cid) {

--- a/src/stdio-bridge/stdio-bridge.c
+++ b/src/stdio-bridge/stdio-bridge.c
@@ -26,7 +26,7 @@ static bool arg_quiet = false;
 COMMAND(
         "systemd-stdio-bridge\0",
         "Forward messages between a pipe or socket and a D-Bus bus.",
-        .man_pages = "systemd-stdio-bridge.1\0",
+        .man_pages = "systemd-stdio-bridge(1)\0",
 );
 
 static int parse_argv(int argc, char *argv[]) {

--- a/src/storage/storage-block.c
+++ b/src/storage/storage-block.c
@@ -27,7 +27,7 @@
 COMMAND(
         "systemd-storage-block\0",
         "Expose local block devices as storage volumes.",
-        .man_pages = "systemd-storage-block.8\0",
+        .man_pages = "systemd-storage-block(8)\0",
 );
 
 static int block_device_pick_name(

--- a/src/storage/storage-fs.c
+++ b/src/storage/storage-fs.c
@@ -41,7 +41,7 @@ static RuntimeScope arg_runtime_scope = RUNTIME_SCOPE_SYSTEM;
 COMMAND(
         "systemd-storage-fs\0",
         "Expose regular files and directories as storage volumes.",
-        .man_pages = "systemd-storage-fs.8\0",
+        .man_pages = "systemd-storage-fs(8)\0",
 );
 
 /* For now we maintain a simple, compiled-in list of templates. One of those days we might want to move these

--- a/src/storage/storagectl.c
+++ b/src/storage/storagectl.c
@@ -48,7 +48,7 @@ static RuntimeScope arg_runtime_scope = RUNTIME_SCOPE_SYSTEM;
 COMMAND(
         "storagectl\0",
         "Enumerate storage volumes and providers.",
-        .man_pages = "storagectl.1\0",
+        .man_pages = "storagectl(1)\0",
         .option_namespace = "storagectl",
         .pager_flags = &arg_pager_flags,
 );
@@ -372,7 +372,7 @@ static int verb_providers(int argc, char *argv[], uintptr_t data, void *userdata
 COMMAND(
         "mount.storage\0",
         "External helper for mount.8 to expose storage volumes.",
-        .man_pages = "storagectl.1\0",
+        .man_pages = "storagectl(1)\0",
         .option_namespace = "mount.storage",
         .pager_flags = &arg_pager_flags,
 );

--- a/src/storagetm/storagetm.c
+++ b/src/storagetm/storagetm.c
@@ -53,7 +53,7 @@ COMMAND(
                 "DEVICE…\0"
                 "--all\0"
                 "--list-devices\0",
-        .man_pages = "systemd-storagetm.8\0",
+        .man_pages = "systemd-storagetm(8)\0",
 );
 
 static int parse_argv(int argc, char *argv[]) {

--- a/src/sysctl/sysctl.c
+++ b/src/sysctl/sysctl.c
@@ -44,7 +44,7 @@ COMMAND(
         "systemd-sysctl\0",
         "Apply kernel sysctl settings.",
         .argspec = "[CONFIGURATION FILE…]\0",
-        .man_pages = "systemd-sysctl.service.8\0",
+        .man_pages = "systemd-sysctl.service(8)\0",
         .pager_flags = &arg_pager_flags,
 );
 

--- a/src/sysext/sysext.c
+++ b/src/sysext/sysext.c
@@ -134,14 +134,14 @@ STATIC_DESTRUCTOR_REGISTER(arg_image_policy, image_policy_freep);
 COMMAND(
         "systemd-sysext\0",
         "Merge system extension images into /usr/ and /opt/.",
-        .man_pages = "systemd-sysext.8\0",
+        .man_pages = "systemd-sysext(8)\0",
         .flags = COMMAND_VERBS_SHARED,
         .pager_flags = &arg_pager_flags,
 );
 COMMAND(
         "systemd-confext\0",
         "Merge configuration extension images into /etc/.",
-        .man_pages = "systemd-confext.8\0",
+        .man_pages = "systemd-confext(8)\0",
         .flags = COMMAND_VERBS_SHARED,
         .pager_flags = &arg_pager_flags,
 );

--- a/src/sysinstall/sysinstall.c
+++ b/src/sysinstall/sysinstall.c
@@ -74,7 +74,7 @@ COMMAND(
         "systemd-sysinstall\0",
         "Install the OS to another block device.",
         .argspec = "[DEVICE]\0",
-        .man_pages = "systemd-sysinstall.8\0",
+        .man_pages = "systemd-sysinstall(8)\0",
 );
 
 typedef enum ProgressPhase {

--- a/src/systemctl/systemctl-compat-halt.c
+++ b/src/systemctl/systemctl-compat-halt.c
@@ -20,7 +20,7 @@ COMMAND(
         "Halt the system.",
         .footer = "This is a compatibility interface, please use the more powerful "
                   "'systemctl halt' command instead.",
-        .man_pages = "halt.8\0",
+        .man_pages = "halt(8)\0",
         .option_namespace = "halt",
 );
 
@@ -29,7 +29,7 @@ COMMAND(
         "Power off the system.",
         .footer = "This is a compatibility interface, please use the more powerful "
                   "'systemctl poweroff' command instead.",
-        .man_pages = "poweroff.8\0",
+        .man_pages = "poweroff(8)\0",
         .option_namespace = "halt",
 );
 
@@ -39,7 +39,7 @@ COMMAND(
         .argspec = "[ARG]\0",
         .footer = "This is a compatibility interface, please use the more powerful "
                   "'systemctl reboot' command instead.",
-        .man_pages = "reboot.8\0",
+        .man_pages = "reboot(8)\0",
         .option_namespace = "halt",
 );
 

--- a/src/systemctl/systemctl-compat-shutdown.c
+++ b/src/systemctl/systemctl-compat-shutdown.c
@@ -19,7 +19,7 @@ COMMAND(
         .argspec = "[TIME] [WALL…]\0",
         .footer = "This is a compatibility interface, please use the more powerful 'systemctl halt', "
                   "'systemctl poweroff', 'systemctl reboot' commands instead.",
-        .man_pages = "shutdown.8\0",
+        .man_pages = "shutdown(8)\0",
         .option_namespace = "shutdown",
 );
 

--- a/src/systemctl/systemctl.c
+++ b/src/systemctl/systemctl.c
@@ -114,7 +114,7 @@ STATIC_DESTRUCTOR_REGISTER(arg_kill_subgroup, freep);
 COMMAND(
         "systemctl\0",
         "Query or send control commands to the system manager.",
-        .man_pages = "systemctl.1\0",
+        .man_pages = "systemctl(1)\0",
         .option_namespace = "systemctl",
         .pager_flags = &arg_pager_flags,
 );

--- a/src/sysupdate/sysupdate.c
+++ b/src/sysupdate/sysupdate.c
@@ -84,7 +84,7 @@ STATIC_DESTRUCTOR_REGISTER(arg_transfer_source, freep);
 COMMAND(
         "systemd-sysupdate\0",
         "Update OS images.",
-        .man_pages = "systemd-sysupdate.8\0",
+        .man_pages = "systemd-sysupdate(8)\0",
         .pager_flags = &arg_pager_flags,
 );
 

--- a/src/sysupdate/sysupdated.c
+++ b/src/sysupdate/sysupdated.c
@@ -2164,7 +2164,7 @@ static int manager_run(Manager *m) {
 COMMAND(
         "systemd-sysupdated\0",
         "Manage system updates.",
-        .man_pages = "systemd-sysupdated.service.8\0",
+        .man_pages = "systemd-sysupdated.service(8)\0",
         .option_namespace = "service",
         .option_groups =
                 "Options\0"

--- a/src/sysupdate/updatectl.c
+++ b/src/sysupdate/updatectl.c
@@ -41,7 +41,7 @@ static const char *arg_host = NULL;
 COMMAND(
         "updatectl\0",
         "Manage system updates.",
-        .man_pages = "updatectl.1\0",
+        .man_pages = "updatectl(1)\0",
         .pager_flags = &arg_pager_flags,
 );
 

--- a/src/sysusers/sysusers.c
+++ b/src/sysusers/sysusers.c
@@ -118,7 +118,7 @@ COMMAND(
         "systemd-sysusers\0",
         "Create system user and group accounts.",
         .argspec = "[CONFIGURATION FILE…]\0",
-        .man_pages = "systemd-sysusers.service.8\0",
+        .man_pages = "systemd-sysusers.service(8)\0",
         .pager_flags = &arg_pager_flags,
 );
 

--- a/src/timedate/timedatectl.c
+++ b/src/timedate/timedatectl.c
@@ -182,7 +182,7 @@ static int print_status_info(const StatusInfo *i) {
 COMMAND(
         "timedatectl\0",
         "Query or change system time and date settings.",
-        .man_pages = "timedatectl.1\0",
+        .man_pages = "timedatectl(1)\0",
         .pager_flags = &arg_pager_flags,
 );
 

--- a/src/timedate/timedated.c
+++ b/src/timedate/timedated.c
@@ -1171,7 +1171,7 @@ static bool context_check_idle(void *userdata) {
 COMMAND(
         "systemd-timedated\0",
         "Manage the system clock and timezone and NTP enablement.",
-        .man_pages = "systemd-timedated.service.8\0",
+        .man_pages = "systemd-timedated.service(8)\0",
         .option_namespace = "service",
         .option_groups =
                 "Options\0"

--- a/src/timesync/timesyncd.c
+++ b/src/timesync/timesyncd.c
@@ -126,7 +126,7 @@ static int load_clock_timestamp(void) {
 COMMAND(
         "systemd-timesyncd\0",
         "Synchronize the system clock across the network.",
-        .man_pages = "systemd-timesyncd.service.8\0",
+        .man_pages = "systemd-timesyncd.service(8)\0",
         .option_namespace = "service",
         .option_groups =
                 "Options\0"

--- a/src/tmpfiles/tmpfiles.c
+++ b/src/tmpfiles/tmpfiles.c
@@ -254,7 +254,7 @@ COMMAND(
         "systemd-tmpfiles\0",
         "Create, delete, and clean up files and directories.",
         .argspec = "[CONFIGURATION FILE…]\0",
-        .man_pages = "systemd-tmpfiles.8\0",
+        .man_pages = "systemd-tmpfiles(8)\0",
         .pager_flags = &arg_pager_flags,
 );
 

--- a/src/tpm2-setup/tpm2-clear.c
+++ b/src/tpm2-setup/tpm2-clear.c
@@ -18,7 +18,7 @@ static bool arg_graceful = false;
 COMMAND(
         "systemd-tpm2-clear\0",
         "Request clearing of the TPM2 from PC firmware.",
-        .man_pages = "systemd-tpm2-clear.service.8\0",
+        .man_pages = "systemd-tpm2-clear.service(8)\0",
 );
 
 static int parse_argv(int argc, char *argv[]) {

--- a/src/tpm2-setup/tpm2-setup.c
+++ b/src/tpm2-setup/tpm2-setup.c
@@ -43,7 +43,7 @@ STATIC_DESTRUCTOR_REGISTER(arg_tpm2_device, freep);
 COMMAND(
         "systemd-tpm2-setup\0",
         "Set up the TPM2 Storage Root Key (SRK) and Endorsement Key (EK), and initialize NvPCRs.",
-        .man_pages = "systemd-tpm2-setup.8\0",
+        .man_pages = "systemd-tpm2-setup(8)\0",
 );
 
 #define TPM2_SRK_PEM_PERSISTENT_PATH "/var/lib/systemd/tpm2-srk-public-key.pem"

--- a/src/tty-ask-password-agent/tty-ask-password-agent.c
+++ b/src/tty-ask-password-agent/tty-ask-password-agent.c
@@ -61,7 +61,7 @@ STATIC_DESTRUCTOR_REGISTER(arg_device, freep);
 COMMAND(
         "systemd-tty-ask-password-agent\0",
         "Process system password requests.",
-        .man_pages = "systemd-tty-ask-password-agent.1\0",
+        .man_pages = "systemd-tty-ask-password-agent(1)\0",
 );
 
 static int send_passwords(const char *socket_name, char **passwords) {

--- a/src/udev/iocost/iocost.c
+++ b/src/udev/iocost/iocost.c
@@ -23,7 +23,7 @@ STATIC_DESTRUCTOR_REGISTER(arg_target_solution, freep);
 COMMAND(
         "iocost\0",
         "Set up iocost model and qos solutions for block devices.",
-        .man_pages = "iocost.conf.5\0",
+        .man_pages = "iocost.conf(5)\0",
 );
 
 static int parse_config(void) {

--- a/src/update-done/update-done.c
+++ b/src/update-done/update-done.c
@@ -26,7 +26,7 @@ STATIC_DESTRUCTOR_REGISTER(arg_root, freep);
 COMMAND(
         "systemd-update-done\0",
         "Mark /etc/ and /var/ as fully updated.",
-        .man_pages = "systemd-update-done.8\0",
+        .man_pages = "systemd-update-done(8)\0",
 );
 
 static int save_timestamp(const char *dir, struct timespec *ts) {

--- a/src/userdb/userdbctl.c
+++ b/src/userdb/userdbctl.c
@@ -73,7 +73,7 @@ STATIC_DESTRUCTOR_REGISTER(arg_from_file, sd_json_variant_unrefp);
 COMMAND(
         "userdbctl\0",
         "Show user and group information.",
-        .man_pages = "userdbctl.1\0",
+        .man_pages = "userdbctl(1)\0",
         .pager_flags = &arg_pager_flags,
 );
 

--- a/src/validatefs/validatefs.c
+++ b/src/validatefs/validatefs.c
@@ -35,7 +35,7 @@ COMMAND(
         "systemd-validatefs\0",
         "Check file system validation constraints.",
         .argspec = "MOUNTPOINT\0",
-        .man_pages = "systemd-validatefs@.service.8\0",
+        .man_pages = "systemd-validatefs@.service(8)\0",
 );
 
 static int parse_argv(int argc, char *argv[]) {

--- a/src/varlinkctl/varlinkctl.c
+++ b/src/varlinkctl/varlinkctl.c
@@ -289,7 +289,7 @@ static void get_info_data_done(GetInfoData *d) {
 COMMAND(
         "varlinkctl\0",
         "Introspect Varlink Services.",
-        .man_pages = "varlinkctl.1\0",
+        .man_pages = "varlinkctl(1)\0",
         .footer = "With --exec, specify the command to invoke:\n"
                   "  varlinkctl --exec call ADDRESS METHOD PARAMS -- CMDLINE…",
         .pager_flags = &arg_pager_flags,

--- a/src/veritysetup/veritysetup.c
+++ b/src/veritysetup/veritysetup.c
@@ -300,7 +300,7 @@ static int parse_options(const char *options) {
 COMMAND(
         "systemd-veritysetup\0",
         "Attach or detach a verity-protected block device.",
-        .man_pages = "systemd-veritysetup@.service.8\0",
+        .man_pages = "systemd-veritysetup@.service(8)\0",
 );
 
 VERB(verb_attach, "attach", "VOLUME DATADEVICE HASHDEVICE ROOTHASH [OPTIONS]", 5, 6, 0,

--- a/src/vmspawn/vmspawn.c
+++ b/src/vmspawn/vmspawn.c
@@ -236,7 +236,7 @@ COMMAND(
         "systemd-vmspawn\0",
         "Spawn a command or OS in a virtual machine.",
         .argspec = "[ARGUMENTS…]\0",
-        .man_pages = "systemd-vmspawn.1\0",
+        .man_pages = "systemd-vmspawn(1)\0",
         .pager_flags = &arg_pager_flags,
 );
 

--- a/src/vpick/vpick-tool.c
+++ b/src/vpick/vpick-tool.c
@@ -47,7 +47,7 @@ COMMAND(
         "systemd-vpick\0",
         "Pick entry from versioned directory.",
         .argspec = "PATH…\0",
-        .man_pages = "systemd-vpick.1\0",
+        .man_pages = "systemd-vpick(1)\0",
 );
 
 static const char *print_table[_PRINT_MAX] = {

--- a/test/units/TEST-74-AUX-UTILS.introspect-cli.sh
+++ b/test/units/TEST-74-AUX-UTILS.introspect-cli.sh
@@ -152,7 +152,8 @@ INTROSPECTABLE=(
 for i in "${INTROSPECTABLE[@]}"; do
     command -v "$i" >/dev/null || continue
 
-    $i --help >/dev/null
+    help="$($i --help)"
+    (! grep -E '^See the [^[:space:]]+\.[[:alnum:]]+ man page for details\.$' <<<"$help" >/dev/null)
 
     $i --introspect-cli | jq -e \
         '.mediaType == "application/vnd.io.systemd.cli-introspection-0"'


### PR DESCRIPTION
## Overview

* Use the conventional `foo(1)` notation for man page references in generated `--help` output
* Extend `TEST-74-AUX-UTILS` to verify the new format and reject `foo.1` references.

Fixes #43514 