### PR TITLE
meson: add extra-exec-search-path option

### DIFF
--- a/man/systemd.exec.xml
+++ b/man/systemd.exec.xml
@@ -4193,11 +4193,12 @@ StandardInputData=V2XigLJyZSBubyBzdHJhbmdlcnMgdG8gbG92ZQpZb3Uga25vdyB0aGUgcnVsZX
           <term><varname>$PATH</varname></term>
 
           <listitem><para>Colon-separated list of directories to use when launching
-          executables. <command>systemd</command> uses a fixed value of
+          executables. <command>systemd</command> uses a built-in value of
           <literal><filename>/usr/local/sbin</filename>:<filename>/usr/local/bin</filename>:<filename>/usr/sbin</filename>:<filename>/usr/bin</filename></literal>
           in the system manager. In case of the user manager, a different path may be configured by the
-          distribution. It is recommended to not rely on the order of entries, and have only one program
-          with a given name in <varname>$PATH</varname>.</para>
+          distribution. The distribution may also add other paths to the end of this list for both the
+          system and the user manager. It is recommended to not rely on the order of entries, and have only
+          one program with a given name in <varname>$PATH</varname>.</para>
 
           <xi:include href="version-info.xml" xpointer="v208"/></listitem>
         </varlistentry>

--- a/meson.build
+++ b/meson.build
@@ -1021,6 +1021,17 @@ if default_user_path != ''
         conf.set_quoted('DEFAULT_USER_PATH', default_user_path)
 endif
 
+extra_exec_search_path = get_option('extra-exec-search-path')
+if extra_exec_search_path != ''
+        foreach p : extra_exec_search_path.split(':')
+                if not p.startswith('/')
+                        error(f'Extra exec search path is not absolute: "@p@"')
+                endif
+        endforeach
+        extra_exec_search_path = f':@extra_exec_search_path@'
+endif
+conf.set_quoted('EXTRA_EXEC_SEARCH_PATH_SUFFIX', extra_exec_search_path)
+
 #####################################################################
 
 libm = cc.find_library('m')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -83,6 +83,8 @@ option('log-trace', type : 'boolean', value : false,
        description : 'enable low level debug logging')
 option('user-path', type : 'string',
        description : '$PATH to use for user sessions')
+option('extra-exec-search-path', type : 'string',
+       description : 'colon-separated list of additional absolute directories appended to the built-in executable search path')
 
 option('utmp', type : 'boolean',
        description : 'support for utmp/wtmp log handling')

--- a/src/basic/path-util.h
+++ b/src/basic/path-util.h
@@ -9,17 +9,17 @@
 #define PATH_MERGED_BIN(x) x "bin"
 #define PATH_MERGED_BIN_NULSTR(x) x "bin\0"
 
-#define DEFAULT_PATH_WITH_FULL_SBIN PATH_SPLIT_BIN("/usr/local/") ":" PATH_SPLIT_BIN("/usr/")
-#define DEFAULT_PATH_WITH_LOCAL_SBIN PATH_SPLIT_BIN("/usr/local/") ":" PATH_MERGED_BIN("/usr/")
-#define DEFAULT_PATH_WITHOUT_SBIN PATH_MERGED_BIN("/usr/local/") ":" PATH_MERGED_BIN("/usr/")
+#define DEFAULT_PATH_WITH_FULL_SBIN PATH_SPLIT_BIN("/usr/local/") ":" PATH_SPLIT_BIN("/usr/") EXTRA_EXEC_SEARCH_PATH_SUFFIX
+#define DEFAULT_PATH_WITH_LOCAL_SBIN PATH_SPLIT_BIN("/usr/local/") ":" PATH_MERGED_BIN("/usr/") EXTRA_EXEC_SEARCH_PATH_SUFFIX
+#define DEFAULT_PATH_WITHOUT_SBIN PATH_MERGED_BIN("/usr/local/") ":" PATH_MERGED_BIN("/usr/") EXTRA_EXEC_SEARCH_PATH_SUFFIX
 
-#define DEFAULT_PATH_COMPAT DEFAULT_PATH_WITH_FULL_SBIN ":" PATH_SPLIT_BIN("/")
+#define DEFAULT_PATH_COMPAT PATH_SPLIT_BIN("/usr/local/") ":" PATH_SPLIT_BIN("/usr/") ":" PATH_SPLIT_BIN("/") EXTRA_EXEC_SEARCH_PATH_SUFFIX
 
 const char* default_PATH(void);
 
 static inline const char* default_user_PATH(void) {
 #ifdef DEFAULT_USER_PATH
-        return DEFAULT_USER_PATH;
+        return DEFAULT_USER_PATH EXTRA_EXEC_SEARCH_PATH_SUFFIX;
 #else
         return default_PATH();
 #endif


### PR DESCRIPTION
As per the discussion with @poettering in this PR: https://github.com/systemd/systemd/pull/43672

This is the compile time variant of the same idea. It will accomplish the same goals as the other PR.