### PR TITLE
resolved: don't disable the listening socket when a datagram is dropped

### DIFF
--- a/src/resolve/meson.build
+++ b/src/resolve/meson.build
@@ -124,6 +124,9 @@ executables += [
                 'sources' : files('test-resolved-etc-hosts.c'),
         },
         resolve_test_template + {
+                'sources' : files('test-resolved-manager.c'),
+        },
+        resolve_test_template + {
                 'sources' : files('test-resolved-packet.c'),
         },
         resolve_test_template + {

--- a/src/resolve/resolved-manager.c
+++ b/src/resolve/resolved-manager.c
@@ -956,6 +956,13 @@ int manager_recv(Manager *m, int fd, DnsProtocol protocol, DnsPacket **ret) {
         assert(ret);
 
         ms = next_datagram_size_fd(fd);
+        /* The MSG_PEEK recv() in next_datagram_size_fd() validates the datagram's checksum, and drops it if
+         * it is bad. Hence we can end up here with nothing left to read even though the event source said
+         * otherwise, and must treat that like the recvmsg_safe() below does: as "no packet", not as a
+         * failure. Our callers propagate a failure to the event loop, which would then turn the listening
+         * socket's event source off for good. */
+        if (ERRNO_IS_NEG_TRANSIENT(ms))
+                return 0;
         if (ms < 0)
                 return ms;
 

--- a/src/resolve/test-resolved-manager.c
+++ b/src/resolve/test-resolved-manager.c
@@ -1,0 +1,32 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include <sys/socket.h>
+
+#include "dns-packet.h"
+#include "fd-util.h"
+#include "resolved-manager.h"
+#include "tests.h"
+
+/* ================================================================
+ * manager_recv()
+ * ================================================================ */
+
+TEST(manager_recv_nothing_to_read) {
+        Manager manager = {};
+        _cleanup_(dns_packet_unrefp) DnsPacket *p = NULL;
+        _cleanup_close_ int fd = -EBADF;
+
+        /* The event source may hand us a socket whose datagram is gone by the time we look at it: the
+         * MSG_PEEK recv() in next_datagram_size_fd() verifies the UDP checksum and drops the datagram if it
+         * is bad. That must be reported as "no packet", not as an error, as our callers pass an error on to
+         * the event loop, which then turns the listening socket's event source off. An empty non-blocking
+         * socket puts us in exactly that situation. */
+
+        fd = socket(AF_INET, SOCK_DGRAM|SOCK_NONBLOCK|SOCK_CLOEXEC, 0);
+        ASSERT_OK_ERRNO(fd);
+
+        ASSERT_OK_ZERO(manager_recv(&manager, fd, DNS_PROTOCOL_DNS, &p));
+        ASSERT_NULL(p);
+}
+
+DEFINE_TEST_MAIN(LOG_DEBUG);


### PR DESCRIPTION
`manager_recv()` sizes its packet buffer with `next_datagram_size_fd()`, which peeks at the next datagram with `recv(fd, NULL, 0, MSG_PEEK|MSG_TRUNC)`. That is deliberate, and the comment on that helper spells out why: unlike `FIONREAD`, the peek makes the kernel verify the datagram's checksum, so the size we get back is the size we will actually read.

Verifying the checksum also means dropping the datagram when it is bad. The queued datagram that woke our event source can therefore be gone by the time we peek at it, and the peek then returns `EAGAIN` - there is nothing else to read. `EINTR` is possible here as well.

`manager_recv()` passes that on as an error:

```c
ms = next_datagram_size_fd(fd);
if (ms < 0)
        return ms;
```

while the `recvmsg_safe()` a few lines further down, which can fail the same way, already treats it as "no packet":

```c
l = recvmsg_safe(fd, &mh, 0);
if (ERRNO_IS_NEG_TRANSIENT(l))
        return 0;
```

The callers on the UDP listening sockets - `on_mdns_packet()`, `on_llmnr_packet()` and `on_dns_stub_packet_internal()` - hand a negative return straight back to the event loop:

```c
r = manager_recv(m, fd, DNS_PROTOCOL_MDNS, &p);
if (r <= 0)
        return r;
```

An `sd_event` I/O callback that returns an error has its event source disabled (these sources don't set `exit_on_failure`), so a single datagram with a bad checksum takes the socket out of service for the lifetime of the process: no further mDNS, LLMNR or stub-listener traffic is received, without any of that being visible above debug level. On the mDNS and LLMNR sockets that is reachable by anyone on the link.

`on_dns_packet()`, on the DNS UDP transaction socket, does not return the error to the event loop, but completes the transaction with `-EAGAIN` instead of letting it time out and retry, so a corrupted response fails the lookup rather than being ignored.

So treat a transient error from `next_datagram_size_fd()` the way the `recvmsg_safe()` below already does, and return 0. This matches what the other users of the helper on an event source do (`sd-lldp-rx.c`, `sd-dhcp-client.c`, `sd-dhcp6-client.c`, `coredump-worker.c`). Disconnect errors are deliberately left alone: `ECONNREFUSED` and friends surface here from ICMP errors on the connected UDP socket, and `on_dns_packet()` handles those explicitly.

The added test calls `manager_recv()` on an empty non-blocking UDP socket, which is the same situation the dropped datagram leaves us in. It fails on the current code with `-11/EAGAIN`.
