### PR TITLE
journalctl: make the read path 1.7x to 2.5x faster

### DIFF
--- a/src/basic/ratelimit.c
+++ b/src/basic/ratelimit.c
@@ -6,15 +6,11 @@
 /* Modelled after Linux' lib/ratelimit.c by Dave Young
  * <hidave.darkstar@gmail.com>, which is licensed GPLv2. */
 
-bool ratelimit_below(RateLimit *rl) {
-        usec_t ts;
-
+bool ratelimit_below_at(RateLimit *rl, usec_t ts) {
         assert(rl);
 
         if (!ratelimit_configured(rl))
                 return true;
-
-        ts = now(CLOCK_BOOTTIME);
 
         if (rl->begin <= 0 ||
             usec_sub_unsigned(ts, rl->begin) > rl->interval) {
@@ -28,6 +24,16 @@ bool ratelimit_below(RateLimit *rl) {
 
         rl->num++;
         return rl->num <= rl->burst;
+}
+
+bool ratelimit_below(RateLimit *rl) {
+        assert(rl);
+
+        if (!ratelimit_configured(rl)) /* Keep this check here too: the argument below is evaluated
+                                        * before the callee could short-circuit on it. */
+                return true;
+
+        return ratelimit_below_at(rl, now(CLOCK_BOOTTIME));
 }
 
 unsigned ratelimit_num_dropped(const RateLimit *rl) {

--- a/src/basic/ratelimit.h
+++ b/src/basic/ratelimit.h
@@ -21,6 +21,11 @@ static inline bool ratelimit_configured(const RateLimit *rl) {
 }
 
 bool ratelimit_below(RateLimit *rl);
+/* Like ratelimit_below(), but takes the current CLOCK_BOOTTIME timestamp from the caller, for callers
+ * that check many rate limits in a row and should not read the clock for each of them. The timestamps
+ * passed for a given RateLimit must not go backwards: a ts before the one that opened the current
+ * window makes usec_sub_unsigned() return 0, i.e. the window looks like it just started. */
+bool ratelimit_below_at(RateLimit *rl, usec_t ts);
 
 unsigned ratelimit_num_dropped(const RateLimit *rl);
 

--- a/src/basic/utf8.c
+++ b/src/basic/utf8.c
@@ -11,6 +11,7 @@
 #include "gunicode.h"
 #include "hexdecoct.h"
 #include "string-util.h"
+#include "unaligned.h"
 #include "utf8.h"
 
 bool unichar_is_valid(char32_t ch) {
@@ -102,6 +103,20 @@ int utf8_encoded_to_unichar(const char *str, char32_t *ret_unichar) {
         return len;
 }
 
+/* Tests whether all eight bytes of a word are plain printable ASCII, i.e. within 0x20…0x7e. The three
+ * terms below cover the three ways a byte can fail. A byte that fails is always flagged in its own
+ * lane, but the converse does not hold: the two subtractions are whole-word ones, so a borrow out of
+ * a failing lane also flags bytes above it. Only the aggregate test is meaningful, the mask is not a
+ * per-byte map of which bytes failed. */
+static bool is_printable_fastpath_u64(uint64_t w) {
+        uint64_t x = w ^ UINT64_C(0x7f7f7f7f7f7f7f7f);
+
+        return (((w & UINT64_C(0x8080808080808080)) |                                  /* >= 0x80 */
+                 ((w - UINT64_C(0x2020202020202020)) & ~w) |                           /* < 0x20 */
+                 ((x - UINT64_C(0x0101010101010101)) & ~x)) &                          /* == 0x7f */
+                UINT64_C(0x8080808080808080)) == 0;
+}
+
 bool utf8_is_printable_newline(const char* str, size_t length, bool allow_newline) {
         assert(str);
 
@@ -109,14 +124,41 @@ bool utf8_is_printable_newline(const char* str, size_t length, bool allow_newlin
                 int encoded_len;
                 char32_t val;
 
-                encoded_len = utf8_encoded_valid_unichar(p, length);
+                /* Bulk fast path: almost everything we are asked about is plain printable ASCII, so
+                 * test eight bytes of it at once. Anything else falls through to the per-character
+                 * path below, which handles it as before. A remainder of less than eight bytes is
+                 * copied into a word padded with spaces, so that it can be tested the same way. */
+                while (length > 0) {
+                        uint64_t w;
+                        size_t n;
+
+                        if (length < sizeof(uint64_t)) {
+                                n = length;
+                                w = UINT64_C(0x2020202020202020);
+                                memcpy(&w, p, n);
+                        } else {
+                                n = sizeof(uint64_t);
+                                w = unaligned_read_ne64(p);
+                        }
+
+                        if (!is_printable_fastpath_u64(w))
+                                break;
+
+                        length -= n;
+                        p += n;
+                }
+
+                /* Note that this is not redundant with the loop condition above: the fast path may
+                 * have consumed the remainder of the string, and then there's nothing left to decode. */
+                if (length == 0)
+                        break;
+
+                encoded_len = utf8_encoded_valid_unichar_full(p, length, &val);
                 if (encoded_len < 0)
                         return false;
                 assert(encoded_len > 0 && (size_t) encoded_len <= length);
 
-                if (utf8_encoded_to_unichar(p, &val) < 0 ||
-                    unichar_is_control(val) ||
-                    (!allow_newline && val == '\n'))
+                if (unichar_is_control(val) || (!allow_newline && val == '\n'))
                         return false;
 
                 length -= encoded_len;
@@ -535,7 +577,7 @@ static int utf8_unichar_to_encoded_len(char32_t unichar) {
 }
 
 /* validate one encoded unicode char and return its length */
-int utf8_encoded_valid_unichar(const char *str, size_t length /* bytes */) {
+int utf8_encoded_valid_unichar_full(const char *str, size_t length /* bytes */, char32_t *ret_unichar) {
         char32_t unichar;
         size_t len;
         int r;
@@ -543,7 +585,9 @@ int utf8_encoded_valid_unichar(const char *str, size_t length /* bytes */) {
         assert(str);
         assert(length > 0);
 
-        /* We read until NUL, at most length bytes. SIZE_MAX may be used to disable the length check. */
+        /* We read until NUL, at most length bytes. SIZE_MAX may be used to disable the length check.
+         * If ret_unichar is non-NULL the decoded character is returned in it, so that callers
+         * interested in both validity and value needn't decode the character a second time. */
 
         len = utf8_encoded_expected_len(str[0]);
         if (len == 0)
@@ -554,8 +598,11 @@ int utf8_encoded_valid_unichar(const char *str, size_t length /* bytes */) {
                 return -EINVAL;
 
         /* ascii is valid */
-        if (len == 1)
+        if (len == 1) {
+                if (ret_unichar)
+                        *ret_unichar = (char32_t) (uint8_t) str[0];
                 return 1;
+        }
 
         /* check if expected encoded chars are available */
         for (size_t i = 0; i < len; i++)
@@ -573,6 +620,9 @@ int utf8_encoded_valid_unichar(const char *str, size_t length /* bytes */) {
         /* check if value has valid range */
         if (!unichar_is_valid(unichar))
                 return -EINVAL;
+
+        if (ret_unichar)
+                *ret_unichar = unichar;
 
         return (int) len;
 }

--- a/src/basic/utf8.h
+++ b/src/basic/utf8.h
@@ -38,7 +38,10 @@ char16_t *utf8_to_utf16(const char *s, size_t length);
 size_t char16_strlen(const char16_t *s) _pure_; /* returns the number of 16-bit words in the string (not bytes!) */
 size_t char16_strsize(const char16_t *s) _pure_;
 
-int utf8_encoded_valid_unichar(const char *str, size_t length) _pure_;
+int utf8_encoded_valid_unichar_full(const char *str, size_t length, char32_t *ret_unichar);
+static inline int _pure_ utf8_encoded_valid_unichar(const char *str, size_t length) {
+        return utf8_encoded_valid_unichar_full(str, length, NULL);
+}
 int utf8_encoded_to_unichar(const char *str, char32_t *ret_unichar);
 
 static inline bool utf16_is_surrogate(char16_t c) {

--- a/src/libsystemd/sd-journal/sd-journal.c
+++ b/src/libsystemd/sd-journal/sd-journal.c
@@ -996,7 +996,7 @@ static int next_with_matches(
                               direction, ret, ret_offset);
 }
 
-static int next_beyond_location(sd_journal *j, JournalFile *f, direction_t direction) {
+static int next_beyond_location(sd_journal *j, JournalFile *f, direction_t direction, usec_t ts) {
         Object *c;
         uint64_t cp, n_entries;
         int r;
@@ -1008,7 +1008,7 @@ static int next_beyond_location(sd_journal *j, JournalFile *f, direction_t direc
          * O(N x files) volatile mmap overhead that makes large 'journalctl -n N' queries unusably
          * slow. Periodic refresh keeps cross-boot ordering reasonably fresh and provides a fallback
          * for any missed inotify events. */
-        if (ratelimit_below(&f->tail_timestamp_ratelimit))
+        if (ratelimit_below_at(&f->tail_timestamp_ratelimit, ts))
                 (void) journal_file_read_tail_timestamp(j, f);
 
         n_entries = le64toh(f->header->n_entries);
@@ -1134,6 +1134,10 @@ static int real_journal_next(sd_journal *j, direction_t direction) {
         assert_return(j, -EINVAL);
         assert_return(!journal_origin_changed(j), -ECHILD);
 
+        /* Read the clock once for the whole call: next_beyond_location() rate-limits its tail timestamp
+         * refresh, which would otherwise be one clock read per file for every entry. */
+        usec_t ts = now(CLOCK_BOOTTIME);
+
         for (;;) {
                 JournalFile *new_file = NULL, *exact_match = NULL;
                 Object *o;
@@ -1146,7 +1150,7 @@ static int real_journal_next(sd_journal *j, direction_t direction) {
                         JournalFile *f = (JournalFile*) *_f;
                         bool found;
 
-                        r = next_beyond_location(j, f, direction);
+                        r = next_beyond_location(j, f, direction, ts);
                         if (r < 0) {
                                 log_debug_errno(r, "Can't iterate through %s, ignoring: %m", f->path);
                                 remove_file_real(j, f);

--- a/src/shared/logs-show.c
+++ b/src/shared/logs-show.c
@@ -1254,6 +1254,12 @@ int journal_entry_to_json(
         if (!h)
                 return log_oom();
 
+        /* A typical entry has around twenty fields and this hashmap is built fresh for each one, so
+         * size it up front rather than rehashing repeatedly while filling it. */
+        r = hashmap_reserve(h, 32);
+        if (r < 0)
+                return log_oom();
+
         r = update_json_data(h, flags, "__CURSOR", cursor, SIZE_MAX);
         if (r < 0)
                 return r;

--- a/src/test/test-utf8.c
+++ b/src/test/test-utf8.c
@@ -7,6 +7,13 @@
 #include "utf8.h"
 
 TEST(utf8_is_printable) {
+        /* Control bytes, plus the exact values the fast path's masks turn on: the last byte below
+         * 0x20 and the first at it, the last byte at or below 0x7e and the first above it, and the
+         * first byte with the topmost bit set. */
+        static const char interesting[] = {
+                '\r', '\177', '\001', '\033', '\t', '\n', '\037', '\040', '\176', '\200',
+        };
+
         assert_se(utf8_is_printable("ascii is valid\tunicode", 22));
         assert_se(utf8_is_printable("\342\204\242", 3));
         assert_se(!utf8_is_printable("\341\204", 2));
@@ -14,6 +21,34 @@ TEST(utf8_is_printable) {
         assert_se(!utf8_is_printable("\r", 1));
         assert_se(utf8_is_printable("\n", 1));
         assert_se(utf8_is_printable("\t", 1));
+        ASSERT_TRUE(utf8_is_printable("", 0));
+
+        /* DEL and the C1 range */
+        ASSERT_FALSE(utf8_is_printable("\177", 1));
+        ASSERT_FALSE(utf8_is_printable("\302\233", 2));
+
+        /* Lengths around the eight byte word the fast path works on: an exact multiple of it, one
+         * short of it, and a multi-byte character straddling its end. */
+        ASSERT_TRUE(utf8_is_printable("abcdefgh", 8));
+        ASSERT_TRUE(utf8_is_printable("abcdefg", 7));
+        ASSERT_TRUE(utf8_is_printable("aaaaaaa\342\204\242aaaaa", 15));
+        ASSERT_FALSE(utf8_is_printable("aaaaaaa\342\204", 9));
+
+        /* Put each of the interesting bytes at each offset of a longer string, so that a fast path
+         * that mishandles a single byte position doesn't go unnoticed. */
+        char buf[16];
+        FOREACH_ELEMENT(c, interesting)
+                for (size_t i = 0; i < sizeof(buf); i++) {
+                        memset(buf, 'a', sizeof(buf));
+                        buf[i] = *c;
+
+                        /* Note that 0x80 on its own is not a valid encoding either, so it is
+                         * expected to be rejected just like the control bytes. */
+                        bool printable = (uint8_t) *c >= 0x20 && (uint8_t) *c <= 0x7e;
+
+                        ASSERT_EQ(utf8_is_printable(buf, sizeof(buf)), printable || IN_SET(*c, '\t', '\n'));
+                        ASSERT_EQ(utf8_is_printable_newline(buf, sizeof(buf), false), printable || *c == '\t');
+                }
 }
 
 TEST(utf8_n_is_valid) {


### PR DESCRIPTION
## journalctl: make the read path 1.7x to 2.5x faster

Three independent fixes to code on `journalctl`'s per-entry read and output path. Each of them removes work that was never needed, rather than trading away anything. There is no behaviour change: the output is byte for byte identical for every format except `-o json`, where only the order of the keys within each object can shift, which is already nondeterministic between two runs of the unpatched binary (see the correctness section below). Nothing about the formats, tunables or public API changes.

Measured on a 730 MB journal spread over 100 files (roughly 2M entries):

| command | before | after | |
|---|---:|---:|---:|
| `journalctl -o cat` | 1.93s | 0.77s | **2.51x** |
| `journalctl --grep=<no match>` | 1.97s | 0.82s | **2.40x** |
| `journalctl -o export` | 4.06s | 1.73s | **2.35x** |
| `journalctl -n 100000 -o short` | 0.86s | 0.43s | **2.00x** |
| `journalctl -o json -n 200000` | 5.85s | 3.50s | 1.67x |
| `journalctl -o short` (the default) | 3.32s | 1.96s | **1.69x** |
| `journalctl -o verbose` | 5.99s | 3.61s | 1.66x |

### 1. `utf8_is_printable_newline()` decoded every character twice

`utf8_encoded_valid_unichar()` decodes the character internally in order to validate it, and then throws the codepoint away. The caller immediately called `utf8_encoded_to_unichar()` again to get the very same codepoint back. So for every byte of every field printed, the UTF-8 decoder ran twice, only to answer whether the byte was a control character.

This is fixed where it originates rather than at the call site: `utf8_encoded_valid_unichar_full()` optionally returns the character it had to decode anyway, so a caller that wants both the validity and the value decodes once. On top of that, eight bytes are tested at once for plain printable ASCII, which is what almost all journal content is. A word that does not qualify falls through to the per character path unchanged, so tabs, newlines and multibyte sequences behave exactly as before.

On its own, against unmodified main: `-o export` 4.02s to 2.89s.

### 2. sd-journal read the clock once per journal file, per entry

`sd_journal_next()` sweeps every open journal file to find the next entry, and `next_beyond_location()` rate limits its tail timestamp refresh per file. Since `ratelimit_below()` reads the clock itself, a journal spread over a hundred files meant a hundred `clock_gettime()` calls for every single entry iterated, nearly all of them only to conclude that the one second interval had not elapsed yet.

This was the single largest cost in `journalctl`. In a profile of `-o export` it was over a fifth of the entire run, spent deciding not to do the thing it was guarding.

Add `ratelimit_below_at()`, which takes the timestamp from the caller, and read the clock once per sweep instead. `ratelimit_below()` keeps its behaviour and becomes a wrapper.

The timestamp is now sampled once per sweep rather than once per file. The interval being rate limited is one second and a sweep takes microseconds, so this makes no practical difference.

On its own: `-o export` 4.02s to 2.93s, and `-o short` 3.30s to 2.14s. This is the largest single contributor for the default output mode.

### 3. The JSON output built a fresh, unsized hashmap for every entry

`journal_entry_to_json()` creates an empty hashmap per entry and fills it with that entry's fields, of which there are typically around twenty. Because it starts empty it has to grow several times per entry, and every growth rehashes everything inserted so far. `-o json` spent about a quarter of its time in siphash, a third of that under `resize_buckets()`.

Reserving room up front is a one line change.

On its own: `-o json -n 200000` 5.71s to 4.64s.

### How this was measured

AMD Ryzen AI 7 350 (16 threads), Fedora 44, gcc 16.2.1, kernel 7.1.12, against a live 730 MB journal in 100 files. Built with `--buildtype=debugoptimized -Dmode=release`, which matters: the tree's default `build/` is `-O0`, and profiles taken from it are dominated by call overhead and missing inlining rather than by the real costs. Profiles were taken with `perf record --call-graph=dwarf`.

The headline table is a drift cancelled A/B: both binaries were built up front and then run alternately within each workload, five repetitions each, reporting the minimum, so that any thermal or cache drift over the run cannot favour one side. The per commit figures were each measured separately against unmodified main, not derived by subtracting from the cumulative total.

### Correctness

- `journalctl -o export` over the whole journal is **byte for byte identical**, verified by sha256 over all 654,439,014 bytes the two runs have in common (the journal is live, so the later run has a few more entries appended at the end).
- `short`, `short-precise`, `short-iso`, `short-monotonic`, `cat`, `verbose` and `with-unit` are byte for byte identical.
- `-o json` is identical up to the ordering of keys within each object, which is already nondeterministic between two runs of the *unpatched* binary since it follows hashmap iteration order. Compared order insensitively, it is identical.
- The eight byte scan in commit 1 was differential tested against the original implementation over **20,901,381 inputs**, with zero disagreements, for both values of `allow_newline`: - every byte string of length 0 to 3 over all 256 byte values (exhaustive),
  - 4,000,000 random strings over three alphabets: uniform bytes, ASCII heavy, and one built purely from encoding boundary bytes (`0x00 0x09 0x0a 0x1f 0x20 0x7e 0x7f 0x80 0x9f 0xa0 0xc0 0xc2 0xe0 0xed 0xf0 0xf4 0xf8 0xfc`),
  - a targeted corpus placing every byte value in every one of the eight lanes at every leading offset, with valid and truncated multibyte sequences straddling the word boundary, and long runs of tab, newline and `0x7f`.
- `meson test` for the `test`, `libsystemd` and `journal` suites: 264 passed, 0 failed.

### Considered and deliberately not done

- **Sharing the entry object between the output getters.** `output_export()` and `output_json()` each call four public getters, and every one independently re-locates the same entry through `journal_file_move_to_object()`, which itself runs `check_object_header()` twice plus
  `check_object()` plus two mmap lookups. Rather than guess, I measured the ceiling: memoizing the validated object is worth 3.5%, and caching the resolved pointer outright with no invalidation at all, which is not a shippable design, is worth 6.4%. Reaching even that means weakening revalidation of a mapping that journald rewrites underneath us, so it is not worth it.
- **A lookup table for `journal_field_valid()`.** It profiled at 3.8%, and replacing the comparison chain with a bitmap was worth exactly nothing. The compiler and the branch predictor already handle it.
- **Hand formatting the cursor in `sd_journal_get_cursor()` instead of `asprintf()`.** Worth about 2%, which does not justify a hand written hex formatter inside a public API function.
- **`getpid_cached()`**, which runs a locked seq-cst compare and exchange on every call even when the cache is long since populated. Loading first and only attempting the exchange when the value is unset makes the function itself 6.2x faster (6.34ns to 1.02ns per call over 500M iterations), but it is not measurable end to end here, where the latency of the locked instruction is hidden by surrounding independent work. It is kept out of this series so that every commit here is backed by a wall clock number, and can be proposed separately on its own merits.

