### PR TITLE
NEWS: move "systemd-sysext status --json=" change to right place

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,15 +1,5 @@
 systemd System and Service Manager
 
-CHANGES WITH 263:
-
-        Feature Removals and Incompatible Changes:
-
-        * The "extensions" field of "systemd-sysext status --json=" and
-          "systemd-confext status --json=" is now always an array. A hierarchy
-          that is not merged reports an empty array, instead of the string
-          "none" returned previously. In the human-readable table output a
-          hierarchy that is not merged is now shown as "-" instead of "none".
-
 CHANGES WITH 262 in spe:
 
         Announcements of Future Feature Removals and Incompatible Changes:
@@ -146,6 +136,12 @@ CHANGES WITH 262 in spe:
           again marked as experimental. It will be stabilized in a future
           release. The libexecdir path is the backwards compatible way to call
           it.
+
+        * The "extensions" field of "systemd-sysext status --json=" and
+          "systemd-confext status --json=" is now always an array. A hierarchy
+          that is not merged reports an empty array, instead of the string
+          "none" returned previously. In the human-readable table output a
+          hierarchy that is not merged is now shown as "-" instead of "none".
 
         Changes in the system and service manager:
 


### PR DESCRIPTION
Originally https://github.com/systemd/systemd/pull/43595 was targeted for v263 and the NEWS entry was for v263 too.

However it got merged now for v262 (for the right reasons) so this commit updates the NEWS file.