### PR TITLE
report: Include some attested TPM capabilities in the TPM signature

### DIFF
--- a/man/systemd-report-sign-tpm2@.service.xml
+++ b/man/systemd-report-sign-tpm2@.service.xml
@@ -44,21 +44,38 @@
     TPM2 device to generate a set of signed attestations that also bind the report digest passed to it,
     together providing a verifier with evidence about the state of the system that produced the report.</para>
 
-    <para>The returned report consists of several signed components, each carrying a JSON encoded
-    attestation structure and its corresponding signature. The signature is provided as a JSON encoded
-    <constant>TPMT_SIGNATURE</constant> structure and in PEM encoded form. The signed component types are:</para>
+    <para>The returned report consists of several components. Some of these carry a JSON encoded attestation
+    structure (<constant>TPMS_ATTEST</constant>) and its corresponding signature. The signature is provided as
+    a JSON encoded <constant>TPMT_SIGNATURE</constant> structure and in PEM encoded form. The components are:</para>
 
     <itemizedlist>
-      <listitem><para>A PCR quote, generated with <constant>TPM2_Quote</constant></para></listitem>
+      <listitem><para>A PCR quote, generated with <constant>TPM2_Quote</constant>. This contains the JSON
+      encoded attestation and the corresponding signature.</para></listitem>
 
       <listitem><para>One attestation per NvPCR, generated with <constant>TPM2_NV_Certify</constant>. Each
-      component also includes the readable name of the NvPCR, the NV index public area (as a JSON encoded
+      of these contain the JSON encoded attestation structure and its signature. In addition to this, each
+      one also includes the readable name of the NvPCR, the NV index public area (as a JSON encoded
       <constant>TPMS_NV_PUBLIC</constant> structure), and a JSON blob of authenticated data (the NvPCR name
       and priority) that is digested and supplied as the qualifying data to the certify command.</para></listitem>
 
+      <listitem><para>One component per reported TPM property, generated with <constant>TPM2_GetCapability</constant>.
+      Each of these contain the property and its value as a JSON encoded <constant>TPMS_TAGGED_PROPERTY</constant>
+      structure, as well as a boolean indicating the value of the <constant>moreData</constant> parameter returned
+      from the TPM. These components contain no signature of their own, but the response is included in the
+      audit session digest.</para></listitem>
+
+      <listitem><para>One component per reported TPM permanent handle authorization policy, generated with
+      <constant>TPM2_GetCapability</constant>. Each of these contain the handle, the policy digest algorithm,
+      and the policy digest (if the algorithm is not NULL) as a JSON encoded <constant>TPMS_TAGGED_POLICY</constant>
+      structure, as well as a boolean indicating the value of the <constant>moreData</constant> parameter
+      returned from the TPM. These components contain no signature of their own, but the response is included
+      in the audit session digest. Note that these components are omitted on TPMs that don't support
+      <constant>TPM_CAP_AUTH_POLICIES</constant>.</para></listitem>
+
       <listitem><para>An audit session attestation, generated with
       <constant>TPM2_GetSessionAuditDigest</constant>. This is always the last component. The report digest
-      passed in via Varlink is supplied as its qualifying data.</para></listitem>
+      passed in via Varlink is supplied as its qualifying data. All other components are generated using this
+      audit session.</para></listitem>
     </itemizedlist>
 
     <para>The report additionally includes the measurement event log, and the public area of the signing key.
@@ -71,9 +88,12 @@
     single, consistent snapshot of the system, with no other TPM commands interleaved while it was
     generated.</para>
 
-    <para>The set of attested PCRs and NvPCRs is currently fixed. It covers all firmware PCRs except PCR 6,
-    all other S-RTM PCRs except the IMA PCR (which is not useful without the IMA log), and all defined
-    NvPCRs.</para>
+    <para>The set of attested PCRs, NvPCRs, TPM properties and permanent handle authorization policies is
+    currently fixed. It covers all firmware PCRs except PCR 6, all other S-RTM PCRs except the IMA PCR (which is
+    not useful without the IMA log), all defined NvPCRs, the TPM_PT_PERMANENT, TPM_PT_MAX_AUTH_FAIL,
+    TPM_PT_LOCKOUT_INTERVAL and TPM_PT_LOCKOUT_RECOVERY TPM properties, and the authorization policies for the
+    storage, endorsement and lockout hierarchies. Note that authorization policies are omitted on TPMs that
+    don't support <constant>TPM_CAP_AUTH_POLICIES</constant></para>
   </refsect1>
 
   <refsect1>

--- a/src/report/report-sign-tpm2.c
+++ b/src/report/report-sign-tpm2.c
@@ -5,6 +5,7 @@
 #include "sd-json.h"
 #include "sd-varlink.h"
 
+#include "alloc-util.h"
 #include "build.h"
 #include "dlopen-note.h"
 #include "fd-util.h"
@@ -92,9 +93,36 @@ static int make_default_report_options(Tpm2ReportOptions *ret) {
                 (UINT32_C(1) << TPM2_PCR_SHIM_POLICY) |
                 (UINT32_C(1) << TPM2_PCR_SYSTEM_IDENTITY);
 
+        /* Include TPM properties pertaining to hierarchy authorization and
+         * dictionary attack logic configuration. */
+        static const TPM2_PT tpm_props[] = {
+                TPM2_PT_PERMANENT,
+                TPM2_PT_MAX_AUTH_FAIL,
+                TPM2_PT_LOCKOUT_INTERVAL,
+                TPM2_PT_LOCKOUT_RECOVERY,
+        };
+
+        _cleanup_free_ TPM2_PT *props = newdup(TPM2_PT, tpm_props, ELEMENTSOF(tpm_props));
+        if (!props)
+                return log_oom();
+
+        static const TPM2_HANDLE handles[] = {
+                TPM2_RH_OWNER,
+                TPM2_RH_LOCKOUT,
+                TPM2_RH_ENDORSEMENT,
+        };
+
+        _cleanup_free_ TPM2_HANDLE *policies = newdup(TPM2_HANDLE, handles, ELEMENTSOF(handles));
+        if (!policies)
+                return log_oom();
+
         *ret = (Tpm2ReportOptions) {
                 .pcr_mask = pcr_mask,
                 .nv_pcrs = TAKE_PTR(nv_pcrs),
+                .tpm_props = TAKE_PTR(props),
+                .n_tpm_props = ELEMENTSOF(tpm_props),
+                .auth_policies = TAKE_PTR(policies),
+                .n_auth_policies = ELEMENTSOF(handles),
         };
         return 0;
 }
@@ -579,46 +607,78 @@ static int reply_report(sd_varlink *link, const Tpm2Report *report, const struct
 
         _cleanup_(sd_json_variant_unrefp) sd_json_variant *cv = NULL;
         FOREACH_ARRAY(c, report->components, report->n_components) {
-                _cleanup_(sd_json_variant_unrefp) sd_json_variant *nv_public = NULL;
-                if (c->type == TPM2_REPORT_TYPE_NVPCR) {
+                _cleanup_(sd_json_variant_unrefp) sd_json_variant *nv_public = NULL, *tpm_prop = NULL,
+                        *auth_policy = NULL;
+
+                switch (c->type) {
+
+                case TPM2_REPORT_TYPE_PCR:
+                case TPM2_REPORT_TYPE_SESSION_AUDIT:
+                        break;
+
+                case TPM2_REPORT_TYPE_NVPCR:
                         r = tpm2_tpms_nv_public_to_json(c->nv_public, &nv_public);
                         if (r < 0)
                                 return log_error_errno(r, "Cannot convert NvPCR public area to JSON: %m");
+                        break;
+
+                case TPM2_REPORT_TYPE_CAPABILITY_TPM_PROPERTY:
+                        r = tpm2_tpms_tagged_property_to_json(c->property, &tpm_prop);
+                        if (r < 0)
+                                return log_error_errno(r, "Cannot convert tagged TPM property to JSON: %m");
+                        break;
+
+                case TPM2_REPORT_TYPE_CAPABILITY_AUTH_POLICY:
+                        r = tpm2_tpms_tagged_policy_to_json(c->auth_policy, &auth_policy);
+                        if (r < 0)
+                                return log_error_errno(r, "Cannot convert tagged auth policy to JSON: %m");
+                        break;
+
+                default:
+                        assert_not_reached();
                 }
 
-                TPMT_SIG_SCHEME scheme = {
-                        .scheme = c->signature->sigAlg,
-                };
-                if (IN_SET(scheme.scheme, TPM2_ALG_RSASSA, TPM2_ALG_RSAPSS, TPM2_ALG_ECDSA))
-                        scheme.details.any = c->signature->signature.any;
-                else if (scheme.scheme != TPM2_ALG_NULL)
-                        return log_error_errno(SYNTHETIC_ERRNO(ENOTRECOVERABLE),
-                                               "Unsupported signature scheme 0x%" PRIx16, scheme.scheme);
-
-                _cleanup_(sd_json_variant_unrefp) sd_json_variant *attest_info = NULL;
-                r = tpm2_attest_info_to_json(&scheme, c->attestation, &attest_info);
-                if (r < 0)
-                        return log_error_errno(r, "Cannot convert attestation info to JSON: %m");
-
-                _cleanup_(sd_json_variant_unrefp) sd_json_variant *sig = NULL;
-                r = tpm2_tpmt_signature_to_json(c->signature, &sig);
-                if (r < 0)
-                        return log_error_errno(r, "Cannot convert signature to JSON: %m");
-
+                /* Capability components aren't individually signed - they are covered by the session audit
+                 * digest in the final component instead. */
+                _cleanup_(sd_json_variant_unrefp) sd_json_variant *attest_info = NULL, *sig = NULL;
                 _cleanup_free_ char *sig_pem = NULL;
-                r = tpm2_tpmt_signature_to_pem(c->signature, &sig_pem);
-                if (r < 0)
-                        return log_error_errno(r, "Cannot convert signature to PEM: %m");
+                if (c->signature) {
+                        TPMT_SIG_SCHEME scheme = {
+                                .scheme = c->signature->sigAlg,
+                        };
+                        if (IN_SET(scheme.scheme, TPM2_ALG_RSASSA, TPM2_ALG_RSAPSS, TPM2_ALG_ECDSA))
+                                scheme.details.any = c->signature->signature.any;
+                        else if (scheme.scheme != TPM2_ALG_NULL)
+                                return log_error_errno(SYNTHETIC_ERRNO(ENOTRECOVERABLE),
+                                                       "Unsupported signature scheme 0x%" PRIx16, scheme.scheme);
+
+                        r = tpm2_attest_info_to_json(&scheme, c->attestation, &attest_info);
+                        if (r < 0)
+                                return log_error_errno(r, "Cannot convert attestation info to JSON: %m");
+
+                        r = tpm2_tpmt_signature_to_json(c->signature, &sig);
+                        if (r < 0)
+                                return log_error_errno(r, "Cannot convert signature to JSON: %m");
+
+                        r = tpm2_tpmt_signature_to_pem(c->signature, &sig_pem);
+                        if (r < 0)
+                                return log_error_errno(r, "Cannot convert signature to PEM: %m");
+                }
 
                 r = sd_json_variant_append_arraybo(
                                 &cv,
                                 SD_JSON_BUILD_PAIR_STRING("type", tpm2_report_component_type_to_string(c->type)),
-                                SD_JSON_BUILD_PAIR_CONDITION(c->type == TPM2_REPORT_TYPE_NVPCR, "nvpcrName", SD_JSON_BUILD_STRING(c->nv_pcr_name)),
-                                SD_JSON_BUILD_PAIR_CONDITION(c->type == TPM2_REPORT_TYPE_NVPCR, "nvPublic", SD_JSON_BUILD_VARIANT(nv_public)),
-                                SD_JSON_BUILD_PAIR_CONDITION(c->type != TPM2_REPORT_TYPE_SESSION_AUDIT && c->authenticated_data, "authenticatedData", SD_JSON_BUILD_STRING(c->authenticated_data)),
-                                SD_JSON_BUILD_PAIR_VARIANT("attestInfo", attest_info),
-                                SD_JSON_BUILD_PAIR_VARIANT("signature", sig),
-                                SD_JSON_BUILD_PAIR_STRING("signaturePEM", sig_pem));
+                                JSON_BUILD_PAIR_STRING_NON_EMPTY("nvpcrName", c->nv_pcr_name),
+                                JSON_BUILD_PAIR_VARIANT_NON_NULL("nvPublic", nv_public),
+                                JSON_BUILD_PAIR_STRING_NON_EMPTY("authenticatedData", c->authenticated_data),
+                                JSON_BUILD_PAIR_CONDITION_BOOLEAN(
+                                                IN_SET(c->type, TPM2_REPORT_TYPE_CAPABILITY_TPM_PROPERTY, TPM2_REPORT_TYPE_CAPABILITY_AUTH_POLICY),
+                                                "capabilityMoreData", c->more_caps),
+                                JSON_BUILD_PAIR_VARIANT_NON_NULL("tpmProperty", tpm_prop),
+                                JSON_BUILD_PAIR_VARIANT_NON_NULL("authPolicy", auth_policy),
+                                JSON_BUILD_PAIR_VARIANT_NON_NULL("attestInfo", attest_info),
+                                JSON_BUILD_PAIR_VARIANT_NON_NULL("signature", sig),
+                                JSON_BUILD_PAIR_STRING_NON_EMPTY("signaturePEM", sig_pem));
                 if (r < 0)
                         return log_error_errno(r, "Cannot add component to report array: %m");
         }

--- a/src/shared/tpm2-report.c
+++ b/src/shared/tpm2-report.c
@@ -17,12 +17,18 @@ void tpm2_report_options_done(Tpm2ReportOptions *opts) {
         assert(opts);
 
         opts->nv_pcrs = strv_free(opts->nv_pcrs);
+        opts->tpm_props = mfree(opts->tpm_props);
+        opts->n_tpm_props = 0;
+        opts->auth_policies = mfree(opts->auth_policies);
+        opts->n_auth_policies = 0;
 }
 
 static const char* const tpm2_report_component_type_table[_TPM2_REPORT_TYPE_MAX] = {
-        [TPM2_REPORT_TYPE_PCR]           = "pcr",
-        [TPM2_REPORT_TYPE_NVPCR]         = "nvpcr",
-        [TPM2_REPORT_TYPE_SESSION_AUDIT] = "session-audit",
+        [TPM2_REPORT_TYPE_PCR]                     = "pcr",
+        [TPM2_REPORT_TYPE_NVPCR]                   = "nvpcr",
+        [TPM2_REPORT_TYPE_CAPABILITY_TPM_PROPERTY] = "capability-tpm-property",
+        [TPM2_REPORT_TYPE_CAPABILITY_AUTH_POLICY]  = "capability-auth-policy",
+        [TPM2_REPORT_TYPE_SESSION_AUDIT]           = "session-audit",
 };
 DEFINE_STRING_TABLE_LOOKUP(tpm2_report_component_type, Tpm2ReportComponentType);
 
@@ -33,6 +39,10 @@ static void tpm2_report_component_done(Tpm2ReportComponent *c) {
         c->nv_public = mfree(c->nv_public);
 
         c->authenticated_data = mfree(c->authenticated_data);
+
+        c->property = mfree(c->property);
+
+        c->auth_policy = mfree(c->auth_policy);
 
         c->attestation = mfree(c->attestation);
         sym_Esys_Free(c->signature);
@@ -141,8 +151,12 @@ static int tpm2_generate_report_try(
                 Tpm2Context *c,
                 const Tpm2Handle *key,
                 const TPML_PCR_SELECTION *pcrs,
-                NvPCRReportRequest *nv_pcrs,
+                const NvPCRReportRequest *nv_pcrs,
                 size_t n_nv_pcrs,
+                const TPM2_PT *tpm_props,
+                size_t n_tpm_props,
+                const TPM2_HANDLE *auth_policies,
+                size_t n_auth_policies,
                 const TPM2B_DATA *external_data,
                 sd_json_variant **ret_event_log,
                 Tpm2ReportComponent **ret_components,
@@ -283,6 +297,55 @@ static int tpm2_generate_report_try(
                 r = sd_json_variant_new_array(&event_log, /* array= */ NULL, /* n= */ 0);
                 if (r < 0)
                         return log_debug_errno(r, "Failed to allocate empty event log array: %m");
+        }
+
+        FOREACH_ARRAY(prop, tpm_props, n_tpm_props) {
+                uint32_t value;
+                r = tpm2_get_capability_property(c, audit_session, *prop, &value);
+                if (r < 0)
+                        return log_debug_errno(r, "Failed to fetch TPM property 0x%08" PRIx32 ": %m", *prop);
+
+                _cleanup_free_ TPMS_TAGGED_PROPERTY *tp = new(TPMS_TAGGED_PROPERTY, 1);
+                if (!tp)
+                        return log_oom_debug();
+                *tp = (TPMS_TAGGED_PROPERTY) {
+                        .property = *prop,
+                        .value = value,
+                };
+
+                if (!GREEDY_REALLOC(components, n_components + 1))
+                        return log_oom_debug();
+                components[n_components++] = (Tpm2ReportComponent) {
+                        .type = TPM2_REPORT_TYPE_CAPABILITY_TPM_PROPERTY,
+                        .more_caps = r > 0,
+                        .property = TAKE_PTR(tp),
+                };
+        }
+
+        FOREACH_ARRAY(handle, auth_policies, n_auth_policies) {
+                TPMT_HA policy;
+                r = tpm2_get_capability_auth_policy(c, audit_session, *handle, &policy);
+                if (r == -ENXIO) {
+                        /* TPMs older than v1.38 don't support TPM_CAP_AUTH_POLICIES. */
+                        log_debug("Not including authorization policies in report as TPM_CAP_AUTH_POLICIES is not supported by the TPM.");
+                        break;
+                }
+                if (r < 0)
+                        return log_debug_errno(r, "Failed to fetch auth policy for TPM handle 0x%08" PRIx32 ": %m", *handle);
+
+                _cleanup_free_ TPMS_TAGGED_POLICY *tp = new0(TPMS_TAGGED_POLICY, 1);
+                if (!tp)
+                        return log_oom_debug();
+                tp->handle = *handle;
+                tp->policyHash = policy;
+
+                if (!GREEDY_REALLOC(components, n_components + 1))
+                        return log_oom_debug();
+                components[n_components++] = (Tpm2ReportComponent) {
+                        .type = TPM2_REPORT_TYPE_CAPABILITY_AUTH_POLICY,
+                        .more_caps = r > 0,
+                        .auth_policy = TAKE_PTR(tp),
+                };
         }
 
         _cleanup_free_ TPMS_ATTEST *audit_info = NULL;
@@ -439,6 +502,8 @@ int tpm2_generate_report(
                                 key,
                                 &pcrs,
                                 nv_pcrs, n_nv_pcrs,
+                                options->tpm_props, options->n_tpm_props,
+                                options->auth_policies, options->n_auth_policies,
                                 external_data,
                                 &event_log,
                                 &components, &n_components);

--- a/src/shared/tpm2-report.h
+++ b/src/shared/tpm2-report.h
@@ -12,6 +12,10 @@
 typedef struct Tpm2ReportOptions {
         uint32_t pcr_mask;
         char **nv_pcrs;
+        TPM2_PT *tpm_props;
+        size_t n_tpm_props;
+        TPM2_HANDLE *auth_policies;
+        size_t n_auth_policies;
 } Tpm2ReportOptions;
 
 void tpm2_report_options_done(Tpm2ReportOptions *opts);
@@ -19,6 +23,8 @@ void tpm2_report_options_done(Tpm2ReportOptions *opts);
 typedef enum Tpm2ReportComponentType {
         TPM2_REPORT_TYPE_PCR,
         TPM2_REPORT_TYPE_NVPCR,
+        TPM2_REPORT_TYPE_CAPABILITY_TPM_PROPERTY,
+        TPM2_REPORT_TYPE_CAPABILITY_AUTH_POLICY,
         TPM2_REPORT_TYPE_SESSION_AUDIT,
 
         _TPM2_REPORT_TYPE_MAX,
@@ -39,7 +45,16 @@ typedef struct Tpm2ReportComponent {
          * data is the report digest we get. */
         char *authenticated_data;
 
-        /* Common fields */
+        /* For TPM property and auth policy capability components. */
+        bool more_caps;
+
+        /* For TPM property capability components only. */
+        TPMS_TAGGED_PROPERTY *property;
+
+        /* For auth policy capability components only. */
+        TPMS_TAGGED_POLICY *auth_policy;
+
+        /* Common fields for PCR, NvPCR and session audit components. */
         TPMS_ATTEST *attestation;
         TPMT_SIGNATURE *signature;
 } Tpm2ReportComponent;

--- a/src/shared/tpm2-util.c
+++ b/src/shared/tpm2-util.c
@@ -4,6 +4,7 @@
 #include <unistd.h>
 
 #include "sd-device.h"
+#include "sd-json.h"
 
 #include "alloc-util.h"
 #include "ansi-color.h"
@@ -355,6 +356,20 @@ static void tpm2b_sensitive_data_erase_and_esys_freep(TPM2B_SENSITIVE_DATA **p) 
         sym_Esys_Free(*p);
 }
 
+static bool tpm2_is_audit_session(Tpm2Context *c, const Tpm2Handle *session) {
+        TPMA_SESSION flags = 0;
+        TSS2_RC rc;
+
+        assert(c);
+        assert(session);
+
+        rc = sym_Esys_TRSess_GetAttributes(c->esys_context, session->esys_handle, &flags);
+        if (rc != TSS2_RC_SUCCESS)
+                return false;
+
+        return flags & TPMA_SESSION_AUDIT;
+}
+
 /* Get a specific TPM capability (or capabilities).
  *
  * Returns 0 if there are no more capability properties of the requested type, or 1 if there are more, or < 0
@@ -372,6 +387,7 @@ static void tpm2b_sensitive_data_erase_and_esys_freep(TPM2B_SENSITIVE_DATA **p) 
  * details. */
 static int tpm2_get_capability(
                 Tpm2Context *c,
+                const Tpm2Handle *audit_session,
                 TPM2_CAP capability,
                 uint32_t property,
                 uint32_t count,
@@ -386,9 +402,13 @@ static int tpm2_get_capability(
         log_debug("Getting TPM2 capability 0x%04" PRIx32 " property 0x%04" PRIx32 " count %" PRIu32 ".",
                   capability, property, count);
 
+        if (audit_session && !tpm2_is_audit_session(c, audit_session))
+                return log_debug_errno(SYNTHETIC_ERRNO(EINVAL),
+                                       "Supplied session handle is not an audit session.");
+
         rc = sym_Esys_GetCapability(
                         c->esys_context,
-                        ESYS_TR_NONE,
+                        audit_session ? audit_session->esys_handle : ESYS_TR_NONE,
                         ESYS_TR_NONE,
                         ESYS_TR_NONE,
                         capability,
@@ -396,10 +416,14 @@ static int tpm2_get_capability(
                         count,
                         &more,
                         &capabilities);
-        if (rc == TPM2_RC_VALUE)
+        if (rc == TPM2_RC_EXCLUSIVE)
+                return log_debug_errno(SYNTHETIC_ERRNO(EBUSY),
+                                       "Failed to get TPM2 capability 0x%04" PRIx32 " property 0x%04" PRIx32 ": audit session required exclusivity",
+                                       capability, property);
+        /* A TPM2_RC_VALUE for the first command parameter means the TPM doesn't know the requested capability. */
+        if (rc == (TPM2_RC_VALUE|TPM2_RC_P|TPM2_RC_1))
                 return log_debug_errno(SYNTHETIC_ERRNO(ENXIO),
-                                       "Requested TPM2 capability 0x%04" PRIx32 " property 0x%04" PRIx32 " apparently doesn't exist: %s",
-                                       capability, property, sym_Tss2_RC_Decode(rc));
+                                       "Requested TPM2 capability 0x%04" PRIx32 " is not supported", capability);
         if (rc != TSS2_RC_SUCCESS)
                 return log_debug_errno(SYNTHETIC_ERRNO(ENOTRECOVERABLE),
                                        "Failed to get TPM2 capability 0x%04" PRIx32 " property 0x%04" PRIx32 ": %s",
@@ -413,25 +437,6 @@ static int tpm2_get_capability(
                 *ret_capability_data = capabilities->data;
 
         return more == TPM2_YES;
-}
-
-static int tpm2_get_capability_property(Tpm2Context *c, uint32_t property, uint32_t *ret_value) {
-        int r;
-
-        assert(c);
-        assert(ret_value);
-
-        TPMU_CAPABILITIES capabilities = {};
-        r = tpm2_get_capability(c, TPM2_CAP_TPM_PROPERTIES, property, 1, &capabilities);
-        if (r < 0)
-                return r;
-
-        if (capabilities.tpmProperties.count == 0 ||
-            capabilities.tpmProperties.tpmProperty[0].property != property)
-                return log_debug_errno(SYNTHETIC_ERRNO(ENOENT), "TPM property 0x%04" PRIx32 " does not exist", property);
-
-        *ret_value = capabilities.tpmProperties.tpmProperty[0].value;
-        return 0;
 }
 
 int tpm2_vendor_info_to_modalias(const Tpm2VendorInfo *info, char **ret) {
@@ -502,6 +507,7 @@ int tpm2_get_vendor_info(
         TPMU_CAPABILITIES capabilities = {};
         r = tpm2_get_capability(
                         c,
+                        /* audit_session= */ NULL,
                         TPM2_CAP_TPM_PROPERTIES,
                         TPM2_PT_FAMILY_INDICATOR,
                         TPM2_PT_FIRMWARE_VERSION_2 - TPM2_PT_FAMILY_INDICATOR + 1, /* get all relevant fields at once */
@@ -579,6 +585,48 @@ int tpm2_get_vendor_info(
         return 0;
 }
 
+/* Fetch a single TPM property. Returns 1 if the TPM has further properties to report after this one
+ * (i.e. TPM2_GetCapability() set moreData), 0 otherwise. */
+int tpm2_get_capability_property(Tpm2Context *c, const Tpm2Handle *audit_session, TPM2_PT property, uint32_t *ret) {
+        int r;
+
+        assert(c);
+        assert(ret);
+
+        TPMU_CAPABILITIES capabilities = {};
+        r = tpm2_get_capability(c, audit_session, TPM2_CAP_TPM_PROPERTIES, property, 1, &capabilities);
+        if (r < 0)
+                return r;
+
+        if (capabilities.tpmProperties.count == 0 ||
+            capabilities.tpmProperties.tpmProperty[0].property != property)
+                return log_debug_errno(SYNTHETIC_ERRNO(ENOENT), "TPM property 0x%08" PRIx32 " does not exist", property);
+
+        *ret = capabilities.tpmProperties.tpmProperty[0].value;
+        return r;
+}
+
+/* Fetch the authorization policy of a single permanent handle. Returns 1 if the TPM has further policies
+ * to report after this one (i.e. TPM2_GetCapability() set moreData), 0 otherwise. */
+int tpm2_get_capability_auth_policy(Tpm2Context *c, const Tpm2Handle *audit_session, TPM2_HANDLE handle, TPMT_HA *ret) {
+        int r;
+
+        assert(c);
+        assert(ret);
+
+        TPMU_CAPABILITIES capabilities = {};
+        r = tpm2_get_capability(c, audit_session, TPM2_CAP_AUTH_POLICIES, handle, 1, &capabilities);
+        if (r < 0)
+                return r;
+
+        if (capabilities.authPolicies.count == 0 ||
+            capabilities.authPolicies.policies[0].handle != handle)
+                return log_debug_errno(SYNTHETIC_ERRNO(ENOENT), "Auth policy for TPM handle 0x%08" PRIx32 " does not exist", handle);
+
+        *ret = capabilities.authPolicies.policies[0].policyHash;
+        return r;
+}
+
 #define TPMA_CC_TO_TPM2_CC(cca) (((cca) & TPMA_CC_COMMANDINDEX_MASK) >> TPMA_CC_COMMANDINDEX_SHIFT)
 
 /* The TCG reference library spec (part 2) doesn't guarantee a minimum size for the
@@ -603,6 +651,7 @@ static int tpm2_cache_capabilities(Tpm2Context *c) {
         for (;;) {
                 r = tpm2_get_capability(
                                 c,
+                                /* audit_session= */ NULL,
                                 TPM2_CAP_ALGS,
                                 (uint32_t) current_alg, /* The spec states to cast TPM2_ALG_ID to uint32_t. */
                                 TPM2_MAX_CAP_ALGS,
@@ -636,6 +685,7 @@ static int tpm2_cache_capabilities(Tpm2Context *c) {
         for (;;) {
                 r = tpm2_get_capability(
                                 c,
+                                /* audit_session= */ NULL,
                                 TPM2_CAP_COMMANDS,
                                 current_cc,
                                 TPM2_MAX_CAP_CC,
@@ -669,6 +719,7 @@ static int tpm2_cache_capabilities(Tpm2Context *c) {
         for (;;) {
                 r = tpm2_get_capability(
                                 c,
+                                /* audit_session= */ NULL,
                                 TPM2_CAP_ECC_CURVES,
                                 current_ecc_curve,
                                 TPM2_MAX_ECC_CURVES,
@@ -704,6 +755,7 @@ static int tpm2_cache_capabilities(Tpm2Context *c) {
          * safely assume the TPM PCR allocation will not change while we are using it. */
         r = tpm2_get_capability(
                         c,
+                        /* audit_session= */ NULL,
                         TPM2_CAP_PCRS,
                         /* property= */ 0,
                         /* count= */ 1,
@@ -724,7 +776,11 @@ static int tpm2_cache_capabilities(Tpm2Context *c) {
          * certificate with a RSA public key. */
         uint32_t max_nv_buffer_size = 0;
 
-        r = tpm2_get_capability_property(c, TPM2_PT_NV_BUFFER_MAX, &max_nv_buffer_size);
+        r = tpm2_get_capability_property(
+                        c,
+                        /* audit_session= */ NULL,
+                        TPM2_PT_NV_BUFFER_MAX,
+                        &max_nv_buffer_size);
         if (r == -ENOENT) {
                 log_debug("TPM bug: didn't report a value for TPM_PT_NV_BUFFER_MAX; using %"PRIu32".", FALLBACK_MAX_NV_BUFFER_SIZE);
                 max_nv_buffer_size = FALLBACK_MAX_NV_BUFFER_SIZE;
@@ -808,7 +864,11 @@ int tpm2_max_data_size(Tpm2Context *c) {
         assert(c);
 
         uint32_t max_digest_size = 0;
-        r = tpm2_get_capability_property(c, TPM2_PT_MAX_DIGEST, &max_digest_size);
+        r = tpm2_get_capability_property(
+                        c,
+                        /* audit_session= */ NULL,
+                        TPM2_PT_MAX_DIGEST,
+                        &max_digest_size);
         if (r < 0)
                 return r;
 
@@ -848,7 +908,13 @@ static int tpm2_get_capability_handles(
 
         while (max > 0) {
                 TPMU_CAPABILITIES capability;
-                r = tpm2_get_capability(c, TPM2_CAP_HANDLES, current, (uint32_t) max, &capability);
+                r = tpm2_get_capability(
+                                c,
+                                /* audit_session= */ NULL,
+                                TPM2_CAP_HANDLES,
+                                current,
+                                (uint32_t) max,
+                                &capability);
                 if (r < 0)
                         return r;
 
@@ -4523,20 +4589,6 @@ int tpm2_make_encryption_session(
         *ret_session = TAKE_PTR(session);
 
         return 0;
-}
-
-static bool tpm2_is_audit_session(Tpm2Context *c, const Tpm2Handle *session) {
-        TPMA_SESSION flags = 0;
-        TSS2_RC rc;
-
-        assert(c);
-        assert(session);
-
-        rc = sym_Esys_TRSess_GetAttributes(c->esys_context, session->esys_handle, &flags);
-        if (rc != TSS2_RC_SUCCESS)
-                return false;
-
-        return flags & TPMA_SESSION_AUDIT;
 }
 
 int tpm2_make_exclusive_audit_session(Tpm2Context *c, Tpm2Handle **ret_session) {
@@ -10407,6 +10459,8 @@ static const char* tpm2_hash_alg_to_string_tss2(TPMI_ALG_HASH alg) {
                 return "SHA384";
         case TPM2_ALG_SHA512:
                 return "SHA512";
+        case TPM2_ALG_NULL:
+                return "NULL";
         default:
                 log_debug("Unknown hash algorithm id 0x%" PRIx16, alg);
                 return NULL;
@@ -10901,6 +10955,115 @@ int tpm2_tpms_nv_public_to_json(const TPMS_NV_PUBLIC *nv_public, sd_json_variant
 
         *ret = TAKE_PTR(v);
         return 0;
+}
+
+/* Convert a TPM property to JSON, in a way that is compatible with the TCG TSS2 JSON data
+ * format, and which is compatible with the TSS2 implementation. These are converted to a string
+ * with the TPM2_PT_ prefix dropped, or a plain base-10 integer for properties that aren't
+ * implemented.
+ *
+ * See https://trustedcomputinggroup.org/wp-content/uploads/TSS_JSON_Policy_v0p7_r08_pub.pdf */
+static int tpm2_tpm_pt_to_json(TPM2_PT prop, sd_json_variant **ret) {
+        assert(ret);
+
+        const char *s = NULL;
+        switch (prop) {
+        case TPM2_PT_PERMANENT:
+                s = "PERMANENT";
+                break;
+        case TPM2_PT_MAX_AUTH_FAIL:
+                s = "MAX_AUTH_FAIL";
+                break;
+        case TPM2_PT_LOCKOUT_INTERVAL:
+                s = "LOCKOUT_INTERVAL";
+                break;
+        case TPM2_PT_LOCKOUT_RECOVERY:
+                s = "LOCKOUT_RECOVERY";
+                break;
+        }
+
+        if (s)
+                return sd_json_variant_new_string(ret, s);
+        return sd_json_variant_new_unsigned(ret, prop);
+}
+
+/* Convert a tagged property to JSON, in a format compatible with the TCG TSS2 JSON data format, and
+ * which is compatible with the TSS2 implementation.
+ *
+ * See https://trustedcomputinggroup.org/wp-content/uploads/TSS_JSON_Policy_v0p7_r08_pub.pdf */
+int tpm2_tpms_tagged_property_to_json(const TPMS_TAGGED_PROPERTY *property, sd_json_variant **ret) {
+        int r;
+
+        assert(property);
+        assert(ret);
+
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *prop = NULL;
+        r = tpm2_tpm_pt_to_json(property->property, &prop);
+        if (r < 0)
+                return r;
+
+        return sd_json_buildo(
+                ret,
+                SD_JSON_BUILD_PAIR_VARIANT("property", prop),
+                SD_JSON_BUILD_PAIR_UNSIGNED("value", property->value));
+}
+
+static int tpm2_tpmt_ha_to_json(const TPMT_HA *ha, sd_json_variant **ret) {
+        assert(ha);
+        assert(ret);
+
+        const uint8_t *digest;
+        size_t digest_len;
+        switch (ha->hashAlg) {
+        case TPM2_ALG_SHA1:
+                digest = ha->digest.sha1;
+                digest_len = sizeof(ha->digest.sha1);
+                break;
+        case TPM2_ALG_SHA256:
+                digest = ha->digest.sha256;
+                digest_len = sizeof(ha->digest.sha256);
+                break;
+        case TPM2_ALG_SHA384:
+                digest = ha->digest.sha384;
+                digest_len = sizeof(ha->digest.sha384);
+                break;
+        case TPM2_ALG_SHA512:
+                digest = ha->digest.sha512;
+                digest_len = sizeof(ha->digest.sha512);
+                break;
+        case TPM2_ALG_NULL:
+                digest = NULL;
+                digest_len = 0;
+                break;
+        default:
+                return log_debug_errno(SYNTHETIC_ERRNO(EINVAL),
+                                       "Unsupported hash algorithm id 0x%" PRIx16, ha->hashAlg);
+        }
+        return sd_json_buildo(
+                        ret,
+                        SD_JSON_BUILD_PAIR_STRING("hashAlg", tpm2_hash_alg_to_string_tss2(ha->hashAlg)),
+                        SD_JSON_BUILD_PAIR_CONDITION(digest != NULL, "digest", SD_JSON_BUILD_HEX(digest, digest_len)));
+}
+
+/* Convert a tagged policy to JSON, in a format compatible with the TCG TSS2 JSON data format, and
+ * which is compatible with the TSS2 implementation.
+ *
+ * See https://trustedcomputinggroup.org/wp-content/uploads/TSS_JSON_Policy_v0p7_r08_pub.pdf */
+int tpm2_tpms_tagged_policy_to_json(const TPMS_TAGGED_POLICY *policy, sd_json_variant **ret) {
+        int r;
+
+        assert(policy);
+        assert(ret);
+
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *policy_hash = NULL;
+        r = tpm2_tpmt_ha_to_json(&policy->policyHash, &policy_hash);
+        if (r < 0)
+                return r;
+
+        return sd_json_buildo(
+                        ret,
+                        SD_JSON_BUILD_PAIR_UNSIGNED("handle", policy->handle),
+                        SD_JSON_BUILD_PAIR_VARIANT("policyHash", policy_hash));
 }
 
 static const TPMT_SIG_SCHEME SIG_SCHEME_TEMPLATE_NULL = {

--- a/src/shared/tpm2-util.h
+++ b/src/shared/tpm2-util.h
@@ -260,6 +260,9 @@ typedef struct Tpm2VendorInfo {
 int tpm2_vendor_info_to_modalias(const Tpm2VendorInfo *info, char **ret);
 int tpm2_get_vendor_info(Tpm2Context *c, Tpm2VendorInfo *ret);
 
+int tpm2_get_capability_property(Tpm2Context *c, const Tpm2Handle *audit_session, TPM2_PT property, uint32_t *ret);
+int tpm2_get_capability_auth_policy(Tpm2Context *c, const Tpm2Handle *audit_session, TPM2_HANDLE handle, TPMT_HA *ret);
+
 void tpm2_log_debug_tpml_pcr_selection(const TPML_PCR_SELECTION *l, const char *msg);
 void tpm2_log_debug_pcr_value(const Tpm2PCRValue *pcr_value, const char *msg);
 void tpm2_log_debug_buffer(const void *buffer, size_t size, const char *msg);
@@ -427,6 +430,8 @@ int tpm2_tpmt_signature_to_json(const TPMT_SIGNATURE *signature, sd_json_variant
 int tpm2_attest_info_to_json(const TPMT_SIG_SCHEME *scheme, const TPMS_ATTEST *attest, sd_json_variant **ret);
 int tpm2_tpmt_public_to_json(const TPMT_PUBLIC *public, sd_json_variant **ret);
 int tpm2_tpms_nv_public_to_json(const TPMS_NV_PUBLIC *nv_public, sd_json_variant **ret);
+int tpm2_tpms_tagged_property_to_json(const TPMS_TAGGED_PROPERTY *property, sd_json_variant **ret);
+int tpm2_tpms_tagged_policy_to_json(const TPMS_TAGGED_POLICY *policy, sd_json_variant **ret);
 
 int tpm2_quote(Tpm2Context *c, const Tpm2Handle *sign_session, const Tpm2Handle *audit_session, const Tpm2Handle *sign_key, const TPM2B_DATA *qualifying_data, const TPML_PCR_SELECTION *pcr_select, TPMS_ATTEST **ret_quoted, TPMT_SIGNATURE **ret_signature);
 int tpm2_nv_certify(Tpm2Context *c, const Tpm2Handle *sign_session, const Tpm2Handle *auth_session, const Tpm2Handle *audit_session, const Tpm2Handle *sign_key, const TPMS_NV_PUBLIC *nv_public, const Tpm2Handle *nv_handle, const TPM2B_DATA *qualifying_data, TPMS_ATTEST **ret_certify_info, TPMT_SIGNATURE **ret_signature);

--- a/src/test/test-tpm2.c
+++ b/src/test/test-tpm2.c
@@ -5,6 +5,7 @@
 #include "crypto-util.h"
 #include "hexdecoct.h"
 #include "iovec-util.h"
+#include "memory-util.h"
 #include "random-util.h"
 #include "tests.h"
 #include "tpm2-util.h"
@@ -1335,6 +1336,92 @@ static void check_supports_command(Tpm2Context *c) {
         assert_se(tpm2_supports_command(c, TPM2_CC_Unseal));
 }
 
+static void check_get_capability_property(Tpm2Context *c) {
+        assert(c);
+
+        TEST_LOG_FUNC();
+
+        /* Fetch the whole group of fixed properties in one go, so that we have something to cross-check the
+         * individual properties we fetch below against. This doesn't use the tpm2_get_capability_property
+         * helper that we are testing. */
+        Tpm2VendorInfo vendor_info;
+        ASSERT_OK(tpm2_get_vendor_info(c, &vendor_info));
+
+        /* The TPM will tell us that there are more properties to report if there are any properties after
+         * the last one we ask for, even if we don't request it. */
+        uint32_t value;
+        ASSERT_OK_POSITIVE(tpm2_get_capability_property(c, /* audit_session= */ NULL, TPM2_PT_LEVEL, &value));
+        ASSERT_EQ(value, vendor_info.level);
+
+        ASSERT_OK_POSITIVE(tpm2_get_capability_property(c, /* audit_session= */ NULL, TPM2_PT_YEAR, &value));
+        ASSERT_EQ(value, vendor_info.year);
+
+        ASSERT_OK_POSITIVE(tpm2_get_capability_property(
+                        c, /* audit_session= */ NULL, TPM2_PT_FIRMWARE_VERSION_2, &value));
+        ASSERT_EQ(value, vendor_info.firmware_version2);
+
+        /* Request a property we know doesn't exist. */
+        ASSERT_ERROR(tpm2_get_capability_property(
+                        c, /* audit_session= */ NULL, TPM2_PT_FIXED + TPM2_PT_GROUP - 1, &value), ENOENT);
+
+        /* Fetching a property with an audit session must give the same result. */
+        _cleanup_(tpm2_handle_freep) Tpm2Handle *session = NULL;
+        ASSERT_OK(tpm2_make_exclusive_audit_session(c, &session));
+
+        uint32_t audited_value;
+        ASSERT_OK_POSITIVE(tpm2_get_capability_property(
+                        c, session, TPM2_PT_FIRMWARE_VERSION_2, &audited_value));
+        ASSERT_EQ(audited_value, vendor_info.firmware_version2);
+}
+
+static void check_get_capability_auth_policy(Tpm2Context *c) {
+        static const TPM2_HANDLE handles[] = {
+                TPM2_RH_OWNER,
+                TPM2_RH_LOCKOUT,
+                TPM2_RH_ENDORSEMENT,
+        };
+        TPMT_HA policies[ELEMENTSOF(handles)] = {};
+        TPMT_HA policy = {};
+        int r;
+
+        assert(c);
+
+        TEST_LOG_FUNC();
+
+        r = tpm2_get_capability_auth_policy(c, /* audit_session= */ NULL, handles[0], &policies[0]);
+        if (r == -ENXIO) {
+                /* TPMs older than v1.38 don't support TPM_CAP_AUTH_POLICIES. */
+                log_notice("TPM does not support TPM_CAP_AUTH_POLICIES, skipping remaining tests.");
+                return;
+        }
+        ASSERT_OK(r);
+
+        for (size_t i = 0; i < ELEMENTSOF(handles); i++) {
+                ASSERT_OK(tpm2_get_capability_auth_policy(
+                                c, /* audit_session= */ NULL, handles[i], &policies[i]));
+
+                /* A hierarchy without an authorization policy is reported with TPM2_ALG_NULL, otherwise the
+                 * policy hash must use a hash algorithm the TPM supports. */
+                if (policies[i].hashAlg != TPM2_ALG_NULL) {
+                        ASSERT_TRUE(tpm2_supports_alg(c, policies[i].hashAlg));
+                }
+        }
+
+        /* The TPM must not report an authorization policy for a reserved permanent handle. */
+        ASSERT_ERROR(tpm2_get_capability_auth_policy(
+                        c, /* audit_session= */ NULL, TPM2_RH_LAST, &policy), ENOENT);
+
+        /* Fetching the same policies through an audit session must give the same results. */
+        _cleanup_(tpm2_handle_freep) Tpm2Handle *session = NULL;
+        ASSERT_OK(tpm2_make_exclusive_audit_session(c, &session));
+
+        for (size_t i = 0; i < ELEMENTSOF(handles); i++) {
+                policy = (TPMT_HA) {};
+                ASSERT_OK(tpm2_get_capability_auth_policy(c, session, handles[i], &policy));
+                ASSERT_EQ(policy.hashAlg, policies[i].hashAlg);
+        }
+}
+
 static void check_get_or_create_srk(Tpm2Context *c) {
         TEST_LOG_FUNC();
 
@@ -2186,6 +2273,123 @@ TEST(tpm2_tpms_nv_public_to_json) {
         ASSERT_STREQ(json, "{\"nvIndex\":30474754,\"nameAlg\":\"SHA256\",\"attributes\":738590792,\"authPolicy\":\"c0f52d0be7f6c1666d90a181a99a74b99c5e0bfd00bc52cc27ae0e66d89afcf5\",\"dataSize\":32}");
 }
 
+TEST(tpm2_tpms_tagged_property_to_json) {
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *v1 = NULL;
+        TPMS_TAGGED_PROPERTY prop1 = {
+                .property = TPM2_PT_PERMANENT,
+                .value = TPMA_PERMANENT_LOCKOUTAUTHSET,
+        };
+        ASSERT_OK(tpm2_tpms_tagged_property_to_json(&prop1, &v1));
+
+        _cleanup_free_ char *json1 = NULL;
+        ASSERT_OK(sd_json_variant_format(v1, 0, &json1));
+        ASSERT_STREQ(json1, "{\"property\":\"PERMANENT\",\"value\":4}");
+
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *v2 = NULL;
+        TPMS_TAGGED_PROPERTY prop2 = {
+                .property = TPM2_PT_LOCKOUT_INTERVAL,
+                .value = 7200,
+        };
+        ASSERT_OK(tpm2_tpms_tagged_property_to_json(&prop2, &v2));
+
+        _cleanup_free_ char *json2 = NULL;
+        ASSERT_OK(sd_json_variant_format(v2, 0, &json2));
+        ASSERT_STREQ(json2, "{\"property\":\"LOCKOUT_INTERVAL\",\"value\":7200}");
+
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *v3 = NULL;
+        TPMS_TAGGED_PROPERTY prop3 = {
+                .property = TPM2_PT_MAX_DIGEST,
+                .value = 48,
+        };
+        ASSERT_OK(tpm2_tpms_tagged_property_to_json(&prop3, &v3));
+
+        _cleanup_free_ char *json3 = NULL;
+        ASSERT_OK(sd_json_variant_format(v3, 0, &json3));
+        ASSERT_STREQ(json3, "{\"property\":288,\"value\":48}");
+}
+
+TEST(tpm2_tpms_tagged_policy_to_json) {
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *v1 = NULL;
+        TPMS_TAGGED_POLICY policy1 = {
+                .handle = TPM2_RH_OWNER,
+                .policyHash = {
+                        .hashAlg = TPM2_ALG_NULL,
+                }
+        };
+
+        ASSERT_OK(tpm2_tpms_tagged_policy_to_json(&policy1, &v1));
+
+        _cleanup_free_ char *json1 = NULL;
+        ASSERT_OK(sd_json_variant_format(v1, 0, &json1));
+        ASSERT_STREQ(json1, "{\"handle\":1073741825,\"policyHash\":{\"hashAlg\":\"NULL\"}}");
+
+        const char policy_hex2[] = "39d64794bd1eba89098fc63aac282c2c4eedf1dee79e4f6b99ca3f57f87d7dfc";
+        DEFINE_HEX_PTR(policy_bytes2, policy_hex2);
+
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *v2 = NULL;
+        TPMS_TAGGED_POLICY policy2 = {
+                .handle = TPM2_RH_LOCKOUT,
+                .policyHash = {
+                        .hashAlg = TPM2_ALG_SHA256,
+                },
+        };
+        ASSERT_EQ(policy_bytes2_len, sizeof(policy2.policyHash.digest.sha256));
+        memcpy(&policy2.policyHash.digest.sha256, policy_bytes2, sizeof(policy2.policyHash.digest.sha256));
+
+        ASSERT_OK(tpm2_tpms_tagged_policy_to_json(&policy2, &v2));
+
+        _cleanup_free_ char *json2 = NULL;
+        ASSERT_OK(sd_json_variant_format(v2, 0, &json2));
+        _cleanup_free_ char *json2_expected = NULL;
+        ASSERT_OK(asprintf(&json2_expected, "{\"handle\":1073741834,\"policyHash\":{\"hashAlg\":\"SHA256\",\"digest\":\"%s\"}}", policy_hex2));
+        ASSERT_STREQ(json2, json2_expected);
+
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *v3 = NULL;
+        TPMS_TAGGED_POLICY policy3 = {
+                .handle = TPM2_RH_PLATFORM,
+                .policyHash = {
+                        .hashAlg = TPM2_ALG_NULL,
+                }
+        };
+
+        ASSERT_OK(tpm2_tpms_tagged_policy_to_json(&policy3, &v3));
+
+        _cleanup_free_ char *json3 = NULL;
+        ASSERT_OK(sd_json_variant_format(v3, 0, &json3));
+        ASSERT_STREQ(json3, "{\"handle\":1073741836,\"policyHash\":{\"hashAlg\":\"NULL\"}}");
+
+        const char policy_hex4[] = "0a6d20fef462389c789b36e42efb94f9f9fd4d0174f0c27e14beff33d1cbdafeef119433117124e77a89b64ec80112f6";
+        DEFINE_HEX_PTR(policy_bytes4, policy_hex4);
+
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *v4 = NULL;
+        TPMS_TAGGED_POLICY policy4 = {
+                .handle = TPM2_RH_ENDORSEMENT,
+                .policyHash = {
+                        .hashAlg = TPM2_ALG_SHA384,
+                },
+        };
+        ASSERT_EQ(policy_bytes4_len, sizeof(policy4.policyHash.digest.sha384));
+        memcpy(&policy4.policyHash.digest.sha384, policy_bytes4, sizeof(policy4.policyHash.digest.sha384));
+
+        ASSERT_OK(tpm2_tpms_tagged_policy_to_json(&policy4, &v4));
+
+        _cleanup_free_ char *json4 = NULL;
+        ASSERT_OK(sd_json_variant_format(v4, 0, &json4));
+        _cleanup_free_ char *json4_expected = NULL;
+        ASSERT_OK(asprintf(&json4_expected, "{\"handle\":1073741835,\"policyHash\":{\"hashAlg\":\"SHA384\",\"digest\":\"%s\"}}", policy_hex4));
+        ASSERT_STREQ(json4, json4_expected);
+
+        _cleanup_(sd_json_variant_unrefp) sd_json_variant *v5 = NULL;
+        TPMS_TAGGED_POLICY policy_unsupported = {
+                .handle = TPM2_RH_OWNER,
+                .policyHash = {
+                        .hashAlg = TPM2_ALG_SM3_256,
+                }
+        };
+
+        ASSERT_ERROR(tpm2_tpms_tagged_policy_to_json(&policy_unsupported, &v5), EINVAL);
+}
+
 static void check_attest_common(const TPMS_ATTEST *attest, TPMI_ST_ATTEST type, const TPM2B_DATA *extra_data) {
         ASSERT_EQ(attest->magic, TPM2_GENERATED_VALUE);
         ASSERT_EQ(attest->type, type);
@@ -2359,6 +2563,8 @@ TEST_RET(tests_which_require_tpm) {
         check_test_parms(c);
         check_supports_alg(c);
         check_supports_command(c);
+        check_get_capability_property(c);
+        check_get_capability_auth_policy(c);
         check_best_srk_template(c);
         check_get_or_create_srk(c);
         check_seal_unseal(c);

--- a/test/units/TEST-70-TPM2.report-sign.sh
+++ b/test/units/TEST-70-TPM2.report-sign.sh
@@ -10,14 +10,20 @@ set -o pipefail
 # only the TPM2 integration test provides.
 #
 # The TPM2 backend returns a set of signed TPM attestations (a PCR quote, one
-# NV certification per NvPCR, and a session audit digest), together with the
-# signing key's public area and the pcrlock event log. The public area, the
-# attestations and the signatures are all serialized as TCG TSS2 JSON. For each
-# attestation we rebuild the public key, re-marshal the TPMS_ATTEST that was
-# signed, and verify the signature using the embedded Python helper below. The
-# helper also cross-checks the parallel PEM encodings (publicKeyPEM and signaturePEM)
-# against the JSON encodings. We also confirm the report digest is carried in the
-# extraData field of the session audit attestation.
+# NV certification per NvPCR, and a session audit digest), a set of unsigned TPM
+# capability readings (a few TPM properties and the hierarchy auth policies),
+# together with the signing key's public area and the pcrlock event log. The
+# public area, the attestations, the capabilities and the signatures are all
+# serialized as TCG TSS2 JSON. For each attestation we rebuild the public key,
+# re-marshal the TPMS_ATTEST that was signed, and verify the signature using the
+# embedded Python helper below. The helper also cross-checks the parallel PEM
+# encodings (publicKeyPEM and signaturePEM) against the JSON encodings. We also
+# confirm the report digest is carried in the extraData field of the session audit
+# attestation.
+#
+# The capability components carry no signature of their own. They are bound to the
+# report by the session audit digest, which covers every command issued inside
+# the audit session, including the TPM2_GetCapability commands.
 #
 # shellcheck source=test/units/util.sh
 . "$(dirname "$0")"/util.sh
@@ -48,8 +54,19 @@ fi
 
 WORK="$(mktemp -d)"
 
+# See below - we temporarily give the lockout hierarchy an authorization value and
+# a policy.
+LOCKOUT_AUTH="systemd-report-sign-test"
+lockout_modified=0
+
 at_exit() {
     set +e
+
+    if [ "$lockout_modified" -eq 1 ]; then
+        tpm2_changeauth -c lockout -p "$LOCKOUT_AUTH" ""
+    fi
+    tpm2_setprimarypolicy -C lockout
+
     systemctl stop systemd-report.socket systemd-report-sign-tpm2.socket
     rm -rf "$WORK"
 }
@@ -62,6 +79,21 @@ trap at_exit EXIT
 if ! tpm2_createek -c 0x81010001 -G ecc; then
     echo "tpm2_createek failed, assuming an EK is already present."
 fi
+
+# None of the hierarchies have an authorization value or a policy in the test
+# environment, so every auth policy the backend reports would be empty and the
+# TPMA_PERMANENT it reports would carry none of the *AuthSet flags. Give the
+# lockout hierarchy both for the duration of the test so that the non-empty cases
+# actually get exercised. We pick the lockout hierarchy because, unlike the owner
+# and endorsement hierarchies, nothing else here makes use of it.
+LOCKOUT_POLICY="$(python3 -c 'import hashlib, sys
+digest = hashlib.sha256(b"systemd report signing test").digest()
+open(sys.argv[1], "wb").write(digest)
+print(digest.hex())' "$WORK/lockout.policy")"
+
+tpm2_setprimarypolicy -C lockout -L "$WORK/lockout.policy" -g sha256
+tpm2_changeauth -c lockout "$LOCKOUT_AUTH"
+lockout_modified=1
 
 # The TPM2 backend reads the event log from pcrlock's Varlink interface, so make
 # sure its socket is up.
@@ -99,6 +131,35 @@ test -n "$sig_json"
 report_digest="$(sha256sum "$WORK/message.bin" | cut -d' ' -f1)"
 [ "$(echo "$sig_json" | jq -r .sha256)" = "$report_digest" ]
 
+# Both python helpers below need the same TPM2 identifier tables, so write them
+# out once as a module the helpers import rather than repeating them in each.
+cat >"$WORK/tpm2_ids.py" <<'EOF'
+"""TPM2 identifiers, named as in the TCG TSS2 JSON format."""
+
+HASH_ALG_ID = {"SHA1": 0x0004, "SHA256": 0x000b, "SHA384": 0x000c, "SHA512": 0x000d,
+               "NULL": 0x0010}
+SIG_ALG_ID = {"RSASSA": 0x0014, "RSAPSS": 0x0016, "ECDSA": 0x0018, "NULL": 0x0010}
+PUB_ALG_ID = {"RSA": 0x0001, "ECC": 0x0023}
+CURVE_ID = {"NIST_P192": 0x0001, "NIST_P224": 0x0002, "NIST_P256": 0x0003,
+            "NIST_P384": 0x0004, "NIST_P521": 0x0005, "BN_P256": 0x0010,
+            "BN_P638": 0x0011, "SM2_P256": 0x0020}
+ST_ATTEST = {"ATTEST_NV": 0x8014, "ATTEST_SESSION_AUDIT": 0x8016, "ATTEST_QUOTE": 0x8018}
+TPM_PT_ID = {"PERMANENT": 0x00000200, "MAX_AUTH_FAIL": 0x0000020f,
+             "LOCKOUT_INTERVAL": 0x00000210, "LOCKOUT_RECOVERY": 0x00000211}
+
+# Derived rather than typed out a second time, so the two directions can't drift apart.
+HASH_ALG_NAME = {v: k for k, v in HASH_ALG_ID.items()}
+
+TPM_GENERATED = 0xff544347
+ALG_NULL = 0x0010
+ST_NO_SESSIONS = 0x8001
+CC_QUOTE = 0x00000158
+CC_GET_CAPABILITY = 0x0000017a
+CC_NV_CERTIFY = 0x00000184
+CAP_TPM_PROPERTIES = 0x00000006
+CAP_AUTH_POLICIES = 0x00000009
+EOF
+
 # Use a python script for verifying the report component signatures because we
 # need to reconstruct the TPM2B_ATTEST bytes from the provided TPMS_ATTEST JSON
 # encoding, and construct a public key from the provided TPMT_PUBLIC JSON encoding.
@@ -117,17 +178,9 @@ from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import ec, padding, rsa
 from cryptography.hazmat.primitives.asymmetric.utils import encode_dss_signature
 
-HASH_ALG_ID = {"SHA1": 0x0004, "SHA256": 0x000b, "SHA384": 0x000c, "SHA512": 0x000d}
-SIG_ALG_ID = {"RSASSA": 0x0014, "RSAPSS": 0x0016, "ECDSA": 0x0018, "NULL": 0x0010}
-PUB_ALG_ID = {"RSA": 0x0001, "ECC": 0x0023}
-CURVE_ID = {"NIST_P192": 0x0001, "NIST_P224": 0x0002, "NIST_P256": 0x0003,
-            "NIST_P384": 0x0004, "NIST_P521": 0x0005, "BN_P256": 0x0010,
-            "BN_P638": 0x0011, "SM2_P256": 0x0020}
-ST_ATTEST = {"ATTEST_NV": 0x8014, "ATTEST_SESSION_AUDIT": 0x8016, "ATTEST_QUOTE": 0x8018}
-TPM_GENERATED = 0xff544347
-ALG_NULL = 0x0010
-CC_QUOTE = 0x00000158
-CC_NV_CERTIFY = 0x00000184
+from tpm2_ids import (ALG_NULL, CAP_AUTH_POLICIES, CAP_TPM_PROPERTIES, CC_GET_CAPABILITY,
+                      CC_NV_CERTIFY, CC_QUOTE, CURVE_ID, HASH_ALG_ID, PUB_ALG_ID,
+                      SIG_ALG_ID, ST_ATTEST, TPM_GENERATED, TPM_PT_ID)
 
 HASHES = {"SHA1": hashes.SHA1, "SHA256": hashes.SHA256,
           "SHA384": hashes.SHA384, "SHA512": hashes.SHA512}
@@ -149,7 +202,23 @@ def sha256(data):
     return h.finalize()
 
 
+def tpm_pt_id(prop):
+    """Decode the JSON encoding of a TPM2_PT, which is either the property name with
+    the TPM2_PT_ prefix dropped, or a plain integer for properties that the encoder
+    doesn't know a name for."""
+    if isinstance(prop, int):
+        return prop
+    if prop not in TPM_PT_ID:
+        sys.exit(f"unsupported TPM property {prop}")
+    return TPM_PT_ID[prop]
+
+
 # Helpers to serialize JSON encodings to the TPM wire format.
+
+
+def marshal_bool(v):
+    return marshal_u8(1 if v else 0)
+
 
 def marshal_u8(v):
     return struct.pack(">B", v)
@@ -227,6 +296,16 @@ def marshal_tpms_attest(att):
     return out
 
 
+def marshal_tpmt_ha(ha):
+    """Serialize the supplied JSON encoded TPMT_HA to its wire form. The digest is
+    a fixed size union member, so it carries no size prefix, and it is absent for
+    a null algorithm."""
+    out = marshal_u16(HASH_ALG_ID[ha["hashAlg"]])
+    if ha["hashAlg"] != "NULL":
+        out += bytes.fromhex(ha["digest"])
+    return out
+
+
 def marshal_tpms_nv_public(nv):
     """Serialize the supplied JSON encoded TPMS_NV_PUBLIC to its wire form."""
     out = marshal_u32(nv["nvIndex"] & 0xffffffff)
@@ -292,6 +371,22 @@ def marshal_tpmt_signature(sig):
     sys.exit(f"unsupported sigAlg {alg}")
 
 
+def marshal_attestation_rp(comp):
+    """Serialize the response parameter area of an audited attestation command."""
+    out = marshal_bytes_tpm2b(marshal_tpms_attest(comp["attestInfo"]["attest"])) # TPM2B_ATTEST out
+    out += marshal_tpmt_signature(comp["signature"])                             # signature
+    return out
+
+
+def marshal_capability_rp(moreData, cap, entry):
+    """Serialize the response parameter area of an audited TPM2_GetCapability
+    command that returned the single supplied capability list entry."""
+    out = marshal_bool(moreData) # moreData
+    out += marshal_u32(cap)      # capabilityData.capability
+    out += marshal_u32(1)        # capabilityData.data.<list>.count
+    return out + entry
+
+
 def build_pubkey(pub):
     """Build a public key from the supplied JSON encoded TPMT_PUBLIC structure."""
     if pub["type"] == "RSA":
@@ -341,7 +436,10 @@ def verify(key, scheme, sig_bytes, message):
 
 def check_nvpcr(i, comp):
     """Check the properties of the nvpcr component."""
-    nv = comp["nvPublic"]
+    nv = comp.get("nvPublic")
+    if nv is None:
+        sys.exit(f"component {i}: no nvPublic")
+
     att = comp["attestInfo"]["attest"]
 
     # Make sure that nvPublic is consistent with the indexName in the attestation.
@@ -356,22 +454,73 @@ def check_nvpcr(i, comp):
         sys.exit(f"component {i}: authenticatedData digest does not match attested extraData")
 
 
+def check_capability_common(i, comp):
+    moreData = comp.get("capabilityMoreData")
+    if moreData is None:
+        sys.exit(f"component {i}: no capabilityMoreData")
+
+    if not isinstance(moreData, bool):
+        sys.exit(f"component {i}: capabilityMoreData is not a boolean")
+
+
+def check_tpm_property(i, comp):
+    """Check the properties of the capability-tpm-property component."""
+    prop = comp.get("tpmProperty")
+    if prop is None:
+        sys.exit(f"component {i}: no tpmProperty")
+
+    # The property must be one we know how to marshal for the audit digest check
+    # below, and its value must be a plain integer.
+    tpm_pt_id(prop["property"])
+    if not isinstance(prop["value"], int):
+        sys.exit(f"component {i}: tpmProperty value is not an integer")
+
+    check_capability_common(i, comp)
+
+
+def check_auth_policy(i, comp):
+    """Check the properties of the capability-auth-policy component."""
+    policy = comp.get("authPolicy")
+    if policy is None:
+        sys.exit(f"component {i}: no authPolicy")
+
+    if not isinstance(policy["handle"], int):
+        sys.exit(f"component {i}: authPolicy.handle value is not an integer")
+
+    # A hierarchy without an auth policy is reported as a TPMT_HA with a null
+    # algorithm and no digest. Anything else must carry a digest of the length
+    # implied by the algorithm.
+    ha = policy["policyHash"]
+    alg = ha["hashAlg"]
+    if alg == "NULL":
+        if "digest" in ha:
+            sys.exit(f"component {i}: policyHash has no algorithm but carries a digest")
+    elif alg not in HASHES:
+        sys.exit(f"component {i}: unsupported policyHash algorithm {alg}")
+    elif len(bytes.fromhex(ha["digest"])) != HASHES[alg]().digest_size:
+        sys.exit(f"component {i}: policyHash digest doesn't match algorithm {alg}")
+
+    check_capability_common(i, comp)
+
+
 def check_session_audit(doc, key_name):
     """Check the properties of the session-audit component."""
     digest = b"\x00" * 32 # Starting audit digest
 
     reported = None
     for comp in doc["components"]:
-        # Determine the command code, command handle names and cpBytes.
-        att = comp["attestInfo"]["attest"]
+        # Determine the command code, command handle names, cpBytes and rpBytes.
         t = comp["type"]
         if t == "pcr":
+            att = comp["attestInfo"]["attest"]
             cc = CC_QUOTE
             names = key_name                                               # signHandle only
             cp = marshal_hex_tpm2b("")                                     # qualifyingData
             cp += marshal_u16(ALG_NULL)                                    # inScheme.scheme
             cp += marshal_tpml_pcr_selection(att["attested"]["pcrSelect"]) # pcrSelect
+            rp = marshal_attestation_rp(comp)
         elif t == "nvpcr":
+            att = comp["attestInfo"]["attest"]
             cc = CC_NV_CERTIFY
             nv_name = digest_bytes_and_marshal_tpmt_ha(comp["nvPublic"]["nameAlg"], marshal_tpms_nv_public(comp["nvPublic"]))
             # Handle area is signHandle, authHandle, nvIndex - we pass the NV index for both
@@ -381,15 +530,34 @@ def check_session_audit(doc, key_name):
             cp += marshal_u16(ALG_NULL)                     # inScheme.scheme
             cp += marshal_u16(comp["nvPublic"]["dataSize"]) # size
             cp += marshal_u16(0)                            # offset
+            rp = marshal_attestation_rp(comp)
+        elif t == "capability-tpm-property":
+            prop = tpm_pt_id(comp["tpmProperty"]["property"])
+            cc = CC_GET_CAPABILITY
+            names = b""                          # no command handles
+            cp = marshal_u32(CAP_TPM_PROPERTIES) # capability
+            cp += marshal_u32(prop)              # property
+            cp += marshal_u32(1)                 # propertyCount
+            rp = marshal_capability_rp(
+                    comp["capabilityMoreData"],
+                    CAP_TPM_PROPERTIES,
+                    marshal_u32(prop) + marshal_u32(comp["tpmProperty"]["value"]))
+        elif t == "capability-auth-policy":
+            handle = comp["authPolicy"]["handle"]
+            cc = CC_GET_CAPABILITY
+            names = b""                         # no command handles
+            cp = marshal_u32(CAP_AUTH_POLICIES) # capability
+            cp += marshal_u32(handle)           # property
+            cp += marshal_u32(1)                # propertyCount
+            rp = marshal_capability_rp(
+                    comp["capabilityMoreData"],
+                    CAP_AUTH_POLICIES,
+                    marshal_u32(handle) + marshal_tpmt_ha(comp["authPolicy"]["policyHash"]))
         elif t == "session-audit":
-            reported = att["attested"]["sessionDigest"]
+            reported = comp["attestInfo"]["attest"]["attested"]["sessionDigest"]
             continue                                    # not audited itself
         else:
             sys.exit(f"unsupported component type {t}")
-
-        # Calculate rpBytes.
-        rp = marshal_bytes_tpm2b(marshal_tpms_attest(att)) # TPM2B_ATTEST out
-        rp += marshal_tpmt_signature(comp["signature"])    # signature
 
         # Calculate cpHash and rpHash.
         cp_hash = sha256(marshal_u32(cc) + names + cp)
@@ -420,31 +588,48 @@ def main():
 
     saw_report_binding = False
     for i, comp in enumerate(data["components"]):
-        scheme = comp["attestInfo"]["sig_scheme"]
-        message = marshal_tpms_attest(comp["attestInfo"]["attest"])
+        if comp["type"] in ("capability-tpm-property", "capability-auth-policy"):
+            # The capability components are read inside the audit session but are not
+            # signed individually, so they are bound to the report solely by the session
+            # audit digest, which is checked below.
+            for field in ("attestInfo", "signature", "signaturePEM"):
+                if field in comp:
+                    sys.exit(f"component {i}: capability component carries a {field} field")
+        else:
+            for field in ("attestInfo", "signature", "signaturePEM"):
+                if field not in comp:
+                    sys.exit(f"component {i}: component does not carry a {field} field")
 
-        sig = comp["signature"]
+            scheme = comp["attestInfo"]["sig_scheme"]
+            message = marshal_tpms_attest(comp["attestInfo"]["attest"])
 
-        # Make sure that the signature scheme in the attestInfo matches the
-        # information in the JSON encoded signature.
-        if scheme["scheme"] != sig["sigAlg"] or scheme["details"]["hashAlg"] != sig["signature"]["hash"]:
-            sys.exit(f"component {i}: signature scheme inconsistent with signature")
+            sig = comp["signature"]
 
-        # Reconstruct the signature from the JSON fields and decode the parallel
-        # signaturePEM blob. They should be the same.
-        sig_json, label = json_signature_bytes(sig)
-        sig_pem = pem_to_der(comp["signaturePEM"], label)
-        if sig_pem != sig_json:
-            sys.exit(f"component {i}: signaturePEM does not match the JSON signature")
+            # Make sure that the signature scheme in the attestInfo matches the
+            # information in the JSON encoded signature.
+            if scheme["scheme"] != sig["sigAlg"] or scheme["details"]["hashAlg"] != sig["signature"]["hash"]:
+                sys.exit(f"component {i}: signature scheme inconsistent with signature")
 
-        # Verify using the PEM-loaded key and PEM-decoded signature.
-        try:
-            verify(key_pem, scheme, sig_pem, message)
-        except InvalidSignature:
-            sys.exit(f"component {i} ({comp['type']}): signature verification FAILED")
+            # Reconstruct the signature from the JSON fields and decode the parallel
+            # signaturePEM blob. They should be the same.
+            sig_json, label = json_signature_bytes(sig)
+            sig_pem = pem_to_der(comp["signaturePEM"], label)
+            if sig_pem != sig_json:
+                sys.exit(f"component {i}: signaturePEM does not match the JSON signature")
 
+            # Verify using the PEM-loaded key and PEM-decoded signature.
+            try:
+                verify(key_pem, scheme, sig_pem, message)
+            except InvalidSignature:
+                sys.exit(f"component {i} ({comp['type']}): signature verification FAILED")
+
+        # Perform some checks specific to each component now.
         if comp["type"] == "nvpcr":
             check_nvpcr(i, comp)
+        elif comp["type"] == "capability-tpm-property":
+            check_tpm_property(i, comp)
+        elif comp["type"] == "capability-auth-policy":
+            check_auth_policy(i, comp)
         elif comp["type"] == "session-audit":
             # The report digest passed to the signer is the session audit's
             # qualifying data, so it appears as extraData prefixed with the SHA256
@@ -479,6 +664,90 @@ nvpcrs_json="$(systemd-analyze nvpcrs --json=short)"
 expected_nvpcrs="$(echo "$nvpcrs_json" | jq 'length')"
 [ "$expected_nvpcrs" -gt 0 ]
 
+# The backend also reports a fixed set of TPM properties and hierarchy auth
+# policies, read with TPM2_GetCapability inside the audit session. Properties are
+# reported by name, permanent handles as plain integers.
+TPM2_RH_OWNER=$((0x40000001))
+TPM2_RH_LOCKOUT=$((0x4000000a))
+TPM2_RH_ENDORSEMENT=$((0x4000000b))
+expected_props=(PERMANENT MAX_AUTH_FAIL LOCKOUT_INTERVAL LOCKOUT_RECOVERY)
+expected_policies=("$TPM2_RH_OWNER" "$TPM2_RH_LOCKOUT" "$TPM2_RH_ENDORSEMENT")
+
+# TPMA_PERMANENT.lockoutAuthSet, i.e. bit 2.
+TPMA_PERMANENT_LOCKOUT_AUTH_SET=$((1 << 2))
+
+# The values the backend reports for those must be the ones the TPM reports now,
+# so we have to query them ourselves. tpm2_getcap can't do that for us: it has no
+# way to query TPM2_CAP_AUTH_POLICIES at all, and it prints TPM2_PT_PERMANENT
+# decomposed into its individual flags rather than as a value. So assemble the
+# TPM2_GetCapability commands by hand and push them through the TPM with tpm2_send.
+GETCAP="$WORK/tpm-getcap.py"
+cat >"$GETCAP" <<'EOF'
+#!/usr/bin/env python3
+"""Print a single TPM capability value, as named in the TCG TSS2 JSON format.
+
+For 'property' this prints the value of the named TPM2_PT as a decimal number, for
+'auth-policy' the policy digest of the permanent handle given as an integer, as the
+hash algorithm followed by the digest in hex (the digest is empty for a null
+algorithm, i.e. when the hierarchy has no policy set)."""
+
+import struct
+import subprocess
+import sys
+
+from tpm2_ids import (CAP_AUTH_POLICIES, CAP_TPM_PROPERTIES, CC_GET_CAPABILITY,
+                      HASH_ALG_NAME, ST_NO_SESSIONS, TPM_PT_ID)
+
+
+def get_capability(capability, prop):
+    """Run a TPM2_GetCapability for a single property, returning the one entry of
+    the returned capability list."""
+    body = struct.pack(">III", capability, prop, 1) # capability, property, propertyCount
+    cmd = struct.pack(">HII", ST_NO_SESSIONS, 10 + len(body), CC_GET_CAPABILITY) + body
+
+    rsp = subprocess.run(["tpm2_send"], input=cmd, stdout=subprocess.PIPE, check=True).stdout
+
+    _, _, rc = struct.unpack(">HII", rsp[:10])
+    if rc != 0:
+        sys.exit(f"TPM2_GetCapability failed with response code {rc:#010x}")
+
+    # The response parameters are moreData followed by a TPMS_CAPABILITY_DATA, i.e.
+    # the capability, the number of list entries and the entries themselves.
+    _, cap, count = struct.unpack(">BII", rsp[10:19])
+    if cap != capability or count != 1:
+        sys.exit(f"TPM2_GetCapability returned capability {cap:#010x} with {count} entries")
+
+    return rsp[19:]
+
+
+def main():
+    kind, prop = sys.argv[1], sys.argv[2]
+
+    if kind == "property":
+        # TPMS_TAGGED_PROPERTY
+        ret_prop, value = struct.unpack(">II", get_capability(CAP_TPM_PROPERTIES, TPM_PT_ID[prop]))
+        if ret_prop != TPM_PT_ID[prop]:
+            sys.exit(f"TPM reported property {ret_prop:#010x} instead of {prop}")
+        print(value)
+    elif kind == "auth-policy":
+        # TPMS_TAGGED_POLICY, whose policyHash is a TPMT_HA: the digest is a fixed
+        # size union member, so the rest of the entry is the digest.
+        want_handle = int(prop, 0)
+        entry = get_capability(CAP_AUTH_POLICIES, want_handle)
+        handle, alg = struct.unpack(">IH", entry[:6])
+        if handle != want_handle:
+            sys.exit(f"TPM reported handle {handle:#010x} instead of {want_handle:#010x}")
+        if alg not in HASH_ALG_NAME:
+            sys.exit(f"TPM reported unknown hash algorithm id {alg:#06x}")
+        print(HASH_ALG_NAME[alg], entry[6:].hex())
+    else:
+        sys.exit(f"unsupported capability kind {kind}")
+
+
+if __name__ == "__main__":
+    main()
+EOF
+
 # Verify every component signature and collect the component types.
 echo "$sig_json" | python3 "$VERIFY" "$report_digest" >"$WORK/component-types"
 mapfile -t comp_types <"$WORK/component-types"
@@ -487,6 +756,8 @@ mapfile -t comp_types <"$WORK/component-types"
 saw_pcr=0
 saw_audit=0
 n_nvpcr=0
+seen_props=()
+seen_policies=()
 
 for i in "${!comp_types[@]}"; do
     type="${comp_types[$i]}"
@@ -520,6 +791,41 @@ for i in "${!comp_types[@]}"; do
             [ "$(echo "$auth" | jq -r '.name')" = "$name" ]
             [ "$(echo "$auth" | jq -r '.priority')" = "$(echo "$expected_nvpcr" | jq -r '.priority')" ]
             ;;
+        capability-tpm-property)
+            prop="$(echo "$comp" | jq -r '.tpmProperty.property')"
+            value="$(echo "$comp" | jq -r '.tpmProperty.value')"
+            seen_props+=("$prop")
+
+            # The reported value must be the one the TPM reports for this property.
+            [ "$value" -eq "$(python3 "$GETCAP" property "$prop")" ]
+
+            # We gave the lockout hierarchy an authorization value above, so the
+            # reported TPMA_PERMANENT must carry lockoutAuthSet.
+            if [ "$prop" = "PERMANENT" ]; then
+                [ $((value & TPMA_PERMANENT_LOCKOUT_AUTH_SET)) -ne 0 ]
+            fi
+            ;;
+        capability-auth-policy)
+            handle="$(echo "$comp" | jq -r '.authPolicy.handle')"
+            alg="$(echo "$comp" | jq -r '.authPolicy.policyHash.hashAlg')"
+            # A hierarchy with no policy set is reported with a null algorithm and
+            # no digest at all, so this may legitimately be empty.
+            digest="$(echo "$comp" | jq -r '.authPolicy.policyHash.digest // ""')"
+            seen_policies+=("$handle")
+
+            # The reported policy hash must be the one the TPM reports for this
+            # hierarchy, digest included.
+            read -r expected_alg expected_digest <<<"$(python3 "$GETCAP" auth-policy "$handle")"
+            [ "$alg" = "$expected_alg" ]
+            [ "$digest" = "$expected_digest" ]
+
+            # We set a policy on the lockout hierarchy above, so that one must be
+            # reported as the digest we installed rather than as an empty policy.
+            if [ "$handle" -eq "$TPM2_RH_LOCKOUT" ]; then
+                [ "$alg" = "SHA256" ]
+                [ "$digest" = "$LOCKOUT_POLICY" ]
+            fi
+            ;;
         session-audit)
             saw_audit=1
             ;;
@@ -530,3 +836,5 @@ done
 [ "$saw_pcr" -eq 1 ]
 [ "$saw_audit" -eq 1 ]
 [ "$n_nvpcr" -eq "$expected_nvpcrs" ]
+diff <(printf '%s\n' "${expected_props[@]}" | sort) <(printf '%s\n' "${seen_props[@]}" | sort)
+diff <(printf '%s\n' "${expected_policies[@]}" | sort) <(printf '%s\n' "${seen_policies[@]}" | sort)


### PR DESCRIPTION
As the TPM2 report signer uses an audit session, we can use this to
attest some TPM capabilities by executing `TPM2_GetCapability` with the
audit session.

Whilst it would be great for this to be configurable at some point in
the future, this adds what I think are a reasonable set of defaults for
now - these are all capabilities pertaining to hierarchy authorization
and dictionary attack settings:

- `TPM_CAP_TPM_PROPERTIES`:
  - `TPM_PT_PERMANENT`
  - `TPM_PT_MAX_AUTH_FAIL`
  - `TPM_PT_LOCKOUT_INTERVAL`
  - `TPM_PT_LOCKOUT_RECOVERY`
- `TPM_CAP_AUTH_POLICIES`:
  - `TPM_RH_OWNER`
  - `TPM_RH_LOCKOUT`
  - `TPM_RH_ENDORSEMENT`

To support this, the TPM report signature contains 2 new report
components - "capability-tpm-property" and "capability-auth-policy".