### PR TITLE
bash-completion: systemctl: complete clean verb

### DIFF
--- a/shell-completion/bash/systemctl.in
+++ b/shell-completion/bash/systemctl.in
@@ -217,7 +217,7 @@ _systemctl () {
 
     local -A VERBS=(
         [ALL_UNITS]='cat mask'
-        [NONTEMPLATE_UNITS]='is-active is-failed is-enabled status show preset help list-dependencies edit set-property revert'
+        [NONTEMPLATE_UNITS]='is-active is-failed is-enabled status show preset help list-dependencies edit set-property revert clean'
         [ENABLED_UNITS]='disable'
         [DISABLED_UNITS]='enable'
         [REENABLABLE_UNITS]='reenable'


### PR DESCRIPTION
Add `clean` to the non-template unit verbs so it is suggested by systemctl Bash completion and completes valid unit names.

Fixes #43670.