### PR TITLE
cryptsetup: probe for a FIDO2 token before we ask for its PIN

### DIFF
--- a/src/cryptsetup/cryptsetup-tokens/luks2-fido2.c
+++ b/src/cryptsetup/cryptsetup-tokens/luks2-fido2.c
@@ -39,6 +39,17 @@ int acquire_luks2_key(
                         return crypt_log_oom(cd);
         }
 
+        /* Before we report that we need a PIN, check if a token actually is plugged in. Otherwise we'd
+         * ask for the PIN already when no device is around, which is confusing. This matters even more
+         * here than in the non-plugin codepath: libcryptsetup ranks -ENOANO above -EAGAIN when it
+         * aggregates the results of all tokens, hence a single PIN-requiring token would otherwise hide
+         * the "no token plugged in" state of all the other ones. */
+        r = fido2_have_device(device);
+        if (r < 0)
+                return r;
+        if (r == 0) /* no device found, return EAGAIN so that caller will wait/watch udev */
+                return -EAGAIN;
+
         /* configured to use pin but none was provided */
         if ((required & FIDO2ENROLL_PIN) && strv_isempty(pins))
                 return -ENOANO;


### PR DESCRIPTION
The `systemd-fido2` libcryptsetup token plugin returns `-ENOANO` from the LUKS2 header metadata alone, before any device I/O. A token that is enrolled with a client PIN therefore reports "PIN needed" even while no token is plugged in.

libcryptsetup ranks `-ENOANO` above `-EAGAIN` when it aggregates the results of all tokens. A single absent PIN-requiring token thus masks the `-EAGAIN` of every other token. `systemd-cryptsetup` prompts for a PIN, and never enters its "token not present, please plug it in" udev wait. With two tokens enrolled, one with a PIN and one without, the no-PIN token cannot unlock the volume on presence alone. The operator must first dismiss a PIN prompt for the absent token.

The built-in FIDO2 codepath in `src/shared/cryptsetup-fido2.c` does not have this problem. It probes for the device first, and its comment states the intent.

This adds the same `fido2_have_device()` pre-flight to `acquire_luks2_key()`. An absent token now gives `-EAGAIN`, so the caller waits for the token on udev.

`fido2_have_device()` needs no new link dependency. It is in `src/shared/libfido2-util.c`, the plugin already links `libshared`, and `acquire_luks2_key()` already calls `fido2_use_hmac_hash()` from that same file.
