### PR TITLE
Explicitly note intentional closure of watchdog

### DIFF
--- a/src/shutdown/shutdown.c
+++ b/src/shutdown/shutdown.c
@@ -620,6 +620,7 @@ static int run(int argc, char *argv[]) {
          * data. */
         watchdog_close(/* disarm= */ false);
         watchdog_free_device();
+        log_info("Closed watchdog as a last-resort system reset option.");
 
         const char *arguments[] = {
                 NULL, /* Filled in by execute_directories(), when needed */


### PR DESCRIPTION
The hardware watchdog is used as a last resort system reset option in case things go wrong while systemd is shutting the system down. Since the kernel can not determine if a running watchdog being closed was intentional or malicious/accidental, it presumes the closure was in error and reports "watchdog did not stop!" The systemd logs immediately before this indicate systemd is using the watchdog and the watchdog is running. This can seem like some sort of issue occurred with the watchdog. For example;

```
Jul 23 07:09:50 systemd[1]: Using hardware watchdog /dev/watchdog0: 'SP5100 TCO timer', version 0.
Jul 23 07:09:50 systemd[1]: Watchdog running with a hardware timeout of 10min.
Jul 23 07:09:50 kernel: watchdog: watchdog0: watchdog did not stop!
```

This change simply adds an additional line to explicitly indicate the watchdog is closed as a last resort option to help explain a critical-level log line from the kernel.