### PR TITLE
boot: Update aa64 hwids

### DIFF
--- a/src/boot/hwids/aa64/glymur-asus-zenbook-a14-ux3407na.json
+++ b/src/boot/hwids/aa64/glymur-asus-zenbook-a14-ux3407na.json
@@ -1,0 +1,18 @@
+{
+    "type": "devicetree",
+    "name": "ASUS Zenbook A14 UX3407NA",
+    "compatible": "asus,zenbook-a14-ux3407na",
+    "hwids": [
+        "f83b2743-4d7a-5fc5-ab29-8f7c3955ce91",
+        "239dac86-8b01-592b-b89d-405153e44194",
+        "a44af168-a1f5-59cb-9af2-451316f4fe3d",
+        "1a80da71-97b3-50c6-a8c2-5c8c4356cbd1",
+        "889cd77f-34a1-541f-a95f-6566c8fcda20",
+        "b680d605-b115-5d67-b413-93f44ff3220a",
+        "48008168-2010-52ff-aaaf-ab706ba99638",
+        "27fc49a6-607b-5f8d-bcd4-eb8bdedfb31a",
+        "16ae4df2-f7ce-59fb-82be-33464322d7ee",
+        "7a71569d-bdb8-5feb-bf86-3c17d3eece44",
+        "c0717bbf-62ca-5ab1-a76b-75f3fd1bc013"
+    ]
+}

--- a/src/boot/hwids/aa64/glymur-asus-zenbook-a16-ux3607oa.json
+++ b/src/boot/hwids/aa64/glymur-asus-zenbook-a16-ux3607oa.json
@@ -1,0 +1,19 @@
+{
+    "type": "devicetree",
+    "name": "ASUS Zenbook A16 UX3607OA",
+    "compatible": "asus,zenbook-a16-ux3607oa",
+    "hwids": [
+        "5b6d366d-9a43-536d-9637-8e47abfb8e63",
+        "40ce3633-a61c-59ae-8336-6d861b933733",
+        "9aca06aa-73c1-5b12-9bdb-d88c0111910c",
+        "ef65dda1-fabb-5a20-9f5b-173b9876cf17",
+        "176f35e1-a53c-5823-85ec-0e69ddccc718",
+        "aa97280b-2a64-5146-8cf5-1ab4cff4f4f7",
+        "8d1e50f4-5fca-5e73-91f3-21e46a9419ab",
+        "a29d04c1-686b-5861-9ff7-cadf33cbcb97",
+        "e2bb821e-aeef-5cfc-a062-392f2539fd67",
+        "c4e7b7b9-2520-5397-8040-8ac279f540d8",
+        "ab022687-b75a-5f75-a1c3-b3996e227c96",
+        "d8bcee6b-2797-55ca-86b7-d69170e86bbb"
+    ]
+}

--- a/src/boot/hwids/aa64/glymur-crd.json
+++ b/src/boot/hwids/aa64/glymur-crd.json
@@ -1,0 +1,16 @@
+{
+    "type": "devicetree",
+    "name": "Qualcomm Technologies, Inc. Glymur CRD",
+    "compatible": "qcom,glymur-crd",
+    "hwids": [
+        "e88849e7-af59-5c58-9776-75cfb6bac078",
+        "d9972e14-0a66-56a8-9cee-8c5647fbe470",
+        "e53db94e-68fe-541f-b06e-4b5a253dadf9",
+        "ce496e01-9bd8-522e-8937-8045126ed39a",
+        "031a5cd7-883e-5004-90c2-92d29025c777",
+        "4bb05d50-6c4f-525d-a9ec-8924afd6edea",
+        "339fc6d2-e0f4-5226-9dd9-62c4dc41881d",
+        "49bcdd2b-d769-5071-b3a4-4a02ff1d36f5",
+        "6fcbdad8-149e-5f72-b2e3-0fd78572ff93"
+    ]
+}

--- a/src/boot/hwids/aa64/glymur-hp-elitebook-x-g2q.json
+++ b/src/boot/hwids/aa64/glymur-hp-elitebook-x-g2q.json
@@ -1,0 +1,19 @@
+{
+    "type": "devicetree",
+    "name": "HP 103C_5336AN HP EliteBook",
+    "compatible": "hp,elitebook-x-g2q",
+    "hwids": [
+        "a8eb125e-80bb-5eb6-a448-8b9a73a9fda4",
+        "2111654e-fca0-5191-adf1-a341304be9ac",
+        "547910dc-38d6-509e-af6a-1bac70567950",
+        "6778dcb3-7a6c-5aa9-90fe-4b131dc2076a",
+        "1f684671-96d7-5c00-a060-54604fe83c55",
+        "02de9849-4c7c-5a0e-acda-f575977ecb10",
+        "b0d41b70-a607-5e5e-9da8-cce48044dfaf",
+        "99590fa9-8fc9-5066-80b8-49e1dbf06f4d",
+        "19fe40b5-1900-5d4a-a48f-b9f9938f3e69",
+        "4c84c882-b54c-58d5-b412-26bcdf254c3e",
+        "24c45613-de19-5b89-9fa1-9e269daf079d",
+        "93f84748-c854-5d6b-b78a-13c2361e0758"
+    ]
+}

--- a/src/boot/hwids/aa64/glymur-lenovo-yoga-slim7x.json
+++ b/src/boot/hwids/aa64/glymur-lenovo-yoga-slim7x.json
@@ -1,0 +1,22 @@
+{
+    "type": "devicetree",
+    "name": "LENOVO Yoga Slim 7 14Q8Y11",
+    "compatible": "lenovo,yoga-slim7x-gen11",
+    "hwids": [
+        "7859b01c-8448-5fce-bc9c-3ef5b6fcd5c7",
+        "4caf4999-fe35-5dd4-a32f-fe0ad2bbd139",
+        "229ef25c-5932-58ac-9f2d-1d0ce7f73f28",
+        "c9a98d97-803d-5f57-b68a-3bf9183764b3",
+        "fb337336-053c-55be-a877-2f1537ee6d51",
+        "ef043aee-e791-5919-ab57-409a5e063228",
+        "54ea1316-e372-5801-a3dd-a69ce58da3b5",
+        "7822b8e3-4c2b-58f7-b5d5-1bec836f09ec",
+        "2a58c488-aaca-53e6-9883-378fa23611a5",
+        "5e820764-888e-529d-a6f9-dfd12bacb160",
+        "71d86d4d-02f8-5566-a7a1-529cef184b7e",
+        "6de5d951-d755-576b-bd09-c5cf66b27234",
+        "51ae1f74-c06a-5ada-a4d3-57c5b050aa9c",
+        "4d7e2d2e-d9b8-54e5-a859-89fe74ceb38c",
+        "c98707aa-1249-5670-b3d8-3c560d008628"
+    ]
+}

--- a/src/boot/hwids/aa64/purwa-lenovo-ideacentre-mini-01q8x10.json
+++ b/src/boot/hwids/aa64/purwa-lenovo-ideacentre-mini-01q8x10.json
@@ -1,0 +1,20 @@
+{
+    "type": "devicetree",
+    "name": "LENOVO IdeaCentre Mini 01Q8X10 (Purwa)",
+    "compatible": "lenovo,purwa-ideacentre-mini-01q8x10",
+    "hwids": [
+        "694ae0fe-f407-5a28-a7b8-42874f767fd1",
+        "ce9593db-c21e-5d92-922a-b5881d3b5bc0",
+        "a1a3bdb0-0bf6-51ba-84b8-15bc0ffa1085",
+        "0fa5b19a-d837-55eb-8cc3-2961dcbcc5cc",
+        "8db38791-9759-5f99-9fda-4528aa7fcd85",
+        "434b3aab-4cfb-5916-af0f-015b1887af66",
+        "e9b204d4-c5de-5235-a9e1-ca1a27930eae",
+        "03b204a1-c87d-5d0a-a830-71c3b267efe1",
+        "8cf5845d-547c-558e-b5db-2dc96c3a1918",
+        "3553f25c-472d-519d-9e7b-93284da42015",
+        "cedd9e06-b4d3-5a74-944e-7fba5d8f8faa",
+        "737534ab-4396-53d7-9bb7-3c21176b24b0",
+        "d3ff9b34-1c07-5574-ad73-f90bdc1d33f6"
+    ]
+}

--- a/src/boot/hwids/aa64/sc7180-ecs-liva-qc710.json
+++ b/src/boot/hwids/aa64/sc7180-ecs-liva-qc710.json
@@ -1,0 +1,17 @@
+{
+    "type": "devicetree",
+    "name": "Elitegroup Computer Systems Co., LTD. SC7180",
+    "compatible": "ecs,liva-qc710",
+    "hwids": [
+        "6303e758-6932-5e81-a3b9-cc9570590686",
+        "11bb94a9-341f-50bd-a569-2f61f7c745d3",
+        "9879a093-0829-5ddc-ad6c-2069f38bb66e",
+        "332352d0-6474-53ce-b480-46ced6d1327b",
+        "0253c128-80b3-584d-9fc1-74b546aad2e6",
+        "c0ef167b-7a32-5ad7-8dbb-2462f696c107",
+        "0a89edb3-78c9-5b09-b58a-c5a5c7890945",
+        "8d7bc998-a131-5a67-8f6b-3971a6a418ba",
+        "dfc147a4-4369-5b01-8148-86f55396b8f3",
+        "36a999ce-a606-57b5-a404-45bb5821669f"
+    ]
+}

--- a/src/boot/hwids/aa64/sc8280xp-radxa-dragon-q8b.json
+++ b/src/boot/hwids/aa64/sc8280xp-radxa-dragon-q8b.json
@@ -1,0 +1,17 @@
+{
+    "type": "devicetree",
+    "name": "Radxa Computer Co., Ltd. Dragon Q8B",
+    "compatible": "radxa,dragon-q8b",
+    "hwids": [
+        "32978e78-153f-5ce0-a6c7-05332e9be35b",
+        "93975fa3-a84a-5a58-a065-1de7e0bcf58f",
+        "616a4751-7393-5af2-9d86-bd0830b2879c",
+        "72cee887-e3b7-569a-b301-a6c60ce4fe94",
+        "e12e80ad-d8a6-57e1-be79-ec1bc76f96e5",
+        "6f487192-b176-566b-b165-3a56ff779c1a",
+        "0892d6ad-c297-548b-813b-d3ade091f75a",
+        "fc3f2e5b-9d50-5e13-9002-b9765dcc78e5",
+        "67ae360a-59f4-5f6a-9100-15270232f899",
+        "5c83a423-e471-5160-be87-bf824c48b38c"
+    ]
+}

--- a/src/boot/hwids/aa64/x126100-lenovo-ideapad-slim3.json
+++ b/src/boot/hwids/aa64/x126100-lenovo-ideapad-slim3.json
@@ -1,0 +1,25 @@
+{
+    "type": "devicetree",
+    "name": "LENOVO IdeaPad Slim 3 15Q8X10",
+    "compatible": "lenovo,ideapad-slim3",
+    "hwids": [
+        "d0a73ed7-fc46-5f8c-bfaa-62375492a303",
+        "14d6f910-fb4f-5ff1-87e4-03a16448a255",
+        "57530352-2dd8-5087-8350-77d82bdc984d",
+        "4f6c85c4-b6e2-5cd9-9a22-91b839f31474",
+        "0549a586-ab3b-5606-a55a-f9374515909c",
+        "1bee74fc-5f4d-53a1-92a3-f532d4170a95",
+        "b59e5273-1ed4-51d7-9beb-da0e48f96459",
+        "123d7adb-792e-5e3e-9044-3d5eec53b59d",
+        "67f92433-2c48-5d27-8423-afe79c8f86e1",
+        "0b1ba81f-8f6b-5ba3-aebc-a6e71b280d83",
+        "f9f59b59-b3f3-5b8a-a65a-84bc573ee694",
+        "216c17d6-9f5b-5020-b8cc-1be8b74f6204",
+        "e093d715-70f7-51f4-b6c8-b4a7e31def85",
+        "71d86d4d-02f8-5566-a7a1-529cef184b7e",
+        "6de5d951-d755-576b-bd09-c5cf66b27234",
+        "9c54c867-8153-5607-8f22-413c8f17fc13",
+        "5963a641-1d3e-5431-86a8-5d0d98f90e3e",
+        "99431f53-09a1-5869-be79-65e2fa3f341d"
+    ]
+}

--- a/src/boot/hwids/aa64/x1e80100-honor-magicbook-art-14.json
+++ b/src/boot/hwids/aa64/x1e80100-honor-magicbook-art-14.json
@@ -1,0 +1,20 @@
+{
+    "type": "devicetree",
+    "name": "HONOR MagicBook Art 14 Snapdragon",
+    "compatible": "honor,magicbook-art-14-snapdragon",
+    "hwids": [
+        "ea3d6abf-d171-51d9-aadc-2f01715a2526",
+        "8c4f216d-a380-5720-b036-13e1c9e6ed9f",
+        "533dd95d-f27c-5c70-bbfd-f60ed0ff9b8c",
+        "16f2294f-2175-5bac-8752-f304c65bccc3",
+        "8ca9c5e4-6465-5841-a567-b4c54597cf16",
+        "d9a47875-303e-5a56-bc53-a98ef97dda55",
+        "f470a9a4-99c0-5b88-8309-927c60430477",
+        "f05c7d5e-f47a-58de-88dc-4d92ac4c00a7",
+        "8850ea33-9bd6-5aaf-a013-45d1c87937a5",
+        "74e5317c-21cf-5cf6-bc70-5c78a3320848",
+        "b7b0f714-757e-5bee-83bf-061428e79201",
+        "9ecaf40d-d1bd-5963-888a-9757fcc95448",
+        "6a798bf3-64eb-5107-948b-810b9eabffba"
+    ]
+}

--- a/src/boot/hwids/aa64/x1p42100-hp-elitebook-6-g1q.json
+++ b/src/boot/hwids/aa64/x1p42100-hp-elitebook-6-g1q.json
@@ -1,0 +1,20 @@
+{
+    "type": "devicetree",
+    "name": "HP 103C_5336AN HP EliteBook",
+    "compatible": "hp,elitebook-6-g1q",
+    "hwids": [
+        "351005d4-e3e1-5387-a703-21cc93bd30ea",
+        "180994cf-7159-5b2d-be28-5624845887b1",
+        "3bf4bc3c-a850-5a6a-a95c-8e3eaf14bc96",
+        "aa2c3726-f5ea-53b6-8ed5-90f5a1abaaff",
+        "3c513e7a-56b8-5edf-8d1e-d90fa4a8974d",
+        "66ae13b5-9c0f-5f57-b2dd-dc699ccc409d",
+        "70b42fea-f55e-5d19-8110-d71be6bd5e32",
+        "be685a81-758f-58d4-8c4e-65cf4877588c",
+        "5ae54112-632c-57ee-b615-c2df8ba319cd",
+        "c7e47171-659b-55ad-a977-3df485a15742",
+        "2c1d5a7e-43d1-5fef-89d6-a3b368779536",
+        "ea8400a5-7227-5163-9664-225070358fa0",
+        "2dae3dcd-51ea-5422-9980-5220f02b883a"
+    ]
+}

--- a/src/boot/hwids/aa64/x1p64100-dell-latitude-5455.json
+++ b/src/boot/hwids/aa64/x1p64100-dell-latitude-5455.json
@@ -1,0 +1,20 @@
+{
+    "type": "devicetree",
+    "name": "Dell Inc. Latitude 5455",
+    "compatible": "dell,latitude-5455",
+    "hwids": [
+        "4d1ff2c8-dd8d-556b-befa-0cab2bc86be3",
+        "2d75e18e-e107-5c79-8a69-5f163d28ee6f",
+        "9195a554-2255-55ce-ab3f-59a2aba05c4e",
+        "6329967e-8fcd-5544-8869-36881d8b997b",
+        "f069ee1a-448c-55df-b8a2-eebce2ccaf7f",
+        "75d1456b-5a14-5868-b877-7b9f58f4dd0d",
+        "d33d10f9-d59d-5dc6-b13b-686ac24ea3c0",
+        "745f5023-2386-5aaa-944d-b825bea80756",
+        "9e9723ce-65b3-57d5-a98d-bf4e0b8f87ed",
+        "2f11e817-91c9-5aa2-acb1-bd1d317c9ba6",
+        "53c465c5-6425-51cd-b0aa-3382f3ad3622",
+        "dfb300e4-c621-562c-a147-521e95ce6b7f",
+        "838cf30a-6594-5200-8432-b94de34ce905"
+    ]
+}


### PR DESCRIPTION
The essentially syncs all the latest hwids we use in Ubuntu with stubble.

fyi @xnox 