### PR TITLE
sysext: Order sysext unit after confext to provide guarantees

### DIFF
--- a/src/sysext/sysext.c
+++ b/src/sysext/sysext.c
@@ -3030,12 +3030,13 @@ static int vl_method_on_completed_update(sd_varlink *link, sd_json_variant *para
         /* Triggered by systemd-sysupdate after an update completed. We deliberately ignore all parameters
          * (we don't even dispatch them). This method is reached through the sysext socket, but a single
          * notification refreshes both image classes, so freshly downloaded sysexts and confexts are both
-         * picked up, equivalent to "systemd-sysext refresh" plus "systemd-confext refresh". We attempt both
-         * classes and only fail afterwards, so a problem with one does not prevent refreshing the other. */
+         * picked up, equivalent to "systemd-confext refresh" plus "systemd-sysext refresh", in the same order
+         * as at boot. We attempt both classes and only fail afterwards, so a problem with one does not
+         * prevent refreshing the other. */
 
         r = 0;
-        RET_GATHER(r, refresh_class(IMAGE_SYSEXT));
         RET_GATHER(r, refresh_class(IMAGE_CONFEXT));
+        RET_GATHER(r, refresh_class(IMAGE_SYSEXT));
         if (r < 0)
                 return r;
 

--- a/test/units/TEST-50-DISSECT.dissect.sh
+++ b/test/units/TEST-50-DISSECT.dissect.sh
@@ -1134,6 +1134,76 @@ EOF
 
 test_sysupdate_notify_confext_mutable
 
+cleanup_sysupdate_notify_confext_before_sysext() {
+    local notify_socket_was_active="$1"
+
+    if [[ "$notify_socket_was_active" == "yes" ]]; then
+        systemctl restart systemd-sysupdate-notify-sysext.socket || :
+    else
+        systemctl stop systemd-sysupdate-notify-sysext.socket || :
+    fi
+
+    systemctl stop test-order-foo.service || :
+    systemd-sysext unmerge || :
+    systemd-confext unmerge || :
+    rm -rf /run/extensions/test-order /run/confexts/test-order
+    rm -f /run/test-order-marker
+}
+
+test_sysupdate_notify_confext_before_sysext() {
+    local notify_socket_was_active=no
+
+    if systemctl is-active --quiet systemd-sysupdate-notify-sysext.socket; then
+        notify_socket_was_active=yes
+    fi
+
+    trap 'cleanup_sysupdate_notify_confext_before_sysext "$notify_socket_was_active"' RETURN ERR
+
+    # Check that the sysupdate notification refresh merges confexts before sysexts, same order as for unit
+    # startup at boot. The confext ships a drop-in for a whole prefix of units, meaning it can't know what
+    # units to restart through EXTENSION_RESTART_UNITS= if it would be merged after the sysext that defines
+    # the unit affected by the drop-in. Only if the confext is merged first the unit picks up the drop-in.
+    # This is just one example the general scenario when a confext has to create state before a sysext's
+    # service is started and the confext does not know what sysext's services would be affected.
+    mkdir -p /run/confexts/test-order/etc/extension-release.d /run/confexts/test-order/etc/systemd/system/test-order-.service.d
+    cat >/run/confexts/test-order/etc/extension-release.d/extension-release.test-order <<EOF
+ID=_any
+ARCHITECTURE=_any
+EXTENSION_RELOAD_MANAGER=1
+EOF
+    cat >/run/confexts/test-order/etc/systemd/system/test-order-.service.d/10-marker.conf <<EOF
+[Service]
+Environment=MARKER=from-confext
+EOF
+
+    mkdir -p /run/extensions/test-order/usr/lib/extension-release.d /run/extensions/test-order/usr/lib/systemd/system
+    cat >/run/extensions/test-order/usr/lib/extension-release.d/extension-release.test-order <<EOF
+ID=_any
+ARCHITECTURE=_any
+EXTENSION_RELOAD_MANAGER=1
+EXTENSION_RESTART_UNITS=test-order-foo.service
+EOF
+    cat >/run/extensions/test-order/usr/lib/systemd/system/test-order-foo.service <<'EOF'
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=sh -c 'echo "${MARKER:-unset}" >/run/test-order-marker'
+EOF
+
+    systemctl start systemd-sysupdate-notify-sysext.socket
+    varlinkctl call /run/systemd/sysupdate/notify/io.systemd.sysext io.systemd.SysUpdate.Notify.OnCompletedUpdate '{}'
+
+    test -f /etc/systemd/system/test-order-.service.d/10-marker.conf
+    test -f /usr/lib/systemd/system/test-order-foo.service
+    systemctl --quiet is-active test-order-foo.service
+    grep -F "from-confext" /run/test-order-marker >/dev/null
+
+    trap - RETURN ERR
+    cleanup_sysupdate_notify_confext_before_sysext "$notify_socket_was_active"
+}
+
+test_sysupdate_notify_confext_before_sysext
+
 unsquashfs -force -no-xattrs -d /tmp/img "$MINIMAL_IMAGE.raw"
 systemd-run --unit=test-root-ephemeral \
     -p RootDirectory=/tmp/img \

--- a/units/systemd-sysext-initrd.service
+++ b/units/systemd-sysext-initrd.service
@@ -21,6 +21,7 @@ ConditionPathExists=/etc/initrd-release
 ConditionKernelCommandLine=!rd.systemd.sysext=0
 
 DefaultDependencies=no
+After=systemd-confext-initrd.service
 Before=local-fs-pre.target cryptsetup-pre.target systemd-tmpfiles-setup.service
 Wants=local-fs-pre.target cryptsetup-pre.target
 Conflicts=initrd-switch-root.target

--- a/units/systemd-sysext-sysroot.service
+++ b/units/systemd-sysext-sysroot.service
@@ -18,6 +18,7 @@ ConditionPathExists=/etc/initrd-release
 ConditionKernelCommandLine=!systemd.sysext=0
 
 DefaultDependencies=no
+After=systemd-confext-sysroot.service
 Conflicts=shutdown.target
 Before=initrd-root-fs.target shutdown.target
 Wants=modprobe@loop.service modprobe@dm_mod.service

--- a/units/systemd-sysext.service
+++ b/units/systemd-sysext.service
@@ -20,6 +20,7 @@ ConditionPathExists=!/etc/initrd-release
 ConditionKernelCommandLine=!systemd.sysext=0
 
 DefaultDependencies=no
+After=systemd-confext.service
 After=local-fs.target
 Before=sysinit.target systemd-tmpfiles-setup.service
 Conflicts=shutdown.target


### PR DESCRIPTION
Up to now there was no clear ordering of confext and sysext units. Normally, configuration should be able to influence the behavior of services (config files or unit drop-ins), so it makes sense to order confext before sysext. The mounting from the initrd for the final system makes this less important together with the fact that live merges/ refreshes can encode unit restarts now. Yet I think it's better to know what gets merged first and if wanted one can avoid encoding restarts if one doesn't care about later live content changes. Where it matters more for me is consistent behavior for the refresh check during boot for non-verity images because they get compared by file handle and mount ID which means whether the overlay was set up or not determines the identity and decides if we do a refresh or not and this should not vary by boot merely due to timing or other dependencies impacting the ordering. (Note that one extension type shipping another extension type is not the reason for the ordering and these cycles should be avoided because they never free the mounts and backing loop devices.)

Replaces https://github.com/systemd/systemd/pull/41427