### PR TITLE
network: fix DHCPv6 Private Enterprise Number range

### DIFF
--- a/man/systemd.network.xml
+++ b/man/systemd.network.xml
@@ -3130,7 +3130,7 @@ MultiPathRoute=2001:db8::1@eth0</programlisting>
         <term><varname>SendOption=</varname></term>
         <listitem>
           <para>As in the [DHCPv4] section, however because DHCPv6 uses 16-bit fields to store option
-          numbers, the option number is an integer in the range 1…65536.</para>
+          numbers, the option number is an integer in the range 1…65535.</para>
 
           <xi:include href="version-info.xml" xpointer="v246"/>
         </listitem>

--- a/src/network/networkd-dhcp-common.c
+++ b/src/network/networkd-dhcp-common.c
@@ -1159,9 +1159,11 @@ int config_parse_dhcp_request_options(
                         continue;
                 }
 
-                if (i < 1 || i >= UINT8_MAX) {
+                uint32_t option_max = ltype == AF_INET ? UINT8_MAX - 1 : UINT16_MAX;
+                if (i < 1 || i > option_max) {
                         log_syntax(unit, LOG_WARNING, filename, line, 0,
-                                   "DHCP request option is invalid, valid range is 1-254, ignoring assignment: %s", n);
+                                   "DHCP request option is invalid, valid range is 1-%"PRIu32", ignoring assignment: %s",
+                                   option_max, n);
                         continue;
                 }
 

--- a/src/network/networkd-dhcp-common.c
+++ b/src/network/networkd-dhcp-common.c
@@ -794,6 +794,12 @@ int config_parse_dhcp6_send_option(
                                    "Failed to parse DHCPv6 enterprise identifier data, ignoring assignment: %s", p);
                         return 0;
                 }
+                if (enterprise_identifier < 1 || enterprise_identifier >= UINT32_MAX) {
+                        log_syntax(unit, LOG_WARNING, filename, line, 0,
+                                   "Invalid DHCPv6 enterprise identifier, valid range is 1-%"PRIu32", ignoring assignment: %s",
+                                   UINT32_MAX -1, rvalue);
+                        return 0;
+                }
                 word = mfree(word);
         }
 

--- a/src/network/networkd-dhcp-common.c
+++ b/src/network/networkd-dhcp-common.c
@@ -807,12 +807,16 @@ int config_parse_dhcp6_send_option(
         }
 
         r = safe_atou16(word, &u16);
-        if (r < 0) {
+        if (r == -ERANGE) {
+                log_syntax(unit, LOG_WARNING, filename, line, 0,
+                           "Invalid DHCP option, valid range is 1-65535, ignoring assignment: %s", rvalue);
+                return 0;
+        } else if (r < 0) {
                 log_syntax(unit, LOG_WARNING, filename, line, r,
                            "Invalid DHCP option, ignoring assignment: %s", rvalue);
                 return 0;
         }
-        if (u16 < 1 || u16 >= UINT16_MAX) {
+        if (u16 < 1) {
                 log_syntax(unit, LOG_WARNING, filename, line, 0,
                            "Invalid DHCP option, valid range is 1-65535, ignoring assignment: %s", rvalue);
                 return 0;

--- a/src/network/networkd-dhcp-common.h
+++ b/src/network/networkd-dhcp-common.h
@@ -26,7 +26,7 @@ typedef enum DHCPOptionDataType {
         DHCP_OPTION_DATA_IPV4ADDRESS,
         DHCP_OPTION_DATA_IPV6ADDRESS,
         _DHCP_OPTION_DATA_MAX,
-        _DHCP_OPTION_DATA_INVALID,
+        _DHCP_OPTION_DATA_INVALID = -EINVAL,
 } DHCPOptionDataType;
 
 typedef struct DUID {

--- a/src/network/test-networkd-conf.c
+++ b/src/network/test-networkd-conf.c
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
 #include "conf-parser.h"
+#include "dhcp6-option.h"
 #include "hexdecoct.h"
 #include "net-condition.h"
 #include "networkd-address.h"
@@ -533,6 +534,90 @@ TEST(config_parse_dhcp_request_options) {
 
         set_clear(expected_options);
         test_config_parse_dhcp_request_options_helper(AF_INET6, "test", expected_options);
+}
+
+static void test_config_parse_dhcp6_send_option_helper(const char *lvalue, const char *rvalue, sd_dhcp6_option *expected) {
+        _cleanup_(ordered_hashmap_freep) OrderedHashmap *options = NULL;
+
+        ASSERT_OK(config_parse_dhcp6_send_option("network", "filename", 1, "section", 1, lvalue, 0, rvalue, &options, NULL));
+
+        if (expected) {
+                sd_dhcp6_option *actual_option = ordered_hashmap_get(options, UINT_TO_PTR(expected->option));
+                ASSERT_NOT_NULL(actual_option);
+                ASSERT_EQ(actual_option->enterprise_identifier, expected->enterprise_identifier);
+                ASSERT_EQ(memcmp_nn(actual_option->data, actual_option->length, expected->data, expected->length), 0);
+                ASSERT_EQ(actual_option->length, expected->length);
+                ASSERT_EQ(actual_option->option, expected->option);
+        } else
+                ASSERT_TRUE(ordered_hashmap_isempty(options));
+}
+
+static void test_config_parse_dhcp6_send_option_ok(const char *lvalue, const char *rvalue, uint16_t option,
+                                                   const void *data, size_t length, uint32_t enterprise_identifier) {
+        _cleanup_(sd_dhcp6_option_unrefp) sd_dhcp6_option *expected = NULL;
+
+        ASSERT_OK(sd_dhcp6_option_new(option, data, length, enterprise_identifier, &expected));
+        test_config_parse_dhcp6_send_option_helper(lvalue, rvalue, expected);
+}
+
+TEST(config_parse_dhcp6_send_option) {
+        /* First valid DHCP option is accepted */
+        test_config_parse_dhcp6_send_option_ok("SendOption", "1:string:test", 1, "test", 4, 0);
+
+        /* Last valid DHCP option is accepted */
+        test_config_parse_dhcp6_send_option_ok("SendOption", "65535:string:test", 65535u, "test", 4, 0);
+
+        /* First invalid DHCP option is ignored */
+        test_config_parse_dhcp6_send_option_helper("SendOption", "0:string:test", NULL);
+
+        /* Invalid DHCP option after last valid option is ignored */
+        test_config_parse_dhcp6_send_option_helper("SendOption", "65536:string:test", NULL);
+
+        /* Invalid non-numeric DHCP option is ignored */
+        test_config_parse_dhcp6_send_option_helper("SendOption", "option:string:test", NULL);
+
+        /* First valid PEN is accepted */
+        test_config_parse_dhcp6_send_option_ok("SendVendorOption", "0:1:string:test", 1, "test", 4, 0);
+
+        /* Last valid PEN is accepted */
+        test_config_parse_dhcp6_send_option_ok("SendVendorOption", "4294967295:1:string:test", 1, "test", 4,
+                                               4294967295U);
+
+        /* Invalid PEN bigger then 32 bit is ignored */
+        test_config_parse_dhcp6_send_option_helper("SendVendorOption", "4294967296:1:string:test", NULL);
+
+        /* Invalid non-numeric PEN is ignored */
+        test_config_parse_dhcp6_send_option_helper("SendVendorOption", "test:1:string:test", NULL);
+
+        /* Each data type is converted to its wire representation */
+        test_config_parse_dhcp6_send_option_ok("SendOption", "1:uint8:1", 1, &(const uint8_t[]){ 0x01 }, 1, 0);
+        test_config_parse_dhcp6_send_option_ok("SendOption", "1:uint16:255", 1,
+                                               &(const uint8_t[]){ 0x00, 0xff }, 2, 0);
+        test_config_parse_dhcp6_send_option_ok("SendOption", "1:uint32:65535", 1,
+                                               &(const uint8_t[]){ 0x00, 0x00, 0xff, 0xff }, 4, 0);
+        test_config_parse_dhcp6_send_option_ok("SendOption", "1:ipv4address:192.168.0.1", 1,
+                                               &(const uint8_t[]){ 192, 168, 0, 1 }, 4, 0);
+        test_config_parse_dhcp6_send_option_ok("SendOption", "1:ipv6address:2001:db8::1", 1,
+                                               &(const uint8_t[]){ 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01 },
+                                               16, 0);
+        test_config_parse_dhcp6_send_option_ok("SendOption", "1:string:🐱", 1, "🐱", 4, 0);
+
+        /* Values that do not correspond with their data type or are invalid are ignored */
+        test_config_parse_dhcp6_send_option_helper("SendOption", "1:uint8:invalid", NULL);
+        test_config_parse_dhcp6_send_option_helper("SendOption", "1:uint16:invalid", NULL);
+        test_config_parse_dhcp6_send_option_helper("SendOption", "1:uint32:invalid", NULL);
+        test_config_parse_dhcp6_send_option_helper("SendOption", "1:ipv4address:invalid", NULL);
+        test_config_parse_dhcp6_send_option_helper("SendOption", "1:ipv6address:invalid", NULL);
+        test_config_parse_dhcp6_send_option_helper("SendOption", "1:string:\\", NULL);
+
+        /* Invalid data type is ignored */
+        test_config_parse_dhcp6_send_option_helper("SendOption", "1:invalid:invalid", NULL);
+
+        /* Configuration values with missing fields are ignored */
+        test_config_parse_dhcp6_send_option_helper("SendOption", "1", NULL);
+        test_config_parse_dhcp6_send_option_helper("SendOption", "1:string", NULL);
+        test_config_parse_dhcp6_send_option_helper("SendVendorOption", "1:string", NULL);
+        test_config_parse_dhcp6_send_option_helper("SendVendorOption", "1:1:string", NULL);
 }
 
 TEST(config_parse_stacked_netdev) {

--- a/src/network/test-networkd-conf.c
+++ b/src/network/test-networkd-conf.c
@@ -577,11 +577,17 @@ TEST(config_parse_dhcp6_send_option) {
         test_config_parse_dhcp6_send_option_helper("SendOption", "option:string:test", NULL);
 
         /* First valid PEN is accepted */
-        test_config_parse_dhcp6_send_option_ok("SendVendorOption", "0:1:string:test", 1, "test", 4, 0);
+        test_config_parse_dhcp6_send_option_ok("SendVendorOption", "1:1:string:test", 1, "test", 4, 1);
 
         /* Last valid PEN is accepted */
-        test_config_parse_dhcp6_send_option_ok("SendVendorOption", "4294967295:1:string:test", 1, "test", 4,
-                                               4294967295U);
+        test_config_parse_dhcp6_send_option_ok("SendVendorOption", "4294967294:1:string:test", 1, "test", 4,
+                                               4294967294U);
+
+        /* First invalid PEN is ignored */
+        test_config_parse_dhcp6_send_option_helper("SendVendorOption", "0:1:string:test", NULL);
+
+        /* Invalid PEN after last valid PEN is ignored */
+        test_config_parse_dhcp6_send_option_helper("SendVendorOption", "4294967295:1:string:test", NULL);
 
         /* Invalid PEN bigger then 32 bit is ignored */
         test_config_parse_dhcp6_send_option_helper("SendVendorOption", "4294967296:1:string:test", NULL);

--- a/src/network/test-networkd-conf.c
+++ b/src/network/test-networkd-conf.c
@@ -466,6 +466,75 @@ TEST(config_parse_multipath_route) {
         test_config_parse_multipath_route_one("@wg0 abc", 0, 0); /* Non-numeric */
 }
 
+static void test_config_parse_dhcp_request_options_helper(int ltype, const char *rvalue, Set *expected) {
+        _cleanup_(network_unrefp) Network *network = NULL;
+        ASSERT_NOT_NULL(network = new0(Network, 1));
+        network->n_ref = 1;
+
+        ASSERT_OK(config_parse_dhcp_request_options("network", "filename", 1, "section", 1, "RequestOptions",
+                                                    ltype, rvalue, network, network));
+        if (ltype == AF_INET) {
+                ASSERT_TRUE(set_equal(expected, network->dhcp_request_options));
+                ASSERT_NULL(network->dhcp6_request_options);
+        } else {
+                ASSERT_TRUE(set_equal(expected, network->dhcp6_request_options));
+                ASSERT_NULL(network->dhcp_request_options);
+        }
+}
+
+TEST(config_parse_dhcp_request_options) {
+        _cleanup_(set_freep) Set *expected_options = set_new(NULL);
+
+        /* Empty string parses without error */
+        set_clear(expected_options);
+        test_config_parse_dhcp_request_options_helper(AF_INET, "", expected_options);
+
+        set_clear(expected_options);
+        test_config_parse_dhcp_request_options_helper(AF_INET6, "", expected_options);
+
+        /* Valid DHCPv4 range 1-254 is accepted */
+        set_clear(expected_options);
+        ASSERT_OK(set_put(expected_options, UINT32_TO_PTR(1)));
+        ASSERT_OK(set_put(expected_options, UINT32_TO_PTR(254)));
+        test_config_parse_dhcp_request_options_helper(AF_INET, "1 254", expected_options);
+
+        /* Non-valid DHCPv4 options 0 and 255 are ignored */
+        set_clear(expected_options);
+        test_config_parse_dhcp_request_options_helper(AF_INET, "0 255", expected_options);
+
+        /* Non 8 bit DHCPv4 options -1 and 256 are ignored */
+        set_clear(expected_options);
+        test_config_parse_dhcp_request_options_helper(AF_INET, "-1 256", expected_options);
+
+        /* Valid DHCPv6 range 1-65535 is accepted */
+        set_clear(expected_options);
+        ASSERT_OK(set_put(expected_options, UINT32_TO_PTR(1)));
+        ASSERT_OK(set_put(expected_options, UINT32_TO_PTR(65535)));
+        test_config_parse_dhcp_request_options_helper(AF_INET6, "1 65535", expected_options);
+
+        /* Non-valid DHCPv6 option 0 is ignored */
+        set_clear(expected_options);
+        test_config_parse_dhcp_request_options_helper(AF_INET6, "0", expected_options);
+
+        /* Non 16 bit DHCPv6 options -1 and 65536 are ignored */
+        set_clear(expected_options);
+        test_config_parse_dhcp_request_options_helper(AF_INET, "-1 65536", expected_options);
+
+        /* Quoted values are ignored */
+        set_clear(expected_options);
+        test_config_parse_dhcp_request_options_helper(AF_INET, "\"1\"", expected_options);
+
+        set_clear(expected_options);
+        test_config_parse_dhcp_request_options_helper(AF_INET6, "\"1\"", expected_options);
+
+        /* Non-numeric values are ignored */
+        set_clear(expected_options);
+        test_config_parse_dhcp_request_options_helper(AF_INET, "test", expected_options);
+
+        set_clear(expected_options);
+        test_config_parse_dhcp_request_options_helper(AF_INET6, "test", expected_options);
+}
+
 TEST(config_parse_stacked_netdev) {
         _cleanup_hashmap_free_ Hashmap *netdevs = NULL;
         ASSERT_OK(config_parse_stacked_netdev("network", "filename", 1, "section", 1, "VLAN", NETDEV_KIND_VLAN, "foo bar baz invalid:name", &netdevs, NULL));


### PR DESCRIPTION
Limit the size of the enterprise identifier AKA PEN in accordance with RFC
9371, Section 3 and the existing documentation for the `SendVendorOption=`
in the `[DHCPV6]` section of `.network` files.  The allowed range is "[...]
0 to 2**32-1".