### PR TITLE
include: update kernel headers from v7.3-rc2

### DIFF
--- a/src/include/override/linux/magic.h
+++ b/src/include/override/linux/magic.h
@@ -68,13 +68,6 @@ static_assert(ORANGEFS_DEVREQ_MAGIC == 0x20030529, "");
 static_assert(GFS2_MAGIC == 0x01161970, "");
 #endif
 
-/* Not exposed yet. Defined at fs/configfs/mount.c */
-#ifndef CONFIGFS_MAGIC
-#  define CONFIGFS_MAGIC 0x62656570
-#else
-static_assert(CONFIGFS_MAGIC == 0x62656570, "");
-#endif
-
 /* Not exposed yet. Defined at fs/vboxsf/super.c */
 #ifndef VBOXSF_SUPER_MAGIC
 #  define VBOXSF_SUPER_MAGIC 0x786f4256

--- a/src/include/uapi/linux/magic.h
+++ b/src/include/uapi/linux/magic.h
@@ -8,6 +8,7 @@
 #define AUTOFS_SUPER_MAGIC	0x0187
 #define CEPH_SUPER_MAGIC	0x00c36400
 #define CODA_SUPER_MAGIC	0x73757245
+#define CONFIGFS_MAGIC		0x62656570	/* some random number */
 #define CRAMFS_MAGIC		0x28cd3d45	/* some random number */
 #define CRAMFS_MAGIC_WEND	0x453dcd28	/* magic number with the wrong endianess */
 #define DEBUGFS_MAGIC          0x64626720


### PR DESCRIPTION
The only difference from the previous update is that now CONFIGFS_MAGIC is listed in the magic.h, hence the override is not necessary anymore.