### PR TITLE
kmod-setup: remove warning for autofs load failure

### DIFF
--- a/src/core/kmod-setup.c
+++ b/src/core/kmod-setup.c
@@ -111,7 +111,7 @@ int kmod_setup(void) {
         } kmod_table[] = {
                 /* This one we need to load explicitly, since auto-loading on use doesn't work
                  * before udev created the ghost device nodes, and we need it earlier than that. */
-                { "autofs4",                    "/sys/class/misc/autofs",       true,  false, NULL                      },
+                { "autofs4",                    "/sys/class/misc/autofs",       false, false, NULL                      },
 
                 /* This one we need to load explicitly, since auto-loading of IPv6 is not done when
                  * we try to configure ::1 on the loopback device. */


### PR DESCRIPTION
Sponsor: 21SoftWare LLC

There are many situations where autofs is not required. A kernel lacking support is a valid possibility. A strong argument could be made against issuing a warning when the autofs module fails to load.

From the `CONFIG_AUTOFS_FS` [docs page](https://www.kernelconfig.io/config_autofs_fs):

> If you are not a part of a fairly large, distributed network or
don't have a laptop which needs to dynamically reconfigure to the
local network, you probably do not need an automounter, and can say
N here.

This is a similar change to https://github.com/systemd/systemd/commit/b4aa82f168913b7bff42017023b43933b3aa0d24. It appears a similar warning has been given since the module was first added to setup in https://github.com/systemd/systemd/commit/7491e6e7c5fcb3c445a0656a440bd1551adb6ba1, and I haven't been able to find justification for a warning to remain in the `ENOENT` case. According to 85c675538fd18eefe0bbfd6fc87d9e0f38f3207a, a warning is still given if `kmod` returns anything else, and a message is still provided at the debugging log level.

Successfully implemented and tested a patch of `systemd 255.21` in the TSEL Linux distribution, and successfully tested using `mkosi` exactly as-is over main.