### PR TITLE
sysext: Use atomic mount replacement for extension refresh

### DIFF
--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -438,6 +438,14 @@ All tools:
   default. Mutable hierarchies have the following mount options added by
   default: `redirect_dir=on,noatime,metacopy=off,index=off`.
 
+* `$SYSTEMD_SYSEXT_MOUNT_BENEATH` — this boolean variable may be used in tests
+  to exercise the code path on old kernels. If false, `systemd-sysext` does not
+  attempt to mount a new `overlayfs` instance beneath the existing one when
+  refreshing, but unmounts the existing one first and mounts the new one in its
+  place, as done on kernels that do not support mounting beneath. Defaults to
+  true. Similarly, `$SYSTEMD_CONFEXT_MOUNT_BENEATH` works for confext images
+  and supports the systemd-confext multi-call functionality of sysext.
+
 `systemd-tmpfiles`:
 
 * `$SYSTEMD_TMPFILES_FORCE_SUBVOL` — if unset, `v`/`q`/`Q` lines will create

--- a/man/systemd-sysext.xml
+++ b/man/systemd-sysext.xml
@@ -358,14 +358,23 @@
       <varlistentry>
         <term><option>refresh</option></term>
         <listitem><para>A combination of <option>unmerge</option> and <option>merge</option>: if already
-        mounted the existing <literal>overlayfs</literal> instance is unmounted temporarily, and then
-        replaced by a new version. This command is useful after installing/removing system extension images,
-        in order to update the <literal>overlayfs</literal> file system accordingly. If no system extensions
-        are installed when this command is executed, the equivalent of <option>unmerge</option> is executed,
-        without establishing any new <literal>overlayfs</literal> instance.
-        Note that currently there's a brief moment where neither the old nor the new <literal>overlayfs</literal>
-        file system is mounted. This implies that all resources supplied by a system extension will briefly
-        disappear — even if it exists continuously during the refresh operation.</para>
+        mounted the existing <literal>overlayfs</literal> instance is replaced by a new version. This command
+        is useful after installing/removing system extension images, in order to update the
+        <literal>overlayfs</literal> file system accordingly. If no system extensions are installed when this
+        command is executed, the equivalent of <option>unmerge</option> is executed, without establishing any
+        new <literal>overlayfs</literal> instance.</para>
+
+        <para>The new <literal>overlayfs</literal> instance is fully assembled before the existing one is
+        touched. If assembling it fails, the existing instance stays in place unmodified. On kernels
+        supporting mounting beneath an existing mount (Linux 6.5 and newer) the replacement is atomic: the new
+        instance is mounted beneath the old one, which is then unmounted, so that resources supplied by a
+        system extension that exists continuously do not disappear during the refresh operation. On older
+        kernels, or if the kernel refuses to mount beneath the existing instance for the mount topology at
+        hand, the old instance is unmounted right before the new one is mounted, hence there is a brief
+        moment where neither is mounted (a mount failure after successful assembly of the new instance
+        leaves the hierarchy unmerged on older kernels). Each hierarchy is replaced on its own, i.e.,
+        <filename>/usr/</filename> and <filename>/opt/</filename> are switched over one after the other, so
+        that a failure may leave some hierarchies replaced and others not.</para>
 
         <xi:include href="version-info.xml" xpointer="v248"/></listitem>
       </varlistentry>

--- a/src/sysext/sysext.c
+++ b/src/sysext/sysext.c
@@ -39,11 +39,13 @@
 #include "hashmap.h"
 #include "image-policy.h"
 #include "initrd-util.h"
+#include "iovec-util.h"
 #include "label-util.h"                 /* IWYU pragma: keep */
 #include "libmount-util.h"
 #include "log.h"
 #include "loop-util.h"
 #include "main-func.h"
+#include "memory-util.h"
 #include "mkdir.h"
 #include "mount-util.h"
 #include "mountpoint-util.h"
@@ -55,10 +57,12 @@
 #include "pidref.h"
 #include "proc-cmdline.h"
 #include "process-util.h"
+#include "random-util.h"
 #include "rm-rf.h"
 #include "runtime-scope.h"
 #include "selinux-util.h"
 #include "set.h"
+#include "socket-util.h"
 #include "sort-util.h"
 #include "stat-util.h"
 #include "string-table.h"
@@ -158,6 +162,7 @@ static const struct {
         const char *name_env;
         const char *mode_env;
         const char *opts_env;
+        const char *beneath_env;
         const ImagePolicy *default_image_policy;
         unsigned long default_mount_flags;
 } image_class_info[_IMAGE_CLASS_MAX] = {
@@ -172,6 +177,7 @@ static const struct {
                 .name_env = "SYSTEMD_SYSEXT_HIERARCHIES",
                 .mode_env = "SYSTEMD_SYSEXT_MUTABLE_MODE",
                 .opts_env = "SYSTEMD_SYSEXT_OVERLAYFS_MOUNT_OPTIONS",
+                .beneath_env = "SYSTEMD_SYSEXT_MOUNT_BENEATH",
                 .default_image_policy = &image_policy_sysext,
                 .default_mount_flags = MS_RDONLY|MS_NODEV,
         },
@@ -186,6 +192,7 @@ static const struct {
                 .name_env = "SYSTEMD_CONFEXT_HIERARCHIES",
                 .mode_env = "SYSTEMD_CONFEXT_MUTABLE_MODE",
                 .opts_env = "SYSTEMD_CONFEXT_OVERLAYFS_MOUNT_OPTIONS",
+                .beneath_env = "SYSTEMD_CONFEXT_MOUNT_BENEATH",
                 .default_image_policy = &image_policy_confext,
                 .default_mount_flags = MS_RDONLY|MS_NODEV|MS_NOSUID|MS_NOEXEC,
         }
@@ -213,6 +220,7 @@ typedef struct Context {
          * context owns it and frees it in context_done(). */
         bool image_policy_owned;
         const char *overlayfs_mount_options;
+        bool mount_beneath;
 } Context;
 
 #define CONTEXT_NULL                            \
@@ -220,6 +228,7 @@ typedef struct Context {
                 .image_class = IMAGE_SYSEXT,    \
                 .noexec = -1,                   \
                 .mutable = MUTABLE_NO,          \
+                .mount_beneath = true,          \
         }
 
 static void context_done(Context *c) {
@@ -253,6 +262,13 @@ static void parse_env_image_class_config(Context *c) {
         env_var = secure_getenv(image_class_info[c->image_class].opts_env);
         if (env_var)
                 c->overlayfs_mount_options = env_var;
+
+        /* Debugging aid, to exercise the code path taken on kernels without support for mounting beneath */
+        r = secure_getenv_bool(image_class_info[c->image_class].beneath_env);
+        if (r >= 0)
+                c->mount_beneath = r;
+        else if (r != -ENXIO)
+                log_warning_errno(r, "Failed to parse $%s, ignoring: %m", image_class_info[c->image_class].beneath_env);
 }
 
 static int parse_config_file(Context *c) {
@@ -326,6 +342,12 @@ static int context_from_cmdline(Context *ret, ImageClass image_class) {
         if (r < 0)
                 return log_error_errno(r, "Failed to determine %s hierarchies: %m", image_class_info[image_class].short_identifier);
 
+        /* Each hierarchy is processed once, also if listed repeatedly in the environment variable (possibly
+         * with a trailing slash, which the normalization check allows) */
+        STRV_FOREACH(h, c.hierarchies)
+                path_simplify(*h);
+        strv_uniq(c.hierarchies);
+
         parse_env_image_class_config(&c);
 
         if (arg_mutable_argv_set) {
@@ -347,8 +369,9 @@ static int context_from_cmdline(Context *ret, ImageClass image_class) {
         return 0;
 }
 
-static int is_our_mount_point(
+static int is_our_mount_point_at(
                 ImageClass image_class,
+                int fd,
                 const char *p) {
 
         _cleanup_free_ char *buf = NULL, *f = NULL;
@@ -356,13 +379,10 @@ static int is_our_mount_point(
         dev_t dev;
         int r;
 
+        assert(fd >= 0);
         assert(p);
 
-        r = path_is_mount_point(p);
-        if (r == -ENOENT) {
-                log_debug_errno(r, "Hierarchy '%s' doesn't exist.", p);
-                return false;
-        }
+        r = is_mount_point_at(fd, /* path= */ NULL, /* flags= */ 0);
         if (r < 0)
                 return log_error_errno(r, "Failed to determine whether '%s' is a mount point: %m", p);
         if (r == 0) {
@@ -378,11 +398,11 @@ static int is_our_mount_point(
          * confused if people tar up one of our merged trees and untar them elsewhere where we might mistake
          * them for a live sysext tree. */
 
-        f = path_join(p, image_class_info[image_class].dot_directory_name, "dev");
+        f = path_join(image_class_info[image_class].dot_directory_name, "dev");
         if (!f)
                 return log_oom();
 
-        r = read_one_line_file(f, &buf);
+        r = read_one_line_file_at(fd, f, &buf);
         if (r == -ENOENT) {
                 log_debug("Hierarchy '%s' does not carry a %s/dev file, not a merged tree.", p, image_class_info[image_class].dot_directory_name);
                 return false;
@@ -394,7 +414,7 @@ static int is_our_mount_point(
         if (r < 0)
                 return log_error_errno(r, "Failed to parse device major/minor stored in '%s/dev' file on '%s': %m", image_class_info[image_class].dot_directory_name, p);
 
-        if (lstat(p, &st) < 0)
+        if (fstat(fd, &st) < 0)
                 return log_error_errno(errno, "Failed to stat %s: %m", p);
 
         if (st.st_dev != dev) {
@@ -403,6 +423,27 @@ static int is_our_mount_point(
         }
 
         return true;
+}
+
+static int is_our_mount_point(
+                ImageClass image_class,
+                const char *p) {
+
+        _cleanup_close_ int fd = -EBADF;
+
+        assert(p);
+
+        fd = open(p, O_PATH|O_CLOEXEC|O_DIRECTORY|O_NOFOLLOW);
+        if (fd < 0) {
+                if (IN_SET(errno, ENOENT, ENOTDIR)) {
+                        log_debug_errno(errno, "Hierarchy '%s' doesn't exist or is not a directory.", p);
+                        return false;
+                }
+
+                return log_error_errno(errno, "Failed to open '%s': %m", p);
+        }
+
+        return is_our_mount_point_at(image_class, fd, p);
 }
 
 static int split_unit_string(const char *s, const char *field, const char *extension, Set **units) {
@@ -548,19 +589,20 @@ static int get_extension_release_metadata(
         return 0;
 }
 
-static int move_submounts(const char *src, const char *dst) {
-        SubMount *submounts = NULL;
-        size_t n_submounts = 0;
-        int r;
+static int attach_submounts(
+                SubMount *submounts,
+                size_t n_submounts,
+                const char *src,
+                const char *dst) {
 
+        int r, ret = 0;
+
+        assert(submounts || n_submounts == 0);
         assert(src);
         assert(dst);
 
-        CLEANUP_ARRAY(submounts, n_submounts, sub_mount_array_free);
-
-        r = get_sub_mounts(src, &submounts, &n_submounts);
-        if (r < 0)
-                return log_error_errno(r, "Failed to get submounts for %s: %m", src);
+        /* Continue on failure, so that as many submounts as possible end up in place. The clones we cannot
+         * attach are lost once the caller frees them. */
 
         FOREACH_ARRAY(m, submounts, n_submounts) {
                 _cleanup_free_ char *t = NULL;
@@ -569,8 +611,10 @@ static int move_submounts(const char *src, const char *dst) {
 
                 assert_se(suffix = path_startswith(m->path, src));
 
-                if (fstat(m->mount_fd, &st) < 0)
-                        return log_error_errno(errno, "Failed to stat %s: %m", m->path);
+                if (fstat(m->mount_fd, &st) < 0) {
+                        RET_GATHER(ret, log_error_errno(errno, "Failed to stat %s: %m", m->path));
+                        continue;
+                }
 
                 t = path_join(dst, suffix);
                 if (!t)
@@ -579,29 +623,32 @@ static int move_submounts(const char *src, const char *dst) {
                 _cleanup_free_ char *fn = NULL;
                 _cleanup_close_ int fd = -EBADF;
                 r = chase(t, /* root= */ NULL, CHASE_PARENT|CHASE_EXTRACT_FILENAME|CHASE_PROHIBIT_SYMLINKS|CHASE_MKDIR_0755, &fn, &fd);
-                if (r < 0)
-                        return log_error_errno(r, "Failed to create and pin parent directory of %s: %m", t);
+                if (r < 0) {
+                        RET_GATHER(ret, log_error_errno(r, "Failed to create and pin parent directory of %s: %m", t));
+                        continue;
+                }
 
                 r = make_mount_point_inode_from_mode(fd, fn, st.st_mode, 0755);
-                if (r < 0 && r != -EEXIST)
-                        return log_error_errno(r, "Failed to create mountpoint %s: %m", t);
+                if (r < 0 && r != -EEXIST) {
+                        RET_GATHER(ret, log_error_errno(r, "Failed to create mountpoint %s: %m", t));
+                        continue;
+                }
 
                 _cleanup_close_ int child_fd = openat(fd, fn, O_PATH|O_CLOEXEC);
-                if (child_fd < 0)
-                        return log_error_errno(errno, "Failed to pin mountpoint %s: %m", t);
+                if (child_fd < 0) {
+                        RET_GATHER(ret, log_error_errno(errno, "Failed to pin mountpoint %s: %m", t));
+                        continue;
+                }
 
                 /* Instead of a bind mount we attach the detached clone produced by
                  * open_tree_attr_with_fallback() from get_sub_mounts() because that has no propagation
-                 * relationship with the original anymore and the MNT_DETACH below won't propagate for
-                 * nested mounts. */
+                 * relationship with the original anymore. */
                 r = RET_NERRNO(move_mount(m->mount_fd, "", child_fd, "", MOVE_MOUNT_F_EMPTY_PATH|MOVE_MOUNT_T_EMPTY_PATH));
                 if (r < 0)
-                        return log_error_errno(r, "Failed to move mount '%s' to '%s': %m", m->path, t);
-
-                (void) umount_verbose(LOG_WARNING, m->path, MNT_DETACH);
+                        RET_GATHER(ret, log_error_errno(r, "Failed to move mount '%s' to '%s': %m", m->path, t));
         }
 
-        return 0;
+        return ret;
 }
 
 static int daemon_reload(void) {
@@ -836,8 +883,10 @@ static int work_dir_for_hierarchy(
         f = hierarchy_as_single_path_component(hierarchy);
         if (!f)
                 return log_oom();
-        dir_name = strjoin(".systemd-", f, "-workdir");
-        if (!dir_name)
+
+        /* Use a unique name per merge, so that a refresh never reuses the work dir of the overlayfs
+         * instance that is still mounted while the new one is set up. */
+        if (asprintf(&dir_name, ".systemd-%s-workdir-%016" PRIx64, f, random_u64()) < 0)
                 return log_oom();
 
         free(f);
@@ -1679,10 +1728,12 @@ static int merge_hierarchy(
                 const char *origin_content,
                 const char *meta_path,
                 const char *overlay_path,
-                const char *workspace_path) {
+                const char *workspace_path,
+                char **ret_work_dir) {
 
         _cleanup_(overlayfs_paths_freep) OverlayFSPaths *op = NULL;
         _cleanup_strv_free_ char **used_paths = NULL;
+        _cleanup_(rm_rf_physical_and_freep) char *work_dir = NULL;
         size_t extensions_used = 0;
         int r;
 
@@ -1692,6 +1743,7 @@ static int merge_hierarchy(
         assert(meta_path);
         assert(overlay_path);
         assert(workspace_path);
+        assert(ret_work_dir);
 
         mac_selinux_init();
 
@@ -1699,8 +1751,10 @@ static int merge_hierarchy(
         if (r < 0)
                 return r;
 
-        if (extensions_used == 0 && c->mutable == MUTABLE_NO) /* No extension with files in this hierarchy? Then don't do anything. */
+        if (extensions_used == 0 && c->mutable == MUTABLE_NO) { /* No extension with files in this hierarchy? Then don't do anything. */
+                *ret_work_dir = NULL;
                 return 0;
+        }
 
         r = overlayfs_paths_new(c, hierarchy, workspace_path, &op);
         if (r < 0)
@@ -1719,6 +1773,13 @@ static int merge_hierarchy(
         if (r < 0)
                 return r;
 
+        /* The work directory is created below, remove it again if we fail (it may be on persistent storage) */
+        if (op->work_dir) {
+                work_dir = strdup(op->work_dir);
+                if (!work_dir)
+                        return log_oom();
+        }
+
         r = mount_overlayfs_with_op(op, c->image_class, c->noexec, overlay_path, meta_path, c->overlayfs_mount_options);
         if (r < 0)
                 return r;
@@ -1730,6 +1791,8 @@ static int merge_hierarchy(
         r = make_mounts_read_only(c->image_class, overlay_path, op->upper_dir && op->work_dir);
         if (r < 0)
                 return r;
+
+        *ret_work_dir = TAKE_PTR(work_dir);
 
         return 1;
 }
@@ -1775,24 +1838,85 @@ static const ImagePolicy* pick_image_policy(const Context *c, const Image *img) 
         return image_class_info[img->class].default_image_policy;
 }
 
-static int unmerge_hierarchy(const Context *c, const char *p, const char *submounts_path) {
-        _cleanup_free_ char *dot_dir = NULL, *work_dir_info_file = NULL;
+static int read_work_dir_at(
+                const Context *c,
+                int dir_fd,
+                const char *hierarchy_path,
+                const char *log_path,
+                char **ret) {
+
+        _cleanup_free_ char *work_dir_info_file = NULL, *escaped_work_dir_in_root = NULL,
+                        *work_dir_in_root = NULL, *work_dir = NULL;
+        ssize_t l;
+        int r;
+
+        assert(c);
+        assert(hierarchy_path);
+        assert(log_path);
+        assert(ret);
+
+        work_dir_info_file = path_join(hierarchy_path, image_class_info[c->image_class].dot_directory_name, "work_dir");
+        if (!work_dir_info_file)
+                return log_oom();
+
+        r = read_one_line_file_at(dir_fd, work_dir_info_file, &escaped_work_dir_in_root);
+        if (r == -ENOENT) {
+                *ret = NULL;
+                return 0;
+        }
+        if (r < 0)
+                return log_error_errno(r, "Failed to read work directory path of hierarchy '%s': %m", log_path);
+
+        l = cunescape(escaped_work_dir_in_root, 0, &work_dir_in_root);
+        if (l < 0)
+                return log_error_errno(l, "Failed to unescape work directory path of hierarchy '%s': %m", log_path);
+        if (path_is_absolute(work_dir_in_root) || !path_is_normalized(work_dir_in_root))
+                return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
+                                       "Invalid work directory path '%s' of hierarchy '%s'.", work_dir_in_root, log_path);
+
+        work_dir = path_join(empty_to_root(c->root), work_dir_in_root);
+        if (!work_dir)
+                return log_oom();
+
+        *ret = TAKE_PTR(work_dir);
+        return 1;
+}
+
+static int unmerge_hierarchy(
+                const Context *c,
+                const char *p,
+                bool unpeel_only,
+                SubMount **ret_submounts,
+                size_t *ret_n_submounts) {
+
+        _cleanup_free_ char *dot_dir = NULL;
+        SubMount *submounts = NULL;
+        size_t n_submounts = 0;
         int n_unmerged = 0;
         int r;
 
         assert(c);
         assert(p);
+        assert(ret_submounts);
+        assert(ret_n_submounts);
+
+        CLEANUP_ARRAY(submounts, n_submounts, sub_mount_array_free);
+
+        /* Detached clones of the submounts below the hierarchy are returned for the caller to attach them
+         * where they belong now. With unpeel_only=true we only expose what's below our own copy of the mount
+         * tree during a refresh. Since the overlayfs is still in use in the host namespace, the work
+         * directory of a mutable overlayfs is then left in place. */
 
         dot_dir = path_join(p, image_class_info[c->image_class].dot_directory_name);
         if (!dot_dir)
                 return log_oom();
 
-        work_dir_info_file = path_join(dot_dir, "work_dir");
-        if (!work_dir_info_file)
-                return log_oom();
-
         for (;;) {
-                _cleanup_free_ char *escaped_work_dir_in_root = NULL, *work_dir = NULL;
+                _cleanup_free_ char *work_dir = NULL;
+                SubMount *layer_submounts = NULL;
+                size_t n_layer_submounts = 0;
+
+                CLEANUP_ARRAY(layer_submounts, n_layer_submounts, sub_mount_array_free);
 
                 /* We only unmount /usr/ if it is a mount point and really one of ours, in order not to break
                  * systems where /usr/ is a mount point of its own already. */
@@ -1803,25 +1927,9 @@ static int unmerge_hierarchy(const Context *c, const char *p, const char *submou
                 if (r == 0)
                         break;
 
-                r = read_one_line_file(work_dir_info_file, &escaped_work_dir_in_root);
-                if (r < 0) {
-                        if (r != -ENOENT)
-                                return log_error_errno(r, "Failed to read '%s': %m", work_dir_info_file);
-                } else {
-                        _cleanup_free_ char *work_dir_in_root = NULL;
-                        ssize_t l;
-
-                        l = cunescape_length(escaped_work_dir_in_root, r, 0, &work_dir_in_root);
-                        if (l < 0)
-                                return log_error_errno(l, "Failed to unescape work directory path: %m");
-                        if (path_is_absolute(work_dir_in_root) || !path_is_normalized(work_dir_in_root))
-                                return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
-                                                       "Invalid work directory path '%s'.", work_dir_in_root);
-
-                        work_dir = path_join(c->root, work_dir_in_root);
-                        if (!work_dir)
-                                return log_oom();
-                }
+                r = read_work_dir_at(c, AT_FDCWD, p, p, &work_dir);
+                if (r < 0)
+                        return r;
 
                 r = umount_verbose(LOG_DEBUG, dot_dir, MNT_DETACH|UMOUNT_NOFOLLOW);
                 if (r < 0) {
@@ -1832,56 +1940,80 @@ static int unmerge_hierarchy(const Context *c, const char *p, const char *submou
                                 return log_error_errno(r, "Failed to unmount '%s': %m", dot_dir);
                 }
 
-                /* After we've unmounted the metadata directory, save all other submounts so we can restore
-                 * them after unmerging the hierarchy. */
-                r = move_submounts(p, submounts_path);
+                /* After we've unmounted the metadata directory, save all other submounts so that they can
+                 * be restored after unmerging the hierarchy. */
+                r = get_sub_mounts(p, &layer_submounts, &n_layer_submounts);
                 if (r < 0)
-                        return r;
+                        return log_error_errno(r, "Failed to get submounts for %s: %m", p);
+
+                if (!GREEDY_REALLOC(submounts, n_submounts + n_layer_submounts))
+                        return log_oom();
+                FOREACH_ARRAY(m, layer_submounts, n_layer_submounts)
+                        submounts[n_submounts++] = (SubMount) {
+                                .path = TAKE_PTR(m->path),
+                                .mount_fd = TAKE_FD(m->mount_fd),
+                        };
 
                 r = umount_verbose(LOG_ERR, p, MNT_DETACH|UMOUNT_NOFOLLOW);
                 if (r < 0)
                         return r;
 
-                if (work_dir) {
+                /* Note that on the error paths from here on (and in further iterations for stacked
+                 * overlayfs mounts) the clones collected so far are destroyed without being returned, while
+                 * the originals are gone with the unmounted overlayfs already, hence the submounts are lost
+                 * for the caller. We could hand out what we have on error, too, so that the caller can put
+                 * it back in place, but that is probably not worth the complexity. */
+
+                if (work_dir && !unpeel_only) {
                         r = rm_rf(work_dir, REMOVE_ROOT | REMOVE_MISSING_OK | REMOVE_PHYSICAL);
                         if (r < 0)
-                                return log_error_errno(r, "Failed to remove '%s': %m", work_dir);
+                                return log_error_errno(r, "Failed to remove '%s', submounts of '%s' might be lost: %m", work_dir, p);
                 }
 
-                log_info("Unmerged '%s'.", p);
+                if (unpeel_only)
+                        log_debug("Unpeeled '%s'.", p);
+                else
+                        log_info("Unmerged '%s'.", p);
                 n_unmerged++;
         }
+
+        *ret_submounts = TAKE_PTR(submounts);
+        *ret_n_submounts = n_submounts;
+        n_submounts = 0;
 
         return n_unmerged;
 }
 
-static int unmerge_subprocess(
-                const Context *c,
-                const char *workspace) {
-
-        int r, ret = 0;
+static int unmerge_hierarchy_in_place(const Context *c, const char *p) {
+        SubMount *submounts = NULL;
+        size_t n_submounts = 0;
+        int r, n_unmerged;
 
         assert(c);
-        assert(workspace);
-        assert(path_startswith(workspace, "/run/"));
+        assert(p);
 
-        /* Mark the whole of /run as MS_SLAVE, so that we can mount stuff below it that doesn't show up on
-         * the host otherwise. */
-        r = mount_nofollow_verbose(LOG_ERR, NULL, "/run", NULL, MS_SLAVE|MS_REC, NULL);
+        CLEANUP_ARRAY(submounts, n_submounts, sub_mount_array_free);
+
+        /* Unmerges the hierarchy and puts its submounts back in place on the bare hierarchy. */
+
+        n_unmerged = unmerge_hierarchy(c, p, /* unpeel_only= */ false, &submounts, &n_submounts);
+        if (n_unmerged <= 0)
+                return n_unmerged;
+
+        r = attach_submounts(submounts, n_submounts, p, p);
         if (r < 0)
                 return r;
 
-        /* Let's create the workspace if it's missing */
-        r = mkdir_p(workspace, 0700);
-        if (r < 0)
-                return log_error_errno(r, "Failed to create '%s': %m", workspace);
+        return n_unmerged;
+}
+
+static int unmerge_hierarchies(const Context *c) {
+        int r, ret = 0;
+
+        assert(c);
 
         STRV_FOREACH(h, c->hierarchies) {
-                _cleanup_free_ char *submounts_path = NULL, *resolved = NULL;
-
-                submounts_path = path_join(workspace, "submounts", *h);
-                if (!submounts_path)
-                        return log_oom();
+                _cleanup_free_ char *resolved = NULL;
 
                 r = chase(*h, c->root, CHASE_PREFIX_ROOT, &resolved, NULL);
                 if (r == -ENOENT) {
@@ -1893,20 +2025,7 @@ static int unmerge_subprocess(
                         continue;
                 }
 
-                r = unmerge_hierarchy(c, resolved, submounts_path);
-                if (r < 0) {
-                        RET_GATHER(ret, r);
-                        continue;
-                }
-                if (r == 0)
-                        continue;
-
-                /* If we unmerged something, then we have to move the submounts from the hierarchy back into
-                 * place in the host's original hierarchy. */
-
-                r = move_submounts(submounts_path, resolved);
-                if (r < 0)
-                        return r;
+                RET_GATHER(ret, unmerge_hierarchy_in_place(c, resolved));
         }
 
         return ret;
@@ -1926,22 +2045,9 @@ static int unmerge(const Context *c) {
         if (r < 0)
                 return r;
 
-        r = pidref_safe_fork(
-                        "(sd-unmerge)",
-                        FORK_WAIT|FORK_DEATHSIG_SIGTERM|FORK_LOG|FORK_NEW_MOUNTNS,
-                        /* ret= */ NULL);
+        r = unmerge_hierarchies(c);
         if (r < 0)
                 return r;
-        if (r == 0) {
-                /* Child with its own mount namespace */
-
-                r = unmerge_subprocess(c, "/run/systemd/sysext");
-
-                /* Our namespace ceases to exist here, also implicitly detaching all temporary mounts we
-                 * created below /run. Nice! */
-
-                _exit(r < 0 ? EXIT_FAILURE : EXIT_SUCCESS);
-        }
 
         if (need_to_reload) {
                 r = daemon_reload();
@@ -1957,10 +2063,27 @@ static int unmerge(const Context *c) {
         return 0;
 }
 
+typedef struct WorkDirs {
+        char **paths;
+        bool keep;
+} WorkDirs;
+
+static void work_dirs_done(WorkDirs *w) {
+        assert(w);
+
+        /* Removes the work directories we created, unless the merge was handed over to our parent. */
+        if (!w->keep)
+                STRV_FOREACH(p, w->paths)
+                        (void) rm_rf(*p, REMOVE_ROOT|REMOVE_MISSING_OK|REMOVE_PHYSICAL);
+
+        w->paths = strv_free(w->paths);
+}
+
 static int merge_subprocess(
                 const Context *c,
                 Hashmap *images,
-                const char *workspace) {
+                const char *workspace,
+                int socket_fd) {
 
         _cleanup_free_ char *host_os_release_id = NULL, *host_os_release_id_like = NULL,
                         *host_os_release_version_id = NULL, *host_os_release_api_level = NULL,
@@ -1969,6 +2092,7 @@ static int merge_subprocess(
         _cleanup_strv_free_ char **extensions = NULL, **extensions_v = NULL, **paths = NULL;
         _cleanup_(sd_json_variant_unrefp) sd_json_variant *extensions_origin_entries = NULL,
                         *extensions_origin_json = NULL, *mutable_dir_entries = NULL;
+        _cleanup_(work_dirs_done) WorkDirs work_dirs = {};
         size_t n_extensions = 0;
         unsigned n_ignored = 0;
         Image *img;
@@ -1983,12 +2107,11 @@ static int merge_subprocess(
         }
 
         assert(path_startswith(workspace, "/run/"));
+        assert(socket_fd >= 0);
 
-        /* Mark the whole of /run as MS_SLAVE, so that we can mount stuff below it that doesn't show up on
-         * the host otherwise. */
-        r = mount_nofollow_verbose(LOG_ERR, NULL, "/run", NULL, MS_SLAVE|MS_REC, NULL);
-        if (r < 0)
-                return log_error_errno(r, "Failed to remount /run/ MS_SLAVE: %m");
+        /* Note that we run in our own mount namespace with MS_SLAVE, hence nothing we mount or unmount here
+         * is visible on the host. The finished overlayfs trees are handed to our parent process, which
+         * places them in the host's mount namespace. */
 
         /* Let's create the workspace if it's missing */
         r = mkdir_p(workspace, 0700);
@@ -1996,9 +2119,7 @@ static int merge_subprocess(
                 return log_error_errno(r, "Failed to create '%s': %m", workspace);
 
         /* Let's mount a tmpfs to our workspace. This way we don't need to clean up the inodes we mount over,
-         * but let the kernel do that entirely automatically, once our namespace dies. Note that this file
-         * system won't be visible to anyone but us, since we opened our own namespace and then made the
-         * /run/ hierarchy (which our workspace is contained in) MS_SLAVE, see above. */
+         * but let the kernel do that entirely automatically, once our namespace dies. */
         r = mount_nofollow_verbose(LOG_ERR, image_class_info[c->image_class].short_identifier, workspace, "tmpfs", 0, "mode=0700");
         if (r < 0)
                 return r;
@@ -2391,36 +2512,13 @@ static int merge_subprocess(
                 paths[k] = TAKE_PTR(p);
         }
 
-        /* Let's now unmerge the status quo ante, since to build the new overlayfs we need a reference to the
-         * underlying fs. */
-        STRV_FOREACH(h, c->hierarchies) {
-                _cleanup_free_ char *submounts_path = NULL, *resolved = NULL;
-
-                submounts_path = path_join(workspace, "submounts", *h);
-                if (!submounts_path)
-                        return log_oom();
-
-                r = chase(*h, c->root, CHASE_PREFIX_ROOT|CHASE_NONEXISTENT, &resolved, NULL);
-                if (r < 0)
-                        return log_error_errno(r, "Failed to resolve hierarchy '%s%s': %m", strempty(c->root), *h);
-
-                r = unmerge_hierarchy(c, resolved, submounts_path);
-                if (r < 0)
-                        return r;
-                if (r > 0)
-                        continue;
-
-                /* If we didn't unmerge anything, then we have to move the submounts from the host's
-                 * original hierarchy. */
-
-                r = move_submounts(resolved, submounts_path);
-                if (r < 0)
-                        return r;
-        }
-
         /* Create overlayfs mounts for all hierarchies */
         STRV_FOREACH(h, c->hierarchies) {
-                _cleanup_free_ char *meta_path = NULL, *overlay_path = NULL, *merge_hierarchy_workspace = NULL, *submounts_path = NULL;
+                _cleanup_free_ char *meta_path = NULL, *overlay_path = NULL, *merge_hierarchy_workspace = NULL, *resolved = NULL;
+                SubMount *submounts = NULL;
+                size_t n_submounts = 0;
+
+                CLEANUP_ARRAY(submounts, n_submounts, sub_mount_array_free);
 
                 meta_path = path_join(workspace, "meta", *h); /* The place where to store metadata about this instance */
                 if (!meta_path)
@@ -2435,10 +2533,25 @@ static int merge_subprocess(
                 if (!merge_hierarchy_workspace)
                         return log_oom();
 
-                submounts_path = path_join(workspace, "submounts", *h);
-                if (!submounts_path)
-                        return log_oom();
+                r = chase(*h, c->root, CHASE_PREFIX_ROOT|CHASE_NONEXISTENT, &resolved, NULL);
+                if (r < 0)
+                        return log_error_errno(r, "Failed to resolve hierarchy '%s%s': %m", strempty(c->root), *h);
 
+                /* Let's now unpeel the status quo ante in our private copy of the mount tree, since to build
+                 * the new overlayfs we need a reference to the underlying fs. The host keeps the old
+                 * overlayfs until our parent replaces it. This hands us clones of the submounts of the old
+                 * overlayfs, which we'll attach to the new one below. */
+                r = unmerge_hierarchy(c, resolved, /* unpeel_only= */ true, &submounts, &n_submounts);
+                if (r < 0)
+                        return r;
+                if (r == 0) {
+                        /* Nothing merged so far, hence clone the submounts of the host's hierarchy instead. */
+                        r = get_sub_mounts(resolved, &submounts, &n_submounts);
+                        if (r < 0)
+                                return log_error_errno(r, "Failed to get submounts for %s: %m", resolved);
+                }
+
+                _cleanup_free_ char *work_dir = NULL;
                 r = merge_hierarchy(
                                 c,
                                 *h,
@@ -2447,21 +2560,29 @@ static int merge_subprocess(
                                 extensions_origin_content,
                                 meta_path,
                                 overlay_path,
-                                merge_hierarchy_workspace);
+                                merge_hierarchy_workspace,
+                                &work_dir);
                 if (r < 0)
                         return r;
 
-                /* After the new hierarchy is set up, move the submounts from the original hierarchy into
-                 * place. */
+                if (work_dir && strv_consume(&work_dirs.paths, TAKE_PTR(work_dir)) < 0)
+                        return log_oom();
+                /* If the hierarchy is empty in all extensions and mutability is off, nothing was mounted. If
+                 * the hierarchy is currently merged on the host, our parent will unmerge it, preserving its
+                 * submounts. */
+                if (r == 0)
+                        continue;
 
-                r = move_submounts(submounts_path, overlay_path);
+                /* After the new hierarchy is set up, move the submounts into place on top of it. */
+                r = attach_submounts(submounts, n_submounts, resolved, overlay_path);
                 if (r < 0)
                         return r;
         }
 
-        /* And move them all into place. This is where things appear in the host namespace */
+        /* And hand them all to our parent, which will move them into place in the host namespace. */
         STRV_FOREACH(h, c->hierarchies) {
-                _cleanup_free_ char *p = NULL, *resolved = NULL;
+                _cleanup_free_ char *p = NULL;
+                _cleanup_close_ int tree_fd = -EBADF;
 
                 p = path_join(workspace, "overlay", *h);
                 if (!p)
@@ -2473,27 +2594,359 @@ static int merge_subprocess(
                 if (r < 0)
                         return log_error_errno(r, "Failed to check if '%s' exists: %m", p);
 
-                r = chase(*h, c->root, CHASE_PREFIX_ROOT|CHASE_NONEXISTENT, &resolved, NULL);
-                if (r < 0)
-                        return log_error_errno(r, "Failed to resolve hierarchy '%s%s': %m", strempty(c->root), *h);
+                /* Clone recursively to bring along the submounts and our read-only bind mount of metadata. */
+                tree_fd = open_tree(AT_FDCWD, p, OPEN_TREE_CLONE|OPEN_TREE_CLOEXEC|AT_RECURSIVE|AT_NO_AUTOMOUNT);
+                if (tree_fd < 0)
+                        return log_error_errno(errno, "Failed to clone mount tree '%s': %m", p);
 
-                r = mkdir_p(resolved, 0755);
+                /* Our parent only reads the socket once we exited, hence don't block if its buffer is full */
+                struct iovec iov = IOVEC_MAKE_STRING(*h);
+                r = send_one_fd_iov(socket_fd, tree_fd, &iov, 1, MSG_DONTWAIT);
+                if (r == -EAGAIN)
+                        return log_error_errno(r, "Too many hierarchies to hand over to parent at once, refusing.");
                 if (r < 0)
-                        return log_error_errno(r, "Failed to create hierarchy mount point '%s': %m", resolved);
-
-                /* Using MS_REC to potentially bring in our read-only bind mount of metadata. */
-                r = mount_nofollow_verbose(LOG_ERR, p, resolved, NULL, MS_BIND|MS_REC, NULL);
-                if (r < 0)
-                        return r;
-
-                log_info("Merged extensions into '%s'.", resolved);
+                        return log_error_errno(r, "Failed to send mount tree '%s' to parent: %m", p);
         }
+
+        /* Everything was handed over, our parent takes care of the work directories from now on */
+        work_dirs.keep = true;
 
         return MERGE_MOUNTED;
 }
 
+typedef struct HierarchyTree {
+        char *hierarchy;
+        int tree_fd;
+        char *work_dir; /* The work directory of the tree's overlayfs, if any */
+} HierarchyTree;
+
+static void hierarchy_tree_done(HierarchyTree *t) {
+        bool never_mounted;
+
+        assert(t);
+
+        /* If the tree fd is still open the tree was never mounted, hence nothing but the tree itself
+         * references its work directory. Close the fd first, so that the directory is unused when we remove
+         * it. */
+        never_mounted = t->tree_fd >= 0;
+        t->tree_fd = safe_close(t->tree_fd);
+
+        if (never_mounted && t->work_dir)
+                (void) rm_rf(t->work_dir, REMOVE_ROOT|REMOVE_MISSING_OK|REMOVE_PHYSICAL);
+
+        t->hierarchy = mfree(t->hierarchy);
+        t->work_dir = mfree(t->work_dir);
+}
+
+static void hierarchy_tree_array_free(HierarchyTree *trees, size_t n) {
+        FOREACH_ARRAY(t, trees, n)
+                hierarchy_tree_done(t);
+
+        free(trees);
+}
+
+static HierarchyTree* hierarchy_tree_find(HierarchyTree *trees, size_t n, const char *hierarchy) {
+        assert(hierarchy);
+
+        FOREACH_ARRAY(t, trees, n)
+                if (path_equal(t->hierarchy, hierarchy))
+                        return t;
+
+        return NULL;
+}
+
+static int receive_hierarchy_trees(const Context *c, int socket_fd, HierarchyTree **ret_trees, size_t *ret_n_trees) {
+        HierarchyTree *trees = NULL;
+        size_t n_trees = 0;
+        int r;
+
+        assert(c);
+        assert(socket_fd >= 0);
+        assert(ret_trees);
+        assert(ret_n_trees);
+
+        CLEANUP_ARRAY(trees, n_trees, hierarchy_tree_array_free);
+
+        /* Receives the detached overlayfs mount trees the merge subprocess sent us, one message per
+         * hierarchy. This is called after the subprocess exited, and everything is queued already and we
+         * can drain the socket without blocking. Note that if we fail midway, the trees still queued are
+         * released when the socket is closed, but their work directories are not removed since we never
+         * got to know them. That's accepted, as the messages come from our own child and failures here
+         * mean a protocol bug or running out of memory. */
+
+        for (;;) {
+                char buf[PATH_MAX];
+                struct iovec iov = IOVEC_MAKE(buf, sizeof(buf));
+                _cleanup_close_ int fd = -EBADF;
+                _cleanup_free_ char *h = NULL;
+                ssize_t k;
+
+                k = receive_one_fd_iov(socket_fd, &iov, 1, MSG_DONTWAIT, &fd);
+                if (IN_SET(k, -EAGAIN, -EIO)) /* Nothing queued anymore, or EOF */
+                        break;
+                if (k < 0)
+                        return log_error_errno(k, "Failed to receive mount tree from merge subprocess: %m");
+                if (fd < 0 || k == 0)
+                        return log_error_errno(SYNTHETIC_ERRNO(EIO), "Received incomplete mount tree message from merge subprocess.");
+                if ((size_t) k >= sizeof(buf))
+                        return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "Received overly long hierarchy path from merge subprocess.");
+
+                h = strndup(buf, k);
+                if (!h)
+                        return log_oom();
+
+                if (!path_is_absolute(h))
+                        return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "Received invalid hierarchy path '%s' from merge subprocess.", h);
+
+                /* Remember the tree's work directory, so that it can be removed if the tree is never mounted */
+                _cleanup_free_ char *work_dir = NULL;
+                r = read_work_dir_at(c, fd, /* hierarchy_path= */ "", h, &work_dir);
+                if (r < 0)
+                        return r;
+
+                if (!GREEDY_REALLOC(trees, n_trees + 1))
+                        return log_oom();
+
+                trees[n_trees++] = (HierarchyTree) {
+                        .hierarchy = TAKE_PTR(h),
+                        .tree_fd = TAKE_FD(fd),
+                        .work_dir = TAKE_PTR(work_dir),
+                };
+        }
+
+        *ret_trees = TAKE_PTR(trees);
+        *ret_n_trees = n_trees;
+        return 0;
+}
+
+static int exchange_hierarchy_tree(
+                int tree_fd,
+                int hierarchy_fd,
+                int parent_fd,
+                const char *name,
+                const char *where,
+                bool replacing,
+                bool try_beneath,
+                bool *new_mounted,
+                bool *old_detached) {
+
+        int r;
+
+        assert(tree_fd >= 0);
+        assert(hierarchy_fd >= 0);
+        assert(parent_fd >= 0);
+        assert(name);
+        assert(where);
+        assert(new_mounted);
+        assert(old_detached);
+
+        /* Mounts the detached tree on the hierarchy pinned by hierarchy_fd ('where' only used for logging).
+         * If that is our previous overlayfs (replacing=true), it is replaced atomically by mounting beneath
+         * it and unmounting it afterwards, or, if the kernel doesn't support that (added in 6.5), by
+         * unmounting it first and mounting the tree in its place, with a brief moment where neither is
+         * mounted. Unlike mount_exchange_graceful() we go by the pinning fd rather than by path, so that we
+         * never unmount something that replaced the old overlayfs meanwhile (a mount stacked on top of it
+         * would be hit instead though) and never mount the tree somewhere else than checked, and we don't
+         * leave the old overlayfs stacked below the new tree in the fallback case, since that would keep
+         * its images and work directory referenced. Both output parameters are set on failure, too, so that
+         * the caller knows what state things are in. Returns > 0 if the tree was mounted beneath. */
+
+        *new_mounted = *old_detached = false;
+
+        if (replacing) {
+                if (try_beneath)
+                        r = RET_NERRNO(move_mount(tree_fd, "", hierarchy_fd, "", MOVE_MOUNT_F_EMPTY_PATH|MOVE_MOUNT_T_EMPTY_PATH|MOVE_MOUNT_BENEATH));
+                else
+                        r = -EINVAL; /* Behave as if the kernel didn't support it */
+                if (r >= 0) {
+                        *new_mounted = true;
+
+                        /* The old overlayfs is the topmost mount now, with nothing stacked on its root,
+                         * hence the pinning fd resolves to exactly it. */
+                        r = umountat_detach_verbose(LOG_ERR, hierarchy_fd, /* where= */ "");
+                        if (r < 0)
+                                return r;
+
+                        *old_detached = true;
+                        return 1;
+                }
+                if (r != -EINVAL)
+                        return log_error_errno(r, "Failed to mount beneath '%s': %m", where);
+
+                // FIXME: This compatibility code path shall be removed once kernel 6.5 becomes the new minimal baseline
+
+                /* Note that we can't mount on top first and detach the old overlayfs afterwards: with the
+                 * new tree stacked on its root, the pinning fd would resolve to the new tree. */
+                log_debug_errno(r, "Mounting beneath '%s' is not supported, unmounting previous merge first: %m", where);
+
+                r = umountat_detach_verbose(LOG_ERR, hierarchy_fd, /* where= */ "");
+                if (r < 0)
+                        return r;
+
+                *old_detached = true;
+
+                /* The pinning fd refers to the detached old overlayfs now, hence go by the parent directory
+                 * and the name, which resolves to what became visible below the old overlayfs. */
+                r = RET_NERRNO(move_mount(tree_fd, "", parent_fd, name, MOVE_MOUNT_F_EMPTY_PATH));
+        } else
+                r = RET_NERRNO(move_mount(tree_fd, "", hierarchy_fd, "", MOVE_MOUNT_F_EMPTY_PATH|MOVE_MOUNT_T_EMPTY_PATH));
+        if (r < 0)
+                return log_error_errno(r, "Failed to mount on '%s': %m", where);
+
+        *new_mounted = true;
+        return 0;
+}
+
+static int install_hierarchy(const Context *c, const char *hierarchy, HierarchyTree *tree) {
+        _cleanup_free_ char *resolved = NULL, *old_work_dir = NULL;
+        bool replacing, new_mounted, old_detached;
+        int r;
+
+        assert(c);
+        assert(hierarchy);
+
+        /* Places the new overlayfs tree of a hierarchy (if any) in the host's mount namespace, replacing the
+         * old one, and unmerges the hierarchy if we got no new tree. */
+
+        r = chase(hierarchy, c->root, CHASE_PREFIX_ROOT|CHASE_NONEXISTENT, &resolved, NULL);
+        if (r < 0)
+                return log_error_errno(r, "Failed to resolve hierarchy '%s%s': %m", strempty(c->root), hierarchy);
+
+        if (!tree) {
+                /* The extensions don't provide this hierarchy anymore, unmerge it if it is merged. */
+                r = unmerge_hierarchy_in_place(c, resolved);
+                if (r < 0)
+                        return r;
+
+                return 0;
+        }
+
+        if (tree->tree_fd < 0) /* Already installed, i.e. the hierarchy was listed more than once */
+                return log_error_errno(SYNTHETIC_ERRNO(EEXIST), "Hierarchy '%s' was already installed.", hierarchy);
+
+        r = mkdir_p(resolved, 0755);
+        if (r < 0)
+                return log_error_errno(r, "Failed to create hierarchy mount point '%s': %m", resolved);
+
+        /* Pin the parent directory and what's currently on the hierarchy, so that the checks, the eventual
+         * detaching of the old overlayfs and the mounting of the new tree below all refer to the same
+         * inodes, regardless of what happens to the path meanwhile. Note that we only ever look at the
+         * topmost mount: if there's more than one of our overlayfs stacked here (which can only be the
+         * result of somebody bind mounting the hierarchy onto itself), the lower ones remain until the
+         * hierarchy is unmerged, and since they share the superblock with the one we replace they lose their
+         * work directory when we remove it below. */
+        _cleanup_free_ char *name = NULL;
+        _cleanup_close_ int parent_fd = -EBADF;
+        r = chase(resolved, /* root= */ NULL, CHASE_PARENT|CHASE_EXTRACT_FILENAME|CHASE_PROHIBIT_SYMLINKS, &name, &parent_fd);
+        if (r < 0)
+                return log_error_errno(r, "Failed to pin parent directory of '%s': %m", resolved);
+
+        _cleanup_close_ int hierarchy_fd = openat(parent_fd, name, O_PATH|O_CLOEXEC|O_DIRECTORY|O_NOFOLLOW);
+        if (hierarchy_fd < 0)
+                return log_error_errno(errno, "Failed to open '%s': %m", resolved);
+
+        r = is_our_mount_point_at(c->image_class, hierarchy_fd, resolved);
+        if (r < 0)
+                return r;
+        replacing = r > 0;
+
+        if (replacing) {
+                r = read_work_dir_at(c, hierarchy_fd, /* hierarchy_path= */ "", resolved, &old_work_dir);
+                if (r < 0)
+                        return r;
+        }
+
+        SubMount *submounts = NULL;
+        size_t n_submounts = 0;
+        CLEANUP_ARRAY(submounts, n_submounts, sub_mount_array_free);
+
+        if (!replacing) {
+                /* The new tree carries clones of the submounts currently below the hierarchy. Pin the
+                 * originals now, so that we can detach them once the tree is in place and hides them.
+                 * (When replacing a previous merge the originals are attached to the old overlayfs and go
+                 * away with it.) */
+                r = get_sub_mounts(resolved, &submounts, &n_submounts);
+                if (r < 0)
+                        return log_error_errno(r, "Failed to get submounts for %s: %m", resolved);
+
+                FOREACH_ARRAY(m, submounts, n_submounts) {
+                        _cleanup_close_ int fd = open(m->path, O_PATH|O_CLOEXEC|O_NOFOLLOW);
+                        if (fd < 0)
+                                return log_error_errno(errno, "Failed to pin submount '%s': %m", m->path);
+
+                        /* We don't need a clone but a pinning fd of the original. Note that this resolves the
+                         * path a second time after get_sub_mounts() did, hence a mount that appeared there
+                         * meanwhile would be pinned (and detached below) instead. That's within the window we
+                         * accept anyway between the child cloning the submounts and us installing the tree.
+                         * If this ever matters, get_sub_mounts() could hand out a pin of the original
+                         * alongside the clone. */
+                        close_and_replace(m->mount_fd, fd);
+                }
+        }
+
+        r = exchange_hierarchy_tree(
+                        tree->tree_fd,
+                        hierarchy_fd,
+                        parent_fd,
+                        name,
+                        resolved,
+                        replacing,
+                        c->mount_beneath,
+                        &new_mounted,
+                        &old_detached);
+
+        if (new_mounted) {
+                /* The tree is in place, hence its work directory is in use now, don't remove it anymore */
+                tree->tree_fd = safe_close(tree->tree_fd);
+                tree->work_dir = mfree(tree->work_dir);
+        }
+
+        if (old_detached && old_work_dir) {
+                /* Now that the old overlayfs is gone, its unique work directory should go, too. A leftover
+                 * is not worth failing the switch that already happened for. */
+                int k = rm_rf(old_work_dir, REMOVE_ROOT|REMOVE_MISSING_OK|REMOVE_PHYSICAL);
+                if (k < 0)
+                        log_warning_errno(k, "Failed to remove '%s', ignoring: %m", old_work_dir);
+        }
+
+        if (r < 0) {
+                if (old_detached && !new_mounted)
+                        /* Unmounted the old overlayfs but failed to mount the new tree. Its submounts went
+                         * away with it, and their clones only exist in the tree we couldn't mount. */
+                        log_error("Failed to replace previous merge of '%s', the hierarchy is unmerged now, without its submounts.", resolved);
+                else if (new_mounted && !old_detached)
+                        /* Mounted the new tree beneath the old overlayfs but failed to unmount that. The
+                         * new tree is hidden below it, and stays there until the hierarchy is unmerged. */
+                        log_error("Failed to replace previous merge of '%s', the new one is stacked beneath it now.", resolved);
+
+                return r;
+        }
+
+        if (replacing)
+                log_debug("Replaced previous merge of '%s' by mounting %s it.", resolved, r > 0 ? "beneath" : "in place of");
+
+        /* Detach the now hidden original submounts, going by fd since they can't be reached by path anymore */
+        FOREACH_ARRAY(m, submounts, n_submounts)
+                (void) umountat_detach_verbose(LOG_WARNING, m->mount_fd, /* where= */ "");
+
+        log_info("Merged extensions into '%s'.", resolved);
+        return 0;
+}
+
+static int install_hierarchies(const Context *c, HierarchyTree *trees, size_t n_trees) {
+        int ret = 0;
+
+        assert(c);
+
+        STRV_FOREACH(h, c->hierarchies)
+                RET_GATHER(ret, install_hierarchy(c, *h, hierarchy_tree_find(trees, n_trees, *h)));
+
+        return ret;
+}
+
 static int merge(const Context *c, Hashmap *images) {
 
+        _cleanup_close_pair_ int pair[2] = EBADF_PAIR;
         int r;
 
         assert(c);
@@ -2502,14 +2955,33 @@ static int merge(const Context *c, Hashmap *images) {
         (void) dlopen_libblkid(LOG_DEBUG);
         (void) dlopen_libmount(LOG_DEBUG);
 
+        if (socketpair(AF_UNIX, SOCK_SEQPACKET|SOCK_CLOEXEC, 0, pair) < 0)
+                return log_error_errno(errno, "Failed to create socket pair: %m");
+
+        /* The child queues one message per hierarchy before we start reading, and we must make sure they
+         * all fit into the socket buffer. Per message we allocate for the payload (the hierarchy path,
+         * i.e. at most PATH_MAX) plus the skb head, which the allocator rounds up to the next size class
+         * (so twice the payload in the worst case), plus the skb structure and its shared info (a few
+         * hundred bytes but we assume a page here). The fd we pass along is not accounted for. Note that
+         * fd_inc_sndbuf() ignores the wmem_max limit if we have the privileges for that, hence failing here
+         * means we really can't hand over that many hierarchies, and we better fail before doing any work. */
+        size_t n_hierarchies = strv_length(c->hierarchies),
+                per_message = 2 * PATH_MAX + page_size();
+
+        r = fd_inc_sndbuf(pair[1], n_hierarchies * per_message);
+        if (r < 0)
+                return log_error_errno(r, "Failed to size socket buffer for handing over %zu hierarchies: %m", n_hierarchies);
+
         _cleanup_(pidref_done) PidRef pidref = PIDREF_NULL;
-        r = pidref_safe_fork("(sd-merge)", FORK_DEATHSIG_SIGTERM|FORK_LOG|FORK_NEW_MOUNTNS, &pidref);
+        r = pidref_safe_fork("(sd-merge)", FORK_DEATHSIG_SIGTERM|FORK_LOG|FORK_NEW_MOUNTNS|FORK_MOUNTNS_SLAVE, &pidref);
         if (r < 0)
                 return log_error_errno(r, "Failed to fork off child: %m");
         if (r == 0) {
-                /* Child with its own mount namespace */
+                /* Child with its own mount namespace (MS_SLAVE) */
 
-                r = merge_subprocess(c, images, "/run/systemd/sysext");
+                pair[0] = safe_close(pair[0]);
+
+                r = merge_subprocess(c, images, "/run/systemd/sysext", pair[1]);
 
                 /* Our namespace ceases to exist here, also implicitly detaching all temporary mounts we
                  * created below /run. Nice! */
@@ -2524,6 +2996,8 @@ static int merge(const Context *c, Hashmap *images) {
                 _exit(EXIT_SUCCESS);
         }
 
+        pair[1] = safe_close(pair[1]);
+
         r = pidref_wait_for_terminate_and_check("(sd-merge)", &pidref, WAIT_LOG_ABNORMAL);
         if (r < 0)
                 return r;
@@ -2533,6 +3007,20 @@ static int merge(const Context *c, Hashmap *images) {
                 return 1; /* Same return code as below when we have merged new */
         if (r > 0)
                 return log_error_errno(SYNTHETIC_ERRNO(EPROTO), "Failed to merge hierarchies");
+
+        /* The child assembled the new overlayfs trees without touching the host. Now that it succeeded, pick
+         * up the trees and move them into place. */
+        HierarchyTree *trees = NULL;
+        size_t n_trees = 0;
+        CLEANUP_ARRAY(trees, n_trees, hierarchy_tree_array_free);
+
+        r = receive_hierarchy_trees(c, pair[0], &trees, &n_trees);
+        if (r < 0)
+                return r;
+
+        r = install_hierarchies(c, trees, n_trees);
+        if (r < 0)
+                return r;
 
         _cleanup_set_free_ Set *units_to_restart = NULL, *units_to_reload_or_restart = NULL;
         bool need_to_reload;

--- a/test/units/TEST-50-DISSECT.sysext.sh
+++ b/test/units/TEST-50-DISSECT.sysext.sh
@@ -382,6 +382,43 @@ extension_verify_status_json() (
        "any(.[]; .hierarchy == \$h and .extensions == \$e and $since_filter)" >/dev/null <<<"$status_json"
 )
 
+# Checks that exactly one mount is established on a path, i.e. no stale copy hides below the visible one
+verify_single_mount() {
+    local path=${1:?}
+    local message=${2:?}
+    local n
+
+    mountpoint "$path"
+    n=$(awk -v t="$path" '$5 == t' /proc/self/mountinfo | wc -l)
+    if [ "$n" != 1 ]; then
+        echo >&2 "Expected exactly one mount on $path $message, found $n"
+        exit 1
+    fi
+}
+
+# Checks that exactly one overlayfs is mounted on a hierarchy
+verify_single_overlay() {
+    local path=${1:?}
+    local message=${2:?}
+    local n
+
+    n=$(awk -v t="$path" '$5 == t && $0 ~ / - overlay /' /proc/self/mountinfo | wc -l)
+    if [ "$n" != 1 ]; then
+        echo >&2 "Expected exactly one overlayfs on $path $message, found $n"
+        exit 1
+    fi
+}
+
+# Checks a mount option of the sysext overlayfs mounted on a hierarchy
+verify_sysext_mount_option() {
+    local target=${1:?}
+    local option=${2:?}
+
+    # extension_verify_mount_option() also passes if no mount matches, so check that one does
+    grep "^sysext $target " /proc/mounts >/dev/null
+    extension_verify_mount_option "$target" "$option"
+}
+
 run_systemd_sysext() {
     local root=${1:-}
     shift
@@ -1977,6 +2014,270 @@ mountpoint "$inner_mp"
 test -f "$outer_mp/outer-marker"
 test -f "$inner_mp/inner-marker"
 )
+
+# Run once with mounting beneath (the default) and once forcing the fallback path taken on kernels without
+# support for it, where the old overlayfs is unmounted before the new one is mounted
+for mount_beneath in yes no; do
+( init_trap
+: "Failed refresh leaves the existing merge and its submounts untouched, successful refresh replaces it (mount beneath: $mount_beneath)"
+# shellcheck disable=SC2030,SC2031 # The setting is meant to be confined to this test case's subshell
+export SYSTEMD_SYSEXT_MOUNT_BENEATH=$mount_beneath
+fake_root=${roots_dir:+"$roots_dir/refresh-failure-$mount_beneath"}
+hierarchy=/opt
+
+# Identifies the overlayfs instance on the hierarchy by its unique mount ID from listmount. Without that
+# (kernels before 6.8) use the device number instead: each instance has its own anonymous one, and since a
+# new instance is set up while the previous one is still mounted, consecutive ones never share it.
+if findmnt --kernel=listmount >/dev/null; then
+    overlay_id() {
+        findmnt --kernel=listmount -o UNIQ-ID --raw --noheadings --target "$fake_root$hierarchy"
+    }
+else
+    overlay_id() {
+        stat -c %d "$fake_root$hierarchy"
+    }
+fi
+if ! systemd-analyze compare-versions "$(uname -r)" ge 5.12; then
+    echo >&2 "Kernel too old for mount_setattr (need >= 5.12), skipping test"
+    exit 0
+fi
+
+prepare_root "$fake_root" "$hierarchy"
+prepare_extension_image "$fake_root" "$hierarchy"
+prepare_hierarchy "$fake_root" "$hierarchy"
+
+# A submount that exists before the first merge
+submount="$fake_root$hierarchy/submount"
+mkdir -p "$submount"
+prepend_trap "rmdir ${submount@Q} 2>/dev/null || true"
+mount -t tmpfs tmpfs "$submount"
+prepend_trap "umount -l ${submount@Q} 2>/dev/null || true"
+touch "$submount/marker"
+
+# Mount point for a submount that is added on top of the merged (read-only) hierarchy later
+later_submount="$fake_root$hierarchy/later"
+mkdir -p "$later_submount"
+prepend_trap "rmdir ${later_submount@Q} 2>/dev/null || true"
+
+# Nested inside the later submount, added between two refreshes
+nested_submount="$later_submount/nested"
+
+run_systemd_sysext "$fake_root" merge
+extension_verify_after_merge "$fake_root" "$hierarchy" -e -h
+OVERLAYID1=$(overlay_id)
+# The submount is carried over into the merged hierarchy, the original below it is detached
+verify_single_mount "$submount" "after merge"
+test -f "$submount/marker"
+
+# Add a submount on top of the merged hierarchy
+mount -t tmpfs tmpfs "$later_submount"
+prepend_trap "umount -l ${later_submount@Q} 2>/dev/null || true"
+touch "$later_submount/later-marker"
+
+# An unknown overlayfs mount option makes assembling the new overlayfs fail. The existing merge must survive
+# this, including the submounts.
+if SYSTEMD_SYSEXT_OVERLAYFS_MOUNT_OPTIONS=nonexistent_option=1 run_systemd_sysext "$fake_root" refresh --always-refresh=yes; then
+    echo >&2 "Refresh with an invalid overlayfs mount option unexpectedly succeeded"
+    exit 1
+fi
+extension_verify_after_merge "$fake_root" "$hierarchy" -e -h
+OVERLAYID2=$(overlay_id)
+if [ "$OVERLAYID1" != "$OVERLAYID2" ]; then
+    echo >&2 "Failed refresh replaced the existing merge"
+    exit 1
+fi
+verify_single_overlay "$fake_root$hierarchy" "after failed refresh"
+# The injected failure happens while building /usr/, which is the first hierarchy, so check that one too
+test -f "$fake_root/usr/.systemd-sysext/extensions"
+verify_single_overlay "$fake_root/usr" "after failed refresh"
+verify_single_mount "$submount" "after failed refresh"
+test -f "$submount/marker"
+verify_single_mount "$later_submount" "after failed refresh"
+test -f "$later_submount/later-marker"
+
+# A successful refresh replaces the merge, keeps both submounts, and leaves exactly one overlayfs behind
+run_systemd_sysext "$fake_root" refresh --always-refresh=yes
+extension_verify_after_merge "$fake_root" "$hierarchy" -e -h
+OVERLAYID3=$(overlay_id)
+if [ "$OVERLAYID2" = "$OVERLAYID3" ]; then
+    echo >&2 "Refresh did not replace the existing merge"
+    exit 1
+fi
+verify_single_overlay "$fake_root$hierarchy" "after refresh"
+verify_single_overlay "$fake_root/usr" "after refresh"
+verify_single_mount "$submount" "after refresh"
+test -f "$submount/marker"
+verify_single_mount "$later_submount" "after refresh"
+test -f "$later_submount/later-marker"
+
+# Add a nested submount between two refreshes
+mkdir -p "$nested_submount"
+mount -t tmpfs tmpfs "$nested_submount"
+prepend_trap "umount -l ${nested_submount@Q} 2>/dev/null || true"
+touch "$nested_submount/nested-marker"
+
+run_systemd_sysext "$fake_root" refresh --always-refresh=yes
+extension_verify_after_merge "$fake_root" "$hierarchy" -e -h
+OVERLAYID4=$(overlay_id)
+if [ "$OVERLAYID3" = "$OVERLAYID4" ]; then
+    echo >&2 "Second refresh did not replace the existing merge"
+    exit 1
+fi
+verify_single_overlay "$fake_root$hierarchy" "after second refresh"
+verify_single_overlay "$fake_root/usr" "after second refresh"
+verify_single_mount "$submount" "after second refresh"
+test -f "$submount/marker"
+verify_single_mount "$later_submount" "after second refresh"
+test -f "$later_submount/later-marker"
+verify_single_mount "$nested_submount" "after second refresh"
+test -f "$nested_submount/nested-marker"
+
+# All of them survive the unmerge, too
+run_systemd_sysext "$fake_root" unmerge
+extension_verify_after_unmerge "$fake_root" "$hierarchy" -h
+verify_single_mount "$submount" "after unmerge"
+test -f "$submount/marker"
+verify_single_mount "$later_submount" "after unmerge"
+test -f "$later_submount/later-marker"
+verify_single_mount "$nested_submount" "after unmerge"
+test -f "$nested_submount/nested-marker"
+)
+done
+
+( init_trap
+: "Refresh unmerges a hierarchy that is no longer provided by any extension"
+fake_root=${roots_dir:+"$roots_dir/refresh-dropped-hierarchy"}
+hierarchy=/opt
+
+if ! systemd-analyze compare-versions "$(uname -r)" ge 5.12; then
+    echo >&2 "Kernel too old for mount_setattr (need >= 5.12), skipping test"
+    exit 0
+fi
+
+prepare_root "$fake_root" "$hierarchy"
+prepare_extension_image "$fake_root" "$hierarchy"
+prepare_hierarchy "$fake_root" "$hierarchy"
+
+submount="$fake_root$hierarchy/submount"
+mkdir -p "$submount"
+mount -t tmpfs tmpfs "$submount"
+prepend_trap "umount -l ${submount@Q} 2>/dev/null || true"
+touch "$submount/marker"
+
+run_systemd_sysext "$fake_root" merge
+extension_verify_after_merge "$fake_root" "$hierarchy" -e -h
+# The extension-release file makes /usr/ part of the merge, too
+test -f "$fake_root/usr/.systemd-sysext/extensions"
+mountpoint "$submount"
+test -f "$submount/marker"
+
+# Drop the hierarchy from the extension by emptying its directory, the refresh then unmerges it while /usr/
+# stays merged. An empty hierarchy directory in the extension counts as not provided. This relies on the
+# extension-release file living below /usr/, hence make sure that's not the hierarchy we empty.
+if [ "$hierarchy" = "/usr" ]; then
+    echo >&2 "This test requires a hierarchy other than /usr"
+    exit 1
+fi
+find "$fake_root/var/lib/extensions/test-extension$hierarchy" -mindepth 1 -delete
+run_systemd_sysext "$fake_root" refresh --always-refresh=yes
+extension_verify_after_unmerge "$fake_root" "$hierarchy" -h
+test ! -e "$fake_root$hierarchy/.systemd-sysext"
+test -f "$fake_root/usr/.systemd-sysext/extensions"
+verify_single_mount "$submount" "after refresh"
+test -f "$submount/marker"
+
+run_systemd_sysext "$fake_root" unmerge
+test ! -e "$fake_root/usr/.systemd-sysext"
+verify_single_mount "$submount" "after unmerge"
+test -f "$submount/marker"
+)
+
+# As above, run once with mounting beneath and once forcing the fallback path
+for mount_beneath in yes no; do
+( init_trap
+: "Refresh of a mutable merge switches to a new work directory and removes the old one (mount beneath: $mount_beneath)"
+# shellcheck disable=SC2030,SC2031 # The setting is meant to be confined to this test case's subshell
+export SYSTEMD_SYSEXT_MOUNT_BENEATH=$mount_beneath
+fake_root=${roots_dir:+"$roots_dir/refresh-mutable-work-dir-$mount_beneath"}
+hierarchy=/opt
+extension_data_dir="$fake_root/var/lib/extensions.mutable$hierarchy"
+extension_data_dir_usr="$fake_root/var/lib/extensions.mutable/usr"
+
+[[ "$FSTYPE" == "fuseblk" ]] && exit 0
+
+prepare_root "$fake_root" "$hierarchy"
+prepare_extension_image "$fake_root" "$hierarchy"
+prepare_extension_mutable_dir "$extension_data_dir"
+prepare_read_only_hierarchy "$fake_root" "$hierarchy"
+# The extension-release file makes /usr/ mutable as well, clean up its extensions.mutable directory, too
+prepend_trap "rm -rf ${extension_data_dir_usr@Q}"
+
+# Counts the work directories of all hierarchies, i.e. of /usr/ and of $hierarchy
+count_work_dirs() {
+    find "$fake_root/var/lib/extensions.mutable" -mindepth 1 -maxdepth 1 -name '.systemd-*-workdir*' | wc -l
+}
+
+verify_work_dirs() {
+    local expected=${1:?}
+    local message=${2:?}
+    local n
+
+    n=$(count_work_dirs)
+    if [ "$n" != "$expected" ]; then
+        echo >&2 "Expected $expected work directories $message, found $n"
+        exit 1
+    fi
+}
+
+run_systemd_sysext "$fake_root" --mutable=yes merge
+extension_verify_after_merge "$fake_root" "$hierarchy" -e -h -u
+WORKDIR1=$(<"$fake_root$hierarchy/.systemd-sysext/work_dir")
+test -d "$fake_root/$WORKDIR1"
+# The mounted overlayfs must use the work directory recorded in the metadata
+verify_sysext_mount_option "$fake_root$hierarchy" "workdir=$fake_root/$WORKDIR1"
+verify_work_dirs 2 "after merge"
+
+# A failed refresh must leave the work directory of the existing merge alone, and must not leave the work
+# directory it created for the new overlayfs behind
+if SYSTEMD_SYSEXT_OVERLAYFS_MOUNT_OPTIONS=nonexistent_option=1 run_systemd_sysext "$fake_root" --mutable=yes refresh --always-refresh=yes; then
+    echo >&2 "Mutable refresh with an invalid overlayfs mount option unexpectedly succeeded"
+    exit 1
+fi
+extension_verify_after_merge "$fake_root" "$hierarchy" -e -h -u
+test -d "$fake_root/$WORKDIR1"
+verify_work_dirs 2 "after failed refresh"
+
+# Make the refresh fail on $hierarchy only, after /usr/ was assembled already: with a tmpfs on the write
+# routing directory no work directory can be placed next to it (it must be on the same file system), so the
+# work directory already created for /usr/ must be removed again.
+mount -t tmpfs -o mode=0755 tmpfs "$extension_data_dir"
+prepend_trap "umount -l ${extension_data_dir@Q} 2>/dev/null || true"
+if run_systemd_sysext "$fake_root" --mutable=yes refresh --always-refresh=yes; then
+    echo >&2 "Mutable refresh with a write routing directory on a different file system unexpectedly succeeded"
+    exit 1
+fi
+umount "$extension_data_dir"
+extension_verify_after_merge "$fake_root" "$hierarchy" -e -h -u
+test -d "$fake_root/$WORKDIR1"
+verify_work_dirs 2 "after failed refresh of one hierarchy"
+
+run_systemd_sysext "$fake_root" --mutable=yes refresh --always-refresh=yes
+extension_verify_after_merge "$fake_root" "$hierarchy" -e -h -u
+WORKDIR2=$(<"$fake_root$hierarchy/.systemd-sysext/work_dir")
+if [ "$WORKDIR1" = "$WORKDIR2" ]; then
+    echo >&2 "Refresh reused the work directory of the previous merge"
+    exit 1
+fi
+test ! -e "$fake_root/$WORKDIR1"
+test -d "$fake_root/$WORKDIR2"
+verify_sysext_mount_option "$fake_root$hierarchy" "workdir=$fake_root/$WORKDIR2"
+verify_work_dirs 2 "after refresh"
+
+run_systemd_sysext "$fake_root" unmerge
+extension_verify_after_unmerge "$fake_root" "$hierarchy" -h
+verify_work_dirs 0 "after unmerge"
+)
+done
 
 } # End of run_sysext_tests
 


### PR DESCRIPTION
On kernels that support mount beneath we can fix the problems that all extensions are gone for a short time when we refresh and that any failure would end up with no overlay at all.

Restructure refresh to assemble the new overlay first and then, if possible, use mount beneath for an atomic replacement, otherwise we do a fallback where we shortly unmount as before (even shorter). On failure we keep the existing overlay. The assembly happens in a decoupled mount namespace where when done we send the mount FD to the parent through a socket. Per mount workdirs are also needed and get a random suffix and cleanup on failure which also fixes the case where we relied on / as CWD for deletion of workdirs with --root= not set. Make unmerge_hierarchy() return the cloned submounts for the peeling of the stack. While at it remove the forking done in the simple unmerge case. For the corner case where the fallback path would have removed the old overlay but can't move the new one in, the original submounts are lost.