### PR TITLE
systemctl: avoid parsing properties twice for show

### DIFF
--- a/src/shared/bus-map-properties.c
+++ b/src/shared/bus-map-properties.c
@@ -216,6 +216,37 @@ int bus_message_map_all_properties(
         return r;
 }
 
+int bus_get_all_properties(
+                sd_bus *bus,
+                const char *destination,
+                const char *path,
+                sd_bus_error *reterr_error,
+                sd_bus_message **ret_reply) {
+
+        _cleanup_(sd_bus_message_unrefp) sd_bus_message *reply = NULL;
+        int r;
+
+        assert(bus);
+        assert(destination);
+        assert(path);
+        assert(ret_reply);
+
+        r = sd_bus_call_method(
+                        bus,
+                        destination,
+                        path,
+                        "org.freedesktop.DBus.Properties",
+                        "GetAll",
+                        reterr_error,
+                        &reply,
+                        "s", "");
+        if (r < 0)
+                return r;
+
+        *ret_reply = TAKE_PTR(reply);
+        return 0;
+}
+
 int bus_map_all_properties(
                 sd_bus *bus,
                 const char *destination,
@@ -235,15 +266,7 @@ int bus_map_all_properties(
         assert(map);
         assert(ret_reply || (flags & BUS_MAP_STRDUP));
 
-        r = sd_bus_call_method(
-                        bus,
-                        destination,
-                        path,
-                        "org.freedesktop.DBus.Properties",
-                        "GetAll",
-                        reterr_error,
-                        &reply,
-                        "s", "");
+        r = bus_get_all_properties(bus, destination, path, reterr_error, &reply);
         if (r < 0)
                 return r;
 

--- a/src/shared/bus-map-properties.h
+++ b/src/shared/bus-map-properties.h
@@ -24,3 +24,9 @@ int bus_map_job_id(sd_bus *bus, const char *member, sd_bus_message *m, sd_bus_er
 int bus_message_map_all_properties(sd_bus_message *m, const struct bus_properties_map *map, unsigned flags, sd_bus_error *reterr_error, void *userdata);
 int bus_map_all_properties(sd_bus *bus, const char *destination, const char *path, const struct bus_properties_map *map,
                            unsigned flags, sd_bus_error *reterr_error, sd_bus_message **ret_reply, void *userdata);
+int bus_get_all_properties(
+                sd_bus *bus,
+                const char *destination,
+                const char *path,
+                sd_bus_error *reterr_error,
+                sd_bus_message **ret_reply);

--- a/src/systemctl/systemctl-show.c
+++ b/src/systemctl/systemctl-show.c
@@ -2355,15 +2355,14 @@ static int show_one(
 
         log_debug("Showing one %s", path);
 
-        r = bus_map_all_properties(
-                        bus,
-                        "org.freedesktop.systemd1",
-                        path,
-                        show_mode == SYSTEMCTL_SHOW_STATUS ? status_map : property_map,
-                        BUS_MAP_BOOLEAN_AS_BOOL,
-                        &error,
-                        &reply,
-                        &info);
+        r = bus_get_all_properties(bus, "org.freedesktop.systemd1", path, &error, &reply);
+        if (r >= 0 && (show_mode != SYSTEMCTL_SHOW_PROPERTIES || DEBUG_LOGGING))
+                r = bus_message_map_all_properties(
+                                reply,
+                                show_mode == SYSTEMCTL_SHOW_STATUS ? status_map : property_map,
+                                BUS_MAP_BOOLEAN_AS_BOOL,
+                                &error,
+                                &info);
         if (r < 0)
                 return log_error_errno(r, "Failed to get properties: %s", bus_error_message(&error, r));
 


### PR DESCRIPTION
Pass the GetAll reply directly to the property printer for non-debug show operations, reducing client CPU by approximately 21%