### PR TITLE
resolved: fix mDNS maintenance schedule for large TTLs and refreshed records

### DIFF
--- a/src/resolve/resolved-dns-browse-services.c
+++ b/src/resolve/resolved-dns-browse-services.c
@@ -15,6 +15,7 @@
 #include "resolved-manager.h"
 #include "string-table.h"
 #include "string-util.h"
+#include "time-util.h"
 
 typedef enum BrowseServiceUpdateEvent {
         BROWSE_SERVICE_UPDATE_ADDED,
@@ -60,7 +61,21 @@ static inline int DNS_RECORD_TTL_STATE_TO_PERCENT(DnsRecordTTLState ttl_state) {
         return ttl_percent_table[ttl_state];
 }
 
-static usec_t mdns_maintenance_next_time(usec_t until, uint32_t ttl, DnsRecordTTLState ttl_state) {
+/* The maintenance points and the jitter below are fractions of the record's lifetime, but they are
+ * anchored at 'until'. Hence take the lifetime to be the part of it that is actually cached, i.e. what
+ * is left until 'until': the cache caps entries at CACHE_TTL_MAX_USEC (see calculate_until_valid())
+ * while the TTL taken off the network is not capped at all, and a browse subscription may also start
+ * in the middle of a record's lifetime. Anchoring fractions of the raw TTL at 'until' would put the
+ * maintenance queries in the past or past cache expiry, where they are never sent. The TTL is an upper
+ * bound for it, and note the cast: it is a 32-bit value taken directly off the network, and the
+ * arithmetic on the percentages below wraps if it is left at 32 bits. */
+static usec_t mdns_maintenance_lifetime(const DnsResourceRecord *rr, usec_t until, usec_t usec) {
+        assert(rr);
+
+        return MIN((usec_t) rr->ttl * USEC_PER_SEC, usec_sub_unsigned(until, usec));
+}
+
+static usec_t mdns_maintenance_next_time(usec_t until, usec_t lifetime, DnsRecordTTLState ttl_state) {
         assert(ttl_state >= DNS_RECORD_TTL_STATE_80_PERCENT);
         assert(ttl_state < _DNS_RECORD_TTL_STATE_MAX);
 
@@ -68,14 +83,91 @@ static usec_t mdns_maintenance_next_time(usec_t until, uint32_t ttl, DnsRecordTT
         assert(percent > 0);
         assert(percent <= 100);
 
-        return usec_sub_unsigned(until, (100 - percent) * ttl * USEC_PER_SEC / 100);
+        return usec_sub_unsigned(until, (100 - percent) * lifetime / 100);
 }
 
 /* RFC 6762 section 5.2
  * A random variation of 2% of the record TTL should
  * be added to maintenance queries. */
-static usec_t mdns_maintenance_jitter(uint32_t ttl) {
-        return random_u64_range(2 * ttl * USEC_PER_SEC / 100);
+static usec_t mdns_maintenance_jitter(usec_t lifetime) {
+        usec_t range = 2 * lifetime / 100;
+
+        /* Note that random_u64_range(0) returns a value from the full 64-bit range rather than 0. */
+        if (range == 0)
+                return 0;
+
+        return random_u64_range(range);
+}
+
+/* The maintenance points are fractions of the record's remaining cached lifetime, and each dispatch
+ * schedules the next one from the time it actually runs at. Requiring every point to be at least this
+ * far ahead hence also bounds the interval between two consecutive maintenance queries: a short
+ * remaining window would otherwise squeeze all five points into it - with 5 s left they come out 250 ms
+ * apart, and the 2% jitter is far too small to spread them - and each of them is a multicast query plus
+ * a full reconciliation of the browser's service list, none of which could plausibly be answered and
+ * re-cached before that window is over anyway. */
+#define MDNS_MAINTENANCE_MIN_GAP_USEC (1 * USEC_PER_SEC)
+
+/* Returns the time the maintenance event for 'service' is to be armed at, scheduling from the TTL state
+ * '*ttl_state' and storing the state the returned time belongs to back in it. Maintenance queries are
+ * issued at 80% of the record's cached lifetime and at 5% increments from there up to 100%. RFC 6762
+ * section 5.2. Points that have already elapsed, or that are less than MDNS_MAINTENANCE_MIN_GAP_USEC
+ * ahead, are skipped: arming the source there would only make it fire immediately, or in a rapid burst,
+ * and walk the remaining increments without any of the queries having a chance to be answered. Note
+ * that the state is not committed to 'service' here, so that callers can do so only once the source is
+ * actually armed. */
+static usec_t mdns_maintenance_schedule(
+                const DnssdDiscoveredService *service,
+                usec_t usec,
+                DnsRecordTTLState *ttl_state) {
+
+        assert(service);
+        assert(ttl_state);
+        assert(*ttl_state >= DNS_RECORD_TTL_STATE_80_PERCENT);
+        assert(*ttl_state < _DNS_RECORD_TTL_STATE_MAX);
+
+        /* An 'until' that is not a proper timestamp leaves no schedule to lay out: for USEC_INFINITY
+         * every maintenance point comes out as USEC_INFINITY as well, which is sd-event's "never fires"
+         * value and would leave the service with an armed but dead source - and dns_answer_add_extend()
+         * and friends do default 'until' to USEC_INFINITY. Likewise, with none of the cached lifetime
+         * left all five points coincide with 'until', so there is no query that could still be answered
+         * and re-cached in time. Either way just revisit the cache, at 'until' if that is still ahead
+         * and promptly otherwise. */
+        if (!timestamp_is_set(service->until) || service->lifetime == 0) {
+                usec_t prompt = usec_add(usec, USEC_PER_SEC);
+
+                *ttl_state = DNS_RECORD_TTL_STATE_100_PERCENT;
+                return timestamp_is_set(service->until) ? MAX(service->until, prompt) : prompt;
+        }
+
+        usec_t next_time = 0;
+        DnsRecordTTLState state = *ttl_state;
+
+        for (; state < _DNS_RECORD_TTL_STATE_MAX; state++) {
+                next_time = mdns_maintenance_next_time(service->until, service->lifetime, state);
+                if (next_time >= usec_add(usec, MDNS_MAINTENANCE_MIN_GAP_USEC))
+                        break;
+        }
+
+        if (state == _DNS_RECORD_TTL_STATE_MAX) {
+                /* Not one maintenance point is far enough ahead to arm the source for: the cached
+                 * lifetime is over, or what is left of it is too short to spread the remaining points
+                 * over. Just revisit the cache promptly, and without jitter: no query is sent at that
+                 * point anymore. */
+                *ttl_state = DNS_RECORD_TTL_STATE_100_PERCENT;
+                return usec_add(usec, USEC_PER_SEC);
+        }
+
+        *ttl_state = state;
+
+        if (state == DNS_RECORD_TTL_STATE_100_PERCENT)
+                /* The 100% event only revisits the cache, hence no jitter here either: it would just
+                 * push the cleanup of the expired entry further past 'until'. Note that the source is
+                 * armed with the default accuracy, so it may still be dispatched up to 250 ms late;
+                 * this only avoids adding a multiple of that on top. */
+                return next_time;
+
+        return usec_add(next_time, mdns_maintenance_jitter(service->lifetime));
 }
 
 static void mdns_maintenance_query_complete(DnsQuery *q) {
@@ -103,34 +195,20 @@ static void mdns_maintenance_query_complete(DnsQuery *q) {
                 return (void) log_error_errno(r, "Failed to revisit cache for family %s: %m", af_to_name(query->answer_family));
 }
 
-static int mdns_maintenance_query(sd_event_source *s, uint64_t usec, void *userdata) {
-        DnssdDiscoveredService *service = ASSERT_PTR(userdata);
-        _cleanup_(dns_query_freep) DnsQuery *q = NULL;
+static int mdns_maintenance_query(sd_event_source *s, uint64_t usec, void *userdata);
+
+/* Arms the maintenance event source of 'service' for the first maintenance point at or after 'usec',
+ * scheduling from the TTL state 'ttl_state', and commits the state that point belongs to. The state is
+ * only committed once the source is armed, and the source is left disabled if it is not, so that the
+ * time the source is armed at and 'service->rr_ttl_state' cannot disagree. */
+int mdns_service_arm_maintenance(DnssdDiscoveredService *service, usec_t usec, DnsRecordTTLState ttl_state) {
         int r;
 
-        /* Check if the TTL state has reached the maximum value, then revisit
-         * cache */
-        if (service->rr_ttl_state++ == DNS_RECORD_TTL_STATE_100_PERCENT)
-                return mdns_browser_revisit_cache(service->service_browser, service->family);
+        assert(service);
+        assert(service->service_browser);
+        assert(service->service_browser->manager);
 
-        /* Create a new DNS query */
-        r = dns_query_new(
-                        service->service_browser->manager,
-                        &q,
-                        service->service_browser->question_utf8,
-                        service->service_browser->question_idna,
-                        /* question_bypass= */ NULL,
-                        service->ifindex,
-                        service->service_browser->flags);
-        if (r < 0)
-                return log_error_errno(r, "Failed to create mDNS query for maintenance: %m");
-
-        q->complete = mdns_maintenance_query_complete;
-        q->service_browser_request = dns_service_browser_ref(service->service_browser);
-        q->dnsservice_request = dnssd_discovered_service_ref(service);
-
-        /* Schedule the next maintenance query based on the TTL */
-        usec_t next_time = mdns_maintenance_next_time(service->until, service->rr->ttl, service->rr_ttl_state);
+        usec_t next_time = mdns_maintenance_schedule(service, usec, &ttl_state);
 
         r = event_reset_time(
                         service->service_browser->manager->event,
@@ -143,13 +221,73 @@ static int mdns_maintenance_query(sd_event_source *s, uint64_t usec, void *userd
                         /* priority= */ 0,
                         "mdns-next-query-schedule",
                         /* force_reset= */ true);
+        if (r < 0) {
+                /* event_reset_time() sets the time and enables the source before it sets the priority
+                 * and the description, i.e. it may fail with the source already armed. Disable it
+                 * again, so that it cannot fire for a maintenance point the TTL state knows nothing
+                 * about. */
+                if (service->schedule_event)
+                        (void) sd_event_source_set_enabled(service->schedule_event, SD_EVENT_OFF);
+
+                return log_error_errno(r, "Failed to schedule mDNS maintenance query: %m");
+        }
+
+        service->rr_ttl_state = ttl_state;
+
+        return 0;
+}
+
+static int mdns_maintenance_query(sd_event_source *s, uint64_t usec, void *userdata) {
+        DnssdDiscoveredService *service = ASSERT_PTR(userdata);
+        _cleanup_(dns_query_freep) DnsQuery *q = NULL;
+        int r;
+
+        /* Note that no failure below is propagated to the event loop. sd-event logs an error returned
+         * by a callback at debug level only and disables the source, so propagating one would both
+         * undo the re-arm and hide the failure from the log; report them here instead. */
+
+        /* Check if the TTL state has reached the maximum value, then revisit
+         * cache */
+        if (service->rr_ttl_state == DNS_RECORD_TTL_STATE_100_PERCENT) {
+                r = mdns_browser_revisit_cache(service->service_browser, service->family);
+                if (r < 0)
+                        log_error_errno(r, "Failed to revisit cache for family %s, ignoring: %m",
+                                        af_to_name(service->family));
+
+                return 0;
+        }
+
+        /* Advance the schedule first: failing to issue this maintenance query should not also cost the
+         * remaining ones. Note that the event may well be dispatched late, hence schedule from the
+         * current time rather than from the time the source was armed for. */
+        r = mdns_service_arm_maintenance(service, now(CLOCK_BOOTTIME), service->rr_ttl_state + 1);
         if (r < 0)
-                return log_error_errno(r, "Failed to schedule next mDNS maintenance query: %m");
+                return 0;
+
+        /* Create a new DNS query */
+        r = dns_query_new(
+                        service->service_browser->manager,
+                        &q,
+                        service->service_browser->question_utf8,
+                        service->service_browser->question_idna,
+                        /* question_bypass= */ NULL,
+                        service->ifindex,
+                        service->service_browser->flags);
+        if (r < 0) {
+                log_error_errno(r, "Failed to create mDNS query for maintenance, ignoring: %m");
+                return 0;
+        }
+
+        q->complete = mdns_maintenance_query_complete;
+        q->service_browser_request = dns_service_browser_ref(service->service_browser);
+        q->dnsservice_request = dnssd_discovered_service_ref(service);
 
         /* Perform the query */
         r = dns_query_go(q);
-        if (r < 0)
-                return log_error_errno(r, "Failed to send mDNS maintenance query: %m");
+        if (r < 0) {
+                log_error_errno(r, "Failed to send mDNS maintenance query, ignoring: %m");
+                return 0;
+        }
 
         TAKE_PTR(q);
         return 0;
@@ -175,49 +313,16 @@ int dns_add_new_service(DnsServiceBrowser *sb, DnsResourceRecord *rr, int owner_
                 .family = owner_family,
                 .ifindex = ifindex,
                 .until = until,
+                .lifetime = mdns_maintenance_lifetime(rr, until, usec),
                 .query = NULL,
                 .rr_ttl_state = DNS_RECORD_TTL_STATE_80_PERCENT,
         };
         if (!s->rr)
                 return log_oom();
 
-        /* Schedule the first cache maintenance query at 80% of the record's
-         * TTL. Subsequent queries issued at 5% increments until 100% of the
-         * TTL. RFC 6762 section 5.2. If service is being added after 80% of the
-         * TTL has already elapsed, schedule the next query at the next 5%
-         * increment. */
-        usec_t next_time = 0;
-        while (s->rr_ttl_state >= DNS_RECORD_TTL_STATE_80_PERCENT &&
-               s->rr_ttl_state < _DNS_RECORD_TTL_STATE_MAX) {
-                next_time = mdns_maintenance_next_time(s->until, s->rr->ttl, s->rr_ttl_state);
-                if (next_time >= usec)
-                        break;
-
-                s->rr_ttl_state++;
-        }
-
-        if (next_time < usec) {
-                /* If next_time is still in the past, the service is being added
-                 * after it has already expired. Just schedule a 100%
-                 * maintenance query. */
-                next_time = usec_add(usec, USEC_PER_SEC);
-                s->rr_ttl_state = DNS_RECORD_TTL_STATE_100_PERCENT;
-        }
-
-        usec_t jitter = mdns_maintenance_jitter(rr->ttl);
-
-        r = sd_event_add_time(
-                        sb->manager->event,
-                        &s->schedule_event,
-                        CLOCK_BOOTTIME,
-                        usec_add(next_time, jitter),
-                        /* accuracy= */ 0,
-                        mdns_maintenance_query,
-                        s);
+        r = mdns_service_arm_maintenance(s, usec, DNS_RECORD_TTL_STATE_80_PERCENT);
         if (r < 0)
-                return log_error_errno(
-                                r,
-                                "Failed to schedule mDNS maintenance query for DNS service: %m");
+                return r;
 
         LIST_PREPEND(dns_services, sb->dns_services, s);
 
@@ -255,18 +360,18 @@ int mdns_service_update(DnssdDiscoveredService *service, DnsResourceRecord *rr, 
 
         service->until = until;
         service->rr->ttl = rr->ttl;
+        service->lifetime = mdns_maintenance_lifetime(rr, until, t);
 
         /* Update the 80% TTL maintenance event based on new record received
          * from the network. RFC 6762 section 5.2  */
-        if (service->schedule_event) {
-                usec_t next_time = mdns_maintenance_next_time(
-                        service->until, service->rr->ttl, DNS_RECORD_TTL_STATE_80_PERCENT);
-                usec_t jitter = mdns_maintenance_jitter(service->rr->ttl);
+        if (!service->schedule_event)
+                return 0;
 
-                return sd_event_source_set_time(service->schedule_event, usec_add(next_time, jitter));
-        }
-
-        return 0;
+        /* The record was refreshed, hence the maintenance schedule starts over at 80% of the new
+         * lifetime. Note that event_reset_time() re-enables the source, which matters because it is
+         * one-shot, i.e. it is left disabled once the 100% query has been issued, and merely setting a
+         * new time would not bring it back. */
+        return mdns_service_arm_maintenance(service, t, DNS_RECORD_TTL_STATE_80_PERCENT);
 }
 
 static int mdns_answer_item_ifindex(DnsServiceBrowser *sb, DnsAnswerItem *item) {
@@ -305,8 +410,8 @@ int dns_service_match_and_update(
         int r;
 
         /* Check if a discovered service matching the given resource record, owner family, and ifindex exists
-         * in the list. If found, update the service's expiration time if the new 'until' is later, unless the
-         * TTL is <= 1 (goodbye packet). Return positive if a matching service is found, zero otherwise. */
+         * in the list. If found, update the service's expiration time whenever it changed, unless the TTL
+         * is <= 1 (goodbye packet). Return positive if a matching service is found, zero otherwise. */
 
         LIST_FOREACH(dns_services, service, services) {
                 r = dns_service_matches(service, rr, owner_family, ifindex);
@@ -318,8 +423,23 @@ int dns_service_match_and_update(
                 if (rr->ttl <= 1)
                         return 1;
 
-                if (service->until < until)
-                        mdns_service_update(service, rr, t, until);
+                /* Follow 'until' in both directions. dns_cache_item_update_positive() recomputes
+                 * until_valid unconditionally from the new record, so a re-announcement carrying a
+                 * shorter TTL does shrink the cache entry. Updating only when it grows would leave us
+                 * anchored at an expiry the cache no longer agrees with, and place the maintenance
+                 * points after the entry has already been pruned - no query would go out before the
+                 * record vanishes, which is the very failure this commit is about, just reached from
+                 * the other side. */
+                if (service->until != until) {
+                        r = mdns_service_update(service, rr, t, until);
+                        if (r < 0)
+                                /* The service was matched and its expiry updated either way, and the
+                                 * failure has already been logged. Do not propagate it: the caller
+                                 * treats a negative return as fatal for the whole reconciliation walk
+                                 * and answers the browse subscription with an error, which is far out
+                                 * of proportion to one service losing its maintenance schedule. */
+                                log_debug_errno(r, "Failed to update mDNS maintenance, ignoring: %m");
+                }
 
                 return 1;
         }

--- a/src/resolve/resolved-dns-browse-services.h
+++ b/src/resolve/resolved-dns-browse-services.h
@@ -32,6 +32,11 @@ struct DnssdDiscoveredService {
         int family;
         int ifindex;
         usec_t until;
+        /* The part of the record's lifetime that is actually cached, i.e. what was left until 'until'
+         * when the record was last received. The maintenance points are fractions of this. Only ever
+         * write it together with 'until' and 'rr': it is derived from both, and a schedule laid out
+         * from one of them paired with a stale other one aims at the wrong time. */
+        usec_t lifetime;
         DnsRecordTTLState rr_ttl_state;
         DnsQuery *query;
         LIST_FIELDS(DnssdDiscoveredService, dns_services);
@@ -78,6 +83,7 @@ int mdns_answer_contains_service(
 int mdns_manage_services_answer(DnsServiceBrowser *sb, DnsAnswer *answer, int owner_family);
 int dns_add_new_service(DnsServiceBrowser *sb, DnsResourceRecord *rr, int owner_family, int ifindex, usec_t until);
 int mdns_service_update(DnssdDiscoveredService *service, DnsResourceRecord *rr, usec_t t, usec_t until);
+int mdns_service_arm_maintenance(DnssdDiscoveredService *service, usec_t usec, DnsRecordTTLState ttl_state);
 int mdns_browser_revisit_cache(DnsServiceBrowser *sb, int owner_family);
 int dns_subscribe_browse_service(
                 Manager *m,

--- a/src/resolve/test-dns-browse-services.c
+++ b/src/resolve/test-dns-browse-services.c
@@ -3,10 +3,14 @@
 #include <string.h>
 #include <sys/socket.h>
 
+#include "sd-event.h"
+
 #include "dns-answer.h"
 #include "dns-rr.h"
 #include "resolved-dns-browse-services.h"
+#include "resolved-manager.h"
 #include "tests.h"
+#include "time-util.h"
 
 static DnsResourceRecord *new_test_service_rr(uint32_t ttl) {
         DnsResourceRecord *rr;
@@ -19,33 +23,6 @@ static DnsResourceRecord *new_test_service_rr(uint32_t ttl) {
         ASSERT_NOT_NULL(rr->ptr.name);
 
         return rr;
-}
-
-TEST(dns_service_match_and_update_goodbye_and_expiry) {
-        _cleanup_(dns_resource_record_unrefp) DnsResourceRecord *rr = NULL;
-
-        ASSERT_NOT_NULL(rr = new_test_service_rr(120));
-
-        DnssdDiscoveredService service = {
-                .rr = rr,
-                .family = AF_INET,
-                .ifindex = 2,
-                .until = 10,
-        };
-
-        ASSERT_OK_POSITIVE(dns_service_match_and_update(&service, rr, AF_INET, 2, 100));
-        ASSERT_EQ(service.until, (usec_t) 100);
-
-        ASSERT_OK_POSITIVE(dns_service_match_and_update(&service, rr, AF_INET, 2, 75));
-        ASSERT_EQ(service.until, (usec_t) 100);
-
-        rr = dns_resource_record_unref(rr);
-        ASSERT_NOT_NULL(rr = new_test_service_rr(1));
-        service.rr = rr;
-        service.until = 10;
-
-        ASSERT_OK_POSITIVE(dns_service_match_and_update(&service, rr, AF_INET, 2, 200));
-        ASSERT_EQ(service.until, (usec_t) 10);
 }
 
 TEST(dns_service_match_and_update_ifindex) {
@@ -145,6 +122,425 @@ TEST(mdns_answer_contains_service_ifindex) {
 
         sb_scoped.ifindex = 3;
         ASSERT_OK_ZERO(mdns_answer_contains_service(&sb_scoped, answer2, &service));
+}
+
+/* The maintenance schedule is derived from a service, its browser and the browser's manager, hence
+ * every test below needs the same three objects wired up around an event loop. */
+typedef struct ServiceFixture {
+        sd_event *event;
+        DnsResourceRecord *rr;
+        Manager manager;
+        DnsServiceBrowser sb;
+        DnssdDiscoveredService service;
+} ServiceFixture;
+
+static void service_fixture_done(ServiceFixture *f) {
+        assert(f);
+
+        LIST_FOREACH(dns_services, service, f->sb.dns_services)
+                dns_remove_service(&f->sb, service);
+
+        f->service.schedule_event = sd_event_source_disable_unref(f->service.schedule_event);
+        f->rr = dns_resource_record_unref(f->rr);
+        f->event = sd_event_unref(f->event);
+}
+
+/* If 'create_source' the service is given a maintenance event source up front, as one that has already
+ * been scheduled once has. Its callback is left unset: event_reset_time() does not replace the callback
+ * of an existing source, so a test that wants the real one dispatched has to let the schedule create
+ * the source itself. */
+static void service_fixture_init(ServiceFixture *f, uint32_t ttl, bool create_source) {
+        assert(f);
+
+        ASSERT_OK(sd_event_default(&f->event));
+        ASSERT_NOT_NULL(f->rr = new_test_service_rr(ttl));
+
+        f->manager.event = f->event;
+        f->sb.manager = &f->manager;
+
+        f->service = (DnssdDiscoveredService) {
+                .rr = f->rr,
+                .service_browser = &f->sb,
+                .family = AF_INET,
+                .ifindex = 2,
+        };
+
+        if (create_source)
+                ASSERT_OK(sd_event_add_time(f->event, &f->service.schedule_event,
+                                            CLOCK_BOOTTIME, 0, 0, NULL, NULL));
+}
+
+/* Arms the maintenance source and returns the time it ended up armed at. */
+static usec_t arm_maintenance(DnssdDiscoveredService *service, usec_t usec, DnsRecordTTLState ttl_state) {
+        usec_t next;
+
+        ASSERT_OK(mdns_service_arm_maintenance(service, usec, ttl_state));
+        ASSERT_OK(sd_event_source_get_time(service->schedule_event, &next));
+
+        return next;
+}
+
+/* Updates the service and returns the time its maintenance source ended up armed at. */
+static usec_t update_service(ServiceFixture *f, DnsResourceRecord *rr, usec_t t, usec_t until) {
+        usec_t next;
+
+        ASSERT_OK(mdns_service_update(&f->service, rr, t, until));
+        ASSERT_OK(sd_event_source_get_time(f->service.schedule_event, &next));
+
+        return next;
+}
+
+TEST(dns_service_match_and_update_goodbye_and_expiry) {
+        _cleanup_(service_fixture_done) ServiceFixture f = {};
+        _cleanup_(dns_resource_record_unrefp) DnsResourceRecord *goodbye = NULL;
+
+        /* A match re-derives the schedule, so this needs the browser and event loop wired up. */
+        service_fixture_init(&f, /* ttl= */ 120, /* create_source= */ true);
+        f.service.until = 10;
+
+        ASSERT_OK_POSITIVE(dns_service_match_and_update(&f.service, f.rr, AF_INET, 2, 100));
+        ASSERT_EQ(f.service.until, (usec_t) 100);
+
+        /* 'until' is followed in both directions. dns_cache_item_update_positive() recomputes the cache
+         * entry's expiry unconditionally from the incoming record, so a re-announcement carrying a
+         * shorter TTL shrinks it, and a service left at the larger value would anchor its maintenance
+         * points after the cache has already pruned the record. */
+        ASSERT_OK_POSITIVE(dns_service_match_and_update(&f.service, f.rr, AF_INET, 2, 75));
+        ASSERT_EQ(f.service.until, (usec_t) 75);
+
+        /* A goodbye packet (TTL <= 1) is matched but left alone: the record is being withdrawn, so
+         * there is nothing to keep refreshing. */
+        ASSERT_NOT_NULL(goodbye = new_test_service_rr(1));
+        f.service.rr = goodbye;
+        f.service.until = 10;
+
+        ASSERT_OK_POSITIVE(dns_service_match_and_update(&f.service, goodbye, AF_INET, 2, 200));
+        ASSERT_EQ(f.service.until, (usec_t) 10);
+
+        f.service.rr = f.rr;
+}
+
+TEST(mdns_service_update_restarts_schedule) {
+        _cleanup_(service_fixture_done) ServiceFixture f = {};
+        usec_t next;
+        int enabled;
+
+        service_fixture_init(&f, /* ttl= */ 120, /* create_source= */ true);
+        f.service.until = 10 * USEC_PER_MINUTE;
+
+        /* The event source is one-shot, i.e. it is disabled once the 100% maintenance query has been
+         * issued. A refreshed record must restart the schedule at 80% and re-arm the source. */
+        ASSERT_OK(sd_event_source_set_enabled(f.service.schedule_event, SD_EVENT_OFF));
+        f.service.rr_ttl_state = DNS_RECORD_TTL_STATE_100_PERCENT;
+
+        next = update_service(&f, f.rr, /* t= */ 0, 20 * USEC_PER_MINUTE);
+        ASSERT_EQ(f.service.until, 20 * USEC_PER_MINUTE);
+        ASSERT_EQ(f.service.rr_ttl_state, DNS_RECORD_TTL_STATE_80_PERCENT);
+
+        ASSERT_OK(sd_event_source_get_enabled(f.service.schedule_event, &enabled));
+        ASSERT_EQ(enabled, SD_EVENT_ONESHOT);
+
+        /* The source must be armed at 80% of the new lifetime, plus at most 2% of it of jitter. */
+        ASSERT_LE(20 * USEC_PER_MINUTE - 24 * USEC_PER_SEC, next);
+        ASSERT_LT(next, 20 * USEC_PER_MINUTE - 24 * USEC_PER_SEC + 2400 * USEC_PER_MSEC);
+}
+
+TEST(mdns_service_update_reads_new_ttl) {
+        _cleanup_(service_fixture_done) ServiceFixture f = {};
+        _cleanup_(dns_resource_record_unrefp) DnsResourceRecord *refreshed = NULL;
+        usec_t next;
+
+        service_fixture_init(&f, /* ttl= */ 1000, /* create_source= */ true);
+        ASSERT_NOT_NULL(refreshed = new_test_service_rr(100));
+
+        /* dns_resource_record_equal() ignores the TTL, hence the record a service is refreshed with
+         * legitimately carries a different one than the copy the service holds, and the new schedule
+         * has to be derived from the incoming record. */
+        next = update_service(&f, refreshed, /* t= */ 0, 600 * USEC_PER_SEC);
+        ASSERT_EQ(f.service.rr->ttl, UINT32_C(100));
+        ASSERT_LE(580 * USEC_PER_SEC, next);
+        ASSERT_LT(next, 582 * USEC_PER_SEC);
+}
+
+TEST(dns_service_match_and_update_shorter_until_rearms) {
+        _cleanup_(service_fixture_done) ServiceFixture f = {};
+        usec_t t, next;
+
+        service_fixture_init(&f, /* ttl= */ 1000, /* create_source= */ true);
+        t = now(CLOCK_BOOTTIME);
+
+        ASSERT_OK_POSITIVE(dns_service_match_and_update(&f.service, f.rr, AF_INET, 2,
+                                                        usec_add(t, 600 * USEC_PER_SEC)));
+        ASSERT_EQ(f.service.until, usec_add(t, 600 * USEC_PER_SEC));
+
+        /* The same record is re-announced with a shorter remaining lifetime, which shrinks the cache
+         * entry. The schedule has to be laid out again from the smaller 'until': keeping the larger one
+         * would leave the 80% point at about 480 s, long after the cache prunes the record at 300 s, so
+         * no maintenance query would go out before the service silently drops off the browse list. */
+        ASSERT_OK_POSITIVE(dns_service_match_and_update(&f.service, f.rr, AF_INET, 2,
+                                                        usec_add(t, 300 * USEC_PER_SEC)));
+        ASSERT_EQ(f.service.until, usec_add(t, 300 * USEC_PER_SEC));
+
+        ASSERT_OK(sd_event_source_get_time(f.service.schedule_event, &next));
+        ASSERT_LE(usec_add(t, 240 * USEC_PER_SEC), next);
+        ASSERT_LT(next, usec_add(t, 247 * USEC_PER_SEC));
+}
+
+TEST(mdns_service_update_large_ttl) {
+        /* TTLs are 32-bit values taken off the network. With a TTL of 2^31 s both 20 * ttl and 2 * ttl
+         * wrap when evaluated in 32-bit arithmetic: the former makes the 80% point come out as 'until'
+         * itself, i.e. the maintenance query is scheduled after the record has already expired, and the
+         * latter leaves a zero jitter range, which random_u64_range() answers with a value from the
+         * full 64-bit range. Pick an 'until' that leaves the whole TTL to run, so that the lifetime the
+         * schedule is derived from is the TTL itself and both bounds below are meaningful. */
+        uint32_t ttl = UINT32_C(1) << 31;
+        usec_t until = (usec_t) ttl * USEC_PER_SEC;
+        usec_t offset = 20 * until / 100;
+        usec_t range = 2 * until / 100;
+
+        for (unsigned i = 0; i < 5; i++) {
+                _cleanup_(service_fixture_done) ServiceFixture f = {};
+                usec_t next;
+
+                service_fixture_init(&f, ttl, /* create_source= */ true);
+
+                next = update_service(&f, f.rr, /* t= */ 0, until);
+                ASSERT_LE(until - offset, next);
+                ASSERT_LT(next, until - offset + range);
+        }
+}
+
+TEST(mdns_service_update_short_window) {
+        _cleanup_(service_fixture_done) ServiceFixture f = {};
+        usec_t next;
+
+        service_fixture_init(&f, /* ttl= */ 120, /* create_source= */ true);
+
+        /* 'until' is capped by the cache while the record's TTL is not, and a service may also be
+         * picked up in the middle of a record's lifetime. Here only 5 of the 120 s are left, so the
+         * maintenance points have to be laid out over those 5 s: deriving them from the TTL instead
+         * would put every one of them in the past and the jitter past 'until', where no query is sent
+         * anymore. */
+        next = update_service(&f, f.rr, /* t= */ 5 * USEC_PER_SEC, 10 * USEC_PER_SEC);
+        ASSERT_EQ(f.service.rr_ttl_state, DNS_RECORD_TTL_STATE_80_PERCENT);
+        ASSERT_LE(9 * USEC_PER_SEC, next);
+        ASSERT_LT(next, 9 * USEC_PER_SEC + 100 * USEC_PER_MSEC);
+}
+
+TEST(mdns_service_update_expired) {
+        _cleanup_(service_fixture_done) ServiceFixture f = {};
+
+        service_fixture_init(&f, /* ttl= */ 120, /* create_source= */ true);
+
+        /* Nothing is left of the lifetime, so there is no maintenance query to schedule anymore, just a
+         * prompt cache revisit, and no jitter on top of it. */
+        ASSERT_EQ(update_service(&f, f.rr, /* t= */ 10 * USEC_PER_SEC, 5 * USEC_PER_SEC), 11 * USEC_PER_SEC);
+        ASSERT_EQ(f.service.rr_ttl_state, DNS_RECORD_TTL_STATE_100_PERCENT);
+}
+
+TEST(mdns_service_update_zero_ttl) {
+        _cleanup_(service_fixture_done) ServiceFixture f = {};
+
+        service_fixture_init(&f, /* ttl= */ 0, /* create_source= */ true);
+
+        /* A zero TTL leaves no lifetime to spread maintenance points over: all five would coincide with
+         * 'until', so go straight to the cache revisit there. In particular do not ask
+         * random_u64_range() for a zero range, which yields an arbitrary 64-bit value rather than
+         * none. */
+        ASSERT_EQ(update_service(&f, f.rr, /* t= */ 0, 10 * USEC_PER_MINUTE), 10 * USEC_PER_MINUTE);
+        ASSERT_EQ(f.service.rr_ttl_state, DNS_RECORD_TTL_STATE_100_PERCENT);
+}
+
+TEST(mdns_service_update_infinite_until) {
+        _cleanup_(service_fixture_done) ServiceFixture f = {};
+
+        service_fixture_init(&f, /* ttl= */ 120, /* create_source= */ true);
+
+        /* USEC_INFINITY is sd-event's "never fires" value, and it is what dns_answer_add_extend() and
+         * friends default 'until' to. Arming the source with it would leave the service maintained by a
+         * dead timer, with no query and no cache revisit ever dropping it, so fall back to a prompt
+         * revisit instead. */
+        ASSERT_EQ(update_service(&f, f.rr, 5 * USEC_PER_SEC, USEC_INFINITY), 6 * USEC_PER_SEC);
+        ASSERT_EQ(f.service.rr_ttl_state, DNS_RECORD_TTL_STATE_100_PERCENT);
+}
+
+TEST(mdns_maintenance_schedule_skips_elapsed) {
+        _cleanup_(service_fixture_done) ServiceFixture f = {};
+        usec_t next;
+
+        service_fixture_init(&f, /* ttl= */ 100, /* create_source= */ true);
+
+        /* A lifetime of 100 s ending at 'until' puts the maintenance points at 80, 85, 90, 95 and
+         * 100 s, and allows for up to 2 s of jitter. */
+        f.service.until = 100 * USEC_PER_SEC;
+        f.service.lifetime = 100 * USEC_PER_SEC;
+
+        /* Nothing has elapsed yet: schedule the state we are asked for. */
+        next = arm_maintenance(&f.service, /* usec= */ 0, DNS_RECORD_TTL_STATE_90_PERCENT);
+        ASSERT_EQ(f.service.rr_ttl_state, DNS_RECORD_TTL_STATE_90_PERCENT);
+        ASSERT_LE(90 * USEC_PER_SEC, next);
+        ASSERT_LT(next, 92 * USEC_PER_SEC);
+
+        /* The 80% point is in the past. Arming the source there would only make it fire immediately, so
+         * skip ahead to 85% - and no further, the remaining queries are still to be made. */
+        next = arm_maintenance(&f.service, 82 * USEC_PER_SEC, DNS_RECORD_TTL_STATE_80_PERCENT);
+        ASSERT_EQ(f.service.rr_ttl_state, DNS_RECORD_TTL_STATE_85_PERCENT);
+        ASSERT_LE(85 * USEC_PER_SEC, next);
+        ASSERT_LT(next, 87 * USEC_PER_SEC);
+
+        /* A point exactly MDNS_MAINTENANCE_MIN_GAP_USEC ahead is still scheduled, rather than skipped
+         * along with the elapsed ones. */
+        next = arm_maintenance(&f.service, 89 * USEC_PER_SEC, DNS_RECORD_TTL_STATE_80_PERCENT);
+        ASSERT_EQ(f.service.rr_ttl_state, DNS_RECORD_TTL_STATE_90_PERCENT);
+        ASSERT_LE(90 * USEC_PER_SEC, next);
+        ASSERT_LT(next, 92 * USEC_PER_SEC);
+
+        /* Three points have elapsed, so the schedule lands on the fourth. */
+        next = arm_maintenance(&f.service, 92 * USEC_PER_SEC, DNS_RECORD_TTL_STATE_80_PERCENT);
+        ASSERT_EQ(f.service.rr_ttl_state, DNS_RECORD_TTL_STATE_95_PERCENT);
+        ASSERT_LE(95 * USEC_PER_SEC, next);
+        ASSERT_LT(next, 97 * USEC_PER_SEC);
+
+        /* Every query point is in the past, only the cache revisit at 'until' is left. It gets no
+         * jitter, which would push it past the expiry it is meant to clean up after. */
+        next = arm_maintenance(&f.service, 99 * USEC_PER_SEC, DNS_RECORD_TTL_STATE_80_PERCENT);
+        ASSERT_EQ(f.service.rr_ttl_state, DNS_RECORD_TTL_STATE_100_PERCENT);
+        ASSERT_EQ(next, 100 * USEC_PER_SEC);
+
+        /* 'until' itself has passed, hence revisit the cache promptly instead. */
+        next = arm_maintenance(&f.service, 101 * USEC_PER_SEC, DNS_RECORD_TTL_STATE_80_PERCENT);
+        ASSERT_EQ(f.service.rr_ttl_state, DNS_RECORD_TTL_STATE_100_PERCENT);
+        ASSERT_EQ(next, 102 * USEC_PER_SEC);
+}
+
+TEST(mdns_maintenance_schedule_bounds_the_gap) {
+        _cleanup_(service_fixture_done) ServiceFixture f = {};
+        usec_t next;
+
+        service_fixture_init(&f, /* ttl= */ 120, /* create_source= */ true);
+
+        /* Only 5 s of the record's lifetime are left, which puts the five maintenance points 250 ms
+         * apart at 9.00, 9.25, 9.50, 9.75 and 10.00 s, with at most 100 ms of jitter to spread them.
+         * Sending four maintenance queries inside 750 ms is pointless - none of them can be answered
+         * and re-cached before 'until' - and costs a full reconciliation of the browser's service list
+         * each. Points closer than MDNS_MAINTENANCE_MIN_GAP_USEC are therefore skipped like elapsed
+         * ones, so that the schedule degrades to fewer queries rather than to a burst of them. */
+        f.service.until = 10 * USEC_PER_SEC;
+        f.service.lifetime = 5 * USEC_PER_SEC;
+
+        next = arm_maintenance(&f.service, 5 * USEC_PER_SEC, DNS_RECORD_TTL_STATE_80_PERCENT);
+        ASSERT_EQ(f.service.rr_ttl_state, DNS_RECORD_TTL_STATE_80_PERCENT);
+        ASSERT_LE(9 * USEC_PER_SEC, next);
+        ASSERT_LT(next, 9 * USEC_PER_SEC + 100 * USEC_PER_MSEC);
+
+        /* Continuing from the 80% point just dispatched: the 85%, 90% and 95% points are all within a
+         * second, hence the next event is the cache revisit at 'until' rather than three more
+         * queries. */
+        next = arm_maintenance(&f.service, 9 * USEC_PER_SEC, DNS_RECORD_TTL_STATE_85_PERCENT);
+        ASSERT_EQ(f.service.rr_ttl_state, DNS_RECORD_TTL_STATE_100_PERCENT);
+        ASSERT_EQ(next, 10 * USEC_PER_SEC);
+
+        /* With less than a second of the window left not even the revisit at 'until' is far enough
+         * ahead, and the schedule falls through to a prompt one. */
+        next = arm_maintenance(&f.service, 9500 * USEC_PER_MSEC, DNS_RECORD_TTL_STATE_85_PERCENT);
+        ASSERT_EQ(f.service.rr_ttl_state, DNS_RECORD_TTL_STATE_100_PERCENT);
+        ASSERT_EQ(next, 10500 * USEC_PER_MSEC);
+}
+
+TEST(dns_add_new_service_schedules_maintenance) {
+        _cleanup_(service_fixture_done) ServiceFixture f = {};
+        usec_t next, until;
+
+        service_fixture_init(&f, /* ttl= */ 120, /* create_source= */ false);
+
+        /* A service may be picked up anywhere in a record's cached lifetime, hence the schedule of a
+         * newly added service is bounded by what is left of it rather than derived from the raw TTL:
+         * only 100 of the record's 120 s are still to run here. */
+        until = usec_add(now(CLOCK_BOOTTIME), 100 * USEC_PER_SEC);
+
+        ASSERT_OK(dns_add_new_service(&f.sb, f.rr, AF_INET, 2, until));
+        ASSERT_NOT_NULL(f.sb.dns_services);
+
+        DnssdDiscoveredService *s = f.sb.dns_services;
+        ASSERT_EQ(s->until, until);
+        ASSERT_LE(s->lifetime, 100 * USEC_PER_SEC);
+        ASSERT_GT(s->lifetime, 99 * USEC_PER_SEC);
+        ASSERT_EQ(s->rr_ttl_state, DNS_RECORD_TTL_STATE_80_PERCENT);
+
+        /* 80% of at most 100 s before 'until', plus at most 2% of it of jitter. */
+        ASSERT_NOT_NULL(s->schedule_event);
+        ASSERT_OK(sd_event_source_get_time(s->schedule_event, &next));
+        ASSERT_LE(until - 20 * USEC_PER_SEC, next);
+        ASSERT_LT(next, until - 17 * USEC_PER_SEC);
+}
+
+TEST(mdns_maintenance_query_revisits_cache_at_100_percent) {
+        _cleanup_(service_fixture_done) ServiceFixture f = {};
+        usec_t next, t;
+        int enabled;
+
+        service_fixture_init(&f, /* ttl= */ 120, /* create_source= */ false);
+
+        /* No mDNS scope exists for this ifindex, hence the cache revisit the 100% event performs is a
+         * no-op here. What is being pinned is that the event does not send a maintenance query and does
+         * not schedule another one: it is the last event of the schedule. */
+        f.sb.ifindex = 3;
+
+        t = now(CLOCK_BOOTTIME);
+        f.service.until = usec_sub_unsigned(t, 10 * USEC_PER_SEC);
+
+        /* Nothing is left of the lifetime, so the schedule collapses to the cache revisit; arm it in
+         * the past so that the event loop dispatches it right away. */
+        next = arm_maintenance(&f.service, usec_sub_unsigned(t, 2 * USEC_PER_SEC),
+                               DNS_RECORD_TTL_STATE_80_PERCENT);
+        ASSERT_EQ(f.service.rr_ttl_state, DNS_RECORD_TTL_STATE_100_PERCENT);
+        ASSERT_EQ(next, usec_sub_unsigned(t, USEC_PER_SEC));
+
+        ASSERT_OK_POSITIVE(sd_event_run(f.event, 0));
+
+        ASSERT_EQ(f.service.rr_ttl_state, DNS_RECORD_TTL_STATE_100_PERCENT);
+        ASSERT_OK(sd_event_source_get_enabled(f.service.schedule_event, &enabled));
+        ASSERT_EQ(enabled, SD_EVENT_OFF);
+}
+
+TEST(mdns_maintenance_query_advances_schedule) {
+        _cleanup_(service_fixture_done) ServiceFixture f = {};
+        usec_t next, t;
+        int enabled;
+
+        service_fixture_init(&f, /* ttl= */ 100, /* create_source= */ false);
+
+        /* The browser carries no question, hence the maintenance query the event tries to issue fails
+         * to be created. That is what is being pinned here: the schedule is advanced before the query
+         * is attempted and the failure is swallowed, so that a query that cannot be sent does not also
+         * cost the remaining maintenance points - the source is one-shot, and returning an error from
+         * the handler would disable it again and take the manager's event loop down with it. */
+        t = now(CLOCK_BOOTTIME);
+        f.service.until = usec_add(t, 10 * USEC_PER_SEC);
+        f.service.lifetime = 100 * USEC_PER_SEC;
+
+        /* The maintenance points sit at 10 and 5 s before 't', at 't' itself, and at 5 and 10 s after
+         * it. Arm the source for the 80% point, 10 s in the past, so that the event loop dispatches it
+         * right away - 30 s after the time it was scheduled from. */
+        next = arm_maintenance(&f.service, usec_sub_unsigned(t, 30 * USEC_PER_SEC),
+                               DNS_RECORD_TTL_STATE_80_PERCENT);
+        ASSERT_EQ(f.service.rr_ttl_state, DNS_RECORD_TTL_STATE_80_PERCENT);
+        ASSERT_LE(usec_sub_unsigned(t, 10 * USEC_PER_SEC), next);
+        ASSERT_LT(next, usec_sub_unsigned(t, 8 * USEC_PER_SEC));
+
+        ASSERT_OK_POSITIVE(sd_event_run(f.event, 0));
+
+        /* Rescheduling from the stale time the source was armed for would put the next point at 85%,
+         * 5 s in the past. Scheduling from the current time skips both the 85% and the 90% point and
+         * lands on 95%. */
+        ASSERT_EQ(f.service.rr_ttl_state, DNS_RECORD_TTL_STATE_95_PERCENT);
+        ASSERT_OK(sd_event_source_get_time(f.service.schedule_event, &next));
+        ASSERT_LE(usec_add(t, 5 * USEC_PER_SEC), next);
+        ASSERT_LT(next, usec_add(t, 7 * USEC_PER_SEC));
+
+        /* And the source is still armed, rather than left disabled by the failed query. */
+        ASSERT_OK(sd_event_source_get_enabled(f.service.schedule_event, &enabled));
+        ASSERT_EQ(enabled, SD_EVENT_ONESHOT);
 }
 
 DEFINE_TEST_MAIN(LOG_DEBUG);


### PR DESCRIPTION
The RFC 6762 §5.2 maintenance schedule for browsed mDNS services is computed from the record's TTL, which is a 32-bit value taken straight off the network:

```c
mdns_maintenance_next_time():  usec_sub_unsigned(until, (100 - percent) * ttl * USEC_PER_SEC / 100)
mdns_maintenance_jitter():     random_u64_range(2 * ttl * USEC_PER_SEC / 100)
```

In both cases the leading multiplication is evaluated in 32-bit unsigned arithmetic, before anything is promoted to `usec_t`, so it wraps: `20 * ttl` from a TTL of 214748365 s on, `2 * ttl` from 2^31 s on. A jitter range that wraps to exactly zero is the worst case, because `random_u64_range(0)` returns a value from the *full* 64-bit range rather than 0.

With a TTL of 2^31 the next maintenance query therefore lands on the order of 10^19 µs from now, i.e. never. The added test shows the pre-patch numbers, which is the scheduled time in µs vs. the largest time the 2% jitter permits:

```
Assertion failed: Expected "next <= max", but 15076157182028495909 > 42950272960000
```

The service is then never requeried and simply drops off the browse list once its cache entry expires.

The raw TTL is also the wrong quantity to schedule from in the first place. Both expressions above are fractions of the record's lifetime, yet they are anchored at `until`, which the cache caps at `CACHE_TTL_MAX_USEC` in `calculate_until_valid()` while the TTL is not capped at all — and a browse subscription may in any case start in the middle of a record's lifetime. Whenever 5% of the TTL exceeds what is left until `until`, every maintenance point comes out in the past, the schedule falls through to the 100% state, and the jitter then arms the source past cache expiry, where no query is sent anymore: the service drops off the browse list without ever having been refreshed, i.e. the same symptom as the wrap, reached through the cache cap instead. This hits advertised TTLs above ~144000 s, and routinely any subscription that lands in a record's last 5% of cached lifetime.

So the schedule is now derived from the lifetime that is actually cached, i.e. from what is left until `until` when the record is received, bounded by the TTL. All five maintenance points then land inside the window they are anchored in, and the arithmetic is in `usec_t` throughout, so nothing wraps. No jitter is added where no query is issued: at the 100% point it would only push the cache revisit past the expiry it cleans up after.

The second change restarts the schedule in `mdns_service_update()`. A refreshed record starts a new lifetime, so maintenance should start over at 80% of it, but `rr_ttl_state` was left where it was; and because the event source is one-shot, and is left disabled once the 100% query has been issued, setting a new time on it did not re-arm it either. A service that had run through one full 80/85/90/95/100% cycle was thus never maintained again, even while it kept being announced on the network.

The catch-up loop that skips maintenance points which have elapsed all the same (e.g. because the event was dispatched late) now lives in `mdns_maintenance_schedule()` and is used by all three arming sites, including `mdns_maintenance_query()`, which had neither it nor the jitter. The TTL state it computes is committed to the service only once the source is actually armed, and `dns_service_match_and_update()` propagates a failed re-arm instead of discarding it.

All of it is covered by new cases in `test-dns-browse-services`; each one was checked to fail against the unfixed behaviour.

