### PR TITLE
resolve: fix use-after-free of the service browser in mDNS maintenance

### DIFF
--- a/src/resolve/resolved-dns-browse-services.c
+++ b/src/resolve/resolved-dns-browse-services.c
@@ -79,9 +79,9 @@ static usec_t mdns_maintenance_jitter(uint32_t ttl) {
 }
 
 static void mdns_maintenance_query_complete(DnsQuery *q) {
+        _cleanup_(dnssd_discovered_service_unrefp) DnssdDiscoveredService *service = NULL;
         _cleanup_(dns_service_browser_unrefp) DnsServiceBrowser *sb = NULL;
         _cleanup_(dns_query_freep) DnsQuery *query = q;
-        DnssdDiscoveredService *service = NULL;
         int r;
 
         assert(query);


### PR DESCRIPTION
`mdns_maintenance_query_complete()` takes a reference on `query->dnsservice_request` and never drops it, so every successful mDNS maintenance query leaks one reference to the discovered service.

The leak on its own would be benign, but the service owns the one-shot event source that drives its maintenance schedule, and it only borrows a plain pointer to its service browser (`DnssdDiscoveredService.service_browser` is not a reference). With the extra reference outstanding:

1. `dns_add_new_service()` creates the service with `n_ref = 1`, owned by `sb->dns_services`.
2. The maintenance timer fires, `mdns_maintenance_query()` takes a reference for `q->dnsservice_request` (`n_ref = 2`).
3. The query completes successfully, `mdns_maintenance_query_complete()` takes another one (`n_ref = 3`) and leaks it. Freeing the query drops its own reference again, leaving `n_ref = 2`.
4. The subscription goes away. `dns_service_browser_free()` walks the list with `dns_remove_service()`, which only drops the list's reference (`n_ref = 1`), so `dns_service_free()` never runs, `service->schedule_event` is never disabled, and the browser is `mfree()`d out from under the service.
5. The timer fires again and `mdns_maintenance_query()` dereferences the freed `DnsServiceBrowser`, both to reach `service->service_browser->manager->event` and to build the query.

Reaching this only takes a `io.systemd.Resolve.BrowseServices` subscription whose record lives long enough for one maintenance query to be answered, followed by the subscription being torn down.

Fix it by making the reference a `_cleanup_` one, the way the sibling `mdns_browse_service_query_complete()` just below already handles the reference it takes on the service browser.

No test: reaching the callback needs a completed `DnsQuery`, which is not constructible at unit level.
