### PR TITLE
libseccomp: fix a crash with unknown syscall ids

### DIFF
--- a/src/core/exec-invoke.c
+++ b/src/core/exec-invoke.c
@@ -1598,6 +1598,11 @@ static bool seccomp_allows_drop_privileges(const ExecContext *c) {
 
                 name = sym_seccomp_syscall_resolve_num_arch(SCMP_ARCH_NATIVE, PTR_TO_INT(id) - 1);
 
+                if (!name) {
+                        log_debug("System call number %d is not known on the native architecture, ignoring.", PTR_TO_INT(id) - 1);
+                        continue;
+                }
+
                 if (streq(name, "capget"))
                         have_capget = true;
                 else if (streq(name, "capset"))

--- a/src/test/test-execute.c
+++ b/src/test/test-execute.c
@@ -889,6 +889,10 @@ static void test_exec_systemcallfilter(Manager *m) {
         test(m, "exec-systemcallfilter-failing2.service", SIGSYS, CLD_KILLED);
         test(m, "exec-systemcallfilter-failing3.service", SIGSYS, CLD_KILLED);
 
+#if defined(__x86_64__)
+        test(m, "exec-systemcallfilter-unknown-syscall.service", SIGSYS, CLD_KILLED);
+#endif
+
         r = find_executable("python3", NULL);
         if (r < 0) {
                 log_notice_errno(r, "Skipping remaining tests in %s, could not find python3 binary: %m", __func__);

--- a/test/test-execute/exec-systemcallfilter-unknown-syscall.service
+++ b/test/test-execute/exec-systemcallfilter-unknown-syscall.service
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+
+[Unit]
+Description=Crash seccomp_allows_drop_privileges for unknown syscalls
+
+[Service]
+Type=oneshot
+
+# Condition 1: needs_setuid — triggers the setresuid path
+User=1
+
+# Condition 2: SystemCallFilter — populates c->syscall_filter hashmap
+# Use an allowlist (~ prefix omitted = allowlist) which exercises
+# seccomp_allows_drop_privileges() to check for capget/capset/prctl.
+# Architecture should not support `cacheflush` for this test.
+SystemCallFilter=cacheflush
+
+ExecStart=/bin/true


### PR DESCRIPTION
A unit file may contain a syscall name in `SystemCallFilter=` that is not recognized by specific architectures and results in a crash while starting the service.