### PR TITLE
test: fix ConditionCPUFeature= tests with architecture prefix

### DIFF
--- a/src/test/test-condition.c
+++ b/src/test/test-condition.c
@@ -846,51 +846,63 @@ TEST(condition_test_credential) {
         ASSERT_OK(set_unset_env("ENCRYPTED_CREDENTIALS_DIRECTORY", d2, /* overwrite= */ true));
 }
 
-#if defined(__i386__) || defined(__x86_64__) || defined(__aarch64__)
 TEST(condition_test_cpufeature) {
         Condition *condition;
 
-#if defined(__i386__)
-        ASSERT_NOT_NULL((condition = condition_new(CONDITION_CPU_FEATURE, "fpu", false, false)));
-        ASSERT_OK_POSITIVE(condition_test(condition, environ));
-        condition_free(condition);
+        switch (uname_architecture()) {
+        case ARCHITECTURE_X86:
+                ASSERT_NOT_NULL((condition = condition_new(CONDITION_CPU_FEATURE, "fpu", false, false)));
+                ASSERT_OK_POSITIVE(condition_test(condition, environ));
+                condition_free(condition);
 
-        ASSERT_NOT_NULL((condition = condition_new(CONDITION_CPU_FEATURE, "x86.fpu", false, false)));
-        ASSERT_OK_POSITIVE(condition_test(condition, environ));
-        condition_free(condition);
+                ASSERT_NOT_NULL((condition = condition_new(CONDITION_CPU_FEATURE, "x86.fpu", false, false)));
+                ASSERT_OK_POSITIVE(condition_test(condition, environ));
+                condition_free(condition);
 
-        ASSERT_NOT_NULL((condition = condition_new(CONDITION_CPU_FEATURE, "bogus.fpu", false, false)));
+                ASSERT_NOT_NULL((condition = condition_new(CONDITION_CPU_FEATURE, "bogus.fpu", false, false)));
+                ASSERT_OK_ZERO(condition_test(condition, environ));
+                condition_free(condition);
+                break;
+        case ARCHITECTURE_X86_64:
+                ASSERT_NOT_NULL((condition = condition_new(CONDITION_CPU_FEATURE, "fpu", false, false)));
+                ASSERT_OK_POSITIVE(condition_test(condition, environ));
+                condition_free(condition);
+
+                ASSERT_NOT_NULL((condition = condition_new(CONDITION_CPU_FEATURE, "x86-64.fpu", false, false)));
+                ASSERT_OK_POSITIVE(condition_test(condition, environ));
+                condition_free(condition);
+
+                ASSERT_NOT_NULL((condition = condition_new(CONDITION_CPU_FEATURE, "bogus.fpu", false, false)));
+                ASSERT_OK_ZERO(condition_test(condition, environ));
+                condition_free(condition);
+                break;
+        case ARCHITECTURE_ARM64: {
+                int expected = native_architecture() == ARCHITECTURE_ARM64;
+
+                ASSERT_NOT_NULL((condition = condition_new(CONDITION_CPU_FEATURE, "fp", false, false)));
+                ASSERT_OK_EQ(condition_test(condition, environ), expected);
+                condition_free(condition);
+
+                ASSERT_NOT_NULL((condition = condition_new(CONDITION_CPU_FEATURE, "asimd", false, false)));
+                ASSERT_OK_EQ(condition_test(condition, environ), expected);
+                condition_free(condition);
+
+                ASSERT_NOT_NULL((condition = condition_new(CONDITION_CPU_FEATURE, "arm64.asimd", false, false)));
+                ASSERT_OK_EQ(condition_test(condition, environ), expected);
+                condition_free(condition);
+
+                ASSERT_NOT_NULL((condition = condition_new(CONDITION_CPU_FEATURE, "bogus.asimd", false, false)));
+                ASSERT_OK_ZERO(condition_test(condition, environ));
+                condition_free(condition);
+                break;
+        }
+        default:
+                ;
+        }
+
+        ASSERT_NOT_NULL((condition = condition_new(CONDITION_CPU_FEATURE, "bogus.featurethatshouldnotexist", false, false)));
         ASSERT_OK_ZERO(condition_test(condition, environ));
         condition_free(condition);
-#elif defined(__x86_64__)
-        ASSERT_NOT_NULL((condition = condition_new(CONDITION_CPU_FEATURE, "fpu", false, false)));
-        ASSERT_OK_POSITIVE(condition_test(condition, environ));
-        condition_free(condition);
-
-        ASSERT_NOT_NULL((condition = condition_new(CONDITION_CPU_FEATURE, "x86-64.fpu", false, false)));
-        ASSERT_OK_POSITIVE(condition_test(condition, environ));
-        condition_free(condition);
-
-        ASSERT_NOT_NULL((condition = condition_new(CONDITION_CPU_FEATURE, "bogus.fpu", false, false)));
-        ASSERT_OK_ZERO(condition_test(condition, environ));
-        condition_free(condition);
-#elif defined(__aarch64__)
-        ASSERT_NOT_NULL((condition = condition_new(CONDITION_CPU_FEATURE, "fp", false, false)));
-        ASSERT_OK_POSITIVE(condition_test(condition, environ));
-        condition_free(condition);
-
-        ASSERT_NOT_NULL((condition = condition_new(CONDITION_CPU_FEATURE, "asimd", false, false)));
-        ASSERT_OK_POSITIVE(condition_test(condition, environ));
-        condition_free(condition);
-
-        ASSERT_NOT_NULL((condition = condition_new(CONDITION_CPU_FEATURE, "arm64.asimd", false, false)));
-        ASSERT_OK_POSITIVE(condition_test(condition, environ));
-        condition_free(condition);
-
-        ASSERT_NOT_NULL((condition = condition_new(CONDITION_CPU_FEATURE, "bogus.asimd", false, false)));
-        ASSERT_OK_ZERO(condition_test(condition, environ));
-        condition_free(condition);
-#endif
 
         ASSERT_NOT_NULL((condition = condition_new(CONDITION_CPU_FEATURE, "somecpufeaturethatreallydoesntmakesense", false, false)));
         ASSERT_OK_ZERO(condition_test(condition, environ));
@@ -900,7 +912,6 @@ TEST(condition_test_cpufeature) {
         ASSERT_OK_ZERO(condition_test(condition, environ));
         condition_free(condition);
 }
-#endif
 
 TEST(condition_test_security) {
         Condition *condition;


### PR DESCRIPTION
CPU architecture is determined by uname(), rather than the compile time macros like `__i386__`, `__x86_64__`, `__aarch64__`.

Let's conditionalize with uname_architecture().

Follow-up for d5186757411e272ce6e26216565530d667859fe9.