### PR TITLE
uki: add a .mokkeys section for kernel module signing certificates

### DIFF
--- a/man/systemd-measure.xml
+++ b/man/systemd-measure.xml
@@ -77,7 +77,8 @@
         <option>--osrel=</option>, <option>--cmdline=</option>, <option>--initrd=</option>,
         <option>--ucode=</option>, <option>--splash=</option>, <option>--dtb=</option>,
         <option>--uname=</option>, <option>--sbat=</option>, <option>--pcrpkey=</option>,
-        <option>--profile=</option>, <option>--dtbauto=</option>, <option>--hwids=</option>, see below.  Only <option>--linux=</option> is mandatory. (Alternatively,
+        <option>--profile=</option>, <option>--dtbauto=</option>, <option>--hwids=</option>,
+        <option>--efifw=</option>, see below.  Only <option>--linux=</option> is mandatory. (Alternatively,
         specify <option>--current</option> to use the current values of PCR register 11 instead.)</para>
 
         <xi:include href="version-info.xml" xpointer="v252"/>
@@ -141,6 +142,7 @@
         <term><option>--profile=<replaceable>PATH</replaceable></option></term>
         <term><option>--dtbauto=<replaceable>PATH</replaceable></option></term>
         <term><option>--hwids=<replaceable>PATH</replaceable></option></term>
+        <term><option>--efifw=<replaceable>PATH</replaceable></option></term>
 
         <listitem><para>When used with the <command>calculate</command> or <command>sign</command> verb,
         configures the files to read the unified kernel image components from. Each option corresponds with
@@ -151,7 +153,9 @@
         <xi:include href="version-info.xml" xpointer="v252"/>
 
         <para id="v257">With the exception of <option>--profile=</option>, <option>--dtbauto=</option> and <option>--hwids=</option>, which have been added in version
-        257.</para></listitem>
+        257.</para>
+
+        <para id="v258"><option>--efifw=</option> was added in v258.</para></listitem>
       </varlistentry>
 
       <varlistentry>

--- a/man/systemd-measure.xml
+++ b/man/systemd-measure.xml
@@ -78,7 +78,8 @@
         <option>--ucode=</option>, <option>--splash=</option>, <option>--dtb=</option>,
         <option>--uname=</option>, <option>--sbat=</option>, <option>--pcrpkey=</option>,
         <option>--profile=</option>, <option>--dtbauto=</option>, <option>--hwids=</option>,
-        <option>--efifw=</option>, see below.  Only <option>--linux=</option> is mandatory. (Alternatively,
+        <option>--efifw=</option>, <option>--mokkeys=</option>, see below.  Only
+        <option>--linux=</option> is mandatory. (Alternatively,
         specify <option>--current</option> to use the current values of PCR register 11 instead.)</para>
 
         <xi:include href="version-info.xml" xpointer="v252"/>
@@ -143,6 +144,7 @@
         <term><option>--dtbauto=<replaceable>PATH</replaceable></option></term>
         <term><option>--hwids=<replaceable>PATH</replaceable></option></term>
         <term><option>--efifw=<replaceable>PATH</replaceable></option></term>
+        <term><option>--mokkeys=<replaceable>PATH</replaceable></option></term>
 
         <listitem><para>When used with the <command>calculate</command> or <command>sign</command> verb,
         configures the files to read the unified kernel image components from. Each option corresponds with
@@ -155,7 +157,9 @@
         <para id="v257">With the exception of <option>--profile=</option>, <option>--dtbauto=</option> and <option>--hwids=</option>, which have been added in version
         257.</para>
 
-        <para id="v258"><option>--efifw=</option> was added in v258.</para></listitem>
+        <para id="v258"><option>--efifw=</option> was added in v258.</para>
+
+        <para id="v262"><option>--mokkeys=</option> was added in v262.</para></listitem>
       </varlistentry>
 
       <varlistentry>

--- a/man/systemd-stub.xml
+++ b/man/systemd-stub.xml
@@ -126,6 +126,14 @@
 
       <listitem><para>An optional <literal>.pcrpkey</literal> section with a public key in the PEM format
       matching the signature data in the <literal>.pcrsig</literal> section.</para></listitem>
+
+      <listitem><para>An optional <literal>.mokkeys</literal> section with one or more concatenated
+      <constant>EFI_SIGNATURE_LIST</constant> structures holding X.509 certificates, one list per
+      certificate, of signature type <constant>EFI_CERT_X509_GUID</constant> and with a zero owner GUID.
+      The section is written by the <option>--mokkeys=</option> option of
+      <citerefentry><refentrytitle>ukify</refentrytitle><manvolnum>1</manvolnum></citerefentry>. Like the
+      other sections listed here it is covered by the signature over the whole UKI, and is measured into
+      PCR 11.</para></listitem>
     </itemizedlist>
 
     <!-- FIXME: how does .dtauto/.hwids matching interact with profiles? -->

--- a/man/ukify.xml
+++ b/man/ukify.xml
@@ -81,6 +81,7 @@
       <varname>DeviceTree=</varname>/<option>--devicetree=</option>,
       <varname>DeviceTreeAuto=</varname>/<option>--devicetree-auto=</option>,
       <varname>HWIDs=</varname>/<option>--hwids=</option>,
+      <varname>MokKeys=</varname>/<option>--mokkeys=</option>,
       <varname>Splash=</varname>/<option>--splash=</option>,
       <varname>PCRPKey=</varname>/<option>--pcrpkey=</option>,
       <varname>Uname=</varname>/<option>--uname=</option>,
@@ -489,6 +490,22 @@
           this parameter if automatically selectable DeviceTrees are to be used.</para>
 
           <xi:include href="version-info.xml" xpointer="v257"/></listitem>
+        </varlistentry>
+
+        <varlistentry>
+          <term><varname>MokKeys=<replaceable>PATH</replaceable>...</varname></term>
+          <term><option>--mokkeys=<replaceable>PATH</replaceable></option></term>
+
+          <listitem><para>Zero or more X.509 certificates in DER format to embed in the
+          <literal>.mokkeys</literal> section, for the kernel to trust when it checks module
+          signatures. In the configuration file, items are separated by whitespace; on the command
+          line the option may be specified more than once. The certificates are wrapped as
+          <constant>EFI_SIGNATURE_LIST</constant> structures, one per certificate. If not specified,
+          the section will not be present. See
+          <citerefentry><refentrytitle>systemd-stub</refentrytitle><manvolnum>7</manvolnum></citerefentry>
+          for what the boot loader does with them.</para>
+
+          <xi:include href="version-info.xml" xpointer="v262"/></listitem>
         </varlistentry>
 
         <varlistentry>

--- a/src/fundamental/uki.c
+++ b/src/fundamental/uki.c
@@ -24,5 +24,6 @@ const char* const unified_sections[_UNIFIED_SECTION_MAX + 1] = {
         [UNIFIED_SECTION_DTBAUTO] = ".dtbauto",
         [UNIFIED_SECTION_HWIDS]   = ".hwids",
         [UNIFIED_SECTION_EFIFW]   = ".efifw",
+        [UNIFIED_SECTION_MOKKEYS] = ".mokkeys",
         NULL,
 };

--- a/src/fundamental/uki.h
+++ b/src/fundamental/uki.h
@@ -21,6 +21,7 @@ typedef enum UnifiedSection {
         UNIFIED_SECTION_DTBAUTO,
         UNIFIED_SECTION_HWIDS,
         UNIFIED_SECTION_EFIFW,
+        UNIFIED_SECTION_MOKKEYS,
         _UNIFIED_SECTION_MAX,
 } UnifiedSection;
 

--- a/src/measure/measure-tool.c
+++ b/src/measure/measure-tool.c
@@ -262,8 +262,10 @@ static int parse_argv(int argc, char *argv[], char ***ret_args) {
                                  "Path to HWIDs file (→ .hwids)"): {}
                 OPTION_LONG_DATA("efifw", "PATH", UNIFIED_SECTION_EFIFW,
                                  "Path to EFI firmware file (→ .efifw)"): {}
+                OPTION_LONG_DATA("mokkeys", "PATH", UNIFIED_SECTION_MOKKEYS,
+                                 "Path to machine owner key signature lists (→ .mokkeys)"): {}
                         /* Make sure that if new sections are added, the list here is updated. */
-                        assert_cc(UNIFIED_SECTION_EFIFW + 1 == _UNIFIED_SECTION_MAX);
+                        assert_cc(UNIFIED_SECTION_MOKKEYS + 1 == _UNIFIED_SECTION_MAX);
                         assert(opts.opt->data < _UNIFIED_SECTION_MAX);
 
                         r = parse_path_argument(opts.arg, /* suppress_root= */ false, arg_sections + opts.opt->data);

--- a/src/ukify/test/test_ukify.py
+++ b/src/ukify/test/test_ukify.py
@@ -21,6 +21,7 @@ import os
 import pathlib
 import re
 import shutil
+import struct
 import subprocess
 import sys
 import tempfile
@@ -343,6 +344,43 @@ def test_parse_sections():
     assert opts.sections[1].content == pathlib.Path('FILE')
     assert opts.sections[1].tmpfile is None
     assert opts.sections[1].measure is False
+
+
+def test_pack_mokkeys(tmp_path):
+    assert ukify.pack_mokkeys([]) is None
+
+    # pack_mokkeys() looks at the DER SEQUENCE tag and nothing else, so the certificate bodies
+    # can be arbitrary here.
+    cert1 = tmp_path / 'cert1.der'
+    cert1.write_bytes(b'\x30\x82\x00\x0c' + b'\xa1' * 12)
+    cert2 = tmp_path / 'cert2.der'
+    cert2.write_bytes(b'\x30\x82\x00\x1c' + b'\xb2' * 28)
+
+    blob = ukify.pack_mokkeys([cert1])
+    assert blob is not None
+    sig_type, list_size, header_size, sig_size = struct.unpack('<16sIII', blob[:28])
+    assert sig_type == ukify.EFI_CERT_X509_GUID.bytes_le
+    assert list_size == len(blob)
+    assert header_size == 0
+    assert sig_size == 16 + len(cert1.read_bytes())
+    # The owner GUID is zero, and the certificate follows it verbatim.
+    assert blob[28:44] == bytes(16)
+    assert blob[44:] == cert1.read_bytes()
+
+    # One list per certificate, concatenated in the order given.
+    blob = ukify.pack_mokkeys([cert1, cert2])
+    first = 28 + 16 + len(cert1.read_bytes())
+    second = 28 + 16 + len(cert2.read_bytes())
+    assert len(blob) == first + second
+    assert struct.unpack('<I', blob[16:20])[0] == first
+    assert struct.unpack('<I', blob[first + 16 : first + 20])[0] == second
+    assert blob[first + 44 :] == cert2.read_bytes()
+
+    # A PEM certificate is the mistake to expect, and it is rejected rather than embedded.
+    pem = tmp_path / 'cert.pem'
+    pem.write_bytes(b'-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----\n')
+    with pytest.raises(ValueError):
+        ukify.pack_mokkeys([pem])
 
 
 def test_config_priority(tmp_path):

--- a/src/ukify/ukify.py
+++ b/src/ukify/ukify.py
@@ -280,6 +280,7 @@ class UkifyConfig:
     hwids: Union[str, Path, None]
     initrd: list[Path]
     efifw: list[Path]
+    mokkeys: list[Path]
     join_profiles: list[Path]
     sign_profiles: list[str]
     json: Union[Literal['pretty'], Literal['short'], Literal['off']]
@@ -416,6 +417,7 @@ DEFAULT_SECTIONS_TO_SHOW = {
     '.dtbauto': 'binary',
     '.hwids':   'binary',
     '.efifw':   'binary',
+    '.mokkeys': 'binary',
     '.cmdline': 'text',
     '.osrel':   'text',
     '.uname':   'text',
@@ -1308,6 +1310,38 @@ def parse_hwid_dir(path: Path) -> bytes:
     return devices_blob + strings_blob
 
 
+EFI_CERT_X509_GUID = uuid.UUID('a5c059a1-94e4-4aa7-87b5-ab155c2bf072')
+EFI_SIGNATURE_LIST_HEADER_SIZE = 16 + 4 + 4 + 4
+
+
+def pack_mokkeys(paths: list[Path]) -> Optional[bytes]:
+    """Wrap DER certificates as concatenated EFI_SIGNATURE_LISTs for the .mokkeys section.
+
+    One list per certificate, each holding a single signature with a zero owner GUID, which is
+    the layout the kernel's EFI signature list parser expects and the only signature type its
+    MOK handler accepts. Keeping the wrapping here means the boot loader needs no structure
+    building code of its own.
+    """
+    if not paths:
+        return None
+
+    blob = b''
+    for path in paths:
+        cert = path.read_bytes()
+        if cert[:1] != b'\x30':
+            raise ValueError(f'{path} is not a DER certificate (expected a SEQUENCE tag)')
+        signature = uuid.UUID(int=0).bytes_le + cert
+        blob += (
+            EFI_CERT_X509_GUID.bytes_le
+            + struct.pack('<I', EFI_SIGNATURE_LIST_HEADER_SIZE + len(signature))
+            + struct.pack('<I', 0)
+            + struct.pack('<I', len(signature))
+            + signature
+        )
+
+    return blob
+
+
 def parse_efifw_dir(path: Path) -> bytes:
     if not path.is_dir():
         raise ValueError(f'{path} is not a directory or it does not exist')
@@ -1460,6 +1494,7 @@ def make_uki(opts: UkifyConfig) -> None:
         ('.linux',   linux,           True),
         ('.initrd',  initrd,          True),
         *(('.efifw', parse_efifw_dir(fw), False) for fw in opts.efifw),
+        ('.mokkeys', pack_mokkeys(opts.mokkeys), True),
         ('.ucode',   opts.microcode,  True),
     ]  # fmt: skip
 
@@ -2065,6 +2100,16 @@ CONFIG_ITEMS = [
         default=[],
         help='Directory with efi firmware binary file [.efifw section]',
         config_key='UKI/Firmware',
+        config_push=ConfigItem.config_list_prepend,
+    ),
+    ConfigItem(
+        '--mokkeys',
+        metavar='PATH',
+        type=Path,
+        action='append',
+        default=[],
+        help='DER certificate to offer to the kernel .machine keyring [.mokkeys section]',
+        config_key='UKI/MokKeys',
         config_push=ConfigItem.config_list_prepend,
     ),
     ConfigItem(

--- a/test/units/TEST-70-TPM2.measure.sh
+++ b/test/units/TEST-70-TPM2.measure.sh
@@ -71,10 +71,10 @@ EOF
 "$SD_MEASURE" calculate --linux=/tmp/tpmdata1 --initrd=/tmp/tpmdata2 --bank=sha1 --bank=sha256 --bank=sha384 --bank=sha512 --phase=foo -j | diff -u - /tmp/result.json
 
 cat >/tmp/result <<EOF
-11:sha1=8a625cbc3c497b9a86dcf4f6a32582895ce969bb
+11:sha1=da84b7bde93d889d3fe7c3711b203b81e6d0465a
 EOF
 "$SD_MEASURE" calculate \
-              --{linux,osrel,cmdline,initrd,ucode,splash,dtb,dtbauto,uname,sbat,pcrpkey,profile,hwids,efifw}=/tmp/tpmdata1 \
+              --{linux,osrel,cmdline,initrd,ucode,splash,dtb,dtbauto,uname,sbat,pcrpkey,profile,hwids,efifw,mokkeys}=/tmp/tpmdata1 \
               --bank=sha1 --phase=foo | cmp - /tmp/result
 rm /tmp/result /tmp/result.json
 


### PR DESCRIPTION
This is the carrier half of #43539. `ukify --mokkeys=` takes DER certificates, wraps each in an EFI_SIGNATURE_LIST and writes them into a new `.mokkeys` section. systemd-measure and ukify measure it, and the man pages describe the format. I've kept the stub side for a separate PR so this one reads on its own. The stub does nothing with the section yet. The stub side is ready at https://github.com/andrewdunndev/systemd/tree/mokkeys-b-stub and follows as its own PR once this lands; the UKI specification entry is uapi-group/specifications#226. While there, the systemd-measure page gains the `--efifw=` option it was missing. Tests: a pack_mokkeys unit test in test_ukify.py, and TEST-70's measure check gains the section with the hash recomputed by systemd-measure calculate. Built and tested on Fedora 44.

