### PR TITLE
hwdb: mark Apple T2 MacBook touchpads as internal

### DIFF
--- a/hwdb.d/70-touchpad.hwdb
+++ b/hwdb.d/70-touchpad.hwdb
@@ -39,6 +39,16 @@
 # ID_INPUT_TOUCHPAD_INTEGRATION=internal
 
 ###########################################################
+# Apple T2 MacBook internal trackpad
+###########################################################
+# The T2 virtual USB host controller reports the device as having unknown
+# removability, so 65-integration.rules classifies the touchpad as external
+# and libinput skips disable-while-typing.
+# The touchpad is physically integrated; mark it internal to enable DWT.
+touchpad:usb:v05acp0340:name:Apple Inc. Apple Internal Keyboard / Trackpad:*
+ ID_INPUT_TOUCHPAD_INTEGRATION=internal
+
+###########################################################
 # ASUS ROG Flow Z13 (GZ302EA)
 ###########################################################
 # The USB port is reported as removable by firmware, so 65-integration.rules


### PR DESCRIPTION
Apple T2 MacBooks expose the built-in keyboard and trackpad through the t2bce_vhci virtual USB host controller.

The USB device reports its removable attribute as unknown. As a result, 65-integration.rules classifies the touchpad as external and libinput does not enable disable-while-typing, despite the device being physically integrated into the laptop.

Add a touchpad hwdb override for Apple USB ID 05ac:0340 and the exact Apple Inc. Apple Internal Keyboard / Trackpad device name.

Tested on a MacBookPro16,1 with:

- systemd 261.2
- libinput 1.31.3
- linux-t2 7.1.8

After applying the override, /dev/input/event6 reports:

    ID_INTEGRATION=internal
    ID_INPUT_TOUCHPAD_INTEGRATION=internal

and disable-while-typing works as expected.