### PR TITLE
mkosi: update opensuse commit reference to 60fbc2d95581a933f9dcdfdb8d7e27d2a7d13e35

### DIFF
--- a/mkosi/mkosi.pkgenv/mkosi.conf.d/opensuse.conf
+++ b/mkosi/mkosi.pkgenv/mkosi.conf.d/opensuse.conf
@@ -8,5 +8,5 @@ Environment=
         GIT_URL=https://github.com/bmwiedemann/openSUSE
         GIT_SUBDIR=packages/s/systemd
         GIT_BRANCH=master
-        GIT_COMMIT=462bd9f5eae8d113d0e477455278f64d0284afe8
+        GIT_COMMIT=60fbc2d95581a933f9dcdfdb8d7e27d2a7d13e35
         PKG_SUBDIR=opensuse


### PR DESCRIPTION
* 60fbc2d955 Update systemd to version 261.2 / rev 473 via SR 1368021
* c32d9727e6 Update systemd to version 261.1 / rev 472 via SR 1365923
* 74fd672013 Update systemd to version 260.3 / rev 471 via SR 1362701
* 769e1c4254 Update systemd to version 260.2 / rev 470 via SR 1361320

Fixes https://github.com/systemd/systemd/issues/43618