### PR TITLE
Revert "hwdb: add support for PineTab2 to 60-sensor.hwdb (#35304)"

### DIFF
--- a/hwdb.d/60-sensor.hwdb
+++ b/hwdb.d/60-sensor.hwdb
@@ -902,13 +902,6 @@ sensor:modalias:acpi:SMO8500:*:dmi:*:svnPEAQ:pnPEAQPMMC1010MD99187:*    # MMC101
  ACCEL_MOUNT_MATRIX=-1, 0, 0; 0, 1, 0; 0, 0, 1
 
 #########################################
-# Pine64
-#########################################
-
-sensor:modalias:of:NaccelerometerT_null_Csilan,sc7a20:*    # PineTab2
- ACCEL_MOUNT_MATRIX=0, 0, -1; 1, 0, 0; 0, -1, 0
-
-#########################################
 # Pipo
 #########################################
 


### PR DESCRIPTION
Reverts bc4a027f9cb66d56fd1305f41bed25751305fc27, as suggested in #43321.

The match key names the chip, not the machine. `of:N<name>T<type>C<compatible>`
describes the sensor node, and the PineNote carries the same silan sc7a20
mounted differently, so it presents an identical modalias:

```
$ cat /sys/bus/iio/devices/iio:device2/../modalias
of:NaccelerometerT(null)Csilan,sc7a20
```

On a device-tree machine there is no `/sys/class/dmi/id/modalias` to narrow it
with, so the DMI half of the lookup key is empty and both boards land on the one
entry. Adding a second, PineNote-scoped entry is not possible: it would carry the
same match string and simply shadow the first.

On the PineNote the entry also overrides a value that was already right. The
device tree supplies the matrix and the kernel publishes it:

```
$ cat /sys/bus/iio/devices/iio:device2/mount_matrix
-1, 0, 0; 0, 1, 0; 0, 0, 1
```

udev then replaces it with the PineTab2's, and the four orientations collapse
into two, both landscape — `iio-sensor-proxy` only ever reports `normal` and
`bottom-up`, so the display never selects portrait.

### What this costs the PineTab2

I should be plain about this: I have a PineNote, not a PineTab2, so I cannot
check whether its device tree also supplies `mount-matrix`. If it does, the
entry was redundant there too and nothing is lost. If it does not, this revert
returns that board to an uncalibrated accelerometer until its device tree gains
the property or a local hwdb entry is added — the trade-off named in
https://github.com/systemd/systemd/issues/43321#issuecomment-5257406161.
Someone with the hardware could settle it with one `cat`, and I would rather
that were checked than assumed.

### Testing

- PineNote v1.2, kernel 6.12.11, systemd 257 (Debian trixie): with the entry
  removed, the device-tree matrix survives into the udev environment and all
  four orientations are reported.
- `hwdb.d/parse_hwdb.py` passes on the edited tree.

Closes #43321
