### PR TITLE
various: mark files with the usual license tags

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT-0
+#
 # This configuration file can be used to auto-format the code base.
 # Not all guidelines specified in CODING_STYLE are followed, so the
 # result MUST NOT be committed indiscriminately, but each automated

--- a/.github/advanced-issue-labeler.yml
+++ b/.github/advanced-issue-labeler.yml
@@ -1,4 +1,4 @@
----
+# SPDX-License-Identifier: LGPL-2.1-or-later
 # syntax - https://github.com/redhat-plumbers-in-action/advanced-issue-labeler#policy
 
 policy:

--- a/.github/development-freeze.yml
+++ b/.github/development-freeze.yml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
 # syntax - https://github.com/redhat-plumbers-in-action/devel-freezer#policy
 ---
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
 # Integrates Claude Code as an AI assistant for reviewing pull requests.
 # Mention @claude in any PR comment to request a review. Claude authenticates
 # via AWS Bedrock using OIDC — no long-lived API keys required.

--- a/.github/workflows/development-freeze.yml
+++ b/.github/workflows/development-freeze.yml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
 # doc: https://github.com/redhat-plumbers-in-action/devel-freezer#readme
 ---
 

--- a/.github/workflows/differential-shellcheck.yml
+++ b/.github/workflows/differential-shellcheck.yml
@@ -1,4 +1,4 @@
----
+# SPDX-License-Identifier: LGPL-2.1-or-later
 # https://github.com/redhat-plumbers-in-action/differential-shellcheck#readme
 
 name: Differential ShellCheck

--- a/.github/workflows/gather-pr-metadata.yml
+++ b/.github/workflows/gather-pr-metadata.yml
@@ -1,4 +1,4 @@
----
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 name: Gather Pull Request Metadata
 

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -1,4 +1,4 @@
----
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 name: Issue labeler
 on:

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 name: Make a Github release
 
 on:

--- a/man/systemd.pcrlock.xml
+++ b/man/systemd.pcrlock.xml
@@ -1,6 +1,8 @@
 <?xml version='1.0'?>
 <!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
   "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
+<!-- SPDX-License-Identifier: LGPL-2.1-or-later -->
+
 <refentry id="systemd.pcrlock"
           xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/mime/io.systemd.xml
+++ b/mime/io.systemd.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- SPDX-License-Identifier: LGPL-2.1-or-later -->
+
 <mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
   <mime-type type="application/x.systemd-sysext">
     <sub-class-of type="application/vnd.efi.img"/>

--- a/mkosi/mkosi.images/minimal-base/mkosi.postinst
+++ b/mkosi/mkosi.images/minimal-base/mkosi.postinst
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: LGPL-2.1-or-later
 set -e
 
 # We don't use mkosi.extra because /usr/sbin could be a symlink and cp doesn't handle that properly until

--- a/mkosi/mkosi.sanitizers/mkosi.extra/usr/lib/systemd/leak-sanitizer-suppressions
+++ b/mkosi/mkosi.sanitizers/mkosi.extra/usr/lib/systemd/leak-sanitizer-suppressions
@@ -1,1 +1,2 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
 leak:libselinux

--- a/po/ar.po
+++ b/po/ar.po
@@ -1,6 +1,7 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
 # This file is distributed under the same license as the systemd package.
+#
 # joo es <johndevand@tutanota.com>, 2025.
 # joo es <jonnyse@users.noreply.translate.fedoraproject.org>, 2025, 2026.
 msgid ""

--- a/po/ia.po
+++ b/po/ia.po
@@ -1,6 +1,7 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
 # This file is distributed under the same license as the systemd package.
+#
 # Emilio Sepulveda <emism.translations@gmail.com>, 2025, 2026.
 msgid ""
 msgstr ""

--- a/po/kk.po
+++ b/po/kk.po
@@ -1,6 +1,7 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
 # This file is distributed under the same license as the systemd package.
+#
 # Baurzhan Muftakhidinov <baurthefirst@gmail.com>, 2026.
 msgid ""
 msgstr ""

--- a/po/km.po
+++ b/po/km.po
@@ -1,6 +1,7 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
 # This file is distributed under the same license as the systemd package.
+#
 # kanitha chim <kchim@redhat.com>, 2025, 2026.
 msgid ""
 msgstr ""

--- a/po/kn.po
+++ b/po/kn.po
@@ -1,6 +1,7 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
 # This file is distributed under the same license as the systemd package.
+#
 # tim tom <aktimtom@gmail.com>, 2025.
 msgid ""
 msgstr ""

--- a/po/kw.po
+++ b/po/kw.po
@@ -1,6 +1,7 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
 # This file is distributed under the same license as the systemd package.
+#
 # Jasmine Andrever-Wright <cam.jpw@gmail.com>, 2025.
 msgid ""
 msgstr ""

--- a/po/lo.po
+++ b/po/lo.po
@@ -1,6 +1,7 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
 # This file is distributed under the same license as the systemd package.
+#
 # Bone NI <bounkirdni@gmail.com>, 2026.
 msgid ""
 msgstr ""

--- a/po/systemd.pot
+++ b/po/systemd.pot
@@ -1,6 +1,7 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
 # This file is distributed under the same license as the systemd package.
+#
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy

--- a/profile.d/70-systemd-shell-extra.sh
+++ b/profile.d/70-systemd-shell-extra.sh
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
 # shellcheck shell=sh
 
 #  This file is part of systemd.

--- a/shell-completion/zsh/_run0
+++ b/shell-completion/zsh/_run0
@@ -1,4 +1,5 @@
 #compdef run0
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 (( $+functions[_run0_unit_properties] )) ||
 _run0_unit_properties() {

--- a/shell-completion/zsh/_sd_bus_address
+++ b/shell-completion/zsh/_sd_bus_address
@@ -1,4 +1,5 @@
 #compdef -value-,DBUS_SESSION_BUS_ADDRESS,-default- -value-,DBUS_SYSTEM_BUS_ADDRESS,-default-
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 local context state state_descr line
 typeset -A val_args

--- a/shell-completion/zsh/_systemd-id128
+++ b/shell-completion/zsh/_systemd-id128
@@ -1,4 +1,5 @@
 #compdef systemd-id128
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 local context state state_descr line
 typeset -A opt_args

--- a/shell-completion/zsh/_userdbctl
+++ b/shell-completion/zsh/_userdbctl
@@ -1,4 +1,5 @@
 #compdef userdbctl
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 local context state state_descr line
 typeset -A opt_args

--- a/src/ukify/test/pytest.ini
+++ b/src/ukify/test/pytest.ini
@@ -1,2 +1,4 @@
+# SPDX-License-Identifier: MIT-0
+
 [pytest]
 tmp_path_retention_policy = failed

--- a/test/integration-tests/TEST-03-JOBS/TEST-03-JOBS.units/always-activating.service
+++ b/test/integration-tests/TEST-03-JOBS/TEST-03-JOBS.units/always-activating.service
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 [Unit]
 Description=Service that never leaves state ACTIVATING
 Requires=always-activating.socket

--- a/test/integration-tests/TEST-03-JOBS/TEST-03-JOBS.units/always-activating.socket
+++ b/test/integration-tests/TEST-03-JOBS/TEST-03-JOBS.units/always-activating.socket
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 [Unit]
 Description=Socket that activates always-activating.service
 

--- a/test/integration-tests/TEST-04-JOURNAL/TEST-04-JOURNAL.units/delegated-cgroup-filtering.service
+++ b/test/integration-tests/TEST-04-JOURNAL/TEST-04-JOURNAL.units/delegated-cgroup-filtering.service
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 [Unit]
 Description=Test service for delegated logs filtering
 

--- a/test/integration-tests/TEST-04-JOURNAL/TEST-04-JOURNAL.units/logs-filtering-syslog.service
+++ b/test/integration-tests/TEST-04-JOURNAL/TEST-04-JOURNAL.units/logs-filtering-syslog.service
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 [Unit]
 Description=Log filtering unit
 

--- a/test/integration-tests/TEST-04-JOURNAL/TEST-04-JOURNAL.units/logs-filtering.service
+++ b/test/integration-tests/TEST-04-JOURNAL/TEST-04-JOURNAL.units/logs-filtering.service
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 [Unit]
 Description=Log filtering unit
 

--- a/test/integration-tests/TEST-07-PID1/TEST-07-PID1.units/defer-reactivation.service
+++ b/test/integration-tests/TEST-07-PID1/TEST-07-PID1.units/defer-reactivation.service
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 [Unit]
 Description=Test for DeferReactivation=yes (service)
 

--- a/test/integration-tests/TEST-07-PID1/TEST-07-PID1.units/defer-reactivation.timer
+++ b/test/integration-tests/TEST-07-PID1/TEST-07-PID1.units/defer-reactivation.timer
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 [Unit]
 Description=Test for DeferReactivation=yes (timer)
 

--- a/test/integration-tests/TEST-07-PID1/TEST-07-PID1.units/issue2730.mount
+++ b/test/integration-tests/TEST-07-PID1/TEST-07-PID1.units/issue2730.mount
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 [Mount]
 What=tmpfs
 Where=/issue2730

--- a/test/integration-tests/TEST-23-UNIT-FILE/TEST-23-UNIT-FILE.units/TEST-23-UNIT-FILE-openfile-server.socket
+++ b/test/integration-tests/TEST-23-UNIT-FILE/TEST-23-UNIT-FILE.units/TEST-23-UNIT-FILE-openfile-server.socket
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 [Unit]
 Description=OpenFile= test server socket
 

--- a/test/integration-tests/TEST-23-UNIT-FILE/TEST-23-UNIT-FILE.units/TEST-23-UNIT-FILE-openfile-server@.service
+++ b/test/integration-tests/TEST-23-UNIT-FILE/TEST-23-UNIT-FILE.units/TEST-23-UNIT-FILE-openfile-server@.service
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 [Unit]
 Description=OpenFile= test server service
 

--- a/test/integration-tests/TEST-23-UNIT-FILE/TEST-23-UNIT-FILE.units/success-failure-test-failure.service
+++ b/test/integration-tests/TEST-23-UNIT-FILE/TEST-23-UNIT-FILE.units/success-failure-test-failure.service
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 [Service]
 Type=notify
 ExecStart=bash -c "echo failure >>/tmp/success-failure-test-result && systemd-notify --ready && sleep infinity"

--- a/test/integration-tests/TEST-23-UNIT-FILE/TEST-23-UNIT-FILE.units/success-failure-test-success.service
+++ b/test/integration-tests/TEST-23-UNIT-FILE/TEST-23-UNIT-FILE.units/success-failure-test-success.service
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 [Service]
 Type=notify
-ExecStart=bash -c "echo success >> /tmp/success-failure-test-result && systemd-notify --ready && sleep infinity"
+ExecStart=bash -c "echo success >>/tmp/success-failure-test-result && systemd-notify --ready && sleep infinity"

--- a/test/integration-tests/TEST-23-UNIT-FILE/TEST-23-UNIT-FILE.units/success-failure-test.service
+++ b/test/integration-tests/TEST-23-UNIT-FILE/TEST-23-UNIT-FILE.units/success-failure-test.service
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 [Unit]
 OnSuccess=success-failure-test-success.service
 OnFailure=success-failure-test-failure.service

--- a/test/test-dlopen-note.py
+++ b/test/test-dlopen-note.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 """
 Compare statically linked dlopen symbols against shared library ELF notes.
 

--- a/test/test-execute/exec-personality-loongarch64.service
+++ b/test/test-execute/exec-personality-loongarch64.service
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 [Unit]
 Description=Test for Personality=loongarch64
 

--- a/test/test-network/conf/25-bond-property.netdev
+++ b/test/test-network/conf/25-bond-property.netdev
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 [NetDev]
 Name=bond97
 Kind=bond

--- a/test/test-network/conf/26-bridge-vlan-tunnel.network
+++ b/test/test-network/conf/26-bridge-vlan-tunnel.network
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 [Match]
 Name=dummy97
 

--- a/test/test-sysusers/test-00-basic.input
+++ b/test/test-sysusers/test-00-basic.input
@@ -1,9 +1,4 @@
-#  This file is part of systemd.
-#
-#  systemd is free software; you can redistribute it and/or modify it
-#  under the terms of the GNU Lesser General Public License as published by
-#  the Free Software Foundation; either version 2.1 of the License, or
-#  (at your option) any later version.
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 # The superuser
 g root    0       -            -

--- a/test/units/TEST-19-CGROUP.ExitType-cgroup.sh
+++ b/test/units/TEST-19-CGROUP.ExitType-cgroup.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: LGPL-2.1-or-later
 set -eux
 
 # Test ExitType=cgroup


### PR DESCRIPTION
For .clang-format, CC0-1.0 is used because people might want to copy this.