### PR TITLE
timer: allow to disable catch up on reload

### DIFF
--- a/man/systemd.timer.xml
+++ b/man/systemd.timer.xml
@@ -401,6 +401,21 @@
       </varlistentry>
 
       <varlistentry>
+        <term><varname>CatchUp=</varname></term>
+
+        <listitem>
+          <para>Takes a boolean argument. If <constant>true</constant>, the timer will "catch up" after reload
+          or wake-up from suspend. That is, the associated service is triggered immediately if it would have
+          been triggered at least once since the last time. If <constant>false</constant>, no "catch up" is
+          done; instead, the next activation time is recomputed from current time. Note that this setting only
+          has an effect on timers configured with <varname>OnCalendar=</varname>. Defaults to
+          <constant>true</constant>.</para>
+
+          <xi:include href="version-info.xml" xpointer="v263"/>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
         <term><varname>WakeSystem=</varname></term>
 
         <listitem><para>Takes a boolean argument. If true, an elapsing timer will cause the system to resume

--- a/src/core/dbus-timer.c
+++ b/src/core/dbus-timer.c
@@ -122,6 +122,7 @@ const sd_bus_vtable bus_timer_vtable[] = {
         SD_BUS_PROPERTY("WakeSystem", "b", bus_property_get_bool, offsetof(Timer, wake_system), SD_BUS_VTABLE_PROPERTY_CONST),
         SD_BUS_PROPERTY("RemainAfterElapse", "b", bus_property_get_bool, offsetof(Timer, remain_after_elapse), SD_BUS_VTABLE_PROPERTY_CONST),
         SD_BUS_PROPERTY("DeferReactivation", "b", bus_property_get_bool, offsetof(Timer, defer_reactivation), SD_BUS_VTABLE_PROPERTY_CONST),
+        SD_BUS_PROPERTY("CatchUp", "b", bus_property_get_bool, offsetof(Timer, catch_up), SD_BUS_VTABLE_PROPERTY_CONST),
         SD_BUS_VTABLE_END
 };
 
@@ -242,6 +243,9 @@ static int bus_timer_set_transient_property(
 
         if (streq(name, "DeferReactivation"))
                 return bus_set_transient_bool(u, name, &t->defer_reactivation, message, flags, reterr_error);
+
+        if (streq(name, "CatchUp"))
+                return bus_set_transient_bool(u, name, &t->catch_up, message, flags, reterr_error);
 
         if (streq(name, "TimersMonotonic")) {
                 const char *base_name;

--- a/src/core/load-fragment-gperf.gperf.in
+++ b/src/core/load-fragment-gperf.gperf.in
@@ -618,6 +618,7 @@ Timer.WakeSystem,                             config_parse_bool,                
 Timer.RemainAfterElapse,                      config_parse_bool,                                  0,                                  offsetof(Timer, remain_after_elapse)
 Timer.FixedRandomDelay,                       config_parse_bool,                                  0,                                  offsetof(Timer, fixed_random_delay)
 Timer.DeferReactivation,                      config_parse_bool,                                  0,                                  offsetof(Timer, defer_reactivation)
+Timer.CatchUp,                                config_parse_bool,                                  0,                                  offsetof(Timer, catch_up)
 Timer.AccuracySec,                            config_parse_sec,                                   0,                                  offsetof(Timer, accuracy_usec)
 Timer.RandomizedDelaySec,                     config_parse_sec,                                   0,                                  offsetof(Timer, random_delay_usec)
 Timer.RandomizedOffsetSec,                    config_parse_sec,                                   0,                                  offsetof(Timer, random_offset_usec)

--- a/src/core/timer.c
+++ b/src/core/timer.c
@@ -378,7 +378,6 @@ static void calculate_next_elapse_base(
                 bool *ret_rebase_after_boot_time) {
         bool rebase_after_boot_time = false;
         usec_t b, random_offset = 0;
-        usec_t boot_monotonic = UNIT(t)->manager->timestamps[MANAGER_TIMESTAMP_USERSPACE].monotonic;
 
         assert(t);
         assert(ts);
@@ -407,6 +406,7 @@ static void calculate_next_elapse_base(
                  * boot. If so, this means the timestamp came from a stamp file of a
                  * persistent timer and we need to rebase it to make RandomizedDelaySec=
                  * work (see below). */
+                usec_t boot_monotonic = UNIT(t)->manager->timestamps[MANAGER_TIMESTAMP_USERSPACE].monotonic;
                 if (t->last_trigger.monotonic < boot_monotonic)
                         rebase_after_boot_time = true;
         } else if (dual_timestamp_is_set(&UNIT(t)->inactive_exit_timestamp))
@@ -468,7 +468,6 @@ static void timer_enter_waiting(Timer *t, bool time_change) {
                 if (v->base == TIMER_CALENDAR) {
                         bool rebase_after_boot_time;
                         usec_t b, random_offset;
-                        usec_t boot_monotonic = UNIT(t)->manager->timestamps[MANAGER_TIMESTAMP_USERSPACE].monotonic;
 
                         calculate_next_elapse_base(
                                         t,
@@ -489,6 +488,7 @@ static void timer_enter_waiting(Timer *t, bool time_change) {
                                  * time has already passed, set the time when systemd first started as the scheduled
                                  * time. Note that we base this on the monotonic timestamp of the boot, not the
                                  * realtime one, since the wallclock might have been off during boot. */
+                                usec_t boot_monotonic = UNIT(t)->manager->timestamps[MANAGER_TIMESTAMP_USERSPACE].monotonic;
                                 usec_t rebased = map_clock_usec(boot_monotonic, CLOCK_MONOTONIC, CLOCK_REALTIME);
                                 if (v->next_elapse < rebased)
                                         v->next_elapse = rebased;

--- a/src/core/timer.c
+++ b/src/core/timer.c
@@ -489,7 +489,7 @@ static void timer_enter_waiting(Timer *t, bool time_change) {
                                         continue;
                         }
 
-                        v->next_elapse += random_offset;
+                        v->next_elapse = usec_add(v->next_elapse, random_offset);
 
                         if (rebase_after_boot_time) {
                                 /* To make the delay due to RandomizedDelaySec= work even at boot, if the scheduled

--- a/src/core/timer.c
+++ b/src/core/timer.c
@@ -44,6 +44,7 @@ static void timer_init(Unit *u) {
         t->next_elapse_realtime = USEC_INFINITY;
         t->accuracy_usec = u->manager->defaults.timer_accuracy_usec;
         t->remain_after_elapse = true;
+        t->catch_up = true;
 }
 
 void timer_free_values(Timer *t) {
@@ -480,6 +481,13 @@ static void timer_enter_waiting(Timer *t, bool time_change) {
                         r = calendar_spec_next_usec(v->calendar_spec, b, &v->next_elapse);
                         if (r < 0)
                                 continue;
+
+                        if (!t->catch_up && v->next_elapse <= ts.realtime) {
+                                /* Don't catch up with past events */
+                                r = calendar_spec_next_usec(v->calendar_spec, ts.realtime, &v->next_elapse);
+                                if (r < 0)
+                                        continue;
+                        }
 
                         v->next_elapse += random_offset;
 

--- a/src/core/timer.c
+++ b/src/core/timer.c
@@ -369,6 +369,80 @@ static void add_random_delay(Timer *t, usec_t *v) {
         log_unit_debug(UNIT(t), "Adding %s random time.", FORMAT_TIMESPAN(add, 0));
 }
 
+static void calculate_next_elapse_base(
+                Timer *t,
+                const triple_timestamp *ts,
+                Unit *trigger,
+                usec_t *ret_base,
+                usec_t *ret_random_offset,
+                bool *ret_rebase_after_boot_time) {
+        bool rebase_after_boot_time = false;
+        usec_t b, random_offset = 0;
+        usec_t boot_monotonic = UNIT(t)->manager->timestamps[MANAGER_TIMESTAMP_USERSPACE].monotonic;
+
+        assert(t);
+        assert(ts);
+        assert(ret_base);
+        assert(ret_random_offset);
+        assert(ret_rebase_after_boot_time);
+
+        if (t->random_offset_usec != 0)
+                random_offset = timer_get_fixed_delay_hash(t) % t->random_offset_usec;
+
+        /* If DeferReactivation= is enabled, schedule the job based on the last time
+         * the trigger unit entered inactivity. Otherwise, if we know the last time
+         * this was triggered, schedule the job based relative to that. If we don't,
+         * just start from the activation time or realtime. */
+        if (t->defer_reactivation &&
+            dual_timestamp_is_set(&trigger->inactive_enter_timestamp)) {
+                if (dual_timestamp_is_set(&t->last_trigger))
+                        b = MAX(trigger->inactive_enter_timestamp.realtime,
+                                t->last_trigger.realtime);
+                else
+                        b = trigger->inactive_enter_timestamp.realtime;
+        } else if (dual_timestamp_is_set(&t->last_trigger)) {
+                b = t->last_trigger.realtime;
+
+                /* Check if the last_trigger timestamp is older than the current machine
+                 * boot. If so, this means the timestamp came from a stamp file of a
+                 * persistent timer and we need to rebase it to make RandomizedDelaySec=
+                 * work (see below). */
+                if (t->last_trigger.monotonic < boot_monotonic)
+                        rebase_after_boot_time = true;
+        } else if (dual_timestamp_is_set(&UNIT(t)->inactive_exit_timestamp))
+                b = UNIT(t)->inactive_exit_timestamp.realtime;
+        else {
+                b = ts->realtime;
+                rebase_after_boot_time = true;
+        }
+
+        if (b > ts->realtime) {
+                /* The base we picked is in the future relative to the current realtime. This
+                 * happens when the wall clock is set backwards while the timer is already
+                 * waiting: the base was recorded from the old, later time. Feeding a future
+                 * base to calendar_spec_next_usec() would schedule the next elapse relative to
+                 * that stale time instead of now, so systemctl list-timers keeps showing the
+                 * pre-adjustment elapse and the timer never catches up (see #6036). Clamp to
+                 * now so we recalculate from the current time. */
+                log_unit_debug(UNIT(t),
+                                "Calendar timer base time %s is in the future, recalculating from the current time.",
+                                FORMAT_TIMESTAMP(b));
+                b = ts->realtime;
+        }
+
+        /* We always subtract random_offset from the base time because
+         * calendar_spec_next_usec() finds the next calendar event, and then we add the
+         * offset back afterwards (see below). The base time needs to be in "pre-offset"
+         * space so the next calendar match is computed correctly. Without this, a timer
+         * that fires late (e.g. persistent catch-up) would skip the next scheduled
+         * activation. */
+        b = usec_sub_unsigned(b, random_offset);
+
+        *ret_base = b;
+        *ret_random_offset = random_offset;
+        *ret_rebase_after_boot_time = rebase_after_boot_time;
+}
+
 static void timer_enter_waiting(Timer *t, bool time_change) {
         bool found_monotonic = false, found_realtime = false;
         bool leave_around = false;
@@ -392,61 +466,17 @@ static void timer_enter_waiting(Timer *t, bool time_change) {
                         continue;
 
                 if (v->base == TIMER_CALENDAR) {
-                        bool rebase_after_boot_time = false;
-                        usec_t b, random_offset = 0;
+                        bool rebase_after_boot_time;
+                        usec_t b, random_offset;
                         usec_t boot_monotonic = UNIT(t)->manager->timestamps[MANAGER_TIMESTAMP_USERSPACE].monotonic;
 
-                        if (t->random_offset_usec != 0)
-                                random_offset = timer_get_fixed_delay_hash(t) % t->random_offset_usec;
-
-                        /* If DeferReactivation= is enabled, schedule the job based on the last time
-                         * the trigger unit entered inactivity. Otherwise, if we know the last time
-                         * this was triggered, schedule the job based relative to that. If we don't,
-                         * just start from the activation time or realtime. */
-                        if (t->defer_reactivation &&
-                            dual_timestamp_is_set(&trigger->inactive_enter_timestamp)) {
-                                if (dual_timestamp_is_set(&t->last_trigger))
-                                        b = MAX(trigger->inactive_enter_timestamp.realtime,
-                                                t->last_trigger.realtime);
-                                else
-                                        b = trigger->inactive_enter_timestamp.realtime;
-                        } else if (dual_timestamp_is_set(&t->last_trigger)) {
-                                b = t->last_trigger.realtime;
-
-                                /* Check if the last_trigger timestamp is older than the current machine
-                                 * boot. If so, this means the timestamp came from a stamp file of a
-                                 * persistent timer and we need to rebase it to make RandomizedDelaySec=
-                                 * work (see below). */
-                                if (t->last_trigger.monotonic < boot_monotonic)
-                                        rebase_after_boot_time = true;
-                        } else if (dual_timestamp_is_set(&UNIT(t)->inactive_exit_timestamp))
-                                b = UNIT(t)->inactive_exit_timestamp.realtime;
-                        else {
-                                b = ts.realtime;
-                                rebase_after_boot_time = true;
-                        }
-
-                        if (b > ts.realtime) {
-                                /* The base we picked is in the future relative to the current realtime. This
-                                 * happens when the wall clock is set backwards while the timer is already
-                                 * waiting: the base was recorded from the old, later time. Feeding a future
-                                 * base to calendar_spec_next_usec() would schedule the next elapse relative to
-                                 * that stale time instead of now, so systemctl list-timers keeps showing the
-                                 * pre-adjustment elapse and the timer never catches up (see #6036). Clamp to
-                                 * now so we recalculate from the current time. */
-                                log_unit_debug(UNIT(t),
-                                               "Calendar timer base time %s is in the future, recalculating from the current time.",
-                                               FORMAT_TIMESTAMP(b));
-                                b = ts.realtime;
-                        }
-
-                        /* We always subtract random_offset from the base time because
-                         * calendar_spec_next_usec() finds the next calendar event, and then we add the
-                         * offset back afterwards (see below). The base time needs to be in "pre-offset"
-                         * space so the next calendar match is computed correctly. Without this, a timer
-                         * that fires late (e.g. persistent catch-up) would skip the next scheduled
-                         * activation. */
-                        b = usec_sub_unsigned(b, random_offset);
+                        calculate_next_elapse_base(
+                                        t,
+                                        &ts,
+                                        trigger,
+                                        &b,
+                                        &random_offset,
+                                        &rebase_after_boot_time);
 
                         r = calendar_spec_next_usec(v->calendar_spec, b, &v->next_elapse);
                         if (r < 0)

--- a/src/core/timer.h
+++ b/src/core/timer.h
@@ -60,6 +60,8 @@ typedef struct Timer {
         bool on_timezone_change;
         bool fixed_random_delay;
         bool defer_reactivation;
+        bool catch_up; /* Trigger immediately if the next activation time is in the past, which may happen after
+                        * daemon-reload */
 
         char *stamp_path;
 } Timer;

--- a/src/core/varlink-timer.c
+++ b/src/core/varlink-timer.c
@@ -62,7 +62,8 @@ int timer_context_build_json(sd_json_variant **ret, const char *name, void *user
                         SD_JSON_BUILD_PAIR_BOOLEAN("Persistent", t->persistent),
                         SD_JSON_BUILD_PAIR_BOOLEAN("WakeSystem", t->wake_system),
                         SD_JSON_BUILD_PAIR_BOOLEAN("RemainAfterElapse", t->remain_after_elapse),
-                        SD_JSON_BUILD_PAIR_BOOLEAN("DeferReactivation", t->defer_reactivation));
+                        SD_JSON_BUILD_PAIR_BOOLEAN("DeferReactivation", t->defer_reactivation),
+                        SD_JSON_BUILD_PAIR_BOOLEAN("CatchUp", t->catch_up));
 }
 
 int timer_runtime_build_json(sd_json_variant **ret, const char *name, void *userdata) {

--- a/src/shared/bus-unit-util.c
+++ b/src/shared/bus-unit-util.c
@@ -2882,6 +2882,7 @@ static const BusProperty timer_properties[] = {
         { "OnClockChange",                         bus_append_parse_boolean                      },
         { "FixedRandomDelay",                      bus_append_parse_boolean                      },
         { "DeferReactivation",                     bus_append_parse_boolean                      },
+        { "CatchUp",                               bus_append_parse_boolean                      },
         { "AccuracySec",                           bus_append_parse_sec_rename                   },
         { "RandomizedDelaySec",                    bus_append_parse_sec_rename                   },
         { "RandomizedOffsetSec",                   bus_append_parse_sec_rename                   },

--- a/src/shared/varlink-io.systemd.Unit.c
+++ b/src/shared/varlink-io.systemd.Unit.c
@@ -1316,7 +1316,9 @@ static SD_VARLINK_DEFINE_STRUCT_TYPE(
                 SD_VARLINK_FIELD_COMMENT("https://www.freedesktop.org/software/systemd/man/"PROJECT_VERSION_STR"/systemd.timer.html#RemainAfterElapse="),
                 SD_VARLINK_DEFINE_FIELD(RemainAfterElapse, SD_VARLINK_BOOL, SD_VARLINK_NULLABLE),
                 SD_VARLINK_FIELD_COMMENT("https://www.freedesktop.org/software/systemd/man/"PROJECT_VERSION_STR"/systemd.timer.html#DeferReactivation="),
-                SD_VARLINK_DEFINE_FIELD(DeferReactivation, SD_VARLINK_BOOL, SD_VARLINK_NULLABLE));
+                SD_VARLINK_DEFINE_FIELD(DeferReactivation, SD_VARLINK_BOOL, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("https://www.freedesktop.org/software/systemd/man/"PROJECT_VERSION_STR"/systemd.timer.html#CatchUp="),
+                SD_VARLINK_DEFINE_FIELD(CatchUp, SD_VARLINK_BOOL, SD_VARLINK_NULLABLE));
 
 SD_VARLINK_DEFINE_ENUM_TYPE(
                 TimerResult,

--- a/src/test/test-bus-unit-util.c
+++ b/src/test/test-bus-unit-util.c
@@ -952,6 +952,7 @@ TEST(timer_properties) {
                         "OnClockChange=true",
                         "FixedRandomDelay=yes",
                         "DeferReactivation=true",
+                        "CatchUp=no",
 
                         "AccuracySec=1s",
                         "AccuracySec=10min",


### PR DESCRIPTION
Currently, if a timer's next elapse after daemon-reload is in the past, it would be triggered immediately. This "catch up" is deemed desirable in general, but there are cases where it is not. This commit adds a new directive `CatchUp=` that allows to select the behavior that's wanted. The default remains as it is now.

Fixes: #16732
