### PR TITLE
hwdb: add MacBookAir9,1 T2 touchpad

### DIFF
--- a/hwdb.d/70-touchpad.hwdb
+++ b/hwdb.d/70-touchpad.hwdb
@@ -45,6 +45,7 @@
 # removability, so 65-integration.rules classifies the touchpad as external
 # and libinput skips disable-while-typing.
 # The touchpad is physically integrated; mark it internal to enable DWT.
+touchpad:usb:v05acp0280:name:Apple Inc. Apple Internal Keyboard / Trackpad:*
 touchpad:usb:v05acp0340:name:Apple Inc. Apple Internal Keyboard / Trackpad:*
  ID_INPUT_TOUCHPAD_INTEGRATION=internal
 


### PR DESCRIPTION
## Summary

The existing Apple T2 entry covers USB product `05ac:0340`. Add the
directly verified `05ac:0280` touchpad used by MacBookAir9,1.

Apple T2 MacBooks expose their built-in keyboard/trackpad through
`t2bce_vhci` as USB. The virtual USB device reports
`removable=unknown`, so `65-integration.rules` classifies the touchpad
as external and libinput skips disable-while-typing.

## Reference hardware

- DMI product: `MacBookAir9,1`
- T2 PCI: `106b:1801` / `106b:1802`
- USB input: `05ac:0280`
- Kernel path: `t2bce_core → t2bce_vhci → USB HID`
- Input name: `Apple Inc. Apple Internal Keyboard / Trackpad`
- USB `removable`: `unknown`
- Kernel: `linux-t2` 7.1.8 with `t2bce_vhci`
- systemd: 261.2

Before the override:

```text
ID_INPUT_TOUCHPAD=1
ID_INPUT_TOUCHPAD_INTEGRATION=external
ID_INTEGRATION=external
```

After the override and an input-device trigger:

```text
ID_INPUT_TOUCHPAD=1
ID_INPUT_TOUCHPAD_INTEGRATION=internal
ID_INTEGRATION=internal
```

The exact name distinguishes the built-in T2 keyboard/trackpad from
external Apple Magic Trackpads. Linux's
[`hid-ids.h`](https://github.com/torvalds/linux/blob/master/drivers/hid/hid-ids.h)
defines `0280` as `USB_DEVICE_ID_APPLE_WELLSPRINGT2_J230K`.

Other Wellspring T2 product IDs are deliberately not added without
device-specific evidence.

## Verification

```bash
systemd-hwdb --strict --root="$test_root" update
systemd-hwdb --root="$test_root" query \
  'touchpad:usb:v05acp0280:name:Apple Inc. Apple Internal Keyboard / Trackpad:'
```

The query returns:

```text
ID_INPUT_TOUCHPAD_INTEGRATION=internal
```
