### PR TITLE
systemctl: add new "wait" command

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -344,10 +344,6 @@ SPDX-License-Identifier: LGPL-2.1-or-later
 - repart: add MatchLabel= which matches against partition label, so that we
   truly can install different images in parallel
 
-- add "systemctl wait" or so, which does what "systemd-run --wait" does, but
-  for all units. It should be both a way to pin units into memory as well as a
-  wait to retrieve their exit data.
-
 - add "systemd-analyze debug" + AttachDebugger= in unit files: The former
   specifies a command to execute; the latter specifies that an already running
   "systemd-analyze debug" instance shall be contacted and execution paused

--- a/man/systemctl.xml
+++ b/man/systemctl.xml
@@ -571,6 +571,39 @@ Jan 12 10:46:45 example.com bluetoothd[8900]: gatt-time-server: Input/output err
           </listitem>
         </varlistentry>
         <varlistentry>
+          <term><command>wait <replaceable>UNIT</replaceable></command></term>
+
+          <listitem>
+            <para>Wait for the specified unit to terminate, i.e. to enter the <literal>inactive</literal> or
+            <literal>failed</literal> state. If the unit already terminated (or was not started yet), this
+            returns immediately. A unit that does not exist is treated like a unit that terminated
+            successfully, and a message about this is shown.</para>
+
+            <para>On exit, unless <option>--quiet</option> is specified, terse information about the unit's
+            runtime is shown, including total runtime (as well as CPU, memory, IO, and IP accounting data, if
+            the corresponding cgroup accounting settings are enabled) and the exit code and status of the
+            main process, similar to <command>systemd-run</command>'s <option>--wait</option> switch. Combine
+            with <option>--verbose</option> to also show the unit's log output while waiting.</para>
+
+            <para>The exit status of the unit is propagated: 0 is returned if the unit terminated
+            successfully, the exit status of the unit's main process if it failed with a non-zero exit code,
+            255 if it was terminated by a signal without dumping core, and a non-zero value otherwise (for
+            example if it dumped core, timed out, or was terminated via the watchdog logic).</para>
+
+            <para>Note that while waiting, the unit is referenced with the service manager (so that its final
+            state remains queriable after it terminated), which requires privileges, similarly to the other
+            unit lifecycle commands.</para>
+
+            <para>If invoked as the main process of a service with <varname>Type=notify</varname>, a
+            <literal>READY=1</literal> notification is sent once the command is fully subscribed to the unit's
+            state changes, i.e. from that point on no state change of the unit will be missed. See
+            <citerefentry><refentrytitle>systemd.service</refentrytitle><manvolnum>5</manvolnum></citerefentry>
+            for details.</para>
+
+            <xi:include href="version-info.xml" xpointer="v262"/>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
           <term><command>kill <replaceable>PATTERN</replaceable>…</command></term>
 
           <listitem>
@@ -2392,7 +2425,8 @@ Jan 12 10:46:45 example.com bluetoothd[8900]: gatt-time-server: Input/output err
         <term><option>--verbose</option></term>
 
         <listitem>
-          <para>Display unit log output while executing unit operations.</para>
+          <para>Display unit log output while executing unit operations, or while waiting with
+          <command>wait</command>.</para>
 
           <xi:include href="version-info.xml" xpointer="v258"/>
         </listitem>
@@ -3062,6 +3096,10 @@ EOF
     <para>The mapping of LSB service states to systemd unit states is imperfect, so it is better to
     not rely on those return values but to look for specific unit states and substates instead.
     </para>
+
+    <para>The <command>wait</command> command does not use the LSB codes: it propagates the exit status of
+    the waited-for unit, in the same way <command>systemd-run</command>'s <option>--wait</option> switch
+    does. See above for details.</para>
   </refsect1>
 
   <refsect1>

--- a/shell-completion/bash/systemctl.in
+++ b/shell-completion/bash/systemctl.in
@@ -63,6 +63,8 @@ __get_template_names () { __systemctl $1 list-unit-files "$2*" |
                               { while read -r a b; do [[ $a =~ @\. ]] && echo " ${a%%@.*}@"; done; }; }
 __get_active_units   () { __systemctl $1 list-units "$2*" |
                               { while read -r a b; do echo " $a"; done; }; }
+__get_loaded_units   () { __systemctl $1 list-units --all "$2*" |
+                              { while read -r a b; do echo " $a"; done; }; }
 __get_active_services() { __systemctl $1 list-units "$2*.service" |
                               { while read -r a b; do echo " $a"; done; }; }
 
@@ -134,7 +136,7 @@ _systemctl () {
                       --help -h --no-ask-password --no-block --legend=no --no-pager --no-reload --no-wall --now
                       --quiet -q --system --user --version --runtime --recursive -r --firmware-setup
                       --show-types --plain --failed --value --fail --dry-run --wait --no-warn --with-dependencies
-                      --show-transaction -T --mkdir --read-only --kernel-cmdline-reuse'
+                      --show-transaction -T --mkdir --read-only --kernel-cmdline-reuse --verbose -v'
         [ARG]='--host -H --kill-whom --property -p -P --signal -s --type -t --state --job-mode --root
                --preset-mode -n --lines -o --output -M --machine --message --timestamp --check-inhibitors --what
                --image --boot-loader-menu --boot-loader-entry --reboot-argument --kernel-cmdline --drop-in --when'
@@ -224,6 +226,7 @@ _systemctl () {
         [FAILED_UNITS]='reset-failed'
         [STARTABLE_UNITS]='start'
         [STOPPABLE_UNITS]='stop condstop kill try-restart condrestart freeze thaw'
+        [WAITABLE_UNITS]='wait'
         [ISOLATABLE_UNITS]='isolate'
         [RELOADABLE_UNITS]='reload condreload try-reload-or-restart force-reload'
         [RESTARTABLE_UNITS]='restart reload-or-restart'
@@ -315,6 +318,10 @@ _systemctl () {
 
     elif __contains_word "$verb" ${VERBS[STOPPABLE_UNITS]}; then
         comps=$( __get_stoppable_units $mode "$cur" )
+        compopt -o filenames
+
+    elif __contains_word "$verb" ${VERBS[WAITABLE_UNITS]}; then
+        comps=$( __get_loaded_units $mode "$cur" )
         compopt -o filenames
 
     elif __contains_word "$verb" ${VERBS[RELOADABLE_UNITS]}; then

--- a/shell-completion/zsh/_systemctl.in
+++ b/shell-completion/zsh/_systemctl.in
@@ -22,6 +22,7 @@
         "force-reload:Reload one or more units if possible, otherwise restart if active"
         "try-reload-or-restart:Reload one or more units if possible, otherwise restart if active"
         "isolate:Start one unit and stop all others"
+        "wait:Wait for a unit to terminate"
         "kill:Send signal to processes of a unit"
         "is-active:Check whether units are active"
         "is-failed:Check whether units are failed"
@@ -338,6 +339,15 @@ for fun in stop condstop kill try-restart condrestart freeze thaw; do
     }
 done
 
+# Completion function for WAITABLE_UNITS. "wait" takes any unit, but only ones the service manager currently
+# has loaded are useful candidates, so complete from those, without any CanStop= filtering.
+(( $+functions[_systemctl_wait] )) || _systemctl_wait()
+{
+    _systemctl_all_units
+    _wanted systemd-units expl 'unit' \
+            compadd "$@" -a - _sys_all_units || _message "no units found"
+}
+
 (( $+functions[_systemctl_service-log-level] )) ||
     _systemctl_service-log-level() {
         local -a log_levels=( emerg alert crit err warning notice info debug )
@@ -536,6 +546,7 @@ _sys_arguments=(
     '--show-types[When showing sockets, show socket type]'
     '--check-inhibitors[Specify if inhibitors should be checked]:mode:_systemctl_check_inhibitors'
     '(-q --quiet)'{-q,--quiet}'[Suppress output]'
+    '(-v --verbose)'{-v,--verbose}'[Show unit logs while executing operation]'
     '--no-warn[Suppress several warnings shown by default]'
     '--no-block[Do not wait until operation finished]'
     '--legend=no[Do not print a legend, i.e. the column headers and the footer with hints]'

--- a/src/run/run.c
+++ b/src/run/run.c
@@ -35,10 +35,8 @@
 #include "escape.h"
 #include "event-util.h"
 #include "exec-util.h"
-#include "exit-status.h"
 #include "fd-util.h"
 #include "fork-notify.h"
-#include "format-table.h"
 #include "format-util.h"
 #include "fs-util.h"
 #include "hostname-util.h"
@@ -52,11 +50,9 @@
 #include "pidref.h"
 #include "polkit-agent.h"
 #include "pretty-print.h"
-#include "process-util.h"
 #include "ptyfwd.h"
 #include "run-polkit.h"
 #include "runtime-scope.h"
-#include "signal-util.h"
 #include "special.h"
 #include "string-table.h"
 #include "string-util.h"
@@ -65,6 +61,7 @@
 #include "time-util.h"
 #include "unit-def.h"
 #include "unit-name.h"
+#include "unit-result.h"
 #include "user-util.h"
 #include "verbs.h"
 #include "virt.h"
@@ -1625,22 +1622,10 @@ typedef struct RunContext {
         sd_event_source *retry_timer;
 
         /* Current state of the unit */
-        char *active_state;
         char *job;
 
-        /* The exit data of the unit */
-        uint64_t inactive_exit_usec;
-        uint64_t inactive_enter_usec;
-        char *result;
-        uint64_t cpu_usage_nsec;
-        uint64_t memory_peak;
-        uint64_t memory_swap_peak;
-        uint64_t ip_ingress_bytes;
-        uint64_t ip_egress_bytes;
-        uint64_t io_read_bytes;
-        uint64_t io_write_bytes;
-        uint32_t exit_code;
-        uint32_t exit_status;
+        /* The final state and exit data of the unit */
+        UnitResult result;
 } RunContext;
 
 static int run_context_update(RunContext *c);
@@ -1658,9 +1643,9 @@ static void run_context_done(RunContext *c) {
         c->forward = pty_forward_free(c->forward);
         c->event = sd_event_unref(c->event);
 
-        free(c->active_state);
+        unit_result_done(&c->result);
+
         free(c->job);
-        free(c->result);
         free(c->unit);
         free(c->bus_path);
         free(c->start_job);
@@ -1762,7 +1747,7 @@ static int run_context_check_started(RunContext *c) {
                 return r;
         }
 
-        if (STRPTR_IN_SET(c->active_state, "inactive", "failed"))
+        if (STRPTR_IN_SET(c->result.active_state, "inactive", "failed"))
                 return 0; /* Already finished or failed? */
 
         /* Notify our caller that the service is now running, just in case. */
@@ -1778,7 +1763,7 @@ static void run_context_check_done(RunContext *c) {
 
         assert(c);
 
-        if (!STRPTR_IN_SET(c->active_state, "inactive", "failed") ||
+        if (!STRPTR_IN_SET(c->result.active_state, "inactive", "failed") ||
             c->start_job ||   /* our start job */
             c->job)           /* any other job */
                 return;
@@ -1820,24 +1805,12 @@ static int map_job(sd_bus *bus, const char *member, sd_bus_message *m, sd_bus_er
 static int run_context_update(RunContext *c) {
 
         static const struct bus_properties_map map[] = {
-                { "ActiveState",                     "s",    NULL,    offsetof(RunContext, active_state)        },
-                { "InactiveExitTimestampMonotonic",  "t",    NULL,    offsetof(RunContext, inactive_exit_usec)  },
-                { "InactiveEnterTimestampMonotonic", "t",    NULL,    offsetof(RunContext, inactive_enter_usec) },
-                { "Result",                          "s",    NULL,    offsetof(RunContext, result)              },
-                { "ExecMainCode",                    "i",    NULL,    offsetof(RunContext, exit_code)           },
-                { "ExecMainStatus",                  "i",    NULL,    offsetof(RunContext, exit_status)         },
-                { "CPUUsageNSec",                    "t",    NULL,    offsetof(RunContext, cpu_usage_nsec)      },
-                { "MemoryPeak",                      "t",    NULL,    offsetof(RunContext, memory_peak)         },
-                { "MemorySwapPeak",                  "t",    NULL,    offsetof(RunContext, memory_swap_peak)    },
-                { "IPIngressBytes",                  "t",    NULL,    offsetof(RunContext, ip_ingress_bytes)    },
-                { "IPEgressBytes",                   "t",    NULL,    offsetof(RunContext, ip_egress_bytes)     },
-                { "IOReadBytes",                     "t",    NULL,    offsetof(RunContext, io_read_bytes)       },
-                { "IOWriteBytes",                    "t",    NULL,    offsetof(RunContext, io_write_bytes)      },
-                { "Job",                             "(uo)", map_job, offsetof(RunContext, job)                 },
+                { "Job", "(uo)", map_job, offsetof(RunContext, job) },
                 {}
         };
 
         _cleanup_(sd_bus_error_free) sd_bus_error error = SD_BUS_ERROR_NULL;
+        _cleanup_(sd_bus_message_unrefp) sd_bus_message *reply = NULL;
         int r;
 
         assert(c);
@@ -1850,8 +1823,14 @@ static int run_context_update(RunContext *c) {
                         map,
                         BUS_MAP_STRDUP,
                         &error,
-                        NULL,
+                        &reply,
                         c);
+        if (r >= 0) {
+                /* Pick the final state and exit data from the same GetAll() reply */
+                r = sd_bus_message_rewind(reply, /* complete= */ true);
+                if (r >= 0)
+                        r = bus_message_map_all_properties(reply, unit_result_property_map, BUS_MAP_STRDUP, &error, &c->result);
+        }
         if (r < 0) {
                 /* If this is a connection error, then try to reconnect. This might be because the service
                  * manager is being restarted. Handle this gracefully. */
@@ -2148,142 +2127,6 @@ static int run_context_setup_ptyfwd(RunContext *c) {
         return 0;
 }
 
-static int run_context_show_result(RunContext *c) {
-        int r;
-
-        assert(c);
-
-        _cleanup_(table_unrefp) Table *t = table_new_vertical();
-        if (!t)
-                return log_oom();
-
-        if (!isempty(c->result)) {
-                r = table_add_many(
-                                t,
-                                TABLE_FIELD, "Finished with result",
-                                TABLE_STRING, c->result,
-                                TABLE_SET_COLOR, streq(c->result, "success") ? ansi_highlight_green() : ansi_highlight_red());
-                if (r < 0)
-                        return table_log_add_error(r);
-        }
-
-        if (c->exit_code > 0) {
-                r = table_add_cell(
-                                t,
-                                /* ret_cell= */ NULL,
-                                TABLE_FIELD,
-                                "Main processes terminated with");
-                if (r < 0)
-                        return table_log_add_error(r);
-
-                r = table_add_cell_stringf(
-                                t,
-                                /* ret_cell= */ NULL,
-                                "code=%s, status=%u/%s",
-                                sigchld_code_to_string(c->exit_code),
-                                c->exit_status,
-                                strna(c->exit_code == CLD_EXITED ?
-                                      exit_status_to_string(c->exit_status, EXIT_STATUS_FULL) :
-                                      signal_to_string(c->exit_status)));
-                if (r < 0)
-                        return table_log_add_error(r);
-        }
-
-        if (timestamp_is_set(c->inactive_enter_usec) &&
-            timestamp_is_set(c->inactive_exit_usec) &&
-            c->inactive_enter_usec > c->inactive_exit_usec) {
-                r = table_add_many(
-                                t,
-                                TABLE_FIELD, "Service runtime",
-                                TABLE_TIMESPAN_MSEC, c->inactive_enter_usec - c->inactive_exit_usec);
-                if (r < 0)
-                        return table_log_add_error(r);
-        }
-
-        if (c->cpu_usage_nsec != NSEC_INFINITY) {
-                r = table_add_many(
-                                t,
-                                TABLE_FIELD, "CPU time consumed",
-                                TABLE_TIMESPAN_MSEC, DIV_ROUND_UP(c->cpu_usage_nsec, NSEC_PER_USEC));
-                if (r < 0)
-                        return table_log_add_error(r);
-        }
-
-        if (c->memory_peak != UINT64_MAX) {
-                const char *swap;
-
-                if (c->memory_swap_peak != UINT64_MAX)
-                        swap = strjoina(" (swap: ", FORMAT_BYTES(c->memory_swap_peak), ")");
-                else
-                        swap = "";
-
-                r = table_add_cell(
-                                t,
-                                /* ret_cell= */ NULL,
-                                TABLE_FIELD, "Memory peak");
-                if (r < 0)
-                        return table_log_add_error(r);
-
-                r = table_add_cell_stringf(
-                                t,
-                                /* ret_cell= */ NULL,
-                                "%s%s",
-                                FORMAT_BYTES(c->memory_peak), swap);
-                if (r < 0)
-                        return table_log_add_error(r);
-        }
-
-        const char *ip_ingress = NULL, *ip_egress = NULL;
-        if (!IN_SET(c->ip_ingress_bytes, 0, UINT64_MAX))
-                ip_ingress = strjoina("received ", FORMAT_BYTES(c->ip_ingress_bytes));
-        if (!IN_SET(c->ip_egress_bytes, 0, UINT64_MAX))
-                ip_egress = strjoina("sent ", FORMAT_BYTES(c->ip_egress_bytes));
-
-        if (ip_ingress || ip_egress) {
-                r = table_add_cell(
-                                t,
-                                /* ret_cell= */ NULL,
-                                TABLE_FIELD, "IP Traffic");
-                if (r < 0)
-                        return table_log_add_error(r);
-
-                r = table_add_cell_stringf(
-                                t,
-                                /* ret_cell= */ NULL,
-                                "%s%s%s", strempty(ip_ingress), ip_ingress && ip_egress ? ", " : "", strempty(ip_egress));
-                if (r < 0)
-                        return table_log_add_error(r);
-        }
-
-        const char *io_read = NULL, *io_write = NULL;
-        if (!IN_SET(c->io_read_bytes, 0, UINT64_MAX))
-                io_read = strjoina("read ", FORMAT_BYTES(c->io_read_bytes));
-        if (!IN_SET(c->io_write_bytes, 0, UINT64_MAX))
-                io_write = strjoina("written ", FORMAT_BYTES(c->io_write_bytes));
-
-        if (io_read || io_write) {
-                r = table_add_cell(
-                                t,
-                                /* ret_cell= */ NULL,
-                                TABLE_FIELD, "IO Bytes");
-                if (r < 0)
-                        return table_log_add_error(r);
-
-                r = table_add_cell_stringf(
-                                t,
-                                /* ret_cell= */ NULL,
-                                "%s%s%s", strempty(io_read), io_read && io_write ? ", " : "", strempty(io_write));
-                if (r < 0)
-                        return table_log_add_error(r);
-        }
-
-        r = table_print_full(t, stderr, /* flush= */ true);
-        if (r < 0)
-                return table_log_print_error(r);
-
-        return 0;
-}
-
 static int start_transient_service(sd_bus *bus) {
         _cleanup_(sd_bus_message_unrefp) sd_bus_message *m = NULL, *reply = NULL;
         _cleanup_(sd_bus_error_free) sd_bus_error error = SD_BUS_ERROR_NULL;
@@ -2299,15 +2142,7 @@ static int start_transient_service(sd_bus *bus) {
 
         _cleanup_(run_context_done) RunContext c = {
                 .pty_fd = -EBADF,
-                .cpu_usage_nsec = NSEC_INFINITY,
-                .memory_peak = UINT64_MAX,
-                .memory_swap_peak = UINT64_MAX,
-                .ip_ingress_bytes = UINT64_MAX,
-                .ip_egress_bytes = UINT64_MAX,
-                .io_read_bytes = UINT64_MAX,
-                .io_write_bytes = UINT64_MAX,
-                .inactive_exit_usec = USEC_INFINITY,
-                .inactive_enter_usec = USEC_INFINITY,
+                .result = UNIT_RESULT_INIT,
         };
 
         if (arg_stdio == ARG_STDIO_PTY) {
@@ -2489,17 +2324,10 @@ static int start_transient_service(sd_bus *bus) {
                 fork_notify_terminate(&journal_pid);
 
                 if (arg_wait && !arg_quiet)
-                        run_context_show_result(&c);
+                        (void) unit_result_show(&c.result, stderr, arg_json_format_flags);
 
-                /* Try to propagate the service's return value. But if the service defines
-                 * e.g. SuccessExitStatus, honour this, and return 0 to mean "success". */
-                if (streq_ptr(c.result, "success"))
-                        return EXIT_SUCCESS;
-                if (streq_ptr(c.result, "exit-code") && c.exit_status > 0)
-                        return c.exit_status;
-                if (streq_ptr(c.result, "signal"))
-                        return EXIT_EXCEPTION;
-                return EXIT_FAILURE;
+                /* Try to propagate the service's return value */
+                return unit_result_to_exit_status(&c.result);
         }
 
         return EXIT_SUCCESS;

--- a/src/shared/bus-wait-for-units.c
+++ b/src/shared/bus-wait-for-units.c
@@ -47,6 +47,11 @@ typedef struct WaitForItem {
          * because we might have missed state changes in the meantime. */
         bool requery:1;
 
+        /* Set while the PropertiesChanged match installation resp. the GetAll() query are in progress, see
+         * BusWaitForUnits.n_pending */
+        bool pending_match:1;
+        bool pending_query:1;
+
         UnitResult result;
 } WaitForItem;
 
@@ -64,7 +69,49 @@ typedef struct BusWaitForUnits {
         bool has_failed:1;
         bool subscribed:1;  /* We successfully called Subscribe(), hence we should Unsubscribe() when done */
         bool reloading:1;   /* The service manager is currently reloading/reexecuting */
+        bool ready:1;       /* All asynchronous setup operations completed, and the ready callback was invoked */
+        bool setup_failed:1; /* Installing a signal match or Subscribe() failed, hence we cannot guarantee to notice all state changes */
+
+        /* Number of asynchronous setup operations (signal match installations, Subscribe(), initial GetAll()
+         * queries) that are still in progress. Once this drops to zero we consider ourselves fully set up,
+         * i.e. we'll get told about any relevant change from then on, and invoke the ready callback. */
+        unsigned n_pending;
+        bus_wait_for_units_ready_callback_t ready_callback;
+        void *ready_userdata;
 } BusWaitForUnits;
+
+static void bus_wait_for_units_pending_inc(BusWaitForUnits *d) {
+        assert(d);
+
+        /* If we were fully set up before, we no longer are, since a new setup operation is now in progress
+         * (for example because a unit was added after the fact). We'll invoke the ready callback again once
+         * it completed. */
+        if (d->n_pending == 0)
+                d->ready = false;
+
+        d->n_pending++;
+}
+
+static void bus_wait_for_units_pending_dec(BusWaitForUnits *d) {
+        assert(d);
+        assert(d->n_pending > 0);
+
+        d->n_pending--;
+
+        if (d->n_pending > 0 || d->ready)
+                return;
+
+        if (!d->bus) /* Disconnected or being torn down? Then don't bother. */
+                return;
+
+        if (d->setup_failed) /* We cannot guarantee to notice all state changes, hence never claim we do */
+                return;
+
+        d->ready = true;
+
+        if (d->ready_callback)
+                d->ready_callback(d, d->ready_userdata);
+}
 
 static WaitForItem* wait_for_item_free(WaitForItem *item) {
         int r;
@@ -89,6 +136,13 @@ static WaitForItem* wait_for_item_free(WaitForItem *item) {
                 }
 
                 assert_se(hashmap_remove_value(item->parent->items, item->bus_path, item));
+
+                /* If we are freed while setup operations are still in progress, their callbacks will never
+                 * be called, hence account for them here. */
+                if (item->pending_match)
+                        bus_wait_for_units_pending_dec(item->parent);
+                if (item->pending_query)
+                        bus_wait_for_units_pending_dec(item->parent);
         }
 
         sd_bus_slot_unref(item->slot_properties_changed);
@@ -179,6 +233,24 @@ static void wait_for_item_fail(WaitForItem *item) {
         d->has_failed = true;
 
         call_unit_callback_and_wait(d, item, false);
+        bus_wait_for_units_check_ready(d);
+}
+
+static void bus_wait_for_units_setup_failed(BusWaitForUnits *d) {
+        WaitForItem *item;
+
+        assert(d);
+
+        /* Without all signal matches in place we cannot guarantee to notice all relevant state changes, and
+         * might hence wait forever. Rather than doing that, give up on all units we are waiting for, and
+         * refuse any further ones. */
+
+        d->setup_failed = true;
+        d->has_failed = true;
+
+        while ((item = hashmap_first(d->items)))
+                call_unit_callback_and_wait(d, item, false);
+
         bus_wait_for_units_check_ready(d);
 }
 
@@ -297,6 +369,7 @@ static void wait_for_item_check_ready(WaitForItem *item) {
 }
 
 static int on_properties_changed(sd_bus_message *m, void *userdata, sd_bus_error *reterr_error);
+static int on_item_match_installed(sd_bus_message *m, void *userdata, sd_bus_error *reterr_error);
 
 static int wait_for_item_resolve_alias(WaitForItem *item) {
         _cleanup_(sd_bus_slot_unrefp) sd_bus_slot *slot = NULL;
@@ -327,6 +400,8 @@ static int wait_for_item_resolve_alias(WaitForItem *item) {
                                        "Unit %s is already being waited for under its primary name %s.",
                                        item->name, item->id);
 
+        bool bus_client = sd_bus_is_bus_client(d->bus) > 0;
+
         r = sd_bus_match_signal_async(
                         d->bus,
                         &slot,
@@ -335,7 +410,7 @@ static int wait_for_item_resolve_alias(WaitForItem *item) {
                         "org.freedesktop.DBus.Properties",
                         "PropertiesChanged",
                         on_properties_changed,
-                        /* install_callback= */ NULL,
+                        bus_client ? on_item_match_installed : NULL,
                         item);
         if (r < 0)
                 return r;
@@ -351,6 +426,13 @@ static int wait_for_item_resolve_alias(WaitForItem *item) {
         free_and_replace(item->bus_path, bus_path);
         sd_bus_slot_unref(item->slot_properties_changed);
         item->slot_properties_changed = TAKE_PTR(slot);
+
+        /* If the installation of the old match was still in progress, its callback will never be invoked
+         * now, but the new match's will be, hence the accounting stays correct in that case. */
+        if (bus_client && !item->pending_match) {
+                item->pending_match = true;
+                bus_wait_for_units_pending_inc(d);
+        }
 
         return 0;
 }
@@ -425,19 +507,28 @@ static int on_properties_changed(sd_bus_message *m, void *userdata, sd_bus_error
 
 static int on_get_all_properties(sd_bus_message *m, void *userdata, sd_bus_error *reterr_error) {
         WaitForItem *item = ASSERT_PTR(userdata);
+        BusWaitForUnits *d = ASSERT_PTR(item->parent);
         const sd_bus_error *e;
         int r;
+
+        /* Note that we only decrease the pending counter at the very end of this function, since doing so
+         * might invoke the ready callback, which might free the item (or even the whole object). Hence
+         * don't touch the item anymore after that. */
+        bool was_pending = item->pending_query;
+        item->pending_query = false;
 
         e = sd_bus_message_get_error(m);
         if (e) {
                 r = sd_bus_error_get_errno(e);
 
-                if (item->parent->reloading) {
+                if (d->reloading) {
                         /* The service manager is reloading or reexecuting right now, and might have dropped
-                         * our request on the floor. Let's try again once it is done. */
+                         * our request on the floor. Let's try again once it is done. Since we still haven't
+                         * learnt the unit's state, keep the query accounted as pending until then. */
                         log_debug_errno(r, "GetAll() failed for %s while service manager is reloading, retrying later: %s",
                                         item->bus_path, bus_error_message(e, r));
                         item->requery = true;
+                        item->pending_query = was_pending;
                         return 0;
                 }
 
@@ -445,23 +536,29 @@ static int on_get_all_properties(sd_bus_message *m, void *userdata, sd_bus_error
                                 item->bus_path, bus_error_message(e, r));
 
                 wait_for_item_fail(item);
-                return 0;
+                goto finish;
         }
 
         r = wait_for_item_parse_properties(item, m);
         if (r < 0)
                 log_debug_errno(r, "Failed to process GetAll method reply: %m");
 
+finish:
+        if (was_pending)
+                bus_wait_for_units_pending_dec(d);
+
         return 0;
 }
 
 static int wait_for_item_query(WaitForItem *item) {
+        int r;
+
         assert(item);
         assert(item->parent);
 
         item->slot_get_all = sd_bus_slot_unref(item->slot_get_all);
 
-        return sd_bus_call_method_async(
+        r = sd_bus_call_method_async(
                         item->parent->bus,
                         &item->slot_get_all,
                         "org.freedesktop.systemd1",
@@ -471,6 +568,61 @@ static int wait_for_item_query(WaitForItem *item) {
                         on_get_all_properties,
                         item,
                         "s", FLAGS_SET(item->flags, BUS_WAIT_FOR_MAINTENANCE_END) ? NULL : "org.freedesktop.systemd1.Unit");
+        if (r < 0)
+                return r;
+
+        if (!item->pending_query) {
+                item->pending_query = true;
+                bus_wait_for_units_pending_inc(item->parent);
+        }
+
+        return 0;
+}
+
+static int on_item_match_installed(sd_bus_message *m, void *userdata, sd_bus_error *reterr_error) {
+        WaitForItem *item = ASSERT_PTR(userdata);
+        const sd_bus_error *e;
+        int r;
+
+        assert(m);
+
+        e = sd_bus_message_get_error(m);
+        if (e) {
+                r = sd_bus_error_get_errno(e);
+                log_warning_errno(r, "Failed to install PropertiesChanged match for %s, giving up waiting for it: %s",
+                                  item->name, bus_error_message(e, r));
+
+                /* Without the match we'd never learn about state changes of the unit, hence give up on it.
+                 * (This frees the item, and accounts for the match installation still being pending.) */
+                wait_for_item_fail(item);
+                return 0;
+        }
+
+        if (item->pending_match) {
+                item->pending_match = false;
+                bus_wait_for_units_pending_dec(item->parent);
+        }
+
+        return 0;
+}
+
+static int on_match_installed(sd_bus_message *m, void *userdata, sd_bus_error *reterr_error) {
+        BusWaitForUnits *d = ASSERT_PTR(userdata);
+        const sd_bus_error *e;
+        int r;
+
+        assert(m);
+
+        e = sd_bus_message_get_error(m);
+        if (e) {
+                r = sd_bus_error_get_errno(e);
+                log_warning_errno(r, "Failed to install signal match, giving up waiting for units: %s",
+                                  bus_error_message(e, r));
+                bus_wait_for_units_setup_failed(d);
+        }
+
+        bus_wait_for_units_pending_dec(d);
+        return 0;
 }
 
 static int on_unit_removed(sd_bus_message *m, void *userdata, sd_bus_error *reterr_error) {
@@ -602,14 +754,14 @@ static int on_subscribe(sd_bus_message *m, void *userdata, sd_bus_error *reterr_
                  * either way. But let's leave the subscription in place in that case. */
                 if (!sd_bus_error_has_name(e, BUS_ERROR_ALREADY_SUBSCRIBED)) {
                         r = sd_bus_error_get_errno(e);
-                        log_debug_errno(r, "Failed to subscribe to service manager signals, ignoring: %s",
-                                        bus_error_message(e, r));
+                        log_warning_errno(r, "Failed to subscribe to service manager signals, giving up waiting for units: %s",
+                                          bus_error_message(e, r));
+                        bus_wait_for_units_setup_failed(d);
                 }
+        } else
+                d->subscribed = true;
 
-                return 0;
-        }
-
-        d->subscribed = true;
+        bus_wait_for_units_pending_dec(d);
         return 0;
 }
 
@@ -640,16 +792,22 @@ int bus_wait_for_units_new(sd_bus *bus, BusWaitForUnits **ret) {
         if (r < 0)
                 return r;
 
+        /* Note that the install callbacks are only ever invoked on bus client connections, since only there
+         * matches are installed server-side. Hence only count them on such connections. */
+        bool bus_client = sd_bus_is_bus_client(bus) > 0;
+
         r = bus_match_signal_async(
                         bus,
                         &d->slot_unit_removed,
                         bus_systemd_mgr,
                         "UnitRemoved",
                         on_unit_removed,
-                        /* install_callback= */ NULL,
+                        bus_client ? on_match_installed : NULL,
                         d);
         if (r < 0)
                 return r;
+        if (bus_client)
+                bus_wait_for_units_pending_inc(d);
 
         r = bus_match_signal_async(
                         bus,
@@ -657,15 +815,17 @@ int bus_wait_for_units_new(sd_bus *bus, BusWaitForUnits **ret) {
                         bus_systemd_mgr,
                         "Reloading",
                         on_reloading,
-                        /* install_callback= */ NULL,
+                        bus_client ? on_match_installed : NULL,
                         d);
         if (r < 0)
                 return r;
+        if (bus_client)
+                bus_wait_for_units_pending_inc(d);
 
         /* On reexecution the Reloading(true) signal might get lost, see on_name_owner_changed(). Hence also
          * watch the service manager's bus name. (This is only meaningful on bus client connections, as only
          * there a bus daemon exists that manages names.) */
-        if (sd_bus_is_bus_client(bus) > 0) {
+        if (bus_client) {
                 r = sd_bus_add_match_async(
                                 bus,
                                 &d->slot_name_owner_changed,
@@ -676,10 +836,11 @@ int bus_wait_for_units_new(sd_bus *bus, BusWaitForUnits **ret) {
                                 "member='NameOwnerChanged',"
                                 "arg0='org.freedesktop.systemd1'",
                                 on_name_owner_changed,
-                                /* install_callback= */ NULL,
+                                on_match_installed,
                                 d);
                 if (r < 0)
                         return r;
+                bus_wait_for_units_pending_inc(d);
         }
 
         /* The Reloading signal is only sent to subscribed clients on the API bus, hence subscribe. (The
@@ -688,9 +849,25 @@ int bus_wait_for_units_new(sd_bus *bus, BusWaitForUnits **ret) {
         r = bus_call_method_async(bus, &d->slot_subscribe, bus_systemd_mgr, "Subscribe", on_subscribe, d, NULL);
         if (r < 0)
                 return r;
+        bus_wait_for_units_pending_inc(d);
 
         *ret = TAKE_PTR(d);
         return 0;
+}
+
+void bus_wait_for_units_set_ready_callback(
+                BusWaitForUnits *d,
+                bus_wait_for_units_ready_callback_t callback,
+                void *userdata) {
+
+        assert(d);
+
+        d->ready_callback = callback;
+        d->ready_userdata = userdata;
+
+        /* If we are already fully set up, tell the caller right-away. */
+        if (d->ready && d->bus && callback)
+                callback(d, userdata);
 }
 
 BusWaitForUnits* bus_wait_for_units_free(BusWaitForUnits *d) {
@@ -724,6 +901,10 @@ int bus_wait_for_units_add_unit(
         assert(d);
         assert(unit);
         assert((flags & _BUS_WAIT_FOR_TARGET) != 0);
+
+        if (d->setup_failed)
+                return log_debug_errno(SYNTHETIC_ERRNO(ENOTCONN),
+                                       "Refusing to wait for unit %s, since setting up signal subscriptions failed.", unit);
 
         bus_path = unit_dbus_path_from_name(unit);
         if (!bus_path)
@@ -766,6 +947,15 @@ int bus_wait_for_units_add_unit(
                 item->flags |= BUS_WAIT_REFFED;
         }
 
+        r = hashmap_ensure_put(&d->items, &string_hash_ops, item->bus_path, item);
+        if (r < 0)
+                return r;
+        assert(r > 0);
+
+        item->parent = d;
+
+        bool bus_client = sd_bus_is_bus_client(d->bus) > 0;
+
         r = sd_bus_match_signal_async(
                         d->bus,
                         &item->slot_properties_changed,
@@ -774,17 +964,15 @@ int bus_wait_for_units_add_unit(
                         "org.freedesktop.DBus.Properties",
                         "PropertiesChanged",
                         on_properties_changed,
-                        NULL,
+                        bus_client ? on_item_match_installed : NULL,
                         item);
         if (r < 0)
                 return log_debug_errno(r, "Failed to request match for PropertiesChanged signal: %m");
 
-        r = hashmap_ensure_put(&d->items, &string_hash_ops, item->bus_path, item);
-        if (r < 0)
-                return r;
-        assert(r > 0);
-
-        item->parent = d;
+        if (bus_client) {
+                item->pending_match = true;
+                bus_wait_for_units_pending_inc(d);
+        }
 
         r = wait_for_item_query(item);
         if (r < 0)

--- a/src/shared/bus-wait-for-units.c
+++ b/src/shared/bus-wait-for-units.c
@@ -12,12 +12,14 @@
 #include "log.h"
 #include "string-util.h"
 #include "unit-def.h"
+#include "unit-result.h"
 
 typedef struct WaitForItem {
         BusWaitForUnits *parent;
 
         BusWaitForUnitsFlags flags;
 
+        char *name;
         char *bus_path;
 
         /* The unit's primary name, as reported by the service manager. Might differ from what the caller
@@ -26,6 +28,7 @@ typedef struct WaitForItem {
 
         sd_bus_slot *slot_get_all;
         sd_bus_slot *slot_properties_changed;
+        sd_bus_slot *slot_collect_result;
 
         bus_wait_for_units_unit_callback_t unit_callback;
         void *userdata;
@@ -43,6 +46,8 @@ typedef struct WaitForItem {
         /* Set if we should query the unit's properties again once the service manager finished reloading,
          * because we might have missed state changes in the meantime. */
         bool requery:1;
+
+        UnitResult result;
 } WaitForItem;
 
 typedef struct BusWaitForUnits {
@@ -88,7 +93,11 @@ static WaitForItem* wait_for_item_free(WaitForItem *item) {
 
         sd_bus_slot_unref(item->slot_properties_changed);
         sd_bus_slot_unref(item->slot_get_all);
+        sd_bus_slot_unref(item->slot_collect_result);
 
+        unit_result_done(&item->result);
+
+        free(item->name);
         free(item->bus_path);
         free(item->id);
         free(item->load_state);
@@ -103,7 +112,11 @@ DEFINE_TRIVIAL_CLEANUP_FUNC(WaitForItem*, wait_for_item_free);
 
 static void call_unit_callback_and_wait(BusWaitForUnits *d, WaitForItem *item, bool good) {
         if (item->unit_callback)
-                item->unit_callback(d, item->bus_path, good, item->userdata);
+                item->unit_callback(d,
+                                    item->name,
+                                    good,
+                                    FLAGS_SET(item->flags, BUS_WAIT_COLLECT_RESULT) ? &item->result : NULL,
+                                    item->userdata);
 
         wait_for_item_free(item);
 }
@@ -169,6 +182,59 @@ static void wait_for_item_fail(WaitForItem *item) {
         bus_wait_for_units_check_ready(d);
 }
 
+static int on_collect_result(sd_bus_message *m, void *userdata, sd_bus_error *reterr_error) {
+        WaitForItem *item = ASSERT_PTR(userdata);
+        BusWaitForUnits *d = ASSERT_PTR(item->parent);
+        const sd_bus_error *e;
+        bool good = true;
+        int r;
+
+        assert(m);
+
+        e = sd_bus_message_get_error(m);
+        if (e) {
+                r = sd_bus_error_get_errno(e);
+
+                if (d->reloading) {
+                        /* The service manager is reloading or reexecuting right now, and might have dropped
+                         * our request on the floor. Let's refresh the unit's properties once it is done,
+                         * which will reissue this query if the unit is still in its final state. For that
+                         * we must drop the slot here, as otherwise wait_for_item_check_ready() would
+                         * consider the query still to be in progress. */
+                        log_debug_errno(r, "Failed to query final state of unit %s while service manager is reloading, retrying later: %s",
+                                        item->name, bus_error_message(e, r));
+                        item->slot_collect_result = sd_bus_slot_unref(item->slot_collect_result);
+                        item->requery = true;
+                        return 0;
+                }
+
+                log_debug_errno(r, "Failed to query final state of unit %s: %s",
+                                item->name, bus_error_message(e, r));
+                good = false;
+        } else {
+                r = bus_message_map_all_properties(
+                                m,
+                                unit_result_property_map,
+                                BUS_MAP_STRDUP,
+                                /* reterr_error= */ NULL,
+                                &item->result);
+                if (r < 0) {
+                        log_debug_errno(r, "Failed to parse final state of unit %s: %m", item->name);
+                        good = false;
+                }
+        }
+
+        /* If we couldn't determine how the unit finished, propagate this as failure, so that callers don't
+         * mistake an empty result for a successfully collected one. */
+        if (!good)
+                d->has_failed = true;
+
+        call_unit_callback_and_wait(d, item, good);
+        bus_wait_for_units_check_ready(d);
+
+        return 0;
+}
+
 static void wait_for_item_check_ready(WaitForItem *item) {
         BusWaitForUnits *d;
 
@@ -196,6 +262,34 @@ static void wait_for_item_check_ready(WaitForItem *item) {
                         d->has_failed = true;
                 else if (!streq_ptr(item->active_state, "inactive"))
                         return;
+        }
+
+        if (FLAGS_SET(item->flags, BUS_WAIT_COLLECT_RESULT)) {
+                int r;
+
+                if (item->slot_collect_result) /* Query already in progress? */
+                        return;
+
+                /* Now that the unit is done, query its final state and resource usage asynchronously, so
+                 * that we can pass the data to the callback. Note that a full GetAll() query covering all
+                 * interfaces is necessary for this, since the various resource accounting properties are not
+                 * included in PropertiesChanged signals. */
+                r = sd_bus_call_method_async(
+                                d->bus,
+                                &item->slot_collect_result,
+                                "org.freedesktop.systemd1",
+                                item->bus_path,
+                                "org.freedesktop.DBus.Properties",
+                                "GetAll",
+                                on_collect_result,
+                                item,
+                                "s", "");
+                if (r < 0) {
+                        log_debug_errno(r, "Failed to query final state of unit %s: %m", item->name);
+                        wait_for_item_fail(item);
+                }
+
+                return;
         }
 
         call_unit_callback_and_wait(d, item, true);
@@ -231,7 +325,7 @@ static int wait_for_item_resolve_alias(WaitForItem *item) {
         if (hashmap_contains(d->items, bus_path))
                 return log_debug_errno(SYNTHETIC_ERRNO(EEXIST),
                                        "Unit %s is already being waited for under its primary name %s.",
-                                       item->bus_path, item->id);
+                                       item->name, item->id);
 
         r = sd_bus_match_signal_async(
                         d->bus,
@@ -252,7 +346,7 @@ static int wait_for_item_resolve_alias(WaitForItem *item) {
 
         assert_se(hashmap_remove_value(d->items, item->bus_path, item));
 
-        log_debug("Unit %s is an alias of %s, tracking the latter from now on.", item->bus_path, item->id);
+        log_debug("Unit %s is an alias of %s, tracking the latter from now on.", item->name, item->id);
 
         free_and_replace(item->bus_path, bus_path);
         sd_bus_slot_unref(item->slot_properties_changed);
@@ -286,7 +380,7 @@ static int wait_for_item_parse_properties(WaitForItem *item, sd_bus_message *m) 
         if (r < 0) {
                 /* Without a signal match on the right object path we'd never learn about state changes of
                  * the unit, hence give up on it. */
-                log_debug_errno(r, "Failed to track unit %s under its primary name: %m", item->bus_path);
+                log_debug_errno(r, "Failed to track unit %s under its primary name: %m", item->name);
                 wait_for_item_fail(item);
                 return 0;
         }
@@ -296,7 +390,7 @@ static int wait_for_item_parse_properties(WaitForItem *item, sd_bus_message *m) 
                  * whether it came back. If it isn't loaded anymore it's gone for good. */
                 if (streq_ptr(item->load_state, "not-found")) {
                         log_error("Unit %s has been removed during service manager reload while waiting for it.",
-                                  item->bus_path);
+                                  item->name);
                         wait_for_item_fail(item);
                         return 0;
                 }
@@ -648,7 +742,12 @@ int bus_wait_for_units_add_unit(
                 .unit_callback = callback,
                 .userdata = userdata,
                 .job_id = UINT32_MAX,
+                .result = UNIT_RESULT_INIT,
         };
+
+        item->name = strdup(unit);
+        if (!item->name)
+                return -ENOMEM;
 
         if (!FLAGS_SET(item->flags, BUS_WAIT_REFFED)) {
                 r = sd_bus_call_method_async(

--- a/src/shared/bus-wait-for-units.c
+++ b/src/shared/bus-wait-for-units.c
@@ -3,7 +3,9 @@
 #include "sd-bus.h"
 
 #include "alloc-util.h"
+#include "bus-common-errors.h"
 #include "bus-error.h"
+#include "bus-locator.h"
 #include "bus-map-properties.h"
 #include "bus-wait-for-units.h"
 #include "hashmap.h"
@@ -18,26 +20,45 @@ typedef struct WaitForItem {
 
         char *bus_path;
 
+        /* The unit's primary name, as reported by the service manager. Might differ from what the caller
+         * specified, if the caller used an alias. */
+        char *id;
+
         sd_bus_slot *slot_get_all;
         sd_bus_slot *slot_properties_changed;
 
         bus_wait_for_units_unit_callback_t unit_callback;
         void *userdata;
 
+        char *load_state;
         char *active_state;
         uint32_t job_id;
         char *clean_result;
         char *live_mount_result;
+
+        /* Set if we saw a UnitRemoved signal for this unit while the service manager was reloading, and
+         * haven't verified yet whether it came back after the reload finished. */
+        bool removed:1;
+
+        /* Set if we should query the unit's properties again once the service manager finished reloading,
+         * because we might have missed state changes in the meantime. */
+        bool requery:1;
 } WaitForItem;
 
 typedef struct BusWaitForUnits {
         sd_bus *bus;
         sd_bus_slot *slot_disconnected;
+        sd_bus_slot *slot_subscribe;
+        sd_bus_slot *slot_unit_removed;
+        sd_bus_slot *slot_reloading;
+        sd_bus_slot *slot_name_owner_changed;
 
         Hashmap *items;
 
         BusWaitForUnitsState state;
         bool has_failed:1;
+        bool subscribed:1;  /* We successfully called Subscribe(), hence we should Unsubscribe() when done */
+        bool reloading:1;   /* The service manager is currently reloading/reexecuting */
 } BusWaitForUnits;
 
 static WaitForItem* wait_for_item_free(WaitForItem *item) {
@@ -69,6 +90,8 @@ static WaitForItem* wait_for_item_free(WaitForItem *item) {
         sd_bus_slot_unref(item->slot_get_all);
 
         free(item->bus_path);
+        free(item->id);
+        free(item->load_state);
         free(item->active_state);
         free(item->clean_result);
         free(item->live_mount_result);
@@ -91,6 +114,10 @@ static void bus_wait_for_units_clear(BusWaitForUnits *d) {
         assert(d);
 
         d->slot_disconnected = sd_bus_slot_unref(d->slot_disconnected);
+        d->slot_subscribe = sd_bus_slot_unref(d->slot_subscribe);
+        d->slot_unit_removed = sd_bus_slot_unref(d->slot_unit_removed);
+        d->slot_reloading = sd_bus_slot_unref(d->slot_reloading);
+        d->slot_name_owner_changed = sd_bus_slot_unref(d->slot_name_owner_changed);
         d->bus = sd_bus_unref(d->bus);
 
         while ((item = hashmap_first(d->items)))
@@ -112,48 +139,6 @@ static int match_disconnected(sd_bus_message *m, void *userdata, sd_bus_error *r
         return 0;
 }
 
-int bus_wait_for_units_new(sd_bus *bus, BusWaitForUnits **ret) {
-        _cleanup_(bus_wait_for_units_freep) BusWaitForUnits *d = NULL;
-        int r;
-
-        assert(bus);
-        assert(ret);
-
-        d = new(BusWaitForUnits, 1);
-        if (!d)
-                return -ENOMEM;
-
-        *d = (BusWaitForUnits) {
-                .state = BUS_WAIT_SUCCESS,
-                .bus = sd_bus_ref(bus),
-        };
-
-        r = sd_bus_match_signal_async(
-                        bus,
-                        &d->slot_disconnected,
-                        "org.freedesktop.DBus.Local",
-                        NULL,
-                        "org.freedesktop.DBus.Local",
-                        "Disconnected",
-                        match_disconnected, NULL, d);
-        if (r < 0)
-                return r;
-
-        *ret = TAKE_PTR(d);
-        return 0;
-}
-
-BusWaitForUnits* bus_wait_for_units_free(BusWaitForUnits *d) {
-        if (!d)
-                return NULL;
-
-        bus_wait_for_units_clear(d);
-        sd_bus_slot_unref(d->slot_disconnected);
-        sd_bus_unref(d->bus);
-
-        return mfree(d);
-}
-
 static bool bus_wait_for_units_is_ready(BusWaitForUnits *d) {
         assert(d);
 
@@ -170,6 +155,18 @@ static void bus_wait_for_units_check_ready(BusWaitForUnits *d) {
                 return;
 
         d->state = d->has_failed ? BUS_WAIT_FAILURE : BUS_WAIT_SUCCESS;
+}
+
+static void wait_for_item_fail(WaitForItem *item) {
+        BusWaitForUnits *d;
+
+        assert(item);
+        assert_se(d = item->parent);
+
+        d->has_failed = true;
+
+        call_unit_callback_and_wait(d, item, false);
+        bus_wait_for_units_check_ready(d);
 }
 
 static void wait_for_item_check_ready(WaitForItem *item) {
@@ -205,9 +202,70 @@ static void wait_for_item_check_ready(WaitForItem *item) {
         bus_wait_for_units_check_ready(d);
 }
 
+static int on_properties_changed(sd_bus_message *m, void *userdata, sd_bus_error *reterr_error);
+
+static int wait_for_item_resolve_alias(WaitForItem *item) {
+        _cleanup_(sd_bus_slot_unrefp) sd_bus_slot *slot = NULL;
+        _cleanup_free_ char *bus_path = NULL;
+        BusWaitForUnits *d;
+        int r;
+
+        assert(item);
+        assert_se(d = item->parent);
+
+        /* The caller might have specified the unit by one of its aliases, but the service manager emits its
+         * signals (PropertiesChanged, UnitNew, UnitRemoved) with the object path derived from the unit's
+         * primary name only. Hence, once we learnt the primary name from the GetAll() reply, switch over to
+         * it, so that our signal match and our lookups line up with what the service manager sends. */
+
+        if (!item->id)
+                return 0;
+
+        bus_path = unit_dbus_path_from_name(item->id);
+        if (!bus_path)
+                return -ENOMEM;
+
+        if (streq(bus_path, item->bus_path))
+                return 0;
+
+        if (hashmap_contains(d->items, bus_path))
+                return log_debug_errno(SYNTHETIC_ERRNO(EEXIST),
+                                       "Unit %s is already being waited for under its primary name %s.",
+                                       item->bus_path, item->id);
+
+        r = sd_bus_match_signal_async(
+                        d->bus,
+                        &slot,
+                        "org.freedesktop.systemd1",
+                        bus_path,
+                        "org.freedesktop.DBus.Properties",
+                        "PropertiesChanged",
+                        on_properties_changed,
+                        /* install_callback= */ NULL,
+                        item);
+        if (r < 0)
+                return r;
+
+        r = hashmap_put(d->items, bus_path, item);
+        if (r < 0)
+                return r;
+
+        assert_se(hashmap_remove_value(d->items, item->bus_path, item));
+
+        log_debug("Unit %s is an alias of %s, tracking the latter from now on.", item->bus_path, item->id);
+
+        free_and_replace(item->bus_path, bus_path);
+        sd_bus_slot_unref(item->slot_properties_changed);
+        item->slot_properties_changed = TAKE_PTR(slot);
+
+        return 0;
+}
+
 static int wait_for_item_parse_properties(WaitForItem *item, sd_bus_message *m) {
 
         static const struct bus_properties_map map[] = {
+                { "Id",              "s",    NULL,                offsetof(WaitForItem, id)                },
+                { "LoadState",       "s",    NULL,                offsetof(WaitForItem, load_state)        },
                 { "ActiveState",     "s",    NULL,                offsetof(WaitForItem, active_state)      },
                 { "Job",             "(uo)", bus_map_job_id,      offsetof(WaitForItem, job_id)            },
                 { "CleanResult",     "s",    NULL,                offsetof(WaitForItem, clean_result)      },
@@ -223,6 +281,28 @@ static int wait_for_item_parse_properties(WaitForItem *item, sd_bus_message *m) 
         r = bus_message_map_all_properties(m, map, BUS_MAP_STRDUP, NULL, item);
         if (r < 0)
                 return r;
+
+        r = wait_for_item_resolve_alias(item);
+        if (r < 0) {
+                /* Without a signal match on the right object path we'd never learn about state changes of
+                 * the unit, hence give up on it. */
+                log_debug_errno(r, "Failed to track unit %s under its primary name: %m", item->bus_path);
+                wait_for_item_fail(item);
+                return 0;
+        }
+
+        if (item->removed) {
+                /* The unit was removed while the service manager was reloading, and we are now checking
+                 * whether it came back. If it isn't loaded anymore it's gone for good. */
+                if (streq_ptr(item->load_state, "not-found")) {
+                        log_error("Unit %s has been removed during service manager reload while waiting for it.",
+                                  item->bus_path);
+                        wait_for_item_fail(item);
+                        return 0;
+                }
+
+                item->removed = false;
+        }
 
         wait_for_item_check_ready(item);
         return 0;
@@ -256,16 +336,21 @@ static int on_get_all_properties(sd_bus_message *m, void *userdata, sd_bus_error
 
         e = sd_bus_message_get_error(m);
         if (e) {
-                BusWaitForUnits *d = item->parent;
-
-                d->has_failed = true;
-
                 r = sd_bus_error_get_errno(e);
+
+                if (item->parent->reloading) {
+                        /* The service manager is reloading or reexecuting right now, and might have dropped
+                         * our request on the floor. Let's try again once it is done. */
+                        log_debug_errno(r, "GetAll() failed for %s while service manager is reloading, retrying later: %s",
+                                        item->bus_path, bus_error_message(e, r));
+                        item->requery = true;
+                        return 0;
+                }
+
                 log_debug_errno(r, "GetAll() failed for %s: %s",
                                 item->bus_path, bus_error_message(e, r));
 
-                call_unit_callback_and_wait(d, item, false);
-                bus_wait_for_units_check_ready(d);
+                wait_for_item_fail(item);
                 return 0;
         }
 
@@ -274,6 +359,261 @@ static int on_get_all_properties(sd_bus_message *m, void *userdata, sd_bus_error
                 log_debug_errno(r, "Failed to process GetAll method reply: %m");
 
         return 0;
+}
+
+static int wait_for_item_query(WaitForItem *item) {
+        assert(item);
+        assert(item->parent);
+
+        item->slot_get_all = sd_bus_slot_unref(item->slot_get_all);
+
+        return sd_bus_call_method_async(
+                        item->parent->bus,
+                        &item->slot_get_all,
+                        "org.freedesktop.systemd1",
+                        item->bus_path,
+                        "org.freedesktop.DBus.Properties",
+                        "GetAll",
+                        on_get_all_properties,
+                        item,
+                        "s", FLAGS_SET(item->flags, BUS_WAIT_FOR_MAINTENANCE_END) ? NULL : "org.freedesktop.systemd1.Unit");
+}
+
+static int on_unit_removed(sd_bus_message *m, void *userdata, sd_bus_error *reterr_error) {
+        BusWaitForUnits *d = ASSERT_PTR(userdata);
+        const char *id, *path;
+        WaitForItem *item;
+        int r;
+
+        assert(m);
+
+        r = sd_bus_message_read(m, "so", &id, &path);
+        if (r < 0) {
+                log_debug_errno(r, "Failed to parse UnitRemoved signal, ignoring: %m");
+                return 0;
+        }
+
+        item = hashmap_get(d->items, path);
+        if (!item)
+                return 0;
+
+        if (d->reloading) {
+                /* While the service manager is reloading or reexecuting it removes all units and adds them
+                 * back once it finished deserializing its state. Hence, don't fail right away, but remember
+                 * the fact, and check again once reloading is complete. */
+                log_debug("Unit %s has been removed while the service manager is reloading, deferring.", id);
+                item->removed = true;
+                return 0;
+        }
+
+        log_error("Unit %s has been removed while waiting for it.", id);
+        wait_for_item_fail(item);
+
+        return 0;
+}
+
+static int on_reloading(sd_bus_message *m, void *userdata, sd_bus_error *reterr_error) {
+        BusWaitForUnits *d = ASSERT_PTR(userdata);
+        WaitForItem *item;
+        int b, r;
+
+        assert(m);
+
+        r = sd_bus_message_read(m, "b", &b);
+        if (r < 0) {
+                log_debug_errno(r, "Failed to parse Reloading signal, ignoring: %m");
+                return 0;
+        }
+
+        if (b) {
+                log_debug("Service manager is reloading, deferring UnitRemoved handling.");
+                d->reloading = true;
+                return 0;
+        }
+
+        if (!d->reloading)
+                return 0;
+
+        log_debug("Service manager finished reloading, checking for removed units.");
+        d->reloading = false;
+
+        /* Reloading is complete. Any unit that was removed in the meantime typically has been added back
+         * right after, but we cannot rely on being told about that: after a reexecution the service manager
+         * doesn't send UnitNew for the units it deserialized, since at that point nobody is subscribed to
+         * its signals yet. Hence query the properties of those units again, which tells us whether they are
+         * still loaded, and refreshes our knowledge about them, since we might have missed state changes in
+         * the meantime. */
+        HASHMAP_FOREACH(item, d->items) {
+                if (item->removed)
+                        item->requery = true;
+
+                if (!item->requery)
+                        continue;
+
+                item->requery = false;
+
+                r = wait_for_item_query(item);
+                if (r < 0) {
+                        /* Without a fresh query we'd never learn about state changes we missed during the
+                         * reload, hence give up on this unit. */
+                        log_debug_errno(r, "Failed to request properties of unit %s: %m", item->bus_path);
+                        wait_for_item_fail(item);
+                }
+        }
+
+        return 0;
+}
+
+static int on_name_owner_changed(sd_bus_message *m, void *userdata, sd_bus_error *reterr_error) {
+        BusWaitForUnits *d = ASSERT_PTR(userdata);
+        const char *name, *old_owner, *new_owner;
+        int r;
+
+        assert(m);
+
+        r = sd_bus_message_read(m, "sss", &name, &old_owner, &new_owner);
+        if (r < 0) {
+                log_debug_errno(r, "Failed to parse NameOwnerChanged signal, ignoring: %m");
+                return 0;
+        }
+
+        if (!streq(name, "org.freedesktop.systemd1") || !isempty(new_owner))
+                return 0;
+
+        if (d->reloading)
+                return 0;
+
+        /* The service manager gave up its bus name, which happens when it reexecutes: it sends
+         * Reloading(true) right before, but without going through its event loop again, hence that signal
+         * might never make it to the bus. The bus daemon however reliably tells us about the loss of the
+         * name, hence use that as fallback to detect reexecution, and handle it the same way as a reload.
+         * Once the service manager is back it will send us Reloading(false), since it keeps track of its
+         * subscribers across reexecution. */
+        log_debug("Service manager released its bus name, assuming it is reexecuting, deferring UnitRemoved handling.");
+        d->reloading = true;
+
+        return 0;
+}
+
+static int on_subscribe(sd_bus_message *m, void *userdata, sd_bus_error *reterr_error) {
+        BusWaitForUnits *d = ASSERT_PTR(userdata);
+        const sd_bus_error *e;
+        int r;
+
+        assert(m);
+
+        e = sd_bus_message_get_error(m);
+        if (e) {
+                /* If the caller already subscribed on this connection, that's fine, we'll get the signals
+                 * either way. But let's leave the subscription in place in that case. */
+                if (!sd_bus_error_has_name(e, BUS_ERROR_ALREADY_SUBSCRIBED)) {
+                        r = sd_bus_error_get_errno(e);
+                        log_debug_errno(r, "Failed to subscribe to service manager signals, ignoring: %s",
+                                        bus_error_message(e, r));
+                }
+
+                return 0;
+        }
+
+        d->subscribed = true;
+        return 0;
+}
+
+int bus_wait_for_units_new(sd_bus *bus, BusWaitForUnits **ret) {
+        _cleanup_(bus_wait_for_units_freep) BusWaitForUnits *d = NULL;
+        int r;
+
+        assert(bus);
+        assert(ret);
+
+        d = new(BusWaitForUnits, 1);
+        if (!d)
+                return -ENOMEM;
+
+        *d = (BusWaitForUnits) {
+                .state = BUS_WAIT_SUCCESS,
+                .bus = sd_bus_ref(bus),
+        };
+
+        r = sd_bus_match_signal_async(
+                        bus,
+                        &d->slot_disconnected,
+                        "org.freedesktop.DBus.Local",
+                        NULL,
+                        "org.freedesktop.DBus.Local",
+                        "Disconnected",
+                        match_disconnected, NULL, d);
+        if (r < 0)
+                return r;
+
+        r = bus_match_signal_async(
+                        bus,
+                        &d->slot_unit_removed,
+                        bus_systemd_mgr,
+                        "UnitRemoved",
+                        on_unit_removed,
+                        /* install_callback= */ NULL,
+                        d);
+        if (r < 0)
+                return r;
+
+        r = bus_match_signal_async(
+                        bus,
+                        &d->slot_reloading,
+                        bus_systemd_mgr,
+                        "Reloading",
+                        on_reloading,
+                        /* install_callback= */ NULL,
+                        d);
+        if (r < 0)
+                return r;
+
+        /* On reexecution the Reloading(true) signal might get lost, see on_name_owner_changed(). Hence also
+         * watch the service manager's bus name. (This is only meaningful on bus client connections, as only
+         * there a bus daemon exists that manages names.) */
+        if (sd_bus_is_bus_client(bus) > 0) {
+                r = sd_bus_add_match_async(
+                                bus,
+                                &d->slot_name_owner_changed,
+                                "type='signal',"
+                                "sender='org.freedesktop.DBus',"
+                                "path='/org/freedesktop/DBus',"
+                                "interface='org.freedesktop.DBus',"
+                                "member='NameOwnerChanged',"
+                                "arg0='org.freedesktop.systemd1'",
+                                on_name_owner_changed,
+                                /* install_callback= */ NULL,
+                                d);
+                if (r < 0)
+                        return r;
+        }
+
+        /* The Reloading signal is only sent to subscribed clients on the API bus, hence subscribe. (The
+         * UnitRemoved signal is also sent to clients holding a reference on the unit, which we always do,
+         * but subscribing covers it too.) */
+        r = bus_call_method_async(bus, &d->slot_subscribe, bus_systemd_mgr, "Subscribe", on_subscribe, d, NULL);
+        if (r < 0)
+                return r;
+
+        *ret = TAKE_PTR(d);
+        return 0;
+}
+
+BusWaitForUnits* bus_wait_for_units_free(BusWaitForUnits *d) {
+        int r;
+
+        if (!d)
+                return NULL;
+
+        if (d->subscribed && d->bus) {
+                r = bus_call_method_async(d->bus, NULL, bus_systemd_mgr, "Unsubscribe", NULL, NULL, NULL);
+                if (r < 0)
+                        log_debug_errno(r, "Failed to unsubscribe from service manager signals, ignoring: %m");
+        }
+
+        bus_wait_for_units_clear(d);
+
+        return mfree(d);
 }
 
 int bus_wait_for_units_add_unit(
@@ -340,26 +680,18 @@ int bus_wait_for_units_add_unit(
         if (r < 0)
                 return log_debug_errno(r, "Failed to request match for PropertiesChanged signal: %m");
 
-        r = sd_bus_call_method_async(
-                        d->bus,
-                        &item->slot_get_all,
-                        "org.freedesktop.systemd1",
-                        item->bus_path,
-                        "org.freedesktop.DBus.Properties",
-                        "GetAll",
-                        on_get_all_properties,
-                        item,
-                        "s", FLAGS_SET(item->flags, BUS_WAIT_FOR_MAINTENANCE_END) ? NULL : "org.freedesktop.systemd1.Unit");
-        if (r < 0)
-                return log_debug_errno(r, "Failed to request properties of unit %s: %m", unit);
-
         r = hashmap_ensure_put(&d->items, &string_hash_ops, item->bus_path, item);
         if (r < 0)
                 return r;
         assert(r > 0);
 
-        d->state = BUS_WAIT_RUNNING;
         item->parent = d;
+
+        r = wait_for_item_query(item);
+        if (r < 0)
+                return log_debug_errno(r, "Failed to request properties of unit %s: %m", unit);
+
+        d->state = BUS_WAIT_RUNNING;
         TAKE_PTR(item);
 
         return 1;

--- a/src/shared/bus-wait-for-units.h
+++ b/src/shared/bus-wait-for-units.h
@@ -32,6 +32,13 @@ typedef void (*bus_wait_for_units_unit_callback_t)(
                 UnitResult *result,
                 void *userdata);
 
+/* Invoked once all asynchronous setup operations completed, i.e. once we are subscribed to all relevant
+ * signals and have retrieved the initial state of all units added so far. From that point on no relevant
+ * state change will go unnoticed. If further units are added later on, the callback is invoked again once
+ * their setup completed, too. It is never invoked if any of the setup operations failed; instead all units
+ * are reported as failed via their unit callbacks in that case. */
+typedef void (*bus_wait_for_units_ready_callback_t)(BusWaitForUnits *d, void *userdata);
+
 int bus_wait_for_units_new(sd_bus *bus, BusWaitForUnits **ret);
 
 BusWaitForUnits* bus_wait_for_units_free(BusWaitForUnits *d);
@@ -42,6 +49,11 @@ int bus_wait_for_units_add_unit(
                 const char *unit,
                 BusWaitForUnitsFlags flags,
                 bus_wait_for_units_unit_callback_t callback,
+                void *userdata);
+
+void bus_wait_for_units_set_ready_callback(
+                BusWaitForUnits *d,
+                bus_wait_for_units_ready_callback_t callback,
                 void *userdata);
 
 int bus_wait_for_units_run(BusWaitForUnits *d);

--- a/src/shared/bus-wait-for-units.h
+++ b/src/shared/bus-wait-for-units.h
@@ -18,10 +18,19 @@ typedef enum BusWaitForUnitsFlags {
         BUS_WAIT_FOR_INACTIVE        = 1 << 1, /* Wait until the unit is back in inactive or dead state */
         BUS_WAIT_NO_JOB              = 1 << 2, /* Wait until there's no more job pending */
         BUS_WAIT_REFFED              = 1 << 3, /* The unit is already reffed with RefUnit() */
+        BUS_WAIT_COLLECT_RESULT      = 1 << 4, /* Query the unit's final state and resource usage once done,
+                                                * and pass it to the callback */
         _BUS_WAIT_FOR_TARGET         = BUS_WAIT_FOR_MAINTENANCE_END|BUS_WAIT_FOR_INACTIVE|BUS_WAIT_NO_JOB,
 } BusWaitForUnitsFlags;
 
-typedef void (*bus_wait_for_units_unit_callback_t)(BusWaitForUnits *d, const char *unit_path, bool good, void *userdata);
+/* Note: 'result' is non-NULL only if BUS_WAIT_COLLECT_RESULT was set for the unit. The callback may take
+ * ownership of its contents via TAKE_STRUCT(). */
+typedef void (*bus_wait_for_units_unit_callback_t)(
+                BusWaitForUnits *d,
+                const char *unit,
+                bool good,
+                UnitResult *result,
+                void *userdata);
 
 int bus_wait_for_units_new(sd_bus *bus, BusWaitForUnits **ret);
 

--- a/src/shared/forward.h
+++ b/src/shared/forward.h
@@ -94,6 +94,7 @@ typedef struct Tpm2Context Tpm2Context;
 typedef struct Tpm2Handle Tpm2Handle;
 typedef struct Tpm2PCRValue Tpm2PCRValue;
 typedef struct UnitInfo UnitInfo;
+typedef struct UnitResult UnitResult;
 typedef struct UserRecord UserRecord;
 typedef struct Verb Verb;
 typedef struct VeritySettings VeritySettings;

--- a/src/shared/meson.build
+++ b/src/shared/meson.build
@@ -215,6 +215,7 @@ shared_sources = files(
         'tsm-report.c',
         'udev-util.c',
         'unit-file.c',
+        'unit-result.c',
         'user-record-nss.c',
         'user-record-show.c',
         'user-record.c',

--- a/src/shared/unit-result.c
+++ b/src/shared/unit-result.c
@@ -1,0 +1,198 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include "sd-json.h"
+
+#include "ansi-color.h"
+#include "bus-map-properties.h"
+#include "exit-status.h"
+#include "format-table.h"
+#include "format-util.h"
+#include "log.h"
+#include "process-util.h"
+#include "signal-util.h"
+#include "string-util.h"
+#include "time-util.h"
+#include "unit-result.h"
+
+void unit_result_done(UnitResult *u) {
+        assert(u);
+
+        u->load_state = mfree(u->load_state);
+        u->active_state = mfree(u->active_state);
+        u->result = mfree(u->result);
+}
+
+const struct bus_properties_map unit_result_property_map[] = {
+        { "LoadState",                       "s", NULL, offsetof(UnitResult, load_state)          },
+        { "ActiveState",                     "s", NULL, offsetof(UnitResult, active_state)        },
+        { "InactiveExitTimestampMonotonic",  "t", NULL, offsetof(UnitResult, inactive_exit_usec)  },
+        { "InactiveEnterTimestampMonotonic", "t", NULL, offsetof(UnitResult, inactive_enter_usec) },
+        { "Result",                          "s", NULL, offsetof(UnitResult, result)              },
+        { "ExecMainCode",                    "i", NULL, offsetof(UnitResult, exit_code)           },
+        { "ExecMainStatus",                  "i", NULL, offsetof(UnitResult, exit_status)         },
+        { "CPUUsageNSec",                    "t", NULL, offsetof(UnitResult, cpu_usage_nsec)      },
+        { "MemoryPeak",                      "t", NULL, offsetof(UnitResult, memory_peak)         },
+        { "MemorySwapPeak",                  "t", NULL, offsetof(UnitResult, memory_swap_peak)    },
+        { "IPIngressBytes",                  "t", NULL, offsetof(UnitResult, ip_ingress_bytes)    },
+        { "IPEgressBytes",                   "t", NULL, offsetof(UnitResult, ip_egress_bytes)     },
+        { "IOReadBytes",                     "t", NULL, offsetof(UnitResult, io_read_bytes)       },
+        { "IOWriteBytes",                    "t", NULL, offsetof(UnitResult, io_write_bytes)      },
+        {}
+};
+
+int unit_result_show(const UnitResult *u, FILE *f, sd_json_format_flags_t json_format_flags) {
+        int r;
+
+        assert(u);
+        assert(f);
+
+        _cleanup_(table_unrefp) Table *t = table_new_vertical();
+        if (!t)
+                return log_oom();
+
+        if (!isempty(u->result)) {
+                r = table_add_many(
+                                t,
+                                TABLE_FIELD, "Finished with result",
+                                TABLE_STRING, u->result,
+                                TABLE_SET_COLOR, streq(u->result, "success") ? ansi_highlight_green() : ansi_highlight_red());
+                if (r < 0)
+                        return table_log_add_error(r);
+        }
+
+        if (u->exit_code > 0) {
+                r = table_add_cell(
+                                t,
+                                /* ret_cell= */ NULL,
+                                TABLE_FIELD,
+                                "Main processes terminated with");
+                if (r < 0)
+                        return table_log_add_error(r);
+
+                r = table_add_cell_stringf(
+                                t,
+                                /* ret_cell= */ NULL,
+                                "code=%s, status=%i/%s",
+                                strna(sigchld_code_to_string(u->exit_code)),
+                                u->exit_status,
+                                strna(u->exit_code == CLD_EXITED ?
+                                      exit_status_to_string(u->exit_status, EXIT_STATUS_FULL) :
+                                      signal_to_string(u->exit_status)));
+                if (r < 0)
+                        return table_log_add_error(r);
+        }
+
+        if (timestamp_is_set(u->inactive_enter_usec) &&
+            timestamp_is_set(u->inactive_exit_usec) &&
+            u->inactive_enter_usec > u->inactive_exit_usec) {
+                r = table_add_many(
+                                t,
+                                TABLE_FIELD, "Service runtime",
+                                TABLE_TIMESPAN_MSEC, u->inactive_enter_usec - u->inactive_exit_usec);
+                if (r < 0)
+                        return table_log_add_error(r);
+        }
+
+        if (u->cpu_usage_nsec != NSEC_INFINITY) {
+                r = table_add_many(
+                                t,
+                                TABLE_FIELD, "CPU time consumed",
+                                TABLE_TIMESPAN_MSEC, DIV_ROUND_UP(u->cpu_usage_nsec, NSEC_PER_USEC));
+                if (r < 0)
+                        return table_log_add_error(r);
+        }
+
+        if (u->memory_peak != UINT64_MAX) {
+                const char *swap;
+
+                if (u->memory_swap_peak != UINT64_MAX)
+                        swap = strjoina(" (swap: ", FORMAT_BYTES(u->memory_swap_peak), ")");
+                else
+                        swap = "";
+
+                r = table_add_cell(
+                                t,
+                                /* ret_cell= */ NULL,
+                                TABLE_FIELD, "Memory peak");
+                if (r < 0)
+                        return table_log_add_error(r);
+
+                r = table_add_cell_stringf(
+                                t,
+                                /* ret_cell= */ NULL,
+                                "%s%s",
+                                FORMAT_BYTES(u->memory_peak), swap);
+                if (r < 0)
+                        return table_log_add_error(r);
+        }
+
+        const char *ip_ingress = NULL, *ip_egress = NULL;
+        if (!IN_SET(u->ip_ingress_bytes, 0, UINT64_MAX))
+                ip_ingress = strjoina("received ", FORMAT_BYTES(u->ip_ingress_bytes));
+        if (!IN_SET(u->ip_egress_bytes, 0, UINT64_MAX))
+                ip_egress = strjoina("sent ", FORMAT_BYTES(u->ip_egress_bytes));
+
+        if (ip_ingress || ip_egress) {
+                r = table_add_cell(
+                                t,
+                                /* ret_cell= */ NULL,
+                                TABLE_FIELD, "IP Traffic");
+                if (r < 0)
+                        return table_log_add_error(r);
+
+                r = table_add_cell_stringf(
+                                t,
+                                /* ret_cell= */ NULL,
+                                "%s%s%s", strempty(ip_ingress), ip_ingress && ip_egress ? ", " : "", strempty(ip_egress));
+                if (r < 0)
+                        return table_log_add_error(r);
+        }
+
+        const char *io_read = NULL, *io_write = NULL;
+        if (!IN_SET(u->io_read_bytes, 0, UINT64_MAX))
+                io_read = strjoina("read ", FORMAT_BYTES(u->io_read_bytes));
+        if (!IN_SET(u->io_write_bytes, 0, UINT64_MAX))
+                io_write = strjoina("written ", FORMAT_BYTES(u->io_write_bytes));
+
+        if (io_read || io_write) {
+                r = table_add_cell(
+                                t,
+                                /* ret_cell= */ NULL,
+                                TABLE_FIELD, "IO Bytes");
+                if (r < 0)
+                        return table_log_add_error(r);
+
+                r = table_add_cell_stringf(
+                                t,
+                                /* ret_cell= */ NULL,
+                                "%s%s%s", strempty(io_read), io_read && io_write ? ", " : "", strempty(io_write));
+                if (r < 0)
+                        return table_log_add_error(r);
+        }
+
+        if (sd_json_format_enabled(json_format_flags))
+                r = table_print_json(t, f, json_format_flags);
+        else
+                r = table_print_full(t, f, /* flush= */ true);
+        if (r < 0)
+                return table_log_print_error(r);
+
+        return 0;
+}
+
+int unit_result_to_exit_status(const UnitResult *u) {
+        assert(u);
+
+        /* Converts the result of a unit into an exit status to return, propagating the unit's main process
+         * exit status where we can. If the unit defines e.g. SuccessExitStatus=, honour this, and return 0
+         * to mean "success". */
+
+        if (streq_ptr(u->result, "success"))
+                return EXIT_SUCCESS;
+        if (streq_ptr(u->result, "exit-code") && u->exit_status > 0)
+                return u->exit_status;
+        if (streq_ptr(u->result, "signal"))
+                return EXIT_EXCEPTION;
+
+        return EXIT_FAILURE;
+}

--- a/src/shared/unit-result.h
+++ b/src/shared/unit-result.h
@@ -1,0 +1,47 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#pragma once
+
+#include "bus-map-properties.h"
+#include "forward.h"
+
+/* The final state of a unit that terminated, and the resources it consumed while running, as queried from
+ * the unit's bus object. */
+typedef struct UnitResult {
+        char *load_state;
+        char *active_state;
+        char *result;
+        int exit_code;                  /* CLD_* of the main process */
+        int exit_status;
+        usec_t inactive_exit_usec;
+        usec_t inactive_enter_usec;
+        uint64_t cpu_usage_nsec;
+        uint64_t memory_peak;
+        uint64_t memory_swap_peak;
+        uint64_t ip_ingress_bytes;
+        uint64_t ip_egress_bytes;
+        uint64_t io_read_bytes;
+        uint64_t io_write_bytes;
+} UnitResult;
+
+#define UNIT_RESULT_INIT                                \
+        (UnitResult) {                                  \
+                .inactive_exit_usec = USEC_INFINITY,    \
+                .inactive_enter_usec = USEC_INFINITY,   \
+                .cpu_usage_nsec = NSEC_INFINITY,        \
+                .memory_peak = UINT64_MAX,              \
+                .memory_swap_peak = UINT64_MAX,         \
+                .ip_ingress_bytes = UINT64_MAX,         \
+                .ip_egress_bytes = UINT64_MAX,          \
+                .io_read_bytes = UINT64_MAX,            \
+                .io_write_bytes = UINT64_MAX,           \
+        }
+
+void unit_result_done(UnitResult *u);
+
+/* Note: the property mapping calls only write the fields actually found in the reply, hence the structure
+ * must be initialized with UNIT_RESULT_INIT before mapping properties into it. */
+extern const struct bus_properties_map unit_result_property_map[];
+
+int unit_result_show(const UnitResult *u, FILE *f, sd_json_format_flags_t json_format_flags);
+
+int unit_result_to_exit_status(const UnitResult *u);

--- a/src/systemctl/fuzz-systemctl-parse-argv.c
+++ b/src/systemctl/fuzz-systemctl-parse-argv.c
@@ -54,6 +54,7 @@ _alias_(verb_noop)
         verb_start_system_special,
         verb_switch_root,
         verb_trivial_method,
+        verb_wait,
         verb_whoami;
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {

--- a/src/systemctl/meson.build
+++ b/src/systemctl/meson.build
@@ -28,6 +28,7 @@ systemctl_sources = files(
         'systemctl-start-special.c',
         'systemctl-switch-root.c',
         'systemctl-trivial-method.c',
+        'systemctl-wait.c',
         'systemctl-whoami.c',
 )
 systemctl_export_sources = files(

--- a/src/systemctl/systemctl-wait.c
+++ b/src/systemctl/systemctl-wait.c
@@ -1,0 +1,137 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include <stdio.h>
+
+#include "sd-daemon.h"
+#include "sd-json.h"
+
+#include "alloc-util.h"
+#include "bus-wait-for-units.h"
+#include "fork-notify.h"
+#include "log.h"
+#include "output-mode.h"
+#include "pidref.h"
+#include "runtime-scope.h"
+#include "string-util.h"
+#include "systemctl.h"
+#include "systemctl-util.h"
+#include "systemctl-wait.h"
+#include "unit-name.h"
+#include "unit-result.h"
+
+typedef struct WaitContext {
+        UnitResult result;
+        bool good;
+} WaitContext;
+
+static void wait_context_done(WaitContext *c) {
+        assert(c);
+
+        unit_result_done(&c->result);
+}
+
+static void wait_unit_callback(BusWaitForUnits *d, const char *unit, bool good, UnitResult *result, void *userdata) {
+        WaitContext *c = ASSERT_PTR(userdata);
+
+        c->good = good;
+
+        if (result) {
+                unit_result_done(&c->result);
+                c->result = TAKE_STRUCT(*result);
+        }
+}
+
+static void wait_ready_callback(BusWaitForUnits *d, void *userdata) {
+        /* We are now subscribed to all relevant signals and know the current state of the unit, i.e. from
+         * here on we won't miss any state change. If we are running as a Type=notify service, let the service
+         * manager know, so that callers can synchronize on this. */
+        (void) sd_notify(/* unset_environment= */ false, "READY=1");
+}
+
+int verb_wait(int argc, char *argv[], uintptr_t _data, void *userdata) {
+        /* Note that the watcher must be declared after the context, since freeing it invokes the callback
+         * with the context as userdata for any unit still queued, hence it must be destroyed first. */
+        _cleanup_(wait_context_done) WaitContext c = {
+                .result = UNIT_RESULT_INIT,
+        };
+        _cleanup_(bus_wait_for_units_freep) BusWaitForUnits *w = NULL;
+        _cleanup_free_ char *name = NULL;
+        sd_bus *bus;
+        int r;
+
+        if (arg_no_block)
+                return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "--no-block may not be combined with 'wait', refusing.");
+
+        r = unit_name_mangle_with_suffix(argv[1], /* operation= */ NULL, arg_quiet ? 0 : UNIT_NAME_MANGLE_WARN, ".service", &name);
+        if (r < 0)
+                return log_error_errno(r, "Failed to mangle unit name: %m");
+
+        if (unit_name_is_valid(name, UNIT_NAME_TEMPLATE))
+                return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "Cannot wait for template unit %s.", name);
+
+        /* We need the full bus for this, since we reference the unit with RefUnit(), so that it is not
+         * released while we are waiting for it, and its final state remains queriable. */
+        r = acquire_bus(BUS_FULL, &bus);
+        if (r < 0)
+                return r;
+
+        polkit_agent_open_maybe();
+
+        r = bus_wait_for_units_new(bus, &w);
+        if (r < 0)
+                return log_error_errno(r, "Failed to allocate unit watch context: %m");
+
+        r = bus_wait_for_units_add_unit(
+                        w,
+                        name,
+                        BUS_WAIT_FOR_INACTIVE|BUS_WAIT_NO_JOB|BUS_WAIT_COLLECT_RESULT,
+                        wait_unit_callback,
+                        &c);
+        if (r < 0)
+                return log_error_errno(r, "Failed to watch unit %s: %m", name);
+
+        bus_wait_for_units_set_ready_callback(w, wait_ready_callback, /* userdata= */ NULL);
+
+        _cleanup_(fork_notify_terminate) PidRef journal_pid = PIDREF_NULL;
+        if (arg_verbose)
+                (void) journal_fork(arg_runtime_scope, STRV_MAKE(name), arg_output, &journal_pid);
+
+        r = bus_wait_for_units_run(w);
+        if (r < 0)
+                return log_error_errno(r, "Failed to wait for unit %s: %m", name);
+
+        /* Close the journal watch logic before we output the exit summary */
+        fork_notify_terminate(&journal_pid);
+
+        /* Send out READY=1 here. This might be redundant, because wait_ready_callback() already sent it
+         * out. But this might also not be redundant, as we might have completed work before all signal
+         * matches have been successfully installed. Since sending this out twice doesn't hurt, let's
+         * generate it in both cases. */
+        (void) sd_notify(/* unset_environment= */ false, "READY=1");
+
+        if (!c.good)
+                return log_error_errno(SYNTHETIC_ERRNO(EIO), "Failed to wait for unit %s to terminate.", name);
+
+        /* A unit that does not exist is treated like one that already terminated successfully. */
+        if (streq_ptr(c.result.load_state, "not-found")) {
+                if (!arg_quiet)
+                        printf("Unit %s does not exist, treating as terminated.\n", name);
+
+                return EXIT_SUCCESS;
+        }
+
+        if (!arg_quiet)
+                (void) unit_result_show(
+                                &c.result,
+                                stdout,
+                                OUTPUT_MODE_IS_JSON(arg_output) ?
+                                output_mode_to_json_format_flags(arg_output) | SD_JSON_FORMAT_COLOR_AUTO :
+                                SD_JSON_FORMAT_OFF);
+
+        /* Some unit types (e.g. targets or slices) do not have a Result property. For those, go by the unit
+         * state instead. */
+        if (isempty(c.result.result))
+                return streq_ptr(c.result.active_state, "inactive") ? EXIT_SUCCESS : EXIT_FAILURE;
+
+        return unit_result_to_exit_status(&c.result);
+}

--- a/src/systemctl/systemctl-wait.h
+++ b/src/systemctl/systemctl-wait.h
@@ -1,0 +1,6 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#pragma once
+
+#include "forward.h"
+
+int verb_wait(int argc, char *argv[], uintptr_t _data, void *userdata);

--- a/src/systemctl/systemctl.c
+++ b/src/systemctl/systemctl.c
@@ -954,6 +954,8 @@ VERB_SCOPE(, verb_start,             "try-reload-or-restart", "UNIT…\0", 2,   
            "If active, reload one or more units, if supported, otherwise restart");
 VERB_SCOPE(, verb_start,             "isolate",          "UNIT\0",       2,        2,        VERB_ONLINE_ONLY,
            "Start one unit and stop all others");
+VERB_SCOPE(, verb_wait,              "wait",             "UNIT\0",       2,        2,        VERB_ONLINE_ONLY,
+           "Wait for a unit to terminate, i.e. enter inactive or failed state");
 VERB_SCOPE(, verb_kill,              "kill",             "UNIT…\0",      2,        VERB_ANY, VERB_ONLINE_ONLY,
            "Send signal to processes of a unit");
 VERB_SCOPE(, verb_clean_or_freeze,   "clean",            "UNIT…\0",      2,        VERB_ANY, VERB_ONLINE_ONLY,

--- a/test/units/TEST-03-JOBS.sh
+++ b/test/units/TEST-03-JOBS.sh
@@ -19,6 +19,18 @@ at_exit() {
 
     systemctl log-level "$ORIG_LOG_LEVEL"
 
+    # The "systemctl wait" subtest leaves units in failed state behind (wait-sigkill.service may even still
+    # be running its "sleep 60" if the subtest aborted midway), which would leak into the remaining subtests
+    # of this file, hence clean up unconditionally here.
+    systemctl stop wait2.service wait5fail.service wait-exit7.service wait-sigkill.service wait-log.service wait-gc.service wait-watcher.service
+    systemctl reset-failed wait2.service wait5fail.service wait-exit7.service wait-sigkill.service wait-log.service wait-gc.service wait-watcher.service
+    rm -f /tmp/wait-log.fifo
+
+    if [[ -e /etc/dbus-1/system.d/systemd-test-deny-ref.conf ]]; then
+        rm -f /etc/dbus-1/system.d/systemd-test-deny-ref.conf
+        systemctl reload dbus.service
+    fi
+
     if [[ -v UNIT_NAME && -e /run/systemd/system/"$UNIT_NAME" ]]; then
         systemctl stop "$UNIT_NAME"
         rm -f /run/systemd/system/"$UNIT_NAME"
@@ -115,6 +127,133 @@ START_SEC=$(date -u '+%s')
 END_SEC=$(date -u '+%s')
 ELAPSED=$((END_SEC-START_SEC))
 [[ "$ELAPSED" -ge 5 ]]
+
+# Test "systemctl wait"
+# An already inactive unit terminates the wait immediately, successfully
+timeout 5 systemctl wait wait2.service
+
+# A running unit is waited for until it terminates
+systemctl --no-block start wait2.service
+START_SEC=$(date -u '+%s')
+timeout 10 systemctl wait wait2.service
+END_SEC=$(date -u '+%s')
+ELAPSED=$((END_SEC-START_SEC))
+[[ "$ELAPSED" -ge 1 ]]
+
+# The exit status of the unit's main process is propagated
+systemctl --no-block start wait5fail.service
+assert_rc 1 timeout 10 systemctl wait wait5fail.service
+systemd-run --no-block --unit=wait-exit7.service bash -c 'sleep 2; exit 7'
+assert_rc 7 timeout 10 systemctl wait wait-exit7.service
+# ... with termination by signal reported as 255
+systemd-run --unit=wait-sigkill.service sleep 60
+systemctl kill --signal=SIGKILL wait-sigkill.service
+assert_rc 255 timeout 10 systemctl wait wait-sigkill.service
+
+# A summary is shown on stdout, unless --quiet is given
+systemctl --no-block start wait2.service
+timeout 10 systemctl wait wait2.service | grep "Finished with result" >/dev/null
+systemctl --no-block start wait2.service
+OUT="$(timeout 10 systemctl --quiet wait wait2.service)"
+[[ -z "$OUT" ]]
+
+# --verbose forwards the unit's log output. To make this race-free, run "systemctl wait" as a Type=notify
+# service: it sends READY=1 once it is fully set up, including the journal follow logic, hence any log output
+# of the unit generated after systemd-run returned is guaranteed to be caught. Block the unit on a FIFO until
+# then, so that it doesn't log too early.
+mkfifo /tmp/wait-log.fifo
+systemd-run --unit=wait-log.service bash -c 'read -r </tmp/wait-log.fifo; echo hello-from-wait'
+systemd-run --unit=wait-watcher.service --service-type=notify systemctl --verbose wait wait-log.service
+INVOCATION_ID="$(systemctl show --property=InvocationID --value wait-watcher.service)"
+echo go >/tmp/wait-log.fifo
+timeout 10 systemctl wait wait-watcher.service
+journalctl --sync
+journalctl -b _SYSTEMD_INVOCATION_ID="$INVOCATION_ID" | grep hello-from-wait >/dev/null
+rm /tmp/wait-log.fifo
+
+# A non-existent unit is treated as terminated successfully, with a message in place of the summary
+systemctl wait nonexistent.service | grep "does not exist" >/dev/null
+OUT="$(systemctl --quiet wait nonexistent.service)"
+[[ -z "$OUT" ]]
+
+# A unit type without a Result property (e.g. a target) exits successfully once inactive
+timeout 5 systemctl wait hello-after-sleep.target
+
+# Template unit names are refused
+(! systemctl wait 'foo@.service')
+
+# Test that "systemctl wait" notices if the unit it waits for is removed from the service manager while
+# waiting. Normally "systemctl wait" pins the unit via Ref(), so that it is not garbage collected before its
+# final state was collected. Hence deny Ref() via D-Bus policy, and make the unit be garbage collected
+# aggressively via CollectMode=inactive-or-failed. "systemctl wait" itself runs as a Type=notify service: it
+# sends READY=1 once it is fully subscribed to the unit's state changes, so that we can synchronize on that.
+mkdir -p /etc/dbus-1/system.d/
+cat >/etc/dbus-1/system.d/systemd-test-deny-ref.conf <<EOF
+<?xml version="1.0"?>
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+        "https://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+        <policy context="mandatory">
+                <deny send_destination="org.freedesktop.systemd1" send_interface="org.freedesktop.systemd1.Unit" send_member="Ref"/>
+        </policy>
+</busconfig>
+EOF
+systemctl reload dbus.service
+
+systemd-run --unit=wait-gc.service --property=CollectMode=inactive-or-failed sleep infinity
+systemd-run --unit=wait-watcher.service --service-type=notify systemctl wait wait-gc.service
+systemctl is-active wait-watcher.service
+INVOCATION_ID="$(systemctl show --property=InvocationID --value wait-watcher.service)"
+# Stopping the unit makes it disappear right-away, which "systemctl wait" must notice and report as failure
+systemctl stop wait-gc.service
+assert_rc 1 timeout 10 systemctl wait wait-watcher.service
+journalctl --sync
+journalctl -b _SYSTEMD_INVOCATION_ID="$INVOCATION_ID" | grep "has been removed while waiting for it" >/dev/null
+systemctl reset-failed wait-watcher.service
+
+# A daemon-reload while waiting removes and re-adds the unit, which must not confuse "systemctl wait"
+systemd-run --unit=wait-gc.service --property=CollectMode=inactive-or-failed sleep infinity
+systemd-run --unit=wait-watcher.service --service-type=notify systemctl wait wait-gc.service
+INVOCATION_ID="$(systemctl show --property=InvocationID --value wait-watcher.service)"
+systemctl daemon-reload
+systemctl is-active wait-watcher.service
+systemctl is-active wait-gc.service
+# ... but once the unit is stopped and garbage collected, "systemctl wait" must notice again
+systemctl stop wait-gc.service
+assert_rc 1 timeout 10 systemctl wait wait-watcher.service
+journalctl --sync
+journalctl -b _SYSTEMD_INVOCATION_ID="$INVOCATION_ID" | grep "has been removed while waiting for it" >/dev/null
+(! journalctl -b _SYSTEMD_INVOCATION_ID="$INVOCATION_ID" | grep "removed during service manager reload" >/dev/null)
+systemctl reset-failed wait-watcher.service
+
+# With Ref() allowed again the unit is pinned, and hence not garbage collected before its final state was
+# collected, even with an aggressive CollectMode= and a daemon-reload while waiting
+rm /etc/dbus-1/system.d/systemd-test-deny-ref.conf
+systemctl reload dbus.service
+
+systemd-run --unit=wait-gc.service --property=CollectMode=inactive-or-failed sleep infinity
+systemd-run --unit=wait-watcher.service --service-type=notify systemctl wait wait-gc.service
+INVOCATION_ID="$(systemctl show --property=InvocationID --value wait-watcher.service)"
+systemctl daemon-reload
+systemctl is-active wait-watcher.service
+systemctl stop wait-gc.service
+timeout 10 systemctl wait wait-watcher.service
+journalctl --sync
+journalctl -b _SYSTEMD_INVOCATION_ID="$INVOCATION_ID" | grep "Finished with result: success" >/dev/null
+
+# The same must hold for a daemon-reexec, where the Reloading(true) signal might not reach "systemctl wait",
+# and it has to fall back to noticing the loss of the service manager's bus name instead
+systemd-run --unit=wait-gc.service --property=CollectMode=inactive-or-failed sleep infinity
+systemd-run --unit=wait-watcher.service --service-type=notify systemctl wait wait-gc.service
+INVOCATION_ID="$(systemctl show --property=InvocationID --value wait-watcher.service)"
+systemctl daemon-reexec
+systemctl is-active wait-watcher.service
+systemctl is-active wait-gc.service
+systemctl stop wait-gc.service
+timeout 10 systemctl wait wait-watcher.service
+journalctl --sync
+journalctl -b _SYSTEMD_INVOCATION_ID="$INVOCATION_ID" | grep "Finished with result: success" >/dev/null
+(! journalctl -b _SYSTEMD_INVOCATION_ID="$INVOCATION_ID" | grep "removed during service manager reload" >/dev/null)
 
 # Test time-limited scopes
 START_SEC=$(date -u '+%s')


### PR DESCRIPTION
systemctl: add new "systemctl wait" command
   
It's quite useful being able to wait for a unit to be terminated and see
its exit data, just like we do it for systemd-run, without triggering
any other operation (which is what systemctl stop would do).

Fixes: #32017