### PR TITLE
manager: add DefaultExecSearchPath=

### DIFF
--- a/man/systemd-system.conf.xml
+++ b/man/systemd-system.conf.xml
@@ -814,6 +814,24 @@
   </refsect1>
 
   <refsect1>
+    <title>Paths</title>
+
+    <variablelist class='config-directives'>
+      <varlistentry>
+        <term><varname>DefaultExecSearchPath=</varname></term>
+
+        <listitem><para>Configures the default <varname>ExecSearchPath=</varname> path for all units.</para>
+
+        <para>Takes a colon separated list of absolute paths relative to which the executable used by the
+        <varname>Exec*=</varname> (e.g. <varname>ExecStart=</varname>,<varname>ExecStop=</varname>, etc.)
+        properties can be found.</para>
+
+        <xi:include href="version-info.xml" xpointer="v262"/></listitem>
+      </varlistentry>
+    </variablelist>
+  </refsect1>
+
+  <refsect1>
     <title>Specifiers</title>
 
     <para>Specifiers may be used in the <varname>DefaultEnvironment=</varname> and

--- a/src/core/exec-invoke.c
+++ b/src/core/exec-invoke.c
@@ -6252,7 +6252,10 @@ int exec_invoke(
 
         _cleanup_free_ char *executable = NULL;
         _cleanup_close_ int executable_fd = -EBADF;
-        r = find_executable_full(path, /* root= */ NULL, context->exec_search_path, false, &executable, &executable_fd);
+        if (strv_isempty(context->exec_search_path))
+                r = find_executable_full(path, /* root= */ NULL, params->fallback_exec_search_path, false, &executable, &executable_fd);
+        else
+                r = find_executable_full(path, /* root= */ NULL, context->exec_search_path, false, &executable, &executable_fd);
         if (r < 0) {
                 *exit_status = EXIT_EXEC;
                 log_struct_errno(LOG_NOTICE, r,

--- a/src/core/execute-serialize.c
+++ b/src/core/execute-serialize.c
@@ -1249,6 +1249,10 @@ static int exec_parameters_serialize(const ExecParameters *p, const ExecContext 
         if (r < 0)
                 return r;
 
+        r = serialize_strv(f, "exec-parameters-fallback-exec-search-path", p->fallback_exec_search_path);
+        if (r < 0)
+                return r;
+
         fputc('\n', f); /* End marker */
 
         return 0;
@@ -1525,6 +1529,10 @@ static int exec_parameters_deserialize(ExecParameters *p, FILE *f, FDSet *fds) {
                                 return r;
 
                         p->debug_invocation = r;
+                } else if ((val = startswith(l, "exec-parameters-fallback-exec-search-path="))) {
+                        r = deserialize_strv(val, &p->fallback_exec_search_path);
+                        if (r < 0)
+                                return r;
                 } else
                         log_warning("Failed to parse serialized line, ignoring: %s", l);
         }

--- a/src/core/execute.c
+++ b/src/core/execute.c
@@ -1160,6 +1160,7 @@ void exec_params_dump(const ExecParameters *p, FILE* f, const char *prefix) {
                 fprintf(f, "%sOpenFile: %s %s", prefix, file->path, open_file_flags_to_string(file->flags));
 
         strv_dump(f, prefix, "FilesEnv", p->files_env);
+        strv_dump(f, prefix, "FallbackExecSearchPath", p->fallback_exec_search_path);
 }
 
 void exec_context_dump(const ExecContext *c, FILE* f, const char *prefix) {
@@ -3030,6 +3031,8 @@ void exec_params_deep_clear(ExecParameters *p) {
         open_file_free_many(&p->open_files);
 
         p->fallback_smack_process_label = mfree(p->fallback_smack_process_label);
+
+        p->fallback_exec_search_path = strv_free(p->fallback_exec_search_path);
 
         exec_params_shallow_clear(p);
 }

--- a/src/core/execute.h
+++ b/src/core/execute.h
@@ -470,6 +470,8 @@ typedef struct ExecParameters {
 
         bool debug_invocation;
         bool selinux_context_net;
+
+        char **fallback_exec_search_path;
 } ExecParameters;
 
 #define EXEC_PARAMETERS_INIT(_flags)              \

--- a/src/core/load-fragment.c
+++ b/src/core/load-fragment.c
@@ -470,7 +470,7 @@ int config_parse_colon_separated_paths(
                 void *userdata) {
 
         char ***sv = ASSERT_PTR(data);
-        const Unit *u = ASSERT_PTR(userdata);
+        const Unit *u = userdata;
         int r;
 
         assert(filename);
@@ -482,6 +482,14 @@ int config_parse_colon_separated_paths(
                 *sv = strv_free(*sv);
                 return 0;
         }
+
+        const Specifier *table = u ? NULL : (const Specifier[]) {
+                COMMON_SYSTEM_SPECIFIERS,
+                COMMON_TMP_SPECIFIERS,
+                { 'h', specifier_user_home,  NULL },
+                { 's', specifier_user_shell, NULL },
+                {}
+        };
 
         for (const char *p = rvalue;;) {
                 _cleanup_free_ char *word = NULL, *k = NULL;
@@ -496,7 +504,10 @@ int config_parse_colon_separated_paths(
                 if (r == 0)
                         break;
 
-                r = unit_path_printf(u, word, &k);
+                if (table)
+                        r = specifier_printf(word, sc_arg_max(), table, NULL, NULL, &k);
+                else
+                        r = unit_path_printf(u, word, &k);
                 if (r < 0) {
                         log_syntax(unit, LOG_WARNING, filename, line, r,
                                    "Failed to resolve unit specifiers in '%s', ignoring: %m", word);

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -914,6 +914,7 @@ static int parse_config_file(void) {
                 { "Manager", "EventLoopRateLimitBurst",           config_parse_unsigned,              0,                        &arg_event_loop_ratelimit_burst                        },
                 { "Manager", "DefaultMemoryZSwapWriteback",       config_parse_bool,                  0,                        &arg_defaults.memory_zswap_writeback                   },
                 { "Manager", "MinimumUptimeSec",                  config_parse_sec,                   0,                        &arg_minimum_uptime_usec                               },
+                { "Manager", "DefaultExecSearchPath",             config_parse_colon_separated_paths, 0,                        &arg_defaults.exec_search_path                         },
 #if ENABLE_SMACK
                 { "Manager", "DefaultSmackProcessLabel",          config_parse_string,                0,                        &arg_defaults.smack_process_label                      },
 #else

--- a/src/core/manager.c
+++ b/src/core/manager.c
@@ -4611,6 +4611,7 @@ int manager_get_effective_environment(Manager *m, char ***ret) {
 
 int manager_set_unit_defaults(Manager *m, const UnitDefaults *defaults) {
         _cleanup_free_ char *label = NULL;
+        _cleanup_strv_free_ char **exec_search_path = NULL;
         struct rlimit *rlimit[_RLIMIT_MAX];
         int r;
 
@@ -4670,6 +4671,13 @@ int manager_set_unit_defaults(Manager *m, const UnitDefaults *defaults) {
         free_and_replace(m->defaults.smack_process_label, label);
         rlimit_free_all(m->defaults.rlimit);
         memcpy(m->defaults.rlimit, rlimit, sizeof(struct rlimit*) * _RLIMIT_MAX);
+
+        if (defaults->exec_search_path) {
+                exec_search_path = strv_copy(defaults->exec_search_path);
+                if (!exec_search_path)
+                        return -ENOMEM;
+        }
+        strv_free_and_replace(m->defaults.exec_search_path, exec_search_path);
 
         return 0;
 }
@@ -5587,6 +5595,7 @@ void unit_defaults_done(UnitDefaults *defaults) {
         assert(defaults);
 
         defaults->smack_process_label = mfree(defaults->smack_process_label);
+        defaults->exec_search_path = strv_free(defaults->exec_search_path);
         rlimit_free_all(defaults->rlimit);
 }
 

--- a/src/core/manager.h
+++ b/src/core/manager.h
@@ -178,6 +178,8 @@ typedef struct UnitDefaults {
         char *smack_process_label;
 
         struct rlimit *rlimit[_RLIMIT_MAX];
+
+        char **exec_search_path;
 } UnitDefaults;
 
 typedef struct Manager {

--- a/src/core/system.conf.in
+++ b/src/core/system.conf.in
@@ -91,3 +91,4 @@
 #EventLoopRateLimitIntervalSec=1s
 #EventLoopRateLimitBurst=50000
 #DefaultMemoryZSwapWriteback=yes
+#DefaultExecSearchPath=

--- a/src/core/unit.c
+++ b/src/core/unit.c
@@ -5711,6 +5711,8 @@ int unit_set_exec_params(Unit *u, ExecParameters *p) {
 
         p->debug_invocation = u->debug_invocation;
 
+        p->fallback_exec_search_path = u->manager->defaults.exec_search_path;
+
         return 0;
 }
 

--- a/src/core/user.conf.in
+++ b/src/core/user.conf.in
@@ -64,3 +64,4 @@
 #ReloadLimitBurst=
 #EventLoopRateLimitIntervalSec=1s
 #EventLoopRateLimitBurst=50000
+#DefaultExecSearchPath=


### PR DESCRIPTION
Allow setting a default `ExecSearchPath=` in system.conf.

Works like `DefaultEnvironment=` in system.conf but for `ExecSearch=`

This is mainly motivated by making it possible to drop [another systemd patch we apply in NixOS](https://github.com/NixOS/nixpkgs/blob/master/pkgs/os-specific/linux/systemd/0004-path-util.h-add-placeholder-for-DEFAULT_PATH_NORMAL.patch).