### PR TITLE
sysupdate: keep incomplete flag for pending-missing updates

### DIFF
--- a/src/sysupdate/sysupdate-update-set-flags.c
+++ b/src/sysupdate/sysupdate-update-set-flags.c
@@ -9,6 +9,9 @@ const char* update_set_flags_to_color(UpdateSetFlags flags) {
         if (flags == 0 || (flags & UPDATE_OBSOLETE))
                 return (flags & UPDATE_NEWEST) ? ansi_highlight_grey() : ansi_grey();
 
+        if (FLAGS_SET(flags, UPDATE_INSTALLED|UPDATE_INCOMPLETE))
+                flags &= ~UPDATE_PENDING;
+
         if (flags & (UPDATE_PARTIAL|UPDATE_PENDING))
                 return ansi_highlight_cyan();
 
@@ -32,6 +35,9 @@ const char* update_set_flags_to_glyph(UpdateSetFlags flags) {
         if (flags == 0 || (flags & UPDATE_OBSOLETE))
                 return glyph(GLYPH_MULTIPLICATION_SIGN);
 
+        if (FLAGS_SET(flags, UPDATE_INSTALLED|UPDATE_INCOMPLETE))
+                flags &= ~UPDATE_PENDING;
+
         if (flags & (UPDATE_PARTIAL|UPDATE_PENDING))
                 return glyph(GLYPH_DOWNLOAD);
 
@@ -48,6 +54,9 @@ const char* update_set_flags_to_glyph(UpdateSetFlags flags) {
 }
 
 const char* update_set_flags_to_string(UpdateSetFlags flags) {
+
+        if (FLAGS_SET(flags, UPDATE_INSTALLED|UPDATE_INCOMPLETE))
+                flags &= ~UPDATE_PENDING;
 
         switch ((unsigned) flags) {
 

--- a/src/sysupdate/sysupdate.c
+++ b/src/sysupdate/sysupdate.c
@@ -605,7 +605,7 @@ static int context_discover_update_sets_by_flag(Context *c, UpdateSetFlags flags
                                 assert(flags == UPDATE_INSTALLED);
 
                                 match = resource_find_instance(&t->target, cursor);
-                                if (!match && !(extra_flags & (UPDATE_PARTIAL|UPDATE_PENDING)))
+                                if (!match && !FLAGS_SET(extra_flags, UPDATE_PARTIAL))
                                         /* When we're looking for installed versions, let's be robust and treat
                                          * an incomplete installation as an installation. Otherwise, there are
                                          * situations that can lead to sysupdate wiping the currently booted OS.
@@ -621,16 +621,17 @@ static int context_discover_update_sets_by_flag(Context *c, UpdateSetFlags flags
                         if (strv_contains(t->protected_versions, cursor))
                                 extra_flags |= UPDATE_PROTECTED;
 
-                        /* Partial or pending updates by definition are not incomplete, they’re
-                         * partial/pending instead. While an individual Instance cannot be both partial and
-                         * pending, an UpdateSet as a whole can contain both partial and pending instances. */
+                        /* A partial or pending instance is not incomplete by itself. Partial status takes
+                         * precedence over missing instances, while a pending instance does not. While an
+                         * individual Instance cannot be both partial and pending, an UpdateSet as a whole
+                         * can contain both partial and pending instances. */
                         assert(!match || !(match->is_partial && match->is_pending));
 
                         if (match && match->is_partial)
                                 extra_flags = (extra_flags | UPDATE_PARTIAL) & ~UPDATE_INCOMPLETE;
 
                         if (match && match->is_pending)
-                                extra_flags = (extra_flags | UPDATE_PENDING) & ~UPDATE_INCOMPLETE;
+                                extra_flags |= UPDATE_PENDING;
                 }
 
                 r = free_and_strdup_warn(&boundary, cursor);
@@ -1015,7 +1016,7 @@ static int context_show_version(Context *c, const char *version) {
                        strempty(update_set_flags_to_color(us->flags)), update_set_flags_to_string(us->flags), ansi_normal(),
                        yes_no(us->flags & UPDATE_INSTALLED), FLAGS_SET(us->flags, UPDATE_INSTALLED|UPDATE_NEWEST) ? " (newest)" : "",
                        FLAGS_SET(us->flags, UPDATE_INCOMPLETE) ? ansi_highlight_yellow() : "", FLAGS_SET(us->flags, UPDATE_INCOMPLETE) ? " (incomplete)" : "", ansi_normal(),
-                       FLAGS_SET(us->flags, UPDATE_INSTALLED|UPDATE_PENDING) ? " (pending)" : "", FLAGS_SET(us->flags, UPDATE_INSTALLED|UPDATE_PARTIAL) ? " (partial)" : "",
+                       FLAGS_SET(us->flags, UPDATE_INSTALLED|UPDATE_PENDING) && !FLAGS_SET(us->flags, UPDATE_INCOMPLETE) ? " (pending)" : "", FLAGS_SET(us->flags, UPDATE_INSTALLED|UPDATE_PARTIAL) ? " (partial)" : "",
                        yes_no(us->flags & UPDATE_AVAILABLE), (us->flags & (UPDATE_INSTALLED|UPDATE_AVAILABLE|UPDATE_NEWEST)) == (UPDATE_AVAILABLE|UPDATE_NEWEST) ? " (newest)" : "",
                        FLAGS_SET(us->flags, UPDATE_INSTALLED|UPDATE_PROTECTED) ? ansi_highlight() : "", yes_no(FLAGS_SET(us->flags, UPDATE_INSTALLED|UPDATE_PROTECTED)), ansi_normal(),
                        us->flags & UPDATE_OBSOLETE ? ansi_highlight_red() : "", yes_no(us->flags & UPDATE_OBSOLETE), ansi_normal());
@@ -1042,7 +1043,7 @@ static int context_show_version(Context *c, const char *version) {
                                           SD_JSON_BUILD_PAIR_BOOLEAN("available", FLAGS_SET(us->flags, UPDATE_AVAILABLE)),
                                           SD_JSON_BUILD_PAIR_BOOLEAN("installed", FLAGS_SET(us->flags, UPDATE_INSTALLED)),
                                           SD_JSON_BUILD_PAIR_BOOLEAN("partial", FLAGS_SET(us->flags, UPDATE_PARTIAL)),
-                                          SD_JSON_BUILD_PAIR_BOOLEAN("pending", FLAGS_SET(us->flags, UPDATE_PENDING)),
+                                          SD_JSON_BUILD_PAIR_BOOLEAN("pending", FLAGS_SET(us->flags, UPDATE_PENDING) && !FLAGS_SET(us->flags, UPDATE_INCOMPLETE)),
                                           SD_JSON_BUILD_PAIR_BOOLEAN("obsolete", FLAGS_SET(us->flags, UPDATE_OBSOLETE)),
                                           SD_JSON_BUILD_PAIR_BOOLEAN("protected", FLAGS_SET(us->flags, UPDATE_PROTECTED)),
                                           SD_JSON_BUILD_PAIR_BOOLEAN("incomplete", FLAGS_SET(us->flags, UPDATE_INCOMPLETE)),
@@ -1653,6 +1654,15 @@ static int context_acquire(
 
                 if (inst->resource == &t->target) { /* a present transfer in an incomplete installation */
                         assert(FLAGS_SET(us->flags, UPDATE_INCOMPLETE));
+
+                        if (inst->is_pending && t->target.type == RESOURCE_PARTITION) {
+                                /* The partition was selected during the original acquire, which we skip here.
+                                 * Preserve that information for the install phase. */
+                                r = partition_info_copy(&t->partition_info, &inst->partition_info);
+                                if (r < 0)
+                                        return r;
+                        }
+
                         continue;
                 }
 
@@ -1692,8 +1702,8 @@ static int context_process_partial_and_pending(
         }
 
         if (FLAGS_SET(us->flags, UPDATE_INCOMPLETE))
-                log_info("Selected update '%s' is already installed, but incomplete. Repairing.", us->version);
-        else if ((us->flags & (UPDATE_PARTIAL|UPDATE_PENDING|UPDATE_INSTALLED)) == UPDATE_INSTALLED) {
+                return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "Selected update '%s' is incomplete, refusing. Run a non-offline update to repair it.", us->version);
+        if ((us->flags & (UPDATE_PARTIAL|UPDATE_PENDING|UPDATE_INSTALLED)) == UPDATE_INSTALLED) {
                 log_info("Selected update '%s' is already installed. Skipping update.", us->version);
 
                 return 0;
@@ -1986,7 +1996,8 @@ static int verb_list(int argc, char *argv[], uintptr_t _data, void *userdata) {
                         if (FLAGS_SET(us->flags, UPDATE_INSTALLED) &&
                             FLAGS_SET(us->flags, UPDATE_NEWEST)) {
                                 current = us->version;
-                                current_is_pending = FLAGS_SET(us->flags, UPDATE_PENDING);
+                                current_is_pending = FLAGS_SET(us->flags, UPDATE_PENDING) &&
+                                                     !FLAGS_SET(us->flags, UPDATE_INCOMPLETE);
                         }
 
                         r = strv_extend(&versions, us->version);

--- a/src/sysupdate/test-sysupdate-util.c
+++ b/src/sysupdate/test-sysupdate-util.c
@@ -1,5 +1,7 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
+#include "glyph-util.h"
+#include "sysupdate-update-set-flags.h"
 #include "sysupdate-util.h"
 #include "tests.h"
 
@@ -21,6 +23,14 @@ TEST(component_name_valid) {
         ASSERT_FALSE(component_name_valid("foo\nbar"));
         ASSERT_FALSE(component_name_valid("foo\x7f"));
         ASSERT_FALSE(component_name_valid("\xff"));           /* not valid UTF-8 */
+}
+
+TEST(update_set_flags_glyph) {
+        ASSERT_STREQ(update_set_flags_to_glyph(UPDATE_INSTALLED|UPDATE_INCOMPLETE), " ");
+        ASSERT_STREQ(update_set_flags_to_glyph(UPDATE_INSTALLED|UPDATE_INCOMPLETE|UPDATE_PENDING), " ");
+        ASSERT_STREQ(update_set_flags_to_glyph(UPDATE_INSTALLED|UPDATE_INCOMPLETE|UPDATE_NEWEST), glyph(GLYPH_BLACK_CIRCLE));
+        ASSERT_STREQ(update_set_flags_to_glyph(UPDATE_INSTALLED|UPDATE_INCOMPLETE|UPDATE_PROTECTED), glyph(GLYPH_WHITE_CIRCLE));
+        ASSERT_STREQ(update_set_flags_to_glyph(UPDATE_INSTALLED|UPDATE_INCOMPLETE|UPDATE_PARTIAL|UPDATE_PENDING), glyph(GLYPH_DOWNLOAD));
 }
 
 DEFINE_TEST_MAIN(LOG_INFO);

--- a/test/units/TEST-72-SYSUPDATE.sh
+++ b/test/units/TEST-72-SYSUPDATE.sh
@@ -762,6 +762,100 @@ set -e
 [[ $rc -ne 134 ]]
 grep -F "Manifest hash at line 1 decoded to 31 bytes" "$WORKDIR/malformed-manifest/check-new.log" >/dev/null
 
+# Check that a version with some pending resources and some missing resources is
+# treated as incomplete, rather than as fully pending. Otherwise, installing the
+# pending version would try to move non-existent pending files into place.
+rm -rf "$WORKDIR/pending-missing"
+mkdir -p "$WORKDIR/pending-missing/definitions" "$WORKDIR/pending-missing/source" "$WORKDIR/pending-missing/target"
+printf 'first source\n' >"$WORKDIR/pending-missing/source/first-v1.bin"
+printf 'second source\n' >"$WORKDIR/pending-missing/source/second-v1.bin"
+printf 'first pending\n' >"$WORKDIR/pending-missing/target/.sysupdate.pending.first-v1.bin"
+cat >"$WORKDIR/pending-missing/definitions/01-first.transfer" <<EOF
+[Source]
+Type=regular-file
+Path=$WORKDIR/pending-missing/source
+MatchPattern=first-@v.bin
+
+[Target]
+Type=regular-file
+Path=$WORKDIR/pending-missing/target
+MatchPattern=first-@v.bin
+InstancesMax=2
+EOF
+cat >"$WORKDIR/pending-missing/definitions/02-second.transfer" <<EOF
+[Source]
+Type=regular-file
+Path=$WORKDIR/pending-missing/source
+MatchPattern=second-@v.bin
+
+[Target]
+Type=regular-file
+Path=$WORKDIR/pending-missing/target
+MatchPattern=second-@v.bin
+InstancesMax=2
+EOF
+"$SYSUPDATE" --definitions="$WORKDIR/pending-missing/definitions" --verify=no --offline list v1 | grep -F "current+incomplete" >/dev/null
+(! "$SYSUPDATE" --definitions="$WORKDIR/pending-missing/definitions" --verify=no --offline update) |& grep -F "Selected update 'v1' is incomplete, refusing. Run a non-offline update to repair it." >/dev/null
+"$SYSUPDATE" --definitions="$WORKDIR/pending-missing/definitions" --verify=no --sync=no update
+printf 'first pending\n' | cmp - "$WORKDIR/pending-missing/target/first-v1.bin"
+cmp "$WORKDIR/pending-missing/source/second-v1.bin" "$WORKDIR/pending-missing/target/second-v1.bin"
+
+# Check that a pending partition in an otherwise incomplete update keeps its
+# partition information when the missing resource is acquired and installed.
+rm -rf "$WORKDIR/partition-pending-missing"
+mkdir -p "$WORKDIR/partition-pending-missing/definitions" "$WORKDIR/partition-pending-missing/source"
+PARTITION_BACKING_FILE="$BACKING_FILE"
+truncate -s $((512 * 2048 * 4 + 1024 * 1024 * 2)) "$PARTITION_BACKING_FILE"
+if [[ -e /dev/loop-control ]]; then
+    partition_blockdev="$(losetup --find --show --sector-size 512 "$PARTITION_BACKING_FILE")"
+else
+    partition_blockdev="$PARTITION_BACKING_FILE"
+fi
+sfdisk "$partition_blockdev" <<EOF
+label: gpt
+unit: sectors
+sector-size: 512
+
+size=2048, type=4f68bce3-e8cd-4db1-96e7-fbcaf984b709, name=_empty
+size=2048, type=4f68bce3-e8cd-4db1-96e7-fbcaf984b709, name=_empty
+size=2048, type=4f68bce3-e8cd-4db1-96e7-fbcaf984b709, name=_empty
+size=2048, type=4f68bce3-e8cd-4db1-96e7-fbcaf984b709, name=_empty
+EOF
+dd if=/dev/urandom of="$WORKDIR/partition-pending-missing/source/first-v1.raw" bs=512 count=2048
+dd if=/dev/urandom of="$WORKDIR/partition-pending-missing/source/second-v1.raw" bs=512 count=2048
+cat >"$WORKDIR/partition-pending-missing/definitions/01-first.transfer" <<EOF
+[Source]
+Type=regular-file
+Path=$WORKDIR/partition-pending-missing/source
+MatchPattern=first-@v.raw
+
+[Target]
+Type=partition
+Path=$partition_blockdev
+MatchPattern=first-@v
+MatchPartitionType=root-x86-64
+EOF
+"$SYSUPDATE" --definitions="$WORKDIR/partition-pending-missing/definitions" --verify=no acquire v1
+cat >"$WORKDIR/partition-pending-missing/definitions/02-second.transfer" <<EOF
+[Source]
+Type=regular-file
+Path=$WORKDIR/partition-pending-missing/source
+MatchPattern=second-@v.raw
+
+[Target]
+Type=partition
+Path=$partition_blockdev
+MatchPattern=second-@v
+MatchPartitionType=root-x86-64
+EOF
+"$SYSUPDATE" --definitions="$WORKDIR/partition-pending-missing/definitions" --verify=no --offline list v1 | grep -F "current+incomplete" >/dev/null
+(! "$SYSUPDATE" --definitions="$WORKDIR/partition-pending-missing/definitions" --verify=no --offline update) |& grep -F "Selected update 'v1' is incomplete, refusing. Run a non-offline update to repair it." >/dev/null
+"$SYSUPDATE" --definitions="$WORKDIR/partition-pending-missing/definitions" --verify=no --sync=no update
+dd if="$partition_blockdev" bs=512 skip=2048 count=2048 | cmp "$WORKDIR/partition-pending-missing/source/first-v1.raw"
+dd if="$partition_blockdev" bs=512 skip=4096 count=2048 | cmp "$WORKDIR/partition-pending-missing/source/second-v1.raw"
+[[ ! -b "$partition_blockdev" ]] || losetup --detach "$partition_blockdev"
+rm -f "$PARTITION_BACKING_FILE"
+
 # Check the "cleanup" verb and the underlying install database. A successful
 # update must record an install database entry for every transfer that installs
 # into the file system, and those entries must cover all installed resources


### PR DESCRIPTION
If an update is interrupted after one resource is acquired as pending but before another resource creates its temporary file, the update set contains both a pending instance and a missing instance. The pending instance cleared UPDATE_INCOMPLETE for the whole set, so offline update treated the version as fully pending and tried to install a non-existent pending file.

Keep UPDATE_INCOMPLETE when pending instances are combined with missing resources. Refuse the pending-install path for incomplete sets, while still letting the online acquire/install path repair the missing resources in place.

Fixes: #42186