### PR TITLE
networkd: allow systemd-network user to control ModemManager

### DIFF
--- a/src/network/systemd-networkd.pkla
+++ b/src/network/systemd-networkd.pkla
@@ -1,7 +1,7 @@
 # This file is part of systemd.
 # See systemd-networkd.service(8) and polkit(8) for more information.
 
-[Allow systemd-networkd to set timezone and transient hostname]
+[Allow systemd-networkd to set timezone, get product UUID, transient hostname and control ModemManager]
 Identity=unix-user:systemd-network
-Action=org.freedesktop.hostname1.set-hostname;org.freedesktop.hostname1.get-product-uuid;org.freedesktop.timedate1.set-timezone;
+Action=org.freedesktop.hostname1.set-hostname;org.freedesktop.hostname1.get-product-uuid;org.freedesktop.timedate1.set-timezone;org.freedesktop.ModemManager1.Device.Control;
 ResultAny=yes

--- a/src/network/systemd-networkd.rules
+++ b/src/network/systemd-networkd.rules
@@ -2,11 +2,12 @@
 // See systemd-networkd.service(8) and polkit(8) for more information.
 
 // Allow systemd-networkd to set timezone, get product UUID,
-// and transient hostname
+// transient hostname and control ModemManager
 polkit.addRule(function(action, subject) {
     if ((action.id == "org.freedesktop.hostname1.set-hostname" ||
          action.id == "org.freedesktop.hostname1.get-product-uuid" ||
-         action.id == "org.freedesktop.timedate1.set-timezone") &&
+         action.id == "org.freedesktop.timedate1.set-timezone" ||
+         action.id == "org.freedesktop.ModemManager1.Device.Control") &&
         subject.user == "systemd-network") {
         return polkit.Result.YES;
     }


### PR DESCRIPTION
systemd-networkd needs authorization for
`org.freedesktop.ModemManager1.Device.Control` to allow establishing a connection:

    systemd-networkd[1457]: ModemManager: starting simple connect on huawei E3276 interface wwp106s0u4i2
    systemd-networkd[1457]: Could not connect modem huawei E3276: Unauthorized: PolicyKit authorization failed: not authorized for 'org.freedesktop.ModemManager1.Device.Control'