### PR TITLE
hwdb: do not tag the G502 X Lightspeed macro interface as a keyboard

### DIFF
--- a/hwdb.d/60-input-id.hwdb
+++ b/hwdb.d/60-input-id.hwdb
@@ -93,6 +93,10 @@ id-input:modalias:input:b0005v045Ep0B22e0517*
 id-input:modalias:input:b0003v04B3p301Ee0100-e0,1,2,4*
  ID_INPUT_POINTINGSTICK=1
 
+# Logitech G502 X Lightspeed (wired); the macro/G-key interface is not a keyboard
+id-input:modalias:input:b0003v046DpC098e0111-e0,1,2,3,*
+ ID_INPUT_KEYBOARD=0
+
 # Logitech G915 TKL Keyboard (Bluetooth)
 id-input:modalias:input:b0005v046DpB35Fe0022*
  ID_INPUT_MOUSE=0


### PR DESCRIPTION
When the Logitech G502 X Lightspeed is used with its cable it enumerates as its own USB device (046d:c098), and one of its interfaces, the channel for macro/G-key events, presents a full keyboard descriptor. input_id then tags it as ID_INPUT_KEYBOARD, which makes UPower classify the mouse's battery as a keyboard. This entry clears ID_INPUT_KEYBOARD on that interface while leaving ID_INPUT_KEY in place, so its key events keep working, and matches only that interface by its event signature. The wired mouse is already listed as a mouse in 70-mouse.hwdb.

Without it: 
```
Without this entry:
== input57 (Logitech G502 X LIGHTSPEED)
modalias: input:b0003v046DpC098e0111-e0,1,2,4,k110,111,112,113,114,115,116,117,118,119,11A,11B,11C,11D,11E,11F,r0,1,6,8,B,C,am4,lsfw
ID_INPUT=1
ID_INPUT_MOUSE=1
== input58 (Logitech G502 X LIGHTSPEED Keyboard) modalias: input:b0003v046DpC098e0111-e0,1,2,3,4,11,14,k71,72,...,264,265,r6,C,a20,m4,l0,1,2,3,4,sfw
ID_INPUT=1
ID_INPUT_KEY=1
ID_INPUT_KEYBOARD=1
```
 With it, input58 gets ID_INPUT_KEYBOARD=0.