### PR TITLE
ndisc: Fix a memory leak

### DIFF
--- a/src/libsystemd-network/ndisc-option.c
+++ b/src/libsystemd-network/ndisc-option.c
@@ -1275,8 +1275,10 @@ int ndisc_option_add_encrypted_dns_internal(
         assert(options);
 
         sd_ndisc_option *p = ndisc_option_new(SD_NDISC_OPTION_ENCRYPTED_DNS, offset);
-        if (!p)
+        if (!p) {
+                sd_dns_resolver_unref(res);
                 return -ENOMEM;
+        }
 
         p->encrypted_dns = (sd_ndisc_dnr) {
                 .resolver = res,


### PR DESCRIPTION
... in `ndisc_option_parse_encrypted_dns()` function.

Newly allocated `new_res` variable is left unreferenced if memory allocation fails in `ndisc_option_add_encrypted_dns_internal()` and leaves a memory leak.

Discovered by GCC analyzer via OpenScanHub.

Co-developed-by: Opus 4.6 (1M context) <noreply@anthropic.com>