### PR TITLE
gpt-auto-generator: add ESP-only discovery mode

### DIFF
--- a/man/kernel-command-line.xml
+++ b/man/kernel-command-line.xml
@@ -477,8 +477,11 @@
         <term><varname>rd.systemd.gpt_auto=</varname></term>
 
         <listitem>
-          <para>Configures whether GPT-based partition auto-discovery shall be attempted. For details, see
-          <citerefentry><refentrytitle>systemd-gpt-auto-generator</refentrytitle><manvolnum>8</manvolnum></citerefentry>.</para>
+          <para>Configures whether GPT-based partition auto-discovery shall be attempted. The special
+          value <literal>esp-only</literal> limits host-side discovery to the EFI System Partition used for
+          the current boot. For details, see
+          <citerefentry><refentrytitle>systemd-gpt-auto-generator</refentrytitle><manvolnum>8</manvolnum>
+          </citerefentry>.</para>
 
           <xi:include href="version-info.xml" xpointer="v215"/>
         </listitem>

--- a/man/systemd-gpt-auto-generator.xml
+++ b/man/systemd-gpt-auto-generator.xml
@@ -309,9 +309,14 @@
         <term><varname>systemd.gpt_auto</varname></term>
         <term><varname>rd.systemd.gpt_auto</varname></term>
 
-        <listitem><para>Those options take an optional boolean argument, and default to yes.
+        <listitem><para>Those options take an optional boolean argument, or the special value
+        <literal>esp-only</literal>, and default to yes.
         The generator is enabled by default, and a false value may be used to disable it
-        (e.g. <literal>systemd.gpt_auto=0</literal>).
+        (e.g. <literal>systemd.gpt_auto=0</literal>). The value
+        <literal>esp-only</literal> limits the host-side discovery pass to the EFI System Partition
+        used for the current boot. This mode uses the boot loader's
+        <varname>LoaderDevicePartUUID</varname> EFI variable and udev device metadata. No other
+        partitions are discovered, and no mount is generated if the active ESP cannot be resolved.
         </para>
 
         <xi:include href="version-info.xml" xpointer="v242"/></listitem>

--- a/src/gpt-auto-generator/gpt-auto-generator.c
+++ b/src/gpt-auto-generator/gpt-auto-generator.c
@@ -2,6 +2,8 @@
 
 #include <sys/file.h>
 
+#include "sd-device.h"
+#include "sd-gpt.h"
 #include "sd-id128.h"
 
 #include "alloc-util.h"
@@ -45,7 +47,16 @@ typedef enum MountPointFlags {
 
 static const char *arg_dest = NULL;
 static const char *arg_dest_late = NULL;
-static bool arg_enabled = true;
+
+typedef enum GptAutoMode {
+        GPT_AUTO_FULL,
+        GPT_AUTO_ESP_ONLY,
+        GPT_AUTO_OFF,
+        _GPT_AUTO_MODE_MAX,
+        _GPT_AUTO_MODE_INVALID = -EINVAL,
+} GptAutoMode;
+
+static GptAutoMode arg_auto_mode = GPT_AUTO_FULL;
 static GptAutoRoot arg_auto_root = _GPT_AUTO_ROOT_INVALID;
 static GptAutoRoot arg_auto_usr = _GPT_AUTO_ROOT_INVALID;
 static VeritySettings arg_verity_settings = VERITY_SETTINGS_DEFAULT;
@@ -1159,6 +1170,78 @@ mount:
         return r;
 }
 
+static int add_loader_esp_mount(void) {
+#if ENABLE_EFI
+        _cleanup_(sd_device_unrefp) sd_device *device = NULL;
+        _cleanup_free_ char *path = NULL;
+        const char *type, *fstype;
+        sd_id128_t loader_uuid;
+        int r;
+
+        if (in_initrd())
+                return 0;
+
+        if (!is_efi_boot())
+                return 0;
+
+        r = loader_mounts_configured();
+        if (r > 0)
+                return 0;
+
+        r = efi_loader_get_device_part_uuid(&loader_uuid);
+        if (r == -ENOENT) {
+                log_debug("EFI loader partition unknown, not generating ESP mount.");
+                return 0;
+        }
+        if (r < 0) {
+                log_debug_errno(r, "Failed to read loader partition UUID, not generating ESP mount: %m");
+                return 0;
+        }
+
+        path = path_join("/dev/disk/by-partuuid", SD_ID128_TO_UUID_STRING(loader_uuid));
+        if (!path)
+                return -ENOMEM;
+
+        /* udev already has the partition metadata needed here. Avoid opening and dissecting the whole
+         * root disk just to find the partition that the boot loader told us it used. */
+        r = sd_device_new_from_devname(&device, path);
+        if (r < 0) {
+                log_debug_errno(r,
+                                "Failed to resolve loader partition '%s', not generating ESP mount: %m",
+                                path);
+                return 0;
+        }
+
+        r = sd_device_get_property_value(device, "ID_PART_ENTRY_TYPE", &type);
+        if (r < 0) {
+                log_debug_errno(r,
+                                "Failed to query partition type for '%s', not generating ESP mount: %m",
+                                path);
+                return 0;
+        }
+        if (sd_id128_string_equal(type, SD_GPT_ESP) != 1) {
+                log_debug("Loader partition '%s' is not an ESP, not generating ESP mount.", path);
+                return 0;
+        }
+
+        r = sd_device_get_property_value(device, "ID_FS_TYPE", &fstype);
+        if (r < 0) {
+                log_debug_errno(r,
+                                "Failed to query file system type for '%s', not generating ESP mount: %m",
+                                path);
+                return 0;
+        }
+        if (!streq(fstype, "vfat")) {
+                log_debug("Loader partition '%s' is not a VFAT ESP, not generating ESP mount.", path);
+                return 0;
+        }
+
+        return add_esp_automount(path, fstype, fstype, /* has_xbootldr= */ false);
+#else
+        return 0;
+#endif
+}
+
 static int enumerate_partitions(dev_t devnum) {
         _cleanup_(dissected_image_unrefp) DissectedImage *m = NULL;
         _cleanup_(loop_device_unrefp) LoopDevice *loop = NULL;
@@ -1262,11 +1345,17 @@ static int parse_proc_cmdline_item(const char *key, const char *value, void *dat
         if (proc_cmdline_key_streq(key, "systemd.gpt_auto") ||
             proc_cmdline_key_streq(key, "rd.systemd.gpt_auto")) {
 
-                r = value ? parse_boolean(value) : 1;
-                if (r < 0)
-                        log_warning_errno(r, "Failed to parse gpt-auto switch \"%s\", ignoring: %m", value);
-                else
-                        arg_enabled = r;
+                if (streq_ptr(value, "esp-only"))
+                        arg_auto_mode = GPT_AUTO_ESP_ONLY;
+                else {
+                        r = value ? parse_boolean(value) : 1;
+                        if (r < 0)
+                                log_warning_errno(r,
+                                                  "Failed to parse gpt-auto switch \"%s\", ignoring: %m",
+                                                  value);
+                        else
+                                arg_auto_mode = r ? GPT_AUTO_FULL : GPT_AUTO_OFF;
+                }
 
         } else if (streq(key, "root")) {
 
@@ -1402,7 +1491,7 @@ static int run(const char *dest, const char *dest_early, const char *dest_late) 
         if (r < 0)
                 log_warning_errno(r, "Failed to parse kernel command line, ignoring: %m");
 
-        if (!arg_enabled) {
+        if (arg_auto_mode == GPT_AUTO_OFF) {
                 log_debug("Disabled, exiting.");
                 return 0;
         }
@@ -1411,7 +1500,9 @@ static int run(const char *dest, const char *dest_early, const char *dest_late) 
         RET_GATHER(r, add_root_mount());
         RET_GATHER(r, add_usr_mount());
         RET_GATHER(r, add_early_esp_mount());
-        RET_GATHER(r, add_mounts());
+
+        RET_GATHER(r,
+                   arg_auto_mode == GPT_AUTO_ESP_ONLY ? add_loader_esp_mount() : add_mounts());
 
         return r;
 }

--- a/src/gpt-auto-generator/gpt-auto-generator.c
+++ b/src/gpt-auto-generator/gpt-auto-generator.c
@@ -659,19 +659,25 @@ static int add_partition_xbootldr(DissectedPartition *p) {
 }
 
 #if ENABLE_EFI
-static int add_partition_esp(DissectedPartition *p, bool has_xbootldr) {
+static int add_esp_automount(
+                const char *node,
+                const char *options_fstype,
+                const char *mount_fstype,
+                bool has_xbootldr) {
+
         const char *esp_path = NULL, *id = NULL;
         _cleanup_free_ char *options = NULL;
         int r;
 
-        assert(p);
+        assert(node);
         assert(!in_initrd());
 
         /* Check if there's an existing fstab entry for ESP. If so, we just skip the gpt-auto logic. */
-        r = fstab_has_node(p->node);
+        r = fstab_has_node(node);
         if (r < 0)
-                log_warning_errno(r, "Failed to check if fstab entry for device '%s' exists, ignoring: %m",
-                                  p->node);
+                log_warning_errno(r,
+                                  "Failed to check if fstab entry for device '%s' exists, ignoring: %m",
+                                  node);
         if (r > 0)
                 return 0;
 
@@ -701,7 +707,7 @@ static int add_partition_esp(DissectedPartition *p, bool has_xbootldr) {
 
         r = partition_pick_mount_options(
                         PARTITION_ESP,
-                        dissected_partition_fstype(p),
+                        options_fstype,
                         /* rw= */ true,
                         /* discard= */ false,
                         &options,
@@ -711,13 +717,23 @@ static int add_partition_esp(DissectedPartition *p, bool has_xbootldr) {
 
         return add_automount(
                         id,
-                        p->node,
+                        node,
                         esp_path,
-                        p->fstype,
+                        mount_fstype,
                         MOUNT_RW,
                         options,
                         "EFI System Partition Automount",
                         LOADER_PARTITION_IDLE_USEC);
+}
+
+static int add_partition_esp(DissectedPartition *p, bool has_xbootldr) {
+        assert(p);
+
+        return add_esp_automount(
+                        p->node,
+                        dissected_partition_fstype(p),
+                        p->fstype,
+                        has_xbootldr);
 }
 #else
 static int add_partition_esp(DissectedPartition *p, bool has_xbootldr) {
@@ -1075,12 +1091,8 @@ static int add_early_esp_mount(void) {
                          /* conflicts= */ "initrd-switch-root.target");
 }
 
-static int process_loader_partitions(DissectedPartition *esp, DissectedPartition *xbootldr) {
-        sd_id128_t loader_uuid;
+static int loader_mounts_configured(void) {
         int r;
-
-        assert(esp);
-        assert(xbootldr);
 
         /* If any paths in fstab look similar to our favorite paths for ESP or XBOOTLDR, we just exit
          * early. We also don't bother with cases where one is configured explicitly and the other shall be
@@ -1089,10 +1101,24 @@ static int process_loader_partitions(DissectedPartition *esp, DissectedPartition
         r = fstab_has_mount_point_prefix_strv(STRV_MAKE("/boot", "/efi"));
         if (r > 0) {
                 log_debug("Found mount entries in the /boot/ or /efi/ hierarchies in fstab, not generating ESP or XBOOTLDR mounts.");
-                return 0;
+                return 1;
         }
         if (r < 0)
                 log_debug_errno(r, "Failed to check fstab existing paths, ignoring: %m");
+
+        return 0;
+}
+
+static int process_loader_partitions(DissectedPartition *esp, DissectedPartition *xbootldr) {
+        sd_id128_t loader_uuid;
+        int r;
+
+        assert(esp);
+        assert(xbootldr);
+
+        r = loader_mounts_configured();
+        if (r > 0)
+                return 0;
 
         if (!is_efi_boot()) {
                 log_debug("Not an EFI boot, skipping loader partition UUID check.");


### PR DESCRIPTION
Summary
=======

Add a new systemd.gpt_auto=esp-only mode that skips full root-disk dissection while still attempting to generate an automount for the EFI System Partition used for the current boot.

Motivation
==========

On systems that only need automatic ESP mounting, the normal GPT discovery path opens and dissects the root disk to discover all supported partition types. This work can be unnecessary and may delay early boot.
The proposed mode resolves the boot loader partition directly through:

- the LoaderDevicePartUUID EFI variable
- the corresponding udev device metadata

This avoids dissecting the complete root disk.

Behavior
========

With systemd.gpt_auto=esp-only:

- root and /usr mount generation performed before host-side disk dissection remains enabled
- full host-side root-disk dissection is skipped
- automatic discovery of swap, home, srv, var, tmp and XBOOTLDR partitions is skipped
- processing of root-partition GPT growfs/read-write flags is skipped
- an ESP automount is generated only when LoaderDevicePartUUID can be resolved to a valid GPT ESP
- existing boolean values and the default behavior remain unchanged

The option has no additional ESP-discovery effect in the initrd.

