### PR TITLE
shared: extend local-addresses.c to resolve gateway-less p2p default routes

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -334,6 +334,13 @@ CHANGES WITH 262:
           and ResetServerFeatures() methods, and resolvectl uses them where
           available for its flush-caches and reset-server-features commands.
 
+        * nss-myhostname, systemd-resolved, and networkctl now also synthesize
+          "_gateway" and "_outbound" from gateway-less point-to-point
+          default routes when the peer endpoint is unambiguous. This makes
+          ppp-style default routes resolvable even without an explicit
+          gateway address in the routing table. networkctl status will now
+          show synthesized peer addresses in its Gateway: field for such links.
+
         Changes in systemd-timesyncd:
 
         * systemd-timesyncd now resolves NTP server names through

--- a/man/nss-myhostname.xml
+++ b/man/nss-myhostname.xml
@@ -48,15 +48,21 @@
 
       <listitem><para>The hostname <literal>_gateway</literal> is
       resolved to all current default routing gateway addresses,
-      ordered by their metric. This assigns a stable hostname to the
-      current gateway, useful for referencing it independently of the
-      current network configuration state.</para></listitem>
+      ordered by their metric. On point-to-point links with
+      gateway-less default routes, the peer address from
+      <constant>IFA_ADDRESS</constant> may also be synthesized as
+      <literal>_gateway</literal> when the peer is unique and usable.
+      This assigns a stable hostname to the current gateway, useful
+      for referencing it independently of the current network
+      configuration state.</para></listitem>
 
       <listitem><para>The hostname <literal>_outbound</literal> is resolved to the local IPv4 and IPv6
       addresses that are most likely used for communication with other hosts. This is the preferred source
       addresses of default gateways if specified, or determined by requesting a routing decision to the
       configured default gateways from the kernel and then using the local IP addresses selected by this
-      decision. This hostname is only available if there is at least one local default gateway configured.
+      decision. On point-to-point links with gateway-less default routes, the peer address may also be used
+      to derive the outbound source address. This hostname is only available if there is at least one local
+      default gateway configured, or one gateway-less point-to-point default route with an unambiguous peer.
       This assigns a stable hostname to the local outbound IP addresses, useful for referencing them
       independently of the current network configuration state.</para></listitem>
     </itemizedlist>

--- a/man/systemd-resolved.service.xml
+++ b/man/systemd-resolved.service.xml
@@ -114,14 +114,19 @@
       </para></listitem>
 
       <listitem><para>The hostname <literal>_gateway</literal> is resolved to all current default routing
-      gateway addresses, ordered by their metric. This assigns a stable hostname to the current gateway,
-      useful for referencing it independently of the current network configuration state.</para></listitem>
+      gateway addresses, ordered by their metric. On point-to-point links with gateway-less default routes,
+      the peer address from <constant>IFA_ADDRESS</constant> may also be synthesized as
+      <literal>_gateway</literal> when the peer is unique and usable. This assigns a stable hostname to the
+      current gateway, useful for referencing it independently of the current network configuration
+      state.</para></listitem>
 
       <listitem><para>The hostname <literal>_outbound</literal> is resolved to the local IPv4 and IPv6
       addresses that are most likely used for communication with other hosts. This is the preferred source
       addresses of default gateways if specified, or determined by requesting a routing decision to the
       configured default gateways from the kernel and then using the local IP addresses selected by this
-      decision. This hostname is only available if there is at least one local default gateway configured.
+      decision. On point-to-point links with gateway-less default routes, the peer address may also be used
+      to derive the outbound source address. This hostname is only available if there is at least one local
+      default gateway configured, or one gateway-less point-to-point default route with an unambiguous peer.
       This assigns a stable hostname to the local outbound IP addresses, useful for referencing them
       independently of the current network configuration state.</para></listitem>
 

--- a/src/shared/local-addresses.c
+++ b/src/shared/local-addresses.c
@@ -1,19 +1,26 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
+#include <endian.h>
+#include <net/if.h>
+
 #include "sd-netlink.h"
 
 #include "alloc-util.h"
+#include "errno-util.h"
 #include "fd-util.h"
+#include "in-addr-util.h"
 #include "local-addresses.h"
 #include "log.h"
 #include "netlink-util.h"
+#include "set.h"
+#include "siphash24.h"
 #include "socket-util.h"
 #include "sort-util.h"
 
 static int address_compare(const struct local_address *a, const struct local_address *b) {
         int r;
 
-        /* Order lowest scope first, IPv4 before IPv6, lowest interface index first */
+        /* Order lowest scope first, IPv4 before IPv6, lowest interface index first. */
 
         if (a->family == AF_INET && b->family == AF_INET6)
                 return -1;
@@ -36,7 +43,11 @@ static int address_compare(const struct local_address *a, const struct local_add
         if (r != 0)
                 return r;
 
-        return memcmp(&a->address, &b->address, FAMILY_ADDRESS_SIZE(a->family));
+        r = memcmp(&a->address, &b->address, FAMILY_ADDRESS_SIZE(a->family));
+        if (r != 0)
+                return r;
+
+        return memcmp(&a->prefsrc, &b->prefsrc, FAMILY_ADDRESS_SIZE(a->family));
 }
 
 bool has_local_address(const struct local_address *addresses, size_t n_addresses, const struct local_address *needle) {
@@ -254,10 +265,468 @@ static int add_local_gateway(
                         family, address, prefsrc);
 }
 
+/* A gateway-less default route or nexthop that may be backed by a point-to-point peer.
+ * Candidates collapse by (ifindex, family, prefsrc), so only the best metric survives:
+ * lower priority wins, and weight follows that winning candidate. */
+typedef struct GatewayCandidate {
+        int ifindex;
+        uint32_t priority;
+        uint32_t weight;
+        int family;
+        union in_addr_union prefsrc;
+} GatewayCandidate;
+
+/* Key for facts that are scoped by link and address family. */
+typedef struct GatewayLinkKey {
+        int ifindex;
+        int family;
+} GatewayLinkKey;
+
+/* The usable peer endpoint for a key, or ambiguous if distinct peers were found. */
+typedef struct GatewayPeerInfo {
+        union in_addr_union peer;
+        bool ambiguous;
+} GatewayPeerInfo;
+
+/* Peer selected for a link/family pair when the route has no RTA_PREFSRC. */
+typedef struct GatewayPeerByLink {
+        int ifindex;
+        int family;
+        GatewayPeerInfo info;
+} GatewayPeerByLink;
+
+/* Peer selected for one local endpoint when the route carries RTA_PREFSRC. */
+typedef struct GatewayPeerByLocal {
+        int ifindex;
+        int family;
+        union in_addr_union local;
+        GatewayPeerInfo info;
+} GatewayPeerByLocal;
+
+/* Link flags collected from one RTM_GETLINK dump. */
+typedef struct GatewayLinkInfo {
+        int ifindex;
+        unsigned flags;
+} GatewayLinkInfo;
+
+static void gateway_candidate_hash_func(const GatewayCandidate *c, struct siphash *state) {
+        assert(c);
+        assert(state);
+
+        siphash24_compress_typesafe(c->ifindex, state);
+        siphash24_compress_typesafe(c->family, state);
+        in_addr_hash_func(&c->prefsrc, c->family, state);
+}
+
+static int gateway_candidate_compare_func(const GatewayCandidate *a, const GatewayCandidate *b) {
+        int r;
+
+        assert(a);
+        assert(b);
+
+        r = CMP(a->ifindex, b->ifindex);
+        if (r != 0)
+                return r;
+
+        r = CMP(a->family, b->family);
+        if (r != 0)
+                return r;
+
+        return memcmp(&a->prefsrc, &b->prefsrc, FAMILY_ADDRESS_SIZE(a->family));
+}
+
+DEFINE_PRIVATE_HASH_OPS_WITH_KEY_DESTRUCTOR(
+                gateway_candidate_hash_ops,
+                GatewayCandidate,
+                gateway_candidate_hash_func,
+                gateway_candidate_compare_func,
+                free);
+
+static void gateway_link_key_hash_func(const GatewayLinkKey *k, struct siphash *state) {
+        assert(k);
+        assert(state);
+
+        siphash24_compress_typesafe(k->ifindex, state);
+        siphash24_compress_typesafe(k->family, state);
+}
+
+static int gateway_link_key_compare_func(const GatewayLinkKey *a, const GatewayLinkKey *b) {
+        int r;
+
+        assert(a);
+        assert(b);
+
+        r = CMP(a->ifindex, b->ifindex);
+        if (r != 0)
+                return r;
+
+        return CMP(a->family, b->family);
+}
+
+DEFINE_PRIVATE_HASH_OPS_WITH_KEY_DESTRUCTOR(
+                gateway_link_key_hash_ops,
+                GatewayLinkKey,
+                gateway_link_key_hash_func,
+                gateway_link_key_compare_func,
+                free);
+
+static void gateway_peer_by_link_hash_func(const GatewayPeerByLink *p, struct siphash *state) {
+        assert(p);
+        assert(state);
+
+        siphash24_compress_typesafe(p->ifindex, state);
+        siphash24_compress_typesafe(p->family, state);
+}
+
+static int gateway_peer_by_link_compare_func(const GatewayPeerByLink *a, const GatewayPeerByLink *b) {
+        int r;
+
+        assert(a);
+        assert(b);
+
+        r = CMP(a->ifindex, b->ifindex);
+        if (r != 0)
+                return r;
+
+        return CMP(a->family, b->family);
+}
+
+DEFINE_PRIVATE_HASH_OPS_WITH_KEY_DESTRUCTOR(
+                gateway_peer_by_link_hash_ops,
+                GatewayPeerByLink,
+                gateway_peer_by_link_hash_func,
+                gateway_peer_by_link_compare_func,
+                free);
+
+static void gateway_peer_by_local_hash_func(const GatewayPeerByLocal *k, struct siphash *state) {
+        assert(k);
+        assert(state);
+
+        siphash24_compress_typesafe(k->ifindex, state);
+        siphash24_compress_typesafe(k->family, state);
+        in_addr_hash_func(&k->local, k->family, state);
+}
+
+static int gateway_peer_by_local_compare_func(const GatewayPeerByLocal *a, const GatewayPeerByLocal *b) {
+        int r;
+
+        assert(a);
+        assert(b);
+
+        r = CMP(a->ifindex, b->ifindex);
+        if (r != 0)
+                return r;
+
+        r = CMP(a->family, b->family);
+        if (r != 0)
+                return r;
+
+        return memcmp(&a->local, &b->local, FAMILY_ADDRESS_SIZE(a->family));
+}
+
+DEFINE_PRIVATE_HASH_OPS_WITH_KEY_DESTRUCTOR(
+                gateway_peer_by_local_hash_ops,
+                GatewayPeerByLocal,
+                gateway_peer_by_local_hash_func,
+                gateway_peer_by_local_compare_func,
+                free);
+
+static void gateway_link_info_hash_func(const GatewayLinkInfo *i, struct siphash *state) {
+        assert(i);
+        assert(state);
+
+        siphash24_compress_typesafe(i->ifindex, state);
+}
+
+static int gateway_link_info_compare_func(const GatewayLinkInfo *a, const GatewayLinkInfo *b) {
+        assert(a);
+        assert(b);
+
+        return CMP(a->ifindex, b->ifindex);
+}
+
+DEFINE_PRIVATE_HASH_OPS_WITH_KEY_DESTRUCTOR(
+                gateway_link_info_hash_ops,
+                GatewayLinkInfo,
+                gateway_link_info_hash_func,
+                gateway_link_info_compare_func,
+                free);
+
+static int add_gateway_candidate(
+                Set **candidates,
+                int ifindex,
+                uint32_t priority,
+                uint32_t weight,
+                int family,
+                const union in_addr_union *prefsrc) {
+
+        int r;
+
+        assert(candidates);
+        assert(ifindex > 0);
+        assert(IN_SET(family, AF_INET, AF_INET6));
+        assert(prefsrc);
+
+        GatewayCandidate lookup = {
+                .ifindex = ifindex,
+                .family = family,
+                .prefsrc = *prefsrc,
+        };
+        GatewayCandidate *candidate = set_get(*candidates, &lookup);
+        if (candidate) {
+                if (priority < candidate->priority) {
+                        candidate->priority = priority;
+                        candidate->weight = weight;
+                }
+
+                return 0;
+        }
+
+        _cleanup_free_ GatewayCandidate *new_candidate = new(GatewayCandidate, 1);
+        if (!new_candidate)
+                return -ENOMEM;
+
+        *new_candidate = (GatewayCandidate) {
+                .ifindex = ifindex,
+                .priority = priority,
+                .weight = weight,
+                .family = family,
+                .prefsrc = *prefsrc,
+        };
+
+        r = set_ensure_consume(candidates, &gateway_candidate_hash_ops, TAKE_PTR(new_candidate));
+        if (r < 0)
+                return r;
+
+        return 1;
+}
+
+static int add_gateway_link_info(
+                Set **links,
+                int ifindex,
+                unsigned flags) {
+
+        assert(links);
+        assert(ifindex > 0);
+
+        _cleanup_free_ GatewayLinkInfo *new_link = new(GatewayLinkInfo, 1);
+        if (!new_link)
+                return -ENOMEM;
+
+        *new_link = (GatewayLinkInfo) {
+                .ifindex = ifindex,
+                .flags = flags,
+        };
+
+        return set_ensure_consume(links, &gateway_link_info_hash_ops, TAKE_PTR(new_link));
+}
+
+static int collect_gateway_link_infos(sd_netlink *rtnl, Set **links) {
+
+        _cleanup_(sd_netlink_message_unrefp) sd_netlink_message *req = NULL, *reply = NULL;
+        int r;
+
+        assert(rtnl);
+        assert(links);
+
+        r = sd_rtnl_message_new_link(rtnl, &req, RTM_GETLINK, 0);
+        if (r < 0)
+                return r;
+
+        r = sd_netlink_message_set_request_dump(req, true);
+        if (r < 0)
+                return r;
+
+        r = sd_netlink_call(rtnl, req, 0, &reply);
+        if (r < 0)
+                return r;
+
+        for (sd_netlink_message *m = reply; m; m = sd_netlink_message_next(m)) {
+                uint16_t type;
+                unsigned flags;
+                int ifindex;
+
+                r = sd_netlink_message_get_errno(m);
+                if (r < 0) {
+                        log_debug_errno(r, "Failed to process link dump message, ignoring: %m");
+                        continue;
+                }
+
+                r = sd_netlink_message_get_type(m, &type);
+                if (r < 0) {
+                        log_debug_errno(r, "Failed to get link message type, ignoring: %m");
+                        continue;
+                }
+                if (type != RTM_NEWLINK)
+                        continue;
+
+                r = sd_rtnl_message_link_get_ifindex(m, &ifindex);
+                if (r < 0) {
+                        log_debug_errno(r, "Failed to get link interface index, ignoring: %m");
+                        continue;
+                }
+                if (ifindex <= 0)
+                        continue;
+
+                r = sd_rtnl_message_link_get_flags(m, &flags);
+                if (r < 0) {
+                        log_debug_errno(r, "Failed to get link flags, ignoring: %m");
+                        continue;
+                }
+
+                r = add_gateway_link_info(links, ifindex, flags);
+                if (r < 0)
+                        return r;
+        }
+
+        return 0;
+}
+
+/* Remember one usable peer per lookup key. If we see a different peer for the same
+ * key later, the result becomes ambiguous and we stop publishing a synthetic gateway
+ * for that key instead of guessing which peer to return. */
+static void update_gateway_peer_info(
+                GatewayPeerInfo *info,
+                int family,
+                const union in_addr_union *peer) {
+
+        assert(info);
+        assert(IN_SET(family, AF_INET, AF_INET6));
+        assert(peer);
+
+        if (info->ambiguous)
+                return;
+
+        /* Multiple local endpoints may point to the same peer. Distinct peers for the same lookup key
+         * are ambiguous, so no synthetic gateway will be published for that key. */
+        if (in_addr_equal(family, &info->peer, peer) <= 0)
+                info->ambiguous = true;
+}
+
+static int add_gateway_peer_by_link(
+                Set **peers_by_link,
+                int ifindex,
+                int family,
+                const union in_addr_union *peer) {
+
+        int r;
+
+        assert(peers_by_link);
+        assert(ifindex > 0);
+        assert(IN_SET(family, AF_INET, AF_INET6));
+        assert(peer);
+
+        GatewayPeerByLink lookup = {
+                .ifindex = ifindex,
+                .family = family,
+        };
+        GatewayPeerByLink *info = set_get(*peers_by_link, &lookup);
+        if (info) {
+                update_gateway_peer_info(&info->info, family, peer);
+                return 0;
+        }
+
+        _cleanup_free_ GatewayPeerByLink *new_info = new(GatewayPeerByLink, 1);
+        if (!new_info)
+                return -ENOMEM;
+
+        *new_info = (GatewayPeerByLink) {
+                .ifindex = ifindex,
+                .family = family,
+                .info = {
+                        .peer = *peer,
+                        .ambiguous = false,
+                },
+        };
+
+        r = set_ensure_consume(peers_by_link, &gateway_peer_by_link_hash_ops, TAKE_PTR(new_info));
+        if (r < 0)
+                return r;
+
+        return 1;
+}
+
+static int add_gateway_peer_by_local(
+                Set **peers_by_local,
+                int ifindex,
+                int family,
+                const union in_addr_union *local,
+                const union in_addr_union *peer) {
+
+        int r;
+
+        assert(peers_by_local);
+        assert(ifindex > 0);
+        assert(IN_SET(family, AF_INET, AF_INET6));
+        assert(local);
+        assert(peer);
+
+        GatewayPeerByLocal lookup = {
+                .ifindex = ifindex,
+                .family = family,
+                .local = *local,
+        };
+        GatewayPeerByLocal *p = set_get(*peers_by_local, &lookup);
+        if (p) {
+                update_gateway_peer_info(&p->info, family, peer);
+                return 0;
+        }
+
+        _cleanup_free_ GatewayPeerByLocal *new_info = new(GatewayPeerByLocal, 1);
+        if (!new_info)
+                return -ENOMEM;
+
+        *new_info = (GatewayPeerByLocal) {
+                .ifindex = ifindex,
+                .family = family,
+                .local = *local,
+                .info = {
+                        .peer = *peer,
+                        .ambiguous = false,
+                },
+        };
+
+        r = set_ensure_consume(peers_by_local, &gateway_peer_by_local_hash_ops, TAKE_PTR(new_info));
+        if (r < 0)
+                return r;
+
+        return 1;
+}
+
+static int add_gateway_peer(
+                Set **peers_by_link,
+                Set **peers_by_local,
+                int ifindex,
+                int family,
+                const union in_addr_union *local,
+                const union in_addr_union *peer) {
+
+        int r;
+
+        assert(peers_by_link);
+        assert(peers_by_local);
+        assert(ifindex > 0);
+        assert(IN_SET(family, AF_INET, AF_INET6));
+        assert(local);
+        assert(peer);
+
+        r = add_gateway_peer_by_link(peers_by_link, ifindex, family, peer);
+        if (r < 0)
+                return r;
+
+        r = add_gateway_peer_by_local(peers_by_local, ifindex, family, local, peer);
+        if (r < 0)
+                return r;
+
+        return 1;
+}
+
 static int parse_nexthop_one(
                 struct local_address **list,
                 size_t *n_list,
+                Set **candidates,
                 bool allow_via,
+                bool allow_candidate,
                 int family,
                 uint32_t priority,
                 const union in_addr_union *prefsrc,
@@ -317,14 +786,21 @@ static int parse_nexthop_one(
                         break;
                 }
 
+        if (!has_gw && allow_candidate && rtnh->rtnh_ifindex > 0)
+                return add_gateway_candidate(
+                                candidates, rtnh->rtnh_ifindex, priority, rtnh->rtnh_hops,
+                                family, prefsrc);
+
         return 0;
 }
 
 static int parse_nexthops(
                 struct local_address **list,
                 size_t *n_list,
+                Set **candidates,
                 int ifindex,
                 bool allow_via,
+                bool allow_candidate,
                 int family,
                 uint32_t priority,
                 const union in_addr_union *prefsrc,
@@ -351,7 +827,9 @@ static int parse_nexthops(
                 if (ifindex > 0 && rtnh->rtnh_ifindex != ifindex)
                         goto next_nexthop;
 
-                r = parse_nexthop_one(list, n_list, allow_via, family, priority, prefsrc, rtnh);
+                r = parse_nexthop_one(
+                                list, n_list, candidates,
+                                allow_via, allow_candidate, family, priority, prefsrc, rtnh);
                 if (r < 0)
                         return r;
 
@@ -363,6 +841,248 @@ static int parse_nexthops(
         return 0;
 }
 
+static int append_gateways_from_peer_maps(
+                struct local_address **list,
+                size_t *n_list,
+                Set *candidates,
+                Set *peers_by_link,
+                Set *peers_by_local) {
+
+        int r;
+
+        assert(list);
+        assert(n_list);
+
+        GatewayCandidate *candidate;
+        SET_FOREACH(candidate, candidates) {
+                if (in_addr_is_set(candidate->family, &candidate->prefsrc)) {
+                        /* A candidate with prefsrc already narrows the lookup down to one
+                         * local address. In that case we only need to check whether this
+                         * exact local endpoint has a unique peer on the same link/family. */
+                        GatewayPeerByLocal *p = set_get(
+                                        peers_by_local,
+                                        &(GatewayPeerByLocal) {
+                                                .ifindex = candidate->ifindex,
+                                                .family = candidate->family,
+                                                .local = candidate->prefsrc,
+                                        });
+
+                        if (!p || p->info.ambiguous)
+                                continue;
+
+                        r = add_local_gateway(
+                                        list, n_list,
+                                        candidate->ifindex,
+                                        candidate->priority,
+                                        candidate->weight,
+                                        candidate->family,
+                                        &p->info.peer,
+                                        &candidate->prefsrc);
+                        if (r < 0)
+                                return r;
+                        continue;
+                }
+
+                /* Without prefsrc we can only publish a synthetic gateway if the whole
+                 * link/family pair has exactly one usable peer. Otherwise the result is
+                 * ambiguous and we must skip it. */
+                GatewayPeerByLink *p = set_get(
+                                peers_by_link,
+                                &(GatewayPeerByLink) {
+                                        .ifindex = candidate->ifindex,
+                                        .family = candidate->family,
+                                });
+                if (!p || p->info.ambiguous)
+                        continue;
+
+                r = add_local_gateway(
+                                list, n_list,
+                                candidate->ifindex,
+                                candidate->priority,
+                                candidate->weight,
+                                candidate->family,
+                                &p->info.peer,
+                                &candidate->prefsrc);
+                if (r < 0)
+                        return r;
+        }
+
+        return 0;
+}
+
+static int add_gateway_peers(
+                sd_netlink *rtnl,
+                struct local_address **list,
+                size_t *n_list,
+                int ifindex,
+                int af,
+                Set *candidates) {
+
+        _cleanup_(sd_netlink_message_unrefp) sd_netlink_message *req = NULL, *reply = NULL;
+        _cleanup_set_free_ Set *links = NULL, *p2p_candidate_links = NULL, *peers_by_link = NULL, *peers_by_local = NULL;
+        int r;
+
+        assert(rtnl);
+        assert(IN_SET(af, AF_UNSPEC, AF_INET, AF_INET6));
+        assert(list);
+        assert(n_list);
+
+        if (set_isempty(candidates))
+                return 0;
+
+        r = collect_gateway_link_infos(rtnl, &links);
+        if (r < 0)
+                return r;
+
+        /* First narrow the candidate links down to links that are actually
+         * point-to-point. Only those can expose a peer address that is safe to
+         * publish as a synthetic _gateway result. */
+        GatewayCandidate *candidate;
+        SET_FOREACH(candidate, candidates) {
+                GatewayLinkInfo *link = set_get(
+                                links,
+                                &(GatewayLinkInfo) {
+                                        .ifindex = candidate->ifindex,
+                                });
+                if (!link)
+                        continue;
+
+                if (!FLAGS_SET(link->flags, IFF_POINTOPOINT))
+                        continue;
+
+                _cleanup_free_ GatewayLinkKey *new_link = new(GatewayLinkKey, 1);
+                if (!new_link)
+                        return -ENOMEM;
+
+                *new_link = (GatewayLinkKey) {
+                        .ifindex = candidate->ifindex,
+                        .family = candidate->family,
+                };
+                r = set_ensure_consume(&p2p_candidate_links, &gateway_link_key_hash_ops, TAKE_PTR(new_link));
+                if (r < 0)
+                        return r;
+        }
+
+        if (set_isempty(p2p_candidate_links))
+                return 0;
+
+        /* Now dump addresses only for the filtered point-to-point links. This keeps
+         * the address scan small and avoids examining unrelated interfaces that can
+         * never contribute a synthetic gateway. */
+        r = sd_rtnl_message_new_addr(rtnl, &req, RTM_GETADDR, ifindex, af);
+        if (r < 0)
+                return r;
+
+        r = sd_netlink_message_set_request_dump(req, true);
+        if (r < 0)
+                return r;
+
+        r = sd_netlink_call(rtnl, req, 0, &reply);
+        if (r < 0)
+                return r;
+
+        for (sd_netlink_message *m = reply; m; m = sd_netlink_message_next(m)) {
+                union in_addr_union local, peer;
+                unsigned char scope;
+                uint16_t type;
+                int ifi, family;
+
+                r = sd_netlink_message_get_errno(m);
+                if (r < 0) {
+                        log_debug_errno(r, "Failed to process address dump message, ignoring: %m");
+                        continue;
+                }
+
+                r = sd_netlink_message_get_type(m, &type);
+                if (r < 0) {
+                        log_debug_errno(r, "Failed to get address message type, ignoring: %m");
+                        continue;
+                }
+                if (type != RTM_NEWADDR)
+                        continue;
+
+                r = sd_rtnl_message_addr_get_ifindex(m, &ifi);
+                if (r < 0) {
+                        log_debug_errno(r, "Failed to get address interface index, ignoring: %m");
+                        continue;
+                }
+                if (ifi <= 0)
+                        continue;
+                if (ifindex > 0 && ifi != ifindex)
+                        continue;
+
+                r = sd_rtnl_message_addr_get_family(m, &family);
+                if (r < 0) {
+                        log_debug_errno(r, "Failed to get address family, ignoring: %m");
+                        continue;
+                }
+                if (!IN_SET(family, AF_INET, AF_INET6))
+                        continue;
+                if (af != AF_UNSPEC && family != af)
+                        continue;
+                if (!set_contains(p2p_candidate_links,
+                                  &(GatewayLinkKey) {
+                                          .ifindex = ifi,
+                                          .family = family,
+                                  }))
+                        continue;
+
+                uint8_t prefixlen;
+                r = sd_rtnl_message_addr_get_prefixlen(m, &prefixlen);
+                if (r < 0) {
+                        log_debug_errno(r, "Failed to get address prefix length, ignoring: %m");
+                        continue;
+                }
+                if (prefixlen != FAMILY_ADDRESS_SIZE(family) * 8)
+                        continue;
+
+                r = sd_rtnl_message_addr_get_scope(m, &scope);
+                if (r < 0) {
+                        log_debug_errno(r, "Failed to get address scope, ignoring: %m");
+                        continue;
+                }
+                if (IN_SET(scope, RT_SCOPE_HOST, RT_SCOPE_NOWHERE))
+                        continue;
+
+                /* Point-to-point addresses carry the local endpoint in IFA_LOCAL and the peer endpoint in
+                 * IFA_ADDRESS. On regular interfaces, the two addresses are identical. */
+                r = netlink_message_read_in_addr_union(m, IFA_LOCAL, family, &local);
+                if (r == -ENODATA)
+                        continue;
+                if (r < 0) {
+                        log_debug_errno(r, "Failed to read local address, ignoring: %m");
+                        continue;
+                }
+
+                r = netlink_message_read_in_addr_union(m, IFA_ADDRESS, family, &peer);
+                if (r == -ENODATA)
+                        continue;
+                if (r < 0) {
+                        log_debug_errno(r, "Failed to read peer address, ignoring: %m");
+                        continue;
+                }
+
+                if (in_addr_equal(family, &local, &peer) > 0)
+                        continue;
+                if (!in_addr_is_set(family, &peer))
+                        continue;
+                if (family == AF_INET && be32toh(peer.in.s_addr) == INADDR_BROADCAST)
+                        continue;
+                if (in_addr_is_localhost(family, &peer) > 0)
+                        continue;
+                if (in_addr_is_multicast(family, &peer) > 0)
+                        continue;
+
+                /* Record the peer both by link and by local endpoint so the final
+                 * pass can choose between link-based and prefsrc-based lookup. */
+                r = add_gateway_peer(&peers_by_link, &peers_by_local, ifi, family, &local, &peer);
+                if (r < 0)
+                        return r;
+        }
+
+        return append_gateways_from_peer_maps(list, n_list, candidates, peers_by_link, peers_by_local);
+}
+
 int local_gateways(
                 sd_netlink *context,
                 int ifindex,
@@ -372,13 +1092,15 @@ int local_gateways(
         _cleanup_(sd_netlink_message_unrefp) sd_netlink_message *req = NULL, *reply = NULL;
         _cleanup_(sd_netlink_unrefp) sd_netlink *rtnl = NULL;
         _cleanup_free_ struct local_address *list = NULL;
+        _cleanup_set_free_ Set *candidates = NULL;
         size_t n_list = 0;
         int r;
 
         /* The RTA_VIA attribute is used only for IPv4 routes with an IPv6 gateway. If IPv4 gateways are
          * requested (af == AF_INET), then we do not return IPv6 gateway addresses. Similarly, if IPv6
          * gateways are requested (af == AF_INET6), then we do not return gateway addresses for IPv4 routes.
-         * So, the RTA_VIA attribute is only parsed when af == AF_UNSPEC. */
+         * We still parse RTA_VIA for family-specific requests to distinguish explicit next hops from
+         * gateway-less routes. */
         bool allow_via = af == AF_UNSPEC;
 
         if (context)
@@ -412,7 +1134,7 @@ int local_gateways(
         for (sd_netlink_message *m = reply; m; m = sd_netlink_message_next(m)) {
                 union in_addr_union prefsrc = IN_ADDR_NULL;
                 uint16_t type;
-                unsigned char dst_len, src_len, table;
+                unsigned char dst_len, route_type, src_len, table;
                 uint32_t ifi = 0, priority = 0;
                 int family;
 
@@ -425,6 +1147,12 @@ int local_gateways(
                         return r;
                 if (type != RTM_NEWROUTE)
                         continue;
+
+                r = sd_rtnl_message_route_get_type(m, &route_type);
+                if (r < 0) {
+                        log_debug_errno(r, "Failed to get route type, ignoring: %m");
+                        continue;
+                }
 
                 /* We only care for default routes */
                 r = sd_rtnl_message_route_get_dst_prefixlen(m, &dst_len);
@@ -482,27 +1210,36 @@ int local_gateways(
                                 continue;
                         }
 
-                        if (!allow_via)
-                                continue;
-
-                        if (family != AF_INET)
-                                continue;
-
-                        RouteVia via;
-                        r = sd_netlink_message_read(m, RTA_VIA, sizeof(via), &via);
-                        if (r < 0 && r != -ENODATA)
-                                return r;
-                        if (r >= 0) {
-                                if (via.family != AF_INET6)
-                                        return -EBADMSG;
-
-                                /* Ignore prefsrc, and let's take the source address by socket command, if necessary. */
-                                r = add_local_gateway(&list, &n_list, ifi, priority, 0, via.family,
-                                                      &(union in_addr_union) { .in6 = via.address.in6 },
-                                                      /* prefsrc= */ NULL);
-                                if (r < 0)
+                        if (family == AF_INET) {
+                                RouteVia via;
+                                r = sd_netlink_message_read(m, RTA_VIA, sizeof(via), &via);
+                                if (r < 0 && r != -ENODATA)
                                         return r;
+                                if (r >= 0) {
+                                        if (!allow_via)
+                                                continue;
+
+                                        if (via.family != AF_INET6)
+                                                return -EBADMSG;
+
+                                        /* Ignore prefsrc, and let's take the source address by socket command, if necessary. */
+                                        r = add_local_gateway(&list, &n_list, ifi, priority, 0, via.family,
+                                                              &(union in_addr_union) { .in6 = via.address.in6 },
+                                                              /* prefsrc= */ NULL);
+                                        if (r < 0)
+                                                return r;
+
+                                        continue;
+                                }
                         }
+
+                        if (route_type != RTN_UNICAST)
+                                continue;
+
+                        r = add_gateway_candidate(
+                                        &candidates, ifi, priority, 0, family, &prefsrc);
+                        if (r < 0)
+                                return r;
 
                         /* If the route has RTA_OIF, it does not have RTA_MULTIPATH. */
                         continue;
@@ -514,11 +1251,20 @@ int local_gateways(
                 if (r < 0 && r != -ENODATA)
                         return r;
                 if (r >= 0) {
-                        r = parse_nexthops(&list, &n_list, ifindex, allow_via, family, priority, &prefsrc, rta_multipath, rta_len);
+                        r = parse_nexthops(
+                                        &list, &n_list, &candidates,
+                                        ifindex, allow_via, route_type == RTN_UNICAST, family, priority, &prefsrc,
+                                        rta_multipath, rta_len);
                         if (r < 0)
                                 return r;
                 }
         }
+
+        r = add_gateway_peers(rtnl, &list, &n_list, ifindex, af, candidates);
+        if (ERRNO_IS_NEG_RESOURCE(r))
+                return r;
+        if (r < 0)
+                log_debug_errno(r, "Failed to look up point-to-point peers, ignoring: %m");
 
         typesafe_qsort(list, n_list, address_compare);
         suppress_duplicates(list, &n_list);

--- a/src/test/test-local-addresses.c
+++ b/src/test/test-local-addresses.c
@@ -1,5 +1,6 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
+#include <linux/if_tunnel.h>
 #include <net/if.h>
 #include <stdio.h>
 
@@ -7,6 +8,7 @@
 
 #include "af-list.h"
 #include "alloc-util.h"
+#include "errno-util.h"
 #include "in-addr-util.h"
 #include "local-addresses.h"
 #include "netlink-util.h"
@@ -18,6 +20,23 @@ static void print_local_addresses(const struct local_address *a, size_t n) {
                 log_debug("%s ifindex=%i scope=%u priority=%"PRIu32" weight=%"PRIu32" address=%s",
                           af_to_name(i->family), i->ifindex, i->scope, i->priority, i->weight,
                           IN_ADDR_TO_STRING(i->family, &i->address));
+}
+
+static void delete_link_by_name(sd_netlink *rtnl, const char *ifname) {
+        _cleanup_(sd_netlink_message_unrefp) sd_netlink_message *message = NULL;
+        int ifindex;
+
+        assert(rtnl);
+        assert(ifname);
+
+        ifindex = if_nametoindex(ifname);
+        if (ifindex <= 0)
+                return;
+
+        if (sd_rtnl_message_new_link(rtnl, &message, RTM_DELLINK, ifindex) < 0)
+                return;
+
+        (void) sd_netlink_call(rtnl, message, 0, NULL);
 }
 
 TEST(local_addresses) {
@@ -147,6 +166,99 @@ static void check_local_gateways(sd_netlink *rtnl, int ifindex, int request_ifin
                   IN_SET(family, AF_UNSPEC, AF_INET6));
 }
 
+static void check_no_local_gateway_with_priority(
+                sd_netlink *rtnl,
+                int request_ifindex,
+                int family,
+                uint32_t priority) {
+
+        _cleanup_free_ struct local_address *a = NULL;
+        int n;
+
+        log_debug("/* Local Gateways (ifindex:%i, %s, unexpected_priority=%"PRIu32") */",
+                  request_ifindex, family == AF_UNSPEC ? "AF_UNSPEC" : af_to_name(family), priority);
+
+        ASSERT_OK(n = local_gateways(rtnl, request_ifindex, family, &a));
+        print_local_addresses(a, n);
+
+        FOREACH_ARRAY(i, a, n)
+                ASSERT_NE(i->priority, priority);
+}
+
+static void check_no_local_gateway_address(
+                sd_netlink *rtnl,
+                int request_ifindex,
+                int family,
+                const char *address) {
+
+        _cleanup_free_ struct local_address *a = NULL;
+        union in_addr_union u;
+        int n;
+
+        log_debug("/* Local Gateways (ifindex:%i, %s, unexpected_address=%s) */",
+                  request_ifindex, family == AF_UNSPEC ? "AF_UNSPEC" : af_to_name(family), address);
+
+        ASSERT_OK(n = local_gateways(rtnl, request_ifindex, family, &a));
+        print_local_addresses(a, n);
+
+        ASSERT_OK(in_addr_from_string(family, address, &u));
+
+        FOREACH_ARRAY(i, a, n) {
+                if (i->family != family)
+                        continue;
+
+                ASSERT_EQ(in_addr_equal(family, &i->address, &u), 0);
+        }
+}
+
+static void check_local_gateway_peer(
+                sd_netlink *rtnl,
+                int ifindex,
+                int request_ifindex,
+                int request_family,
+                uint32_t priority,
+                uint32_t weight,
+                int family,
+                const char *peer,
+                const char *prefsrc) {
+
+        _cleanup_free_ struct local_address *a = NULL;
+        union in_addr_union prefsrc_address, peer_address;
+        int n;
+
+        log_debug("/* Local Gateway Peer (ifindex:%i, %s, priority=%"PRIu32", weight=%"PRIu32", "
+                  "expected_family=%s) */",
+                  request_ifindex, request_family == AF_UNSPEC ? "AF_UNSPEC" : af_to_name(request_family),
+                  priority, weight, af_to_name(family));
+
+        ASSERT_OK(n = local_gateways(rtnl, request_ifindex, request_family, &a));
+        print_local_addresses(a, n);
+
+        ASSERT_OK(in_addr_from_string(family, peer, &peer_address));
+        if (prefsrc)
+                ASSERT_OK(in_addr_from_string(family, prefsrc, &prefsrc_address));
+
+        bool found = false;
+        FOREACH_ARRAY(i, a, n) {
+                if (i->ifindex != ifindex || i->family != family || i->priority != priority)
+                        continue;
+                if (i->weight != weight)
+                        continue;
+                if (in_addr_equal(family, &i->address, &peer_address) <= 0)
+                        continue;
+
+                if (prefsrc)
+                        ASSERT_OK_POSITIVE(in_addr_equal(family, &i->prefsrc, &prefsrc_address));
+                else
+                        ASSERT_FALSE(in_addr_is_set(family, &i->prefsrc));
+
+                found = true;
+                break;
+        }
+
+        ASSERT_TRUE(found);
+}
+
 static void check_local_outbounds(sd_netlink *rtnl, int ifindex, int request_ifindex, int family, const char *ipv6_expected) {
         _cleanup_free_ struct local_address *a = NULL;
         union in_addr_union u;
@@ -186,13 +298,48 @@ static void check_local_outbounds(sd_netlink *rtnl, int ifindex, int request_ifi
                   IN_SET(family, AF_UNSPEC, AF_INET6));
 }
 
+static void check_local_outbound_address(
+                sd_netlink *rtnl,
+                int request_ifindex,
+                int request_family,
+                int address_ifindex,
+                int address_family,
+                const char *address,
+                bool expected) {
+
+        _cleanup_free_ struct local_address *a = NULL;
+        union in_addr_union u;
+        int n;
+
+        log_debug("/* Local Outbounds (ifindex:%i, %s, %s_address=%s) */",
+                  request_ifindex, request_family == AF_UNSPEC ? "AF_UNSPEC" : af_to_name(request_family),
+                  expected ? "expected" : "unexpected", address);
+
+        ASSERT_OK(n = local_outbounds(rtnl, request_ifindex, request_family, &a));
+        print_local_addresses(a, n);
+
+        ASSERT_OK(in_addr_from_string(address_family, address, &u));
+        ASSERT_EQ(has_local_address(a, n,
+                                    &(struct local_address) {
+                                            .ifindex = address_ifindex,
+                                            .family = address_family,
+                                            .address = u,
+                                    }),
+                  expected);
+}
+
 TEST(local_addresses_with_dummy) {
         _cleanup_(sd_netlink_unrefp) sd_netlink *rtnl = NULL;
         _cleanup_(sd_netlink_message_unrefp) sd_netlink_message *message = NULL, *reply = NULL;
         union in_addr_union u;
-        int r, ifindex;
+        int ifindex, ifindex2, p2p_ifindex = 0, p2p_ifindex2 = 0, r;
 
         ASSERT_OK(sd_netlink_open(&rtnl));
+
+        delete_link_by_name(rtnl, "test-ipip2");
+        delete_link_by_name(rtnl, "test-ipip");
+        delete_link_by_name(rtnl, "test-local-a2");
+        delete_link_by_name(rtnl, "test-local-addr");
 
         /* Create a dummy interface */
         ASSERT_OK(sd_rtnl_message_new_link(rtnl, &message, RTM_NEWLINK, 0));
@@ -216,11 +363,34 @@ TEST(local_addresses_with_dummy) {
         message = sd_netlink_message_unref(message);
         reply = sd_netlink_message_unref(reply);
 
+        /* Create a second dummy interface */
+        ASSERT_OK(sd_rtnl_message_new_link(rtnl, &message, RTM_NEWLINK, 0));
+        ASSERT_OK(sd_netlink_message_append_string(message, IFLA_IFNAME, "test-local-a2"));
+        ASSERT_OK(sd_netlink_message_open_container(message, IFLA_LINKINFO));
+        ASSERT_OK(sd_netlink_message_append_string(message, IFLA_INFO_KIND, "dummy"));
+        ASSERT_OK(sd_netlink_call(rtnl, message, 0, NULL));
+        message = sd_netlink_message_unref(message);
+
+        /* Get second ifindex */
+        ASSERT_OK(sd_rtnl_message_new_link(rtnl, &message, RTM_GETLINK, 0));
+        ASSERT_OK(sd_netlink_message_append_string(message, IFLA_IFNAME, "test-local-a2"));
+        ASSERT_OK(sd_netlink_call(rtnl, message, 0, &reply));
+        ASSERT_OK(sd_rtnl_message_link_get_ifindex(reply, &ifindex2));
+        ASSERT_GT(ifindex2, 0);
+        message = sd_netlink_message_unref(message);
+        reply = sd_netlink_message_unref(reply);
+
         /* Enable IPv6 for the case that it is disabled by default. */
         ASSERT_OK(sysctl_write_ip_property_boolean(AF_INET6, "test-local-addr", "disable_ipv6", false, /* shadow= */ NULL));
 
         /* Bring the interface up */
         ASSERT_OK(sd_rtnl_message_new_link(rtnl, &message, RTM_SETLINK, ifindex));
+        ASSERT_OK(sd_rtnl_message_link_set_flags(message, IFF_UP, IFF_UP));
+        ASSERT_OK(sd_netlink_call(rtnl, message, 0, NULL));
+        message = sd_netlink_message_unref(message);
+
+        /* Bring the second interface up */
+        ASSERT_OK(sd_rtnl_message_new_link(rtnl, &message, RTM_SETLINK, ifindex2));
         ASSERT_OK(sd_rtnl_message_link_set_flags(message, IFF_UP, IFF_UP));
         ASSERT_OK(sd_netlink_call(rtnl, message, 0, NULL));
         message = sd_netlink_message_unref(message);
@@ -293,6 +463,32 @@ TEST(local_addresses_with_dummy) {
         ASSERT_OK(sd_netlink_message_append_u32(message, RTA_OIF, ifindex));
         ASSERT_OK(sd_netlink_call(rtnl, message, 0, NULL));
         message = sd_netlink_message_unref(message);
+
+        /* Add default routes without explicit gateways. Without peer addresses, these must not be
+         * reported. */
+        ASSERT_OK(sd_rtnl_message_new_route(rtnl, &message, RTM_NEWROUTE, AF_INET, RTPROT_STATIC));
+        ASSERT_OK(sd_rtnl_message_route_set_scope(message, RT_SCOPE_LINK));
+        ASSERT_OK(sd_rtnl_message_route_set_type(message, RTN_UNICAST));
+        ASSERT_OK(sd_netlink_message_append_u32(message, RTA_PRIORITY, 2345));
+        ASSERT_OK(sd_netlink_message_append_u32(message, RTA_TABLE, RT_TABLE_MAIN));
+        ASSERT_OK(sd_netlink_message_append_u32(message, RTA_OIF, ifindex));
+        ASSERT_OK(sd_netlink_call(rtnl, message, 0, NULL));
+        message = sd_netlink_message_unref(message);
+
+        ASSERT_OK(sd_rtnl_message_new_route(rtnl, &message, RTM_NEWROUTE, AF_INET6, RTPROT_STATIC));
+        ASSERT_OK(sd_rtnl_message_route_set_type(message, RTN_UNICAST));
+        ASSERT_OK(sd_netlink_message_append_u32(message, RTA_PRIORITY, 2345));
+        ASSERT_OK(sd_netlink_message_append_u32(message, RTA_TABLE, RT_TABLE_MAIN));
+        ASSERT_OK(sd_netlink_message_append_u32(message, RTA_OIF, ifindex));
+        ASSERT_OK(sd_netlink_call(rtnl, message, 0, NULL));
+        message = sd_netlink_message_unref(message);
+
+        check_no_local_gateway_with_priority(rtnl, 0, AF_UNSPEC, 2345);
+        check_no_local_gateway_with_priority(rtnl, 0, AF_INET, 2345);
+        check_no_local_gateway_with_priority(rtnl, 0, AF_INET6, 2345);
+        check_no_local_gateway_with_priority(rtnl, ifindex, AF_UNSPEC, 2345);
+        check_no_local_gateway_with_priority(rtnl, ifindex, AF_INET, 2345);
+        check_no_local_gateway_with_priority(rtnl, ifindex, AF_INET6, 2345);
 
         /* Check */
         check_local_addresses(rtnl, ifindex, 0, AF_UNSPEC);
@@ -388,7 +584,418 @@ TEST(local_addresses_with_dummy) {
         check_local_outbounds(rtnl, ifindex, ifindex, AF_INET, "2001:db8:1:123::124");
         check_local_outbounds(rtnl, ifindex, ifindex, AF_INET6, "2001:db8:1:123::124");
 
+        /* Create a point-to-point IPIP interface. */
+        ASSERT_OK(sd_rtnl_message_new_link(rtnl, &message, RTM_NEWLINK, 0));
+        ASSERT_OK(sd_netlink_message_append_string(message, IFLA_IFNAME, "test-ipip"));
+        ASSERT_OK(sd_netlink_message_open_container(message, IFLA_LINKINFO));
+        ASSERT_OK(sd_netlink_message_append_string(message, IFLA_INFO_KIND, "ipip"));
+        ASSERT_OK(sd_netlink_message_open_container_union(message, IFLA_INFO_DATA, "ipip"));
+        ASSERT_OK(in_addr_from_string(AF_INET, "192.0.2.1", &u));
+        ASSERT_OK(sd_netlink_message_append_in_addr(message, IFLA_IPTUN_LOCAL, &u.in));
+        ASSERT_OK(in_addr_from_string(AF_INET, "192.0.2.2", &u));
+        ASSERT_OK(sd_netlink_message_append_in_addr(message, IFLA_IPTUN_REMOTE, &u.in));
+        ASSERT_OK(sd_netlink_message_close_container(message));
+        ASSERT_OK(sd_netlink_message_close_container(message));
+        r = sd_netlink_call(rtnl, message, 0, NULL);
+        if (ERRNO_IS_NEG_NOT_SUPPORTED(r)) {
+                log_debug_errno(r, "IPIP tunnel is not supported, skipping point-to-point gateway tests: %m");
+                message = sd_netlink_message_unref(message);
+                goto finish;
+        }
+        ASSERT_OK(r);
+        message = sd_netlink_message_unref(message);
+
+        ASSERT_OK(sd_rtnl_message_new_link(rtnl, &message, RTM_GETLINK, 0));
+        ASSERT_OK(sd_netlink_message_append_string(message, IFLA_IFNAME, "test-ipip"));
+        ASSERT_OK(sd_netlink_call(rtnl, message, 0, &reply));
+        ASSERT_OK(sd_rtnl_message_link_get_ifindex(reply, &p2p_ifindex));
+        ASSERT_GT(p2p_ifindex, 0);
+        message = sd_netlink_message_unref(message);
+        reply = sd_netlink_message_unref(reply);
+
+        ASSERT_OK(sd_rtnl_message_new_link(rtnl, &message, RTM_SETLINK, p2p_ifindex));
+        ASSERT_OK(sd_rtnl_message_link_set_flags(message, IFF_UP, IFF_UP));
+        ASSERT_OK(sd_netlink_call(rtnl, message, 0, NULL));
+        message = sd_netlink_message_unref(message);
+
+        /* Enable IPv6 for the case that it is disabled by default. */
+        ASSERT_OK(sysctl_write_ip_property_boolean(AF_INET6, "test-ipip", "disable_ipv6", false, /* shadow= */ NULL));
+
+        ASSERT_OK(sd_rtnl_message_new_link(rtnl, &message, RTM_NEWLINK, 0));
+        ASSERT_OK(sd_netlink_message_append_string(message, IFLA_IFNAME, "test-ipip2"));
+        ASSERT_OK(sd_netlink_message_open_container(message, IFLA_LINKINFO));
+        ASSERT_OK(sd_netlink_message_append_string(message, IFLA_INFO_KIND, "ipip"));
+        ASSERT_OK(sd_netlink_message_open_container_union(message, IFLA_INFO_DATA, "ipip"));
+        ASSERT_OK(in_addr_from_string(AF_INET, "192.0.2.3", &u));
+        ASSERT_OK(sd_netlink_message_append_in_addr(message, IFLA_IPTUN_LOCAL, &u.in));
+        ASSERT_OK(in_addr_from_string(AF_INET, "192.0.2.4", &u));
+        ASSERT_OK(sd_netlink_message_append_in_addr(message, IFLA_IPTUN_REMOTE, &u.in));
+        ASSERT_OK(sd_netlink_message_close_container(message));
+        ASSERT_OK(sd_netlink_message_close_container(message));
+        ASSERT_OK(sd_netlink_call(rtnl, message, 0, NULL));
+        message = sd_netlink_message_unref(message);
+
+        ASSERT_OK(sd_rtnl_message_new_link(rtnl, &message, RTM_GETLINK, 0));
+        ASSERT_OK(sd_netlink_message_append_string(message, IFLA_IFNAME, "test-ipip2"));
+        ASSERT_OK(sd_netlink_call(rtnl, message, 0, &reply));
+        ASSERT_OK(sd_rtnl_message_link_get_ifindex(reply, &p2p_ifindex2));
+        ASSERT_GT(p2p_ifindex2, 0);
+        message = sd_netlink_message_unref(message);
+        reply = sd_netlink_message_unref(reply);
+
+        ASSERT_OK(sd_rtnl_message_new_link(rtnl, &message, RTM_SETLINK, p2p_ifindex2));
+        ASSERT_OK(sd_rtnl_message_link_set_flags(message, IFF_UP, IFF_UP));
+        ASSERT_OK(sd_netlink_call(rtnl, message, 0, NULL));
+        message = sd_netlink_message_unref(message);
+
+        /* Add point-to-point addresses and check that the peer endpoints back the gateway-less routes. */
+        ASSERT_OK(sd_rtnl_message_new_addr_update(rtnl, &message, p2p_ifindex, AF_INET));
+        ASSERT_OK(sd_rtnl_message_addr_set_scope(message, RT_SCOPE_UNIVERSE));
+        ASSERT_OK(sd_rtnl_message_addr_set_prefixlen(message, 32));
+        ASSERT_OK(in_addr_from_string(AF_INET, "10.124.0.1", &u));
+        ASSERT_OK(sd_netlink_message_append_in_addr(message, IFA_LOCAL, &u.in));
+        ASSERT_OK(in_addr_from_string(AF_INET, "10.124.0.2", &u));
+        ASSERT_OK(sd_netlink_message_append_in_addr(message, IFA_ADDRESS, &u.in));
+        ASSERT_OK(sd_netlink_call(rtnl, message, 0, NULL));
+        message = sd_netlink_message_unref(message);
+
+        ASSERT_OK(sd_rtnl_message_new_addr_update(rtnl, &message, p2p_ifindex, AF_INET));
+        ASSERT_OK(sd_rtnl_message_addr_set_scope(message, RT_SCOPE_UNIVERSE));
+        ASSERT_OK(sd_rtnl_message_addr_set_prefixlen(message, 32));
+        ASSERT_OK(in_addr_from_string(AF_INET, "10.124.0.3", &u));
+        ASSERT_OK(sd_netlink_message_append_in_addr(message, IFA_LOCAL, &u.in));
+        ASSERT_OK(in_addr_from_string(AF_INET, "10.124.0.2", &u));
+        ASSERT_OK(sd_netlink_message_append_in_addr(message, IFA_ADDRESS, &u.in));
+        ASSERT_OK(sd_netlink_call(rtnl, message, 0, NULL));
+        message = sd_netlink_message_unref(message);
+
+        ASSERT_OK(sd_rtnl_message_new_addr_update(rtnl, &message, p2p_ifindex2, AF_INET));
+        ASSERT_OK(sd_rtnl_message_addr_set_scope(message, RT_SCOPE_UNIVERSE));
+        ASSERT_OK(sd_rtnl_message_addr_set_prefixlen(message, 32));
+        ASSERT_OK(in_addr_from_string(AF_INET, "10.125.0.1", &u));
+        ASSERT_OK(sd_netlink_message_append_in_addr(message, IFA_LOCAL, &u.in));
+        ASSERT_OK(in_addr_from_string(AF_INET, "10.125.0.2", &u));
+        ASSERT_OK(sd_netlink_message_append_in_addr(message, IFA_ADDRESS, &u.in));
+        ASSERT_OK(sd_netlink_call(rtnl, message, 0, NULL));
+        message = sd_netlink_message_unref(message);
+
+        ASSERT_OK(sd_rtnl_message_new_route(rtnl, &message, RTM_NEWROUTE, AF_INET, RTPROT_STATIC));
+        ASSERT_OK(sd_rtnl_message_route_set_scope(message, RT_SCOPE_LINK));
+        ASSERT_OK(sd_rtnl_message_route_set_type(message, RTN_UNICAST));
+        ASSERT_OK(sd_netlink_message_append_u32(message, RTA_PRIORITY, 2351));
+        ASSERT_OK(sd_netlink_message_append_u32(message, RTA_TABLE, RT_TABLE_MAIN));
+        ASSERT_OK(sd_netlink_message_append_u32(message, RTA_OIF, ifindex2));
+        ASSERT_OK(sd_netlink_call(rtnl, message, 0, NULL));
+        message = sd_netlink_message_unref(message);
+
+        ASSERT_OK(sd_rtnl_message_new_addr_update(rtnl, &message, p2p_ifindex, AF_INET6));
+        ASSERT_OK(sd_rtnl_message_addr_set_scope(message, RT_SCOPE_UNIVERSE));
+        ASSERT_OK(sd_rtnl_message_addr_set_prefixlen(message, 128));
+        ASSERT_OK(in_addr_from_string(AF_INET6, "2001:db8:2:123::1", &u));
+        ASSERT_OK(sd_netlink_message_append_in6_addr(message, IFA_LOCAL, &u.in6));
+        ASSERT_OK(in_addr_from_string(AF_INET6, "2001:db8:2:123::2", &u));
+        ASSERT_OK(sd_netlink_message_append_in6_addr(message, IFA_ADDRESS, &u.in6));
+        ASSERT_OK(sd_netlink_message_append_u32(message, IFA_FLAGS, IFA_F_NODAD));
+        ASSERT_OK(sd_netlink_call(rtnl, message, 0, NULL));
+        message = sd_netlink_message_unref(message);
+
+        ASSERT_OK(sd_rtnl_message_new_addr_update(rtnl, &message, p2p_ifindex, AF_INET6));
+        ASSERT_OK(sd_rtnl_message_addr_set_scope(message, RT_SCOPE_UNIVERSE));
+        ASSERT_OK(sd_rtnl_message_addr_set_prefixlen(message, 128));
+        ASSERT_OK(in_addr_from_string(AF_INET6, "2001:db8:3:123::1", &u));
+        ASSERT_OK(sd_netlink_message_append_in6_addr(message, IFA_LOCAL, &u.in6));
+        ASSERT_OK(in_addr_from_string(AF_INET6, "2001:db8:3:123::2", &u));
+        ASSERT_OK(sd_netlink_message_append_in6_addr(message, IFA_ADDRESS, &u.in6));
+        ASSERT_OK(sd_netlink_message_append_u32(message, IFA_FLAGS, IFA_F_NODAD));
+        ASSERT_OK(sd_netlink_message_append_cache_info(message, IFA_CACHEINFO,
+                                                       &(struct ifa_cacheinfo) {
+                                                               .ifa_prefered = 0,
+                                                               .ifa_valid = UINT32_MAX,
+                                                       }));
+        ASSERT_OK(sd_netlink_call(rtnl, message, 0, NULL));
+        message = sd_netlink_message_unref(message);
+
+        ASSERT_OK(sd_rtnl_message_new_addr_update(rtnl, &message, p2p_ifindex, AF_INET6));
+        ASSERT_OK(sd_rtnl_message_addr_set_scope(message, RT_SCOPE_UNIVERSE));
+        ASSERT_OK(sd_rtnl_message_addr_set_prefixlen(message, 128));
+        ASSERT_OK(in_addr_from_string(AF_INET6, "2001:db8:3:123::3", &u));
+        ASSERT_OK(sd_netlink_message_append_in6_addr(message, IFA_LOCAL, &u.in6));
+        ASSERT_OK(in_addr_from_string(AF_INET6, "::1", &u));
+        ASSERT_OK(sd_netlink_message_append_in6_addr(message, IFA_ADDRESS, &u.in6));
+        ASSERT_OK(sd_netlink_message_append_u32(message, IFA_FLAGS, IFA_F_NODAD));
+        ASSERT_OK(sd_netlink_call(rtnl, message, 0, NULL));
+        message = sd_netlink_message_unref(message);
+
+        ASSERT_OK(sd_rtnl_message_new_addr_update(rtnl, &message, p2p_ifindex, AF_INET6));
+        ASSERT_OK(sd_rtnl_message_addr_set_scope(message, RT_SCOPE_UNIVERSE));
+        ASSERT_OK(sd_rtnl_message_addr_set_prefixlen(message, 128));
+        ASSERT_OK(in_addr_from_string(AF_INET6, "2001:db8:3:123::4", &u));
+        ASSERT_OK(sd_netlink_message_append_in6_addr(message, IFA_LOCAL, &u.in6));
+        ASSERT_OK(in_addr_from_string(AF_INET6, "ff02::1", &u));
+        ASSERT_OK(sd_netlink_message_append_in6_addr(message, IFA_ADDRESS, &u.in6));
+        ASSERT_OK(sd_netlink_message_append_u32(message, IFA_FLAGS, IFA_F_NODAD));
+        ASSERT_OK(sd_netlink_call(rtnl, message, 0, NULL));
+        message = sd_netlink_message_unref(message);
+
+        ASSERT_OK(sd_rtnl_message_new_route(rtnl, &message, RTM_NEWROUTE, AF_INET6, RTPROT_STATIC));
+        ASSERT_OK(sd_rtnl_message_route_set_type(message, RTN_UNICAST));
+        ASSERT_OK(sd_netlink_message_append_u32(message, RTA_PRIORITY, 2347));
+        ASSERT_OK(sd_netlink_message_append_u32(message, RTA_TABLE, RT_TABLE_MAIN));
+        ASSERT_OK(sd_netlink_message_append_u32(message, RTA_OIF, p2p_ifindex));
+        ASSERT_OK(sd_netlink_call(rtnl, message, 0, NULL));
+        message = sd_netlink_message_unref(message);
+
+        ASSERT_OK(sd_rtnl_message_new_route(rtnl, &message, RTM_NEWROUTE, AF_INET6, RTPROT_STATIC));
+        ASSERT_OK(sd_rtnl_message_route_set_type(message, RTN_UNICAST));
+        ASSERT_OK(sd_netlink_message_append_u32(message, RTA_PRIORITY, 2352));
+        ASSERT_OK(sd_netlink_message_append_u32(message, RTA_TABLE, RT_TABLE_MAIN));
+        ASSERT_OK(sd_netlink_message_append_u32(message, RTA_OIF, p2p_ifindex));
+        ASSERT_OK(in_addr_from_string(AF_INET6, "2001:db8:3:123::3", &u));
+        ASSERT_OK(sd_netlink_message_append_in6_addr(message, RTA_PREFSRC, &u.in6));
+        ASSERT_OK(sd_netlink_call(rtnl, message, 0, NULL));
+        message = sd_netlink_message_unref(message);
+
+        ASSERT_OK(sd_rtnl_message_new_route(rtnl, &message, RTM_NEWROUTE, AF_INET6, RTPROT_STATIC));
+        ASSERT_OK(sd_rtnl_message_route_set_type(message, RTN_UNICAST));
+        ASSERT_OK(sd_netlink_message_append_u32(message, RTA_PRIORITY, 2346));
+        ASSERT_OK(sd_netlink_message_append_u32(message, RTA_TABLE, RT_TABLE_MAIN));
+        ASSERT_OK(sd_netlink_message_append_u32(message, RTA_OIF, p2p_ifindex));
+        ASSERT_OK(in_addr_from_string(AF_INET6, "2001:db8:3:123::1", &u));
+        ASSERT_OK(sd_netlink_message_append_in6_addr(message, RTA_PREFSRC, &u.in6));
+        ASSERT_OK(sd_netlink_call(rtnl, message, 0, NULL));
+        message = sd_netlink_message_unref(message);
+
+        bool have_multipath = true;
+        uint32_t gatewayless_priority = 3344, gatewayless_weight = 17;
+        ASSERT_OK(sd_rtnl_message_new_route(rtnl, &message, RTM_NEWROUTE, AF_INET, RTPROT_STATIC));
+        ASSERT_OK(sd_rtnl_message_route_set_scope(message, RT_SCOPE_LINK));
+        ASSERT_OK(sd_rtnl_message_route_set_type(message, RTN_UNICAST));
+        ASSERT_OK(sd_netlink_message_append_u32(message, RTA_PRIORITY, gatewayless_priority));
+        ASSERT_OK(sd_netlink_message_append_u32(message, RTA_TABLE, RT_TABLE_MAIN));
+        ASSERT_OK(sd_netlink_message_append_data(message, RTA_MULTIPATH,
+                                                 ((struct rtnexthop[]) {
+                                                         {
+                                                                 .rtnh_len = sizeof(struct rtnexthop),
+                                                                 .rtnh_ifindex = p2p_ifindex,
+                                                                 .rtnh_hops = gatewayless_weight,
+                                                         },
+                                                         {
+                                                                 .rtnh_len = sizeof(struct rtnexthop),
+                                                                 .rtnh_ifindex = ifindex2,
+                                                                 .rtnh_hops = 3,
+                                                         },
+                                                 }), 2 * sizeof(struct rtnexthop)));
+        r = sd_netlink_call(rtnl, message, 0, NULL);
+        if (r == -EINVAL) {
+                log_debug_errno(r, "Multipath routes are not supported, using single-path fallback: %m");
+                have_multipath = false;
+                gatewayless_priority = 3343;
+                gatewayless_weight = 0;
+        } else
+                ASSERT_OK(r);
+        message = sd_netlink_message_unref(message);
+
+        if (!have_multipath) {
+                ASSERT_OK(sd_rtnl_message_new_route(rtnl, &message, RTM_NEWROUTE, AF_INET, RTPROT_STATIC));
+                ASSERT_OK(sd_rtnl_message_route_set_scope(message, RT_SCOPE_LINK));
+                ASSERT_OK(sd_rtnl_message_route_set_type(message, RTN_UNICAST));
+                ASSERT_OK(sd_netlink_message_append_u32(message, RTA_PRIORITY, gatewayless_priority));
+                ASSERT_OK(sd_netlink_message_append_u32(message, RTA_TABLE, RT_TABLE_MAIN));
+                ASSERT_OK(sd_netlink_message_append_u32(message, RTA_OIF, p2p_ifindex));
+                ASSERT_OK(sd_netlink_call(rtnl, message, 0, NULL));
+                message = sd_netlink_message_unref(message);
+        }
+
+        ASSERT_OK(sd_rtnl_message_new_route(rtnl, &message, RTM_NEWROUTE, AF_INET, RTPROT_STATIC));
+        ASSERT_OK(sd_rtnl_message_route_set_scope(message, RT_SCOPE_LINK));
+        ASSERT_OK(sd_rtnl_message_route_set_type(message, RTN_UNICAST));
+        ASSERT_OK(sd_netlink_message_append_u32(message, RTA_PRIORITY, 3346));
+        ASSERT_OK(sd_netlink_message_append_u32(message, RTA_TABLE, RT_TABLE_MAIN));
+        ASSERT_OK(sd_netlink_message_append_u32(message, RTA_OIF, p2p_ifindex));
+        ASSERT_OK(in_addr_from_string(AF_INET, "10.124.0.1", &u));
+        ASSERT_OK(sd_netlink_message_append_in_addr(message, RTA_PREFSRC, &u.in));
+        ASSERT_OK(sd_netlink_call(rtnl, message, 0, NULL));
+        message = sd_netlink_message_unref(message);
+
+        ASSERT_OK(sd_rtnl_message_new_route(rtnl, &message, RTM_NEWROUTE, AF_INET, RTPROT_STATIC));
+        ASSERT_OK(sd_rtnl_message_route_set_scope(message, RT_SCOPE_LINK));
+        ASSERT_OK(sd_rtnl_message_route_set_type(message, RTN_UNICAST));
+        ASSERT_OK(sd_netlink_message_append_u32(message, RTA_PRIORITY, 3347));
+        ASSERT_OK(sd_netlink_message_append_u32(message, RTA_TABLE, RT_TABLE_MAIN));
+        ASSERT_OK(sd_netlink_message_append_u32(message, RTA_OIF, p2p_ifindex));
+        ASSERT_OK(in_addr_from_string(AF_INET, "10.123.123.123", &u));
+        ASSERT_OK(sd_netlink_message_append_in_addr(message, RTA_PREFSRC, &u.in));
+        ASSERT_OK(sd_netlink_call(rtnl, message, 0, NULL));
+        message = sd_netlink_message_unref(message);
+
+        ASSERT_OK(sd_rtnl_message_new_route(rtnl, &message, RTM_NEWROUTE, AF_INET, RTPROT_STATIC));
+        ASSERT_OK(sd_rtnl_message_route_set_scope(message, RT_SCOPE_UNIVERSE));
+        ASSERT_OK(sd_rtnl_message_route_set_type(message, RTN_UNICAST));
+        ASSERT_OK(sd_netlink_message_append_u32(message, RTA_PRIORITY, 3348));
+        ASSERT_OK(sd_netlink_message_append_u32(message, RTA_TABLE, RT_TABLE_MAIN));
+        ASSERT_OK(in_addr_from_string(AF_INET6, "2001:db8:4:123::1", &u));
+        ASSERT_OK(sd_netlink_message_append_data(message, RTA_VIA,
+                                                 &(RouteVia) {
+                                                         .family = AF_INET6,
+                                                         .address = u,
+                                                 }, sizeof(RouteVia)));
+        ASSERT_OK(sd_netlink_message_append_u32(message, RTA_OIF, p2p_ifindex));
+        ASSERT_OK(sd_netlink_call(rtnl, message, 0, NULL));
+        message = sd_netlink_message_unref(message);
+
+        ASSERT_OK(sd_rtnl_message_new_route(rtnl, &message, RTM_NEWROUTE, AF_INET, RTPROT_STATIC));
+        ASSERT_OK(sd_rtnl_message_route_set_scope(message, RT_SCOPE_LINK));
+        ASSERT_OK(sd_rtnl_message_route_set_type(message, RTN_UNICAST));
+        ASSERT_OK(sd_netlink_message_append_u32(message, RTA_PRIORITY, 3349));
+        ASSERT_OK(sd_netlink_message_append_u32(message, RTA_TABLE, RT_TABLE_MAIN));
+        ASSERT_OK(sd_netlink_message_append_u32(message, RTA_OIF, p2p_ifindex));
+        ASSERT_OK(sd_netlink_call(rtnl, message, 0, NULL));
+        message = sd_netlink_message_unref(message);
+
+        ASSERT_OK(sd_rtnl_message_new_route(rtnl, &message, RTM_NEWROUTE, AF_INET, RTPROT_STATIC));
+        ASSERT_OK(sd_rtnl_message_route_set_scope(message, RT_SCOPE_LINK));
+        ASSERT_OK(sd_rtnl_message_route_set_type(message, RTN_UNICAST));
+        ASSERT_OK(sd_netlink_message_append_u32(message, RTA_PRIORITY, 3350));
+        ASSERT_OK(sd_netlink_message_append_u32(message, RTA_TABLE, RT_TABLE_MAIN));
+        ASSERT_OK(sd_netlink_message_append_u32(message, RTA_OIF, p2p_ifindex));
+        ASSERT_OK(in_addr_from_string(AF_INET, "10.123.123.123", &u));
+        ASSERT_OK(sd_netlink_message_append_in_addr(message, RTA_PREFSRC, &u.in));
+        ASSERT_OK(sd_netlink_call(rtnl, message, 0, NULL));
+        message = sd_netlink_message_unref(message);
+
+        /* Add a gateway-less default route for p2p_ifindex2 so it becomes a candidate link.
+         * This makes the address scan actually reach that interface and exercise both the
+         * broadcast rejection (255.255.255.255) and ambiguity detection (two different peers). */
+        ASSERT_OK(sd_rtnl_message_new_route(rtnl, &message, RTM_NEWROUTE, AF_INET, RTPROT_STATIC));
+        ASSERT_OK(sd_rtnl_message_route_set_scope(message, RT_SCOPE_LINK));
+        ASSERT_OK(sd_rtnl_message_route_set_type(message, RTN_UNICAST));
+        ASSERT_OK(sd_netlink_message_append_u32(message, RTA_PRIORITY, 3351));
+        ASSERT_OK(sd_netlink_message_append_u32(message, RTA_TABLE, RT_TABLE_MAIN));
+        ASSERT_OK(sd_netlink_message_append_u32(message, RTA_OIF, p2p_ifindex2));
+        ASSERT_OK(sd_netlink_call(rtnl, message, 0, NULL));
+        message = sd_netlink_message_unref(message);
+
+        /* Add a valid p2p address on p2p_ifindex2: 10.125.0.1 -> 10.125.0.2 */
+        ASSERT_OK(sd_rtnl_message_new_addr_update(rtnl, &message, p2p_ifindex2, AF_INET));
+        ASSERT_OK(sd_rtnl_message_addr_set_scope(message, RT_SCOPE_UNIVERSE));
+        ASSERT_OK(sd_rtnl_message_addr_set_prefixlen(message, 32));
+        ASSERT_OK(in_addr_from_string(AF_INET, "10.125.0.1", &u));
+        ASSERT_OK(sd_netlink_message_append_in_addr(message, IFA_LOCAL, &u.in));
+        ASSERT_OK(in_addr_from_string(AF_INET, "10.125.0.2", &u));
+        ASSERT_OK(sd_netlink_message_append_in_addr(message, IFA_ADDRESS, &u.in));
+        ASSERT_OK(sd_netlink_message_append_u32(message, IFA_FLAGS, IFA_F_NODAD));
+        ASSERT_OK(sd_netlink_call(rtnl, message, 0, NULL));
+        message = sd_netlink_message_unref(message);
+
+        /* Add a second valid p2p address with a different peer: 10.125.0.4 -> 10.126.0.2
+         * This creates ambiguity (two different peers on the same link/family), so no
+         * synthetic gateway should be published for p2p_ifindex2. */
+        ASSERT_OK(sd_rtnl_message_new_addr_update(rtnl, &message, p2p_ifindex2, AF_INET));
+        ASSERT_OK(sd_rtnl_message_addr_set_scope(message, RT_SCOPE_UNIVERSE));
+        ASSERT_OK(sd_rtnl_message_addr_set_prefixlen(message, 32));
+        ASSERT_OK(in_addr_from_string(AF_INET, "10.125.0.4", &u));
+        ASSERT_OK(sd_netlink_message_append_in_addr(message, IFA_LOCAL, &u.in));
+        ASSERT_OK(in_addr_from_string(AF_INET, "10.126.0.2", &u));
+        ASSERT_OK(sd_netlink_message_append_in_addr(message, IFA_ADDRESS, &u.in));
+        ASSERT_OK(sd_netlink_message_append_u32(message, IFA_FLAGS, IFA_F_NODAD));
+        ASSERT_OK(sd_netlink_call(rtnl, message, 0, NULL));
+        message = sd_netlink_message_unref(message);
+
+        /* Add a third p2p address with a broadcast peer: 10.125.0.3 -> 255.255.255.255
+         * This exercises the INADDR_BROADCAST rejection path. */
+        ASSERT_OK(sd_rtnl_message_new_addr_update(rtnl, &message, p2p_ifindex2, AF_INET));
+        ASSERT_OK(sd_rtnl_message_addr_set_scope(message, RT_SCOPE_UNIVERSE));
+        ASSERT_OK(sd_rtnl_message_addr_set_prefixlen(message, 32));
+        ASSERT_OK(in_addr_from_string(AF_INET, "10.125.0.3", &u));
+        ASSERT_OK(sd_netlink_message_append_in_addr(message, IFA_LOCAL, &u.in));
+        ASSERT_OK(in_addr_from_string(AF_INET, "255.255.255.255", &u));
+        ASSERT_OK(sd_netlink_message_append_in_addr(message, IFA_ADDRESS, &u.in));
+        ASSERT_OK(sd_netlink_call(rtnl, message, 0, NULL));
+        message = sd_netlink_message_unref(message);
+
+        check_local_gateway_peer(
+                        rtnl, p2p_ifindex, 0, AF_UNSPEC, gatewayless_priority, gatewayless_weight,
+                        AF_INET, "10.124.0.2", NULL);
+        check_local_gateway_peer(
+                        rtnl, p2p_ifindex, p2p_ifindex, AF_UNSPEC, gatewayless_priority, gatewayless_weight,
+                        AF_INET, "10.124.0.2", NULL);
+        check_local_gateway_peer(
+                        rtnl, p2p_ifindex, 0, AF_INET, gatewayless_priority, gatewayless_weight,
+                        AF_INET, "10.124.0.2", NULL);
+        check_local_gateway_peer(
+                        rtnl, p2p_ifindex, p2p_ifindex, AF_INET, gatewayless_priority, gatewayless_weight,
+                        AF_INET, "10.124.0.2", NULL);
+        check_local_gateway_peer(
+                        rtnl, p2p_ifindex, 0, AF_UNSPEC, 3348, 0,
+                        AF_INET6, "2001:db8:4:123::1", NULL);
+        check_local_gateway_peer(
+                        rtnl, p2p_ifindex, p2p_ifindex, AF_UNSPEC, 3348, 0,
+                        AF_INET6, "2001:db8:4:123::1", NULL);
+        check_local_gateway_peer(rtnl, p2p_ifindex, 0, AF_INET, 3346, 0, AF_INET, "10.124.0.2", "10.124.0.1");
+        check_local_gateway_peer(
+                        rtnl, p2p_ifindex, p2p_ifindex, AF_INET, 3346, 0, AF_INET, "10.124.0.2", "10.124.0.1");
+        check_no_local_gateway_with_priority(rtnl, 0, AF_UNSPEC, 2347);
+        check_no_local_gateway_with_priority(rtnl, p2p_ifindex, AF_UNSPEC, 2347);
+        check_no_local_gateway_with_priority(rtnl, 0, AF_UNSPEC, 2345);
+        check_no_local_gateway_with_priority(rtnl, p2p_ifindex, AF_UNSPEC, 2345);
+        check_no_local_gateway_with_priority(rtnl, 0, AF_UNSPEC, 3349);
+        check_no_local_gateway_with_priority(rtnl, p2p_ifindex, AF_UNSPEC, 3349);
+        check_no_local_gateway_with_priority(rtnl, 0, AF_INET, 3348);
+        check_no_local_gateway_with_priority(rtnl, p2p_ifindex, AF_INET, 3348);
+        check_no_local_gateway_with_priority(rtnl, 0, AF_INET, 3349);
+        check_no_local_gateway_with_priority(rtnl, p2p_ifindex, AF_INET, 3349);
+        check_local_gateway_peer(rtnl, p2p_ifindex, 0, AF_INET6, 2346, 0,
+                                 AF_INET6, "2001:db8:3:123::2", "2001:db8:3:123::1");
+        check_local_gateway_peer(rtnl, p2p_ifindex, p2p_ifindex, AF_INET6, 2346, 0,
+                                 AF_INET6, "2001:db8:3:123::2", "2001:db8:3:123::1");
+        check_no_local_gateway_with_priority(rtnl, 0, AF_INET, 3347);
+        check_no_local_gateway_with_priority(rtnl, p2p_ifindex, AF_INET, 3347);
+        check_no_local_gateway_with_priority(rtnl, 0, AF_INET, 2351);
+        check_no_local_gateway_with_priority(rtnl, ifindex2, AF_INET, 2351);
+        check_no_local_gateway_with_priority(rtnl, 0, AF_INET, 3350);
+        check_no_local_gateway_with_priority(rtnl, p2p_ifindex, AF_INET, 3350);
+        check_no_local_gateway_with_priority(rtnl, 0, AF_INET6, 2352);
+        check_no_local_gateway_with_priority(rtnl, p2p_ifindex, AF_INET6, 2352);
+        check_no_local_gateway_address(rtnl, 0, AF_INET, "10.125.0.2");
+        /* p2p_ifindex2 has two valid but different peers (10.125.0.2 and 10.126.0.2), so
+         * it should be marked ambiguous and no gateway should be synthesized. */
+        check_no_local_gateway_address(rtnl, p2p_ifindex2, AF_INET, "10.125.0.2");
+        check_no_local_gateway_address(rtnl, 0, AF_INET, "10.126.0.2");
+        check_no_local_gateway_address(rtnl, p2p_ifindex, AF_INET, "10.126.0.2");
+        check_no_local_gateway_address(rtnl, p2p_ifindex2, AF_INET, "10.126.0.2");
+        /* 255.255.255.255 should never be published as a gateway (broadcast address). */
+        check_no_local_gateway_address(rtnl, 0, AF_INET, "255.255.255.255");
+        check_no_local_gateway_address(rtnl, p2p_ifindex2, AF_INET, "255.255.255.255");
+        /* ::1 and ff02::1 should never be published (localhost and multicast). */
+        check_no_local_gateway_address(rtnl, 0, AF_INET6, "::1");
+        check_no_local_gateway_address(rtnl, p2p_ifindex, AF_INET6, "::1");
+        check_no_local_gateway_address(rtnl, 0, AF_INET6, "ff02::1");
+        check_no_local_gateway_address(rtnl, p2p_ifindex, AF_INET6, "ff02::1");
+        check_local_outbound_address(rtnl, 0, AF_INET, p2p_ifindex, AF_INET, "10.124.0.1", true);
+        check_local_outbound_address(rtnl, p2p_ifindex, AF_INET, p2p_ifindex, AF_INET, "10.124.0.1", true);
+        check_local_outbound_address(rtnl, 0, AF_INET6, p2p_ifindex, AF_INET6, "2001:db8:2:123::1", false);
+        check_local_outbound_address(rtnl, p2p_ifindex, AF_INET6, p2p_ifindex, AF_INET6, "2001:db8:2:123::1", false);
+        check_local_outbound_address(rtnl, 0, AF_INET6, p2p_ifindex, AF_INET6, "2001:db8:3:123::1", false);
+        check_local_outbound_address(rtnl, p2p_ifindex, AF_INET6, p2p_ifindex, AF_INET6, "2001:db8:3:123::1", false);
+
+finish:
         /* Cleanup */
+        if (p2p_ifindex2 > 0) {
+                ASSERT_OK(sd_rtnl_message_new_link(rtnl, &message, RTM_DELLINK, p2p_ifindex2));
+                ASSERT_OK(sd_netlink_call(rtnl, message, 0, NULL));
+                message = sd_netlink_message_unref(message);
+        }
+
+        if (p2p_ifindex > 0) {
+                ASSERT_OK(sd_rtnl_message_new_link(rtnl, &message, RTM_DELLINK, p2p_ifindex));
+                ASSERT_OK(sd_netlink_call(rtnl, message, 0, NULL));
+                message = sd_netlink_message_unref(message);
+        }
+
+        ASSERT_OK(sd_rtnl_message_new_link(rtnl, &message, RTM_DELLINK, ifindex2));
+        ASSERT_OK(sd_netlink_call(rtnl, message, 0, NULL));
+        message = sd_netlink_message_unref(message);
+
         ASSERT_OK(sd_rtnl_message_new_link(rtnl, &message, RTM_DELLINK, ifindex));
         ASSERT_OK(sd_netlink_call(rtnl, message, 0, NULL));
         message = sd_netlink_message_unref(message);

--- a/test/units/TEST-71-HOSTNAME.sh
+++ b/test/units/TEST-71-HOSTNAME.sh
@@ -164,7 +164,7 @@ testcase_hardware_serial() {
 }
 
 testcase_nss-myhostname() {
-    local database host i
+    local database have_p2p=0 host i
 
     if ! check_nss_module myhostname; then
         return 0
@@ -181,6 +181,16 @@ testcase_nss-myhostname() {
     done
     ip route add 10.0.0.1 dev foo
     ip route add default via 10.0.0.1 dev foo
+
+    if ip link add p2pfoo type ipip local 192.0.2.1 remote 192.0.2.2; then
+        have_p2p=1
+        trap 'ip link del p2pfoo || :' RETURN
+        ip link set up dev p2pfoo
+        ip addr add 10.1.0.1 peer 10.1.0.2 dev p2pfoo
+        ip route add default dev p2pfoo metric 2048
+    else
+        echo "Skipping p2p _gateway check: failed to create ipip link" >&2
+    fi
 
     # Note: `getent hosts` probes gethostbyname2(), whereas `getent ahosts` probes gethostbyname3()
     #       and gethostbyname4() (through getaddrinfo() -> gaih_inet() -> get_nss_addresses())
@@ -243,6 +253,12 @@ testcase_nss-myhostname() {
         run_and_grep "^10\.0\.0\.1\s+_gateway$" getent hosts -s myhostname "$host"
         run_and_grep "^10\.0\.0\.1\s+STREAM" getent ahosts -s myhostname "$host"
     done
+    if (( have_p2p )); then
+        for host in _gateway{,.} 10.1.0.2; do
+            run_and_grep "^10\.1\.0\.2\s+_gateway$" getent hosts -s myhostname "$host"
+            run_and_grep "^10\.1\.0\.2\s+STREAM" getent ahosts -s myhostname "$host"
+        done
+    fi
 
     # _outbound
     for host in _outbound{,.} 10.0.0.2; do


### PR DESCRIPTION
Gateway-less point-to-point default routes were not exposed through the _gateway pseudo-hostname. The existing implementation only reported routes with an explicit RTA_GATEWAY or RTA_VIA attribute. Consequently, PPP and similar point-to-point links could have a working default route but no _gateway or _outbound result.

Collect gateway-less default-route and nexthop candidates while processing the main routing table. Inspect the corresponding links with one RTM_GETLINK dump and only consider links marked IFF_POINTOPOINT. Read the local and peer endpoints from IFA_LOCAL and IFA_ADDRESS, then publish the peer as a synthetic gateway when it is usable and unambiguous.

Routes with RTA_PREFSRC are matched against the peer belonging to that local endpoint. Routes without RTA_PREFSRC require exactly one peer for the link and address family, avoiding an arbitrary choice when multiple peers are configured. Preserve the original route priority, nexthop weight, and preferred source address in the generated result.

Include prefsrc in address comparison and candidate identity so distinct source-specific gateways are not collapsed. Keep the existing handling of explicit RTA_GATEWAY and RTA_VIA routes unchanged, and use a single link dump instead of issuing one netlink request for every candidate link.

Update the nss-myhostname and systemd-resolved documentation and NEWS entry to describe synthesized _gateway and _outbound results. Extend the tests to cover IPv4 and IPv6 peers, multipath routes, preferred source addresses, non-point-to-point routes, ambiguous peers, invalid peer endpoints, and cleanup of test interfaces.

Closes #41271