### PR TITLE
in-addr-util: fix in_addr_prefix_nth() for prefixes that don't end on a byte boundary

### DIFF
--- a/src/basic/in-addr-util.c
+++ b/src/basic/in-addr-util.c
@@ -295,54 +295,63 @@ int in_addr_prefix_nth(int family, union in_addr_union *u, unsigned prefixlen, u
                 return -ERANGE;
 
         if (family == AF_INET) {
-                uint32_t c, n, t;
-
                 if (prefixlen > 32)
                         return -ERANGE;
 
-                c = be32toh(u->in.s_addr);
+                unsigned shift = 32 - prefixlen;
 
-                t = nth << (32 - prefixlen);
+                /* Do the arithmetic on the network number rather than on the address, so that a 'nth'
+                 * too large to be shifted into place cannot silently wrap around. */
+                uint64_t net = be32toh(u->in.s_addr) >> shift;
+                uint64_t max = (UINT64_C(1) << prefixlen) - 1;
 
-                /* Check for wrap */
-                if (c > UINT32_MAX - t)
+                if (nth > max - net)
                         return -ERANGE;
 
-                n = c + t;
-
-                n &= UINT32_C(0xFFFFFFFF) << (32 - prefixlen);
-                u->in.s_addr = htobe32(n);
+                u->in.s_addr = htobe32((uint32_t) ((net + nth) << shift));
                 return 0;
         }
 
         if (family == AF_INET6) {
-                bool overflow = false;
+                unsigned carry = 0;
 
                 if (prefixlen > 128)
                         return -ERANGE;
 
+                /* Add 'nth' to the network number, walking the address from its least significant byte
+                 * upwards and propagating the carry. The bits of 'nth' are consumed as we go: whatever is
+                 * left over once we run out of address does not fit, and neither does a carry out of the
+                 * most significant byte. */
+
                 for (unsigned i = 16; i > 0; i--) {
                         unsigned t, j = i - 1, p = j * 8;
+                        uint8_t addend;
 
                         if (p >= prefixlen) {
+                                /* Entirely below the prefix: host bits, always cleared. */
                                 u->in6.s6_addr[j] = 0;
                                 continue;
                         }
 
                         if (prefixlen - p < 8) {
-                                u->in6.s6_addr[j] &= 0xff << (8 - (prefixlen - p));
-                                t = u->in6.s6_addr[j] + ((nth & 0xff) << (8 - (prefixlen - p)));
-                                nth >>= prefixlen - p;
+                                /* The byte the prefix ends in. It carries the lowest bits of the network
+                                 * number in its high bits, so take only as many bits off 'nth' as fit. */
+                                unsigned k = prefixlen - p;
+
+                                u->in6.s6_addr[j] &= 0xff << (8 - k);
+                                addend = (nth & ((UINT64_C(1) << k) - 1)) << (8 - k);
+                                nth >>= k;
                         } else {
-                                t = u->in6.s6_addr[j] + (nth & 0xff) + overflow;
+                                addend = nth & 0xff;
                                 nth >>= 8;
                         }
 
-                        overflow = t > UINT8_MAX;
-                        u->in6.s6_addr[j] = (uint8_t) (t & 0xff);
+                        t = u->in6.s6_addr[j] + addend + carry;
+                        u->in6.s6_addr[j] = (uint8_t) t;
+                        carry = t >> 8;
                 }
 
-                if (overflow || nth != 0)
+                if (carry != 0 || nth != 0)
                         return -ERANGE;
 
                 return 0;

--- a/src/test/test-in-addr-util.c
+++ b/src/test/test-in-addr-util.c
@@ -290,6 +290,39 @@ TEST(in_addr_prefix_nth) {
         test_in_addr_prefix_nth_one(AF_INET6, "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff", 128, 1, NULL);
         test_in_addr_prefix_nth_one(AF_INET6, "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff", 0, 1, NULL);
         test_in_addr_prefix_nth_one(AF_INET6, "1234:5678:90ab:cdef:1234:5678:90ab:cdef", 12, 1, "1240::");
+
+        /* An 'nth' that does not fit the prefix must be refused, not silently truncated into a
+         * wrap-around. With a /1 there are exactly two prefixes, so anything above 1 is out of range. */
+        test_in_addr_prefix_nth_one(AF_INET, "0.0.0.0", 1, 1, "128.0.0.0");
+        test_in_addr_prefix_nth_one(AF_INET, "0.0.0.0", 1, 2, NULL);
+        test_in_addr_prefix_nth_one(AF_INET, "0.0.0.0", 1, 3, NULL);
+        test_in_addr_prefix_nth_one(AF_INET, "0.0.0.0", 1, UINT64_C(1) << 32, NULL);
+        test_in_addr_prefix_nth_one(AF_INET, "0.0.0.0", 24, UINT64_C(0x1000000), NULL);
+        test_in_addr_prefix_nth_one(AF_INET, "0.0.0.0", 24, UINT64_C(0x1000001), NULL);
+        test_in_addr_prefix_nth_one(AF_INET, "0.0.0.0", 32, UINT64_MAX, NULL);
+        test_in_addr_prefix_nth_one(AF_INET, "0.0.0.0", 24, 0xffffff, "255.255.255.0");
+
+        test_in_addr_prefix_nth_one(AF_INET6, "::", 1, 1, "8000::");
+        test_in_addr_prefix_nth_one(AF_INET6, "::", 1, 2, NULL);
+        test_in_addr_prefix_nth_one(AF_INET6, "::", 1, 3, NULL);
+
+        /* Prefix lengths that do not end on a byte boundary: the low bits of 'nth' go into the byte the
+         * prefix ends in, the rest into the bytes above it. */
+        test_in_addr_prefix_nth_one(AF_INET6, "::", 9, 1, "80::");
+        test_in_addr_prefix_nth_one(AF_INET6, "::", 9, 2, "100::");
+        test_in_addr_prefix_nth_one(AF_INET6, "::", 9, 3, "180::");
+        test_in_addr_prefix_nth_one(AF_INET6, "::", 9, 255, "7f80::");
+        test_in_addr_prefix_nth_one(AF_INET6, "::", 9, 511, "ff80::");
+        test_in_addr_prefix_nth_one(AF_INET6, "::", 9, 512, NULL);
+        test_in_addr_prefix_nth_one(AF_INET6, "::", 12, 16, "100::");
+        test_in_addr_prefix_nth_one(AF_INET6, "::", 12, 0xfff, "fff0::");
+        test_in_addr_prefix_nth_one(AF_INET6, "::", 12, 0x1000, NULL);
+        test_in_addr_prefix_nth_one(AF_INET6, "2001:db8::", 60, 0x11, "2001:db8:0:110::");
+        test_in_addr_prefix_nth_one(AF_INET6, "2001:db8::", 63, 4, "2001:db8:0:8::");
+
+        /* Carry out of the byte the prefix ends in must propagate into the bytes above it. */
+        test_in_addr_prefix_nth_one(AF_INET6, "0080::", 9, 1, "100::");
+        test_in_addr_prefix_nth_one(AF_INET6, "ff80::", 9, 1, NULL);
 }
 
 static void test_in_addr_prefix_range_one(


### PR DESCRIPTION
`in_addr_prefix_nth()` computes the nth prefix of a given size starting from an address. It is wrong in two ways, both of which need `nth > 1` to show up — which is why the existing tests pass.

### IPv6: the byte the prefix ends in is added to twice

When the prefix does not end on a byte boundary, the byte containing the end of the prefix holds the lowest `k = prefixlen % 8` bits of the network number in its high bits. The code added `nth` to it like this:

```c
u->in6.s6_addr[j] &= 0xff << (8 - (prefixlen - p));
t = u->in6.s6_addr[j] + ((nth & 0xff) << (8 - (prefixlen - p)));
nth >>= prefixlen - p;
```

Only `k` bits of `nth` belong in that byte, but a full 8 are shifted in. The bits above the `k`th end up beyond the byte, and since only `k` bits are consumed from `nth`, they are added again when the loop reaches the bytes above. On top of that they push the sum past `UINT8_MAX`, so

```c
overflow = t > UINT8_MAX;
```

is set even when the addition did not really carry — and being a `bool` it can only ever carry one into the next byte, never the two that a genuine carry plus the spurious one would require.

So for `::/9` plus 2: the partial byte gets `(2 & 0xff) << 7` = `0x100`, which leaves the byte itself at 0 but sets `overflow`; `nth` becomes 1; the next byte up gets `0 + 1 + 1` = 2:

```
in_addr_prefix_nth(AF_INET6, ::, 9, 2)  ->  200::     (should be 100::)
in_addr_prefix_nth(AF_INET6, ::, 12, 16) ->  200::    (should be 100::)
in_addr_prefix_nth(AF_INET6, ::, 9, 255) -> 8080::    (should be 7f80::)
```

Byte-aligned prefix lengths never take that branch and are unaffected.

### IPv4: an `nth` that doesn't fit wraps around instead of failing

```c
t = nth << (32 - prefixlen);

/* Check for wrap */
if (c > UINT32_MAX - t)
        return -ERANGE;
```

`t` is a `uint32_t`, so an `nth` too large for the prefix loses its high bits before the wrap check ever looks at it. The check then sees a small (or zero) addend and lets it through:

```
in_addr_prefix_nth(AF_INET, 0.0.0.0, 1, 2)         -> 0, writes 0.0.0.0
in_addr_prefix_nth(AF_INET, 0.0.0.0, 24, 0x1000001) -> 0, writes 0.0.1.0
```

There are exactly two /1 prefixes, so 2 has to be `-ERANGE`. The IPv6 side already refuses this case via its leftover-`nth` check; IPv4 had no equivalent.

### The fix

IPv4 arithmetic now happens on the network number rather than on the address, where "doesn't fit" is a plain range check and there is nothing to truncate. The IPv6 loop gets a real carry instead of a bool, and takes only as many bits off `nth` as fit in the byte at hand. Leftover bits of `nth`, or a carry out of the most significant byte, still mean `-ERANGE`.

### Impact

`in_addr_prefix_range()` is the only caller in the tree and passes only 0 and 1, which are correct before and after, so no current behaviour changes. This is a latent bug in a general-purpose helper whose documented contract explicitly covers large `nth` (the comment's own example uses `nth = 0xff00`).

### Testing

The new cases in `test-in-addr-util` fail on the current code (the first `-ERANGE` expectation trips the assertion) and pass with the fix. They were cross-checked against Python's `ipaddress`.

I also ran the fixed and unfixed implementations against an independent 128-bit reference over an exhaustive sweep of interesting addresses × every prefix length 1…32/1…128 × a set of boundary `nth` values, plus 300k randomized triples: ~205000 mismatches before, none after. The same harness found no mismatches in `in_addr_prefix_covers_full()`, `in_addr_prefix_intersect()` or `in_addr_prefixlen_to_netmask()`, so the defect looks confined to this function.

The full unit test suite passes (211 ok, 4 skipped, 0 failed).
