### PR TITLE
tar-util: fix an off by one read

### DIFF
--- a/src/shared/tar-util.c
+++ b/src/shared/tar-util.c
@@ -1341,7 +1341,7 @@ static int archive_write_acl(
                 assert_cc(ACL_UNDEFINED_TAG == 0);   /* safety check, we assume that holes are filled with ACL_UNDEFINED_TAG */
                 assert_cc(ELEMENTSOF(tag_map) <= 64); /* safety check, we assume that the tag ids are all packed and low */
 
-                int tag = ntag >= 0 && ntag <= (acl_tag_t) ELEMENTSOF(tag_map) ? tag_map[ntag] : ACL_UNDEFINED_TAG;
+                int tag = ntag >= 0 && ntag < (acl_tag_t) ELEMENTSOF(tag_map) ? tag_map[ntag] : ACL_UNDEFINED_TAG;
 
                 bool skip = false;
                 id_t qualifier = UID_INVALID;


### PR DESCRIPTION
Standard Linux POSIX ACL tag values are `0x00`, `0x01`,` 0x02`, `0x04`, `0x08`, `0x10` and `0x20`. `ELEMENTSOF(tag_map)` evaluates to 33, which is one past the last valid index 32.

Fixes this issue reported by Coverity:

```
Error: OVERRUN (CWE-119):
systemd-262-rc1/src/shared/tar-util.c:1310:9: path: Condition "!!entry", taking true branch.
systemd-262-rc1/src/shared/tar-util.c:1311:9: path: Condition "!!acl", taking true branch.
systemd-262-rc1/src/shared/tar-util.c:1314:9: path: Condition "ntype == 32768", taking true branch.
systemd-262-rc1/src/shared/tar-util.c:1315:53: path: Falling through to end of if statement.
systemd-262-rc1/src/shared/tar-util.c:1324:17: path: Condition "r < 0", taking false branch.
systemd-262-rc1/src/shared/tar-util.c:1326:17: path: Condition "r == 0", taking false branch.
systemd-262-rc1/src/shared/tar-util.c:1330:17: path: Condition "sym_acl_get_tag_type(e, &ntag) < 0", taking false branch.
systemd-262-rc1/src/shared/tar-util.c:1344:17: cond_between: Checking "ntag <= (acl_tag_t)33UL" implies that "ntag" is between 0 and 33 (inclusive) on the true branch.
systemd-262-rc1/src/shared/tar-util.c:1344:17: overrun-local: Overrunning array "tag_map" of 33 4-byte elements at element index 33 (byte offset 135) using index "ntag" (which evaluates to 33).
# 1342|                   assert_cc(ELEMENTSOF(tag_map) <= 64); /* safety check, we assume that the tag ids are all packed and low */
# 1343|   
# 1344|->                 int tag = ntag >= 0 && ntag <= (acl_tag_t) ELEMENTSOF(tag_map) ? tag_map[ntag] : ACL_UNDEFINED_TAG;
# 1345|   
# 1346|                   bool skip = false;
```