### PR TITLE
Add install section for systemd-coredumpd

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -358,7 +358,7 @@ CHANGES WITH 262 in spe:
           kernel.core_pattern. Older kernels continue to use the per-coredump
           systemd-coredump@.service path. Changes to coredump.conf require
           reloading systemd-coredumpd.service, and deployments that set a
-          custom kernel.core_pattern should mask or stop that service.
+          custom kernel.core_pattern should stop and disable that service.
 
         * The coredumpctl dump and debug commands now honor --json= and include
           the selected coredump's metadata in the requested JSON format.

--- a/TODO.md
+++ b/TODO.md
@@ -2049,6 +2049,11 @@ SPDX-License-Identifier: LGPL-2.1-or-later
   - lock image configured with RootDirectory=/RootImage= using the usual nspawn semantics while the unit is up
   - find a way how we can reload unit file configuration for
     specific units only, without reloading the whole of systemd
+  - figure out why 'systemctl set-property --runtime avahi-daemon.service TimeoutStartSec=150'
+    fails with org.freedesktop.DBus.Error.PropertyReadOnly
+  - report org.freedesktop.DBus.Error.PropertyReadOnly better than
+    "Cannot set property JobTimeoutUSec, or unknown property."
+  - allow 'systemctl start --property=…' ?
 
 - **PidRef conversion work:**
   - cg_pid_get_xyz()

--- a/man/systemd-coredump.xml
+++ b/man/systemd-coredump.xml
@@ -328,12 +328,8 @@
     <filename>50-coredump.conf</filename> alone does <emphasis>not</emphasis> override the default
     <varname>kernel.core_pattern</varname> on such systems, since <filename>60-coredump.conf</filename> will
     still take effect. To set a custom <varname>kernel.core_pattern</varname> of your own on a system where
-    <filename>systemd-coredumpd.service</filename> is available, you must additionally stop (if currently
-    running) and mask <filename>systemd-coredumpd.service</filename>:
-    <programlisting>systemctl mask --now systemd-coredumpd.service</programlisting>
-    Masking <filename>systemd-coredumpd.service</filename> also prevents
-    <filename>systemd-coredump-register.service</filename>, which is bound to it, from running and writing
-    <filename>60-coredump.conf</filename>.</para>
+    <filename>systemd-coredumpd.service</filename> is active, stop and disable it:
+    <programlisting>systemctl disable --now systemd-coredumpd.service</programlisting></para>
 
     <para>In order to be used in the <option>--backtrace</option> mode, an appropriate backtrace
     handler must be installed on the sender side. For example, in case of

--- a/presets/90-systemd.preset
+++ b/presets/90-systemd.preset
@@ -22,6 +22,7 @@ enable getty@.service
 enable systemd-boot-clear-sysfail.service
 enable systemd-boot-update.service
 enable systemd-confext.service
+enable systemd-coredumpd.service
 enable systemd-homed.service
 enable systemd-homed-activate.service
 enable systemd-journalctl-metrics.socket

--- a/units/meson.build
+++ b/units/meson.build
@@ -349,7 +349,6 @@ units = [
         {
           'file' : 'systemd-coredumpd.service.in',
           'conditions' : ['ENABLE_COREDUMP'],
-          'symlinks' : ['sysinit.target.wants/'],
         },
         {
           'file' : 'systemd-creds.socket',

--- a/units/systemd-coredumpd.service.in
+++ b/units/systemd-coredumpd.service.in
@@ -57,3 +57,6 @@ SystemCallErrorNumber=EPERM
 SystemCallFilter=@system-service @mount
 TimeoutStopSec=6min
 {{SERVICE_WATCHDOG}}
+
+[Install]
+WantedBy=sysinit.target


### PR DESCRIPTION
When building v262-rc1 in Fedora, I wanted to not enable systemd-coredumpd by default. Add an option to follow the usual enablement through presets instead of hardcoding.

Also add items to TODO.