### PR TITLE
dns-packet: set class=IN for DNS inbound request resolved via mDNS

### DIFF
--- a/src/resolve/test-dns-packet-append.c
+++ b/src/resolve/test-dns-packet-append.c
@@ -209,6 +209,72 @@ TEST(packet_append_key_single_soa_any_class) {
         ASSERT_EQ(memcmp(DNS_PACKET_DATA(packet), data, sizeof(data)), 0);
 }
 
+TEST(packet_append_key_cache_flush_mdns) {
+        _cleanup_(dns_packet_unrefp) DnsPacket *packet = NULL;
+        DnsResourceKey *key = NULL;
+
+        ASSERT_OK(dns_packet_new(&packet, DNS_PROTOCOL_MDNS, 0, DNS_PACKET_SIZE_MAX));
+        ASSERT_NOT_NULL(packet);
+
+        DNS_PACKET_ID(packet) = htobe16(42);
+        DNS_PACKET_HEADER(packet)->flags = htobe16(DNS_PACKET_MAKE_FLAGS(1, 0, 1, 0, 0, 0, 0, 0, DNS_RCODE_SUCCESS));
+        DNS_PACKET_HEADER(packet)->ancount = htobe16(1);
+
+        key = dns_resource_key_new(DNS_CLASS_IN, DNS_TYPE_A, "example.local");
+        ASSERT_NOT_NULL(key);
+        ASSERT_OK(dns_packet_append_key(packet, key, DNS_ANSWER_CACHE_FLUSH, NULL));
+        dns_resource_key_unref(key);
+
+        const uint8_t data[] = {
+                        0x00, 0x2a,     BIT_QR | BIT_AA, DNS_RCODE_SUCCESS,
+                        0x00, 0x00,     0x00, 0x01,     0x00, 0x00,     0x00, 0x00,
+
+        /* name */      0x07, 'e', 'x', 'a', 'm', 'p', 'l', 'e',
+                        0x05, 'l', 'o', 'c', 'a', 'l',
+                        0x00,
+        /* A */         0x00, 0x01,
+        /* IN + cache-flush */
+                        0x80, 0x01
+        };
+
+        ASSERT_EQ(packet->size, sizeof(data));
+        ASSERT_EQ(memcmp(DNS_PACKET_DATA(packet), data, sizeof(data)), 0);
+}
+
+/* The cache-flush bit is defined for mDNS only. RRs taken from our mDNS zone carry
+ * DNS_ANSWER_CACHE_FLUSH, but when they are sent out via the DNS stub the bit must not end up in the
+ * CLASS field, where it would be parsed as class 32769. See RFC 6762, section 10.2. */
+TEST(packet_append_key_cache_flush_dns) {
+        _cleanup_(dns_packet_unrefp) DnsPacket *packet = NULL;
+        DnsResourceKey *key = NULL;
+
+        ASSERT_OK(dns_packet_new(&packet, DNS_PROTOCOL_DNS, 0, DNS_PACKET_SIZE_MAX));
+        ASSERT_NOT_NULL(packet);
+
+        DNS_PACKET_ID(packet) = htobe16(42);
+        DNS_PACKET_HEADER(packet)->flags = htobe16(DNS_PACKET_MAKE_FLAGS(1, 0, 1, 0, 0, 0, 0, 0, DNS_RCODE_SUCCESS));
+        DNS_PACKET_HEADER(packet)->ancount = htobe16(1);
+
+        key = dns_resource_key_new(DNS_CLASS_IN, DNS_TYPE_A, "example.local");
+        ASSERT_NOT_NULL(key);
+        ASSERT_OK(dns_packet_append_key(packet, key, DNS_ANSWER_CACHE_FLUSH, NULL));
+        dns_resource_key_unref(key);
+
+        const uint8_t data[] = {
+                        0x00, 0x2a,     BIT_QR | BIT_AA, DNS_RCODE_SUCCESS,
+                        0x00, 0x00,     0x00, 0x01,     0x00, 0x00,     0x00, 0x00,
+
+        /* name */      0x07, 'e', 'x', 'a', 'm', 'p', 'l', 'e',
+                        0x05, 'l', 'o', 'c', 'a', 'l',
+                        0x00,
+        /* A */         0x00, 0x01,
+        /* IN */        0x00, 0x01
+        };
+
+        ASSERT_EQ(packet->size, sizeof(data));
+        ASSERT_EQ(memcmp(DNS_PACKET_DATA(packet), data, sizeof(data)), 0);
+}
+
 /* ================================================================
  * dns_packet_append_question()
  * ================================================================ */
@@ -813,6 +879,58 @@ TEST(packet_append_answer_single_ptr) {
         /* rdata */     0x00, 0x0d,
         /* name */      0x07, 'e', 'x', 'a', 'm', 'p', 'l', 'e',
                         0x03, 'c', 'o', 'm',
+                        0x00
+        };
+
+        ASSERT_EQ(packet->size, sizeof(data));
+        ASSERT_EQ(memcmp(DNS_PACKET_DATA(packet), data, sizeof(data)), 0);
+}
+
+/* Reverse lookups for link-local addresses are answered from resolved's own mDNS zone, whose answer
+ * items carry DNS_ANSWER_CACHE_FLUSH. When such an RR is handed to a client of the DNS stub the
+ * cache-flush bit must be dropped, otherwise the client sees CLASS32769 instead of IN. */
+TEST(packet_append_answer_single_ptr_ip6_cache_flush) {
+        _cleanup_(dns_packet_unrefp) DnsPacket *packet = NULL;
+        _cleanup_(dns_answer_unrefp) DnsAnswer *answer = NULL;
+        DnsResourceRecord *rr = NULL;
+
+        rr = dns_resource_record_new_full(DNS_CLASS_IN, DNS_TYPE_PTR,
+                                          "1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.e.f.ip6.arpa");
+        ASSERT_NOT_NULL(rr);
+        rr->ttl = 120;
+        rr->ptr.name = strdup("example.local");
+
+        answer = dns_answer_new(1);
+        ASSERT_NOT_NULL(answer);
+        dns_answer_add(answer, rr, 1, DNS_ANSWER_CACHE_FLUSH, NULL);
+        dns_resource_record_unref(rr);
+
+        ASSERT_OK(dns_packet_new(&packet, DNS_PROTOCOL_DNS, 0, DNS_PACKET_SIZE_MAX));
+        ASSERT_NOT_NULL(packet);
+
+        DNS_PACKET_ID(packet) = htobe16(42);
+        DNS_PACKET_HEADER(packet)->flags = htobe16(DNS_PACKET_MAKE_FLAGS(1, 0, 1, 0, 1, 1, 0, 0, DNS_RCODE_SUCCESS));
+        DNS_PACKET_HEADER(packet)->ancount = htobe16(dns_answer_size(answer));
+
+        ASSERT_OK(dns_packet_append_answer(packet, answer, NULL));
+
+        const uint8_t data[] = {
+                        0x00, 0x2a,     BIT_QR | BIT_AA | BIT_RD, BIT_RA | DNS_RCODE_SUCCESS,
+                        0x00, 0x00,     0x00, 0x01,     0x00, 0x00,     0x00, 0x00,
+
+        /* name */      0x01, '1', 0x01, '0', 0x01, '0', 0x01, '0', 0x01, '0', 0x01, '0', 0x01, '0', 0x01, '0',
+                        0x01, '0', 0x01, '0', 0x01, '0', 0x01, '0', 0x01, '0', 0x01, '0', 0x01, '0', 0x01, '0',
+                        0x01, '0', 0x01, '0', 0x01, '0', 0x01, '0', 0x01, '0', 0x01, '0', 0x01, '0', 0x01, '0',
+                        0x01, '0', 0x01, '0', 0x01, '0', 0x01, '0', 0x01, '0', 0x01, '8', 0x01, 'e', 0x01, 'f',
+                        0x03, 'i', 'p', '6',
+                        0x04, 'a', 'r', 'p', 'a',
+                        0x00,
+        /* PTR */       0x00, 0x0c,
+        /* IN */        0x00, 0x01,
+        /* ttl */       0x00, 0x00, 0x00, 0x78,
+        /* rdata */     0x00, 0x0f,
+        /* name */      0x07, 'e', 'x', 'a', 'm', 'p', 'l', 'e',
+                        0x05, 'l', 'o', 'c', 'a', 'l',
                         0x00
         };
 

--- a/src/shared/dns-packet.c
+++ b/src/shared/dns-packet.c
@@ -718,7 +718,12 @@ int dns_packet_append_key(DnsPacket *p, const DnsResourceKey *k, const DnsAnswer
         if (r < 0)
                 goto fail;
 
-        class = flags & DNS_ANSWER_CACHE_FLUSH ? k->class | MDNS_RR_CACHE_FLUSH_OR_QU : k->class;
+        /* Bit 15 of the CLASS field is the cache-flush bit in mDNS only, see RFC 6762, section 10.2. In
+         * unicast DNS it is part of the class value itself, hence never set it there, regardless of the
+         * flags of the answer this RR originates from (it might come from our mDNS zone, but be sent out
+         * via the DNS stub). */
+        class = p->protocol == DNS_PROTOCOL_MDNS && FLAGS_SET(flags, DNS_ANSWER_CACHE_FLUSH) ?
+                        k->class | MDNS_RR_CACHE_FLUSH_OR_QU : k->class;
         r = dns_packet_append_uint16(p, class, NULL);
         if (r < 0)
                 goto fail;


### PR DESCRIPTION
Since 82d39576462b ("resolved: fix mistaking QU bit for cache-flush bit"), DNS request made to resolved resolved over mDNS failed to be parsed by dig/host as the class field is set to 0x8001 which is mDNS cache-flush bit as per RFC 6762. In plain unicast DNS bit 15 is part of the CLASS value, leading to parser incompatibility. Thus, resolved is leaking an mDNS-only wire flag into a unicast replies.

```
  $ dig +nocmd +nocookie -x fe80::d1f:2970:a730:5ab8 @127.0.0.53
  ;; Warning: Message parser reports malformed message packet.
  ;; Got answer:
  ;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 30061
  ;; flags: qr aa rd ra ad; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1

  ;; OPT PSEUDOSECTION:
  ; EDNS: version: 0, flags:; udp: 65494
  ;; QUESTION SECTION:
  ;8.b.a.5.0.3.7.a.0.7.9.2.f.1.d.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.e.f.ip6.arpa. IN PTR

  ;; ANSWER SECTION:
  8.b.a.5.0.3.7.a.0.7.9.2.f.1.d.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.e.f.ip6.arpa. 120 CLASS32769 PTR lady-voodoo.local.

  ;; Query time: 1 msec
  ;; SERVER: 127.0.0.53#53(127.0.0.53) (UDP)
  ;; WHEN: Wed Sep 02 21:40:55 IST 2026
  ;; MSG SIZE  rcvd: 132
```

dns_packet_read_key() already handles this use case, however this is missed in the stub path.

This commit override class in dns_packet_append_key() for request resolved over mDNS without impacting multicast path.