### PR TITLE
udevadm: restore noop behaviour when udevd is not running

### DIFF
--- a/src/udev/udevadm-settle.c
+++ b/src/udev/udevadm-settle.c
@@ -194,8 +194,8 @@ int verb_settle_main(int argc, char *argv[], uintptr_t _data, void *userdata) {
         (void) emit_deprecation_warning();
 
         if (getuid() == 0) {
-                r = udev_ping(MAX(5 * USEC_PER_SEC, arg_timeout_usec));
-                if (r < 0)
+                r = udev_ping(MAX(5 * USEC_PER_SEC, arg_timeout_usec), /* ignore_connection_failure= */ true);
+                if (r <= 0)
                         return r;
         } else {
                 /* For non-privileged users, at least check if udevd is running. */

--- a/src/udev/udevadm-trigger.c
+++ b/src/udev/udevadm-trigger.c
@@ -506,9 +506,10 @@ int verb_trigger_main(int argc, char *argv[], uintptr_t _data, void *userdata) {
                 return r;
 
         if (arg_ping) {
-                r = udev_ping(arg_ping_timeout_usec);
+                r = udev_ping(arg_ping_timeout_usec, /* ignore_connection_failure= */ false);
                 if (r < 0)
                         return r;
+                assert(r > 0);
         }
 
         if (arg_settle) {

--- a/src/udev/udevadm-util.c
+++ b/src/udev/udevadm-util.c
@@ -8,6 +8,7 @@
 #include "conf-files.h"
 #include "constants.h"
 #include "device-private.h"
+#include "errno-util.h"
 #include "extract-word.h"
 #include "log.h"
 #include "path-util.h"
@@ -172,19 +173,24 @@ int parse_key_value_argument(const char *str, bool require_value, char **key, ch
         return 0;
 }
 
-int udev_ping(usec_t timeout_usec) {
+int udev_ping(usec_t timeout_usec, bool ignore_connection_failure) {
         _cleanup_(sd_varlink_flush_close_unrefp) sd_varlink *link = NULL;
         int r;
 
         r = udev_varlink_connect(&link, timeout_usec);
-        if (r < 0)
-                return log_error_errno(r, "Failed to connect to udev via varlink: %m");
+        if (r < 0) {
+                bool ignore = ignore_connection_failure && (ERRNO_IS_NEG_DISCONNECT(r) || r == -ENOENT);
+                log_full_errno(ignore ? LOG_DEBUG : LOG_ERR, r,
+                               "Failed to connect to udev via varlink%s: %m",
+                               ignore ? ", ignoring" : "");
+                return ignore ? 0 : r;  /* nothing to do or error */
+        }
 
         r = varlink_call_and_log(link, "io.systemd.service.Ping", /* parameters= */ NULL, /* reply= */ NULL);
         if (r < 0)
                 return r;
 
-        return 0;
+        return 1;  /* received reply from udevd */
 }
 
 static int search_rules_file_in_conf_dirs(const char *s, const char *root, ConfFile ***files, size_t *n_files) {

--- a/src/udev/udevadm-util.h
+++ b/src/udev/udevadm-util.h
@@ -11,5 +11,5 @@ int find_device_with_action(const char *id, sd_device_action_t action, sd_device
 int parse_device_action(const char *str, sd_device_action_t *ret);
 int parse_resolve_name_timing(const char *str, ResolveNameTiming *ret);
 int parse_key_value_argument(const char *str, bool require_value, char **key, char **value);
-int udev_ping(usec_t timeout);
+int udev_ping(usec_t timeout, bool ignore_connection_failure);
 int search_rules_files(char * const *a, const char *root, ConfFile ***ret_files, size_t *ret_n_files);


### PR DESCRIPTION
This partially reverts 17e911ffc853c54f44edd11ead8b6edab72c1217. Previously 'udevadm settle' would silently succeed if udevd was not reachable. Restore this behaviour.

C.f. https://forge.fedoraproject.org/releng/compose-tracker-issues/issues/9573.