### PR TITLE
man: document that stdio file targets are opened before the MAC transition

### DIFF
--- a/man/systemd.exec.xml
+++ b/man/systemd.exec.xml
@@ -3420,7 +3420,9 @@ SystemCallErrorNumber=EPERM</programlisting>
         system object to standard input. An absolute path following the <literal>:</literal> character is expected,
         which may refer to a regular file, a FIFO or special file. If an <constant>AF_UNIX</constant> socket in the
         file system is specified, a stream socket is connected to it. The latter is useful for connecting standard
-        input of processes to arbitrary system services.</para>
+        input of processes to arbitrary system services. Note that the file system object is opened by the
+        service manager before the executable is invoked; see the note on the security context this
+        happens in for <varname>StandardOutput=</varname> below.</para>
 
         <para>The <option>socket</option> option is valid in socket-activated services only, and requires the relevant
         socket unit file (see
@@ -3514,6 +3516,14 @@ SystemCallErrorNumber=EPERM</programlisting>
         only one process runs at a time, such as services with a single <varname>ExecStart=</varname> and no
         <varname>ExecStartPost=</varname>, <varname>ExecReload=</varname>, <varname>ExecStop=</varname> or
         similar.</para>
+
+        <para>Note that for <option>file:<replaceable>path</replaceable></option>,
+        <option>append:<replaceable>path</replaceable></option> and
+        <option>truncate:<replaceable>path</replaceable></option> of <varname>StandardOutput=</varname>,
+        <varname>StandardError=</varname> or <varname>StandardInput=</varname>, the target path is opened
+        by the service manager before the executable is invoked — and hence before
+        <varname>SELinuxContext=</varname> or any policy-defined transition takes effect. The resulting
+        descriptor is then inherited across that transition into the unit's own domain.</para>
 
         <para><option>socket</option> connects standard output to a socket acquired via socket activation. The
         semantics are similar to the same option of <varname>StandardInput=</varname>, see above.</para>


### PR DESCRIPTION
`StandardInput=` with `file:`, and `StandardOutput=`/`StandardError=` with `file:`, `append:` or `truncate:`, open the target while the process is still being set up — before `execve()`, and therefore before the MAC label of the service process is applied. The open is consequently checked against the context inherited from the service manager, which may differ from the one the service ends up running in.

`systemd.exec(5)` currently mentions the manager's privileges only for *creating* the file:

> it is opened (created if it does not exist yet using privileges of the user executing the systemd process) for writing at the beginning of the file

and says nothing about an existing file being opened in the manager's security context. On SELinux systems that is easy to trip over: labelling the log file only for the domain the service transitions into is not enough, and in enforcing mode the unit's log output is silently dropped.

Ordering in `src/core/exec-invoke.c` is explicit: `setup_input()` and `setup_output()` — which open the target via `acquire_path()` — run at lines 5563, 5576 and 5582, `sym_setexeccon_raw()` at 6471 and `fexecve_or_execve()` at 6754. For SMACK the label is applied to the process itself in `setup_smack()` at 6342, likewise after the targets have been opened. `SELinuxContext=` therefore cannot fix this either, which the note now states explicitly.

Observed in production on CentOS Stream 10 (systemd 257-33.el10, selinux-policy-targeted 42.1.27-2). A single unit — `Type=oneshot`, `User=`, `StandardOutput=append:` at a file labelled `httpd_sys_content_t`, whose `ExecStart` also appends to that same file itself — shows both sides:

```
# manager-side setup of stdout/stderr, pre-exec:
avc: denied { open }   comm="(probe.sh)" exe="/usr/lib/systemd/systemd-executor" ppid=1
     subj=system_u:system_r:init_t:s0 tcontext=system_u:object_r:httpd_sys_content_t:s0 tclass=file
avc: denied { append } comm="(probe.sh)" exe="/usr/lib/systemd/systemd-executor" ppid=1
     subj=system_u:system_r:init_t:s0 tcontext=system_u:object_r:httpd_sys_content_t:s0 tclass=file

# the script's own append to the very same file, post-exec — no denial:
SCRIPT-OWN-WRITE ctx=system_u:system_r:unconfined_service_t:s0
```

`open` and `append` are denied as separate permissions, and a not-yet-existing target adds `create`, which is why the note enumerates the required access rather than saying "for writing". Setting `SELinuxContext=` on the unit leaves those denials unchanged, since `setexeccon()` runs long after the target has been opened.

Documentation only; no behaviour change. This is not proposed as a code fix — the fd must exist before `execve()` and the label cannot be applied before it, and #14385 indicates the fd-passing behaviour is intentional — so the aim is just to make the constraint discoverable.

Follows up on #43455, where I originally misattributed these denials to a failed domain transition for `Type=oneshot` + `User=` units; a correction with the full reproduction matrix is posted there.
