### PR TITLE
resolve: stop the mDNS maintenance timer when a service is removed

### DIFF
--- a/src/resolve/resolved-dns-browse-services.c
+++ b/src/resolve/resolved-dns-browse-services.c
@@ -229,6 +229,12 @@ void dns_remove_service(DnsServiceBrowser *sb, DnssdDiscoveredService *service) 
         assert(sb);
         assert(service);
 
+        /* Stop the maintenance schedule here rather than leaving it to dns_service_free(): the list's
+         * reference is not necessarily the last one - a maintenance query in flight holds one too - so
+         * the service can outlive its removal from the browser with the timer still armed, putting
+         * maintenance queries for a record we no longer track back on the wire. */
+        service->schedule_event = sd_event_source_disable_unref(service->schedule_event);
+
         LIST_REMOVE(dns_services, sb->dns_services, service);
         dnssd_discovered_service_unref(service);
 }

--- a/src/resolve/test-dns-browse-services.c
+++ b/src/resolve/test-dns-browse-services.c
@@ -3,10 +3,14 @@
 #include <string.h>
 #include <sys/socket.h>
 
+#include "sd-event.h"
+
 #include "dns-answer.h"
 #include "dns-rr.h"
 #include "resolved-dns-browse-services.h"
+#include "resolved-manager.h"
 #include "tests.h"
+#include "time-util.h"
 
 static DnsResourceRecord *new_test_service_rr(uint32_t ttl) {
         DnsResourceRecord *rr;
@@ -145,6 +149,38 @@ TEST(mdns_answer_contains_service_ifindex) {
 
         sb_scoped.ifindex = 3;
         ASSERT_OK_ZERO(mdns_answer_contains_service(&sb_scoped, answer2, &service));
+}
+
+TEST(dns_remove_service_disables_maintenance_timer) {
+        _cleanup_(sd_event_unrefp) sd_event *event = NULL;
+        _cleanup_(dns_resource_record_unrefp) DnsResourceRecord *rr = NULL;
+        _cleanup_(dnssd_discovered_service_unrefp) DnssdDiscoveredService *service = NULL;
+
+        ASSERT_OK(sd_event_new(&event));
+
+        Manager manager = {
+                .event = event,
+        };
+
+        DnsServiceBrowser sb = {
+                .manager = &manager,
+        };
+
+        ASSERT_NOT_NULL(rr = new_test_service_rr(120));
+        ASSERT_OK(dns_add_new_service(&sb, rr, AF_INET, 2,
+                                      usec_add(now(CLOCK_BOOTTIME), 120 * USEC_PER_SEC)));
+
+        ASSERT_NOT_NULL(sb.dns_services);
+        ASSERT_NOT_NULL(sb.dns_services->schedule_event);
+
+        /* Pin the service the way an in-flight maintenance query does, so that removing it from the
+         * browser does not free it. */
+        service = dnssd_discovered_service_ref(sb.dns_services);
+
+        dns_remove_service(&sb, service);
+
+        ASSERT_NULL(sb.dns_services);
+        ASSERT_NULL(service->schedule_event);
 }
 
 DEFINE_TEST_MAIN(LOG_DEBUG);


### PR DESCRIPTION
`dns_remove_service()` only drops the browser list's reference to the service:

```c
LIST_REMOVE(dns_services, sb->dns_services, service);
dnssd_discovered_service_unref(service);
```

That reference is not necessarily the last one. `mdns_maintenance_query()` takes one for `q->dnsservice_request`, so while a maintenance query is in flight the service survives its removal from the browser and `dns_service_free()` - which is where `service->schedule_event` is disabled today - does not run.

At that point the service is off `sb->dns_services` - resolved no longer tracks it, and the subscriber is either about to be sent the `removed` update for it in the same batch (`mdns_manage_services_answer()`) or losing its subscription entirely (`dns_service_browser_free()`) - and its one-shot maintenance source is still armed. It fires, bumps `rr_ttl_state` by another 5% increment, and puts a fresh maintenance query for the removed record back on the wire, repeating until the state reaches 100%.

This is not memory-unsafe - the query holds a reference to the service browser as well, so the browser stays valid - it is stale multicast traffic for a record the subscriber was already told is gone, from an object living past its logical lifetime.

Disable the source in `dns_remove_service()` instead, so removal from the browser ends the schedule regardless of who else still holds a reference. Both callers (`mdns_manage_services_answer()` and `dns_service_browser_free()`) are final removals, and `dns_service_free()` keeps its own `disable_unref()` for services freed without going through the list.

The added test pins the service the way an in-flight query does and asserts the schedule is stopped anyway; it aborts on the assertion without the fix.

Split out of #43608, which fixes a use-after-free in the same area but is otherwise independent of this.

