### PR TITLE
tree-wide: close-on-exec by default

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -256,6 +256,12 @@ CHANGES WITH 262 in spe:
           treated as untrusted boot-loader credentials, routed to
           $ENCRYPTED_CREDENTIALS_DIRECTORY for LoadCredentialEncrypted=.
 
+        * StandardInput=file:, StandardOutput=file:/append:/truncate: and
+          StandardError=file:/append:/truncate: no longer create the specified
+          file through a dangling symlink. If the path is a symlink whose
+          target does not exist yet, the service now fails to start with an
+          ELOOP error, in line with the other file-creating code in systemd.
+
         Changes in sd-varlink and varlinkctl:
 
         * Varlink socket inodes are tagged with an
@@ -720,6 +726,11 @@ CHANGES WITH 262 in spe:
         Other changes:
 
         * Support for OpenSSL 4 has been added.
+
+        * systemd-random-seed and "importctl export-tar/export-raw" no longer
+          create their output files through a dangling symlink and fail with an
+          ELOOP error instead, in line with the other file-creating code in
+          systemd.
 
         * systemd-timesyncd now resolves NTP server names through
           systemd-resolved's Varlink API when available. It suppresses DNSSEC

--- a/docs/CODING_STYLE.md
+++ b/docs/CODING_STYLE.md
@@ -879,6 +879,13 @@ SPDX-License-Identifier: LGPL-2.1-or-later
   - `F_DUPFD_CLOEXEC` should be used instead of `F_DUPFD`, and so on,
   - invocations of `fopen()` should take `e`.
 
+- Our dedicated open helpers (`xopenat()`, `chase_and_open()`, `fd_reopen()`,
+  `open_mkdir_at()`, `open_tmpfile_linkable()`, `open_terminal()`,
+  `fopen_unlocked()`, …) set `O_CLOEXEC` by default and will thus only return
+  close-on-exec file descriptors. If a file descriptor must be available after
+  `execve()` the `O_CLOEXEC` bit must be cleared explicitly via
+  `fd_cloexec(fd, false)` right before the `execve()`.
+
 - It's a good idea to use `O_NONBLOCK` when opening 'foreign' regular files,
   i.e.  file system objects that are supposed to be regular files whose paths
   were specified by the user and hence might actually refer to other types of

--- a/src/analyze/analyze-chid.c
+++ b/src/analyze/analyze-chid.c
@@ -15,6 +15,7 @@
 #include "fd-util.h"
 #include "fileio.h"
 #include "format-table.h"
+#include "fs-util.h"
 #include "glyph-util.h"
 #include "parse-util.h"
 #include "string-util.h"
@@ -153,9 +154,9 @@ static int smbios_fields_acquire(char16_t *fields[static _CHID_SMBIOS_FIELDS_MAX
 
         int r;
 
-        _cleanup_close_ int smbios_fd = open("/sys/class/dmi/id", O_RDONLY|O_DIRECTORY|O_CLOEXEC);
+        _cleanup_close_ int smbios_fd = xopenat(AT_FDCWD, "/sys/class/dmi/id", O_RDONLY|O_DIRECTORY);
         if (smbios_fd < 0)
-                return log_error_errno(errno, "Failed to open SMBIOS sysfs object: %m");
+                return log_error_errno(smbios_fd, "Failed to open SMBIOS sysfs object: %m");
 
         for (ChidSmbiosFields f = 0; f < _CHID_SMBIOS_FIELDS_MAX; f++) {
                 _cleanup_free_ char *buf = NULL;

--- a/src/analyze/analyze-dlopen-metadata.c
+++ b/src/analyze/analyze-dlopen-metadata.c
@@ -17,7 +17,7 @@ int verb_dlopen_metadata(int argc, char *argv[], uintptr_t _data, void *userdata
 
         _cleanup_free_ char *abspath = NULL;
         _cleanup_close_ int fd = -EBADF;
-        fd = chase_and_open(argv[1], arg_root, CHASE_PREFIX_ROOT, O_RDONLY|O_CLOEXEC, &abspath);
+        fd = chase_and_open(argv[1], arg_root, CHASE_PREFIX_ROOT, O_RDONLY, &abspath);
         if (fd < 0)
                 return log_error_errno(fd, "Could not open \"%s\": %m", argv[1]);
 

--- a/src/analyze/analyze-inspect-elf.c
+++ b/src/analyze/analyze-inspect-elf.c
@@ -23,7 +23,7 @@ static int analyze_elf(char **filenames, sd_json_format_flags_t json_flags) {
                 _cleanup_close_ int fd = -EBADF;
                 bool coredump = false;
 
-                fd = chase_and_open(*filename, arg_root, CHASE_PREFIX_ROOT, O_RDONLY|O_CLOEXEC, &abspath);
+                fd = chase_and_open(*filename, arg_root, CHASE_PREFIX_ROOT, O_RDONLY, &abspath);
                 if (fd < 0)
                         return log_error_errno(fd, "Could not open \"%s\": %m", *filename);
 

--- a/src/basic/btrfs-util.c
+++ b/src/basic/btrfs-util.c
@@ -59,7 +59,7 @@ int btrfs_subvol_make(int dir_fd, const char *path) {
         if (r < 0 && r != -EDESTADDRREQ) /* Propagate error, unless only a filename was specified, which is OK */
                 return r;
 
-        fd = xopenat(dir_fd, parent ?: ".", O_DIRECTORY|O_RDONLY|O_CLOEXEC);
+        fd = xopenat(dir_fd, parent ?: ".", O_DIRECTORY|O_RDONLY);
         if (fd < 0)
                 return fd;
 

--- a/src/basic/cgroup-util.c
+++ b/src/basic/cgroup-util.c
@@ -56,16 +56,16 @@ int cg_path_open(const char *path) {
         if (r < 0)
                 return r;
 
-        return RET_NERRNO(open(fs, O_DIRECTORY|O_CLOEXEC));
+        return xopenat(AT_FDCWD, fs, O_DIRECTORY);
 }
 
 int cg_cgroupid_open(int cgroupfs_fd, uint64_t id) {
         _cleanup_close_ int fsfd = -EBADF;
 
         if (cgroupfs_fd < 0) {
-                fsfd = open("/sys/fs/cgroup", O_CLOEXEC|O_DIRECTORY);
+                fsfd = xopenat(AT_FDCWD, "/sys/fs/cgroup", O_DIRECTORY);
                 if (fsfd < 0)
-                        return -errno;
+                        return fsfd;
 
                 cgroupfs_fd = fsfd;
         }

--- a/src/basic/chase.c
+++ b/src/basic/chase.c
@@ -483,9 +483,9 @@ int chaseat(int root_fd, int dir_fd, const char *path, ChaseFlags flags, char **
                                 }
                         }
 
-                        fd_parent = openat(fd, "..", O_CLOEXEC|O_NOFOLLOW|O_PATH|O_DIRECTORY);
+                        fd_parent = xopenat(fd, "..", O_NOFOLLOW|O_PATH|O_DIRECTORY);
                         if (fd_parent < 0)
-                                return -errno;
+                                return fd_parent;
 
                         r = chase_statx(fd_parent, &stx_parent);
                         if (r < 0)
@@ -550,9 +550,9 @@ int chaseat(int root_fd, int dir_fd, const char *path, ChaseFlags flags, char **
                                 _cleanup_close_ int fd_grandparent = -EBADF;
                                 struct statx stx_grandparent;
 
-                                fd_grandparent = openat(fd_parent, "..", O_CLOEXEC|O_NOFOLLOW|O_PATH|O_DIRECTORY);
+                                fd_grandparent = xopenat(fd_parent, "..", O_NOFOLLOW|O_PATH|O_DIRECTORY);
                                 if (fd_grandparent < 0)
-                                        return -errno;
+                                        return fd_grandparent;
 
                                 r = chase_statx(fd_grandparent, &stx_grandparent);
                                 if (r < 0)
@@ -838,9 +838,9 @@ int chase(const char *path, const char *root, ChaseFlags flags, char **ret_path,
         if (empty_or_root(root))
                 fd = XAT_FDROOT;
         else {
-                fd = open(root, O_CLOEXEC|O_DIRECTORY|O_PATH);
+                fd = xopenat(AT_FDCWD, root, O_DIRECTORY|O_PATH);
                 if (fd < 0)
-                        return -errno;
+                        return fd;
         }
 
         r = chaseat(fd, fd, path, flags & ~CHASE_PREFIX_ROOT, ret_path ? &p : NULL, ret_fd ? &pfd : NULL);

--- a/src/basic/chase.c
+++ b/src/basic/chase.c
@@ -401,7 +401,7 @@ int chaseat(int root_fd, int dir_fd, const char *path, ChaseFlags flags, char **
                         return -ENOMEM;
         }
 
-        _cleanup_close_ int fd = xopenat(dir_fd, NULL, O_DIRECTORY|O_PATH);
+        _cleanup_close_ int fd = fd_reopen(dir_fd, O_DIRECTORY|O_PATH);
         if (fd < 0)
                 return fd;
 
@@ -993,7 +993,7 @@ int chase_and_open(
                 }
         }
 
-        r = chase_xopenat(path_fd, strempty(open_name), chase_flags, open_flags|O_NOFOLLOW, /* xopen_flags= */ 0);
+        r = chase_xopenat(path_fd, open_name, chase_flags, open_flags|O_NOFOLLOW, XO_EMPTY_PATH);
         if (r < 0)
                 return r;
 
@@ -1204,7 +1204,7 @@ int chase_and_openat(
                 }
         }
 
-        r = chase_xopenat(path_fd, strempty(open_name), chase_flags, open_flags|O_NOFOLLOW, /* xopen_flags= */ 0);
+        r = chase_xopenat(path_fd, open_name, chase_flags, open_flags|O_NOFOLLOW, XO_EMPTY_PATH);
         if (r < 0)
                 return r;
 

--- a/src/basic/chase.c
+++ b/src/basic/chase.c
@@ -401,7 +401,7 @@ int chaseat(int root_fd, int dir_fd, const char *path, ChaseFlags flags, char **
                         return -ENOMEM;
         }
 
-        _cleanup_close_ int fd = xopenat(dir_fd, NULL, O_CLOEXEC|O_DIRECTORY|O_PATH);
+        _cleanup_close_ int fd = xopenat(dir_fd, NULL, O_DIRECTORY|O_PATH);
         if (fd < 0)
                 return fd;
 
@@ -579,7 +579,7 @@ int chaseat(int root_fd, int dir_fd, const char *path, ChaseFlags flags, char **
 
                 /* Otherwise let's pin it by file descriptor, via O_PATH. */
                 child = r = xopenat_full(fd, first,
-                                         O_PATH|O_NOFOLLOW|O_CLOEXEC,
+                                         O_PATH|O_NOFOLLOW,
                                          FLAGS_SET(flags, CHASE_TRIGGER_AUTOFS) ? XO_TRIGGER_AUTOMOUNT : 0,
                                          MODE_INVALID);
                 if (r < 0) {
@@ -592,7 +592,7 @@ int chaseat(int root_fd, int dir_fd, const char *path, ChaseFlags flags, char **
                         if (FLAGS_SET(flags, CHASE_MKDIR_0755) && (!isempty(todo) || !(flags & (CHASE_PARENT|CHASE_NONEXISTENT)))) {
                                 child = xopenat(fd,
                                                 first,
-                                                O_DIRECTORY|O_CREAT|O_EXCL|O_NOFOLLOW|O_PATH|O_CLOEXEC);
+                                                O_DIRECTORY|O_CREAT|O_EXCL|O_NOFOLLOW|O_PATH);
                                 if (child < 0)
                                         return child;
                         } else if (FLAGS_SET(flags, CHASE_PARENT) && isempty(todo)) {
@@ -644,7 +644,7 @@ int chaseat(int root_fd, int dir_fd, const char *path, ChaseFlags flags, char **
                                  * root file descriptor as base. */
 
                                 safe_close(fd);
-                                fd = fd_reopen(root_fd, O_CLOEXEC|O_PATH|O_DIRECTORY);
+                                fd = fd_reopen(root_fd, O_PATH|O_DIRECTORY);
                                 if (fd < 0)
                                         return fd;
 
@@ -1139,7 +1139,7 @@ int chase_and_unlink(const char *path, const char *root, ChaseFlags chase_flags,
         assert(path);
         assert(!(chase_flags & (CHASE_NONEXISTENT|CHASE_STEP|CHASE_PARENT|CHASE_MUST_BE_SOCKET|CHASE_MUST_BE_REGULAR|CHASE_MUST_BE_DIRECTORY|CHASE_EXTRACT_FILENAME|CHASE_MKDIR_0755)));
 
-        fd = chase_and_open(path, root, chase_flags|CHASE_PARENT|CHASE_NOFOLLOW, O_PATH|O_DIRECTORY|O_CLOEXEC, &p);
+        fd = chase_and_open(path, root, chase_flags|CHASE_PARENT|CHASE_NOFOLLOW, O_PATH|O_DIRECTORY, &p);
         if (fd < 0)
                 return fd;
 
@@ -1351,7 +1351,7 @@ int chase_and_unlinkat(int root_fd, int dir_fd, const char *path, ChaseFlags cha
         assert(path);
         assert(!(chase_flags & (CHASE_NONEXISTENT|CHASE_STEP|CHASE_PARENT|CHASE_MUST_BE_SOCKET|CHASE_MUST_BE_REGULAR|CHASE_MUST_BE_DIRECTORY|CHASE_EXTRACT_FILENAME|CHASE_MKDIR_0755)));
 
-        fd = chase_and_openat(root_fd, dir_fd, path, chase_flags|CHASE_PARENT|CHASE_NOFOLLOW, O_PATH|O_DIRECTORY|O_CLOEXEC, &p);
+        fd = chase_and_openat(root_fd, dir_fd, path, chase_flags|CHASE_PARENT|CHASE_NOFOLLOW, O_PATH|O_DIRECTORY, &p);
         if (fd < 0)
                 return fd;
 

--- a/src/basic/chattr-util.c
+++ b/src/basic/chattr-util.c
@@ -29,7 +29,7 @@ int chattr_full(
 
         assert(dir_fd >= 0 || dir_fd == AT_FDCWD);
 
-        fd = xopenat(dir_fd, path, O_RDONLY|O_CLOEXEC|O_NOCTTY|O_NOFOLLOW);
+        fd = xopenat(dir_fd, path, O_RDONLY|O_NOCTTY|O_NOFOLLOW);
         if (fd < 0)
                 return fd;
 
@@ -144,7 +144,7 @@ int read_attr_fd(int fd, unsigned *ret) {
                 return -ENOTTY;
 
         _cleanup_close_ int fd_close = -EBADF;
-        fd = fd_reopen_condition(fd, O_RDONLY|O_CLOEXEC|O_NOCTTY, O_PATH, &fd_close); /* drop O_PATH if it is set */
+        fd = fd_reopen_condition(fd, O_RDONLY|O_NOCTTY, O_PATH, &fd_close); /* drop O_PATH if it is set */
         if (fd < 0)
                 return fd;
 
@@ -161,7 +161,7 @@ int read_attr_at(int dir_fd, const char *path, unsigned *ret) {
         if (isempty(path) && dir_fd != AT_FDCWD)
                 fd = dir_fd;
         else {
-                fd_close = xopenat(dir_fd, path, O_RDONLY|O_CLOEXEC|O_NOCTTY|O_NOFOLLOW);
+                fd_close = xopenat(dir_fd, path, O_RDONLY|O_NOCTTY|O_NOFOLLOW);
                 if (fd_close < 0)
                         return fd_close;
 
@@ -177,7 +177,7 @@ int read_fs_xattr_fd(int fd, uint32_t *ret_xflags, uint32_t *ret_projid) {
 
         assert(fd >= 0);
 
-        fd = fd_reopen_condition(fd, O_RDONLY|O_CLOEXEC|O_NOCTTY, O_PATH, &fd_reopened);
+        fd = fd_reopen_condition(fd, O_RDONLY|O_NOCTTY, O_PATH, &fd_reopened);
         if (fd < 0)
                 return fd;
 
@@ -199,7 +199,7 @@ int set_proj_id(int fd, uint32_t proj_id) {
 
         assert(fd >= 0);
 
-        fd = fd_reopen_condition(fd, O_RDONLY|O_CLOEXEC|O_NOCTTY, O_PATH, &fd_reopened);
+        fd = fd_reopen_condition(fd, O_RDONLY|O_NOCTTY, O_PATH, &fd_reopened);
         if (fd < 0)
                 return fd;
 

--- a/src/basic/conf-files.c
+++ b/src/basic/conf-files.c
@@ -10,6 +10,7 @@
 #include "errno-util.h"
 #include "fd-util.h"
 #include "fileio.h"
+#include "fs-util.h"
 #include "glyph-util.h"
 #include "hashmap.h"
 #include "log.h"
@@ -77,9 +78,9 @@ static int prepare_dirs(
 
                 path_simplify(root_abs);
 
-                rfd = open(root, O_CLOEXEC|O_DIRECTORY|O_PATH);
+                rfd = xopenat(AT_FDCWD, root, O_DIRECTORY|O_PATH);
                 if (rfd < 0)
-                        return log_full_errno(log_level, errno, "Failed to open '%s': %m", root_abs);
+                        return log_full_errno(log_level, rfd, "Failed to open '%s': %m", root_abs);
 
         } else if (ret_dirs) {
                 /* When an empty root or "/" is specified, we will open "/" below, hence we need to make

--- a/src/basic/confidential-virt.c
+++ b/src/basic/confidential-virt.c
@@ -11,6 +11,7 @@
 #include "errno-util.h"                                 /* IWYU pragma: keep */
 #include "fd-util.h"
 #include "fileio.h"                                     /* IWYU pragma: keep */
+#include "fs-util.h"
 #include "log.h"
 #include "string-table.h"
 #include "string-util.h"
@@ -55,9 +56,9 @@ static int msr(uint64_t index, uint64_t *ret) {
 
         assert(ret);
 
-        fd = open(MSR_DEVICE, O_RDONLY|O_CLOEXEC);
+        fd = xopenat(AT_FDCWD, MSR_DEVICE, O_RDONLY);
         if (fd < 0)
-                return log_debug_errno(errno,
+                return log_debug_errno(fd,
                                        "Cannot open MSR device %s (index %" PRIu64 "): %m",
                                        MSR_DEVICE, index);
 

--- a/src/basic/efivars.c
+++ b/src/basic/efivars.c
@@ -11,6 +11,7 @@
 #include "chattr-util.h"
 #include "efivars.h"
 #include "fd-util.h"
+#include "fs-util.h"
 #include "io-util.h"
 #include "log.h"
 #include "memory-util.h"
@@ -45,9 +46,9 @@ int efi_get_variable(
                 begin = now(CLOCK_MONOTONIC);
         }
 
-        _cleanup_close_ int fd = open(p, O_RDONLY|O_NOCTTY|O_CLOEXEC);
+        _cleanup_close_ int fd = xopenat(AT_FDCWD, p, O_RDONLY|O_NOCTTY);
         if (fd < 0)
-                return log_debug_errno(errno, "open(\"%s\") failed: %m", p);
+                return log_debug_errno(fd, "open(\"%s\") failed: %m", p);
 
         uint32_t attr;
         _cleanup_free_ char *buf = NULL;
@@ -274,9 +275,9 @@ int efi_set_variable(const char *variable, const void *value, size_t size) {
                 return 0;
         }
 
-        fd = open(p, O_WRONLY|O_CREAT|O_NOCTTY|O_CLOEXEC, 0644);
+        fd = xopenat_full(AT_FDCWD, p, O_WRONLY|O_CREAT|O_NOCTTY, /* xopen_flags= */ 0, 0644);
         if (fd < 0) {
-                r = -errno;
+                r = fd;
                 goto finish;
         }
 

--- a/src/basic/env-file.c
+++ b/src/basic/env-file.c
@@ -679,7 +679,7 @@ int write_env_file_label(int dir_fd, const char *fname, char **headers, char **l
 
         _cleanup_fclose_ FILE *f = NULL;
         _cleanup_free_ char *p = NULL;
-        r = fopen_tmpfile_linkable_at(dir_fd, fname, O_WRONLY|O_CLOEXEC, &p, &f);
+        r = fopen_tmpfile_linkable_at(dir_fd, fname, O_WRONLY, &p, &f);
         if (r < 0) {
                 if (FLAGS_SET(flags, WRITE_ENV_FILE_LABEL))
                         (void) label_ops_post(dir_fd, fname, /* created= */ false, label_context);

--- a/src/basic/fd-util.c
+++ b/src/basic/fd-util.c
@@ -1066,7 +1066,7 @@ int path_is_root_at(int dir_fd, const char *path) {
 
         _cleanup_close_ int fd = -EBADF;
         if (!isempty(path)) {
-                fd = xopenat(dir_fd, path, O_PATH|O_DIRECTORY|O_CLOEXEC);
+                fd = xopenat(dir_fd, path, O_PATH|O_DIRECTORY);
                 if (fd == -ENOTDIR)
                         return false; /* the root dir must be a dir */
                 if (fd < 0)

--- a/src/basic/fd-util.c
+++ b/src/basic/fd-util.c
@@ -706,10 +706,10 @@ int rearrange_stdio(int original_input_fd, int original_output_fd, int original_
         if (null_readable || null_writable) {
 
                 /* Let's open this with O_CLOEXEC first, and convert it to non-O_CLOEXEC when we move the fd to the final position. */
-                null_fd = open("/dev/null", (null_readable && null_writable ? O_RDWR :
-                                             null_readable ? O_RDONLY : O_WRONLY) | O_CLOEXEC);
+                null_fd = xopenat(AT_FDCWD, "/dev/null", (null_readable && null_writable ? O_RDWR :
+                                                          null_readable ? O_RDONLY : O_WRONLY));
                 if (null_fd < 0) {
-                        r = -errno;
+                        r = null_fd;
                         goto finish;
                 }
 

--- a/src/basic/fd-util.c
+++ b/src/basic/fd-util.c
@@ -983,6 +983,8 @@ int fd_verify_safe_flags_full(int fd, int extra_flags) {
          * RAW_O_LARGEFILE: glibc secretly sets this and neglects to hide it from us if we call fcntl.
          *                  See comment in src/basic/include/fcntl.h for more details about this.
          *
+         * O_EMPTYPATH: Sticks to the file like O_NOFOLLOW does, and is just as meaningless once it is open.
+         *
          * If 'extra_flags' is specified as non-zero the included flags are also allowed.
          */
 
@@ -992,7 +994,7 @@ int fd_verify_safe_flags_full(int fd, int extra_flags) {
         if (flags < 0)
                 return -errno;
 
-        unexpected_flags = flags & ~(O_ACCMODE_STRICT|O_NOFOLLOW|RAW_O_LARGEFILE|extra_flags);
+        unexpected_flags = flags & ~(O_ACCMODE_STRICT|O_NOFOLLOW|O_EMPTYPATH|RAW_O_LARGEFILE|extra_flags);
         if (unexpected_flags != 0)
                 return log_debug_errno(SYNTHETIC_ERRNO(EREMOTEIO),
                                        "Unexpected flags set for extrinsic fd: 0%o",

--- a/src/basic/fd-util.c
+++ b/src/basic/fd-util.c
@@ -798,7 +798,11 @@ int fd_reopen(int fd, int flags) {
          * If the specified file descriptor refers to a symlink via O_PATH, then this function cannot be used
          * to follow that symlink. Because we cannot have non-O_PATH fds to symlinks reopening it without
          * O_PATH will always result in -ELOOP. Or in other words: if you have an O_PATH fd to a symlink you
-         * can reopen it only if you pass O_PATH again. */
+         * can reopen it only if you pass O_PATH again.
+         *
+         * The returned fd always has O_CLOEXEC set, use fd_cloexec() to turn it off. */
+
+        flags |= O_CLOEXEC;
 
         if (FLAGS_SET(flags, O_NOFOLLOW))
                 /* O_NOFOLLOW is not allowed in fd_reopen(), because after all this is primarily implemented

--- a/src/basic/fd-util.c
+++ b/src/basic/fd-util.c
@@ -791,6 +791,9 @@ int fd_reopen(int fd, int flags) {
          *
          * This implicitly resets the file read index to 0.
          *
+         * Kernels with O_EMPTYPATH (7.2+) reopen the fd directly, older ones need /proc/self/fd/ for anything
+         * but directories.
+         *
          * If AT_FDCWD is specified as file descriptor gets an fd to the current cwd.
          *
          * If XAT_FDROOT is specified as fd get an fd to the root directory.
@@ -815,7 +818,24 @@ int fd_reopen(int fd, int flags) {
         if (fd == XAT_FDROOT)
                 return RET_NERRNO(open("/", flags | O_DIRECTORY));
 
-        if (FLAGS_SET(flags, O_DIRECTORY) || fd == AT_FDCWD)
+        if (fd == AT_FDCWD)
+                return RET_NERRNO(openat(AT_FDCWD, ".", flags | O_DIRECTORY));
+
+        /* Kernels since 7.2 reopen the fd itself when passed an empty path with O_EMPTYPATH. */
+        static int have_emptypath = -1;
+        if (have_emptypath != 0) {
+                int new_fd = openat(fd, "", flags | O_EMPTYPATH);
+                if (new_fd >= 0) {
+                        have_emptypath = 1;
+                        return new_fd;
+                }
+                if (errno != ENOENT)
+                        return -errno;
+
+                have_emptypath = 0;
+        }
+
+        if (FLAGS_SET(flags, O_DIRECTORY))
                 /* If we shall reopen the fd as directory we can just go via "." and thus bypass the whole
                  * magic /proc/ directory, and make ourselves independent of that being mounted. */
                 return RET_NERRNO(openat(fd, ".", flags | O_DIRECTORY));

--- a/src/basic/fileio.c
+++ b/src/basic/fileio.c
@@ -1193,9 +1193,7 @@ static int search_and_open_internal(
                 _cleanup_close_ int fd = -EBADF;
 
                 if (ret_fd)
-                        /* We only specify 0777 here to appease static analyzers, it's never used since we
-                         * don't support O_CREAT here */
-                        r = fd = RET_NERRNO(open(path, mode, 0777));
+                        r = fd = xopenat_full(AT_FDCWD, path, mode, /* xopen_flags= */ 0, MODE_INVALID);
                 else
                         r = RET_NERRNO(access(path, mode));
                 if (r < 0)
@@ -1225,8 +1223,7 @@ static int search_and_open_internal(
                         return -ENOMEM;
 
                 if (ret_fd)
-                        /* as above, 0777 is static analyzer appeasement */
-                        r = fd = RET_NERRNO(open(p, mode, 0777));
+                        r = fd = xopenat_full(AT_FDCWD, p, mode, /* xopen_flags= */ 0, MODE_INVALID);
                 else
                         r = RET_NERRNO(access(p, F_OK));
                 if (r >= 0) {

--- a/src/basic/fileio.c
+++ b/src/basic/fileio.c
@@ -319,7 +319,7 @@ int write_string_file_full_label(
         /* We manually build our own version of fopen(..., "we") that works without O_CREAT and with O_NOFOLLOW if needed. */
         if (isempty(fn))
                 r = fd = fd_reopen(
-                                ASSERT_FD(dir_fd), O_CLOEXEC | O_NOCTTY |
+                                ASSERT_FD(dir_fd), O_NOCTTY |
                                 (FLAGS_SET(flags, WRITE_STRING_FILE_TRUNCATE) ? O_TRUNC : 0) |
                                 (FLAGS_SET(flags, WRITE_STRING_FILE_SUPPRESS_REDUNDANT_VIRTUAL) ? O_RDWR : O_WRONLY) |
                                 (FLAGS_SET(flags, WRITE_STRING_FILE_OPEN_NONBLOCKING) ? O_NONBLOCK : 0));
@@ -336,7 +336,7 @@ int write_string_file_full_label(
                 }
 
                 r = fd = openat_report_new(
-                                dir_fd, fn, O_CLOEXEC | O_NOCTTY |
+                                dir_fd, fn, O_NOCTTY |
                                 (FLAGS_SET(flags, WRITE_STRING_FILE_NOFOLLOW) ? O_NOFOLLOW : 0) |
                                 (FLAGS_SET(flags, WRITE_STRING_FILE_CREATE) ? O_CREAT : 0) |
                                 (FLAGS_SET(flags, WRITE_STRING_FILE_TRUNCATE) ? O_TRUNC : 0) |
@@ -538,7 +538,7 @@ int read_virtual_file_at(
 
         _cleanup_close_ int fd = -EBADF;
         if (isempty(filename))
-                fd = fd_reopen(ASSERT_FD(dir_fd), O_RDONLY | O_NOCTTY | O_CLOEXEC);
+                fd = fd_reopen(ASSERT_FD(dir_fd), O_RDONLY | O_NOCTTY);
         else
                 fd = RET_NERRNO(openat(dir_fd, filename, O_RDONLY | O_NOCTTY | O_CLOEXEC));
         if (fd < 0)
@@ -1720,7 +1720,7 @@ int write_data_file_atomic_at(
         }
 
         _cleanup_free_ char *t = NULL;
-        _cleanup_close_ int fd = open_tmpfile_linkable_at(dir_fd, fn, O_WRONLY|O_CLOEXEC, &t);
+        _cleanup_close_ int fd = open_tmpfile_linkable_at(dir_fd, fn, O_WRONLY, &t);
         if (fd < 0)
                 return fd;
 

--- a/src/basic/fileio.c
+++ b/src/basic/fileio.c
@@ -540,7 +540,7 @@ int read_virtual_file_at(
         if (isempty(filename))
                 fd = fd_reopen(ASSERT_FD(dir_fd), O_RDONLY | O_NOCTTY);
         else
-                fd = RET_NERRNO(openat(dir_fd, filename, O_RDONLY | O_NOCTTY | O_CLOEXEC));
+                fd = xopenat(dir_fd, filename, O_RDONLY | O_NOCTTY);
         if (fd < 0)
                 return fd;
 
@@ -990,9 +990,11 @@ DIR* xopendirat(int dir_fd, const char *path, int flags) {
                 flags |= O_NOFOLLOW;
         }
 
-        fd = openat(dir_fd, path, O_NONBLOCK|O_DIRECTORY|O_CLOEXEC|flags);
-        if (fd < 0)
+        fd = xopenat(dir_fd, path, O_NONBLOCK|O_DIRECTORY|flags);
+        if (fd < 0) {
+                errno = -fd;
                 return NULL;
+        }
 
         return take_fdopendir(&fd);
 }

--- a/src/basic/fileio.c
+++ b/src/basic/fileio.c
@@ -1059,10 +1059,8 @@ static int xfopenat_regular(int dir_fd, const char *path, const char *mode, int 
         if (mode_flags < 0)
                 return mode_flags;
 
-        if (isempty(path) && dir_fd == AT_FDCWD)
-                return -EBADF;
-
-        fd = xopenat_full(dir_fd, path, mode_flags | open_flags, /* xopen_flags= */ 0, 0666);
+        /* A NULL or empty path reopens dir_fd, unless something is to be created */
+        fd = xopenat_full(dir_fd, path, mode_flags | open_flags, XO_EMPTY_PATH, 0666);
         if (fd < 0)
                 return fd;
 

--- a/src/basic/fileio.c
+++ b/src/basic/fileio.c
@@ -1044,7 +1044,8 @@ int fopen_mode_to_flags(const char *mode) {
 }
 
 static int xfopenat_regular(int dir_fd, const char *path, const char *mode, int open_flags, FILE **ret) {
-        FILE *f;
+        _cleanup_close_ int fd = -EBADF;
+        int mode_flags;
 
         /* A combination of fopen() with openat() */
 
@@ -1052,37 +1053,18 @@ static int xfopenat_regular(int dir_fd, const char *path, const char *mode, int 
         assert(mode);
         assert(ret);
 
-        if (dir_fd == AT_FDCWD && path && open_flags == 0)
-                f = fopen(path, mode);
-        else if (dir_fd == XAT_FDROOT && path && open_flags == 0) {
-                _cleanup_free_ char *j = strjoin("/", path);
-                if (!j)
-                        return -ENOMEM;
+        mode_flags = fopen_mode_to_flags(mode);
+        if (mode_flags < 0)
+                return mode_flags;
 
-                f = fopen(j, mode);
-        } else {
-                _cleanup_close_ int fd = -EBADF;
-                int mode_flags;
+        if (isempty(path) && dir_fd == AT_FDCWD)
+                return -EBADF;
 
-                mode_flags = fopen_mode_to_flags(mode);
-                if (mode_flags < 0)
-                        return mode_flags;
+        fd = xopenat_full(dir_fd, path, mode_flags | open_flags, /* xopen_flags= */ 0, 0666);
+        if (fd < 0)
+                return fd;
 
-                if (path) {
-                        fd = openat(dir_fd, path, mode_flags | open_flags);
-                        if (fd < 0)
-                                return -errno;
-                } else {
-                        if (dir_fd == AT_FDCWD)
-                                return -EBADF;
-
-                        fd = fd_reopen(dir_fd, (mode_flags | open_flags) & ~O_NOFOLLOW);
-                        if (fd < 0)
-                                return fd;
-                }
-
-                f = take_fdopen(&fd, mode);
-        }
+        FILE *f = take_fdopen(&fd, mode);
         if (!f)
                 return -errno;
 

--- a/src/basic/fs-util.c
+++ b/src/basic/fs-util.c
@@ -1091,7 +1091,7 @@ int openat_report_new(int dirfd, const char *pathname, int flags, mode_t mode, b
          * Note that this routine is a bit more strict with symlinks than regular openat() is. If O_NOFOLLOW
          * is not specified, then we'll follow the symlink when opening an existing file but we will *not*
          * follow it when creating a new one (because that's a terrible UNIX misfeature and generally a
-         * security hole).
+         * security hole), and report -ELOOP in that case.
          *
          * O_CLOEXEC is always set. */
 
@@ -1127,6 +1127,11 @@ int openat_report_new(int dirfd, const char *pathname, int flags, mode_t mode, b
                 }
                 if (errno != EEXIST)
                         return -errno;
+
+                /* If this is a dangling symlink don't needlessly retry. Just report it like O_NOFOLLOW would. */
+                struct stat st;
+                if (fstatat(dirfd, pathname, &st, AT_SYMLINK_NOFOLLOW) >= 0 && S_ISLNK(st.st_mode))
+                        return -ELOOP;
 
                 /* Hmm, so now we got EEXIST? Then someone might have created the file between the first and
                  * second call to openat(). Let's try again but with a limit so we don't spin forever. */

--- a/src/basic/fs-util.c
+++ b/src/basic/fs-util.c
@@ -1196,9 +1196,8 @@ int xopenat_full_label(int dir_fd, const char *path, int open_flags, XOpenFlags 
         assert(directory + FLAGS_SET(xopen_flags, XO_REGULAR) + FLAGS_SET(xopen_flags, XO_SOCKET) <= 1);
         /* O_TMPFILE yields a nameless, regular, writable file: nothing to pin, verify, label or retry read-only */
         assert(!is_tmpfile || !(open_flags & (O_PATH|O_CREAT)));
-        assert(!is_tmpfile || !(xopen_flags & (XO_LABEL|XO_SUBVOLUME|XO_REGULAR|XO_SOCKET|XO_TRIGGER_AUTOMOUNT|XO_AUTO_RW_RO)));
-        /* The reopen path taken for an empty path has no mode to pass, O_TMPFILE needs the parent's name */
-        assert(!is_tmpfile || !isempty(path));
+        assert(!is_tmpfile || !(xopen_flags & (XO_LABEL|XO_SUBVOLUME|XO_REGULAR|XO_SOCKET)));
+        assert(!is_tmpfile || !(xopen_flags & (XO_TRIGGER_AUTOMOUNT|XO_AUTO_RW_RO)));
         /* Sockets cannot be open()ed, only pinned via O_PATH. */
         assert(!FLAGS_SET(xopen_flags, XO_SOCKET) || FLAGS_SET(open_flags, O_PATH));
         /* XO_TRIGGER_AUTOMOUNT requires O_PATH and does not support creating inodes. XO_SUBVOLUME
@@ -1220,7 +1219,9 @@ int xopenat_full_label(int dir_fd, const char *path, int open_flags, XOpenFlags 
          *
          *   • If O_CREAT is used with XO_LABEL, any created file will be immediately relabelled.
          *
-         *   • If the path is specified NULL or empty, behaves like fd_reopen().
+         *   • If XO_EMPTY_PATH is specified and the path is NULL or empty, behaves like fd_reopen(), similar to
+         *     AT_EMPTY_PATH. Without the flag an empty path fails with -ENOENT, as for open(). Creating an inode
+         *     needs a name, O_CREAT and O_TMPFILE with an empty path fail with -ENOENT either way.
          *
          *   • If XO_COW or XO_NOCOW is specified will turn off or on the NOCOW btrfs flag on the file, if
          *     available.
@@ -1258,7 +1259,12 @@ int xopenat_full_label(int dir_fd, const char *path, int open_flags, XOpenFlags 
         }
 
         if (isempty(path)) {
-                assert(!FLAGS_SET(open_flags, O_CREAT|O_EXCL));
+                if (!FLAGS_SET(xopen_flags, XO_EMPTY_PATH)) /* No name to open, as for open("") */
+                        return -ENOENT;
+
+                if (FLAGS_SET(open_flags, O_CREAT) || is_tmpfile) /* Creating an inode needs a name */
+                        return -ENOENT;
+
                 open_flags &= ~O_NOFOLLOW;
 
                 if (FLAGS_SET(xopen_flags, XO_REGULAR)) {
@@ -1580,7 +1586,7 @@ int linkat_replace(int olddirfd, const char *oldpath, int newdirfd, const char *
         if (r != -EEXIST)
                 return r;
 
-        old_fd = xopenat(olddirfd, oldpath, O_PATH);
+        old_fd = xopenat_full(olddirfd, oldpath, O_PATH, XO_EMPTY_PATH, MODE_INVALID); /* oldpath may be NULL */
         if (old_fd < 0)
                 return old_fd;
 

--- a/src/basic/fs-util.c
+++ b/src/basic/fs-util.c
@@ -1049,8 +1049,8 @@ int open_mkdir_at_full_label(int dirfd, const char *path, int flags, XOpenFlags 
         if ((flags & O_ACCMODE_STRICT) != O_RDONLY)
                 return -EINVAL;
 
-        /* Note that O_DIRECTORY|O_NOFOLLOW is implied, but we allow specifying it anyway. The following
-         * flags actually make sense to specify: O_CLOEXEC, O_EXCL, O_NOATIME, O_PATH */
+        /* Note that O_DIRECTORY|O_NOFOLLOW|O_CLOEXEC is implied, but we allow specifying it anyway. The
+         * following flags actually make sense to specify: O_EXCL, O_NOATIME, O_PATH */
 
         /* If this is not a valid filename, it's a path. Let's open the parent directory then, so
          * that we can pin it, and operate below it. */
@@ -1090,7 +1090,11 @@ int openat_report_new(int dirfd, const char *pathname, int flags, mode_t mode, b
          * Note that this routine is a bit more strict with symlinks than regular openat() is. If O_NOFOLLOW
          * is not specified, then we'll follow the symlink when opening an existing file but we will *not*
          * follow it when creating a new one (because that's a terrible UNIX misfeature and generally a
-         * security hole). */
+         * security hole).
+         *
+         * O_CLOEXEC is always set. */
+
+        flags |= O_CLOEXEC;
 
         if (!FLAGS_SET(flags, O_CREAT) || FLAGS_SET(flags, O_EXCL)) {
                 fd = openat(dirfd, pathname, flags, mode);
@@ -1217,7 +1221,11 @@ int xopenat_full_label(int dir_fd, const char *path, int open_flags, XOpenFlags 
          *   • The dir fd can be passed as XAT_FDROOT, in which case any relative paths will be taken relative to the root fs.
          *
          *   • If XO_AUTO_RW_RO is specified and the file cannot be opened in O_RDWR mode due to EACCES/EROFS or similar, retry in O_RDONLY mode.
+         *
+         *   • O_CLOEXEC is always set, use fd_cloexec() on the result to turn it off.
          */
+
+        open_flags |= O_CLOEXEC;
 
         if (mode == MODE_INVALID)
                 mode = (open_flags & O_DIRECTORY) ? 0755 : 0644;

--- a/src/basic/fs-util.c
+++ b/src/basic/fs-util.c
@@ -191,16 +191,16 @@ int chmod_and_chown_at(int dir_fd, const char *path, mode_t mode, uid_t uid, gid
 
         if (path) {
                 /* Let's acquire an O_PATH fd, as precaution to change mode/owner on the same file */
-                fd = openat(dir_fd, path, O_PATH|O_CLOEXEC|O_NOFOLLOW);
+                fd = xopenat(dir_fd, path, O_PATH|O_NOFOLLOW);
                 if (fd < 0)
-                        return -errno;
+                        return fd;
                 dir_fd = fd;
 
         } else if (dir_fd == AT_FDCWD) {
                 /* Let's acquire an O_PATH fd of the current directory */
-                fd = openat(dir_fd, ".", O_PATH|O_CLOEXEC|O_NOFOLLOW|O_DIRECTORY);
+                fd = fd_reopen(dir_fd, O_PATH|O_DIRECTORY);
                 if (fd < 0)
-                        return -errno;
+                        return fd;
                 dir_fd = fd;
         }
 
@@ -403,16 +403,17 @@ int touch_file(const char *path, bool parents, usec_t stamp, uid_t uid, gid_t gi
         /* Initially, we try to open the node with O_PATH, so that we get a reference to the node. This is useful in
          * case the path refers to an existing device or socket node, as we can open it successfully in all cases, and
          * won't trigger any driver magic or so. */
-        fd = open(path, O_PATH|O_CLOEXEC|O_NOFOLLOW);
+        fd = xopenat(AT_FDCWD, path, O_PATH|O_NOFOLLOW);
         if (fd < 0) {
-                if (errno != ENOENT)
-                        return -errno;
+                if (fd != -ENOENT)
+                        return fd;
 
                 /* if the node doesn't exist yet, we create it, but with O_EXCL, so that we only create a regular file
                  * here, and nothing else */
-                fd = open(path, O_WRONLY|O_CREAT|O_EXCL|O_CLOEXEC, IN_SET(mode, 0, MODE_INVALID) ? 0644 : mode);
+                fd = xopenat_full(AT_FDCWD, path, O_WRONLY|O_CREAT|O_EXCL, /* xopen_flags= */ 0,
+                                  IN_SET(mode, 0, MODE_INVALID) ? 0644 : mode);
                 if (fd < 0)
-                        return -errno;
+                        return fd;
         }
 
         /* Let's make a path from the fd, and operate on that. With this logic, we can adjust the access mode,
@@ -737,18 +738,18 @@ int unlinkat_deallocate(int fd, const char *name, UnlinkDeallocateFlags flags) {
          * primary job – to delete the file – is accomplished. */
 
         if (!FLAGS_SET(flags, UNLINK_REMOVEDIR)) {
-                truncate_fd = openat(fd, name, O_WRONLY|O_CLOEXEC|O_NOCTTY|O_NOFOLLOW|O_NONBLOCK);
+                truncate_fd = xopenat(fd, name, O_WRONLY|O_NOCTTY|O_NOFOLLOW|O_NONBLOCK);
                 if (truncate_fd < 0) {
 
                         /* If this failed because the file doesn't exist propagate the error right-away. Also,
                          * AT_REMOVEDIR wasn't set, and we tried to open the file for writing, which means EISDIR is
                          * returned when this is a directory but we are not supposed to delete those, hence propagate
                          * the error right-away too. */
-                        if (IN_SET(errno, ENOENT, EISDIR))
-                                return -errno;
+                        if (IN_SET(truncate_fd, -ENOENT, -EISDIR))
+                                return truncate_fd;
 
-                        if (errno != ELOOP) /* don't complain if this is a symlink */
-                                log_debug_errno(errno, "Failed to open file '%s' for deallocation, ignoring: %m", name);
+                        if (truncate_fd != -ELOOP) /* don't complain if this is a symlink */
+                                log_debug_errno(truncate_fd, "Failed to open file '%s' for deallocation, ignoring: %m", name);
                 }
         }
 
@@ -864,11 +865,11 @@ int conservative_renameat(
          * too much. I.e. whenever we are in doubt, we rather rename than fail. After all reducing inotify
          * events is an optimization only, not more. */
 
-        old_fd = openat(olddirfd, oldpath, O_CLOEXEC|O_RDONLY|O_NOCTTY|O_NOFOLLOW);
+        old_fd = xopenat(olddirfd, oldpath, O_RDONLY|O_NOCTTY|O_NOFOLLOW);
         if (old_fd < 0)
                 goto do_rename;
 
-        new_fd = openat(newdirfd, newpath, O_CLOEXEC|O_RDONLY|O_NOCTTY|O_NOFOLLOW);
+        new_fd = xopenat(newdirfd, newpath, O_RDONLY|O_NOCTTY|O_NOFOLLOW);
         if (new_fd < 0)
                 goto do_rename;
 

--- a/src/basic/fs-util.c
+++ b/src/basic/fs-util.c
@@ -1574,7 +1574,7 @@ int linkat_replace(int olddirfd, const char *oldpath, int newdirfd, const char *
         if (r != -EEXIST)
                 return r;
 
-        old_fd = xopenat(olddirfd, oldpath, O_PATH|O_CLOEXEC);
+        old_fd = xopenat(olddirfd, oldpath, O_PATH);
         if (old_fd < 0)
                 return old_fd;
 

--- a/src/basic/fs-util.c
+++ b/src/basic/fs-util.c
@@ -847,7 +847,7 @@ int open_parent_at(int dir_fd, const char *path, int flags, mode_t mode) {
         if (!FLAGS_SET(flags, O_TMPFILE))
                 flags |= O_DIRECTORY;
 
-        return RET_NERRNO(openat(dir_fd, parent, flags, mode));
+        return xopenat_full(dir_fd, parent, flags, /* xopen_flags= */ 0, mode);
 }
 
 int conservative_renameat(
@@ -1182,8 +1182,17 @@ int xopenat_full_label(int dir_fd, const char *path, int open_flags, XOpenFlags 
 
         assert(wildcard_fd_is_valid(dir_fd));
 
+        /* O_TMPFILE carries O_DIRECTORY, but names the parent and yields a regular file */
+        bool is_tmpfile = FLAGS_SET(open_flags, O_TMPFILE);
+        bool directory = FLAGS_SET(open_flags, O_DIRECTORY) && !is_tmpfile;
+
         /* An inode can only be one of a directory, a regular file or a socket at the same time. */
-        assert(FLAGS_SET(open_flags, O_DIRECTORY) + FLAGS_SET(xopen_flags, XO_REGULAR) + FLAGS_SET(xopen_flags, XO_SOCKET) <= 1);
+        assert(directory + FLAGS_SET(xopen_flags, XO_REGULAR) + FLAGS_SET(xopen_flags, XO_SOCKET) <= 1);
+        /* O_TMPFILE yields a nameless, regular, writable file: nothing to pin, verify, label or retry read-only */
+        assert(!is_tmpfile || !(open_flags & (O_PATH|O_CREAT)));
+        assert(!is_tmpfile || !(xopen_flags & (XO_LABEL|XO_SUBVOLUME|XO_REGULAR|XO_SOCKET|XO_TRIGGER_AUTOMOUNT|XO_AUTO_RW_RO)));
+        /* The reopen path taken for an empty path has no mode to pass, O_TMPFILE needs the parent's name */
+        assert(!is_tmpfile || !isempty(path));
         /* Sockets cannot be open()ed, only pinned via O_PATH. */
         assert(!FLAGS_SET(xopen_flags, XO_SOCKET) || FLAGS_SET(open_flags, O_PATH));
         /* XO_TRIGGER_AUTOMOUNT requires O_PATH and does not support creating inodes. XO_SUBVOLUME
@@ -1223,15 +1232,17 @@ int xopenat_full_label(int dir_fd, const char *path, int open_flags, XOpenFlags 
          *   • If XO_AUTO_RW_RO is specified and the file cannot be opened in O_RDWR mode due to EACCES/EROFS or similar, retry in O_RDONLY mode.
          *
          *   • O_CLOEXEC is always set, use fd_cloexec() on the result to turn it off.
+         *
+         *   • O_TMPFILE is supported, the path then refers to the directory to create the anonymous file in.
          */
 
         open_flags |= O_CLOEXEC;
 
         if (mode == MODE_INVALID)
-                mode = (open_flags & O_DIRECTORY) ? 0755 : 0644;
+                mode = directory ? 0755 : 0644;
 
         if (FLAGS_SET(xopen_flags, XO_AUTO_RW_RO)) {
-                if (open_flags & O_DIRECTORY) {
+                if (directory) {
                         /* Directories can only be opened in read-only mode */
                         xopen_flags &= ~XO_AUTO_RW_RO;
                         open_flags |= O_RDONLY;
@@ -1284,14 +1295,14 @@ int xopenat_full_label(int dir_fd, const char *path, int open_flags, XOpenFlags 
         bool call_label_ops_post = false;
 
         if (FLAGS_SET(open_flags, O_CREAT) && FLAGS_SET(xopen_flags, XO_LABEL)) {
-                r = label_ops_pre(dir_fd, path, FLAGS_SET(open_flags, O_DIRECTORY) ? S_IFDIR : S_IFREG, label_context);
+                r = label_ops_pre(dir_fd, path, directory ? S_IFDIR : S_IFREG, label_context);
                 if (r < 0)
                         return r;
 
                 call_label_ops_post = true;
         }
 
-        if (FLAGS_SET(open_flags, O_DIRECTORY|O_CREAT)) {
+        if (directory && FLAGS_SET(open_flags, O_CREAT)) {
                 if (FLAGS_SET(xopen_flags, XO_SUBVOLUME))
                         r = btrfs_subvol_make_fallback(dir_fd, path, mode);
                 else

--- a/src/basic/fs-util.h
+++ b/src/basic/fs-util.h
@@ -120,6 +120,7 @@ typedef enum XOpenFlags {
         XO_SOCKET            = 1 << 5, /* Fail if the inode is not a socket */
         XO_TRIGGER_AUTOMOUNT = 1 << 6, /* Trigger automounts via open_tree(). Requires O_PATH. */
         XO_AUTO_RW_RO        = 1 << 7, /* Open in O_RDWR mode if possible, O_RDONLY if not */
+        XO_EMPTY_PATH        = 1 << 8, /* Reopen dir_fd if the path is NULL or empty, like AT_EMPTY_PATH */
 } XOpenFlags;
 
 int open_mkdir_at_full_label(int dirfd, const char *path, int flags, XOpenFlags xopen_flags, mode_t mode, LabelContext *label_context);

--- a/src/basic/locale-util.c
+++ b/src/basic/locale-util.c
@@ -11,6 +11,7 @@
 #include "env-util.h"
 #include "fd-util.h"
 #include "fileio.h"
+#include "fs-util.h"
 #include "locale-util.h"
 #include "log.h"
 #include "path-util.h"
@@ -108,9 +109,9 @@ static int add_locales_from_archive(Set *locales) {
         if (!locale_archive_file)
                 return -ENOMEM;
 
-        _cleanup_close_ int fd = open(locale_archive_file, O_RDONLY|O_NOCTTY|O_CLOEXEC);
+        _cleanup_close_ int fd = xopenat(AT_FDCWD, locale_archive_file, O_RDONLY|O_NOCTTY);
         if (fd < 0)
-                return errno == ENOENT ? 0 : -errno;
+                return fd == -ENOENT ? 0 : fd;
 
         struct stat st;
         if (fstat(fd, &st) < 0)

--- a/src/basic/lock-util.c
+++ b/src/basic/lock-util.c
@@ -33,7 +33,7 @@ int make_lock_file_at(int dir_fd, const char *p, int operation, LockFile *ret) {
 
         /* We use UNPOSIX locks as they have nice semantics, and are mostly compatible with NFS. */
 
-        dfd = fd_reopen(dir_fd, O_CLOEXEC|O_PATH|O_DIRECTORY);
+        dfd = fd_reopen(dir_fd, O_PATH|O_DIRECTORY);
         if (dfd < 0)
                 return dfd;
 
@@ -43,7 +43,7 @@ int make_lock_file_at(int dir_fd, const char *p, int operation, LockFile *ret) {
 
         fd = xopenat_lock_full(dfd,
                                p,
-                               O_CREAT|O_RDWR|O_NOFOLLOW|O_CLOEXEC|O_NOCTTY,
+                               O_CREAT|O_RDWR|O_NOFOLLOW|O_NOCTTY,
                                /* xopen_flags= */ 0,
                                0600,
                                LOCK_UNPOSIX,

--- a/src/basic/log.c
+++ b/src/basic/log.c
@@ -17,6 +17,7 @@
 #include "extract-word.h"
 #include "fd-util.h"
 #include "format-util.h"
+#include "fs-util.h"
 #include "iovec-util.h"
 #include "list.h"
 #include "log.h"
@@ -131,9 +132,9 @@ static int log_open_kmsg(void) {
         if (kmsg_fd >= 0)
                 return 0;
 
-        kmsg_fd = open("/dev/kmsg", O_WRONLY|O_NOCTTY|O_CLOEXEC);
+        kmsg_fd = xopenat(AT_FDCWD, "/dev/kmsg", O_WRONLY|O_NOCTTY);
         if (kmsg_fd < 0)
-                return -errno;
+                return kmsg_fd;
 
         kmsg_fd = fd_move_above_stdio(kmsg_fd);
         return 0;

--- a/src/basic/log.c
+++ b/src/basic/log.c
@@ -110,7 +110,7 @@ static int log_open_console(void) {
         if (console_fd < 3) {
                 int fd;
 
-                fd = open_terminal("/dev/console", O_WRONLY|O_NOCTTY|O_CLOEXEC);
+                fd = open_terminal("/dev/console", O_WRONLY|O_NOCTTY);
                 if (fd < 0)
                         return fd;
 

--- a/src/basic/mkdir.c
+++ b/src/basic/mkdir.c
@@ -155,9 +155,9 @@ int mkdir_parents_internal(const char *prefix, const char *path, mode_t mode, ui
                 if (!p)
                         return -EINVAL;
 
-                fd = open(prefix, O_PATH|O_DIRECTORY|O_CLOEXEC);
+                fd = xopenat(AT_FDCWD, prefix, O_PATH|O_DIRECTORY);
                 if (fd < 0)
-                        return -errno;
+                        return fd;
         } else
                 p = path;
 
@@ -214,9 +214,9 @@ int mkdir_p_root_full(const char *root, const char *p, uid_t uid, gid_t gid, mod
         r = path_extract_directory(p, &pp);
         if (r == -EDESTADDRREQ) {
                 /* only fname is passed, no prefix to operate on */
-                dfd = open(".", O_RDONLY|O_CLOEXEC|O_DIRECTORY);
+                dfd = fd_reopen(AT_FDCWD, O_RDONLY|O_DIRECTORY);
                 if (dfd < 0)
-                        return -errno;
+                        return dfd;
         } else if (r == -EADDRNOTAVAIL)
                 /* only root dir or "." was passed, i.e. there is no parent to extract, in that case there's nothing to do. */
                 return 0;

--- a/src/basic/mkdir.c
+++ b/src/basic/mkdir.c
@@ -228,7 +228,7 @@ int mkdir_p_root_full(const char *root, const char *p, uid_t uid, gid_t gid, mod
                 if (r < 0)
                         return r;
 
-                dfd = chase_and_open(pp, root, CHASE_PREFIX_ROOT, O_CLOEXEC|O_DIRECTORY, NULL);
+                dfd = chase_and_open(pp, root, CHASE_PREFIX_ROOT, O_DIRECTORY, /* ret_path= */ NULL);
                 if (dfd < 0)
                         return dfd;
         }
@@ -248,7 +248,7 @@ int mkdir_p_root_full(const char *root, const char *p, uid_t uid, gid_t gid, mod
 
         _cleanup_close_ int nfd = xopenat_full(
                                 dfd, bn,
-                                O_DIRECTORY|O_CREAT|O_EXCL|O_NOFOLLOW|O_CLOEXEC,
+                                O_DIRECTORY|O_CREAT|O_EXCL|O_NOFOLLOW,
                                 flags,
                                 m);
         if (nfd == -EEXIST)

--- a/src/basic/mountpoint-util.c
+++ b/src/basic/mountpoint-util.c
@@ -607,9 +607,9 @@ int mount_nofollow(
          * Note that this disables following only for the final component of the target, i.e symlinks within
          * the path of the target are honoured, as are symlinks in the source path everywhere. */
 
-        fd = open(target, O_PATH|O_CLOEXEC|O_NOFOLLOW);
+        fd = xopenat(AT_FDCWD, target, O_PATH|O_NOFOLLOW);
         if (fd < 0)
-                return -errno;
+                return fd;
 
         return mount_fd(source, fd, filesystemtype, mountflags, data);
 }

--- a/src/basic/namespace-util.c
+++ b/src/basic/namespace-util.c
@@ -14,6 +14,7 @@
 #include "errno-util.h"
 #include "fd-util.h"
 #include "fileio.h"
+#include "fs-util.h"
 #include "log.h"
 #include "mountpoint-util.h"
 #include "namespace-util.h"
@@ -86,7 +87,7 @@ static int pidref_namespace_open_by_type_internal(const PidRef *pidref, Namespac
         const char *p;
 
         p = pid_namespace_path(pidref->pid, type);
-        nsfd = RET_NERRNO(open(p, O_RDONLY|O_NOCTTY|O_CLOEXEC));
+        nsfd = xopenat(AT_FDCWD, p, O_RDONLY|O_NOCTTY);
         if (nsfd == -ENOENT) {
                 r = proc_mounted();
                 if (r == 0)
@@ -179,7 +180,7 @@ int pidref_namespace_open(
                 const char *root;
 
                 root = procfs_file_alloca(pidref->pid, "root");
-                root_fd = RET_NERRNO(open(root, O_CLOEXEC|O_DIRECTORY));
+                root_fd = xopenat(AT_FDCWD, root, O_DIRECTORY);
                 if (root_fd == -ENOENT && proc_mounted() == 0)
                         return -ENOSYS;
                 if (root_fd < 0)

--- a/src/basic/os-util.c
+++ b/src/basic/os-util.c
@@ -191,9 +191,9 @@ int open_os_release(const char *root, char **ret_path, int *ret_fd) {
         int r;
 
         if (!empty_or_root(root)) {
-                rfd = open(root, O_CLOEXEC | O_DIRECTORY | O_PATH);
+                rfd = xopenat(AT_FDCWD, root, O_DIRECTORY | O_PATH);
                 if (rfd < 0)
-                        return -errno;
+                        return rfd;
         }
 
         r = open_os_release_at(rfd, ret_path ? &p : NULL, ret_fd ? &fd : NULL);
@@ -273,9 +273,9 @@ int open_extension_release_at(
 
                 /* We already chased the directory, and checked that this is a real file, so we shouldn't
                  * fail to open it. */
-                fd = openat(dirfd(dir), de->d_name, O_PATH|O_CLOEXEC|O_NOFOLLOW);
+                fd = xopenat(dirfd(dir), de->d_name, O_PATH|O_NOFOLLOW);
                 if (fd < 0)
-                        return log_debug_errno(errno, "Failed to open release file %s/%s: %m", dir_path, de->d_name);
+                        return log_debug_errno(fd, "Failed to open release file %s/%s: %m", dir_path, de->d_name);
 
                 /* Really ensure it is a regular file after we open it. */
                 r = fd_verify_regular(fd);
@@ -339,9 +339,9 @@ int open_extension_release(
         int r;
 
         if (!empty_or_root(root)) {
-                rfd = open(root, O_CLOEXEC | O_DIRECTORY | O_PATH);
+                rfd = xopenat(AT_FDCWD, root, O_DIRECTORY | O_PATH);
                 if (rfd < 0)
-                        return -errno;
+                        return rfd;
         }
 
         r = open_extension_release_at(rfd, image_class, extension, relax_extension_release_check,
@@ -411,9 +411,9 @@ int parse_extension_release_sentinel(
         int r;
 
         if (!empty_or_root(root)) {
-                rfd = open(root, O_CLOEXEC | O_DIRECTORY | O_PATH);
+                rfd = xopenat(AT_FDCWD, root, O_DIRECTORY | O_PATH);
                 if (rfd < 0)
-                        return -errno;
+                        return rfd;
         }
 
         va_start(ap, extension);

--- a/src/basic/path-util.c
+++ b/src/basic/path-util.c
@@ -677,9 +677,9 @@ int open_and_check_executable(const char *name, const char *root, char **ret_pat
         } else {
                 /* We need to use O_PATH because there may be executables for which we have only exec permissions,
                  * but not read (usually suid executables). */
-                fd = open(name, O_PATH|O_CLOEXEC);
+                fd = xopenat(AT_FDCWD, name, O_PATH);
                 if (fd < 0)
-                        return -errno;
+                        return fd;
         }
 
         r = fd_verify_regular(fd);

--- a/src/basic/process-util.c
+++ b/src/basic/process-util.c
@@ -2123,9 +2123,9 @@ int posix_spawn_wrapper(
                 if (r < 0)
                         return r;
 
-                cgroup_fd = open(resolved_cgroup, O_PATH|O_DIRECTORY|O_CLOEXEC);
+                cgroup_fd = xopenat(AT_FDCWD, resolved_cgroup, O_PATH|O_DIRECTORY);
                 if (cgroup_fd < 0)
-                        return -errno;
+                        return cgroup_fd;
 
                 r = posix_spawnattr_setcgroup_np(&attr, cgroup_fd);
                 if (r == 0)

--- a/src/basic/random-util.c
+++ b/src/basic/random-util.c
@@ -13,6 +13,7 @@
 #include "alloc-util.h"
 #include "fd-util.h"
 #include "fileio.h"
+#include "fs-util.h"
 #include "io-util.h"
 #include "iovec-util.h"
 #include "log.h"
@@ -88,7 +89,7 @@ void random_bytes(void *p, size_t n) {
                 /* Interrupted by a signal; keep going. */
         }
 
-        _cleanup_close_ int fd = open("/dev/urandom", O_RDONLY|O_CLOEXEC|O_NOCTTY);
+        _cleanup_close_ int fd = xopenat(AT_FDCWD, "/dev/urandom", O_RDONLY|O_NOCTTY);
         if (fd >= 0 && loop_read_exact(fd, p, n, false) >= 0)
                 return;
 
@@ -184,9 +185,9 @@ int random_write_entropy(int fd, const void *seed, size_t size, bool credit) {
                 return 0;
 
         if (fd < 0) {
-                opened_fd = open("/dev/urandom", O_WRONLY|O_CLOEXEC|O_NOCTTY);
+                opened_fd = xopenat(AT_FDCWD, "/dev/urandom", O_WRONLY|O_NOCTTY);
                 if (opened_fd < 0)
-                        return -errno;
+                        return opened_fd;
 
                 fd = opened_fd;
         }

--- a/src/basic/recurse-dir.c
+++ b/src/basic/recurse-dir.c
@@ -258,18 +258,18 @@ int recurse_dir(
                         p = i->d_name;
 
                 if (IN_SET(i->d_type, DT_UNKNOWN, DT_DIR)) {
-                        subdir_fd = openat(dir_fd, i->d_name, O_DIRECTORY|O_NOFOLLOW|O_CLOEXEC);
+                        subdir_fd = xopenat(dir_fd, i->d_name, O_DIRECTORY|O_NOFOLLOW);
                         if (subdir_fd < 0) {
-                                if (errno == ENOENT) /* Vanished by now, go for next file immediately */
+                                if (subdir_fd == -ENOENT) /* Vanished by now, go for next file immediately */
                                         continue;
 
                                 /* If it is a subdir but we failed to open it, then fail */
-                                if (!IN_SET(errno, ENOTDIR, ELOOP)) {
-                                        log_debug_errno(errno, "Failed to open directory '%s': %m", p);
+                                if (!IN_SET(subdir_fd, -ENOTDIR, -ELOOP)) {
+                                        log_debug_errno(subdir_fd, "Failed to open directory '%s': %m", p);
 
-                                        assert(errno <= RECURSE_DIR_SKIP_OPEN_DIR_ERROR_MAX - RECURSE_DIR_SKIP_OPEN_DIR_ERROR_BASE);
+                                        assert(-subdir_fd <= RECURSE_DIR_SKIP_OPEN_DIR_ERROR_MAX - RECURSE_DIR_SKIP_OPEN_DIR_ERROR_BASE);
 
-                                        r = func(RECURSE_DIR_SKIP_OPEN_DIR_ERROR_BASE + errno,
+                                        r = func(RECURSE_DIR_SKIP_OPEN_DIR_ERROR_BASE - subdir_fd,
                                                  p,
                                                  dir_fd,
                                                  /* inode_fd= */ -EBADF,
@@ -304,16 +304,16 @@ int recurse_dir(
 
                         if (flags & RECURSE_DIR_INODE_FD) {
 
-                                inode_fd = openat(dir_fd, i->d_name, O_PATH|O_NOFOLLOW|O_CLOEXEC);
+                                inode_fd = xopenat(dir_fd, i->d_name, O_PATH|O_NOFOLLOW);
                                 if (inode_fd < 0) {
-                                        if (errno == ENOENT) /* Vanished by now, go for next file immediately */
+                                        if (inode_fd == -ENOENT) /* Vanished by now, go for next file immediately */
                                                 continue;
 
-                                        log_debug_errno(errno, "Failed to open directory entry '%s': %m", p);
+                                        log_debug_errno(inode_fd, "Failed to open directory entry '%s': %m", p);
 
-                                        assert(errno <= RECURSE_DIR_SKIP_OPEN_INODE_ERROR_MAX - RECURSE_DIR_SKIP_OPEN_INODE_ERROR_BASE);
+                                        assert(-inode_fd <= RECURSE_DIR_SKIP_OPEN_INODE_ERROR_MAX - RECURSE_DIR_SKIP_OPEN_INODE_ERROR_BASE);
 
-                                        r = func(RECURSE_DIR_SKIP_OPEN_INODE_ERROR_BASE + errno,
+                                        r = func(RECURSE_DIR_SKIP_OPEN_INODE_ERROR_BASE - inode_fd,
                                                  p,
                                                  dir_fd,
                                                  /* inode_fd= */ -EBADF,
@@ -554,9 +554,9 @@ int recurse_dir_at(
         assert(atfd >= 0 || atfd == AT_FDCWD);
         assert(func);
 
-        fd = openat(atfd, path ?: ".", O_DIRECTORY|O_CLOEXEC);
+        fd = xopenat(atfd, path ?: ".", O_DIRECTORY);
         if (fd < 0)
-                return -errno;
+                return fd;
 
         return recurse_dir(fd, path, statx_mask, n_depth_max, flags, func, userdata);
 }

--- a/src/basic/recurse-dir.c
+++ b/src/basic/recurse-dir.c
@@ -175,7 +175,7 @@ int readdir_all_at(int fd, const char *path, RecurseDirFlags flags, DirectoryEnt
 
         assert(fd >= 0 || fd == AT_FDCWD);
 
-        dir_fd = xopenat(fd, path, O_DIRECTORY|O_CLOEXEC);
+        dir_fd = xopenat(fd, path, O_DIRECTORY);
         if (dir_fd < 0)
                 return dir_fd;
 
@@ -344,7 +344,7 @@ int recurse_dir(
                                          * directory fd — which should be riskless now that we pinned the
                                          * inode. */
 
-                                        subdir_fd = fd_reopen(inode_fd, O_DIRECTORY|O_CLOEXEC);
+                                        subdir_fd = fd_reopen(inode_fd, O_DIRECTORY);
                                         if (subdir_fd < 0)
                                                 return subdir_fd;
 

--- a/src/basic/socket-util.c
+++ b/src/basic/socket-util.c
@@ -22,6 +22,7 @@
 #include "fd-util.h"
 #include "format-ifname.h"
 #include "format-util.h"
+#include "fs-util.h"
 #include "in-addr-util.h"
 #include "io-util.h"
 #include "log.h"
@@ -1651,16 +1652,9 @@ int connect_unix_path(int fd, int dir_fd, const char *path) {
          * exist. If the path is too long, we also need to take the indirect route, since we can't fit this
          * into a sockaddr_un directly. */
 
-        if (dir_fd == XAT_FDROOT) {
-                _cleanup_free_ char *j = strjoin("/", path);
-                if (!j)
-                        return -ENOMEM;
-
-                inode_fd = open(j, O_PATH|O_CLOEXEC);
-        } else
-                inode_fd = openat(dir_fd, path, O_PATH|O_CLOEXEC);
+        inode_fd = xopenat(dir_fd, path, O_PATH);
         if (inode_fd < 0)
-                return -errno;
+                return inode_fd;
 
         return connect_unix_inode(fd, inode_fd);
 }

--- a/src/basic/stat-util.c
+++ b/src/basic/stat-util.c
@@ -294,7 +294,7 @@ int dir_is_empty_at(int dir_fd, const char *path, bool ignore_hidden_or_backup) 
         struct dirent *buf;
         size_t m;
 
-        fd = xopenat(dir_fd, path, O_DIRECTORY|O_CLOEXEC);
+        fd = xopenat(dir_fd, path, O_DIRECTORY);
         if (fd < 0)
                 return fd;
 
@@ -484,7 +484,7 @@ int xstatfsat(int dir_fd, const char *path, struct statfs *ret) {
         assert(ret);
 
         if (!isempty(path)) {
-                fd = xopenat(dir_fd, path, O_PATH|O_CLOEXEC);
+                fd = xopenat(dir_fd, path, O_PATH);
                 if (fd < 0)
                         return fd;
                 dir_fd = fd;

--- a/src/basic/stat-util.c
+++ b/src/basic/stat-util.c
@@ -517,9 +517,9 @@ int path_is_read_only_fs(const char *path) {
 
         assert(path);
 
-        fd = open(path, O_CLOEXEC | O_PATH);
+        fd = xopenat(AT_FDCWD, path, O_PATH);
         if (fd < 0)
-                return -errno;
+                return fd;
 
         return fd_is_read_only_fs(fd);
 }
@@ -548,9 +548,9 @@ int inode_same_at(int fda, const char *filea, int fdb, const char *fileb, int fl
                  * between via O_PATH, unless we already have an fd for it. */
 
                 if (!isempty(filea)) {
-                        pin_a = openat(fda, filea, O_PATH|O_CLOEXEC|(FLAGS_SET(flags, AT_SYMLINK_NOFOLLOW) ? O_NOFOLLOW : 0));
+                        pin_a = xopenat(fda, filea, O_PATH|(FLAGS_SET(flags, AT_SYMLINK_NOFOLLOW) ? O_NOFOLLOW : 0));
                         if (pin_a < 0)
-                                return -errno;
+                                return pin_a;
 
                         fda = pin_a;
                         filea = NULL;
@@ -558,9 +558,9 @@ int inode_same_at(int fda, const char *filea, int fdb, const char *fileb, int fl
                 }
 
                 if (!isempty(fileb)) {
-                        pin_b = openat(fdb, fileb, O_PATH|O_CLOEXEC|(FLAGS_SET(flags, AT_SYMLINK_NOFOLLOW) ? O_NOFOLLOW : 0));
+                        pin_b = xopenat(fdb, fileb, O_PATH|(FLAGS_SET(flags, AT_SYMLINK_NOFOLLOW) ? O_NOFOLLOW : 0));
                         if (pin_b < 0)
-                                return -errno;
+                                return pin_b;
 
                         fdb = pin_b;
                         fileb = NULL;

--- a/src/basic/stat-util.c
+++ b/src/basic/stat-util.c
@@ -294,7 +294,7 @@ int dir_is_empty_at(int dir_fd, const char *path, bool ignore_hidden_or_backup) 
         struct dirent *buf;
         size_t m;
 
-        fd = xopenat(dir_fd, path, O_DIRECTORY);
+        fd = xopenat_full(dir_fd, path, O_DIRECTORY, XO_EMPTY_PATH, MODE_INVALID); /* path may be NULL */
         if (fd < 0)
                 return fd;
 

--- a/src/basic/sync-util.c
+++ b/src/basic/sync-util.c
@@ -26,9 +26,9 @@ int fsync_directory_of_file(int fd) {
                 return -errno;
 
         if (S_ISDIR(st.st_mode)) {
-                dfd = openat(fd, "..", O_RDONLY|O_DIRECTORY|O_CLOEXEC, 0);
+                dfd = xopenat(fd, "..", O_RDONLY|O_DIRECTORY);
                 if (dfd < 0)
-                        return -errno;
+                        return dfd;
 
         } else if (!S_ISREG(st.st_mode)) { /* Regular files are OK regardless if O_PATH or not, for all other
                                             * types check O_PATH flag */
@@ -92,17 +92,17 @@ int fsync_path_at(int at_fd, const char *path) {
 
         if (isempty(path)) {
                 if (at_fd == AT_FDCWD) {
-                        opened_fd = open(".", O_RDONLY|O_DIRECTORY|O_CLOEXEC);
+                        opened_fd = fd_reopen(at_fd, O_RDONLY|O_DIRECTORY);
                         if (opened_fd < 0)
-                                return -errno;
+                                return opened_fd;
 
                         fd = opened_fd;
                 } else
                         fd = at_fd;
         } else {
-                opened_fd = openat(at_fd, path, O_RDONLY|O_CLOEXEC|O_NONBLOCK);
+                opened_fd = xopenat(at_fd, path, O_RDONLY|O_NONBLOCK);
                 if (opened_fd < 0)
-                        return -errno;
+                        return opened_fd;
 
                 fd = opened_fd;
         }
@@ -117,16 +117,16 @@ int fsync_parent_at(int at_fd, const char *path) {
                 if (at_fd != AT_FDCWD)
                         return fsync_directory_of_file(at_fd);
 
-                opened_fd = open("..", O_RDONLY|O_DIRECTORY|O_CLOEXEC);
+                opened_fd = xopenat(AT_FDCWD, "..", O_RDONLY|O_DIRECTORY);
                 if (opened_fd < 0)
-                        return -errno;
+                        return opened_fd;
 
                 return RET_NERRNO(fsync(opened_fd));
         }
 
-        opened_fd = openat(at_fd, path, O_PATH|O_CLOEXEC|O_NOFOLLOW);
+        opened_fd = xopenat(at_fd, path, O_PATH|O_NOFOLLOW);
         if (opened_fd < 0)
-                return -errno;
+                return opened_fd;
 
         return fsync_directory_of_file(opened_fd);
 }
@@ -138,11 +138,14 @@ int fsync_path_and_parent_at(int at_fd, const char *path) {
                 if (at_fd != AT_FDCWD)
                         return fsync_full(at_fd);
 
-                opened_fd = open(".", O_RDONLY|O_DIRECTORY|O_CLOEXEC);
-        } else
-                opened_fd = openat(at_fd, path, O_RDONLY|O_NOFOLLOW|O_NONBLOCK|O_CLOEXEC);
-        if (opened_fd < 0)
-                return -errno;
+                opened_fd = fd_reopen(at_fd, O_RDONLY|O_DIRECTORY);
+                if (opened_fd < 0)
+                        return opened_fd;
+        } else {
+                opened_fd = xopenat(at_fd, path, O_RDONLY|O_NOFOLLOW|O_NONBLOCK);
+                if (opened_fd < 0)
+                        return opened_fd;
+        }
 
         return fsync_full(opened_fd);
 }
@@ -154,11 +157,14 @@ int syncfs_path(int at_fd, const char *path) {
                 if (at_fd != AT_FDCWD)
                         return RET_NERRNO(syncfs(at_fd));
 
-                fd = open(".", O_RDONLY|O_DIRECTORY|O_CLOEXEC);
-        } else
-                fd = openat(at_fd, path, O_RDONLY|O_CLOEXEC|O_NONBLOCK);
-        if (fd < 0)
-                return -errno;
+                fd = fd_reopen(at_fd, O_RDONLY|O_DIRECTORY);
+                if (fd < 0)
+                        return fd;
+        } else {
+                fd = xopenat(at_fd, path, O_RDONLY|O_NONBLOCK);
+                if (fd < 0)
+                        return fd;
+        }
 
         return RET_NERRNO(syncfs(fd));
 }

--- a/src/basic/sync-util.c
+++ b/src/basic/sync-util.c
@@ -62,7 +62,7 @@ int fsync_directory_of_file(int fd) {
                 if (!path_is_absolute(path))
                         return -EINVAL;
 
-                dfd = open_parent(path, O_CLOEXEC|O_NOFOLLOW, 0);
+                dfd = open_parent(path, O_NOFOLLOW, /* mode= */ 0);
                 if (dfd < 0)
                         return dfd;
         }

--- a/src/basic/terminal-util.c
+++ b/src/basic/terminal-util.c
@@ -77,7 +77,7 @@ int chvt(int vt) {
         /* Switch to the specified vt number. If the VT is specified <= 0 switch to the VT the kernel log messages go,
          * if that's configured. */
 
-        fd = open_terminal("/dev/tty0", O_RDWR|O_NOCTTY|O_CLOEXEC|O_NONBLOCK);
+        fd = open_terminal("/dev/tty0", O_RDWR|O_NOCTTY|O_NONBLOCK);
         if (fd < 0)
                 return fd;
 
@@ -702,7 +702,7 @@ int acquire_terminal(
 
                 /* We pass here O_NOCTTY only so that we can check the return value TIOCSCTTY and have a reliable way
                  * to figure out if we successfully became the controlling process of the tty */
-                fd = open_terminal(name, O_RDWR|O_NOCTTY|O_CLOEXEC);
+                fd = open_terminal(name, O_RDWR|O_NOCTTY);
                 if (fd < 0)
                         return fd;
 
@@ -842,7 +842,7 @@ int terminal_vhangup(const char *tty) {
 
         assert(tty);
 
-        fd = open_terminal(tty, O_RDWR|O_NOCTTY|O_CLOEXEC);
+        fd = open_terminal(tty, O_RDWR|O_NOCTTY);
         if (fd < 0)
                 return fd;
 
@@ -857,7 +857,7 @@ int vt_disallocate(const char *tty_path) {
 
         int ttynr = vtnr_from_tty(tty_path);
         if (ttynr > 0) {
-                _cleanup_close_ int fd = open_terminal("/dev/tty0", O_RDWR|O_NOCTTY|O_CLOEXEC|O_NONBLOCK);
+                _cleanup_close_ int fd = open_terminal("/dev/tty0", O_RDWR|O_NOCTTY|O_NONBLOCK);
                 if (fd < 0)
                         return fd;
 
@@ -871,7 +871,7 @@ int vt_disallocate(const char *tty_path) {
         /* So this is not a VT (in which case we cannot deallocate it), or we failed to deallocate. Let's at
          * least clear the screen. */
 
-        _cleanup_close_ int fd2 = open_terminal(tty_path, O_WRONLY|O_NOCTTY|O_CLOEXEC|O_NONBLOCK);
+        _cleanup_close_ int fd2 = open_terminal(tty_path, O_WRONLY|O_NOCTTY|O_NONBLOCK);
         if (fd2 < 0)
                 return fd2;
 
@@ -1036,7 +1036,7 @@ int lock_dev_console(void) {
 
         /* NB: We do not use O_NOFOLLOW here, because some container managers might place a symlink to some
          * pty in /dev/console, in which case it should be fine to lock the target TTY. */
-        fd = open_terminal("/dev/console", O_RDONLY|O_CLOEXEC|O_NOCTTY);
+        fd = open_terminal("/dev/console", O_RDONLY|O_NOCTTY);
         if (fd < 0)
                 return fd;
 
@@ -2045,7 +2045,7 @@ int terminal_get_cursor_position(
         /* Open a 2nd input fd, in non-blocking mode, so that we won't ever hang in read() should someone
          * else process the POLLIN. */
 
-        nonblock_input_fd = r = fd_reopen(input_fd, O_RDONLY|O_CLOEXEC|O_NONBLOCK|O_NOCTTY);
+        nonblock_input_fd = r = fd_reopen(input_fd, O_RDONLY|O_NONBLOCK|O_NOCTTY);
         if (r < 0)
                 return r;
 
@@ -2330,7 +2330,7 @@ int get_default_background_color(double *ret_red, double *ret_green, double *ret
 
         /* Open a 2nd input fd, in non-blocking mode, so that we won't ever hang in read()
          * should someone else process the POLLIN. Do all subsequent operations on the new fd. */
-        _cleanup_close_ int nonblock_input_fd = r = fd_reopen(STDIN_FILENO, O_RDONLY|O_CLOEXEC|O_NONBLOCK|O_NOCTTY);
+        _cleanup_close_ int nonblock_input_fd = r = fd_reopen(STDIN_FILENO, O_RDONLY|O_NONBLOCK|O_NOCTTY);
         if (r < 0)
                 return r;
 
@@ -2516,7 +2516,7 @@ static int terminal_prepare_query(
 
         /* Open a 2nd input fd, in non-blocking mode, so that we won't ever hang in read()
          * should someone else process the POLLIN. Do all subsequent operations on the new fd. */
-        _cleanup_close_ int nonblock_input_fd = r = fd_reopen(input_fd, O_RDONLY|O_CLOEXEC|O_NONBLOCK|O_NOCTTY);
+        _cleanup_close_ int nonblock_input_fd = r = fd_reopen(input_fd, O_RDONLY|O_NONBLOCK|O_NOCTTY);
         if (r < 0)
                 return r;
 
@@ -2860,7 +2860,7 @@ int query_term_for_tty(const char *tty, char **ret_term) {
         /* Try to query the terminal implementation that we're on. This will not work in all
          * cases, which is fine, since this is intended to be used as a fallback. */
 
-        _cleanup_close_ int tty_fd = open_terminal(tty, O_RDWR|O_NOCTTY|O_CLOEXEC|O_NONBLOCK);
+        _cleanup_close_ int tty_fd = open_terminal(tty, O_RDWR|O_NOCTTY|O_NONBLOCK);
         if (tty_fd < 0)
                 return log_debug_errno(tty_fd, "Failed to open %s to query terminfo: %m", tty);
 

--- a/src/basic/terminal-util.c
+++ b/src/basic/terminal-util.c
@@ -624,15 +624,16 @@ int open_terminal(const char *name, int mode) {
          * https://bugs.launchpad.net/ubuntu/+source/linux/+bug/554172/comments/245
          */
 
+        assert(name);
         assert((mode & (O_CREAT|O_PATH|O_DIRECTORY|O_TMPFILE)) == 0);
 
         for (unsigned c = 0;; c++) {
-                fd = open(name, mode, 0);
+                fd = xopenat(AT_FDCWD, name, mode);
                 if (fd >= 0)
                         break;
 
-                if (errno != EIO)
-                        return -errno;
+                if (fd != -EIO)
+                        return fd;
 
                 /* Max 1s in total */
                 if (c >= 20)
@@ -794,9 +795,9 @@ int release_terminal(void) {
         _cleanup_close_ int fd = -EBADF;
         int r;
 
-        fd = open("/dev/tty", O_RDWR|O_NOCTTY|O_CLOEXEC|O_NONBLOCK);
+        fd = xopenat(AT_FDCWD, "/dev/tty", O_RDWR|O_NOCTTY|O_NONBLOCK);
         if (fd < 0)
-                return -errno;
+                return fd;
 
         /* Temporarily ignore SIGHUP, so that we don't get SIGHUP'ed
          * by our own TIOCNOTTY */

--- a/src/basic/time-util.c
+++ b/src/basic/time-util.c
@@ -1621,9 +1621,9 @@ int verify_timezone(const char *name, int log_level) {
 
         t = strjoina("/usr/share/zoneinfo/", name);
 
-        fd = open(t, O_RDONLY|O_CLOEXEC);
+        fd = xopenat(AT_FDCWD, t, O_RDONLY);
         if (fd < 0)
-                return log_full_errno(log_level, errno, "Failed to open timezone file '%s': %m", t);
+                return log_full_errno(log_level, fd, "Failed to open timezone file '%s': %m", t);
 
         r = fd_verify_regular(fd);
         if (r < 0)

--- a/src/basic/tmpfile-util.c
+++ b/src/basic/tmpfile-util.c
@@ -24,9 +24,9 @@ static int fopen_temporary_internal(int dir_fd, const char *path, FILE **ret_fil
         assert(dir_fd >= 0 || dir_fd == AT_FDCWD);
         assert(path);
 
-        fd = openat(dir_fd, path, O_CLOEXEC|O_NOCTTY|O_RDWR|O_CREAT|O_EXCL, 0600);
+        fd = xopenat_full(dir_fd, path, O_NOCTTY|O_RDWR|O_CREAT|O_EXCL, /* xopen_flags= */ 0, 0600);
         if (fd < 0)
-                return -errno;
+                return fd;
 
         /* This assumes that returned FILE object is short-lived and used within the same single-threaded
          * context and never shared externally, hence locking is not necessary. */
@@ -259,7 +259,7 @@ int open_tmpfile_unlinkable(const char *directory, int flags) {
         /* Returns an unlinked temporary file that cannot be linked into the file system anymore */
 
         /* Try O_TMPFILE first, if it is supported */
-        int fd = open(directory, flags|O_TMPFILE|O_EXCL, S_IRUSR|S_IWUSR);
+        int fd = xopenat_full(AT_FDCWD, directory, flags|O_TMPFILE|O_EXCL, /* xopen_flags= */ 0, S_IRUSR|S_IWUSR);
         if (fd >= 0)
                 return fd;
 
@@ -304,9 +304,9 @@ int open_tmpfile_linkable_at(int dir_fd, const char *target, int flags, char **r
         if (r < 0)
                 return r;
 
-        fd = openat(dir_fd, tmp, O_CREAT|O_EXCL|O_NOFOLLOW|O_NOCTTY|flags, 0640);
+        fd = xopenat_full(dir_fd, tmp, O_CREAT|O_EXCL|O_NOFOLLOW|O_NOCTTY|flags, /* xopen_flags= */ 0, 0640);
         if (fd < 0)
-                return -errno;
+                return fd;
 
         *ret_path = TAKE_PTR(tmp);
 
@@ -424,7 +424,7 @@ int mkdtemp_open(const char *template, int flags, char **ret) {
         if (r < 0)
                 return r;
 
-        fd = RET_NERRNO(open(p, O_DIRECTORY|O_CLOEXEC|flags));
+        fd = xopenat(AT_FDCWD, p, O_DIRECTORY|flags);
         if (fd < 0) {
                 (void) rmdir(p);
                 return fd;

--- a/src/basic/user-util.c
+++ b/src/basic/user-util.c
@@ -17,6 +17,7 @@
 #include "fd-util.h"
 #include "fileio.h"
 #include "format-util.h"
+#include "fs-util.h"
 #include "lock-util.h"
 #include "log.h"
 #include "mkdir.h"
@@ -197,7 +198,7 @@ const char* default_root_shell_at(int rfd) {
 const char* default_root_shell(const char *root) {
         _cleanup_close_ int rfd = -EBADF;
 
-        rfd = open(empty_to_root(root), O_CLOEXEC | O_DIRECTORY | O_PATH);
+        rfd = xopenat(AT_FDCWD, empty_to_root(root), O_DIRECTORY | O_PATH);
         if (rfd < 0)
                 return "/bin/sh";
 
@@ -704,9 +705,9 @@ int take_etc_passwd_lock(const char *root) {
 
         (void) mkdir_parents(path, 0755);
 
-        _cleanup_close_ int fd = open(path, O_WRONLY|O_CREAT|O_CLOEXEC|O_NOCTTY|O_NOFOLLOW, 0600);
+        _cleanup_close_ int fd = xopenat_full(AT_FDCWD, path, O_WRONLY|O_CREAT|O_NOCTTY|O_NOFOLLOW, /* xopen_flags= */ 0, 0600);
         if (fd < 0)
-                return log_debug_errno(errno, "Cannot open %s: %m", path);
+                return log_debug_errno(fd, "Cannot open %s: %m", path);
 
         r = unposix_lock(fd, LOCK_EX);
         if (r < 0)

--- a/src/basic/xattr-util.c
+++ b/src/basic/xattr-util.c
@@ -60,9 +60,9 @@ static int normalize_and_maybe_pin_inode(
 
         /* If both have been specified, then we go via O_PATH */
 
-        int tfd = openat(*fd, *path, O_PATH|O_CLOEXEC|(FLAGS_SET(*at_flags, AT_SYMLINK_FOLLOW) ? 0 : O_NOFOLLOW));
+        int tfd = xopenat(*fd, *path, O_PATH|(FLAGS_SET(*at_flags, AT_SYMLINK_FOLLOW) ? 0 : O_NOFOLLOW));
         if (tfd < 0)
-                return -errno;
+                return tfd;
 
         *fd = *ret_tfd = tfd;
         *path = NULL;

--- a/src/battery-check/battery-check.c
+++ b/src/battery-check/battery-check.c
@@ -113,7 +113,7 @@ static int run(int argc, char *argv[]) {
                    LOG_MESSAGE("%s " BATTERY_LOW_MESSAGE, glyph(GLYPH_LOW_BATTERY)),
                    LOG_MESSAGE_ID(SD_MESSAGE_BATTERY_LOW_WARNING_STR));
 
-        fd = open_terminal("/dev/console", O_WRONLY|O_NOCTTY|O_CLOEXEC);
+        fd = open_terminal("/dev/console", O_WRONLY|O_NOCTTY);
         if (fd < 0)
                 log_warning_errno(fd, "Failed to open console, ignoring: %m");
         else

--- a/src/bless-boot/bless-boot.c
+++ b/src/bless-boot/bless-boot.c
@@ -368,12 +368,12 @@ static int verb_status(int argc, char *argv[], uintptr_t _data, void *userdata) 
         STRV_FOREACH(p, arg_path) {
                 _cleanup_close_ int fd = -EBADF;
 
-                fd = open(*p, O_DIRECTORY|O_CLOEXEC|O_RDONLY);
+                fd = xopenat(AT_FDCWD, *p, O_DIRECTORY|O_RDONLY);
                 if (fd < 0) {
-                        if (errno == ENOENT)
+                        if (fd == -ENOENT)
                                 continue;
 
-                        return log_error_errno(errno, "Failed to open $BOOT partition '%s': %m", *p);
+                        return log_error_errno(fd, "Failed to open $BOOT partition '%s': %m", *p);
                 }
 
                 if (faccessat(fd, skip_leading_slash(path), F_OK, 0) >= 0) {
@@ -497,9 +497,9 @@ static int verb_set(int argc, char *argv[], uintptr_t data, void *userdata) {
         STRV_FOREACH(p, arg_path) {
                 _cleanup_close_ int fd = -EBADF;
 
-                fd = open(*p, O_DIRECTORY|O_CLOEXEC|O_RDONLY);
+                fd = xopenat(AT_FDCWD, *p, O_DIRECTORY|O_RDONLY);
                 if (fd < 0)
-                        return log_error_errno(errno, "Failed to open $BOOT partition '%s': %m", *p);
+                        return log_error_errno(fd, "Failed to open $BOOT partition '%s': %m", *p);
 
                 r = rename_in_dir_idempotent(fd, skip_leading_slash(source1), skip_leading_slash(target));
                 if (r == -EEXIST)

--- a/src/bootctl/bootctl-cleanup.c
+++ b/src/bootctl/bootctl-cleanup.c
@@ -71,7 +71,7 @@ static int cleanup_orphaned_files(
                 return log_error_errno(r, "Failed to count files in %s: %m", root);
 
         dir_fd = chase_and_open(arg_entry_token, root, CHASE_PREFIX_ROOT|CHASE_PROHIBIT_SYMLINKS|CHASE_TRIGGER_AUTOFS,
-                        O_DIRECTORY|O_CLOEXEC, &full);
+                                O_DIRECTORY, &full);
         if (dir_fd == -ENOENT)
                 return 0;
         if (dir_fd < 0)

--- a/src/bootctl/bootctl-install.c
+++ b/src/bootctl/bootctl-install.c
@@ -284,7 +284,7 @@ static int load_etc_machine_info(InstallContext *c) {
                                 c->root_fd,
                                 "/etc/machine-info",
                                 CHASE_MUST_BE_REGULAR,
-                                O_RDONLY|O_CLOEXEC,
+                                O_RDONLY,
                                 /* ret_path= */ NULL);
         if (fd == -ENOENT)
                 return 0;
@@ -514,7 +514,7 @@ static int copy_file_with_version_check(
 
         _cleanup_free_ char *t = NULL;
         _cleanup_close_ int write_fd = -EBADF;
-        write_fd = open_tmpfile_linkable_at(dest_parent_fd, dest_filename, O_WRONLY|O_CLOEXEC, &t);
+        write_fd = open_tmpfile_linkable_at(dest_parent_fd, dest_filename, O_WRONLY, &t);
         if (write_fd < 0)
                 return log_error_errno(write_fd, "Failed to open \"%s\" for writing: %m", dest_path);
 
@@ -639,7 +639,7 @@ static int update_efi_boot_binaries(
                 if (strcaseeq_ptr(ignore_filename, de->d_name))
                         continue;
 
-                fd = xopenat_full(dirfd(d), de->d_name, O_RDONLY|O_CLOEXEC|O_NONBLOCK|O_NOCTTY|O_NOFOLLOW, XO_REGULAR, /* mode= */ MODE_INVALID);
+                fd = xopenat_full(dirfd(d), de->d_name, O_RDONLY|O_NONBLOCK|O_NOCTTY|O_NOFOLLOW, XO_REGULAR, MODE_INVALID);
                 if (fd < 0)
                         return log_error_errno(fd, "Failed to open \"%s/%s\" for reading: %m", j, de->d_name);
 
@@ -692,7 +692,7 @@ static int copy_one_file(
                                 c->root_fd,
                                 sp,
                                 CHASE_MUST_BE_REGULAR,
-                                O_RDONLY|O_CLOEXEC,
+                                O_RDONLY,
                                 &source_path);
                 if (source_fd < 0 && (source_fd != -ENOENT || c->install_source != INSTALL_SOURCE_AUTO))
                         return log_error_errno(source_fd, "Failed to resolve path '%s' under directory '%s': %m", sp, c->root);
@@ -704,7 +704,7 @@ static int copy_one_file(
                                 sp,
                                 /* root= */ NULL,
                                 CHASE_MUST_BE_REGULAR,
-                                O_RDONLY|O_CLOEXEC,
+                                O_RDONLY,
                                 &source_path);
                 if (source_fd < 0)
                         return log_error_errno(source_fd, "Failed to resolve path '%s': %m", sp);
@@ -731,7 +731,7 @@ static int copy_one_file(
         if (!dest_path)
                 return log_oom();
 
-        _cleanup_close_ int dest_fd = xopenat_full(dest_parent_fd, dest_name, O_RDONLY|O_CLOEXEC, XO_REGULAR, MODE_INVALID);
+        _cleanup_close_ int dest_fd = xopenat_full(dest_parent_fd, dest_name, O_RDONLY, XO_REGULAR, MODE_INVALID);
         if (dest_fd < 0 && dest_fd != -ENOENT)
                 return log_error_errno(dest_fd, "Failed to open '%s' under '%s/EFI/systemd' directory: %m", dest_name, j);
 
@@ -763,7 +763,7 @@ static int copy_one_file(
                          * fallback yet, LoaderInfo is unavailable, or there is a mismatch, then
                          * overwrite it with the current primary. */
                         bool should_rotate = true;
-                        _cleanup_close_ int fallback_fd = xopenat_full(dest_parent_fd, fallback_name, O_RDONLY|O_CLOEXEC, XO_REGULAR, MODE_INVALID);
+                        _cleanup_close_ int fallback_fd = xopenat_full(dest_parent_fd, fallback_name, O_RDONLY, XO_REGULAR, MODE_INVALID);
                         if (fallback_fd >= 0) {
                                 _cleanup_free_ char *loader_info = NULL, *fallback_version = NULL;
 
@@ -809,7 +809,7 @@ static int copy_one_file(
                 if (!default_dest_path)
                         return log_oom();
 
-                _cleanup_close_ int default_dest_fd = xopenat_full(default_dest_parent_fd, boot_dot_efi, O_RDONLY|O_CLOEXEC, XO_REGULAR, MODE_INVALID);
+                _cleanup_close_ int default_dest_fd = xopenat_full(default_dest_parent_fd, boot_dot_efi, O_RDONLY, XO_REGULAR, MODE_INVALID);
                 if (default_dest_fd < 0 && default_dest_fd != -ENOENT)
                         return log_error_errno(default_dest_fd, "Failed to open '%s' under '%s/EFI/BOOT' directory: %m", boot_dot_efi, j);
 
@@ -920,7 +920,7 @@ static int install_loader_config(InstallContext *c) {
 
         _cleanup_free_ char *t = NULL;
         _cleanup_fclose_ FILE *f = NULL;
-        r = fopen_tmpfile_linkable_at(loader_dir_fd, "loader.conf", O_WRONLY|O_CLOEXEC, &t, &f);
+        r = fopen_tmpfile_linkable_at(loader_dir_fd, "loader.conf", O_WRONLY, &t, &f);
         if (r < 0)
                 return log_error_errno(r, "Failed to open '%s/loader/loader.conf' for writing: %m", j);
 
@@ -975,7 +975,7 @@ static int install_loader_specification(InstallContext *c) {
 
         _cleanup_free_ char *t = NULL;
         _cleanup_fclose_ FILE *f = NULL;
-        r = fopen_tmpfile_linkable_at(loader_dir_fd, "entries.srel", O_WRONLY|O_CLOEXEC, &t, &f);
+        r = fopen_tmpfile_linkable_at(loader_dir_fd, "entries.srel", O_WRONLY, &t, &f);
         if (r < 0)
                 return log_error_errno(r, "Failed to open '%s/loader/entries.srel' for writing: %m", j);
 
@@ -1201,7 +1201,7 @@ static int install_secure_boot_auto_enroll(InstallContext *c) {
                         return log_oom();
 
                 _cleanup_free_ char *t = NULL;
-                _cleanup_close_ int fd = open_tmpfile_linkable_at(keys_fd, filename, O_WRONLY|O_CLOEXEC, &t);
+                _cleanup_close_ int fd = open_tmpfile_linkable_at(keys_fd, filename, O_WRONLY, &t);
                 if (fd < 0)
                         return log_error_errno(fd, "Failed to open secure boot auto-enrollment file for writing: %m");
 
@@ -1534,7 +1534,7 @@ static int are_we_installed(InstallContext *c) {
                         c->esp_fd,
                         "/EFI/systemd",
                         CHASE_PROHIBIT_SYMLINKS|CHASE_MUST_BE_DIRECTORY,
-                        O_RDONLY|O_CLOEXEC|O_DIRECTORY,
+                        O_RDONLY|O_DIRECTORY,
                         /* ret_path= */ NULL);
         if (fd == -ENOENT)
                 return 0;
@@ -1806,7 +1806,7 @@ static int remove_boot_efi(InstallContext *c) {
                 if (!z)
                         return log_oom();
 
-                fd = xopenat_full(dirfd(d), de->d_name, O_RDONLY|O_CLOEXEC|O_NONBLOCK|O_NOCTTY|O_NOFOLLOW, XO_REGULAR, /* mode= */ MODE_INVALID);
+                fd = xopenat_full(dirfd(d), de->d_name, O_RDONLY|O_NONBLOCK|O_NOCTTY|O_NOFOLLOW, XO_REGULAR, MODE_INVALID);
                 if (fd == -ENOENT)
                         continue;
                 if (fd < 0)

--- a/src/bootctl/bootctl-install.c
+++ b/src/bootctl/bootctl-install.c
@@ -153,9 +153,9 @@ static int install_context_from_cmdline(
                 return log_oom();
 
         if (arg_root) {
-                b.root_fd = open(arg_root, O_CLOEXEC|O_DIRECTORY|O_PATH);
+                b.root_fd = xopenat(AT_FDCWD, arg_root, O_DIRECTORY|O_PATH);
                 if (b.root_fd < 0)
-                        return log_error_errno(errno, "Failed to open root directory '%s': %m", arg_root);
+                        return log_error_errno(b.root_fd, "Failed to open root directory '%s': %m", arg_root);
 
                 r = strdup_to(&b.root, arg_root);
                 if (r < 0)
@@ -2159,9 +2159,9 @@ int vl_method_install(
                                 p.context.root = mfree(p.context.root);
                 }
         } else if (p.context.root) {
-                p.context.root_fd = open(p.context.root, O_RDONLY|O_CLOEXEC|O_DIRECTORY);
+                p.context.root_fd = xopenat(AT_FDCWD, p.context.root, O_RDONLY|O_DIRECTORY);
                 if (p.context.root_fd < 0)
-                        return log_debug_errno(errno, "Failed to open '%s': %m", p.context.root);
+                        return log_debug_errno(p.context.root_fd, "Failed to open '%s': %m", p.context.root);
         } else
                 p.context.root_fd = XAT_FDROOT;
 

--- a/src/bootctl/bootctl-link.c
+++ b/src/bootctl/bootctl-link.c
@@ -310,7 +310,7 @@ static int link_context_add_cmdline_extras(LinkContext *b) {
                 if (r == O_DIRECTORY)
                         return log_error_errno(SYNTHETIC_ERRNO(EISDIR), "Extra file path '%s' does not refer to regular file.", *x);
 
-                _cleanup_close_ int fd = xopenat_full(AT_FDCWD, *x, O_RDONLY|O_CLOEXEC|O_NONBLOCK|O_NOCTTY, XO_REGULAR, /* mode= */ MODE_INVALID);
+                _cleanup_close_ int fd = xopenat_full(AT_FDCWD, *x, O_RDONLY|O_NONBLOCK|O_NOCTTY, XO_REGULAR, /* mode= */ MODE_INVALID);
                 if (fd < 0)
                         return log_error_errno(fd, "Failed to open '%s': %m", *x);
 
@@ -360,7 +360,7 @@ static int link_context_from_cmdline(LinkContext *ret, const char *kernel) {
                 return log_error_errno(r, "Failed to extract filename from kernel path '%s': %m", kernel);
         if (!efi_loader_entry_resource_filename_valid(b.kernel_filename))
                 return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "Kernel '%s' is not suitable for reference in a boot menu entry.", kernel);
-        b.kernel_fd = xopenat_full(AT_FDCWD, kernel, O_RDONLY|O_CLOEXEC|O_NONBLOCK|O_NOCTTY, XO_REGULAR, /* mode= */ MODE_INVALID);
+        b.kernel_fd = xopenat_full(AT_FDCWD, kernel, O_RDONLY|O_NONBLOCK|O_NOCTTY, XO_REGULAR, /* mode= */ MODE_INVALID);
         if (b.kernel_fd < 0)
                 return log_error_errno(b.kernel_fd, "Failed to open kernel path '%s': %m", kernel);
 
@@ -446,7 +446,7 @@ static int begin_copy_file(
         }
 
         _cleanup_free_ char *t = NULL;
-        _cleanup_close_ int write_fd = open_tmpfile_linkable_at(target_dir_fd, filename, O_WRONLY|O_CLOEXEC, &t);
+        _cleanup_close_ int write_fd = open_tmpfile_linkable_at(target_dir_fd, filename, O_WRONLY, &t);
         if (write_fd < 0)
                 return log_error_errno(write_fd, "Failed to create '%s': %m", filename);
 
@@ -539,7 +539,7 @@ static int begin_write_entry_file(
         log_info("Writing new boot menu entry '%s/loader/entries/%s' for profile %u.", c->dollar_boot_path, filename, profile_nr);
 
         _cleanup_free_ char *t = NULL;
-        _cleanup_close_ int write_fd = open_tmpfile_linkable_at(c->loader_entries_dir_fd, filename, O_WRONLY|O_CLOEXEC, &t);
+        _cleanup_close_ int write_fd = open_tmpfile_linkable_at(c->loader_entries_dir_fd, filename, O_WRONLY, &t);
         if (write_fd < 0)
                 return log_error_errno(write_fd, "Failed to create '%s': %m", filename);
 
@@ -644,7 +644,7 @@ static int link_context_pick_entry_commit(LinkContext *c) {
         if (c->entry_commit != 0)
                 return 0;
 
-        _cleanup_close_ int opened_fd = fd_reopen(c->loader_entries_dir_fd, O_DIRECTORY|O_CLOEXEC);
+        _cleanup_close_ int opened_fd = fd_reopen(c->loader_entries_dir_fd, O_DIRECTORY);
         if (opened_fd < 0)
                 return log_error_errno(opened_fd, "Failed to reopen loader entries dir: %m");
 
@@ -705,7 +705,7 @@ static int clean_temporary_files(int fd) {
          * materialized before they are fully written. However, vfat currently does not support O_TMPFILE,
          * hence we need to clean things up manually. */
 
-        _cleanup_close_ int dfd = fd_reopen(fd, O_CLOEXEC|O_DIRECTORY);
+        _cleanup_close_ int dfd = fd_reopen(fd, O_DIRECTORY);
         if (dfd < 0)
                 return log_error_errno(dfd, "Failed to open directory: %m");
 
@@ -1087,7 +1087,7 @@ static int link_context_add_extra(LinkContext *c, int dir_fd, const char *path, 
         if (!efi_loader_entry_resource_filename_valid(filename))
                 return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "Extra file '%s' is not suitable for reference in a boot menu entry, refusing.", filename);
 
-        _cleanup_close_ int fd = xopenat_full(dir_fd, path, O_RDONLY|O_CLOEXEC|O_NONBLOCK|O_NOCTTY, XO_REGULAR, /* mode= */ MODE_INVALID);
+        _cleanup_close_ int fd = xopenat_full(dir_fd, path, O_RDONLY|O_NONBLOCK|O_NOCTTY, XO_REGULAR, /* mode= */ MODE_INVALID);
         if (fd < 0)
                 return log_error_errno(fd, "Failed to open extra file '%s': %m", path);
 
@@ -1122,7 +1122,7 @@ static int link_context_add_extras(LinkContext *c, int uki_dir_fd, Set **seen) {
                         uki_dir_fd,
                         "extras.d",
                         /* chase_flags= */ 0,
-                        O_DIRECTORY|O_CLOEXEC,
+                        O_DIRECTORY,
                         /* ret_path= */ NULL);
         if (extras_dir_fd == -ENOENT)
                 return 0;
@@ -1232,7 +1232,7 @@ static int link_context_find_kernel(LinkContext *c, int uki_dir_fd) {
         _cleanup_free_ char *filename = NULL;
         _cleanup_close_ int kernel_fd = xopenat_full(
                         uki_dir_fd, "kernel.efi",
-                        O_RDONLY|O_CLOEXEC|O_NONBLOCK|O_NOCTTY|O_NOFOLLOW,
+                        O_RDONLY|O_NONBLOCK|O_NOCTTY|O_NOFOLLOW,
                         XO_REGULAR,
                         /* mode= */ MODE_INVALID);
         if (kernel_fd == -ENOENT) {
@@ -1254,7 +1254,7 @@ static int link_context_find_kernel(LinkContext *c, int uki_dir_fd) {
                 if (r < 0)
                         return log_error_errno(r, "Failed to extract filename from '%s': %m", pick.path);
 
-                kernel_fd = fd_reopen(pick.fd, O_RDONLY|O_CLOEXEC|O_NONBLOCK|O_NOCTTY);
+                kernel_fd = fd_reopen(pick.fd, O_RDONLY|O_NONBLOCK|O_NOCTTY);
                 if (kernel_fd < 0)
                         return log_error_errno(kernel_fd, "Failed to open UKI '%s': %m", pick.path);
 
@@ -1299,7 +1299,7 @@ static int link_context_discover_resources(LinkContext *c) {
                                 /* dir_fd= */ c->root_fd,
                                 *dir,
                                 CHASE_MUST_BE_DIRECTORY,
-                                O_RDONLY|O_DIRECTORY|O_CLOEXEC,
+                                O_RDONLY|O_DIRECTORY,
                                 /* ret_path= */ NULL);
                 if (uki_dir_fd == -ENOENT)
                         continue;

--- a/src/bootctl/bootctl-link.c
+++ b/src/bootctl/bootctl-link.c
@@ -284,9 +284,9 @@ static int link_context_from_cmdline_common(LinkContext *b) {
                 return log_oom();
 
         if (arg_root) {
-                b->root_fd = open(arg_root, O_CLOEXEC|O_DIRECTORY|O_PATH);
+                b->root_fd = xopenat(AT_FDCWD, arg_root, O_DIRECTORY|O_PATH);
                 if (b->root_fd < 0)
-                        return log_error_errno(errno, "Failed to open root directory '%s': %m", arg_root);
+                        return log_error_errno(b->root_fd, "Failed to open root directory '%s': %m", arg_root);
 
                 if (strdup_to(&b->root, arg_root) < 0)
                         return log_oom();
@@ -1487,9 +1487,9 @@ static int vl_link_prepare(sd_varlink *link, LinkParameters *p) {
                                 p->context.root = mfree(p->context.root);
                 }
         } else if (p->context.root) {
-                p->context.root_fd = open(p->context.root, O_RDONLY|O_CLOEXEC|O_DIRECTORY);
+                p->context.root_fd = xopenat(AT_FDCWD, p->context.root, O_RDONLY|O_DIRECTORY);
                 if (p->context.root_fd < 0)
-                        return log_debug_errno(errno, "Failed to open '%s': %m", p->context.root);
+                        return log_debug_errno(p->context.root_fd, "Failed to open '%s': %m", p->context.root);
         } else
                 p->context.root_fd = XAT_FDROOT;
 

--- a/src/bootctl/bootctl-random-seed.c
+++ b/src/bootctl/bootctl-random-seed.c
@@ -129,7 +129,7 @@ int install_random_seed(const char *esp, int esp_fd) {
 
         (void) random_seed_verify_permissions(esp_fd, S_IFDIR);
 
-        loader_dir_fd = open_mkdir_at(esp_fd, "loader", O_DIRECTORY|O_RDONLY|O_CLOEXEC|O_NOFOLLOW, 0775);
+        loader_dir_fd = open_mkdir_at(esp_fd, "loader", O_DIRECTORY|O_RDONLY|O_NOFOLLOW, 0775);
         if (loader_dir_fd < 0)
                 return log_error_errno(loader_dir_fd, "Failed to open loader directory '%s/loader': %m", esp);
 

--- a/src/bootctl/bootctl-random-seed.c
+++ b/src/bootctl/bootctl-random-seed.c
@@ -140,10 +140,10 @@ int install_random_seed(const char *esp, int esp_fd) {
         sha256_init_ctx(&hash_state);
         sha256_process_bytes_and_size(buffer, sizeof(buffer), &hash_state);
 
-        fd = openat(loader_dir_fd, "random-seed", O_NOFOLLOW|O_CLOEXEC|O_RDONLY|O_NOCTTY);
+        fd = xopenat(loader_dir_fd, "random-seed", O_NOFOLLOW|O_RDONLY|O_NOCTTY);
         if (fd < 0) {
-                if (errno != ENOENT)
-                        return log_error_errno(errno, "Failed to open old random seed file: %m");
+                if (fd != -ENOENT)
+                        return log_error_errno(fd, "Failed to open old random seed file: %m");
 
                 sha256_process_bytes(&(const ssize_t) { 0 }, sizeof(ssize_t), &hash_state);
                 refreshed = false;
@@ -169,7 +169,7 @@ int install_random_seed(const char *esp, int esp_fd) {
         if (tempfn_random("random-seed", "bootctl", &tmp) < 0)
                 return log_oom();
 
-        fd = openat(loader_dir_fd, tmp, O_CREAT|O_EXCL|O_NOFOLLOW|O_NOCTTY|O_WRONLY|O_CLOEXEC, 0600);
+        fd = xopenat_full(loader_dir_fd, tmp, O_CREAT|O_EXCL|O_NOFOLLOW|O_NOCTTY|O_WRONLY, /* xopen_flags= */ 0, 0600);
         if (fd < 0)
                 return log_error_errno(fd, "Failed to open random seed file for writing: %m");
 

--- a/src/bootctl/bootctl-status.c
+++ b/src/bootctl/bootctl-status.c
@@ -17,6 +17,7 @@
 #include "efivars.h"
 #include "errno-util.h"
 #include "fd-util.h"
+#include "fs-util.h"
 #include "locale-setup.h"
 #include "log.h"
 #include "pager.h"
@@ -217,7 +218,7 @@ static int enumerate_binaries(
                         return log_oom();
                 LOG_SET_PREFIX(filename);
 
-                fd = RET_NERRNO(openat(dirfd(d), de->d_name, O_RDONLY|O_CLOEXEC));
+                fd = xopenat(dirfd(d), de->d_name, O_RDONLY);
                 if (fd == -ENOENT)
                         continue;
                 if (fd < 0)

--- a/src/bootctl/bootctl-unlink.c
+++ b/src/bootctl/bootctl-unlink.c
@@ -18,6 +18,7 @@
 #include "errno-util.h"
 #include "fd-util.h"
 #include "find-esp.h"
+#include "fs-util.h"
 #include "hashmap.h"
 #include "id128-util.h"
 #include "json-util.h"
@@ -387,9 +388,9 @@ static int unlink_context_from_cmdline(UnlinkContext *ret) {
                 return log_oom();
 
         if (arg_root) {
-                b.root_fd = open(arg_root, O_CLOEXEC|O_DIRECTORY|O_PATH);
+                b.root_fd = xopenat(AT_FDCWD, arg_root, O_DIRECTORY|O_PATH);
                 if (b.root_fd < 0)
-                        return log_error_errno(errno, "Failed to open root directory '%s': %m", arg_root);
+                        return log_error_errno(b.root_fd, "Failed to open root directory '%s': %m", arg_root);
 
                 if (strdup_to(&b.root, arg_root) < 0)
                         return log_oom();
@@ -626,9 +627,9 @@ int vl_method_unlink(
                                 p.context.root = mfree(p.context.root);
                 }
         } else if (p.context.root) {
-                p.context.root_fd = open(p.context.root, O_RDONLY|O_CLOEXEC|O_DIRECTORY);
+                p.context.root_fd = xopenat(AT_FDCWD, p.context.root, O_RDONLY|O_DIRECTORY);
                 if (p.context.root_fd < 0)
-                        return log_debug_errno(errno, "Failed to open '%s': %m", p.context.root);
+                        return log_debug_errno(p.context.root_fd, "Failed to open '%s': %m", p.context.root);
         } else
                 p.context.root_fd = XAT_FDROOT;
 

--- a/src/clonesetup/clonesetup-ioctl.c
+++ b/src/clonesetup/clonesetup-ioctl.c
@@ -11,6 +11,7 @@
 #include "device-private.h"
 #include "errno-util.h"
 #include "fd-util.h"
+#include "fs-util.h"
 #include "log.h"
 #include "memory-util.h"
 #include "string-util.h"
@@ -68,9 +69,9 @@ static int dm_ioctl_run(const char *name, uint32_t cmd, struct dm_ioctl *data, s
                                "DM device name too long: %s", name);
         strncpy_exact(dm->name, name, sizeof(dm->name));
 
-        fd = open("/dev/mapper/control", O_RDWR | O_CLOEXEC);
+        fd = xopenat(AT_FDCWD, "/dev/mapper/control", O_RDWR);
         if (fd < 0)
-                return log_error_errno(errno, "Failed to open /dev/mapper/control: %m");
+                return log_error_errno(fd, "Failed to open /dev/mapper/control: %m");
 
         r = RET_NERRNO(ioctl(fd, cmd, dm));
         if (r < 0) {

--- a/src/core/automount.c
+++ b/src/core/automount.c
@@ -16,6 +16,7 @@
 #include "errno-util.h"
 #include "fd-util.h"
 #include "format-util.h"
+#include "fs-util.h"
 #include "fstab-util.h"
 #include "io-util.h"
 #include "label-util.h"
@@ -342,9 +343,9 @@ static int open_dev_autofs(Manager *m) {
 
         (void) label_fix("/dev/autofs", 0);
 
-        m->dev_autofs_fd = open("/dev/autofs", O_CLOEXEC|O_RDONLY);
+        m->dev_autofs_fd = xopenat(AT_FDCWD, "/dev/autofs", O_RDONLY);
         if (m->dev_autofs_fd < 0)
-                return log_error_errno(errno, "Failed to open %s: %m", "/dev/autofs");
+                return log_error_errno(m->dev_autofs_fd, "Failed to open %s: %m", "/dev/autofs");
 
         init_autofs_dev_ioctl(&param);
         r = RET_NERRNO(ioctl(m->dev_autofs_fd, AUTOFS_DEV_IOCTL_VERSION, &param));

--- a/src/core/bpf-bind-iface.c
+++ b/src/core/bpf-bind-iface.c
@@ -6,6 +6,7 @@
 #include "bpf-bind-iface.h"
 #include "cgroup.h"
 #include "fd-util.h"
+#include "fs-util.h"
 #include "netlink-util.h"
 #include "string-util.h"
 #include "unit.h"
@@ -92,9 +93,9 @@ static int bind_network_interface_install_impl(Unit *u, CGroupRuntime *crt) {
                 return log_unit_error_errno(u, r, "bind-interface: Failed to load BPF object: %m");
 
         /* Open the cgroup directory */
-        cgroup_fd = open(cgroup_path, O_PATH | O_CLOEXEC | O_DIRECTORY, 0);
+        cgroup_fd = xopenat(AT_FDCWD, cgroup_path, O_PATH | O_DIRECTORY);
         if (cgroup_fd < 0)
-                return log_unit_error_errno(u, errno, "bind-interface: Failed to open cgroup directory '%s': %m", cgroup_path);
+                return log_unit_error_errno(u, cgroup_fd, "bind-interface: Failed to open cgroup directory '%s': %m", cgroup_path);
 
         /* Attach the BPF program to the cgroup */
         link = sym_bpf_program__attach_cgroup(obj->progs.sd_bind_interface, cgroup_fd);

--- a/src/core/bpf-restrict-fsaccess.c
+++ b/src/core/bpf-restrict-fsaccess.c
@@ -10,6 +10,7 @@
 #include "devnum-util.h"
 #include "fd-util.h"
 #include "fileio.h"
+#include "fs-util.h"
 #include "initrd-util.h"
 #include "log.h"
 #include "lsm-util.h"
@@ -125,9 +126,9 @@ static int proc_mem_can_force_override(void) {
         if (p == MAP_FAILED)
                 return -errno;
 
-        fd = open("/proc/self/mem", O_RDWR|O_CLOEXEC);
+        fd = xopenat(AT_FDCWD, "/proc/self/mem", O_RDWR);
         if (fd < 0) {
-                r = -errno;
+                r = fd;
                 goto finish;
         }
 

--- a/src/core/bpf-restrict-ifaces.c
+++ b/src/core/bpf-restrict-ifaces.c
@@ -7,6 +7,7 @@
 #include "cgroup.h"
 #include "fd-util.h"
 #include "fdset.h"
+#include "fs-util.h"
 #include "netlink-util.h"
 #include "set.h"
 #include "unit.h"
@@ -124,9 +125,9 @@ static int restrict_ifaces_install_impl(Unit *u, CGroupRuntime *crt) {
         if (r < 0)
                 return r;
 
-        cgroup_fd = open(cgroup_path, O_PATH | O_CLOEXEC | O_DIRECTORY, 0);
+        cgroup_fd = xopenat(AT_FDCWD, cgroup_path, O_PATH | O_DIRECTORY);
         if (cgroup_fd < 0)
-                return -errno;
+                return cgroup_fd;
 
         ingress_link = sym_bpf_program__attach_cgroup(obj->progs.sd_restrictif_i, cgroup_fd);
         r = bpf_get_error_translated(ingress_link);

--- a/src/core/bpf-socket-bind.c
+++ b/src/core/bpf-socket-bind.c
@@ -5,6 +5,7 @@
 #include "cgroup.h"
 #include "fd-util.h"
 #include "fdset.h"
+#include "fs-util.h"
 #include "unit.h"
 
 #if BPF_FRAMEWORK
@@ -190,9 +191,9 @@ static int socket_bind_install_impl(Unit *u) {
         if (r < 0)
                 return log_unit_error_errno(u, r, "bpf-socket-bind: Failed to load BPF object: %m");
 
-        cgroup_fd = open(cgroup_path, O_RDONLY | O_CLOEXEC, 0);
+        cgroup_fd = xopenat(AT_FDCWD, cgroup_path, O_RDONLY);
         if (cgroup_fd < 0)
-                return log_unit_error_errno(u, errno, "bpf-socket-bind: Failed to open cgroup %s for reading: %m", cgroup_path);
+                return log_unit_error_errno(u, cgroup_fd, "bpf-socket-bind: Failed to open cgroup %s for reading: %m", cgroup_path);
 
         ipv4 = sym_bpf_program__attach_cgroup(obj->progs.sd_bind4, cgroup_fd);
         r = bpf_get_error_translated(ipv4);

--- a/src/core/cgroup.c
+++ b/src/core/cgroup.c
@@ -29,6 +29,7 @@
 #include "fd-util.h"
 #include "fdset.h"
 #include "fileio.h"
+#include "fs-util.h"
 #include "in-addr-prefix-util.h"
 #include "inotify-util.h"
 #include "ip-protocol-list.h"
@@ -3312,9 +3313,9 @@ int manager_setup_cgroup(Manager *m) {
 
         /* 2. Pin the cgroupfs mount, so that it cannot be unmounted */
         safe_close(m->pin_cgroupfs_fd);
-        m->pin_cgroupfs_fd = open("/sys/fs/cgroup", O_PATH|O_CLOEXEC|O_DIRECTORY);
+        m->pin_cgroupfs_fd = xopenat(AT_FDCWD, "/sys/fs/cgroup", O_PATH|O_DIRECTORY);
         if (m->pin_cgroupfs_fd < 0)
-                return log_error_errno(errno, "Failed to pin cgroup hierarchy: %m");
+                return log_error_errno(m->pin_cgroupfs_fd, "Failed to pin cgroup hierarchy: %m");
 
         /* 3. Allocate cgroup empty defer event source */
         m->cgroup_empty_event_source = sd_event_source_disable_unref(m->cgroup_empty_event_source);

--- a/src/core/dynamic-user.c
+++ b/src/core/dynamic-user.c
@@ -13,6 +13,7 @@
 #include "fdset.h"
 #include "fileio.h"
 #include "format-util.h"
+#include "fs-util.h"
 #include "hashmap.h"
 #include "iovec-util.h"
 #include "lock-util.h"
@@ -236,9 +237,9 @@ static int pick_uid(char **suggested_paths, const char *name, uid_t *ret_uid) {
                 xsprintf(lock_path, "/run/systemd/dynamic-uid/" UID_FMT, candidate);
 
                 for (;;) {
-                        lock_fd = open(lock_path, O_CREAT|O_RDWR|O_NOFOLLOW|O_CLOEXEC|O_NOCTTY, 0600);
+                        lock_fd = xopenat_full(AT_FDCWD, lock_path, O_CREAT|O_RDWR|O_NOFOLLOW|O_NOCTTY, /* xopen_flags= */ 0, 0600);
                         if (lock_fd < 0)
-                                return -errno;
+                                return lock_fd;
 
                         r = flock(lock_fd, LOCK_EX|LOCK_NB); /* Try to get a BSD file lock on the UID lock file */
                         if (r < 0) {

--- a/src/core/efi-random.c
+++ b/src/core/efi-random.c
@@ -7,16 +7,17 @@
 #include "efi-random.h"
 #include "efivars.h"
 #include "fd-util.h"
+#include "fs-util.h"
 #include "log.h"
 
 void lock_down_efi_variables(void) {
         _cleanup_close_ int fd = -EBADF;
         int r;
 
-        fd = open(EFIVAR_PATH(EFI_LOADER_VARIABLE_STR("LoaderSystemToken")), O_RDONLY|O_CLOEXEC);
+        fd = xopenat(AT_FDCWD, EFIVAR_PATH(EFI_LOADER_VARIABLE_STR("LoaderSystemToken")), O_RDONLY);
         if (fd < 0) {
-                if (errno != ENOENT)
-                        log_warning_errno(errno, "Unable to open LoaderSystemToken EFI variable, ignoring: %m");
+                if (fd != -ENOENT)
+                        log_warning_errno(fd, "Unable to open LoaderSystemToken EFI variable, ignoring: %m");
                 return;
         }
 

--- a/src/core/exec-credential.c
+++ b/src/core/exec-credential.c
@@ -977,7 +977,7 @@ static int setup_credentials_plain_dir(
         if (!workspace)
                 return -ENOMEM;
 
-        dfd = open_mkdir(workspace, O_CLOEXEC|O_EXCL, 0700);
+        dfd = open_mkdir(workspace, O_EXCL, 0700);
         if (dfd < 0)
                 return log_debug_errno(dfd, "Failed to create workspace for credentials: %m");
         workspace_rm = workspace;
@@ -1059,7 +1059,7 @@ static int setup_credentials_internal(
         if (mfd < 0)
                 return log_debug_errno(mfd, "Failed to mount credentials fs: %m");
 
-        dfd = fd_reopen(mfd, O_DIRECTORY|O_CLOEXEC);
+        dfd = fd_reopen(mfd, O_DIRECTORY);
         if (dfd < 0)
                 return dfd;
 

--- a/src/core/exec-credential.c
+++ b/src/core/exec-credential.c
@@ -423,9 +423,9 @@ static int write_credential(
         assert(id);
         assert(data || size == 0);
 
-        fd = openat(dfd, id, O_CREAT|O_EXCL|O_WRONLY|O_CLOEXEC, 0600);
+        fd = xopenat_full(dfd, id, O_CREAT|O_EXCL|O_WRONLY, /* xopen_flags= */ 0, 0600);
         if (fd < 0)
-                return -errno;
+                return fd;
 
         r = loop_write(fd, data, size);
         if (r < 0)
@@ -836,11 +836,11 @@ static int acquire_credentials(
                  * propagate a credential passed to us from further up. */
 
                 if (path_is_absolute(lc->path)) {
-                        sub_fd = open(lc->path, O_DIRECTORY|O_CLOEXEC);
-                        if (sub_fd < 0 && !IN_SET(errno,
-                                                  ENOTDIR,  /* Not a directory */
-                                                  ENOENT))  /* Doesn't exist? */
-                                return log_debug_errno(errno, "Failed to open credential source '%s': %m", lc->path);
+                        sub_fd = xopenat(AT_FDCWD, lc->path, O_DIRECTORY);
+                        if (sub_fd < 0 && !IN_SET(sub_fd,
+                                                  -ENOTDIR,  /* Not a directory */
+                                                  -ENOENT))  /* Doesn't exist? */
+                                return log_debug_errno(sub_fd, "Failed to open credential source '%s': %m", lc->path);
                 }
 
                 if (sub_fd < 0)
@@ -992,9 +992,9 @@ static int setup_credentials_plain_dir(
         if (r >= 0)
                 workspace_rm = NULL;
         if (IN_SET(r, -ENOTEMPTY, -EEXIST)) {
-                _cleanup_close_ int old_dfd = open(cred_dir, O_DIRECTORY|O_CLOEXEC|O_NOFOLLOW);
+                _cleanup_close_ int old_dfd = xopenat(AT_FDCWD, cred_dir, O_DIRECTORY|O_NOFOLLOW);
                 if (old_dfd < 0)
-                        return log_debug_errno(errno, "Failed to open credentials dir '%s': %m", cred_dir);
+                        return log_debug_errno(old_dfd, "Failed to open credentials dir '%s': %m", cred_dir);
 
                 (void) fd_acl_make_writable(old_dfd);
 

--- a/src/core/exec-invoke.c
+++ b/src/core/exec-invoke.c
@@ -746,7 +746,7 @@ static void write_confirm_error(int err, const char *vc, const char *unit_id) {
         assert(vc);
         assert(unit_id);
 
-        fd = open_terminal(vc, O_WRONLY|O_NOCTTY|O_CLOEXEC);
+        fd = open_terminal(vc, O_WRONLY|O_NOCTTY);
         if (fd < 0)
                 return;
 
@@ -3757,9 +3757,9 @@ static int pin_rootfs(
                  * mountfsd will want this later, and it wants a fully opened fd, so that security checks
                  * have been passed */
                 _cleanup_close_ int reopened_fd = -EBADF;
-                reopened_fd = fd_reopen(result.fd, O_CLOEXEC|O_NONBLOCK|O_NOCTTY|O_RDWR);
+                reopened_fd = fd_reopen(result.fd, O_NONBLOCK|O_NOCTTY|O_RDWR);
                 if (ERRNO_IS_NEG_FS_WRITE_REFUSED(reopened_fd))
-                        reopened_fd = fd_reopen(result.fd, O_CLOEXEC|O_NONBLOCK|O_NOCTTY|O_RDONLY);
+                        reopened_fd = fd_reopen(result.fd, O_NONBLOCK|O_NOCTTY|O_RDONLY);
                 if (reopened_fd < 0) {
                         *reterr_path = strdup(context->root_image);
                         return log_debug_errno(reopened_fd, "Failed to open image '%s': %m", context->root_image);
@@ -4542,7 +4542,7 @@ static int get_open_file_fd(const OpenFile *of) {
                 else if (FLAGS_SET(of->flags, OPENFILE_TRUNCATE))
                         flags |= O_TRUNC;
 
-                fd = fd_reopen(ofd, flags|O_NOCTTY|O_CLOEXEC);
+                fd = fd_reopen(ofd, flags|O_NOCTTY);
                 if (fd < 0)
                         return log_debug_errno(fd, "Failed to reopen file '%s': %m", of->path);
 

--- a/src/core/exec-invoke.c
+++ b/src/core/exec-invoke.c
@@ -138,9 +138,9 @@ static int open_null_as(int flags, int nfd) {
 
         assert(nfd >= 0);
 
-        fd = open("/dev/null", flags|O_NOCTTY);
+        fd = xopenat(AT_FDCWD, "/dev/null", flags|O_NOCTTY);
         if (fd < 0)
-                return -errno;
+                return fd;
 
         return move_fd(fd, nfd, false);
 }
@@ -278,12 +278,12 @@ static int acquire_path(const char *path, int flags, mode_t mode) {
         if (IN_SET(flags & O_ACCMODE_STRICT, O_WRONLY, O_RDWR))
                 flags |= O_CREAT;
 
-        fd = open(path, flags|O_NOCTTY, mode);
+        fd = xopenat_full(AT_FDCWD, path, flags|O_NOCTTY, /* xopen_flags= */ 0, mode);
         if (fd >= 0)
                 return TAKE_FD(fd);
 
-        if (errno != ENXIO) /* ENXIO is returned when we try to open() an AF_UNIX file system socket on Linux */
-                return -errno;
+        if (fd != -ENXIO) /* ENXIO is returned when we try to open() an AF_UNIX file system socket on Linux */
+                return fd;
 
         /* So, it appears the specified path could be an AF_UNIX socket. Let's see if we can connect to it. */
 
@@ -2760,9 +2760,9 @@ static int set_exec_storage_quota(int fd, uint32_t proj_id, const ExecQuotaLimit
                  * used for quotactl_fd(SET) and is passed again for fstatvfs(), the total number of blocks is not
                  * reported accurately (instead, the block limit is reported as total blocks). Thus, use the FD
                  * associated with the parent, so that total blocks is accurate */
-                fd_parent = openat(fd, "..", O_PATH|O_CLOEXEC|O_DIRECTORY);
+                fd_parent = xopenat(fd, "..", O_PATH|O_DIRECTORY);
                 if (fd_parent < 0)
-                        return -errno;
+                        return fd_parent;
 
                 uint32_t xattr_flags = 0;
                 r = read_fs_xattr_fd(fd_parent, &xattr_flags, /* ret_projid= */ NULL);
@@ -2849,9 +2849,9 @@ static int apply_exec_quotas(
         if (!IN_SET(type, EXEC_DIRECTORY_STATE, EXEC_DIRECTORY_CACHE, EXEC_DIRECTORY_LOGS))
                 return 0;
 
-        fd = open(target_dir, O_PATH|O_CLOEXEC|O_DIRECTORY);
+        fd = xopenat(AT_FDCWD, target_dir, O_PATH|O_DIRECTORY);
         if (fd < 0)
-                return log_debug_errno(errno, "Failed to open %s: %m", target_dir);
+                return log_debug_errno(fd, "Failed to open %s: %m", target_dir);
 
         /* Get the project ID of the current directory */
         uint32_t proj_id;
@@ -4519,9 +4519,9 @@ static int get_open_file_fd(const OpenFile *of) {
 
         assert(of);
 
-        ofd = open(of->path, O_PATH | O_CLOEXEC);
+        ofd = xopenat(AT_FDCWD, of->path, O_PATH);
         if (ofd < 0)
-                return log_debug_errno(errno, "Failed to open '%s' as O_PATH: %m", of->path);
+                return log_debug_errno(ofd, "Failed to open '%s' as O_PATH: %m", of->path);
 
         if (fstat(ofd, &st) < 0)
                 return log_debug_errno( errno, "Failed to stat '%s': %m", of->path);

--- a/src/core/execute.c
+++ b/src/core/execute.c
@@ -140,7 +140,7 @@ void exec_context_tty_reset(const ExecContext *context, const ExecParameters *pa
         if (parameters && parameters->stdout_fd >= 0 && isatty_safe(parameters->stdout_fd))
                 fd = parameters->stdout_fd;
         else if (path && exec_context_has_tty(context)) {
-                fd = _fd = open_terminal(path, O_RDWR|O_NOCTTY|O_CLOEXEC|O_NONBLOCK);
+                fd = _fd = open_terminal(path, O_RDWR|O_NOCTTY|O_NONBLOCK);
                 if (fd < 0)
                         return (void) log_debug_errno(fd, "Failed to open terminal '%s', ignoring: %m", path);
         } else

--- a/src/core/execute.c
+++ b/src/core/execute.c
@@ -1784,9 +1784,9 @@ void exec_context_revert_tty(ExecContext *c, sd_id128_t invocation_id) {
         if (!path)
                 return;
 
-        fd = open(path, O_PATH|O_CLOEXEC); /* Pin the inode */
+        fd = xopenat(AT_FDCWD, path, O_PATH); /* Pin the inode */
         if (fd < 0)
-                return (void) log_full_errno(errno == ENOENT ? LOG_DEBUG : LOG_WARNING, errno,
+                return (void) log_full_errno(fd == -ENOENT ? LOG_DEBUG : LOG_WARNING, fd,
                                              "Failed to open TTY inode of '%s' to adjust ownership/access mode, ignoring: %m",
                                              path);
 

--- a/src/core/ima-setup.c
+++ b/src/core/ima-setup.c
@@ -10,6 +10,7 @@
 #include "alloc-util.h"
 #include "fd-util.h"
 #include "fileio.h"
+#include "fs-util.h"
 #include "ima-setup.h"
 #include "log.h"
 
@@ -39,9 +40,9 @@ int ima_setup(void) {
                 return 0;
         }
 
-        imafd = open(IMA_SECFS_POLICY, O_WRONLY|O_CLOEXEC);
+        imafd = xopenat(AT_FDCWD, IMA_SECFS_POLICY, O_WRONLY);
         if (imafd < 0) {
-                log_error_errno(errno, "Failed to open the IMA kernel interface "IMA_SECFS_POLICY", ignoring: %m");
+                log_error_errno(imafd, "Failed to open the IMA kernel interface "IMA_SECFS_POLICY", ignoring: %m");
                 return 0;
         }
 
@@ -58,9 +59,9 @@ int ima_setup(void) {
 
         safe_close(imafd);
 
-        imafd = open(IMA_SECFS_POLICY, O_WRONLY|O_CLOEXEC);
+        imafd = xopenat(AT_FDCWD, IMA_SECFS_POLICY, O_WRONLY);
         if (imafd < 0) {
-                log_error_errno(errno, "Failed to open the IMA kernel interface "IMA_SECFS_POLICY", ignoring: %m");
+                log_error_errno(imafd, "Failed to open the IMA kernel interface "IMA_SECFS_POLICY", ignoring: %m");
                 return 0;
         }
 

--- a/src/core/import-creds.c
+++ b/src/core/import-creds.c
@@ -105,9 +105,9 @@ static int acquire_credential_directory(ImportCredentialsContext *c, const char 
                 /* If not a mount point yet, and the credentials are not encrypted, then let's try to mount a no-swap fs there */
                 (void) mount_credentials_fs(path);
 
-        c->target_dir_fd = open(path, O_RDONLY|O_DIRECTORY|O_CLOEXEC);
+        c->target_dir_fd = xopenat(AT_FDCWD, path, O_RDONLY|O_DIRECTORY);
         if (c->target_dir_fd < 0)
-                return log_error_errno(errno, "Failed to open %s: %m", path);
+                return log_error_errno(c->target_dir_fd, "Failed to open %s: %m", path);
 
         return c->target_dir_fd;
 }
@@ -119,12 +119,12 @@ static int open_credential_file_for_write(int target_dir_fd, const char *dir_nam
         assert(dir_name);
         assert(n);
 
-        fd = openat(target_dir_fd, n, O_WRONLY|O_CLOEXEC|O_CREAT|O_EXCL|O_NOFOLLOW, 0400);
+        fd = xopenat_full(target_dir_fd, n, O_WRONLY|O_CREAT|O_EXCL|O_NOFOLLOW, /* xopen_flags= */ 0, 0400);
         if (fd < 0) {
-                if (errno == EEXIST) /* In case of EEXIST we'll only debug log! */
-                        return log_debug_errno(errno, "Credential '%s' set twice, ignoring.", n);
+                if (fd == -EEXIST) /* In case of EEXIST we'll only debug log! */
+                        return log_debug_errno(fd, "Credential '%s' set twice, ignoring.", n);
 
-                return log_error_errno(errno, "Failed to create %s/%s: %m", dir_name, n);
+                return log_error_errno(fd, "Failed to create %s/%s: %m", dir_name, n);
         }
 
         return fd;
@@ -178,14 +178,14 @@ static int import_credentials_from_initrd_path(
         _cleanup_close_ int source_dir_fd = -EBADF;
         int r;
 
-        source_dir_fd = open(source_path, O_RDONLY|O_DIRECTORY|O_CLOEXEC|O_NOFOLLOW);
+        source_dir_fd = xopenat(AT_FDCWD, source_path, O_RDONLY|O_DIRECTORY|O_NOFOLLOW);
         if (source_dir_fd < 0) {
-                if (errno == ENOENT) {
+                if (source_dir_fd == -ENOENT) {
                         log_debug("No credentials passed via %s.", source_path);
                         return 0;
                 }
 
-                log_warning_errno(errno, "Failed to open '%s', ignoring: %m", source_path);
+                log_warning_errno(source_dir_fd, "Failed to open '%s', ignoring: %m", source_path);
                 return 0;
         }
 
@@ -217,9 +217,9 @@ static int import_credentials_from_initrd_path(
                         continue;
                 }
 
-                cfd = openat(source_dir_fd, d->d_name, O_RDONLY|O_CLOEXEC);
+                cfd = xopenat(source_dir_fd, d->d_name, O_RDONLY);
                 if (cfd < 0) {
-                        log_warning_errno(errno, "Failed to open %s, ignoring: %m", d->d_name);
+                        log_warning_errno(cfd, "Failed to open %s, ignoring: %m", d->d_name);
                         continue;
                 }
 
@@ -426,14 +426,14 @@ static int import_credentials_qemu(ImportCredentialsContext *c) {
         if (detect_confidential_virtualization() > 0) /* don't trust firmware if confidential VMs */
                 return 0;
 
-        source_dir_fd = open(QEMU_FWCFG_PATH, O_RDONLY|O_DIRECTORY|O_CLOEXEC);
+        source_dir_fd = xopenat(AT_FDCWD, QEMU_FWCFG_PATH, O_RDONLY|O_DIRECTORY);
         if (source_dir_fd < 0) {
-                if (errno == ENOENT) {
+                if (source_dir_fd == -ENOENT) {
                         log_debug("No credentials passed via fw_cfg.");
                         return 0;
                 }
 
-                log_warning_errno(errno, "Failed to open '" QEMU_FWCFG_PATH "', ignoring: %m");
+                log_warning_errno(source_dir_fd, "Failed to open '" QEMU_FWCFG_PATH "', ignoring: %m");
                 return 0;
         }
 
@@ -454,9 +454,9 @@ static int import_credentials_qemu(ImportCredentialsContext *c) {
                         continue;
                 }
 
-                vfd = openat(source_dir_fd, d->d_name, O_RDONLY|O_DIRECTORY|O_CLOEXEC);
+                vfd = xopenat(source_dir_fd, d->d_name, O_RDONLY|O_DIRECTORY);
                 if (vfd < 0) {
-                        log_warning_errno(errno, "Failed to open '" QEMU_FWCFG_PATH "'/%s/, ignoring: %m", d->d_name);
+                        log_warning_errno(vfd, "Failed to open '" QEMU_FWCFG_PATH "'/%s/, ignoring: %m", d->d_name);
                         continue;
                 }
 
@@ -479,9 +479,9 @@ static int import_credentials_qemu(ImportCredentialsContext *c) {
                  * having size zero, and we'd rather not have applications support such credential
                  * files. Let's hence copy the files to make them regular. */
 
-                rfd = openat(vfd, "raw", O_RDONLY|O_CLOEXEC);
+                rfd = xopenat(vfd, "raw", O_RDONLY);
                 if (rfd < 0) {
-                        log_warning_errno(errno, "Failed to open '" QEMU_FWCFG_PATH "'/%s/raw, ignoring: %m", d->d_name);
+                        log_warning_errno(rfd, "Failed to open '" QEMU_FWCFG_PATH "'/%s/raw, ignoring: %m", d->d_name);
                         continue;
                 }
 
@@ -670,12 +670,12 @@ static int import_credentials_initrd(ImportCredentialsContext *c) {
         if (in_initrd())
                 return 0;
 
-        source_dir_fd = open("/run/credentials/@initrd", O_RDONLY|O_DIRECTORY|O_CLOEXEC|O_NOFOLLOW);
+        source_dir_fd = xopenat(AT_FDCWD, "/run/credentials/@initrd", O_RDONLY|O_DIRECTORY|O_NOFOLLOW);
         if (source_dir_fd < 0) {
-                if (errno == ENOENT)
-                        log_debug_errno(errno, "No credentials passed from initrd.");
+                if (source_dir_fd == -ENOENT)
+                        log_debug_errno(source_dir_fd, "No credentials passed from initrd.");
                 else
-                        log_warning_errno(errno, "Failed to open '%s', ignoring: %m", "/run/credentials/@initrd");
+                        log_warning_errno(source_dir_fd, "Failed to open '%s', ignoring: %m", "/run/credentials/@initrd");
                 return 0;
         }
 
@@ -695,9 +695,9 @@ static int import_credentials_initrd(ImportCredentialsContext *c) {
                         continue;
                 }
 
-                cfd = openat(source_dir_fd, d->d_name, O_RDONLY|O_CLOEXEC);
+                cfd = xopenat(source_dir_fd, d->d_name, O_RDONLY);
                 if (cfd < 0) {
-                        log_warning_errno(errno, "Failed to open %s, ignoring: %m", d->d_name);
+                        log_warning_errno(cfd, "Failed to open %s, ignoring: %m", d->d_name);
                         continue;
                 }
 

--- a/src/core/ipe-setup.c
+++ b/src/core/ipe-setup.c
@@ -8,6 +8,7 @@
 #include "copy.h"
 #include "fd-util.h"
 #include "fileio.h"
+#include "fs-util.h"
 #include "ipe-setup.h"
 #include "log.h"
 #include "path-util.h"
@@ -63,10 +64,10 @@ int ipe_setup(void) {
                                         "Invalid IPE policy name %s",
                                         policy_name);
 
-                input = open(*policy, O_RDONLY|O_NOFOLLOW|O_CLOEXEC);
+                input = xopenat(AT_FDCWD, *policy, O_RDONLY|O_NOFOLLOW);
                 if (input < 0)
                         return log_error_errno(
-                                        errno,
+                                        input,
                                         "Failed to open the IPE policy file %s: %m",
                                         *policy);
 
@@ -75,13 +76,13 @@ int ipe_setup(void) {
                 if (!output_path)
                         return log_oom();
 
-                output = open(output_path, O_WRONLY|O_CLOEXEC);
-                if (output < 0 && errno == ENOENT)
+                output = xopenat(AT_FDCWD, output_path, O_WRONLY);
+                if (output == -ENOENT)
                         /* Policy is not installed, install it and activate it */
-                        output = open(IPE_SECFS_NEW_POLICY, O_WRONLY|O_CLOEXEC);
+                        output = xopenat(AT_FDCWD, IPE_SECFS_NEW_POLICY, O_WRONLY);
                 if (output < 0)
                         return log_error_errno(
-                                        errno,
+                                        output,
                                         "Failed to open the IPE policy handle for writing: %m");
 
                 /* The policy is inline signed in binary format, so it has to be copied in one go, otherwise the

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -270,7 +270,7 @@ static int console_setup(void) {
 
         _cleanup_close_ int tty_fd = -EBADF;
 
-        tty_fd = open_terminal("/dev/console", O_RDWR|O_NOCTTY|O_CLOEXEC);
+        tty_fd = open_terminal("/dev/console", O_RDWR|O_NOCTTY);
         if (tty_fd < 0)
                 return log_error_errno(tty_fd, "Failed to open %s: %m", "/dev/console");
 
@@ -1637,7 +1637,7 @@ static int write_boot_or_shutdown_osc(const char *type) {
         if (getenv_terminal_is_dumb())
                 return 0;
 
-        _cleanup_close_ int fd = open_terminal("/dev/console", O_WRONLY|O_NOCTTY|O_CLOEXEC);
+        _cleanup_close_ int fd = open_terminal("/dev/console", O_WRONLY|O_NOCTTY);
         if (fd < 0)
                 return log_debug_errno(fd, "Failed to open /dev/console to print %s OSC, ignoring: %m", type);
 
@@ -2149,7 +2149,7 @@ static void reduce_vt(ManagerObjective objective) {
         if (r < 0)
                 log_debug_errno(r, "Failed to switch to VT TTY 1, ignoring: %m");
 
-        _cleanup_close_ int tty0_fd = open_terminal("/dev/tty0", O_RDWR|O_NOCTTY|O_CLOEXEC|O_NONBLOCK);
+        _cleanup_close_ int tty0_fd = open_terminal("/dev/tty0", O_RDWR|O_NOCTTY|O_NONBLOCK);
         if (tty0_fd < 0)
                 return (void) log_debug_errno(tty0_fd, "Failed to open '/dev/tty0', ignoring: %m");
 
@@ -3973,7 +3973,7 @@ finish:
         if (getpid_cached() == 1) {
                 _cleanup_close_ int tty_fd = -EBADF;
 
-                tty_fd = open_terminal("/dev/console", O_WRONLY|O_NOCTTY|O_CLOEXEC);
+                tty_fd = open_terminal("/dev/console", O_WRONLY|O_NOCTTY);
                 if (tty_fd >= 0)
                         __sanitizer_set_report_fd((void*) (intptr_t) tty_fd);
 

--- a/src/core/manager.c
+++ b/src/core/manager.c
@@ -505,7 +505,7 @@ static int manager_enable_special_signals(Manager *m) {
         if (reboot(RB_DISABLE_CAD) < 0 && !IN_SET(errno, EPERM, EINVAL))
                 log_warning_errno(errno, "Failed to enable ctrl-alt-del handling, ignoring: %m");
 
-        fd = open_terminal("/dev/tty0", O_RDWR|O_NOCTTY|O_CLOEXEC);
+        fd = open_terminal("/dev/tty0", O_RDWR|O_NOCTTY);
         if (fd < 0)
                 /* Support systems without virtual console (ENOENT) gracefully */
                 log_full_errno(fd == -ENOENT ? LOG_DEBUG : LOG_WARNING, fd, "Failed to open %s, ignoring: %m", "/dev/tty0");

--- a/src/core/namespace.c
+++ b/src/core/namespace.c
@@ -3543,9 +3543,9 @@ int setup_shareable_ns(int ns_storage_socket[static 2], unsigned long nsflag) {
                 (void) loopback_setup();
 
         ns_path = strjoina("/proc/self/ns/", ns_name);
-        ns = open(ns_path, O_RDONLY|O_CLOEXEC|O_NOCTTY);
+        ns = xopenat(AT_FDCWD, ns_path, O_RDONLY|O_NOCTTY);
         if (ns < 0)
-                return -errno;
+                return ns;
 
         r = send_one_fd(ns_storage_socket[1], ns, MSG_DONTWAIT);
         if (r < 0)
@@ -3585,9 +3585,9 @@ int open_shareable_ns_path(int ns_storage_socket[static 2], const char *path, un
 
         /* Nothing stored yet. Open the file from the file system. */
 
-        ns = open(path, O_RDONLY|O_NOCTTY|O_CLOEXEC);
+        ns = xopenat(AT_FDCWD, path, O_RDONLY|O_NOCTTY);
         if (ns < 0)
-                return -errno;
+                return ns;
 
         r = fd_is_namespace(ns, type);
         if (r < 0)

--- a/src/core/namespace.c
+++ b/src/core/namespace.c
@@ -3408,7 +3408,7 @@ static int make_tmp_prefix(const char *prefix) {
 
         /* umask will corrupt this access mode, but that doesn't matter, we need to call chmod() anyway for
          * the suid bit, below. */
-        fd = open_mkdir(t, O_EXCL|O_CLOEXEC, 0777);
+        fd = open_mkdir(t, O_EXCL, 0777);
         if (fd < 0)
                 return fd;
 

--- a/src/core/show-status.c
+++ b/src/core/show-status.c
@@ -61,7 +61,7 @@ int status_vprintf(const char *status, ShowStatusFlags flags, const char *format
          * but minimizes the time window the kernel might end up killing PID 1 due to SAK). It also makes things easier
          * for us so that we don't have to recover from hangups and suchlike triggered on the console. */
 
-        fd = open_terminal("/dev/console", O_WRONLY|O_NOCTTY|O_CLOEXEC);
+        fd = open_terminal("/dev/console", O_WRONLY|O_NOCTTY);
         if (fd < 0)
                 return fd;
 

--- a/src/core/smack-setup.c
+++ b/src/core/smack-setup.c
@@ -16,6 +16,7 @@
 #include "errno-util.h"
 #include "fd-util.h"
 #include "fileio.h"
+#include "fs-util.h"
 #include "log.h"
 #include "smack-setup.h"
 #include "string-util.h"
@@ -29,12 +30,12 @@ static int fdopen_unlocked_at(int dfd, const char *dir, const char *name, int *s
         assert(status);
         assert(ret_file);
 
-        fd = openat(dfd, name, O_RDONLY|O_CLOEXEC);
+        fd = xopenat(dfd, name, O_RDONLY);
         if (fd < 0) {
                 if (*status == 0)
-                        *status = -errno;
+                        *status = fd;
 
-                return log_warning_errno(errno, "Failed to open \"%s/%s\": %m", dir, name);
+                return log_warning_errno(fd, "Failed to open \"%s/%s\": %m", dir, name);
         }
 
         r = fdopen_unlocked(fd, "r", &f);
@@ -55,14 +56,14 @@ static int write_access2_rules(const char *srcdir) {
         _cleanup_closedir_ DIR *dir = NULL;
         int dfd, r;
 
-        load2_fd = r = RET_NERRNO(open("/sys/fs/smackfs/load2", O_RDWR|O_CLOEXEC|O_NONBLOCK|O_NOCTTY));
+        load2_fd = r = xopenat(AT_FDCWD, "/sys/fs/smackfs/load2", O_RDWR|O_NONBLOCK|O_NOCTTY);
         if (r < 0)  {
                 if (r != -ENOENT)
                         log_warning_errno(r, "Failed to open %s: %m", "/sys/fs/smackfs/load2");
                 return r;
         }
 
-        change_fd = r = RET_NERRNO(open("/sys/fs/smackfs/change-rule", O_RDWR|O_CLOEXEC|O_NONBLOCK|O_NOCTTY));
+        change_fd = r = xopenat(AT_FDCWD, "/sys/fs/smackfs/change-rule", O_RDWR|O_NONBLOCK|O_NOCTTY);
         if (r < 0)  {
                 if (r != -ENOENT)
                         log_warning_errno(r, "Failed to open %s: %m", "/sys/fs/smackfs/change-rule");
@@ -130,7 +131,7 @@ static int write_cipso2_rules(const char *srcdir) {
         _cleanup_closedir_ DIR *dir = NULL;
         int dfd, r;
 
-        cipso2_fd = r = RET_NERRNO(open("/sys/fs/smackfs/cipso2", O_RDWR|O_CLOEXEC|O_NONBLOCK|O_NOCTTY));
+        cipso2_fd = r = xopenat(AT_FDCWD, "/sys/fs/smackfs/cipso2", O_RDWR|O_NONBLOCK|O_NOCTTY);
         if (r < 0)  {
                 if (r != -ENOENT)
                         log_warning_errno(r, "Failed to open %s: %m", "/sys/fs/smackfs/cipso2");
@@ -287,7 +288,7 @@ static int write_onlycap_list(void) {
 
         list[len - 1] = 0;
 
-        onlycap_fd = r = RET_NERRNO(open("/sys/fs/smackfs/onlycap", O_WRONLY|O_CLOEXEC|O_NONBLOCK|O_NOCTTY));
+        onlycap_fd = r = xopenat(AT_FDCWD, "/sys/fs/smackfs/onlycap", O_WRONLY|O_NONBLOCK|O_NOCTTY);
         if (r < 0) {
                 if (r != -ENOENT)
                         log_warning_errno(r, "Failed to open %s: %m", "/sys/fs/smackfs/onlycap");

--- a/src/core/socket.c
+++ b/src/core/socket.c
@@ -1227,9 +1227,9 @@ static int fifo_address_create(
                 goto fail;
         }
 
-        fd = open(path, O_RDWR | O_CLOEXEC | O_NOCTTY | O_NONBLOCK | O_NOFOLLOW);
+        fd = xopenat(AT_FDCWD, path, O_RDWR | O_NOCTTY | O_NONBLOCK | O_NOFOLLOW);
         if (fd < 0) {
-                r = -errno;
+                r = fd;
                 goto fail;
         }
 
@@ -1261,9 +1261,9 @@ static int special_address_create(const char *path, bool writable) {
 
         assert(path);
 
-        fd = open(path, (writable ? O_RDWR : O_RDONLY)|O_CLOEXEC|O_NOCTTY|O_NONBLOCK|O_NOFOLLOW);
+        fd = xopenat(AT_FDCWD, path, (writable ? O_RDWR : O_RDONLY)|O_NOCTTY|O_NONBLOCK|O_NOFOLLOW);
         if (fd < 0)
-                return -errno;
+                return fd;
 
         if (fstat(fd, &st) < 0)
                 return -errno;
@@ -1282,9 +1282,9 @@ static int usbffs_address_create_at(int dfd, const char *name) {
         assert(dfd >= 0);
         assert(name);
 
-        fd = openat(dfd, name, O_RDWR|O_CLOEXEC|O_NOCTTY|O_NONBLOCK|O_NOFOLLOW);
+        fd = xopenat(dfd, name, O_RDWR|O_NOCTTY|O_NONBLOCK|O_NOFOLLOW);
         if (fd < 0)
-                return -errno;
+                return fd;
 
         if (fstat(fd, &st) < 0)
                 return -errno;
@@ -1750,9 +1750,9 @@ static int socket_open_fds(Socket *orig_s) {
                 case SOCKET_USB_FUNCTION: {
                         _cleanup_close_ int dfd = -EBADF;
 
-                        dfd = open(p->path, O_DIRECTORY|O_CLOEXEC);
+                        dfd = xopenat(AT_FDCWD, p->path, O_DIRECTORY);
                         if (dfd < 0)
-                                return log_unit_error_errno(UNIT(s), errno,
+                                return log_unit_error_errno(UNIT(s), dfd,
                                                             "Failed to open USB FunctionFS dir '%s': %m", p->path);
 
                         p->fd = usbffs_address_create_at(dfd, "ep0");

--- a/src/core/unit.c
+++ b/src/core/unit.c
@@ -6948,9 +6948,9 @@ int unit_get_exec_quota_stats(Unit *u, ExecContext *c, ExecDirectoryType dt, uin
         }
 
         const char *target_dir = pp ?: p;
-        fd = open(target_dir, O_PATH | O_CLOEXEC | O_DIRECTORY);
+        fd = xopenat(AT_FDCWD, target_dir, O_PATH | O_DIRECTORY);
         if (fd < 0)
-                return log_unit_debug_errno(u, errno, "Failed to get exec quota stats: %m");
+                return log_unit_debug_errno(u, fd, "Failed to get exec quota stats: %m");
 
         uint32_t proj_id;
         r = read_fs_xattr_fd(fd, /* ret_xflags= */ NULL, &proj_id);

--- a/src/coredump/coredump-context.c
+++ b/src/coredump/coredump-context.c
@@ -105,9 +105,9 @@ static int compose_open_fds(pid_t pid, char **ret) {
         if (!proc_fd_dir)
                 return -errno;
 
-        proc_fdinfo_fd = openat(dirfd(proc_fd_dir), "../fdinfo", O_DIRECTORY|O_NOFOLLOW|O_CLOEXEC|O_PATH);
+        proc_fdinfo_fd = xopenat(dirfd(proc_fd_dir), "../fdinfo", O_DIRECTORY|O_NOFOLLOW|O_PATH);
         if (proc_fdinfo_fd < 0)
-                return -errno;
+                return proc_fdinfo_fd;
 
         stream = memstream_init(&m);
         if (!stream)
@@ -126,7 +126,7 @@ static int compose_open_fds(pid_t pid, char **ret) {
                 fddelim = "\n";
 
                 /* Use the directory entry from /proc/[pid]/fd with /proc/[pid]/fdinfo */
-                fd = openat(proc_fdinfo_fd, de->d_name, O_NOFOLLOW|O_CLOEXEC|O_RDONLY);
+                fd = xopenat(proc_fdinfo_fd, de->d_name, O_NOFOLLOW|O_RDONLY);
                 if (fd < 0)
                         continue;
 

--- a/src/coredump/coredump-submit.c
+++ b/src/coredump/coredump-submit.c
@@ -285,7 +285,7 @@ static int save_external_coredump(
 
         (void) mkdir_parents_label(fn, 0755);
 
-        fd = open_tmpfile_linkable(fn, O_RDWR|O_CLOEXEC, &tmp);
+        fd = open_tmpfile_linkable(fn, O_RDWR, &tmp);
         if (fd < 0)
                 return log_error_errno(fd, "Failed to create temporary file for coredump %s: %m", fn);
 
@@ -369,7 +369,7 @@ static int save_external_coredump(
                 if (!fn_compressed)
                         return log_oom();
 
-                fd_compressed = open_tmpfile_linkable(fn_compressed, O_RDWR|O_CLOEXEC, &tmp_compressed);
+                fd_compressed = open_tmpfile_linkable(fn_compressed, O_RDWR, &tmp_compressed);
                 if (fd_compressed < 0)
                         return log_error_errno(fd_compressed, "Failed to create temporary file for coredump %s: %m", fn_compressed);
 

--- a/src/coredump/coredumpctl-core.c
+++ b/src/coredump/coredumpctl-core.c
@@ -140,7 +140,7 @@ int acquire_core(sd_journal *j, int fd, char **ret_tmpfile, char **ret_path) {
         }
 
 #if HAVE_COMPRESSION
-        _cleanup_close_ int fdf = fd_reopen(fdf_opath, O_RDONLY | O_CLOEXEC);
+        _cleanup_close_ int fdf = fd_reopen(fdf_opath, O_RDONLY);
         if (fdf < 0)
                 return log_error_errno(fdf, "Failed to open '%s': %m", path);
 

--- a/src/coredump/coredumpctl-info.c
+++ b/src/coredump/coredumpctl-info.c
@@ -65,16 +65,16 @@ static void analyze_coredump_file(
         assert(ret_color);
         assert(ret_size);
 
-        fd = open(path, O_PATH|O_CLOEXEC);
+        fd = xopenat(AT_FDCWD, path, O_PATH);
         if (fd < 0) {
-                if (errno == ENOENT) {
+                if (fd == -ENOENT) {
                         *ret_state = "missing";
                         *ret_color = ansi_grey();
                         *ret_size = UINT64_MAX;
                         return;
                 }
 
-                r = -errno;
+                r = fd;
         } else
                 r = access_fd(fd, R_OK);
         if (r < 0) {

--- a/src/creds/creds.c
+++ b/src/creds/creds.c
@@ -18,6 +18,7 @@
 #include "escape.h"
 #include "fileio.h"
 #include "format-table.h"
+#include "fs-util.h"
 #include "hashmap.h"
 #include "hexdecoct.h"
 #include "json-util.h"
@@ -253,12 +254,12 @@ static int add_credentials_to_table(Table *t, bool encrypted) {
                 if (!credential_name_valid(de->d_name))
                         continue;
 
-                fd = openat(dirfd(d), de->d_name, O_PATH|O_CLOEXEC|O_NOFOLLOW);
+                fd = xopenat(dirfd(d), de->d_name, O_PATH|O_NOFOLLOW);
                 if (fd < 0) {
-                        if (errno == ENOENT) /* Vanished by now? */
+                        if (fd == -ENOENT) /* Vanished by now? */
                                 continue;
 
-                        return log_error_errno(errno, "Failed to open credential '%s': %m", de->d_name);
+                        return log_error_errno(fd, "Failed to open credential '%s': %m", de->d_name);
                 }
 
                 if (fstat(fd, &st) < 0)

--- a/src/dissect/dissect.c
+++ b/src/dissect/dissect.c
@@ -1155,7 +1155,7 @@ static int get_file_sha256(int inode_fd, uint8_t ret[static SHA256_DIGEST_SIZE])
         _cleanup_close_ int fd = -EBADF;
 
         /* convert O_PATH fd into a regular one */
-        fd = fd_reopen(inode_fd, O_RDONLY|O_CLOEXEC);
+        fd = fd_reopen(inode_fd, O_RDONLY);
         if (fd < 0)
                 return fd;
 
@@ -1370,7 +1370,7 @@ static int action_list_or_mtree_or_copy_or_make_archive(DissectedImage *m, LoopD
         case ACTION_COPY_FROM: {
                 _cleanup_close_ int source_fd = -EBADF, target_fd = -EBADF;
 
-                source_fd = chase_and_open(arg_source, root, CHASE_PREFIX_ROOT|CHASE_WARN, O_RDONLY|O_CLOEXEC|O_NOCTTY, NULL);
+                source_fd = chase_and_open(arg_source, root, CHASE_PREFIX_ROOT|CHASE_WARN, O_RDONLY|O_NOCTTY, /* ret_path= */ NULL);
                 if (source_fd < 0)
                         return log_error_errno(source_fd, "Failed to open source path '%s' in image '%s': %m", arg_source, arg_image);
 
@@ -1551,7 +1551,7 @@ static int action_list_or_mtree_or_copy_or_make_archive(DissectedImage *m, LoopD
                 _cleanup_close_ int tmp_fd = -EBADF;
                 int output_fd;
                 if (arg_target) {
-                        tmp_fd = open_tmpfile_linkable(arg_target, O_WRONLY|O_CLOEXEC, &tar);
+                        tmp_fd = open_tmpfile_linkable(arg_target, O_WRONLY, &tar);
                         if (tmp_fd < 0)
                                 return log_error_errno(tmp_fd, "Failed to create target file '%s': %m", arg_target);
 

--- a/src/dissect/dissect.c
+++ b/src/dissect/dissect.c
@@ -1403,9 +1403,9 @@ static int action_list_or_mtree_or_copy_or_make_archive(DissectedImage *m, LoopD
                         return log_error_errno(r, "Source path %s in image '%s' is neither regular file nor directory, refusing: %m", arg_source, arg_image);
 
                 /* Nah, it's a plain file! */
-                target_fd = open(arg_target, O_WRONLY|O_CREAT|O_EXCL|O_CLOEXEC|O_NOCTTY|O_NOFOLLOW, 0600);
+                target_fd = xopenat_full(AT_FDCWD, arg_target, O_WRONLY|O_CREAT|O_EXCL|O_NOCTTY|O_NOFOLLOW, /* xopen_flags= */ 0, 0600);
                 if (target_fd < 0)
-                        return log_error_errno(errno, "Failed to create regular file at target path '%s': %m", arg_target);
+                        return log_error_errno(target_fd, "Failed to create regular file at target path '%s': %m", arg_target);
 
                 r = copy_bytes(source_fd, target_fd, UINT64_MAX, /* copy_flags= */ 0);
                 if (r < 0)
@@ -1442,9 +1442,9 @@ static int action_list_or_mtree_or_copy_or_make_archive(DissectedImage *m, LoopD
                         if (is_dir)
                                 return log_error_errno(SYNTHETIC_ERRNO(EISDIR), "Cannot copy STDIN to a directory, refusing.");
 
-                        target_fd = openat(dfd, bn, O_WRONLY|O_CREAT|O_CLOEXEC|O_NOCTTY|O_EXCL, 0644);
+                        target_fd = xopenat_full(dfd, bn, O_WRONLY|O_CREAT|O_NOCTTY|O_EXCL, /* xopen_flags= */ 0, 0644);
                         if (target_fd < 0)
-                                return log_error_errno(errno, "Failed to open target file '%s': %m", arg_target);
+                                return log_error_errno(target_fd, "Failed to open target file '%s': %m", arg_target);
 
                         r = copy_bytes(STDIN_FILENO, target_fd, UINT64_MAX, /* copy_flags= */ 0);
                         if (r < 0)
@@ -1454,7 +1454,7 @@ static int action_list_or_mtree_or_copy_or_make_archive(DissectedImage *m, LoopD
                         return 0;
                 }
 
-                source_fd = open(arg_source, O_RDONLY|O_CLOEXEC|O_NOCTTY);
+                source_fd = xopenat(AT_FDCWD, arg_source, O_RDONLY|O_NOCTTY);
                 if (source_fd < 0)
                         return log_error_errno(source_fd, "Failed to open source path '%s': %m", arg_source);
 
@@ -1465,14 +1465,14 @@ static int action_list_or_mtree_or_copy_or_make_archive(DissectedImage *m, LoopD
 
                         /* We are looking at a directory. */
 
-                        target_fd = openat(dfd, bn, O_RDONLY|O_DIRECTORY|O_CLOEXEC|O_NOFOLLOW);
+                        target_fd = xopenat(dfd, bn, O_RDONLY|O_DIRECTORY|O_NOFOLLOW);
                         if (target_fd < 0) {
-                                if (errno == ELOOP)
+                                if (target_fd == -ELOOP)
                                         return log_error_errno(SYNTHETIC_ERRNO(ELOOP),
                                                         "Refusing to copy directory to symlink destination '%s'.", arg_target);
 
-                                if (errno != ENOENT)
-                                        return log_error_errno(errno, "Failed to open destination '%s': %m", arg_target);
+                                if (target_fd != -ENOENT)
+                                        return log_error_errno(target_fd, "Failed to open destination '%s': %m", arg_target);
 
                                 r = copy_tree_at(
                                                 source_fd, ".",
@@ -1501,9 +1501,9 @@ static int action_list_or_mtree_or_copy_or_make_archive(DissectedImage *m, LoopD
                         return log_error_errno(SYNTHETIC_ERRNO(EISDIR), "Source is a regular file, but target is not, refusing.");
 
                 /* We area looking at a regular file */
-                target_fd = openat(dfd, bn, O_WRONLY|O_CREAT|O_CLOEXEC|O_NOCTTY|O_EXCL, 0600);
+                target_fd = xopenat_full(dfd, bn, O_WRONLY|O_CREAT|O_NOCTTY|O_EXCL, /* xopen_flags= */ 0, 0600);
                 if (target_fd < 0)
-                        return log_error_errno(errno, "Failed to open target file '%s': %m", arg_target);
+                        return log_error_errno(target_fd, "Failed to open target file '%s': %m", arg_target);
 
                 r = copy_bytes(source_fd, target_fd, UINT64_MAX, /* copy_flags= */ 0);
                 if (r < 0)
@@ -1522,9 +1522,9 @@ static int action_list_or_mtree_or_copy_or_make_archive(DissectedImage *m, LoopD
         case ACTION_MTREE: {
                 _cleanup_close_ int dfd = -EBADF;
 
-                dfd = open(root, O_DIRECTORY|O_CLOEXEC|O_RDONLY);
+                dfd = xopenat(AT_FDCWD, root, O_DIRECTORY|O_RDONLY);
                 if (dfd < 0)
-                        return log_error_errno(errno, "Failed to open mount directory: %m");
+                        return log_error_errno(dfd, "Failed to open mount directory: %m");
 
                 pager_open(arg_pager_flags);
 
@@ -1543,9 +1543,9 @@ static int action_list_or_mtree_or_copy_or_make_archive(DissectedImage *m, LoopD
 #if HAVE_LIBARCHIVE
                 _cleanup_close_ int dfd = -EBADF;
 
-                dfd = open(root, O_DIRECTORY|O_CLOEXEC|O_RDONLY);
+                dfd = xopenat(AT_FDCWD, root, O_DIRECTORY|O_RDONLY);
                 if (dfd < 0)
-                        return log_error_errno(errno, "Failed to open mount directory: %m");
+                        return log_error_errno(dfd, "Failed to open mount directory: %m");
 
                 _cleanup_(unlink_and_freep) char *tar = NULL;
                 _cleanup_close_ int tmp_fd = -EBADF;
@@ -1620,9 +1620,9 @@ static int action_umount(const char *path) {
                  * partition. If it does not have the root partition, then we mount the /usr partition on a
                  * tmpfs. Hence, let's try to find the backing block device through the /usr partition. */
 
-                usr_fd = openat(fd, "usr", O_CLOEXEC | O_DIRECTORY | O_NOFOLLOW);
+                usr_fd = xopenat(fd, "usr", O_DIRECTORY | O_NOFOLLOW);
                 if (usr_fd < 0)
-                        return log_error_errno(errno, "Failed to open '%s/usr': %m", canonical);
+                        return log_error_errno(usr_fd, "Failed to open '%s/usr': %m", canonical);
 
                 r = block_device_new_from_fd(usr_fd, BLOCK_DEVICE_LOOKUP_WHOLE_DISK | BLOCK_DEVICE_LOOKUP_BACKING, &dev);
         }
@@ -1837,9 +1837,9 @@ static int action_detach(const char *path) {
 
         assert(path);
 
-        fd = open(path, O_PATH|O_CLOEXEC);
+        fd = xopenat(AT_FDCWD, path, O_PATH);
         if (fd < 0)
-                return log_error_errno(errno, "Failed to open '%s': %m", path);
+                return log_error_errno(fd, "Failed to open '%s': %m", path);
 
         if (fstat(fd, &st) < 0)
                 return log_error_errno(errno, "Failed to stat '%s': %m", path);

--- a/src/firstboot/firstboot.c
+++ b/src/firstboot/firstboot.c
@@ -1794,9 +1794,9 @@ static int run(int argc, char *argv[]) {
                 if (!arg_root)
                         return log_oom();
         } else {
-                rfd = open(empty_to_root(arg_root), O_DIRECTORY|O_CLOEXEC);
+                rfd = xopenat(AT_FDCWD, empty_to_root(arg_root), O_DIRECTORY);
                 if (rfd < 0)
-                        return log_error_errno(errno, "Failed to open %s: %m", empty_to_root(arg_root));
+                        return log_error_errno(rfd, "Failed to open %s: %m", empty_to_root(arg_root));
         }
 
         r = mac_label_context_new(arg_root, &arg_label_context);

--- a/src/getty-generator/getty-generator.c
+++ b/src/getty-generator/getty-generator.c
@@ -9,6 +9,7 @@
 #include "extract-word.h"
 #include "fd-util.h"
 #include "fileio.h"
+#include "fs-util.h"
 #include "generator.h"
 #include "initrd-util.h"
 #include "log.h"
@@ -84,9 +85,9 @@ static int verify_tty(const char *path) {
          * classic ttyS0 and friends. Let's check that and open the device and run isatty() on it. */
 
         /* O_NONBLOCK is essential here, to make sure we don't wait for DCD */
-        fd = open(path, O_RDWR|O_NONBLOCK|O_NOCTTY|O_CLOEXEC|O_NOFOLLOW);
+        fd = xopenat(AT_FDCWD, path, O_RDWR|O_NONBLOCK|O_NOCTTY|O_NOFOLLOW);
         if (fd < 0)
-                return -errno;
+                return fd;
 
         if (!isatty_safe(fd))
                 return -ENOTTY;

--- a/src/growfs/growfs.c
+++ b/src/growfs/growfs.c
@@ -16,6 +16,7 @@
 #include "dlopen-note.h"
 #include "fd-util.h"
 #include "format-util.h"
+#include "fs-util.h"
 #include "log.h"
 #include "main-func.h"
 #include "mountpoint-util.h"
@@ -189,9 +190,9 @@ static int run(int argc, char *argv[]) {
         if (r == 0)
                 return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "\"%s\" is not a mount point.", arg_target);
 
-        mountfd = open(arg_target, O_RDONLY|O_CLOEXEC|O_DIRECTORY);
+        mountfd = xopenat(AT_FDCWD, arg_target, O_RDONLY|O_DIRECTORY);
         if (mountfd < 0)
-                return log_error_errno(errno, "Failed to open \"%s\": %m", arg_target);
+                return log_error_errno(mountfd, "Failed to open \"%s\": %m", arg_target);
 
         r = get_block_device_fd(mountfd, &devno);
         if (r == -EUCLEAN)

--- a/src/home/homectl-recovery-key.c
+++ b/src/home/homectl-recovery-key.c
@@ -200,7 +200,7 @@ int recovery_key_file_write(const char *path, const char *recovery_key) {
         if (!filename_is_valid(filename))
                 return -EINVAL;
 
-        fd = open_tmpfile_linkable_at(dir_fd, filename, O_WRONLY|O_CLOEXEC, &tmp);
+        fd = open_tmpfile_linkable_at(dir_fd, filename, O_WRONLY, &tmp);
         if (fd < 0)
                 return fd;
 

--- a/src/home/homectl.c
+++ b/src/home/homectl.c
@@ -1275,9 +1275,9 @@ static int acquire_merged_blob_dir(UserRecord *hr, bool existing, Hashmap **ret)
                 if (!name)
                         return log_oom();
 
-                fd = openat(dirfd(d), de->d_name, O_RDONLY|O_CLOEXEC|O_NOCTTY);
+                fd = xopenat(dirfd(d), de->d_name, O_RDONLY|O_NOCTTY);
                 if (fd < 0)
-                        return log_error_errno(errno, "Failed to open %s in %s: %m", de->d_name, src_blob_path);
+                        return log_error_errno(fd, "Failed to open %s in %s: %m", de->d_name, src_blob_path);
 
                 r = fd_verify_regular(fd);
                 if (r < 0) {
@@ -4462,9 +4462,9 @@ static int parse_argv(int argc, char *argv[], char ***remaining_args) {
                         }
 
                         if (path) {
-                                fd = open(path, O_RDONLY|O_CLOEXEC|O_NOCTTY);
+                                fd = xopenat(AT_FDCWD, path, O_RDONLY|O_NOCTTY);
                                 if (fd < 0)
-                                        return log_error_errno(errno, "Failed to open %s: %m", path);
+                                        return log_error_errno(fd, "Failed to open %s: %m", path);
 
                                 if (fd_verify_regular(fd) < 0)
                                         return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "Provided blob is not a regular file: %s", path);

--- a/src/home/homed-home.c
+++ b/src/home/homed-home.c
@@ -20,6 +20,7 @@
 #include "fileio.h"
 #include "filesystems.h"
 #include "format-util.h"
+#include "fs-util.h"
 #include "glyph-util.h"
 #include "home-util.h"
 #include "homed-home.h"
@@ -413,9 +414,9 @@ static void home_pin(Home *h) {
                 return;
         }
 
-        h->pin_fd = open(path, O_PATH|O_DIRECTORY|O_CLOEXEC);
+        h->pin_fd = xopenat(AT_FDCWD, path, O_PATH|O_DIRECTORY);
         if (h->pin_fd < 0) {
-                log_warning_errno(errno, "Couldn't open home directory '%s' for pinning, ignoring: %m", path);
+                log_warning_errno(h->pin_fd, "Couldn't open home directory '%s' for pinning, ignoring: %m", path);
                 return;
         }
 
@@ -2511,9 +2512,9 @@ static int home_get_disk_status_directory(
         if (!path)
                 goto finish;
 
-        fd = open(path, O_CLOEXEC|O_RDONLY);
+        fd = xopenat(AT_FDCWD, path, O_RDONLY);
         if (fd < 0) {
-                log_debug_errno(errno, "Failed to open '%s', ignoring: %m", path);
+                log_debug_errno(fd, "Failed to open '%s', ignoring: %m", path);
                 goto finish;
         }
 
@@ -2857,9 +2858,9 @@ int home_create_fifo(Home *h, bool please_suspend) {
                 if (mkfifo(fn, 0600) < 0 && errno != EEXIST)
                         return log_error_errno(errno, "Failed to create FIFO %s: %m", fn);
 
-                ref_fd = open(fn, O_RDONLY|O_CLOEXEC|O_NONBLOCK);
+                ref_fd = xopenat(AT_FDCWD, fn, O_RDONLY|O_NONBLOCK);
                 if (ref_fd < 0)
-                        return log_error_errno(errno, "Failed to open FIFO %s for reading: %m", fn);
+                        return log_error_errno(ref_fd, "Failed to open FIFO %s for reading: %m", fn);
 
                 r = sd_event_add_io(h->manager->event, ss, ref_fd, 0, on_home_ref_eof, h);
                 if (r < 0)
@@ -2880,9 +2881,9 @@ int home_create_fifo(Home *h, bool please_suspend) {
                 TAKE_FD(ref_fd);
         }
 
-        ret_fd = open(fn, O_WRONLY|O_CLOEXEC|O_NONBLOCK);
+        ret_fd = xopenat(AT_FDCWD, fn, O_WRONLY|O_NONBLOCK);
         if (ret_fd < 0)
-                return log_error_errno(errno, "Failed to open FIFO %s for writing: %m", fn);
+                return log_error_errno(ret_fd, "Failed to open FIFO %s for writing: %m", fn);
 
         return TAKE_FD(ret_fd);
 }

--- a/src/home/homed-manager.c
+++ b/src/home/homed-manager.c
@@ -541,9 +541,9 @@ static int search_quota(uid_t uid, const char *exclude_quota_path) {
                 struct dqblk req;
                 struct stat st;
 
-                _cleanup_close_ int fd = open(where, O_RDONLY|O_CLOEXEC|O_DIRECTORY);
+                _cleanup_close_ int fd = xopenat(AT_FDCWD, where, O_RDONLY|O_DIRECTORY);
                 if (fd < 0) {
-                        log_full_errno(errno == ENOENT ? LOG_DEBUG : LOG_ERR, errno,
+                        log_full_errno(fd == -ENOENT ? LOG_DEBUG : LOG_ERR, fd,
                                        "Failed to open '%s', ignoring: %m", where);
                         continue;
                 }
@@ -935,11 +935,11 @@ static int manager_assess_image(
                         return log_error_errno(r, "Failed to split image name into user name/realm: %m");
 
                 if (dir_fd >= 0)
-                        fd = openat(dir_fd, dentry_name, O_DIRECTORY|O_RDONLY|O_CLOEXEC);
+                        fd = xopenat(dir_fd, dentry_name, O_DIRECTORY|O_RDONLY);
                 else
-                        fd = open(path, O_DIRECTORY|O_RDONLY|O_CLOEXEC);
+                        fd = xopenat(AT_FDCWD, path, O_DIRECTORY|O_RDONLY);
                 if (fd < 0)
-                        return log_full_errno(errno == ENOENT ? LOG_DEBUG : LOG_WARNING, errno,
+                        return log_full_errno(fd == -ENOENT ? LOG_DEBUG : LOG_WARNING, fd,
                                               "Failed to open directory '%s', ignoring: %m", path);
 
                 if (fstat(fd, &st) < 0)

--- a/src/home/homework-blob.c
+++ b/src/home/homework-blob.c
@@ -154,11 +154,11 @@ static int replace_blob_at(
         assert(dest_name);
         assert(uid_is_valid(uid));
 
-        src_dfd = openat(src_base_dfd, src_name, O_RDONLY|O_DIRECTORY|O_CLOEXEC|O_NOFOLLOW);
+        src_dfd = xopenat(src_base_dfd, src_name, O_RDONLY|O_DIRECTORY|O_NOFOLLOW);
         if (src_dfd < 0) {
-                if (errno == ENOENT)
+                if (src_dfd == -ENOENT)
                         return 0;
-                return log_debug_errno(errno, "Failed to open src blob dir: %m");
+                return log_debug_errno(src_dfd, "Failed to open src blob dir: %m");
         }
 
         r = tempfn_random(dest_name, NULL, &fn);
@@ -178,9 +178,9 @@ static int replace_blob_at(
                 const char *name = de->entries[i]->d_name;
                 _cleanup_close_ int src_fd = -EBADF;
 
-                src_fd = openat(src_dfd, name, O_RDONLY|O_CLOEXEC|O_NOCTTY|O_NOFOLLOW);
+                src_fd = xopenat(src_dfd, name, O_RDONLY|O_NOCTTY|O_NOFOLLOW);
                 if (src_fd < 0) {
-                        r = log_debug_errno(errno, "Failed to open %s in src blob dir: %m", name);
+                        r = log_debug_errno(src_fd, "Failed to open %s in src blob dir: %m", name);
                         goto fail;
                 }
 
@@ -220,9 +220,9 @@ int home_reconcile_blob_dirs(UserRecord *h, int root_fd, int reconciled) {
         if (reconciled == USER_RECONCILE_IDENTICAL)
                 return 0;
 
-        sys_base_dfd = open(home_system_blob_dir(), O_PATH|O_DIRECTORY|O_CLOEXEC|O_NOFOLLOW);
+        sys_base_dfd = xopenat(AT_FDCWD, home_system_blob_dir(), O_PATH|O_DIRECTORY|O_NOFOLLOW);
         if (sys_base_dfd < 0)
-                return log_error_errno(errno, "Failed to open system blob dir: %m");
+                return log_error_errno(sys_base_dfd, "Failed to open system blob dir: %m");
 
         if (reconciled == USER_RECONCILE_HOST_WON) {
                 r = replace_blob_at(sys_base_dfd, h->user_name, root_fd, ".identity-blob",
@@ -257,9 +257,9 @@ int home_apply_new_blob_dir(UserRecord *h, Hashmap *blobs) {
         if (!blobs) /* Shortcut: If no blobs are passed from dbus, we have nothing to do. */
                 return 0;
 
-        base_dfd = open(home_system_blob_dir(), O_RDONLY|O_DIRECTORY|O_CLOEXEC|O_NOFOLLOW);
+        base_dfd = xopenat(AT_FDCWD, home_system_blob_dir(), O_RDONLY|O_DIRECTORY|O_NOFOLLOW);
         if (base_dfd < 0)
-                return log_error_errno(errno, "Failed to open system blob base dir: %m");
+                return log_error_errno(base_dfd, "Failed to open system blob base dir: %m");
 
         if (hashmap_isempty(blobs)) {
                 /* Shortcut: If blobs was passed but empty, we can simply delete the contents
@@ -276,7 +276,7 @@ int home_apply_new_blob_dir(UserRecord *h, Hashmap *blobs) {
 
         dfd = open_mkdir_at(base_dfd, fn, O_EXCL, 0755);
         if (dfd < 0)
-                return log_error_errno(errno, "Failed to create system blob dir: %m");
+                return log_error_errno(dfd, "Failed to create system blob dir: %m");
 
         HASHMAP_FOREACH_KEY(v, filename, blobs) {
                 r = copy_one_blob(PTR_TO_FD(v), dfd, filename, &total_size, 0, h->blob_manifest);

--- a/src/home/homework-blob.c
+++ b/src/home/homework-blob.c
@@ -97,7 +97,7 @@ static int copy_one_blob(
         if (lseek(src_fd, initial, SEEK_SET) < 0)
                 return log_debug_errno(errno, "Failed to rewind fd for blob %s: %m", name);
 
-        dest = open_tmpfile_linkable_at(dest_dfd, name, O_RDWR|O_CLOEXEC, &dest_tmpname);
+        dest = open_tmpfile_linkable_at(dest_dfd, name, O_RDWR, &dest_tmpname);
         if (dest < 0)
                 return log_debug_errno(dest, "Failed to create dest tmpfile for blob %s: %m", name);
 
@@ -165,7 +165,7 @@ static int replace_blob_at(
         if (r < 0)
                 return r;
 
-        dest_dfd = open_mkdir_at(dest_base_dfd, fn, O_EXCL|O_CLOEXEC, mode);
+        dest_dfd = open_mkdir_at(dest_base_dfd, fn, O_EXCL, mode);
         if (dest_dfd < 0)
                 return log_debug_errno(dest_dfd, "Failed to create/open dest blob dir: %m");
 
@@ -274,7 +274,7 @@ int home_apply_new_blob_dir(UserRecord *h, Hashmap *blobs) {
         if (r < 0)
                 return r;
 
-        dfd = open_mkdir_at(base_dfd, fn, O_EXCL|O_CLOEXEC, 0755);
+        dfd = open_mkdir_at(base_dfd, fn, O_EXCL, 0755);
         if (dfd < 0)
                 return log_error_errno(errno, "Failed to create system blob dir: %m");
 

--- a/src/home/homework-cifs.c
+++ b/src/home/homework-cifs.c
@@ -38,9 +38,9 @@ int home_setup_cifs(
         assert(setup->root_fd < 0);
 
         if (FLAGS_SET(flags, HOME_SETUP_ALREADY_ACTIVATED)) {
-                setup->root_fd = open(user_record_home_directory(h), O_RDONLY|O_CLOEXEC|O_DIRECTORY|O_NOFOLLOW);
+                setup->root_fd = xopenat(AT_FDCWD, user_record_home_directory(h), O_RDONLY|O_DIRECTORY|O_NOFOLLOW);
                 if (setup->root_fd < 0)
-                        return log_error_errno(errno, "Failed to open home directory: %m");
+                        return log_error_errno(setup->root_fd, "Failed to open home directory: %m");
 
                 return 0;
         }

--- a/src/home/homework-cifs.c
+++ b/src/home/homework-cifs.c
@@ -139,7 +139,7 @@ int home_setup_cifs(
                         return log_oom();
 
                 if (FLAGS_SET(flags, HOME_SETUP_CIFS_MKDIR)) {
-                        setup->root_fd = open_mkdir(j, O_CLOEXEC, 0700);
+                        setup->root_fd = open_mkdir(j, /* flags= */ 0, 0700);
                         if (setup->root_fd < 0)
                                 return log_error_errno(setup->root_fd, "Failed to create CIFS subdirectory: %m");
                 }

--- a/src/home/homework-directory.c
+++ b/src/home/homework-directory.c
@@ -215,7 +215,7 @@ int home_create_directory_or_subvolume(UserRecord *h, HomeSetup *setup, UserReco
                 /* If we have established a new mount, then we can use that as new root fd to our home directory. */
                 safe_close(setup->root_fd);
 
-                setup->root_fd = fd_reopen(mount_fd, O_RDONLY|O_CLOEXEC|O_DIRECTORY);
+                setup->root_fd = fd_reopen(mount_fd, O_RDONLY|O_DIRECTORY);
                 if (setup->root_fd < 0)
                         return log_error_errno(setup->root_fd, "Unable to convert mount fd into proper directory fd: %m");
 

--- a/src/home/homework-directory.c
+++ b/src/home/homework-directory.c
@@ -5,6 +5,7 @@
 #include "btrfs-util.h"
 #include "errno-util.h"
 #include "fd-util.h"
+#include "fs-util.h"
 #include "homework-blob.h"
 #include "homework-directory.h"
 #include "homework-fscrypt.h"
@@ -56,9 +57,9 @@ int home_setup_directory(UserRecord *h, HomeSetup *setup) {
         if (r < 0)
                 return r;
 
-        setup->root_fd = open(HOME_RUNTIME_WORK_DIR, O_RDONLY|O_CLOEXEC|O_DIRECTORY|O_NOFOLLOW);
+        setup->root_fd = xopenat(AT_FDCWD, HOME_RUNTIME_WORK_DIR, O_RDONLY|O_DIRECTORY|O_NOFOLLOW);
         if (setup->root_fd < 0)
-                return log_error_errno(errno, "Failed to open home directory: %m");
+                return log_error_errno(setup->root_fd, "Failed to open home directory: %m");
 
         return 0;
 }
@@ -195,9 +196,9 @@ int home_create_directory_or_subvolume(UserRecord *h, HomeSetup *setup, UserReco
         if (r < 0)
                 return r;
 
-        setup->root_fd = open(temporary, O_RDONLY|O_CLOEXEC|O_DIRECTORY|O_NOFOLLOW);
+        setup->root_fd = xopenat(AT_FDCWD, temporary, O_RDONLY|O_DIRECTORY|O_NOFOLLOW);
         if (setup->root_fd < 0)
-                return log_error_errno(errno, "Failed to open temporary home directory: %m");
+                return log_error_errno(setup->root_fd, "Failed to open temporary home directory: %m");
 
         /* Try to apply a UID shift, so that the directory is actually owned by "nobody", and is only mapped
          * to the proper UID while active. — Well, that's at least the theory. Unfortunately, only btrfs does

--- a/src/home/homework-fscrypt.c
+++ b/src/home/homework-fscrypt.c
@@ -13,6 +13,7 @@
 #include "extract-word.h"
 #include "fd-util.h"
 #include "format-util.h"
+#include "fs-util.h"
 #include "hexdecoct.h"
 #include "homework-fscrypt.h"
 #include "homework-mount.h"
@@ -450,7 +451,7 @@ int home_flush_keyring_fscrypt(UserRecord *h) {
          * fallback is the v1 user-keyring walk below, which is a no-op when nothing matches. Reaching
          * the walk also keeps prior behaviour: stale v1 entries get reaped even if the image
          * directory has gone away. */
-        _cleanup_close_ int dir_fd = open(ip, O_RDONLY|O_CLOEXEC|O_DIRECTORY|O_NOFOLLOW);
+        _cleanup_close_ int dir_fd = xopenat(AT_FDCWD, ip, O_RDONLY|O_DIRECTORY|O_NOFOLLOW);
         if (dir_fd >= 0) {
                 struct fscrypt_key_specifier spec;
 
@@ -462,7 +463,7 @@ int home_flush_keyring_fscrypt(UserRecord *h) {
                 if (r < 0 && !IN_SET(r, -ENODATA, -ENOLINK))
                         log_debug_errno(r, "Failed to read fscrypt policy of %s, falling back to v1 keyring walk: %m", ip);
         } else
-                log_debug_errno(errno, "Failed to open %s, falling back to v1 keyring walk: %m", ip);
+                log_debug_errno(dir_fd, "Failed to open %s, falling back to v1 keyring walk: %m", ip);
 
         r = pidref_safe_fork(
                         "(sd-delkey)",
@@ -958,9 +959,9 @@ int home_setup_fscrypt(
 
         assert_se(ip = user_record_image_path(h));
 
-        setup->root_fd = open(ip, O_RDONLY|O_CLOEXEC|O_DIRECTORY);
+        setup->root_fd = xopenat(AT_FDCWD, ip, O_RDONLY|O_DIRECTORY);
         if (setup->root_fd < 0)
-                return log_error_errno(errno, "Failed to open home directory: %m");
+                return log_error_errno(setup->root_fd, "Failed to open home directory: %m");
 
         /* fscrypt has v1 and v2 policy versions with different on-disk formats, and no in-place upgrade:
          * v1 binds the master key by an 8-byte descriptor (truncated double SHA-512), v2 by a 16-byte
@@ -1041,9 +1042,9 @@ int home_setup_fscrypt(
                 return r;
 
         safe_close(setup->root_fd);
-        setup->root_fd = open(HOME_RUNTIME_WORK_DIR, O_RDONLY|O_CLOEXEC|O_DIRECTORY|O_NOFOLLOW);
+        setup->root_fd = xopenat(AT_FDCWD, HOME_RUNTIME_WORK_DIR, O_RDONLY|O_DIRECTORY|O_NOFOLLOW);
         if (setup->root_fd < 0)
-                return log_error_errno(errno, "Failed to open home directory: %m");
+                return log_error_errno(setup->root_fd, "Failed to open home directory: %m");
 
         /* Note we intentionally leave setup->fscrypt_v2_key_undo armed here: whether the key stays
          * installed is decided by the caller (kept on activation, rolled back on teardown). */
@@ -1290,9 +1291,9 @@ int home_create_fscrypt(
         if (r < 0)
                 return r;
 
-        setup->root_fd = open(temporary, O_RDONLY|O_CLOEXEC|O_DIRECTORY|O_NOFOLLOW);
+        setup->root_fd = xopenat(AT_FDCWD, temporary, O_RDONLY|O_DIRECTORY|O_NOFOLLOW);
         if (setup->root_fd < 0)
-                return log_error_errno(errno, "Failed to open temporary home directory: %m");
+                return log_error_errno(setup->root_fd, "Failed to open temporary home directory: %m");
 
         /* Refuse if the parent directory is already encrypted (we'd inherit its policy). The v1-only
          * FS_IOC_GET_ENCRYPTION_POLICY ioctl returns EINVAL on v2-encrypted dirs, so use the helper

--- a/src/home/homework-fscrypt.c
+++ b/src/home/homework-fscrypt.c
@@ -1357,7 +1357,7 @@ int home_create_fscrypt(
                 /* If we have established a new mount, then we can use that as new root fd to our home directory. */
                 safe_close(setup->root_fd);
 
-                setup->root_fd = fd_reopen(mount_fd, O_RDONLY|O_CLOEXEC|O_DIRECTORY);
+                setup->root_fd = fd_reopen(mount_fd, O_RDONLY|O_DIRECTORY);
                 if (setup->root_fd < 0)
                         return log_error_errno(setup->root_fd, "Unable to convert mount fd into proper directory fd: %m");
 

--- a/src/home/homework-luks.c
+++ b/src/home/homework-luks.c
@@ -2508,7 +2508,7 @@ int home_create_luks(
                 /* If we have established a new mount, then we can use that as new root fd to our home directory. */
                 safe_close(setup->root_fd);
 
-                setup->root_fd = fd_reopen(mount_fd, O_RDONLY|O_CLOEXEC|O_DIRECTORY);
+                setup->root_fd = fd_reopen(mount_fd, O_RDONLY|O_DIRECTORY);
                 if (setup->root_fd < 0)
                         return log_error_errno(setup->root_fd, "Unable to convert mount fd into proper directory fd: %m");
 

--- a/src/home/homework-luks.c
+++ b/src/home/homework-luks.c
@@ -124,9 +124,9 @@ int run_mark_dirty_by_path(const char *path, bool b) {
 
         assert(path);
 
-        fd = open(path, O_RDWR|O_CLOEXEC|O_NOCTTY);
+        fd = xopenat(AT_FDCWD, path, O_RDWR|O_NOCTTY);
         if (fd < 0)
-                return log_debug_errno(errno, "Failed to open %s to mark dirty or clean: %m", path);
+                return log_debug_errno(fd, "Failed to open %s to mark dirty or clean: %m", path);
 
         return run_mark_dirty(fd, b);
 }
@@ -194,9 +194,9 @@ static int probe_file_system_by_fd(
 static int probe_file_system_by_path(const char *path, char **ret_fstype, sd_id128_t *ret_uuid) {
         _cleanup_close_ int fd = -EBADF;
 
-        fd = open(path, O_RDONLY|O_CLOEXEC|O_NOCTTY|O_NONBLOCK);
+        fd = xopenat(AT_FDCWD, path, O_RDONLY|O_NOCTTY|O_NONBLOCK);
         if (fd < 0)
-                return negative_errno();
+                return fd;
 
         return probe_file_system_by_fd(fd, ret_fstype, ret_uuid);
 }
@@ -217,9 +217,9 @@ static int block_get_size_by_fd(int fd, uint64_t *ret) {
 static int block_get_size_by_path(const char *path, uint64_t *ret) {
         _cleanup_close_ int fd = -EBADF;
 
-        fd = open(path, O_RDONLY|O_CLOEXEC|O_NOCTTY|O_NONBLOCK);
+        fd = xopenat(AT_FDCWD, path, O_RDONLY|O_NOCTTY|O_NONBLOCK);
         if (fd < 0)
-                return -errno;
+                return fd;
 
         return block_get_size_by_fd(fd, ret);
 }
@@ -1189,9 +1189,9 @@ int run_fallocate(int backing_fd, const struct stat *st) {
 int run_fallocate_by_path(const char *backing_path) {
         _cleanup_close_ int backing_fd = -EBADF;
 
-        backing_fd = open(backing_path, O_RDWR|O_CLOEXEC|O_NOCTTY|O_NONBLOCK);
+        backing_fd = xopenat(AT_FDCWD, backing_path, O_RDWR|O_NOCTTY|O_NONBLOCK);
         if (backing_fd < 0)
-                return log_error_errno(errno, "Failed to open '%s' for fallocate(): %m", backing_path);
+                return log_error_errno(backing_fd, "Failed to open '%s' for fallocate(): %m", backing_path);
 
         return run_fallocate(backing_fd, NULL);
 }
@@ -1248,9 +1248,9 @@ static int open_image_file(
 
         ip = force_image_path ?: user_record_image_path(h);
 
-        image_fd = open(ip, O_RDWR|O_CLOEXEC|O_NOCTTY|O_NONBLOCK);
+        image_fd = xopenat(AT_FDCWD, ip, O_RDWR|O_NOCTTY|O_NONBLOCK);
         if (image_fd < 0)
-                return log_error_errno(errno, "Failed to open image file %s: %m", ip);
+                return log_error_errno(image_fd, "Failed to open image file %s: %m", ip);
 
         if (fstat(image_fd, &st) < 0)
                 return log_error_errno(errno, "Failed to fstat() image file: %m");
@@ -1393,9 +1393,9 @@ int home_setup_luks(
                 log_info("Discovered used loopback device %s.", setup->loop->node);
 
                 if (setup->root_fd < 0) {
-                        setup->root_fd = open(user_record_home_directory(h), O_RDONLY|O_CLOEXEC|O_DIRECTORY|O_NOFOLLOW);
+                        setup->root_fd = xopenat(AT_FDCWD, user_record_home_directory(h), O_RDONLY|O_DIRECTORY|O_NOFOLLOW);
                         if (setup->root_fd < 0)
-                                return log_error_errno(errno, "Failed to open home directory: %m");
+                                return log_error_errno(setup->root_fd, "Failed to open home directory: %m");
                 }
         } else {
                 _cleanup_free_ char *fstype = NULL, *subdir = NULL;
@@ -1498,9 +1498,9 @@ int home_setup_luks(
 
                 setup->undo_mount = true;
 
-                setup->root_fd = open(subdir, O_RDONLY|O_CLOEXEC|O_DIRECTORY|O_NOFOLLOW);
+                setup->root_fd = xopenat(AT_FDCWD, subdir, O_RDONLY|O_DIRECTORY|O_NOFOLLOW);
                 if (setup->root_fd < 0)
-                        return log_error_errno(errno, "Failed to open home directory: %m");
+                        return log_error_errno(setup->root_fd, "Failed to open home directory: %m");
 
                 if (user_record_luks_discard(h))
                         (void) run_fitrim(setup->root_fd);
@@ -2349,9 +2349,9 @@ int home_create_luks(
                 if (r < 0)
                         return log_error_errno(r, "Failed to derive temporary file name for %s: %m", ip);
 
-                setup->image_fd = open(t, O_RDWR|O_CREAT|O_EXCL|O_CLOEXEC|O_NOCTTY|O_NOFOLLOW, 0600);
+                setup->image_fd = xopenat_full(AT_FDCWD, t, O_RDWR|O_CREAT|O_EXCL|O_NOCTTY|O_NOFOLLOW, /* xopen_flags= */ 0, 0600);
                 if (setup->image_fd < 0)
-                        return log_error_errno(errno, "Failed to create home image %s: %m", t);
+                        return log_error_errno(setup->image_fd, "Failed to create home image %s: %m", t);
 
                 setup->temporary_image_path = TAKE_PTR(t);
 
@@ -2498,9 +2498,9 @@ int home_create_luks(
         if (r < 0)
                 return log_error_errno(r, "Failed to create user directory in mounted image file: %m");
 
-        setup->root_fd = open(subdir, O_RDONLY|O_CLOEXEC|O_DIRECTORY|O_NOFOLLOW);
+        setup->root_fd = xopenat(AT_FDCWD, subdir, O_RDONLY|O_DIRECTORY|O_NOFOLLOW);
         if (setup->root_fd < 0)
-                return log_error_errno(errno, "Failed to open user directory in mounted image file: %m");
+                return log_error_errno(setup->root_fd, "Failed to open user directory in mounted image file: %m");
 
         (void) home_shift_uid(setup->root_fd, NULL, UID_NOBODY, h->uid, &mount_fd);
 
@@ -2768,9 +2768,9 @@ static int ext4_offline_resize_fs(
         }
 
         if (re_open) {
-                setup->root_fd = open(HOME_RUNTIME_WORK_DIR, O_RDONLY|O_CLOEXEC|O_DIRECTORY|O_NOFOLLOW);
+                setup->root_fd = xopenat(AT_FDCWD, HOME_RUNTIME_WORK_DIR, O_RDONLY|O_DIRECTORY|O_NOFOLLOW);
                 if (setup->root_fd < 0)
-                        return log_error_errno(errno, "Failed to reopen file system: %m");
+                        return log_error_errno(setup->root_fd, "Failed to reopen file system: %m");
         }
 
         log_info("File system mounted again.");

--- a/src/home/homework-quota.c
+++ b/src/home/homework-quota.c
@@ -6,6 +6,7 @@
 #include "errno-util.h"
 #include "fd-util.h"
 #include "format-util.h"
+#include "fs-util.h"
 #include "homework-quota.h"
 #include "log.h"
 #include "memory-util.h"
@@ -22,9 +23,9 @@ int home_update_quota_btrfs(UserRecord *h, int fd, const char *path) {
 
         _cleanup_close_ int _fd = -EBADF;
         if (fd < 0) {
-                _fd = open(path, O_CLOEXEC|O_RDONLY);
+                _fd = xopenat(AT_FDCWD, path, O_RDONLY);
                 if (_fd < 0)
-                        return log_error_errno(errno, "Failed to open '%s': %m", path);
+                        return log_error_errno(_fd, "Failed to open '%s': %m", path);
 
                 fd = _fd;
         }
@@ -58,9 +59,9 @@ int home_update_quota_classic(UserRecord *h, int fd, const char *path) {
 
         _cleanup_close_ int _fd = -EBADF;
         if (fd < 0) {
-                _fd = open(path, O_CLOEXEC|O_RDONLY);
+                _fd = xopenat(AT_FDCWD, path, O_RDONLY);
                 if (_fd < 0)
-                        return log_error_errno(errno, "Failed to open '%s': %m", path);
+                        return log_error_errno(_fd, "Failed to open '%s': %m", path);
 
                 fd = _fd;
         }
@@ -112,9 +113,9 @@ int home_update_quota_auto(UserRecord *h, int fd, const char *path) {
 
         _cleanup_close_ int _fd = -EBADF;
         if (fd < 0) {
-                _fd = open(path, O_CLOEXEC|O_RDONLY);
+                _fd = xopenat(AT_FDCWD, path, O_RDONLY);
                 if (_fd < 0)
-                        return log_error_errno(errno, "Failed to open '%s': %m", path);
+                        return log_error_errno(_fd, "Failed to open '%s': %m", path);
 
                 fd = _fd;
         }

--- a/src/home/homework.c
+++ b/src/home/homework.c
@@ -997,9 +997,9 @@ static int home_deactivate(UserRecord *h, bool force) {
                 setup.undo_mount = true; /* remember to unmount the new bind mount from HOME_RUNTIME_WORK_DIR */
 
                 /* Let's explicitly open the new root fs, using the moved path */
-                setup.root_fd = open(HOME_RUNTIME_WORK_DIR, O_RDONLY|O_DIRECTORY|O_CLOEXEC);
+                setup.root_fd = xopenat(AT_FDCWD, HOME_RUNTIME_WORK_DIR, O_RDONLY|O_DIRECTORY);
                 if (setup.root_fd < 0)
-                        return log_error_errno(errno, "Failed to open moved home directory: %m");
+                        return log_error_errno(setup.root_fd, "Failed to open moved home directory: %m");
 
                 /* Now get rid of the home at its original place (we only keep the bind mount we created above) */
                 r = umount_verbose(LOG_ERR, user_record_home_directory(h), UMOUNT_NOFOLLOW | (force ? MNT_FORCE|MNT_DETACH : 0));

--- a/src/home/homework.c
+++ b/src/home/homework.c
@@ -567,7 +567,7 @@ static int read_identity_file(int root_fd, sd_json_variant **ret) {
         assert(root_fd >= 0);
         assert(ret);
 
-        _cleanup_close_ int identity_fd = xopenat_full(root_fd, ".identity", O_RDONLY|O_CLOEXEC|O_NOCTTY|O_NOFOLLOW|O_NONBLOCK, XO_REGULAR, MODE_INVALID);
+        _cleanup_close_ int identity_fd = xopenat_full(root_fd, ".identity", O_RDONLY|O_NOCTTY|O_NOFOLLOW|O_NONBLOCK, XO_REGULAR, MODE_INVALID);
         if (identity_fd < 0)
                 return log_error_errno(identity_fd, "Failed to open .identity file in home directory: %m");
 
@@ -855,7 +855,7 @@ int home_maybe_shift_uid(
         if (mount_fd >= 0) {
                 safe_close(setup->root_fd);
 
-                setup->root_fd = fd_reopen(mount_fd, O_RDONLY|O_CLOEXEC|O_DIRECTORY);
+                setup->root_fd = fd_reopen(mount_fd, O_RDONLY|O_DIRECTORY);
                 if (setup->root_fd < 0)
                         return log_error_errno(setup->root_fd, "Failed to convert mount fd into regular directory fd: %m");
         }

--- a/src/home/homework.c
+++ b/src/home/homework.c
@@ -590,7 +590,6 @@ static int read_identity_file(int root_fd, sd_json_variant **ret) {
 static int write_identity_file(int root_fd, sd_json_variant *v, uid_t uid) {
         _cleanup_(sd_json_variant_unrefp) sd_json_variant *normalized = NULL;
         _cleanup_fclose_ FILE *identity_file = NULL;
-        _cleanup_close_ int identity_fd = -EBADF;
         _cleanup_free_ char *fn = NULL;
         int r;
 
@@ -603,45 +602,33 @@ static int write_identity_file(int root_fd, sd_json_variant *v, uid_t uid) {
         if (r < 0)
                 log_warning_errno(r, "Failed to normalize user record, ignoring: %m");
 
-        r = tempfn_random(".identity", NULL, &fn);
+        r = fopen_tmpfile_linkable_at(root_fd, ".identity", O_WRONLY|O_NOCTTY, &fn, &identity_file);
         if (r < 0)
-                return r;
+                return log_error_errno(r, "Failed to create .identity file in home directory: %m");
 
-        identity_fd = openat(root_fd, fn, O_WRONLY|O_CREAT|O_EXCL|O_CLOEXEC|O_NOCTTY|O_NOFOLLOW, 0600);
-        if (identity_fd < 0)
-                return log_error_errno(errno, "Failed to create .identity file in home directory: %m");
+        CLEANUP_TMPFILE_AT(root_fd, fn);
 
-        identity_file = take_fdopen(&identity_fd, "w");
-        if (!identity_file) {
-                r = log_oom();
-                goto fail;
-        }
+        /* Tighten the mode before anything is written */
+        if (fchmod(fileno(identity_file), 0600) < 0)
+                return log_error_errno(errno, "Failed to adjust access mode of identity file: %m");
 
         sd_json_variant_dump(normalized, SD_JSON_FORMAT_PRETTY, identity_file, NULL);
 
         r = fflush_and_check(identity_file);
-        if (r < 0) {
-                log_error_errno(r, "Failed to write .identity file: %m");
-                goto fail;
-        }
+        if (r < 0)
+                return log_error_errno(r, "Failed to write .identity file: %m");
 
-        if (fchown(fileno(identity_file), uid, uid) < 0) {
-                r = log_error_errno(errno, "Failed to change ownership of identity file: %m");
-                goto fail;
-        }
+        if (fchown(fileno(identity_file), uid, uid) < 0)
+                return log_error_errno(errno, "Failed to change ownership of identity file: %m");
 
-        if (renameat(root_fd, fn, root_fd, ".identity") < 0) {
-                r = log_error_errno(errno, "Failed to move identity file into place: %m");
-                goto fail;
-        }
+        r = flink_tmpfile_at(identity_file, root_fd, fn, ".identity", LINK_TMPFILE_REPLACE);
+        if (r < 0)
+                return log_error_errno(r, "Failed to move identity file into place: %m");
+
+        fn = mfree(fn); /* disarm CLEANUP_TMPFILE_AT() */
 
         log_info("Wrote embedded .identity file.");
-
         return 0;
-
-fail:
-        (void) unlinkat(root_fd, fn, 0);
-        return r;
 }
 
 int home_load_embedded_identity(

--- a/src/imds/imds-tool.c
+++ b/src/imds/imds-tool.c
@@ -401,7 +401,7 @@ static int write_credential(const char *dir, const char *name, const struct iove
         assert(dir);
         assert(name);
 
-        _cleanup_close_ int dfd = open_mkdir(dir, O_CLOEXEC|O_PATH, 0700);
+        _cleanup_close_ int dfd = open_mkdir(dir, O_PATH, 0700);
         if (dfd < 0)
                 return log_error_errno(dfd, "Failed to open credential directory '%s': %m", dir);
 
@@ -414,7 +414,7 @@ static int write_credential(const char *dir, const char *name, const struct iove
         }
 
         _cleanup_free_ char *t = NULL;
-        _cleanup_close_ int fd = open_tmpfile_linkable_at(dfd, name, O_WRONLY|O_CLOEXEC, &t);
+        _cleanup_close_ int fd = open_tmpfile_linkable_at(dfd, name, O_WRONLY, &t);
         if (fd < 0)
                 return log_error_errno(fd, "Failed to create credential file '%s/%s': %m", dir, name);
 

--- a/src/imds/imdsd.c
+++ b/src/imds/imdsd.c
@@ -29,6 +29,7 @@
 #include "fd-util.h"
 #include "fileio.h"
 #include "format-ifname.h"
+#include "fs-util.h"
 #include "hash-funcs.h"
 #include "hashmap.h"
 #include "imds-util.h"
@@ -464,9 +465,9 @@ static int context_save_ifname(Context *c) {
         if (!d)
                 return 0;
 
-        _cleanup_close_ int dirfd = open(d, O_PATH|O_CLOEXEC);
+        _cleanup_close_ int dirfd = xopenat(AT_FDCWD, d, O_PATH);
         if (dirfd < 0)
-                return context_log_errno(c, LOG_ERR, errno, "Failed to open runtime directory: %m");
+                return context_log_errno(c, LOG_ERR, dirfd, "Failed to open runtime directory: %m");
 
         _cleanup_free_ char *ifname = NULL;
         r = rtnl_get_ifname_full(&c->rtnl, c->ifindex, &ifname, /* ret_altnames= */ NULL);
@@ -549,10 +550,10 @@ static CacheResult context_process_cache(Context *c) {
 
         c->cache_filename = TAKE_PTR(fn);
 
-        _cleanup_close_ int fd = openat(c->cache_dir_fd, c->cache_filename, O_RDONLY|O_CLOEXEC);
+        _cleanup_close_ int fd = xopenat(c->cache_dir_fd, c->cache_filename, O_RDONLY);
         if (fd < 0) {
-                if (errno != ENOENT)
-                        return context_log_errno(c, LOG_ERR, errno, "Failed to open cache file '%s': %m", c->cache_filename);
+                if (fd != -ENOENT)
+                        return context_log_errno(c, LOG_ERR, fd, "Failed to open cache file '%s': %m", c->cache_filename);
         } else {
                 _cleanup_free_ char *d = NULL;
                 size_t l;
@@ -1349,9 +1350,9 @@ static int context_load_ifname(Context *c) {
         if (!e)
                 return 0;
 
-        _cleanup_close_ int dirfd = open(e, O_PATH|O_CLOEXEC);
+        _cleanup_close_ int dirfd = xopenat(AT_FDCWD, e, O_PATH);
         if (dirfd < 0)
-                return context_log_errno(c, LOG_ERR, errno, "Failed to open runtime directory: %m");
+                return context_log_errno(c, LOG_ERR, dirfd, "Failed to open runtime directory: %m");
 
         _cleanup_free_ char *ifname = NULL;
         r = read_one_line_file_at(dirfd, "ifname", &ifname);

--- a/src/imds/imdsd.c
+++ b/src/imds/imdsd.c
@@ -1080,7 +1080,7 @@ static int context_acquire_data(Context *c) {
         if (c->cache_dir_fd >= 0 &&
             c->cache_filename &&
             c->cache_fd < 0) {
-                c->cache_fd = open_tmpfile_linkable_at(c->cache_dir_fd, c->cache_filename, O_WRONLY|O_CLOEXEC, &c->cache_temporary_filename);
+                c->cache_fd = open_tmpfile_linkable_at(c->cache_dir_fd, c->cache_filename, O_WRONLY, &c->cache_temporary_filename);
                 if (c->cache_fd < 0)
                         return context_log_errno(c, LOG_ERR, c->cache_fd, "Failed to create cache file '%s': %m", c->cache_filename);
 
@@ -1641,7 +1641,7 @@ static int setup_network(void) {
 
         _cleanup_free_ char *t = NULL;
         _cleanup_fclose_ FILE *f = NULL;
-        r = fopen_tmpfile_linkable_at(network_dir_fd, "85-imds-early.network", O_WRONLY|O_CLOEXEC, &t, &f);
+        r = fopen_tmpfile_linkable_at(network_dir_fd, "85-imds-early.network", O_WRONLY, &t, &f);
         if (r < 0)
                 return log_error_errno(r, "Failed to create 85-imds-early.network file: %m");
 

--- a/src/import/export-raw.c
+++ b/src/import/export-raw.c
@@ -263,9 +263,9 @@ static int reflink_snapshot(int fd, const char *path) {
                 if (r < 0)
                         return r;
 
-                new_fd = open(t, O_CLOEXEC|O_CREAT|O_NOCTTY|O_RDWR, 0600);
+                new_fd = xopenat_full(AT_FDCWD, t, O_CREAT|O_NOCTTY|O_RDWR, /* xopen_flags= */ 0, 0600);
                 if (new_fd < 0)
-                        return -errno;
+                        return new_fd;
 
                 (void) unlink(t);
         }
@@ -300,9 +300,9 @@ int raw_export_start(RawExport *e, const char *path, int fd, Compression compres
         if (r < 0)
                 return r;
 
-        sfd = open(path, O_RDONLY|O_CLOEXEC|O_NOCTTY);
+        sfd = xopenat(AT_FDCWD, path, O_RDONLY|O_NOCTTY);
         if (sfd < 0)
-                return -errno;
+                return sfd;
 
         if (fstat(sfd, &e->st) < 0)
                 return -errno;

--- a/src/import/export-raw.c
+++ b/src/import/export-raw.c
@@ -255,7 +255,7 @@ static int raw_export_on_defer(sd_event_source *s, void *userdata) {
 static int reflink_snapshot(int fd, const char *path) {
         int new_fd, r;
 
-        new_fd = open_parent(path, O_TMPFILE|O_CLOEXEC|O_RDWR, 0600);
+        new_fd = open_parent(path, O_TMPFILE|O_RDWR, 0600);
         if (new_fd < 0) {
                 _cleanup_free_ char *t = NULL;
 

--- a/src/import/export-tar.c
+++ b/src/import/export-tar.c
@@ -12,6 +12,7 @@
 #include "export-tar.h"
 #include "fd-util.h"
 #include "format-util.h"
+#include "fs-util.h"
 #include "import-common.h"
 #include "log.h"
 #include "pidref.h"
@@ -276,9 +277,9 @@ int tar_export_start(
         if (e->output_fd >= 0)
                 return -EBUSY;
 
-        sfd = open(path, O_DIRECTORY|O_RDONLY|O_NOCTTY|O_CLOEXEC);
+        sfd = xopenat(AT_FDCWD, path, O_DIRECTORY|O_RDONLY|O_NOCTTY);
         if (sfd < 0)
-                return -errno;
+                return sfd;
 
         if (fstat(sfd, &e->st) < 0)
                 return -errno;
@@ -337,9 +338,9 @@ int tar_export_start(
                 if (r < 0)
                         return r;
 
-                _cleanup_close_ int directory_fd = open(p, O_DIRECTORY|O_CLOEXEC|O_PATH);
+                _cleanup_close_ int directory_fd = xopenat(AT_FDCWD, p, O_DIRECTORY|O_PATH);
                 if (directory_fd < 0)
-                        return log_error_errno(r, "Failed to open '%s': %m", p);
+                        return log_error_errno(directory_fd, "Failed to open '%s': %m", p);
 
                 _cleanup_close_ int mapped_fd = -EBADF;
                 r = mountfsd_mount_directory_fd(
@@ -354,11 +355,11 @@ int tar_export_start(
                 /* Drop O_PATH */
                 e->tree_fd = fd_reopen(mapped_fd, O_DIRECTORY);
                 if (e->tree_fd < 0)
-                        return log_error_errno(errno, "Failed to re-open mapped '%s': %m", p);
+                        return log_error_errno(e->tree_fd, "Failed to re-open mapped '%s': %m", p);
         } else {
-                e->tree_fd = open(p, O_DIRECTORY|O_CLOEXEC);
+                e->tree_fd = xopenat(AT_FDCWD, p, O_DIRECTORY);
                 if (e->tree_fd < 0)
-                        return log_error_errno(errno, "Failed to open '%s': %m", p);
+                        return log_error_errno(e->tree_fd, "Failed to open '%s': %m", p);
         }
 
         e->tar_fd = import_fork_tar_c(e->tree_fd, e->userns_fd, &e->tar_pid);

--- a/src/import/export-tar.c
+++ b/src/import/export-tar.c
@@ -352,7 +352,7 @@ int tar_export_start(
                         return log_error_errno(r, "Failed to mount directory via mountfsd: %m");
 
                 /* Drop O_PATH */
-                e->tree_fd = fd_reopen(mapped_fd, O_DIRECTORY|O_CLOEXEC);
+                e->tree_fd = fd_reopen(mapped_fd, O_DIRECTORY);
                 if (e->tree_fd < 0)
                         return log_error_errno(errno, "Failed to re-open mapped '%s': %m", p);
         } else {

--- a/src/import/export.c
+++ b/src/import/export.c
@@ -3,6 +3,7 @@
 #include <locale.h>
 #include <unistd.h>
 
+#include "fs-util.h"
 #include "sd-event.h"
 #include "sd-json.h"
 
@@ -78,9 +79,9 @@ static int verb_export_tar(int argc, char *argv[], uintptr_t _data, void *userda
         determine_compression_from_filename(path);
 
         if (path) {
-                open_fd = open(path, O_WRONLY|O_CREAT|O_TRUNC|O_CLOEXEC|O_NOCTTY, 0666);
+                open_fd = xopenat_full(AT_FDCWD, path, O_WRONLY|O_CREAT|O_TRUNC|O_NOCTTY, /* xopen_flags= */ 0, 0666);
                 if (open_fd < 0)
-                        return log_error_errno(errno, "Failed to open tar image for export: %m");
+                        return log_error_errno(open_fd, "Failed to open tar image for export: %m");
 
                 fd = open_fd;
 
@@ -161,9 +162,9 @@ static int verb_export_raw(int argc, char *argv[], uintptr_t _data, void *userda
         determine_compression_from_filename(path);
 
         if (path) {
-                open_fd = open(path, O_WRONLY|O_CREAT|O_TRUNC|O_CLOEXEC|O_NOCTTY, 0666);
+                open_fd = xopenat_full(AT_FDCWD, path, O_WRONLY|O_CREAT|O_TRUNC|O_NOCTTY, /* xopen_flags= */ 0, 0666);
                 if (open_fd < 0)
-                        return log_error_errno(errno, "Failed to open raw image for export: %m");
+                        return log_error_errno(open_fd, "Failed to open raw image for export: %m");
 
                 fd = open_fd;
 

--- a/src/import/import-common.c
+++ b/src/import/import-common.c
@@ -234,14 +234,14 @@ int import_mangle_os_tree_fd(int tree_fd, int userns_fd, ImportFlags flags) {
         } else if (errno != 0)
                 return log_error_errno(errno, "Failed to iterate through directory '%s': %m", path);
 
-        _cleanup_close_ int child_fd = openat(dirfd(d), child, O_CLOEXEC|O_DIRECTORY|O_NOFOLLOW|O_NONBLOCK);
+        _cleanup_close_ int child_fd = xopenat(dirfd(d), child, O_DIRECTORY|O_NOFOLLOW|O_NONBLOCK);
         if (child_fd < 0) {
-                if (IN_SET(errno, ENOTDIR, ELOOP)) {
-                        log_debug_errno(errno, "Child '%s' of directory '%s' is not a directory, leaving things as they are.", child, path);
+                if (IN_SET(child_fd, -ENOTDIR, -ELOOP)) {
+                        log_debug_errno(child_fd, "Child '%s' of directory '%s' is not a directory, leaving things as they are.", child, path);
                         return 0;
                 }
 
-                return log_debug_errno(errno, "Failed to open file '%s/%s': %m", path, child);
+                return log_debug_errno(child_fd, "Failed to open file '%s/%s': %m", path, child);
         }
 
         if (fstat(child_fd, &st) < 0)
@@ -310,9 +310,9 @@ int import_mangle_os_tree_fd(int tree_fd, int userns_fd, ImportFlags flags) {
 int import_mangle_os_tree(const char *path, int userns_fd, ImportFlags flags) {
         assert(path);
 
-        _cleanup_close_ int fd = open(path, O_DIRECTORY|O_CLOEXEC|O_PATH);
+        _cleanup_close_ int fd = xopenat(AT_FDCWD, path, O_DIRECTORY|O_PATH);
         if (fd < 0)
-                return log_error_errno(errno, "Failed to open '%s': %m", path);
+                return log_error_errno(fd, "Failed to open '%s': %m", path);
 
         return import_mangle_os_tree_fd(fd, userns_fd, flags);
 }

--- a/src/import/import-fs.c
+++ b/src/import/import-fs.c
@@ -13,6 +13,7 @@
 #include "dlopen-note.h"
 #include "fd-util.h"
 #include "format-util.h"
+#include "fs-util.h"
 #include "import-common.h"
 #include "import-util.h"
 #include "install-file.h"
@@ -174,9 +175,9 @@ static int verb_import_fs(int argc, char *argv[], uintptr_t _data, void *userdat
         }
 
         if (path) {
-                open_fd = open(path, O_DIRECTORY|O_RDONLY|O_CLOEXEC);
+                open_fd = xopenat(AT_FDCWD, path, O_DIRECTORY|O_RDONLY);
                 if (open_fd < 0)
-                        return log_error_errno(errno, "Failed to open directory to import: %m");
+                        return log_error_errno(open_fd, "Failed to open directory to import: %m");
 
                 fd = open_fd;
 

--- a/src/import/import-raw.c
+++ b/src/import/import-raw.c
@@ -190,9 +190,9 @@ static int raw_import_maybe_convert_qcow2(RawImport *i) {
         if (r < 0)
                 return log_oom();
 
-        converted_fd = open(f, O_RDWR|O_CREAT|O_EXCL|O_NOCTTY|O_CLOEXEC, 0664);
+        converted_fd = xopenat_full(AT_FDCWD, f, O_RDWR|O_CREAT|O_EXCL|O_NOCTTY, /* xopen_flags= */ 0, 0664);
         if (converted_fd < 0)
-                return log_error_errno(errno, "Failed to create %s: %m", f);
+                return log_error_errno(converted_fd, "Failed to create %s: %m", f);
 
         t = TAKE_PTR(f);
 
@@ -283,9 +283,9 @@ static int raw_import_open_disk(RawImport *i) {
                  * existing thing (i.e. are not the sole thing stored in the file), in which case we will
                  * neither truncate nor create. */
 
-                i->output_fd = open(i->local, O_RDWR|O_NOCTTY|O_CLOEXEC|(i->offset == UINT64_MAX ? O_TRUNC|O_CREAT : 0), 0664);
+                i->output_fd = xopenat_full(AT_FDCWD, i->local, O_RDWR|O_NOCTTY|(i->offset == UINT64_MAX ? O_TRUNC|O_CREAT : 0), /* xopen_flags= */ 0, 0664);
                 if (i->output_fd < 0)
-                        return log_error_errno(errno, "Failed to open destination '%s': %m", i->local);
+                        return log_error_errno(i->output_fd, "Failed to open destination '%s': %m", i->local);
 
                 if (i->offset == UINT64_MAX)
                         (void) import_set_nocow_and_log(i->output_fd, i->local);
@@ -300,9 +300,9 @@ static int raw_import_open_disk(RawImport *i) {
 
                 (void) mkdir_parents_label(i->temp_path, 0700);
 
-                i->output_fd = open(i->temp_path, O_RDWR|O_CREAT|O_EXCL|O_NOCTTY|O_CLOEXEC, 0664);
+                i->output_fd = xopenat_full(AT_FDCWD, i->temp_path, O_RDWR|O_CREAT|O_EXCL|O_NOCTTY, /* xopen_flags= */ 0, 0664);
                 if (i->output_fd < 0)
-                        return log_error_errno(errno, "Failed to open destination '%s': %m", i->temp_path);
+                        return log_error_errno(i->output_fd, "Failed to open destination '%s': %m", i->temp_path);
 
                 (void) import_set_nocow_and_log(i->output_fd, i->temp_path);
         }

--- a/src/import/import-tar.c
+++ b/src/import/import-tar.c
@@ -14,6 +14,7 @@
 #include "errno-util.h"
 #include "fd-util.h"
 #include "format-util.h"
+#include "fs-util.h"
 #include "import-common.h"
 #include "import-tar.h"
 #include "import-util.h"
@@ -297,9 +298,9 @@ static int tar_import_fork_tar(TarImport *i) {
                         (void) import_assign_pool_quota_and_warn(d);
                 }
 
-                i->tree_fd = open(d, O_DIRECTORY|O_CLOEXEC|O_NOFOLLOW);
+                i->tree_fd = xopenat(AT_FDCWD, d, O_DIRECTORY|O_NOFOLLOW);
                 if (i->tree_fd < 0)
-                        return log_error_errno(errno, "Failed to open '%s': %m", d);
+                        return log_error_errno(i->tree_fd, "Failed to open '%s': %m", d);
         }
 
         i->tar_fd = import_fork_tar_x(i->tree_fd, i->userns_fd, &i->tar_pid);

--- a/src/import/import.c
+++ b/src/import/import.c
@@ -12,6 +12,7 @@
 #include "dlopen-note.h"
 #include "env-util.h"
 #include "fd-util.h"
+#include "fs-util.h"
 #include "import-raw.h"
 #include "import-tar.h"
 #include "import-util.h"
@@ -100,9 +101,9 @@ static int open_source(const char *path, const char *local, int *ret_open_fd) {
         assert(ret_open_fd);
 
         if (path) {
-                open_fd = open(path, O_RDONLY|O_CLOEXEC|O_NOCTTY);
+                open_fd = xopenat(AT_FDCWD, path, O_RDONLY|O_NOCTTY);
                 if (open_fd < 0)
-                        return log_error_errno(errno, "Failed to open source file '%s': %m", path);
+                        return log_error_errno(open_fd, "Failed to open source file '%s': %m", path);
 
                 retval = open_fd;
 

--- a/src/import/importctl.c
+++ b/src/import/importctl.c
@@ -3,6 +3,7 @@
 #include <locale.h>
 #include <unistd.h>
 
+#include "fs-util.h"
 #include "sd-bus.h"
 #include "sd-event.h"
 #include "sd-json.h"
@@ -516,9 +517,9 @@ static int verb_import_tar(int argc, char *argv[], uintptr_t _data, void *userda
                                        local);
 
         if (path) {
-                fd = open(path, O_RDONLY|O_CLOEXEC|O_NOCTTY);
+                fd = xopenat(AT_FDCWD, path, O_RDONLY|O_NOCTTY);
                 if (fd < 0)
-                        return log_error_errno(errno, "Failed to open %s: %m", path);
+                        return log_error_errno(fd, "Failed to open %s: %m", path);
         }
 
         if (arg_image_class == IMAGE_MACHINE && (arg_import_flags & ~(IMPORT_FORCE|IMPORT_READ_ONLY)) == 0) {
@@ -596,9 +597,9 @@ static int verb_import_raw(int argc, char *argv[], uintptr_t _data, void *userda
                                        local);
 
         if (path) {
-                fd = open(path, O_RDONLY|O_CLOEXEC|O_NOCTTY);
+                fd = xopenat(AT_FDCWD, path, O_RDONLY|O_NOCTTY);
                 if (fd < 0)
-                        return log_error_errno(errno, "Failed to open %s: %m", path);
+                        return log_error_errno(fd, "Failed to open %s: %m", path);
         }
 
         if (arg_image_class == IMAGE_MACHINE && (arg_import_flags & ~(IMPORT_FORCE|IMPORT_READ_ONLY)) == 0) {
@@ -667,9 +668,9 @@ static int verb_import_fs(int argc, char *argv[], uintptr_t _data, void *userdat
                                        local);
 
         if (path) {
-                fd = open(path, O_DIRECTORY|O_RDONLY|O_CLOEXEC);
+                fd = xopenat(AT_FDCWD, path, O_DIRECTORY|O_RDONLY);
                 if (fd < 0)
-                        return log_error_errno(errno, "Failed to open directory '%s': %m", path);
+                        return log_error_errno(fd, "Failed to open directory '%s': %m", path);
         }
 
         if (arg_image_class == IMAGE_MACHINE && (arg_import_flags & ~(IMPORT_FORCE|IMPORT_READ_ONLY)) == 0) {
@@ -744,9 +745,9 @@ static int verb_export_tar(int argc, char *argv[], uintptr_t _data, void *userda
         if (path) {
                 determine_compression_from_filename(path);
 
-                fd = open(path, O_WRONLY|O_CREAT|O_TRUNC|O_CLOEXEC|O_NOCTTY, 0666);
+                fd = xopenat_full(AT_FDCWD, path, O_WRONLY|O_CREAT|O_TRUNC|O_NOCTTY, /* xopen_flags= */ 0, 0666);
                 if (fd < 0)
-                        return log_error_errno(errno, "Failed to open %s: %m", path);
+                        return log_error_errno(fd, "Failed to open %s: %m", path);
         }
 
         if (arg_image_class == IMAGE_MACHINE && arg_import_flags == 0) {
@@ -804,9 +805,9 @@ static int verb_export_raw(int argc, char *argv[], uintptr_t _data, void *userda
         if (path) {
                 determine_compression_from_filename(path);
 
-                fd = open(path, O_WRONLY|O_CREAT|O_TRUNC|O_CLOEXEC|O_NOCTTY, 0666);
+                fd = xopenat_full(AT_FDCWD, path, O_WRONLY|O_CREAT|O_TRUNC|O_NOCTTY, /* xopen_flags= */ 0, 0666);
                 if (fd < 0)
-                        return log_error_errno(errno, "Failed to open %s: %m", path);
+                        return log_error_errno(fd, "Failed to open %s: %m", path);
         }
 
         if (arg_image_class == IMAGE_MACHINE && arg_import_flags == 0) {

--- a/src/import/pull-oci.c
+++ b/src/import/pull-oci.c
@@ -1003,7 +1003,7 @@ static int oci_pull_save_nspawn_settings(OciPull *i) {
 
         _cleanup_fclose_ FILE *f = NULL;
         _cleanup_(unlink_and_freep) char *tmpfile = NULL;
-        r = fopen_tmpfile_linkable(j, O_WRONLY|O_CLOEXEC, &tmpfile, &f);
+        r = fopen_tmpfile_linkable(j, O_WRONLY, &tmpfile, &f);
         if (r < 0)
                 return log_error_errno(r, "Failed to create '%s': %m", j);
 
@@ -1093,7 +1093,7 @@ static int oci_pull_save_oci_config(OciPull *i) {
 
         _cleanup_close_ int fd = -EBADF;
         _cleanup_(unlink_and_freep) char *tmpfile = NULL;
-        fd = open_tmpfile_linkable(j, O_WRONLY|O_CLOEXEC, &tmpfile);
+        fd = open_tmpfile_linkable(j, O_WRONLY, &tmpfile);
         if (fd < 0)
                 return log_error_errno(fd, "Failed to create '%s': %m", j);
 
@@ -1131,7 +1131,7 @@ static int oci_pull_save_mstack(OciPull *i) {
         if (r < 0)
                 return log_oom();
 
-        _cleanup_close_ int dir_fd = xopenat(AT_FDCWD, _jt, O_DIRECTORY|O_CREAT|O_CLOEXEC);
+        _cleanup_close_ int dir_fd = xopenat(AT_FDCWD, _jt, O_DIRECTORY|O_CREAT);
         if (dir_fd < 0)
                 return log_error_errno(dir_fd, "Failed to create '%s': %m", j);
 
@@ -1172,7 +1172,7 @@ static int oci_pull_save_mstack(OciPull *i) {
                         if (r < 0)
                                 return r;
                 } else {
-                        _cleanup_close_ int rw_fd = open_mkdir_at(dir_fd, "rw", O_EXCL|O_CLOEXEC, 0755);
+                        _cleanup_close_ int rw_fd = open_mkdir_at(dir_fd, "rw", O_EXCL, 0755);
                         if (rw_fd < 0)
                                 return log_error_errno(rw_fd, "Failed to create 'rw' layer: %m");
                 }

--- a/src/import/pull-oci.c
+++ b/src/import/pull-oci.c
@@ -504,9 +504,9 @@ static int oci_pull_job_on_open_disk(PullJob *j) {
                         (void) import_assign_pool_quota_and_warn(st->temp_path);
                 }
 
-                st->tree_fd = open(st->temp_path, O_DIRECTORY|O_CLOEXEC|O_NOFOLLOW);
+                st->tree_fd = xopenat(AT_FDCWD, st->temp_path, O_DIRECTORY|O_NOFOLLOW);
                 if (st->tree_fd < 0)
-                        return log_error_errno(errno, "Failed to open '%s': %m", st->temp_path);
+                        return log_error_errno(st->tree_fd, "Failed to open '%s': %m", st->temp_path);
         }
 
         j->disk_fd = import_fork_tar_x(st->tree_fd, i->userns_fd, &st->tar_pid);

--- a/src/import/pull-raw.c
+++ b/src/import/pull-raw.c
@@ -252,9 +252,9 @@ static int raw_pull_maybe_convert_qcow2(RawPull *p) {
         if (r < 0)
                 return log_oom();
 
-        converted_fd = open(f, O_RDWR|O_CREAT|O_EXCL|O_NOCTTY|O_CLOEXEC, 0664);
+        converted_fd = xopenat_full(AT_FDCWD, f, O_RDWR|O_CREAT|O_EXCL|O_NOCTTY, /* xopen_flags= */ 0, 0664);
         if (converted_fd < 0)
-                return log_error_errno(errno, "Failed to create %s: %m", f);
+                return log_error_errno(converted_fd, "Failed to create %s: %m", f);
 
         t = TAKE_PTR(f);
 
@@ -355,9 +355,9 @@ static int raw_pull_make_local_copy(RawPull *p) {
 
                 assert(p->raw_job->disk_fd < 0);
 
-                p->raw_job->disk_fd = open(p->final_path, O_RDONLY|O_NOCTTY|O_CLOEXEC);
+                p->raw_job->disk_fd = xopenat(AT_FDCWD, p->final_path, O_RDONLY|O_NOCTTY);
                 if (p->raw_job->disk_fd < 0)
-                        return log_error_errno(errno, "Failed to open vendor image: %m");
+                        return log_error_errno(p->raw_job->disk_fd, "Failed to open vendor image: %m");
         } else {
                 /* We freshly downloaded the image, use it */
 
@@ -381,9 +381,9 @@ static int raw_pull_make_local_copy(RawPull *p) {
                 if (r < 0)
                         return log_oom();
 
-                dfd = open(f, O_WRONLY|O_CREAT|O_EXCL|O_NOCTTY|O_CLOEXEC, 0664);
+                dfd = xopenat_full(AT_FDCWD, f, O_WRONLY|O_CREAT|O_EXCL|O_NOCTTY, /* xopen_flags= */ 0, 0664);
                 if (dfd < 0)
-                        return log_error_errno(errno, "Failed to create writable copy of image: %m");
+                        return log_error_errno(dfd, "Failed to create writable copy of image: %m");
 
                 tp = TAKE_PTR(f);
 
@@ -685,9 +685,9 @@ static int raw_pull_job_on_open_disk_generic(
 
         (void) mkdir_parents_label(*temp_path, 0700);
 
-        j->disk_fd = open(*temp_path, O_RDWR|O_CREAT|O_EXCL|O_NOCTTY|O_CLOEXEC, 0664);
+        j->disk_fd = xopenat_full(AT_FDCWD, *temp_path, O_RDWR|O_CREAT|O_EXCL|O_NOCTTY, /* xopen_flags= */ 0, 0664);
         if (j->disk_fd < 0)
-                return log_error_errno(errno, "Failed to create %s: %m", *temp_path);
+                return log_error_errno(j->disk_fd, "Failed to create %s: %m", *temp_path);
 
         return 0;
 }
@@ -713,9 +713,9 @@ static int raw_pull_job_on_open_disk_raw(PullJob *j) {
 
                 (void) mkdir_parents_label(p->local, 0700);
 
-                j->disk_fd = open(p->local, O_RDWR|O_NOCTTY|O_CLOEXEC|(p->offset == UINT64_MAX ? O_TRUNC|O_CREAT : 0), 0664);
+                j->disk_fd = xopenat_full(AT_FDCWD, p->local, O_RDWR|O_NOCTTY|(p->offset == UINT64_MAX ? O_TRUNC|O_CREAT : 0), /* xopen_flags= */ 0, 0664);
                 if (j->disk_fd < 0)
-                        return log_error_errno(errno, "Failed to open destination '%s': %m", p->local);
+                        return log_error_errno(j->disk_fd, "Failed to open destination '%s': %m", p->local);
 
                 if (p->offset == UINT64_MAX)
                         (void) import_set_nocow_and_log(j->disk_fd, p->local);

--- a/src/import/pull-tar.c
+++ b/src/import/pull-tar.c
@@ -285,9 +285,9 @@ static int tar_pull_make_local_copy(TarPull *p) {
                          * already downloaded the image before, and are just making a copy of the original
                          * download, we need to open ->tree_fd now */
                         if (p->tree_fd < 0) {
-                                _cleanup_close_ int directory_fd = open(p->final_path, O_DIRECTORY|O_CLOEXEC);
+                                _cleanup_close_ int directory_fd = xopenat(AT_FDCWD, p->final_path, O_DIRECTORY);
                                 if (directory_fd < 0)
-                                        return log_error_errno(errno, "Failed to open '%s': %m", p->final_path);
+                                        return log_error_errno(directory_fd, "Failed to open '%s': %m", p->final_path);
 
                                 struct stat st;
                                 if (fstat(directory_fd, &st) < 0)
@@ -657,9 +657,9 @@ static int tar_pull_job_on_open_disk_tar(PullJob *j) {
                         (void) import_assign_pool_quota_and_warn(where);
                 }
 
-                p->tree_fd = open(where, O_DIRECTORY|O_CLOEXEC|O_NOFOLLOW);
+                p->tree_fd = xopenat(AT_FDCWD, where, O_DIRECTORY|O_NOFOLLOW);
                 if (p->tree_fd < 0)
-                        return log_error_errno(errno, "Failed to open '%s': %m", where);
+                        return log_error_errno(p->tree_fd, "Failed to open '%s': %m", where);
         }
 
         j->disk_fd = import_fork_tar_x(p->tree_fd, p->userns_fd, &p->tar_pid);
@@ -687,9 +687,9 @@ static int tar_pull_job_on_open_disk_settings(PullJob *j) {
 
         (void) mkdir_parents_label(p->settings_temp_path, 0700);
 
-        j->disk_fd = open(p->settings_temp_path, O_RDWR|O_CREAT|O_EXCL|O_NOCTTY|O_CLOEXEC, 0664);
+        j->disk_fd = xopenat_full(AT_FDCWD, p->settings_temp_path, O_RDWR|O_CREAT|O_EXCL|O_NOCTTY, /* xopen_flags= */ 0, 0664);
         if (j->disk_fd < 0)
-                return log_error_errno(errno, "Failed to create %s: %m", p->settings_temp_path);
+                return log_error_errno(j->disk_fd, "Failed to create %s: %m", p->settings_temp_path);
 
         return 0;
 }

--- a/src/include/override/fcntl.h
+++ b/src/include/override/fcntl.h
@@ -25,6 +25,12 @@
 #define AT_HANDLE_MNT_ID_UNIQUE 0x001  /* Return the u64 unique mount ID. */
 #endif
 
+/* Not defined by glibc yet.
+ * Supported since kernel v7.2 (31cf44efa6df72a524b40adefb80539f3a4e13ba). */
+#ifndef O_EMPTYPATH
+#define O_EMPTYPATH (1 << 26)  /* allow empty path */
+#endif
+
 #ifndef FD_NSFS_ROOT
 #define FD_NSFS_ROOT -10003 /* Root of the nsfs filesystem */
 #endif

--- a/src/journal-remote/journal-gatewayd.c
+++ b/src/journal-remote/journal-gatewayd.c
@@ -147,7 +147,7 @@ static int request_meta_ensure_tmp(RequestMeta *m) {
         else {
                 _cleanup_close_ int fd = -EBADF;
 
-                fd = open_tmpfile_unlinkable("/tmp", O_RDWR|O_CLOEXEC);
+                fd = open_tmpfile_unlinkable("/tmp", O_RDWR);
                 if (fd < 0)
                         return fd;
 

--- a/src/journal-remote/journal-gatewayd.c
+++ b/src/journal-remote/journal-gatewayd.c
@@ -17,6 +17,7 @@
 #include "errno-util.h"
 #include "fd-util.h"
 #include "fileio.h"
+#include "fs-util.h"
 #include "glob-util.h"
 #include "hostname-setup.h"
 #include "hostname-util.h"
@@ -805,9 +806,9 @@ static int request_handler_file(
         assert(path);
         assert(mime_type);
 
-        fd = open(path, O_RDONLY|O_CLOEXEC);
+        fd = xopenat(AT_FDCWD, path, O_RDONLY);
         if (fd < 0)
-                return mhd_respondf(connection, errno, MHD_HTTP_NOT_FOUND, "Failed to open file %s: %m", path);
+                return mhd_respondf(connection, fd, MHD_HTTP_NOT_FOUND, "Failed to open file %s: %m", path);
 
         if (fstat(fd, &st) < 0)
                 return mhd_respondf(connection, errno, MHD_HTTP_INTERNAL_SERVER_ERROR, "Failed to stat file: %m");

--- a/src/journal/bsod.c
+++ b/src/journal/bsod.c
@@ -135,7 +135,7 @@ static int display_emergency_message_fullscreen(const char *message) {
         if (arg_tty)
                 tty = arg_tty;
         else {
-                fd = open_terminal("/dev/tty1", O_RDWR|O_NOCTTY|O_CLOEXEC);
+                fd = open_terminal("/dev/tty1", O_RDWR|O_NOCTTY);
                 if (fd < 0)
                         return log_error_errno(fd, "Failed to open %s: %m", "/dev/tty1");
 
@@ -149,7 +149,7 @@ static int display_emergency_message_fullscreen(const char *message) {
                 fd = safe_close(fd);
         }
 
-        fd = open_terminal(tty, O_RDWR|O_NOCTTY|O_CLOEXEC);
+        fd = open_terminal(tty, O_RDWR|O_NOCTTY);
         if (fd < 0)
                 return log_error_errno(fd, "Failed to open %s: %m", tty);
 

--- a/src/journal/journalctl-authenticate.c
+++ b/src/journal/journalctl-authenticate.c
@@ -122,7 +122,7 @@ int action_setup_keys(void) {
         n = now(CLOCK_REALTIME);
         n /= arg_interval;
 
-        fd = open_tmpfile_linkable(path, O_WRONLY|O_CLOEXEC, &tmpfile);
+        fd = open_tmpfile_linkable(path, O_WRONLY, &tmpfile);
         if (fd < 0)
                 return log_error_errno(fd, "Failed to open a temporary file for %s: %m", path);
 

--- a/src/journal/journald-console.c
+++ b/src/journal/journald-console.c
@@ -92,7 +92,7 @@ void manager_forward_console(
          * but minimizes the time window the kernel might end up killing journald due to SAK). It also makes things
          * easier for us so that we don't have to recover from hangups and suchlike triggered on the console. */
 
-        fd = open_terminal(tty, O_WRONLY|O_NOCTTY|O_CLOEXEC);
+        fd = open_terminal(tty, O_WRONLY|O_NOCTTY);
         if (fd < 0) {
                 log_debug_errno(fd, "Failed to open %s for logging: %m", tty);
                 return;

--- a/src/journal/journald-kmsg.c
+++ b/src/journal/journald-kmsg.c
@@ -15,6 +15,7 @@
 #include "escape.h"
 #include "fd-util.h"
 #include "format-util.h"
+#include "fs-util.h"
 #include "iovec-util.h"
 #include "journal-internal.h"
 #include "journald-kmsg.h"
@@ -390,12 +391,12 @@ int manager_open_dev_kmsg(Manager *m) {
         assert(m->dev_kmsg_fd < 0);
         assert(!m->dev_kmsg_event_source);
 
-        mode_t mode = O_CLOEXEC|O_NONBLOCK|O_NOCTTY|(m->config.read_kmsg ? O_RDWR : O_WRONLY);
+        mode_t mode = O_NONBLOCK|O_NOCTTY|(m->config.read_kmsg ? O_RDWR : O_WRONLY);
 
-        _cleanup_close_ int fd = open("/dev/kmsg", mode);
+        _cleanup_close_ int fd = xopenat(AT_FDCWD, "/dev/kmsg", mode);
         if (fd < 0) {
-                log_full_errno(errno == ENOENT ? LOG_DEBUG : LOG_WARNING,
-                               errno, "Failed to open /dev/kmsg for %s access, ignoring: %m", accmode_to_string(mode));
+                log_full_errno(fd == -ENOENT ? LOG_DEBUG : LOG_WARNING,
+                               fd, "Failed to open /dev/kmsg for %s access, ignoring: %m", accmode_to_string(mode));
                 return 0;
         }
 

--- a/src/journal/journald-manager.c
+++ b/src/journal/journald-manager.c
@@ -656,10 +656,10 @@ static int manager_archive_offline_user_journals(Manager *m) {
                 if (!full)
                         return log_oom();
 
-                fd = openat(dirfd(d), de->d_name, O_RDWR|O_CLOEXEC|O_NOCTTY|O_NOFOLLOW|O_NONBLOCK);
+                fd = xopenat(dirfd(d), de->d_name, O_RDWR|O_NOCTTY|O_NOFOLLOW|O_NONBLOCK);
                 if (fd < 0) {
-                        log_ratelimit_full_errno(IN_SET(errno, ELOOP, ENOENT) ? LOG_DEBUG : LOG_WARNING,
-                                                 errno, JOURNAL_LOG_RATELIMIT,
+                        log_ratelimit_full_errno(IN_SET(fd, -ELOOP, -ENOENT) ? LOG_DEBUG : LOG_WARNING,
+                                                 fd, JOURNAL_LOG_RATELIMIT,
                                                  "Failed to open journal file '%s' for rotation: %m", full);
                         continue;
                 }
@@ -1922,10 +1922,9 @@ static int manager_open_hostname(Manager *m) {
 
         assert(m);
 
-        m->hostname_fd = open("/proc/sys/kernel/hostname",
-                              O_RDONLY|O_CLOEXEC|O_NONBLOCK|O_NOCTTY);
+        m->hostname_fd = xopenat(AT_FDCWD, "/proc/sys/kernel/hostname", O_RDONLY|O_NONBLOCK|O_NOCTTY);
         if (m->hostname_fd < 0)
-                return log_error_errno(errno, "Failed to open %s: %m", "/proc/sys/kernel/hostname");
+                return log_error_errno(m->hostname_fd, "Failed to open %s: %m", "/proc/sys/kernel/hostname");
 
         r = sd_event_add_io(m->event, &m->hostname_event_source, m->hostname_fd, 0, dispatch_hostname_change, m);
         if (r < 0)
@@ -2091,9 +2090,9 @@ int manager_map_seqnum_file(
         if (!fn)
                 return -ENOMEM;
 
-        fd = open(fn, O_RDWR|O_CREAT|O_CLOEXEC|O_NOCTTY|O_NOFOLLOW, 0644);
+        fd = xopenat_full(AT_FDCWD, fn, O_RDWR|O_CREAT|O_NOCTTY|O_NOFOLLOW, /* xopen_flags= */ 0, 0644);
         if (fd < 0)
-                return -errno;
+                return fd;
 
         r = posix_fallocate_loop(fd, 0, size);
         if (r < 0)

--- a/src/kernel-install/kernel-install.c
+++ b/src/kernel-install/kernel-install.c
@@ -187,7 +187,7 @@ static int context_copy(const Context *source, Context *ret) {
         };
 
         if (source->rfd >= 0) {
-                copy.rfd = fd_reopen(source->rfd, O_CLOEXEC|O_DIRECTORY|O_PATH);
+                copy.rfd = fd_reopen(source->rfd, O_DIRECTORY|O_PATH);
                 if (copy.rfd < 0)
                         return copy.rfd;
         }
@@ -1003,7 +1003,7 @@ static int context_make_entry_dir(Context *c) {
 
         log_debug("mkdir -p %s", c->entry_dir);
         fd = chase_and_openat(c->rfd, c->rfd, c->entry_dir, CHASE_MKDIR_0755,
-                              O_CLOEXEC | O_CREAT | O_DIRECTORY | O_PATH, NULL);
+                              O_CREAT | O_DIRECTORY | O_PATH, NULL);
         if (fd < 0)
                 return log_error_errno(fd, "Failed to make directory '%s': %m", c->entry_dir);
 
@@ -1026,7 +1026,7 @@ static int context_remove_entry_dir(Context *c) {
                 return 0;
 
         log_debug("rm -rf %s", c->entry_dir);
-        fd = chase_and_openat(c->rfd, c->rfd, c->entry_dir, /* chase_flags= */ 0, O_CLOEXEC | O_DIRECTORY, &p);
+        fd = chase_and_openat(c->rfd, c->rfd, c->entry_dir, /* chase_flags= */ 0, O_DIRECTORY, &p);
         if (fd < 0) {
                 if (IN_SET(fd, -ENOTDIR, -ENOENT))
                         return 0;
@@ -1332,7 +1332,7 @@ static int verb_add_all(int argc, char *argv[], uintptr_t _data, void *userdata)
         if (r < 0)
                 return r;
 
-        fd = chase_and_openat(c.rfd, c.rfd, "/usr/lib/modules", /* chase_flags= */ 0, O_DIRECTORY|O_RDONLY|O_CLOEXEC, NULL);
+        fd = chase_and_openat(c.rfd, c.rfd, "/usr/lib/modules", /* chase_flags= */ 0, O_DIRECTORY|O_RDONLY, /* ret_path= */ NULL);
         if (fd < 0)
                 return log_error_errno(fd, "Failed to open %s/usr/lib/modules/: %m", strempty(arg_root));
 
@@ -1562,7 +1562,7 @@ static int verb_list(int argc, char *argv[], uintptr_t _data, void *userdata) {
         if (r < 0)
                 return r;
 
-        fd = chase_and_openat(c.rfd, c.rfd, "/usr/lib/modules", /* chase_flags= */ 0, O_DIRECTORY|O_RDONLY|O_CLOEXEC, NULL);
+        fd = chase_and_openat(c.rfd, c.rfd, "/usr/lib/modules", /* chase_flags= */ 0, O_DIRECTORY|O_RDONLY, /* ret_path= */ NULL);
         if (fd < 0)
                 return log_error_errno(fd, "Failed to open %s/usr/lib/modules/: %m", strempty(arg_root));
 

--- a/src/kernel-install/kernel-install.c
+++ b/src/kernel-install/kernel-install.c
@@ -259,9 +259,9 @@ static int context_open_root(Context *c) {
         if (r > 0)
                 return 0;
 
-        c->rfd = open(arg_root, O_CLOEXEC | O_DIRECTORY | O_PATH);
+        c->rfd = xopenat(AT_FDCWD, arg_root, O_DIRECTORY | O_PATH);
         if (c->rfd < 0)
-                return log_error_errno(errno, "Failed to open root directory '%s': %m", arg_root);
+                return log_error_errno(c->rfd, "Failed to open root directory '%s': %m", arg_root);
 
         return 0;
 }

--- a/src/keyutil/keyutil.c
+++ b/src/keyutil/keyutil.c
@@ -351,7 +351,7 @@ static int verb_pkcs7(int argc, char *argv[], uintptr_t _data, void *userdata) {
 
         _cleanup_fclose_ FILE *output = NULL;
         _cleanup_(unlink_and_freep) char *tmp = NULL;
-        r = fopen_tmpfile_linkable(arg_output, O_WRONLY|O_CLOEXEC, &tmp, &output);
+        r = fopen_tmpfile_linkable(arg_output, O_WRONLY, &tmp, &output);
         if (r < 0)
                 return log_error_errno(r, "Failed to open temporary file: %m");
 

--- a/src/libsystemd-network/sd-dhcp-server.c
+++ b/src/libsystemd-network/sd-dhcp-server.c
@@ -516,7 +516,7 @@ int sd_dhcp_server_set_lease_file(sd_dhcp_server *server, int dir_fd, const char
         _cleanup_close_ int fd = AT_FDCWD; /* Unlike our usual coding style, AT_FDCWD needs to be set,
                                             * to pass a 'valid' fd. */
         if (dir_fd >= 0) {
-                fd = fd_reopen(dir_fd, O_CLOEXEC | O_DIRECTORY | O_PATH);
+                fd = fd_reopen(dir_fd, O_DIRECTORY | O_PATH);
                 if (fd < 0)
                         return fd;
         }

--- a/src/libsystemd/sd-device/sd-device.c
+++ b/src/libsystemd/sd-device/sd-device.c
@@ -2908,6 +2908,13 @@ _public_ int sd_device_open(sd_device *device, int flags) {
         if (fd2 < 0)
                 return fd2;
 
+        /* We've historically returned non-cloexec fds. */
+        if (!FLAGS_SET(flags, O_CLOEXEC)) {
+                r = fd_cloexec(fd2, false);
+                if (r < 0)
+                        return r;
+        }
+
         if (diskseq == 0)
                 return TAKE_FD(fd2);
 

--- a/src/libsystemd/sd-device/sd-device.c
+++ b/src/libsystemd/sd-device/sd-device.c
@@ -2868,9 +2868,9 @@ _public_ int sd_device_open(sd_device *device, int flags) {
         if (r < 0)
                 return r;
 
-        fd = open(devname, FLAGS_SET(flags, O_PATH) ? flags : O_CLOEXEC|O_NOFOLLOW|O_PATH);
+        fd = xopenat(AT_FDCWD, devname, FLAGS_SET(flags, O_PATH) ? flags : O_NOFOLLOW|O_PATH);
         if (fd < 0)
-                return -errno;
+                return fd;
 
         if (fstat(fd, &st) < 0)
                 return -errno;
@@ -2885,8 +2885,16 @@ _public_ int sd_device_open(sd_device *device, int flags) {
                 return -ENXIO;
 
         /* If flags has O_PATH, then we cannot check diskseq. Let's return earlier. */
-        if (FLAGS_SET(flags, O_PATH))
+        if (FLAGS_SET(flags, O_PATH)) {
+                /* We've historically returned non-cloexec fds. */
+                if (!FLAGS_SET(flags, O_CLOEXEC)) {
+                        r = fd_cloexec(fd, false);
+                        if (r < 0)
+                                return r;
+                }
+
                 return TAKE_FD(fd);
+        }
 
         /* If the device is not initialized, then we cannot determine if we should check diskseq through
          * ID_IGNORE_DISKSEQ property. Let's skip to check diskseq in that case. */

--- a/src/libsystemd/sd-device/test-sd-device.c
+++ b/src/libsystemd/sd-device/test-sd-device.c
@@ -245,6 +245,22 @@ static void test_sd_device_one(sd_device *d) {
                         _cleanup_close_ int fd = -EBADF;
                         fd = sd_device_open(d, O_CLOEXEC| O_NONBLOCK | (is_block ? O_RDONLY : O_NOCTTY | O_PATH));
                         ASSERT_TRUE(fd >= 0 || ERRNO_IS_NEG_PRIVILEGE(fd));
+                        if (fd >= 0) {
+                                int fl;
+
+                                ASSERT_OK_ERRNO(fl = fcntl(fd, F_GETFD));
+                                ASSERT_TRUE(FLAGS_SET(fl, FD_CLOEXEC));
+                        }
+
+                        /* Without O_CLOEXEC the fd must not be close-on-exec, both on the O_PATH and the fd_reopen() path */
+                        _cleanup_close_ int fd_nocloexec = sd_device_open(d, O_NONBLOCK | (is_block ? O_RDONLY : O_NOCTTY | O_PATH));
+                        ASSERT_TRUE(fd_nocloexec >= 0 || ERRNO_IS_NEG_PRIVILEGE(fd_nocloexec));
+                        if (fd_nocloexec >= 0) {
+                                int fl;
+
+                                ASSERT_OK_ERRNO(fl = fcntl(fd_nocloexec, F_GETFD));
+                                ASSERT_FALSE(FLAGS_SET(fl, FD_CLOEXEC));
+                        }
                 }
         }
 

--- a/src/libsystemd/sd-event/sd-event.c
+++ b/src/libsystemd/sd-event/sd-event.c
@@ -21,6 +21,7 @@
 #include "event-util.h"
 #include "fd-util.h"
 #include "format-util.h"
+#include "fs-util.h"
 #include "glyph-util.h"
 #include "hashmap.h"
 #include "hexdecoct.h"
@@ -2043,10 +2044,10 @@ static int event_add_pressure(
                 locked = false;
         }
 
-        path_fd = open(watch, O_PATH|O_CLOEXEC);
+        path_fd = xopenat(AT_FDCWD, watch, O_PATH);
         if (path_fd < 0) {
-                if (errno != ENOENT)
-                        return -errno;
+                if (path_fd != -ENOENT)
+                        return path_fd;
 
                 /* We got ENOENT. Two options now: try the fallback if we have one, or return the error as is
                  * (when based on user/env config). */
@@ -2056,11 +2057,11 @@ static int event_add_pressure(
                         return -ENOENT;
                 }
 
-                path_fd = open(watch_fallback, O_PATH|O_CLOEXEC);
+                path_fd = xopenat(AT_FDCWD, watch_fallback, O_PATH);
                 if (path_fd < 0) {
-                        if (errno == ENOENT) /* PSI is not available in the kernel even under the fallback path? */
+                        if (path_fd == -ENOENT) /* PSI is not available in the kernel even under the fallback path? */
                                 return -EOPNOTSUPP;
-                        return -errno;
+                        return path_fd;
                 }
         }
 
@@ -2608,13 +2609,14 @@ _public_ int sd_event_add_inotify(
         sd_event_source *s = NULL; /* avoid false maybe-uninitialized warning */
         int fd, r;
 
-        assert_return(path, -EINVAL);
+        assert_return(!isempty(path), -EINVAL);
 
-        fd = open(path, O_PATH | O_CLOEXEC |
-                        (mask & IN_ONLYDIR ? O_DIRECTORY : 0) |
-                        (mask & IN_DONT_FOLLOW ? O_NOFOLLOW : 0));
+        fd = xopenat(AT_FDCWD, path,
+                     O_PATH |
+                     (mask & IN_ONLYDIR ? O_DIRECTORY : 0) |
+                     (mask & IN_DONT_FOLLOW ? O_NOFOLLOW : 0));
         if (fd < 0)
-                return -errno;
+                return fd;
 
         r = event_add_inotify_fd_internal(e, &s, fd, /* donate= */ true, mask, callback, userdata);
         if (r < 0)

--- a/src/libsystemd/sd-event/sd-event.c
+++ b/src/libsystemd/sd-event/sd-event.c
@@ -2079,7 +2079,7 @@ static int event_add_pressure(
                 events = EPOLLIN;
 
         } else if (S_ISREG(st.st_mode) || S_ISFIFO(st.st_mode) || S_ISCHR(st.st_mode)) {
-                fd = fd_reopen(path_fd, (write_buffer_size > 0 ? O_RDWR : O_RDONLY) |O_CLOEXEC|O_NONBLOCK|O_NOCTTY);
+                fd = fd_reopen(path_fd, (write_buffer_size > 0 ? O_RDWR : O_RDONLY)|O_NONBLOCK|O_NOCTTY);
                 if (fd < 0)
                         return fd;
 

--- a/src/libsystemd/sd-id128/id128-util.c
+++ b/src/libsystemd/sd-id128/id128-util.c
@@ -145,7 +145,7 @@ int id128_read_at(int dir_fd, const char *path, Id128Flag f, sd_id128_t *ret) {
         assert(wildcard_fd_is_valid(dir_fd));
         assert(path);
 
-        fd = xopenat(dir_fd, path, O_RDONLY|O_CLOEXEC|O_NOCTTY);
+        fd = xopenat(dir_fd, path, O_RDONLY|O_NOCTTY);
         if (fd < 0)
                 return fd;
 
@@ -191,7 +191,7 @@ int id128_write_at(int dir_fd, const char *path, Id128Flag f, sd_id128_t id) {
         assert(dir_fd >= 0 || dir_fd == AT_FDCWD);
         assert(path);
 
-        fd = xopenat_full(dir_fd, path, O_WRONLY|O_CREAT|O_CLOEXEC|O_NOCTTY|O_TRUNC, /* xopen_flags= */ 0, 0444);
+        fd = xopenat_full(dir_fd, path, O_WRONLY|O_CREAT|O_NOCTTY|O_TRUNC, /* xopen_flags= */ 0, 0444);
         if (fd < 0)
                 return fd;
 

--- a/src/libsystemd/sd-id128/sd-id128.c
+++ b/src/libsystemd/sd-id128/sd-id128.c
@@ -154,7 +154,7 @@ int id128_get_machine_at(int rfd, sd_id128_t *ret) {
                 return sd_id128_get_machine(ret);
 
         _cleanup_close_ int fd =
-                chase_and_openat(rfd, rfd, "/etc/machine-id", CHASE_MUST_BE_REGULAR, O_RDONLY|O_CLOEXEC|O_NOCTTY, /* ret_path= */ NULL);
+                chase_and_openat(rfd, rfd, "/etc/machine-id", CHASE_MUST_BE_REGULAR, O_RDONLY|O_NOCTTY, /* ret_path= */ NULL);
         if (fd < 0)
                 return fd;
 
@@ -166,7 +166,7 @@ int id128_get_machine(const char *root, sd_id128_t *ret) {
                 return sd_id128_get_machine(ret);
 
         _cleanup_close_ int fd =
-                chase_and_open("/etc/machine-id", root, CHASE_PREFIX_ROOT|CHASE_MUST_BE_REGULAR, O_RDONLY|O_CLOEXEC|O_NOCTTY, /* ret_path= */ NULL);
+                chase_and_open("/etc/machine-id", root, CHASE_PREFIX_ROOT|CHASE_MUST_BE_REGULAR, O_RDONLY|O_NOCTTY, /* ret_path= */ NULL);
         if (fd < 0)
                 return fd;
 

--- a/src/libsystemd/sd-id128/test-id128.c
+++ b/src/libsystemd/sd-id128/test-id128.c
@@ -104,7 +104,7 @@ TEST(id128) {
         ASSERT_FALSE(id128_is_valid("01020304-0506-0708-090a0b0c0d0e0f10"));
         ASSERT_FALSE(id128_is_valid("010203040506-0708-090a-0b0c0d0e0f10"));
 
-        fd = open_tmpfile_unlinkable(NULL, O_RDWR|O_CLOEXEC);
+        fd = open_tmpfile_unlinkable(NULL, O_RDWR);
         ASSERT_OK(fd);
 
         /* First, write as UUID */

--- a/src/libsystemd/sd-id128/test-id128.c
+++ b/src/libsystemd/sd-id128/test-id128.c
@@ -299,7 +299,7 @@ TEST(id128_at) {
         ASSERT_OK_ERRNO(unlinkat(tfd, "etc/machine-id", 0));
         ASSERT_OK(id128_write_at(tfd, "etc2/machine-id", ID128_FORMAT_PLAIN, id));
         ASSERT_OK_ERRNO(unlinkat(tfd, "etc/machine-id", 0));
-        ASSERT_ERROR(id128_write_at(tfd, "etc/hoge-id", ID128_FORMAT_PLAIN, id), EEXIST);
+        ASSERT_ERROR(id128_write_at(tfd, "etc/hoge-id", ID128_FORMAT_PLAIN, id), ELOOP); /* dangling symlink */
         ASSERT_OK(id128_write_at(tfd, "etc2/machine-id", ID128_FORMAT_PLAIN, id));
 
         /* id128_read_at() */

--- a/src/libsystemd/sd-journal/catalog.c
+++ b/src/libsystemd/sd-journal/catalog.c
@@ -503,9 +503,9 @@ static int open_mmap(const char *database, int *ret_fd, struct stat *ret_st, voi
         assert(ret_map);
         assert(ret_strings_offset);
 
-        _cleanup_close_ int fd = open(database, O_RDONLY|O_CLOEXEC);
+        _cleanup_close_ int fd = xopenat(AT_FDCWD, database, O_RDONLY);
         if (fd < 0)
-                return -errno;
+                return fd;
 
         struct stat st;
         if (fstat(fd, &st) < 0)

--- a/src/libsystemd/sd-journal/journal-file.c
+++ b/src/libsystemd/sd-journal/journal-file.c
@@ -4180,7 +4180,7 @@ int journal_file_open(
                  * or so, we likely fail quickly than block for long. For regular files O_NONBLOCK has no effect, hence
                  * it doesn't hurt in that case. */
 
-                f->fd = openat_report_new(AT_FDCWD, fname, f->open_flags|O_CLOEXEC|O_NONBLOCK, f->mode, &newly_created);
+                f->fd = openat_report_new(AT_FDCWD, fname, f->open_flags|O_NONBLOCK, f->mode, &newly_created);
                 if (f->fd < 0) {
                         r = f->fd;
                         goto fail;

--- a/src/libsystemd/sd-journal/journal-vacuum.c
+++ b/src/libsystemd/sd-journal/journal-vacuum.c
@@ -98,12 +98,12 @@ static int journal_file_empty(int dir_fd, const char *name) {
         le64_t n_entries;
         ssize_t n;
 
-        fd = openat(dir_fd, name, O_RDONLY|O_CLOEXEC|O_NOFOLLOW|O_NONBLOCK|O_NOATIME);
+        fd = xopenat(dir_fd, name, O_RDONLY|O_NOFOLLOW|O_NONBLOCK|O_NOATIME);
         if (fd < 0) {
                 /* Maybe failed due to O_NOATIME and lack of privileges? */
-                fd = openat(dir_fd, name, O_RDONLY|O_CLOEXEC|O_NOFOLLOW|O_NONBLOCK);
+                fd = xopenat(dir_fd, name, O_RDONLY|O_NOFOLLOW|O_NONBLOCK);
                 if (fd < 0)
-                        return -errno;
+                        return fd;
         }
 
         if (fstat(fd, &st) < 0)

--- a/src/libsystemd/sd-journal/journal-verify.c
+++ b/src/libsystemd/sd-journal/journal-verify.c
@@ -856,19 +856,19 @@ int journal_file_verify(
                 goto fail;
         }
 
-        data_fd = open_tmpfile_unlinkable(tmp_dir, O_RDWR | O_CLOEXEC);
+        data_fd = open_tmpfile_unlinkable(tmp_dir, O_RDWR);
         if (data_fd < 0) {
                 r = log_error_errno(data_fd, "Failed to create data file: %m");
                 goto fail;
         }
 
-        entry_fd = open_tmpfile_unlinkable(tmp_dir, O_RDWR | O_CLOEXEC);
+        entry_fd = open_tmpfile_unlinkable(tmp_dir, O_RDWR);
         if (entry_fd < 0) {
                 r = log_error_errno(entry_fd, "Failed to create entry file: %m");
                 goto fail;
         }
 
-        entry_array_fd = open_tmpfile_unlinkable(tmp_dir, O_RDWR | O_CLOEXEC);
+        entry_array_fd = open_tmpfile_unlinkable(tmp_dir, O_RDWR);
         if (entry_array_fd < 0) {
                 r = log_error_errno(entry_array_fd,
                                     "Failed to create entry array file: %m");

--- a/src/libsystemd/sd-journal/sd-journal.c
+++ b/src/libsystemd/sd-journal/sd-journal.c
@@ -18,6 +18,7 @@
 #include "fd-util.h"
 #include "fileio.h"
 #include "format-util.h"
+#include "fs-util.h"
 #include "hashmap.h"
 #include "hostname-util.h"
 #include "id128-util.h"
@@ -1633,11 +1634,11 @@ static int add_any_file(
                         /* If there's a top-level fd defined make the path relative, explicitly, since otherwise
                          * openat() ignores the first argument. */
 
-                        fd = our_fd = openat(j->toplevel_fd, skip_leading_slash(path), O_RDONLY|O_CLOEXEC|O_NONBLOCK);
+                        fd = our_fd = xopenat(j->toplevel_fd, skip_leading_slash(path), O_RDONLY|O_NONBLOCK);
                 else
-                        fd = our_fd = open(path, O_RDONLY|O_CLOEXEC|O_NONBLOCK);
+                        fd = our_fd = xopenat(AT_FDCWD, path, O_RDONLY|O_NONBLOCK);
                 if (fd < 0) {
-                        r = log_debug_errno(errno, "Failed to open journal file %s: %m", path);
+                        r = log_debug_errno(fd, "Failed to open journal file %s: %m", path);
                         goto error;
                 }
 

--- a/src/libsystemd/sd-json/sd-json.c
+++ b/src/libsystemd/sd-json/sd-json.c
@@ -3547,7 +3547,7 @@ _public_ int sd_json_parse_fd(
         if (FLAGS_SET(flags, SD_JSON_PARSE_REOPEN_FD)) {
                 assert_return(!FLAGS_SET(flags, SD_JSON_PARSE_DONATE_FD), -EINVAL);
 
-                our_fd = fd_reopen(fd, O_RDONLY|O_CLOEXEC);
+                our_fd = fd_reopen(fd, O_RDONLY);
                 if (our_fd < 0)
                         return our_fd;
 

--- a/src/locale/localed-util.c
+++ b/src/locale/localed-util.c
@@ -7,7 +7,6 @@
 
 #include "alloc-util.h"
 #include "env-file.h"
-#include "errno-util.h"
 #include "escape.h"
 #include "extract-word.h"
 #include "fd-util.h"
@@ -155,7 +154,7 @@ int vconsole_read_data(Context *c, sd_bus_message *m) {
                 c->vc_cache = sd_bus_message_ref(m);
         }
 
-        _cleanup_close_ int fd = RET_NERRNO(open(etc_vconsole_conf(), O_CLOEXEC | O_PATH));
+        _cleanup_close_ int fd = xopenat(AT_FDCWD, etc_vconsole_conf(), O_PATH);
         if (fd == -ENOENT) {
                 c->vc_stat = (struct stat) {};
                 vc_context_clear(&c->vc);
@@ -214,7 +213,7 @@ int x11_read_data(Context *c, sd_bus_message *m) {
                 c->x11_cache = sd_bus_message_ref(m);
         }
 
-        _cleanup_close_ int fd = RET_NERRNO(open("/etc/X11/xorg.conf.d/00-keyboard.conf", O_CLOEXEC | O_PATH));
+        _cleanup_close_ int fd = xopenat(AT_FDCWD, "/etc/X11/xorg.conf.d/00-keyboard.conf", O_PATH);
         if (fd == -ENOENT) {
                 c->x11_stat = (struct stat) {};
                 x11_context_clear(&c->x11_from_xorg);

--- a/src/login/logind-button.c
+++ b/src/login/logind-button.c
@@ -11,6 +11,7 @@
 #include "alloc-util.h"
 #include "async.h"
 #include "fd-util.h"
+#include "fs-util.h"
 #include "hashmap.h"
 #include "log.h"
 #include "logind.h"
@@ -592,9 +593,9 @@ int button_open(Button *b) {
 
         p = strjoina("/dev/input/", b->name);
 
-        fd = open(p, O_RDWR|O_CLOEXEC|O_NOCTTY|O_NONBLOCK);
+        fd = xopenat(AT_FDCWD, p, O_RDWR|O_NOCTTY|O_NONBLOCK);
         if (fd < 0)
-                return log_warning_errno(errno, "Failed to open %s: %m", p);
+                return log_warning_errno(fd, "Failed to open %s: %m", p);
 
         r = button_suitable(fd);
         if (r < 0)

--- a/src/login/logind-core.c
+++ b/src/login/logind-core.c
@@ -560,7 +560,7 @@ static int vt_is_busy(unsigned vtnr) {
 
         fd = open_terminal("/dev/tty1", O_RDWR|O_NOCTTY);
         if (fd < 0)
-                return -errno;
+                return fd;
 
         if (ioctl(fd, VT_GETSTATE, &vt_stat) < 0)
                 r = -errno;

--- a/src/login/logind-core.c
+++ b/src/login/logind-core.c
@@ -558,7 +558,7 @@ static int vt_is_busy(unsigned vtnr) {
          * we avoid this. Since tty1 is special and needs to be an
          * explicitly loaded getty or DM this is safe. */
 
-        fd = open_terminal("/dev/tty1", O_RDWR|O_NOCTTY|O_CLOEXEC);
+        fd = open_terminal("/dev/tty1", O_RDWR|O_NOCTTY);
         if (fd < 0)
                 return -errno;
 

--- a/src/login/logind-inhibit.c
+++ b/src/login/logind-inhibit.c
@@ -102,7 +102,7 @@ static int inhibitor_save(Inhibitor *i) {
 
         _cleanup_(unlink_and_freep) char *temp_path = NULL;
         _cleanup_fclose_ FILE *f = NULL;
-        r = fopen_tmpfile_linkable(i->state_file, O_WRONLY|O_CLOEXEC, &temp_path, &f);
+        r = fopen_tmpfile_linkable(i->state_file, O_WRONLY, &temp_path, &f);
         if (r < 0)
                 return log_error_errno(r, "Failed to create state file '%s': %m", i->state_file);
 

--- a/src/login/logind-inhibit.c
+++ b/src/login/logind-inhibit.c
@@ -9,7 +9,6 @@
 
 #include "alloc-util.h"
 #include "env-file.h"
-#include "errno-util.h"
 #include "escape.h"
 #include "extract-word.h"
 #include "fd-util.h"
@@ -313,9 +312,9 @@ int inhibitor_create_fifo(Inhibitor *i) {
 
         /* Open reading side */
         if (i->fifo_fd < 0) {
-                i->fifo_fd = open(i->fifo_path, O_RDONLY|O_CLOEXEC|O_NONBLOCK);
+                i->fifo_fd = xopenat(AT_FDCWD, i->fifo_path, O_RDONLY|O_NONBLOCK);
                 if (i->fifo_fd < 0)
-                        return -errno;
+                        return i->fifo_fd;
         }
 
         if (!i->event_source) {
@@ -331,7 +330,7 @@ int inhibitor_create_fifo(Inhibitor *i) {
         }
 
         /* Open writing side */
-        return RET_NERRNO(open(i->fifo_path, O_WRONLY|O_CLOEXEC|O_NONBLOCK));
+        return xopenat(AT_FDCWD, i->fifo_path, O_WRONLY|O_NONBLOCK);
 }
 
 static void inhibitor_remove_fifo(Inhibitor *i) {

--- a/src/login/logind-seat.c
+++ b/src/login/logind-seat.c
@@ -355,7 +355,7 @@ static int static_node_acl(Seat *s) {
         }
 
         FOREACH_DIRENT(de, dir, return -errno) {
-                _cleanup_close_ int fd = RET_NERRNO(openat(dirfd(dir), de->d_name, O_CLOEXEC|O_PATH));
+                _cleanup_close_ int fd = xopenat(dirfd(dir), de->d_name, O_PATH);
                 if (ERRNO_IS_NEG_DEVICE_ABSENT_OR_EMPTY(fd))
                         continue;
                 if (fd < 0) {

--- a/src/login/logind-seat.c
+++ b/src/login/logind-seat.c
@@ -112,7 +112,7 @@ int seat_save(Seat *s) {
 
         _cleanup_(unlink_and_freep) char *temp_path = NULL;
         _cleanup_fclose_ FILE *f = NULL;
-        r = fopen_tmpfile_linkable(s->state_file, O_WRONLY|O_CLOEXEC, &temp_path, &f);
+        r = fopen_tmpfile_linkable(s->state_file, O_WRONLY, &temp_path, &f);
         if (r < 0)
                 return log_error_errno(r, "Failed to create state file '%s': %m", s->state_file);
 
@@ -179,7 +179,7 @@ static int vt_allocate(unsigned vtnr) {
         assert(vtnr >= 1);
 
         xsprintf(p, "/dev/tty%u", vtnr);
-        fd = open_terminal(p, O_RDWR|O_NOCTTY|O_CLOEXEC);
+        fd = open_terminal(p, O_RDWR|O_NOCTTY);
         if (fd < 0)
                 return fd;
 

--- a/src/login/logind-session-device.c
+++ b/src/login/logind-session-device.c
@@ -15,6 +15,7 @@
 #include "device-util.h"
 #include "errno-util.h"
 #include "fd-util.h"
+#include "fs-util.h"
 #include "hashmap.h"
 #include "logind.h"
 #include "logind-device.h"
@@ -143,9 +144,9 @@ static int session_device_open(SessionDevice *sd, bool active) {
         assert(sd->node);
 
         /* open device and try to get a udev_device from it */
-        fd = open(sd->node, O_RDWR|O_CLOEXEC|O_NOCTTY|O_NONBLOCK);
+        fd = xopenat(AT_FDCWD, sd->node, O_RDWR|O_NOCTTY|O_NONBLOCK);
         if (fd < 0)
-                return -errno;
+                return fd;
 
         switch (sd->type) {
 

--- a/src/login/logind-session.c
+++ b/src/login/logind-session.c
@@ -351,7 +351,7 @@ int session_save(Session *s) {
 
         _cleanup_(unlink_and_freep) char *temp_path = NULL;
         _cleanup_fclose_ FILE *f = NULL;
-        r = fopen_tmpfile_linkable(s->state_file, O_WRONLY|O_CLOEXEC, &temp_path, &f);
+        r = fopen_tmpfile_linkable(s->state_file, O_WRONLY, &temp_path, &f);
         if (r < 0)
                 return log_error_errno(r, "Failed to create state file '%s': %m", s->state_file);
 
@@ -1427,7 +1427,7 @@ static int session_open_vt(Session *s, bool reopen) {
 
         sprintf(path, "/dev/tty%u", s->vtnr);
 
-        fd = open_terminal(path, O_RDWR | O_CLOEXEC | O_NONBLOCK | O_NOCTTY);
+        fd = open_terminal(path, O_RDWR | O_NONBLOCK | O_NOCTTY);
         if (fd < 0)
                 return log_error_errno(fd, "Cannot open VT %s of session %s: %m", path, s->id);
 

--- a/src/login/logind-user.c
+++ b/src/login/logind-user.c
@@ -171,7 +171,7 @@ static int user_save_internal(User *u) {
 
         _cleanup_(unlink_and_freep) char *temp_path = NULL;
         _cleanup_fclose_ FILE *f = NULL;
-        r = fopen_tmpfile_linkable(u->state_file, O_WRONLY|O_CLOEXEC, &temp_path, &f);
+        r = fopen_tmpfile_linkable(u->state_file, O_WRONLY, &temp_path, &f);
         if (r < 0)
                 return log_error_errno(r, "Failed to create state file '%s': %m", u->state_file);
 

--- a/src/login/logind.c
+++ b/src/login/logind.c
@@ -879,7 +879,7 @@ static int manager_vt_switch(sd_event_source *src, const struct signalfd_siginfo
                 log_warning("Received VT_PROCESS signal without a registered session, restoring VT.");
 
                 /* At this point we only have the kernel mapping for referring to the current VT. */
-                fd = open_terminal("/dev/tty0", O_RDWR|O_NOCTTY|O_CLOEXEC|O_NONBLOCK);
+                fd = open_terminal("/dev/tty0", O_RDWR|O_NOCTTY|O_NONBLOCK);
                 if (fd < 0) {
                         log_warning_errno(fd, "Failed to open current VT, ignoring: %m");
                         return 0;

--- a/src/login/logind.c
+++ b/src/login/logind.c
@@ -775,13 +775,13 @@ static int manager_reserve_vt(Manager *m) {
         if (asprintf(&p, "/dev/tty%u", m->reserve_vt) < 0)
                 return log_oom();
 
-        m->reserve_vt_fd = open(p, O_RDWR|O_NOCTTY|O_CLOEXEC|O_NONBLOCK);
+        m->reserve_vt_fd = xopenat(AT_FDCWD, p, O_RDWR|O_NOCTTY|O_NONBLOCK);
         if (m->reserve_vt_fd < 0) {
 
                 /* Don't complain on VT-less systems */
-                if (errno != ENOENT)
-                        log_warning_errno(errno, "Failed to pin reserved VT: %m");
-                return -errno;
+                if (m->reserve_vt_fd != -ENOENT)
+                        log_warning_errno(m->reserve_vt_fd, "Failed to pin reserved VT: %m");
+                return m->reserve_vt_fd;
         }
 
         return 0;
@@ -916,17 +916,17 @@ static int manager_connect_console(Manager *m) {
         if (access("/dev/tty0", F_OK) < 0)
                 return 0;
 
-        m->console_active_fd = open("/sys/class/tty/tty0/active", O_RDONLY|O_NOCTTY|O_CLOEXEC);
+        m->console_active_fd = xopenat(AT_FDCWD, "/sys/class/tty/tty0/active", O_RDONLY|O_NOCTTY);
         if (m->console_active_fd < 0) {
 
                 /* On some systems /dev/tty0 may exist even though /sys/class/tty/tty0 does not. These are broken, but
                  * common. Let's complain but continue anyway. */
-                if (errno == ENOENT) {
-                        log_warning_errno(errno, "System has /dev/tty0 but not /sys/class/tty/tty0/active which is broken, ignoring: %m");
+                if (m->console_active_fd == -ENOENT) {
+                        log_warning_errno(m->console_active_fd, "System has /dev/tty0 but not /sys/class/tty/tty0/active which is broken, ignoring: %m");
                         return 0;
                 }
 
-                return log_error_errno(errno, "Failed to open %s: %m", "/sys/class/tty/tty0/active");
+                return log_error_errno(m->console_active_fd, "Failed to open %s: %m", "/sys/class/tty/tty0/active");
         }
 
         r = sd_event_add_io(m->event, &m->console_active_event_source, m->console_active_fd, 0, manager_dispatch_console, m);

--- a/src/login/pam_systemd.c
+++ b/src/login/pam_systemd.c
@@ -1408,11 +1408,11 @@ static int mkdir_chown_open_directory(
         assert(mode != MODE_INVALID);
 
         for (unsigned attempt = 0;; attempt++) {
-                _cleanup_close_ int fd = openat(parent_fd, name, O_CLOEXEC|O_DIRECTORY|O_NOFOLLOW);
+                _cleanup_close_ int fd = xopenat(parent_fd, name, O_DIRECTORY|O_NOFOLLOW);
                 if (fd >= 0)
                         return TAKE_FD(fd);
-                if (errno != ENOENT)
-                        return -errno;
+                if (fd != -ENOENT)
+                        return fd;
 
                 /* Let's create the directory under a temporary name first, since we want to make sure that
                  * once it appears under the right name it has the right ownership */
@@ -1464,9 +1464,9 @@ static int make_area_runtime_directory(
         /* Let's be careful with creating these directories, the runtime directory is owned by the user after all,
          * and they might play symlink games with us. */
 
-        _cleanup_close_ int fd = open(runtime_directory, O_CLOEXEC|O_PATH|O_DIRECTORY);
+        _cleanup_close_ int fd = xopenat(AT_FDCWD, runtime_directory, O_PATH|O_DIRECTORY);
         if (fd < 0)
-                return pam_syslog_errno(pamh, LOG_ERR, errno, "Unable to open runtime directory '%s': %m", runtime_directory);
+                return pam_syslog_errno(pamh, LOG_ERR, fd, "Unable to open runtime directory '%s': %m", runtime_directory);
 
         _cleanup_close_ int fd_areas = mkdir_chown_open_directory(fd, "Areas", ur->uid, user_record_gid(ur), 0755);
         if (fd_areas < 0)

--- a/src/login/pam_systemd.c
+++ b/src/login/pam_systemd.c
@@ -1420,7 +1420,7 @@ static int mkdir_chown_open_directory(
                 if (r < 0)
                         return r;
 
-                fd = open_mkdir_at(parent_fd, t, O_CLOEXEC|O_EXCL, 0700); /* Use restrictive mode until ownership is in order */
+                fd = open_mkdir_at(parent_fd, t, O_EXCL, 0700); /* Use restrictive mode until ownership is in order */
                 if (fd < 0)
                         return fd;
 
@@ -1653,7 +1653,7 @@ static int open_osc_context(pam_handle_t *pamh, const char *session_type, UserRe
         /* Keep a reference to the TTY we are operating on, so that we can issue the OSC close sequence also
          * if the TTY is already closed. We use an O_PATH reference here, rather than a properly opened fd,
          * so that we don't delay tty hang-up. */
-        _cleanup_close_ int tty_opath_fd = fd_reopen(STDOUT_FILENO, O_PATH|O_CLOEXEC);
+        _cleanup_close_ int tty_opath_fd = fd_reopen(STDOUT_FILENO, O_PATH);
         if (tty_opath_fd < 0)
                 pam_debug_syslog_errno(pamh, debug, tty_opath_fd, "Failed to pin TTY, ignoring: %m");
         else
@@ -1720,7 +1720,7 @@ static int close_osc_context(pam_handle_t *pamh, bool debug) {
                 return PAM_SUCCESS;
 
         /* Now open the original TTY again, so that we can write on it */
-        _cleanup_close_ int fd = fd_reopen(tty_opath_fd, O_WRONLY|O_CLOEXEC|O_NONBLOCK|O_NOCTTY);
+        _cleanup_close_ int fd = fd_reopen(tty_opath_fd, O_WRONLY|O_NONBLOCK|O_NOCTTY);
         if (fd < 0) {
                 pam_debug_syslog_errno(pamh, debug, fd, "Failed to reopen TTY, ignoring: %m");
                 return PAM_SUCCESS;

--- a/src/login/user-runtime-dir.c
+++ b/src/login/user-runtime-dir.c
@@ -216,9 +216,9 @@ static int apply_tmpfs_quota(
                         continue;
                 }
 
-                _cleanup_close_ int fd = open(*p, O_DIRECTORY|O_CLOEXEC);
+                _cleanup_close_ int fd = xopenat(AT_FDCWD, *p, O_DIRECTORY);
                 if (fd < 0) {
-                        log_warning_errno(errno, "Failed to open '%s' in order to set quota, ignoring: %m", *p);
+                        log_warning_errno(fd, "Failed to open '%s' in order to set quota, ignoring: %m", *p);
                         continue;
                 }
 

--- a/src/machine/image.c
+++ b/src/machine/image.c
@@ -108,7 +108,7 @@ int image_clean_pool_operation(Manager *manager, ImageCleanPoolMode mode, Operat
         /* Create a temporary file we can dump information about deleted images into. We use a temporary file for this
          * instead of a pipe or so, since this might grow quit large in theory and we don't want to process this
          * continuously */
-        result_fd = open_tmpfile_unlinkable(NULL, O_RDWR|O_CLOEXEC);
+        result_fd = open_tmpfile_unlinkable(NULL, O_RDWR);
         if (result_fd < 0)
                 return log_debug_errno(result_fd, "Failed to open tmpfile: %m");
 

--- a/src/machine/machine.c
+++ b/src/machine/machine.c
@@ -183,7 +183,7 @@ int machine_save(Machine *m) {
 
         _cleanup_(unlink_and_freep) char *temp_path = NULL;
         _cleanup_fclose_ FILE *f = NULL;
-        r = fopen_tmpfile_linkable(m->state_file, O_WRONLY|O_CLOEXEC, &temp_path, &f);
+        r = fopen_tmpfile_linkable(m->state_file, O_WRONLY, &temp_path, &f);
         if (r < 0)
                 return log_error_errno(r, "Failed to create state file '%s': %m", m->state_file);
 
@@ -1169,7 +1169,7 @@ int machine_copy_from_to_operation(
         if (r < 0)
                 return log_debug_errno(r, "Failed to extract file name of '%s' path: %m", container_path);
 
-        host_fd = open_parent(host_path, O_CLOEXEC, 0);
+        host_fd = open_parent(host_path, /* flags= */ 0, /* mode= */ 0);
         if (host_fd < 0)
                 return log_debug_errno(host_fd, "Failed to open host directory '%s': %m", host_path);
 
@@ -1203,7 +1203,7 @@ int machine_copy_from_to_operation(
                 errno_pipe_fd[0] = safe_close(errno_pipe_fd[0]);
 
                 _cleanup_close_ int container_fd = -EBADF;
-                container_fd = open_parent(container_path, O_CLOEXEC, 0);
+                container_fd = open_parent(container_path, /* flags= */ 0, /* mode= */ 0);
                 if (container_fd < 0) {
                         log_debug_errno(container_fd, "Failed to open container directory: %m");
                         report_errno_and_exit(errno_pipe_fd[1], container_fd);

--- a/src/measure/measure-tool.c
+++ b/src/measure/measure-tool.c
@@ -14,6 +14,7 @@
 #include "efivars.h"
 #include "fd-util.h"
 #include "fileio.h"
+#include "fs-util.h"
 #include "hexdecoct.h"
 #include "log.h"
 #include "main-func.h"
@@ -588,9 +589,9 @@ static int measure_kernel(PcrState *pcr_states, size_t n) {
                 if (!arg_sections[c])
                         continue;
 
-                fd = open(arg_sections[c], O_RDONLY|O_CLOEXEC);
+                fd = xopenat(AT_FDCWD, arg_sections[c], O_RDONLY);
                 if (fd < 0)
-                        return log_error_errno(errno, "Failed to open '%s': %m", arg_sections[c]);
+                        return log_error_errno(fd, "Failed to open '%s': %m", arg_sections[c]);
 
                 /* Allocate one message digest context per bank (NULL terminated) */
                 mdctx = new0(EVP_MD_CTX*, n + 1);

--- a/src/mountfsd/mountwork.c
+++ b/src/mountfsd/mountwork.c
@@ -1415,7 +1415,7 @@ static int vl_method_make_directory(
         if (r < 0)
                 return r;
 
-        _cleanup_close_ int fd = open_mkdir_at(parent_fd, t, O_CLOEXEC, p.mode);
+        _cleanup_close_ int fd = open_mkdir_at(parent_fd, t, /* flags= */ 0, p.mode);
         if (fd < 0)
                 return fd;
 

--- a/src/mountfsd/mountwork.c
+++ b/src/mountfsd/mountwork.c
@@ -924,9 +924,9 @@ static DirectoryOwnership validate_directory_fd(
                 }
 
                 /* Go one level up */
-                _cleanup_close_ int new_parent_fd = openat(fd, "..", O_DIRECTORY|O_PATH|O_CLOEXEC);
+                _cleanup_close_ int new_parent_fd = xopenat(fd, "..", O_DIRECTORY|O_PATH);
                 if (new_parent_fd < 0)
-                        return log_debug_errno(errno, "Failed to open parent directory of directory file descriptor: %m");
+                        return log_debug_errno(new_parent_fd, "Failed to open parent directory of directory file descriptor: %m");
 
                 struct statx new_stx;
                 r = xstatx_full(new_parent_fd,

--- a/src/network/netdev/tuntap.c
+++ b/src/network/netdev/tuntap.c
@@ -11,6 +11,7 @@
 #include "alloc-util.h"
 #include "daemon-util.h"
 #include "fd-util.h"
+#include "fs-util.h"
 #include "hashmap.h"
 #include "networkd-manager.h"
 #include "socket-util.h"
@@ -141,9 +142,9 @@ static int netdev_create_tuntap(NetDev *netdev) {
 
         assert(netdev->manager);
 
-        fd = open(TUN_DEV, O_RDWR|O_CLOEXEC);
+        fd = xopenat(AT_FDCWD, TUN_DEV, O_RDWR);
         if (fd < 0)
-                return log_netdev_error_errno(netdev, errno,  "Failed to open " TUN_DEV ": %m");
+                return log_netdev_error_errno(netdev, fd,  "Failed to open " TUN_DEV ": %m");
 
         if (netdev->kind == NETDEV_KIND_TAP)
                 ifr.ifr_flags |= IFF_TAP;

--- a/src/network/networkctl-misc.c
+++ b/src/network/networkctl-misc.c
@@ -6,6 +6,7 @@
 #include "errno-util.h"
 #include "fd-util.h"
 #include "format-ifname.h"
+#include "fs-util.h"
 #include "log.h"
 #include "netlink-util.h"
 #include "networkctl.h"
@@ -143,9 +144,9 @@ int verb_persistent_storage(int argc, char *argv[], uintptr_t _data, void *userd
         if (ready) {
                 _cleanup_close_ int fd = -EBADF;
 
-                fd = open("/var/lib/systemd/network/", O_CLOEXEC | O_DIRECTORY);
+                fd = xopenat(AT_FDCWD, "/var/lib/systemd/network/", O_DIRECTORY);
                 if (fd < 0)
-                        return log_error_errno(errno, "Failed to open %s: %m", "/var/lib/systemd/network/");
+                        return log_error_errno(fd, "Failed to open %s: %m", "/var/lib/systemd/network/");
 
                 r = sd_varlink_push_fd(vl, fd);
                 if (r < 0)

--- a/src/network/networkd-manager.c
+++ b/src/network/networkd-manager.c
@@ -25,6 +25,7 @@
 #include "env-util.h"
 #include "errno-util.h"
 #include "fd-util.h"
+#include "fs-util.h"
 #include "initrd-util.h"
 #include "iovec-util.h"
 #include "mount-util.h"
@@ -665,9 +666,9 @@ static int persistent_storage_open(void) {
         if (r <= 0)
                 return -EBADF;
 
-        fd = open("/var/lib/systemd/network/", O_CLOEXEC | O_DIRECTORY);
+        fd = xopenat(AT_FDCWD, "/var/lib/systemd/network/", O_DIRECTORY);
         if (fd < 0)
-                return log_debug_errno(errno, "Failed to open %s, ignoring: %m", "/var/lib/systemd/network/");
+                return log_debug_errno(fd, "Failed to open %s, ignoring: %m", "/var/lib/systemd/network/");
 
         r = fd_is_read_only_fs(fd);
         if (r < 0)

--- a/src/nspawn/nspawn-bind-user.c
+++ b/src/nspawn/nspawn-bind-user.c
@@ -92,7 +92,7 @@ static int write_membership(const char *root, const char *user, const char *grou
                         O_WRONLY|O_CREAT,
                         /* ret_path= */ NULL);
         if (fd < 0)
-                return log_error_errno(errno, "Failed to create %s: %m", p);
+                return log_error_errno(fd, "Failed to create %s: %m", p);
 
         r = userns_chown_at(fd, /* fname= */ NULL, /* uid= */ 0, /* gid= */ 0, /* flags= */ 0);
         if (r < 0)

--- a/src/nspawn/nspawn-bind-user.c
+++ b/src/nspawn/nspawn-bind-user.c
@@ -89,7 +89,7 @@ static int write_membership(const char *root, const char *user, const char *grou
                         p,
                         root,
                         CHASE_PREFIX_ROOT|CHASE_NO_AUTOFS,
-                        O_WRONLY|O_CREAT|O_CLOEXEC,
+                        O_WRONLY|O_CREAT,
                         /* ret_path= */ NULL);
         if (fd < 0)
                 return log_error_errno(errno, "Failed to create %s: %m", p);

--- a/src/nspawn/nspawn-cgroup.c
+++ b/src/nspawn/nspawn-cgroup.c
@@ -8,6 +8,7 @@
 #include "chase.h"
 #include "fd-util.h"
 #include "format-util.h"
+#include "fs-util.h"
 #include "log.h"
 #include "mount-setup.h"
 #include "mount-util.h"
@@ -24,9 +25,9 @@ static int chown_cgroup_path(const char *path, uid_t uid_shift) {
 
         assert(path);
 
-        fd = open(path, O_PATH|O_CLOEXEC|O_DIRECTORY);
+        fd = xopenat(AT_FDCWD, path, O_PATH|O_DIRECTORY);
         if (fd < 0)
-                return -errno;
+                return fd;
 
         FOREACH_STRING(fn,
                        ".",

--- a/src/nspawn/nspawn.c
+++ b/src/nspawn/nspawn.c
@@ -1698,7 +1698,7 @@ int userns_mkdir(const char *root, const char *path, mode_t mode, uid_t uid, gid
         if (r < 0)
                 return r;
 
-        _cleanup_close_ int dir_fd = open_mkdir_at(parent_fd, dname, O_EXCL|O_CLOEXEC, mode);
+        _cleanup_close_ int dir_fd = open_mkdir_at(parent_fd, dname, O_EXCL, mode);
         if (dir_fd == -EEXIST)
                 return 0;
         if (dir_fd < 0)

--- a/src/nspawn/nspawn.c
+++ b/src/nspawn/nspawn.c
@@ -2064,9 +2064,9 @@ static int copy_devnode_one(const char *dest, const char *node, bool check) {
                 /* If 'check' is true, create /dev/fuse only when it is accessible. The check is necessary,
                  * as some custom service units that invoke systemd-nspawn may enable DevicePolicy= without
                  * DeviceAllow= for the device node. */
-                _cleanup_close_ int fd = open(from, O_CLOEXEC|O_RDWR);
+                _cleanup_close_ int fd = xopenat(AT_FDCWD, from, O_RDWR);
                 if (fd < 0) {
-                        log_debug_errno(errno,
+                        log_debug_errno(fd,
                                         "Failed to open %s, skipping creation of the device node in the container, ignoring: %m",
                                         from);
                         return 0;
@@ -2376,9 +2376,9 @@ static int setup_credentials(const char *root) {
                 if (!j)
                         return log_oom();
 
-                fd = open(j, O_CREAT|O_EXCL|O_WRONLY|O_CLOEXEC|O_NOFOLLOW, world_readable ? 0666 : 0600);
+                fd = xopenat_full(AT_FDCWD, j, O_CREAT|O_EXCL|O_WRONLY|O_NOFOLLOW, /* xopen_flags= */ 0, world_readable ? 0666 : 0600);
                 if (fd < 0)
-                        return log_error_errno(errno, "Failed to create credential file %s: %m", j);
+                        return log_error_errno(fd, "Failed to create credential file %s: %m", j);
 
                 r = loop_write(fd, cred->data, cred->size);
                 if (r < 0)
@@ -2439,9 +2439,9 @@ static int setup_kmsg(int fd_inner_socket) {
         if (r < 0)
                 return r;
 
-        fd = open("/run/host/proc-kmsg", O_RDWR|O_NONBLOCK|O_CLOEXEC);
+        fd = xopenat(AT_FDCWD, "/run/host/proc-kmsg", O_RDWR|O_NONBLOCK);
         if (fd < 0)
-                return log_error_errno(errno, "Failed to open fifo: %m");
+                return log_error_errno(fd, "Failed to open fifo: %m");
 
         /* NB: We intentionally do not unlink the backing FIFO. See setup_boot_id_file() for details. */
 

--- a/src/nsresourced/nsresourcework.c
+++ b/src/nsresourced/nsresourcework.c
@@ -27,6 +27,7 @@
 #include "fd-util.h"
 #include "fileio.h"
 #include "format-util.h"
+#include "fs-util.h"
 #include "hashmap.h"
 #include "io-util.h"
 #include "json-util.h"
@@ -2221,12 +2222,12 @@ static int create_tap(
         assert(strlen(ifname_host) < sizeof(ifr.ifr_name));
         strcpy(ifr.ifr_name, ifname_host);
 
-        _cleanup_close_ int fd = open("/dev/net/tun", O_RDWR|O_CLOEXEC);
+        _cleanup_close_ int fd = xopenat(AT_FDCWD, "/dev/net/tun", O_RDWR);
         if (fd < 0) {
-                if (errno == ENOENT) /* Turn ENOENT → EOPNOTSUPP */
+                if (fd == -ENOENT) /* Turn ENOENT → EOPNOTSUPP */
                         return log_error_errno(SYNTHETIC_ERRNO(EOPNOTSUPP), "Network tap device node /dev/net/tun not found, cannot create network interface.");
 
-                return log_error_errno(errno, "Failed to open %s: %m", "/dev/net/tun");
+                return log_error_errno(fd, "Failed to open %s: %m", "/dev/net/tun");
         }
 
         if (ioctl(fd, TUNSETIFF, &ifr) < 0)

--- a/src/nsresourced/userns-registry.c
+++ b/src/nsresourced/userns-registry.c
@@ -1102,9 +1102,9 @@ static int userns_destroy_cgroup(uint64_t cgroup_id) {
         if (r < 0)
                 return log_debug_errno(r, "Failed to extract name of cgroup %" PRIu64 ", ignoring: %m", cgroup_id);
 
-        parent_fd = openat(cgroup_fd, "..", O_CLOEXEC|O_DIRECTORY);
+        parent_fd = xopenat(cgroup_fd, "..", O_DIRECTORY);
         if (parent_fd < 0)
-                return log_debug_errno(errno, "Failed to open parent cgroup of %" PRIu64 ", ignoring: %m", cgroup_id);
+                return log_debug_errno(parent_fd, "Failed to open parent cgroup of %" PRIu64 ", ignoring: %m", cgroup_id);
 
         /* Safety check, never leave cgroupfs */
         r = fd_is_fs_type(parent_fd, CGROUP2_SUPER_MAGIC);

--- a/src/nsresourced/userns-registry.c
+++ b/src/nsresourced/userns-registry.c
@@ -36,7 +36,7 @@ int userns_registry_open_fd(void) {
                         "/run/systemd/nsresource/registry",
                         /* root= */ NULL,
                         CHASE_MKDIR_0755,
-                        O_CLOEXEC|O_DIRECTORY|O_CREAT,
+                        O_DIRECTORY|O_CREAT,
                         /* ret_path= */ NULL);
         if (fd < 0)
                 return log_debug_errno(fd, "Failed to open registry dir: %m");
@@ -55,7 +55,7 @@ int userns_registry_lock(int dir_fd) {
                 dir_fd = registry_fd;
         }
 
-        lock_fd = xopenat_lock_full(dir_fd, "lock", O_CREAT|O_RDWR|O_CLOEXEC, /* xopen_flags= */ 0, 0600, LOCK_BSD, LOCK_EX);
+        lock_fd = xopenat_lock_full(dir_fd, "lock", O_CREAT|O_RDWR, /* xopen_flags= */ 0, 0600, LOCK_BSD, LOCK_EX);
         if (lock_fd < 0)
                 return log_debug_errno(lock_fd, "Failed to open nsresource registry lock file: %m");
 

--- a/src/pcrlock/pcrlock.c
+++ b/src/pcrlock/pcrlock.c
@@ -4887,7 +4887,7 @@ static int acquire_stdin_pe_fd(void) {
         if (r < 0)
                 return log_error_errno(r, "Failed to determine temporary directory: %m");
 
-        fd = open_tmpfile_unlinkable(td, O_RDWR|O_CLOEXEC);
+        fd = open_tmpfile_unlinkable(td, O_RDWR);
         if (fd < 0)
                 return log_error_errno(fd, "Failed to create temporary file for PE binary: %m");
 

--- a/src/pcrlock/pcrlock.c
+++ b/src/pcrlock/pcrlock.c
@@ -4902,9 +4902,9 @@ static int acquire_stdin_pe_fd(void) {
 
 static int acquire_pe_fd(const char *path) {
         if (path) {
-                int fd = open(path, O_RDONLY|O_CLOEXEC);
+                int fd = xopenat(AT_FDCWD, path, O_RDONLY);
                 if (fd < 0)
-                        return log_error_errno(errno, "Failed to open '%s': %m", path);
+                        return log_error_errno(fd, "Failed to open '%s': %m", path);
 
                 return fd;
         }

--- a/src/portable/portable.c
+++ b/src/portable/portable.c
@@ -397,7 +397,7 @@ static int extract_now(
                                         dirfd(d),
                                         de->d_name,
                                         CHASE_MUST_BE_REGULAR,
-                                        O_RDONLY|O_CLOEXEC,
+                                        O_RDONLY,
                                         /* ret_path= */ NULL);
                         if (fd < 0) {
                                 log_debug_errno(fd, "Failed to open unit file '%s', ignoring: %m", de->d_name);
@@ -1755,7 +1755,7 @@ static int attach_unit_file(
 
                 (void) mac_selinux_create_file_prepare_label(path, m->selinux_label);
 
-                fd = open_tmpfile_linkable(path, O_WRONLY|O_CLOEXEC, &tmp);
+                fd = open_tmpfile_linkable(path, O_WRONLY, &tmp);
                 mac_selinux_create_file_clear(); /* Clear immediately in case of errors */
                 if (fd < 0)
                         return log_debug_errno(fd, "Failed to create unit file '%s': %m", path);

--- a/src/portable/portable.c
+++ b/src/portable/portable.c
@@ -480,9 +480,9 @@ static int portable_extract_by_path(
 
         assert(path);
 
-        _cleanup_close_ int rfd = open(path, O_PATH|O_CLOEXEC);
+        _cleanup_close_ int rfd = xopenat(AT_FDCWD, path, O_PATH);
         if (rfd < 0)
-                return log_debug_errno(errno, "Failed to open '%s': %m", path);
+                return log_debug_errno(rfd, "Failed to open '%s': %m", path);
 
         struct stat st;
         if (fstat(rfd, &st) < 0)
@@ -734,9 +734,9 @@ static int portable_extract_by_path(
                                 report_errno_and_exit(errno_pipe_fd[1], r);
                         }
 
-                        _cleanup_close_ int mfd = open(tmpdir, O_DIRECTORY|O_CLOEXEC);
+                        _cleanup_close_ int mfd = xopenat(AT_FDCWD, tmpdir, O_DIRECTORY);
                         if (mfd < 0) {
-                                r = log_debug_errno(errno, "Failed to open '%s': %m", tmpdir);
+                                r = log_debug_errno(mfd, "Failed to open '%s': %m", tmpdir);
                                 report_errno_and_exit(errno_pipe_fd[1], r);
                         }
 
@@ -1845,9 +1845,9 @@ static int install_image(
                         if (userns_fd < 0)
                                 return log_debug_errno(userns_fd, "Failed to allocate user namespace: %m");
 
-                        _cleanup_close_ int fd = open(image_path, O_DIRECTORY|O_CLOEXEC);
+                        _cleanup_close_ int fd = xopenat(AT_FDCWD, image_path, O_DIRECTORY);
                         if (fd < 0)
-                                return log_debug_errno(errno, "Failed to open '%s': %m", image_path);
+                                return log_debug_errno(fd, "Failed to open '%s': %m", image_path);
 
                         struct stat st;
                         if (fstat(fd, &st) < 0)
@@ -2262,12 +2262,12 @@ static int test_chroot_dropin(
         /* We recognize unis created from portable images via the drop-in we created for them */
 
         p = strjoina(fname, ".d/20-portable.conf");
-        fd = openat(dirfd(d), p, O_RDONLY|O_CLOEXEC);
+        fd = xopenat(dirfd(d), p, O_RDONLY);
         if (fd < 0) {
-                if (errno == ENOENT)
+                if (fd == -ENOENT)
                         return 0;
 
-                return log_debug_errno(errno, "Failed to open %s/%s: %m", where, p);
+                return log_debug_errno(fd, "Failed to open %s/%s: %m", where, p);
         }
 
         r = take_fdopen_unlocked(&fd, "r", &f);

--- a/src/pstore/pstore.c
+++ b/src/pstore/pstore.c
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <unistd.h>
 
+#include "fs-util.h"
 #include "sd-journal.h"
 
 #include "alloc-util.h"
@@ -167,7 +168,7 @@ static int append_dmesg(PStoreEntry *pe, const char *subdir1, const char *subdir
         if (!ofd_path)
                 return log_oom();
 
-        ofd = open(ofd_path, O_CREAT|O_NOFOLLOW|O_NOCTTY|O_CLOEXEC|O_APPEND|O_WRONLY, 0640);
+        ofd = xopenat_full(AT_FDCWD, ofd_path, O_CREAT|O_NOFOLLOW|O_NOCTTY|O_APPEND|O_WRONLY, /* xopen_flags= */ 0, 0640);
         if (ofd < 0)
                 return log_error_errno(ofd, "Failed to open file %s: %m", ofd_path);
         wr = write(ofd, pe->content, pe->content_size);

--- a/src/ptyfwd/ptyfwd-tool.c
+++ b/src/ptyfwd/ptyfwd-tool.c
@@ -132,7 +132,7 @@ static int run(int argc, char *argv[]) {
         if (r < 0)
                 return log_error_errno(r, "Failed to get event loop: %m");
 
-        pty_fd = openpt_allocate(O_RDWR|O_NOCTTY|O_NONBLOCK|O_CLOEXEC, /* ret_peer_path= */ NULL);
+        pty_fd = openpt_allocate(O_RDWR|O_NOCTTY|O_NONBLOCK, /* ret_peer_path= */ NULL);
         if (pty_fd < 0)
                 return log_error_errno(pty_fd, "Failed to acquire pseudo tty: %m");
 

--- a/src/random-seed/random-seed-tool.c
+++ b/src/random-seed/random-seed-tool.c
@@ -357,9 +357,9 @@ static int run(int argc, char *argv[]) {
         if (r < 0)
                 return log_error_errno(r, "Failed to create directory %s: %m", RANDOM_SEED);
 
-        random_fd = open("/dev/urandom", O_RDWR|O_CLOEXEC|O_NOCTTY);
+        random_fd = xopenat(AT_FDCWD, "/dev/urandom", O_RDWR|O_NOCTTY);
         if (random_fd < 0)
-                return log_error_errno(errno, "Failed to open %s: %m", "/dev/urandom");
+                return log_error_errno(random_fd, "Failed to open %s: %m", "/dev/urandom");
 
         /* When we load the seed we read it and write it to the device and then immediately update the saved
          * seed with new data, to make sure the next boot gets seeded differently. */
@@ -370,13 +370,13 @@ static int run(int argc, char *argv[]) {
                  * load_machine_id() for an explanation why. */
                 load_machine_id(random_fd);
 
-                seed_fd = RET_NERRNO(open(RANDOM_SEED, O_RDWR|O_CLOEXEC|O_NOCTTY|O_CREAT, 0600));
+                seed_fd = xopenat_full(AT_FDCWD, RANDOM_SEED, O_RDWR|O_NOCTTY|O_CREAT, /* xopen_flags= */ 0, 0600);
                 if (seed_fd < 0) {
                         int open_rw_error = seed_fd;
 
                         write_seed_file = false;
 
-                        seed_fd = RET_NERRNO(open(RANDOM_SEED, O_RDONLY|O_CLOEXEC|O_NOCTTY));
+                        seed_fd = xopenat(AT_FDCWD, RANDOM_SEED, O_RDONLY|O_NOCTTY);
                         if (seed_fd < 0) {
                                 bool missing = seed_fd == -ENOENT;
                                 int level = missing ? LOG_DEBUG : LOG_ERR;
@@ -393,7 +393,7 @@ static int run(int argc, char *argv[]) {
                 break;
 
         case ACTION_SAVE:
-                seed_fd = RET_NERRNO(open(RANDOM_SEED, O_WRONLY|O_CLOEXEC|O_NOCTTY|O_CREAT, 0600));
+                seed_fd = xopenat_full(AT_FDCWD, RANDOM_SEED, O_WRONLY|O_NOCTTY|O_CREAT, /* xopen_flags= */ 0, 0600);
                 if (seed_fd < 0)
                         return log_error_errno(seed_fd, "Failed to open %s: %m", RANDOM_SEED);
 

--- a/src/repart/repart.c
+++ b/src/repart/repart.c
@@ -3289,9 +3289,9 @@ static int context_open_and_lock_backing_fd(const char *node, int operation, int
         if (*backing_fd >= 0)
                 return 0;
 
-        fd = open(node, mode|O_CLOEXEC);
+        fd = xopenat(AT_FDCWD, node, mode);
         if (fd < 0)
-                return log_error_errno(errno, "Failed to open device '%s': %m", node);
+                return log_error_errno(fd, "Failed to open device '%s': %m", node);
 
         /* Tell udev not to interfere while we are processing the device */
         if (flock(fd, operation) < 0)
@@ -3883,9 +3883,9 @@ static int context_load_partition_table(Context *context) {
                 return log_error_errno(r, "Failed to set sector size: %m");
 
         if (context->backing_fd < 0) {
-                fd = open(context->node, context_open_mode(context)|O_CLOEXEC);
+                fd = xopenat(AT_FDCWD, context->node, context_open_mode(context));
                 if (fd < 0)
-                        return log_error_errno(errno, "Failed to open backing node '%s': %m", context->node);
+                        return log_error_errno(fd, "Failed to open backing node '%s': %m", context->node);
         }
         r = sym_fdisk_assign_device_by_fd(
                         c,
@@ -5299,9 +5299,9 @@ static int partition_target_prepare(
 
                         context->needs_rescan = true;
 
-                        dev_fd = open(part_node, O_RDWR|O_CLOEXEC|O_NOCTTY);
+                        dev_fd = xopenat(AT_FDCWD, part_node, O_RDWR|O_NOCTTY);
                         if (dev_fd < 0) {
-                                r = -errno;
+                                r = dev_fd;
                                 int q = block_device_remove_partition(whole_fd, nr);
                                 if (q < 0)
                                         log_warning_errno(q, "Error while removing block device partition '%s', ignoring: %m", part_node);
@@ -5972,9 +5972,9 @@ static int partition_encrypt(Context *context, Partition *p, PartitionTarget *ta
                                  integrity_alg_to_string(p->integrity_alg), p->partno);
                 }
 
-                dev_fd = open(vol, O_RDWR|O_CLOEXEC|O_NOCTTY);
+                dev_fd = xopenat(AT_FDCWD, vol, O_RDWR|O_NOCTTY);
                 if (dev_fd < 0)
-                        return log_error_errno(errno, "Failed to open LUKS volume '%s': %m", vol);
+                        return log_error_errno(dev_fd, "Failed to open LUKS volume '%s': %m", vol);
 
                 if (flock(dev_fd, LOCK_EX) < 0)
                         return log_error_errno(errno, "Failed to lock '%s': %m", vol);
@@ -6797,9 +6797,9 @@ static int file_is_denylisted(const char *source, Hashmap *denylist) {
                 if (stat_inode_same(&st, &rst))
                         break;
 
-                _cleanup_close_ int new_pfd = openat(pfd, "..", O_DIRECTORY|O_RDONLY);
+                _cleanup_close_ int new_pfd = xopenat(pfd, "..", O_DIRECTORY|O_RDONLY);
                 if (new_pfd < 0)
-                        return log_error_errno(errno, "Failed to open parent directory: %m");
+                        return log_error_errno(new_pfd, "Failed to open parent directory: %m");
 
                 close_and_replace(pfd, new_pfd);
         }
@@ -6853,9 +6853,9 @@ static int do_copy_files(Context *context, Partition *p, const char *root) {
                 if (!path_equal(line->target, "/"))
                         continue;
 
-                rfd = open(root, O_DIRECTORY|O_CLOEXEC|O_NOFOLLOW);
+                rfd = xopenat(AT_FDCWD, root, O_DIRECTORY|O_NOFOLLOW);
                 if (rfd < 0)
-                        return -errno;
+                        return rfd;
 
                 sfd = chase_and_open(line->source, arg_copy_source, CHASE_PREFIX_ROOT, O_PATH|O_DIRECTORY|O_NOCTTY, /* ret_path= */ NULL);
                 if (sfd == -ENOTDIR)
@@ -6990,9 +6990,9 @@ static int do_copy_files(Context *context, Partition *p, const char *root) {
                         if (pfd < 0)
                                 return log_error_errno(pfd, "Failed to open parent directory of target: %m");
 
-                        tfd = openat(pfd, fn, O_CREAT|O_EXCL|O_WRONLY|O_CLOEXEC, 0700);
+                        tfd = xopenat_full(pfd, fn, O_CREAT|O_EXCL|O_WRONLY, /* xopen_flags= */ 0, 0700);
                         if (tfd < 0)
-                                return log_error_errno(errno, "Failed to create target file '%s': %m", line->target);
+                                return log_error_errno(tfd, "Failed to create target file '%s': %m", line->target);
 
                         r = copy_bytes(sfd, tfd, UINT64_MAX, COPY_HOLES|COPY_SIGINT|COPY_TRUNCATE);
                         if (r < 0)
@@ -7188,9 +7188,9 @@ static int do_make_validatefs_xattrs(const Partition *p, const char *root) {
         if (!partition_add_validatefs(p))
                 return 0;
 
-        _cleanup_close_ int fd = open(root, O_DIRECTORY|O_CLOEXEC);
+        _cleanup_close_ int fd = xopenat(AT_FDCWD, root, O_DIRECTORY);
         if (fd < 0)
-                return log_error_errno(errno, "Failed to open root inode '%s': %m", root);
+                return log_error_errno(fd, "Failed to open root inode '%s': %m", root);
 
         _cleanup_strv_free_ char **l = NULL;
         r = partition_acquire_sibling_labels(p, &l);
@@ -7261,9 +7261,9 @@ static int partition_populate_directory(Context *context, Partition *p, char **r
                 _cleanup_close_ int rfd = -EBADF;
                 struct timespec tspec;
 
-                rfd = open(root, O_DIRECTORY|O_CLOEXEC|O_NOFOLLOW);
+                rfd = xopenat(AT_FDCWD, root, O_DIRECTORY|O_NOFOLLOW);
                 if (rfd < 0)
-                        return log_error_errno(errno, "Failed to open temporary directory: %m");
+                        return log_error_errno(rfd, "Failed to open temporary directory: %m");
 
                 timespec_store(&tspec, ts);
                 if (futimens(rfd, (const struct timespec[2]) { tspec, tspec }) < 0)
@@ -7675,9 +7675,9 @@ static int context_mkfs(Context *context) {
 
                 if (t->fd >= 0 && t->path && !t->loop && !t->block_partition) {
                         safe_close(t->fd);
-                        t->fd = open(t->path, O_RDWR|O_CLOEXEC);
+                        t->fd = xopenat(AT_FDCWD, t->path, O_RDWR);
                         if (t->fd < 0)
-                                return log_error_errno(errno, "Failed to reopen temporary file: %m");
+                                return log_error_errno(t->fd, "Failed to reopen temporary file: %m");
                 }
 
                 log_info("Successfully formatted future partition %" PRIu64 ".", p->partno);
@@ -9451,9 +9451,9 @@ static int context_open_btrfs_filesystems(Context *context) {
                         return log_error_errno(SYNTHETIC_ERRNO(EOPNOTSUPP), "Btrfs filesystem has multiple devices.");
 
                 /* We need to keep the source device open otherwise, it might be collected. */
-                replacement->source_fd = open(replacement->source_path, O_RDONLY|O_CLOEXEC);
+                replacement->source_fd = xopenat(AT_FDCWD, replacement->source_path, O_RDONLY);
                 if (replacement->source_fd < 0)
-                        return log_error_errno(errno, "Failed to open source device %s: %m", replacement->source_path);
+                        return log_error_errno(replacement->source_fd, "Failed to open source device %s: %m", replacement->source_path);
 
                 r = fd_verify_block(replacement->source_fd);
                 if (r < 0)
@@ -9943,9 +9943,9 @@ static int context_minimize(Context *context) {
                 if (fstype_is_ro(p->format) || is_btrfs) {
                         fd = safe_close(fd);
 
-                        fd = open(temp, O_RDONLY|O_CLOEXEC|O_NONBLOCK);
+                        fd = xopenat(AT_FDCWD, temp, O_RDONLY|O_NONBLOCK);
                         if (fd < 0)
-                                return log_error_errno(errno, "Failed to open temporary file %s: %m", temp);
+                                return log_error_errno(fd, "Failed to open temporary file %s: %m", temp);
 
                         if (fstat(fd, &st) < 0)
                                 return log_error_errno(errno, "Failed to stat temporary file: %m");
@@ -11181,9 +11181,9 @@ static int resize_backing_fd(
         if (*fd < 0) {
                 /* Open the file if we haven't opened it yet. Note that we open it read-only here, just to
                  * keep a reference to the file we can pass around. */
-                *fd = open(node, O_RDONLY|O_CLOEXEC);
+                *fd = xopenat(AT_FDCWD, node, O_RDONLY);
                 if (*fd < 0)
-                        return log_error_errno(errno, "Failed to open '%s' in order to adjust size: %m", node);
+                        return log_error_errno(*fd, "Failed to open '%s' in order to adjust size: %m", node);
         }
 
         if (fstat(*fd, &st) < 0)
@@ -11220,9 +11220,9 @@ static int resize_backing_fd(
                 /* This is a loopback device. We can't really grow those directly, but we can grow the
                  * backing file, hence let's do that. */
 
-                writable_fd = open(backing_file, O_WRONLY|O_CLOEXEC|O_NONBLOCK);
+                writable_fd = xopenat(AT_FDCWD, backing_file, O_WRONLY|O_NONBLOCK);
                 if (writable_fd < 0)
-                        return log_error_errno(errno, "Failed to open backing file '%s': %m", backing_file);
+                        return log_error_errno(writable_fd, "Failed to open backing file '%s': %m", backing_file);
 
                 if (fstat(writable_fd, &st) < 0)
                         return log_error_errno(errno, "Failed to stat() backing file '%s': %m", backing_file);

--- a/src/repart/repart.c
+++ b/src/repart/repart.c
@@ -6857,7 +6857,7 @@ static int do_copy_files(Context *context, Partition *p, const char *root) {
                 if (rfd < 0)
                         return -errno;
 
-                sfd = chase_and_open(line->source, arg_copy_source, CHASE_PREFIX_ROOT, O_PATH|O_DIRECTORY|O_CLOEXEC|O_NOCTTY, NULL);
+                sfd = chase_and_open(line->source, arg_copy_source, CHASE_PREFIX_ROOT, O_PATH|O_DIRECTORY|O_NOCTTY, /* ret_path= */ NULL);
                 if (sfd == -ENOTDIR)
                         continue;
                 if (sfd < 0)
@@ -6889,7 +6889,7 @@ static int do_copy_files(Context *context, Partition *p, const char *root) {
                 if (r < 0)
                         return r;
 
-                sfd = chase_and_open(line->source, arg_copy_source, CHASE_PREFIX_ROOT, O_CLOEXEC|O_NOCTTY, NULL);
+                sfd = chase_and_open(line->source, arg_copy_source, CHASE_PREFIX_ROOT, O_NOCTTY, /* ret_path= */ NULL);
                 if (sfd == -ENOENT) {
                         log_notice_errno(sfd, "Failed to open source file '%s%s', skipping: %m", strempty(arg_copy_source), line->source);
                         continue;
@@ -6903,7 +6903,7 @@ static int do_copy_files(Context *context, Partition *p, const char *root) {
                                 return log_error_errno(r, "Failed to check type of source file '%s': %m", line->source);
 
                         /* We are looking at a directory */
-                        tfd = chase_and_open(line->target, root, CHASE_PREFIX_ROOT, O_RDONLY|O_DIRECTORY|O_CLOEXEC, NULL);
+                        tfd = chase_and_open(line->target, root, CHASE_PREFIX_ROOT, O_RDONLY|O_DIRECTORY, /* ret_path= */ NULL);
                         if (tfd < 0) {
                                 _cleanup_free_ char *dn = NULL, *fn = NULL;
 
@@ -6922,7 +6922,7 @@ static int do_copy_files(Context *context, Partition *p, const char *root) {
                                 if (r < 0)
                                         return log_error_errno(r, "Failed to create parent directory '%s': %m", dn);
 
-                                pfd = chase_and_open(dn, root, CHASE_PREFIX_ROOT, O_RDONLY|O_DIRECTORY|O_CLOEXEC, NULL);
+                                pfd = chase_and_open(dn, root, CHASE_PREFIX_ROOT, O_RDONLY|O_DIRECTORY, /* ret_path= */ NULL);
                                 if (pfd < 0)
                                         return log_error_errno(pfd, "Failed to open parent directory of target: %m");
 
@@ -6986,7 +6986,7 @@ static int do_copy_files(Context *context, Partition *p, const char *root) {
                         if (r < 0)
                                 return log_error_errno(r, "Failed to create parent directory: %m");
 
-                        pfd = chase_and_open(dn, root, CHASE_PREFIX_ROOT, O_RDONLY|O_DIRECTORY|O_CLOEXEC, NULL);
+                        pfd = chase_and_open(dn, root, CHASE_PREFIX_ROOT, O_RDONLY|O_DIRECTORY, /* ret_path= */ NULL);
                         if (pfd < 0)
                                 return log_error_errno(pfd, "Failed to open parent directory of target: %m");
 
@@ -8268,7 +8268,7 @@ static int context_split(Context *context) {
                 fdt = xopenat_full(
                                 AT_FDCWD,
                                 p->split_path,
-                                O_WRONLY|O_NOCTTY|O_CLOEXEC|O_NOFOLLOW|O_CREAT|O_EXCL,
+                                O_WRONLY|O_NOCTTY|O_NOFOLLOW|O_CREAT|O_EXCL,
                                 attrs & FS_NOCOW_FL ? XO_NOCOW : 0,
                                 0666);
                 if (fdt < 0)
@@ -9312,7 +9312,7 @@ static int context_open_copy_block_paths(
 
                 if (p->copy_blocks_path) {
 
-                        source_fd = chase_and_open(p->copy_blocks_path, p->copy_blocks_root, CHASE_PREFIX_ROOT, O_RDONLY|O_CLOEXEC|O_NONBLOCK, &opened);
+                        source_fd = chase_and_open(p->copy_blocks_path, p->copy_blocks_root, CHASE_PREFIX_ROOT, O_RDONLY|O_NONBLOCK, &opened);
                         if (source_fd < 0)
                                 return log_error_errno(source_fd, "Failed to open '%s': %m", p->copy_blocks_path);
 
@@ -9434,7 +9434,7 @@ static int context_open_btrfs_filesystems(Context *context) {
                         .source_fd = -EBADF,
                 };
 
-                replacement->mountpoint_fd = xopenat(AT_FDCWD, p->block_device_replace, O_RDONLY|O_CLOEXEC|O_NONBLOCK|O_NOCTTY);
+                replacement->mountpoint_fd = xopenat(AT_FDCWD, p->block_device_replace, O_RDONLY|O_NONBLOCK|O_NOCTTY);
                 if (replacement->mountpoint_fd < 0)
                         return log_error_errno(replacement->mountpoint_fd, "Failed to open mountpoint %s for btrfs filesystem: %m", p->block_device_replace);
 
@@ -9588,7 +9588,7 @@ static int context_fstab(Context *context) {
         if (!path)
                 return log_oom();
 
-        r = fopen_tmpfile_linkable(path, O_WRONLY|O_CLOEXEC, &t, &f);
+        r = fopen_tmpfile_linkable(path, O_WRONLY, &t, &f);
         if (r < 0)
                 return log_error_errno(r, "Failed to open temporary file for %s: %m", path);
 
@@ -9725,7 +9725,7 @@ static int context_crypttab(Context *context, bool late) {
         if (!path)
                 return log_oom();
 
-        r = fopen_tmpfile_linkable(path, O_WRONLY|O_CLOEXEC, &t, &f);
+        r = fopen_tmpfile_linkable(path, O_WRONLY, &t, &f);
         if (r < 0)
                 return log_error_errno(r, "Failed to open temporary file for %s: %m", path);
 
@@ -9878,7 +9878,7 @@ static int context_minimize(Context *context) {
                 fd = xopenat_full(
                                 AT_FDCWD,
                                 temp,
-                                O_CREAT|O_EXCL|O_CLOEXEC|O_RDWR|O_NOCTTY,
+                                O_CREAT|O_EXCL|O_RDWR|O_NOCTTY,
                                 attrs & FS_NOCOW_FL ? XO_NOCOW : 0,
                                 0600);
                 if (fd < 0)
@@ -10092,7 +10092,7 @@ static int context_minimize(Context *context) {
                 fd = xopenat_full(
                                 AT_FDCWD,
                                 temp,
-                                O_RDONLY|O_CLOEXEC|O_CREAT|O_NONBLOCK,
+                                O_RDONLY|O_CREAT|O_NONBLOCK,
                                 attrs & FS_NOCOW_FL ? XO_NOCOW : 0,
                                 0600);
                 if (fd < 0)
@@ -11243,7 +11243,7 @@ static int resize_backing_fd(
                  * reopen the file for that temporarily. We keep the writable fd only open for this operation though,
                  * as fdisk can't accept it anyway. */
 
-                writable_fd = fd_reopen(*fd, O_WRONLY|O_CLOEXEC);
+                writable_fd = fd_reopen(*fd, O_WRONLY);
                 if (writable_fd < 0)
                         return log_error_errno(writable_fd, "Failed to reopen backing file '%s' writable: %m", node);
         }

--- a/src/report/report-basic.c
+++ b/src/report/report-basic.c
@@ -18,6 +18,7 @@
 #include "errno-util.h"
 #include "fd-util.h"
 #include "fileio.h"
+#include "fs-util.h"
 #include "hostname-setup.h"
 #include "hostname-util.h"
 #include "limits-util.h"
@@ -585,9 +586,9 @@ static int smbios_generate(const MetricFamily *mf, sd_varlink *link, void *userd
          * tags, the system UUID) are privacy sensitive and only readable by root — if we lack the
          * privileges to read them we simply skip them. */
 
-        _cleanup_close_ int dir_fd = open("/sys/class/dmi/id", O_RDONLY|O_DIRECTORY|O_CLOEXEC);
+        _cleanup_close_ int dir_fd = xopenat(AT_FDCWD, "/sys/class/dmi/id", O_RDONLY|O_DIRECTORY);
         if (dir_fd < 0) {
-                log_full_errno(ERRNO_IS_DEVICE_ABSENT(errno) ? LOG_DEBUG : LOG_WARNING, errno,
+                log_full_errno(ERRNO_IS_DEVICE_ABSENT(dir_fd) ? LOG_DEBUG : LOG_WARNING, dir_fd,
                                "Failed to open /sys/class/dmi/id/, ignoring: %m");
                 return 0;
         }

--- a/src/report/report-files.c
+++ b/src/report/report-files.c
@@ -69,7 +69,7 @@ static int file_metric_generate(const MetricFamily *mf, sd_varlink *link, void *
                         return log_oom();
 
                 _cleanup_free_ char *resolved = NULL;
-                _cleanup_close_ int fd = chase_and_open(path, /* root= */ NULL, CHASE_MUST_BE_REGULAR, O_RDONLY|O_CLOEXEC, &resolved);
+                _cleanup_close_ int fd = chase_and_open(path, /* root= */ NULL, CHASE_MUST_BE_REGULAR, O_RDONLY, &resolved);
                 if (fd == -ENOENT) /* Not in this directory (or dangling symlink): try the next one. */
                         continue;
                 if (fd < 0) {

--- a/src/report/report-sign-plain.c
+++ b/src/report/report-sign-plain.c
@@ -179,7 +179,7 @@ static int acquire_key(EVP_PKEY **ret) {
         _cleanup_close_ int dir_fd = xopenat_lock_full(
                         AT_FDCWD,
                         REPORT_SIGN_PLAIN_DIR,
-                        O_CLOEXEC|O_DIRECTORY|O_CREAT,
+                        O_DIRECTORY|O_CREAT,
                         /* xopen_flags= */ 0,
                         /* mode= */ 0700,
                         LOCK_BSD,

--- a/src/report/report-sign-tpm2.c
+++ b/src/report/report-sign-tpm2.c
@@ -483,7 +483,7 @@ static int acquire_key_handle(Tpm2Context *c, Tpm2Handle **ret_handle, struct io
         _cleanup_close_ int dir_fd = xopenat_lock_full(
                         AT_FDCWD,
                         REPORT_SIGN_TPM2_PERSISTENT_DIR,
-                        O_CLOEXEC|O_DIRECTORY|O_CREAT,
+                        O_DIRECTORY|O_CREAT,
                         /* xopen_flags= */ 0,
                         /* mode= */ 0700,
                         LOCK_BSD,
@@ -495,7 +495,7 @@ static int acquire_key_handle(Tpm2Context *c, Tpm2Handle **ret_handle, struct io
         _cleanup_close_ int runtime_dir_fd = xopenat_lock_full(
                         AT_FDCWD,
                         REPORT_SIGN_TPM2_RUNTIME_DIR,
-                        O_CLOEXEC|O_DIRECTORY|O_CREAT,
+                        O_DIRECTORY|O_CREAT,
                         /* xopen_flags = */ 0,
                         /* mode= */ 0700,
                         LOCK_BSD,

--- a/src/resolve/resolved-manager.c
+++ b/src/resolve/resolved-manager.c
@@ -22,6 +22,7 @@
 #include "errno-util.h"
 #include "event-util.h"
 #include "fd-util.h"
+#include "fs-util.h"
 #include "hostname-setup.h"
 #include "hostname-util.h"
 #include "io-util.h"
@@ -520,10 +521,9 @@ static int manager_watch_hostname(Manager *m) {
 
         assert(m);
 
-        m->hostname_fd = open("/proc/sys/kernel/hostname",
-                              O_RDONLY|O_CLOEXEC|O_NONBLOCK|O_NOCTTY);
+        m->hostname_fd = xopenat(AT_FDCWD, "/proc/sys/kernel/hostname", O_RDONLY|O_NONBLOCK|O_NOCTTY);
         if (m->hostname_fd < 0) {
-                log_warning_errno(errno, "Failed to watch hostname: %m");
+                log_warning_errno(m->hostname_fd, "Failed to watch hostname: %m");
                 return 0;
         }
 

--- a/src/rfkill/rfkill.c
+++ b/src/rfkill/rfkill.c
@@ -16,6 +16,7 @@
 #include "escape.h"
 #include "fd-util.h"
 #include "fileio.h"
+#include "fs-util.h"
 #include "io-util.h"
 #include "list.h"
 #include "main-func.h"
@@ -285,14 +286,14 @@ static int run(int argc, char *argv[]) {
                 return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "Got too many file descriptors.");
 
         if (n == 0) {
-                c.rfkill_fd = open("/dev/rfkill", O_RDWR|O_CLOEXEC|O_NOCTTY|O_NONBLOCK);
+                c.rfkill_fd = xopenat(AT_FDCWD, "/dev/rfkill", O_RDWR|O_NOCTTY|O_NONBLOCK);
                 if (c.rfkill_fd < 0) {
-                        if (errno == ENOENT) {
-                                log_debug_errno(errno, "Missing rfkill subsystem, or no device present, exiting.");
+                        if (c.rfkill_fd == -ENOENT) {
+                                log_debug_errno(c.rfkill_fd, "Missing rfkill subsystem, or no device present, exiting.");
                                 return 0;
                         }
 
-                        return log_error_errno(errno, "Failed to open %s: %m", "/dev/rfkill");
+                        return log_error_errno(c.rfkill_fd, "Failed to open %s: %m", "/dev/rfkill");
                 }
         } else {
                 c.rfkill_fd = SD_LISTEN_FDS_START;

--- a/src/run/run.c
+++ b/src/run/run.c
@@ -2313,7 +2313,7 @@ static int start_transient_service(sd_bus *bus) {
         if (arg_stdio == ARG_STDIO_PTY) {
 
                 if (IN_SET(arg_transport, BUS_TRANSPORT_LOCAL, BUS_TRANSPORT_CAPSULE)) {
-                        c.pty_fd = openpt_allocate(O_RDWR|O_NOCTTY|O_CLOEXEC|O_NONBLOCK, &pty_path);
+                        c.pty_fd = openpt_allocate(O_RDWR|O_NOCTTY|O_NONBLOCK, &pty_path);
                         if (c.pty_fd < 0)
                                 return log_error_errno(c.pty_fd, "Failed to acquire pseudo tty: %m");
 

--- a/src/sbsign/sbsign.c
+++ b/src/sbsign/sbsign.c
@@ -456,9 +456,9 @@ static int verb_sign(int argc, char *argv[], uintptr_t _data, void *userdata) {
                 signed_attributes_signature = IOVEC_MAKE(TAKE_PTR(content), contentsz);
         }
 
-        _cleanup_close_ int srcfd = open(argv[1], O_RDONLY|O_CLOEXEC);
+        _cleanup_close_ int srcfd = xopenat(AT_FDCWD, argv[1], O_RDONLY);
         if (srcfd < 0)
-                return log_error_errno(errno, "Failed to open %s: %m", argv[1]);
+                return log_error_errno(srcfd, "Failed to open %s: %m", argv[1]);
 
         struct stat st;
         if (fstat(srcfd, &st) < 0)

--- a/src/sbsign/sbsign.c
+++ b/src/sbsign/sbsign.c
@@ -469,7 +469,7 @@ static int verb_sign(int argc, char *argv[], uintptr_t _data, void *userdata) {
                 return log_error_errno(r, "%s is not a regular file: %m", argv[1]);
 
         _cleanup_(unlink_and_freep) char *tmp = NULL;
-        _cleanup_close_ int dstfd = open_tmpfile_linkable(arg_output, O_RDWR|O_CLOEXEC, &tmp);
+        _cleanup_close_ int dstfd = open_tmpfile_linkable(arg_output, O_RDWR, &tmp);
         if (dstfd < 0)
                 return log_error_errno(dstfd, "Failed to open temporary file: %m");
 

--- a/src/shared/acpi-fpdt.c
+++ b/src/shared/acpi-fpdt.c
@@ -8,6 +8,7 @@
 #include "alloc-util.h"
 #include "fd-util.h"
 #include "fileio.h"
+#include "fs-util.h"
 #include "time-util.h"
 
 struct acpi_table_header {
@@ -138,9 +139,9 @@ int acpi_get_boot_usec(usec_t *ret_loader_start, usec_t *ret_loader_exit) {
                 return -ENODATA;
 
         /* read Firmware Basic Boot Performance Data Record */
-        fd = open("/dev/mem", O_CLOEXEC|O_RDONLY);
+        fd = xopenat(AT_FDCWD, "/dev/mem", O_RDONLY);
         if (fd < 0)
-                return -errno;
+                return fd;
 
         ll = pread(fd, &hbrec, sizeof(struct acpi_fpdt_boot_header), ptr);
         if (ll < 0)

--- a/src/shared/ask-password-api.c
+++ b/src/shared/ask-password-api.c
@@ -102,7 +102,7 @@ static int touch_ask_password_directory(AskPasswordFlags flags) {
         if (r <= 0)
                 return r;
 
-        _cleanup_close_ int fd = open_mkdir(p, O_CLOEXEC, 0755);
+        _cleanup_close_ int fd = open_mkdir(p, /* flags= */ 0, 0755);
         if (fd < 0)
                 return fd;
 
@@ -522,7 +522,7 @@ int ask_password_tty(
                 if (r < 0)
                         return r;
                 if (r > 0) {
-                        _cleanup_close_ int watch_fd = open_mkdir(watch_path, O_CLOEXEC|O_RDONLY, 0755);
+                        _cleanup_close_ int watch_fd = open_mkdir(watch_path, O_RDONLY, 0755);
                         if (watch_fd < 0)
                                 return watch_fd;
 
@@ -877,7 +877,7 @@ int ask_password_agent(
         if (r == 0)
                 return -ENXIO;
 
-        dfd = open_mkdir(askpwdir, O_CLOEXEC, 0755);
+        dfd = open_mkdir(askpwdir, /* flags= */ 0, 0755);
         if (dfd < 0)
                 return log_debug_errno(dfd, "Failed to open directory '%s': %m", askpwdir);
 

--- a/src/shared/ask-password-api.c
+++ b/src/shared/ask-password-api.c
@@ -537,7 +537,7 @@ int ask_password_tty(
         /* If the caller didn't specify a TTY, then use the controlling tty, if we can. */
         int ttyfd;
         if (req->tty_fd < 0)
-                ttyfd = cttyfd = open("/dev/tty", O_RDWR|O_NOCTTY|O_CLOEXEC);
+                ttyfd = cttyfd = open_terminal("/dev/tty", O_RDWR|O_NOCTTY);
         else
                 ttyfd = req->tty_fd;
 

--- a/src/shared/base-filesystem.c
+++ b/src/shared/base-filesystem.c
@@ -13,6 +13,7 @@
 #include "base-filesystem.h"
 #include "errno-util.h"
 #include "fd-util.h"
+#include "fs-util.h"
 #include "log.h"
 #include "nulstr-util.h"
 #include "path-util.h"
@@ -219,9 +220,9 @@ int base_filesystem_create_fd(int fd, const char *root, uid_t uid, gid_t gid) {
 int base_filesystem_create(const char *root, uid_t uid, gid_t gid) {
         _cleanup_close_ int fd = -EBADF;
 
-        fd = open(ASSERT_PTR(root), O_DIRECTORY|O_CLOEXEC);
+        fd = xopenat(AT_FDCWD, ASSERT_PTR(root), O_DIRECTORY);
         if (fd < 0)
-                return log_error_errno(errno, "Failed to open root file system: %m");
+                return log_error_errno(fd, "Failed to open root file system: %m");
 
         return base_filesystem_create_fd(fd, root, uid, gid);
 }

--- a/src/shared/binfmt-util.c
+++ b/src/shared/binfmt-util.c
@@ -15,7 +15,7 @@ int binfmt_mounted_and_writable(void) {
         _cleanup_close_ int fd = -EBADF;
         int r;
 
-        fd = RET_NERRNO(open("/proc/sys/fs/binfmt_misc", O_CLOEXEC | O_DIRECTORY | O_PATH));
+        fd = xopenat(AT_FDCWD, "/proc/sys/fs/binfmt_misc", O_DIRECTORY | O_PATH);
         if (fd == -ENOENT)
                 return false;
         /* ELOOP happens when binfmt_misc is an automount point under a read-only bind mount of /proc —

--- a/src/shared/blockdev-util.c
+++ b/src/shared/blockdev-util.c
@@ -233,9 +233,9 @@ int block_device_new_from_path(const char *path, BlockDeviceLookupFlags flags, s
         assert(path);
         assert(ret);
 
-        fd = open(path, O_CLOEXEC|O_PATH);
+        fd = xopenat(AT_FDCWD, path, O_PATH);
         if (fd < 0)
-                return -errno;
+                return fd;
 
         return block_device_new_from_fd(fd, flags, ret);
 }
@@ -316,9 +316,9 @@ int get_block_device(const char *path, dev_t *ret) {
         assert(path);
         assert(ret);
 
-        fd = open(path, O_RDONLY|O_NOFOLLOW|O_CLOEXEC);
+        fd = xopenat(AT_FDCWD, path, O_RDONLY|O_NOFOLLOW);
         if (fd < 0)
-                return -errno;
+                return fd;
 
         return get_block_device_fd(fd, ret);
 }
@@ -366,9 +366,9 @@ int get_block_device_harder(const char *path, dev_t *ret) {
         assert(path);
         assert(ret);
 
-        fd = open(path, O_RDONLY|O_NOFOLLOW|O_CLOEXEC);
+        fd = xopenat(AT_FDCWD, path, O_RDONLY|O_NOFOLLOW);
         if (fd < 0)
-                return -errno;
+                return fd;
 
         return get_block_device_harder_fd(fd, ret);
 }
@@ -635,9 +635,9 @@ int fd_get_whole_disk(int fd, bool backing, dev_t *ret) {
 int path_get_whole_disk(const char *path, bool backing, dev_t *ret) {
         _cleanup_close_ int fd = -EBADF;
 
-        fd = open(path, O_CLOEXEC|O_PATH);
+        fd = xopenat(AT_FDCWD, path, O_PATH);
         if (fd < 0)
-                return -errno;
+                return fd;
 
         return fd_get_whole_disk(fd, backing, ret);
 }

--- a/src/shared/boot-entry.c
+++ b/src/shared/boot-entry.c
@@ -5,6 +5,7 @@
 #include "chase.h"
 #include "fd-util.h"
 #include "fileio.h"
+#include "fs-util.h"
 #include "log.h"
 #include "os-util.h"
 #include "path-util.h"
@@ -232,9 +233,9 @@ int boot_entry_token_ensure(
 
         _cleanup_close_ int rfd = XAT_FDROOT;
         if (!empty_or_root(root)) {
-                rfd = open(root, O_CLOEXEC | O_DIRECTORY | O_PATH);
+                rfd = xopenat(AT_FDCWD, root, O_DIRECTORY | O_PATH);
                 if (rfd < 0)
-                        return -errno;
+                        return rfd;
         }
 
         return boot_entry_token_ensure_at(rfd, conf_root, machine_id, machine_id_is_random, type, token);

--- a/src/shared/bootspec.c
+++ b/src/shared/bootspec.c
@@ -773,7 +773,7 @@ static int boot_entries_find_type1(
         assert(root);
         assert(dir);
 
-        dir_fd = chase_and_open(dir, root, CHASE_PREFIX_ROOT|CHASE_PROHIBIT_SYMLINKS, O_DIRECTORY|O_CLOEXEC, &full);
+        dir_fd = chase_and_open(dir, root, CHASE_PREFIX_ROOT|CHASE_PROHIBIT_SYMLINKS, O_DIRECTORY, &full);
         if (dir_fd == -ENOENT)
                 return 0;
         if (dir_fd < 0)
@@ -1369,7 +1369,7 @@ static int boot_entries_find_unified_extras(
 
                 _cleanup_free_ char *cmdline = NULL;
                 if (type == BOOT_ENTRY_ADDON) {
-                        _cleanup_close_ int fd = fd_reopen(pin_fd, O_RDONLY|O_CLOEXEC|O_NONBLOCK|O_NOCTTY);
+                        _cleanup_close_ int fd = fd_reopen(pin_fd, O_RDONLY|O_NONBLOCK|O_NOCTTY);
                         if (fd < 0) {
                                 log_debug_errno(fd, "Failed to open '%s', ignoring: %m", location);
                                 continue;

--- a/src/shared/bootspec.c
+++ b/src/shared/bootspec.c
@@ -13,11 +13,11 @@
 #include "efi-loader.h"
 #include "efivars.h"
 #include "env-file.h"
-#include "errno-util.h"
 #include "extract-word.h"
 #include "fd-util.h"
 #include "fileio.h"
 #include "find-esp.h"
+#include "fs-util.h"
 #include "json-util.h"
 #include "log.h"
 #include "parse-util.h"
@@ -1347,9 +1347,9 @@ static int boot_entries_find_unified_extras(
                 if (!location)
                         return log_oom();
 
-                _cleanup_close_ int pin_fd = openat(dirfd(d), de->d_name, O_PATH|O_CLOEXEC|O_NOFOLLOW);
+                _cleanup_close_ int pin_fd = xopenat(dirfd(d), de->d_name, O_PATH|O_NOFOLLOW);
                 if (pin_fd < 0) {
-                        log_debug_errno(errno, "Failed to pin '%s', ignoring: %m", location);
+                        log_debug_errno(pin_fd, "Failed to pin '%s', ignoring: %m", location);
                         continue;
                 }
 
@@ -1397,7 +1397,7 @@ static int boot_entries_find_unified_global_extras(
 
         assert(extras);
 
-        _cleanup_close_ int where_fd = RET_NERRNO(open(where, O_DIRECTORY|O_CLOEXEC));
+        _cleanup_close_ int where_fd = xopenat(AT_FDCWD, where, O_DIRECTORY);
         if (where_fd == -ENOENT)
                 return 0;
         if (where_fd < 0)
@@ -1464,9 +1464,9 @@ static int boot_entries_find_unified(
                 if (!endswith_no_case(de->d_name, ".efi"))
                         continue;
 
-                _cleanup_close_ int fd = openat(dirfd(d), de->d_name, O_RDONLY|O_CLOEXEC|O_NONBLOCK|O_NOFOLLOW|O_NOCTTY);
+                _cleanup_close_ int fd = xopenat(dirfd(d), de->d_name, O_RDONLY|O_NONBLOCK|O_NOFOLLOW|O_NOCTTY);
                 if (fd < 0) {
-                        log_warning_errno(errno, "Failed to open %s/%s, ignoring: %m", full, de->d_name);
+                        log_warning_errno(fd, "Failed to open %s/%s, ignoring: %m", full, de->d_name);
                         continue;
                 }
 

--- a/src/shared/bpf-program.c
+++ b/src/shared/bpf-program.c
@@ -13,6 +13,7 @@
 #include "extract-word.h"
 #include "fd-util.h"
 #include "fdset.h"
+#include "fs-util.h"
 #include "log.h"
 #include "memory-util.h"
 #include "parse-util.h"
@@ -317,9 +318,9 @@ int bpf_program_cgroup_attach(BPFProgram *p, int type, const char *path, uint32_
         if (!copy)
                 return -ENOMEM;
 
-        fd = open(path, O_DIRECTORY|O_RDONLY|O_CLOEXEC);
+        fd = xopenat(AT_FDCWD, path, O_DIRECTORY|O_RDONLY);
         if (fd < 0)
-                return -errno;
+                return fd;
 
         zero(attr);
         attr.attach_type = type;
@@ -345,10 +346,10 @@ int bpf_program_cgroup_detach(BPFProgram *p) {
         if (!p->attached_path)
                 return -EUNATCH;
 
-        fd = open(p->attached_path, O_DIRECTORY|O_RDONLY|O_CLOEXEC);
+        fd = xopenat(AT_FDCWD, p->attached_path, O_DIRECTORY|O_RDONLY);
         if (fd < 0) {
-                if (errno != ENOENT)
-                        return -errno;
+                if (fd != -ENOENT)
+                        return fd;
 
                 /* If the cgroup does not exist anymore, then we don't have to explicitly detach, it got detached
                  * implicitly by the removal, hence don't complain */

--- a/src/shared/btrfs-util.c
+++ b/src/shared/btrfs-util.c
@@ -212,9 +212,9 @@ int btrfs_subvol_get_id(int fd, const char *subvol, uint64_t *ret) {
         assert(fd >= 0);
         assert(ret);
 
-        subvol_fd = openat(fd, subvol, O_RDONLY|O_CLOEXEC|O_NOCTTY|O_NOFOLLOW);
+        subvol_fd = xopenat(fd, subvol, O_RDONLY|O_NOCTTY|O_NOFOLLOW);
         if (subvol_fd < 0)
-                return -errno;
+                return subvol_fd;
 
         return btrfs_subvol_get_id_fd(subvol_fd, ret);
 }
@@ -481,9 +481,9 @@ int btrfs_log_dev_root(int level, int ret, const char *p) {
 int btrfs_qgroup_get_quota(const char *path, uint64_t qgroupid, BtrfsQuotaInfo *ret) {
         _cleanup_close_ int fd = -EBADF;
 
-        fd = open(path, O_RDONLY|O_CLOEXEC|O_NOCTTY|O_NOFOLLOW);
+        fd = xopenat(AT_FDCWD, path, O_RDONLY|O_NOCTTY|O_NOFOLLOW);
         if (fd < 0)
-                return -errno;
+                return fd;
 
         return btrfs_qgroup_get_quota_fd(fd, qgroupid, ret);
 }
@@ -574,9 +574,9 @@ int btrfs_subvol_get_subtree_quota_fd(int fd, uint64_t subvol_id, BtrfsQuotaInfo
 int btrfs_subvol_get_subtree_quota(const char *path, uint64_t subvol_id, BtrfsQuotaInfo *ret) {
         _cleanup_close_ int fd = -EBADF;
 
-        fd = open(path, O_RDONLY|O_CLOEXEC|O_NOCTTY|O_NOFOLLOW);
+        fd = xopenat(AT_FDCWD, path, O_RDONLY|O_NOCTTY|O_NOFOLLOW);
         if (fd < 0)
-                return -errno;
+                return fd;
 
         return btrfs_subvol_get_subtree_quota_fd(fd, subvol_id, ret);
 }
@@ -596,9 +596,9 @@ int btrfs_defrag_fd(int fd) {
 int btrfs_defrag(const char *p) {
         _cleanup_close_ int fd = -EBADF;
 
-        fd = open(p, O_RDWR|O_CLOEXEC|O_NOCTTY|O_NOFOLLOW);
+        fd = xopenat(AT_FDCWD, p, O_RDWR|O_NOCTTY|O_NOFOLLOW);
         if (fd < 0)
-                return -errno;
+                return fd;
 
         return btrfs_defrag_fd(fd);
 }
@@ -623,9 +623,9 @@ int btrfs_quota_enable_fd(int fd, bool b) {
 int btrfs_quota_enable(const char *path, bool b) {
         _cleanup_close_ int fd = -EBADF;
 
-        fd = open(path, O_RDONLY|O_CLOEXEC|O_NOCTTY|O_NOFOLLOW);
+        fd = xopenat(AT_FDCWD, path, O_RDONLY|O_NOCTTY|O_NOFOLLOW);
         if (fd < 0)
-                return -errno;
+                return fd;
 
         return btrfs_quota_enable_fd(fd, b);
 }
@@ -674,9 +674,9 @@ int btrfs_qgroup_set_limit_fd(int fd, uint64_t qgroupid, uint64_t referenced_max
 int btrfs_qgroup_set_limit(const char *path, uint64_t qgroupid, uint64_t referenced_max) {
         _cleanup_close_ int fd = -EBADF;
 
-        fd = open(path, O_RDONLY|O_CLOEXEC|O_NOCTTY|O_NOFOLLOW);
+        fd = xopenat(AT_FDCWD, path, O_RDONLY|O_NOCTTY|O_NOFOLLOW);
         if (fd < 0)
-                return -errno;
+                return fd;
 
         return btrfs_qgroup_set_limit_fd(fd, qgroupid, referenced_max);
 }
@@ -697,9 +697,9 @@ int btrfs_subvol_set_subtree_quota_limit_fd(int fd, uint64_t subvol_id, uint64_t
 int btrfs_subvol_set_subtree_quota_limit(const char *path, uint64_t subvol_id, uint64_t referenced_max) {
         _cleanup_close_ int fd = -EBADF;
 
-        fd = open(path, O_RDONLY|O_CLOEXEC|O_NOCTTY|O_NOFOLLOW);
+        fd = xopenat(AT_FDCWD, path, O_RDONLY|O_NOCTTY|O_NOFOLLOW);
         if (fd < 0)
-                return -errno;
+                return fd;
 
         return btrfs_subvol_set_subtree_quota_limit_fd(fd, subvol_id, referenced_max);
 }
@@ -897,9 +897,9 @@ static int subvol_remove_children(int fd, const char *subvolume, uint64_t subvol
         if (r < 0)
                 return r;
 
-        subvol_fd = openat(fd, subvolume, O_RDONLY|O_NOCTTY|O_CLOEXEC|O_DIRECTORY|O_NOFOLLOW);
+        subvol_fd = xopenat(fd, subvolume, O_RDONLY|O_NOCTTY|O_DIRECTORY|O_NOFOLLOW);
         if (subvol_fd < 0)
-                return -errno;
+                return subvol_fd;
 
         /* Let's check if this is actually a subvolume. Note that this is mostly redundant, as BTRFS_IOC_SNAP_DESTROY
          * would fail anyway if it is not. However, it's a good thing to check this ahead of time so that we can return
@@ -1001,9 +1001,9 @@ static int subvol_remove_children(int fd, const char *subvolume, uint64_t subvol
                                 /* Subvolume is somewhere further down, hence we need to open the
                                  * containing directory first */
 
-                                child_fd = openat(subvol_fd, lookup_args.path, O_RDONLY|O_NOCTTY|O_CLOEXEC|O_DIRECTORY|O_NOFOLLOW);
+                                child_fd = xopenat(subvol_fd, lookup_args.path, O_RDONLY|O_NOCTTY|O_DIRECTORY|O_NOFOLLOW);
                                 if (child_fd < 0)
-                                        return -errno;
+                                        return child_fd;
 
                                 r = subvol_remove_children(child_fd, lookup_args.name, child_subvol_id, flags);
                         }
@@ -1332,26 +1332,26 @@ static int subvol_snapshot_children(
                         if (!c)
                                 return -ENOMEM;
 
-                        old_child_fd = openat(old_fd, c, O_RDONLY|O_NOCTTY|O_CLOEXEC|O_DIRECTORY|O_NOFOLLOW);
+                        old_child_fd = xopenat(old_fd, c, O_RDONLY|O_NOCTTY|O_DIRECTORY|O_NOFOLLOW);
                         if (old_child_fd < 0)
-                                return -errno;
+                                return old_child_fd;
 
                         np = path_join(subvolume, lookup_args.path);
                         if (!np)
                                 return -ENOMEM;
 
-                        new_child_fd = openat(new_fd, np, O_RDONLY|O_NOCTTY|O_CLOEXEC|O_DIRECTORY|O_NOFOLLOW);
+                        new_child_fd = xopenat(new_fd, np, O_RDONLY|O_NOCTTY|O_DIRECTORY|O_NOFOLLOW);
                         if (new_child_fd < 0)
-                                return -errno;
+                                return new_child_fd;
 
                         if (flags & BTRFS_SNAPSHOT_READ_ONLY) {
                                 /* If the snapshot is read-only we need to mark it writable temporarily, to
                                  * put the subsnapshot into place. */
 
                                 if (subvolume_fd < 0) {
-                                        subvolume_fd = openat(new_fd, subvolume, O_RDONLY|O_NOCTTY|O_CLOEXEC|O_DIRECTORY|O_NOFOLLOW);
+                                        subvolume_fd = xopenat(new_fd, subvolume, O_RDONLY|O_NOCTTY|O_DIRECTORY|O_NOFOLLOW);
                                         if (subvolume_fd < 0)
-                                                return -errno;
+                                                return subvolume_fd;
                                 }
 
                                 r = btrfs_subvol_set_read_only_fd(subvolume_fd, false);
@@ -1747,9 +1747,9 @@ int btrfs_subvol_auto_qgroup_fd(int fd, uint64_t subvol_id, bool insert_intermed
 int btrfs_subvol_auto_qgroup(const char *path, uint64_t subvol_id, bool create_intermediary_qgroup) {
         _cleanup_close_ int fd = -EBADF;
 
-        fd = open(path, O_RDONLY|O_NOCTTY|O_CLOEXEC|O_DIRECTORY);
+        fd = xopenat(AT_FDCWD, path, O_RDONLY|O_NOCTTY|O_DIRECTORY);
         if (fd < 0)
-                return -errno;
+                return fd;
 
         return btrfs_subvol_auto_qgroup_fd(fd, subvol_id, create_intermediary_qgroup);
 }
@@ -1761,9 +1761,9 @@ int btrfs_subvol_make_default(const char *path) {
 
         assert(path);
 
-        fd = open(path, O_NOCTTY|O_CLOEXEC|O_DIRECTORY);
+        fd = xopenat(AT_FDCWD, path, O_NOCTTY|O_DIRECTORY);
         if (fd < 0)
-                return -errno;
+                return fd;
 
         r = btrfs_subvol_get_id_fd(fd, &id);
         if (r < 0)
@@ -1855,9 +1855,9 @@ int btrfs_forget_device(const char *path) {
 
         strcpy(args.name, path);
 
-        control_fd = open("/dev/btrfs-control", O_RDWR|O_CLOEXEC);
+        control_fd = xopenat(AT_FDCWD, "/dev/btrfs-control", O_RDWR);
         if (control_fd < 0)
-                return -errno;
+                return control_fd;
 
         return RET_NERRNO(ioctl(control_fd, BTRFS_IOC_FORGET_DEV, &args));
 }

--- a/src/shared/btrfs-util.c
+++ b/src/shared/btrfs-util.c
@@ -58,7 +58,7 @@ int btrfs_subvol_set_read_only_at(int dir_fd, const char *path, bool b) {
 
         assert(dir_fd >= 0 || dir_fd == AT_FDCWD);
 
-        fd = xopenat(dir_fd, path, O_RDONLY|O_NOCTTY|O_CLOEXEC|O_DIRECTORY);
+        fd = xopenat(dir_fd, path, O_RDONLY|O_NOCTTY|O_DIRECTORY);
         if (fd < 0)
                 return fd;
 
@@ -111,7 +111,7 @@ int btrfs_get_block_device_at_full(int dir_fd, const char *path, uint64_t *ret_d
 
         assert(wildcard_fd_is_valid(dir_fd));
 
-        fd = xopenat(dir_fd, path, O_RDONLY|O_CLOEXEC|O_NONBLOCK|O_NOCTTY);
+        fd = xopenat(dir_fd, path, O_RDONLY|O_NONBLOCK|O_NOCTTY);
         if (fd < 0)
                 return fd;
 
@@ -328,7 +328,7 @@ int btrfs_subvol_get_info_fd(int fd, uint64_t subvol_id, BtrfsSubvolInfo *ret) {
 
         /* Make sure this works on O_PATH fds */
         _cleanup_close_ int fd_close = -EBADF;
-        fd = fd_reopen_condition(fd, O_CLOEXEC|O_RDONLY|O_DIRECTORY, O_PATH, &fd_close);
+        fd = fd_reopen_condition(fd, O_RDONLY|O_DIRECTORY, O_PATH, &fd_close);
         if (fd < 0)
                 return fd;
 
@@ -1033,7 +1033,7 @@ int btrfs_subvol_remove_at(int dir_fd, const char *path, BtrfsRemoveFlags flags)
 
         assert(path);
 
-        fd = chase_and_openat(XAT_FDROOT, dir_fd, path, CHASE_PARENT|CHASE_EXTRACT_FILENAME, O_CLOEXEC, &subvolume);
+        fd = chase_and_openat(XAT_FDROOT, dir_fd, path, CHASE_PARENT|CHASE_EXTRACT_FILENAME, O_RDONLY, &subvolume);
         if (fd < 0)
                 return fd;
 
@@ -1261,7 +1261,7 @@ static int subvol_snapshot_children(
 
         if (FLAGS_SET(flags, BTRFS_SNAPSHOT_LOCK_BSD)) {
                 subvolume_fd = xopenat_lock(new_fd, subvolume,
-                                            O_RDONLY|O_NOCTTY|O_CLOEXEC|O_DIRECTORY|O_NOFOLLOW,
+                                            O_RDONLY|O_NOCTTY|O_DIRECTORY|O_NOFOLLOW,
                                             LOCK_BSD,
                                             LOCK_EX);
                 if (subvolume_fd < 0)
@@ -1414,11 +1414,11 @@ int btrfs_subvol_snapshot_at_full(
         assert(dir_fdt >= 0 || dir_fdt == AT_FDCWD);
         assert(to);
 
-        old_fd = xopenat(dir_fdf, from, O_RDONLY|O_NOCTTY|O_CLOEXEC|O_DIRECTORY);
+        old_fd = xopenat(dir_fdf, from, O_RDONLY|O_NOCTTY|O_DIRECTORY);
         if (old_fd < 0)
                 return old_fd;
 
-        new_fd = chase_and_openat(XAT_FDROOT, dir_fdt, to, CHASE_PARENT|CHASE_EXTRACT_FILENAME, O_CLOEXEC, &subvolume);
+        new_fd = chase_and_openat(XAT_FDROOT, dir_fdt, to, CHASE_PARENT|CHASE_EXTRACT_FILENAME, O_RDONLY, &subvolume);
         if (new_fd < 0)
                 return new_fd;
 
@@ -1450,7 +1450,7 @@ int btrfs_subvol_snapshot_at_full(
 
                 if (FLAGS_SET(flags, BTRFS_SNAPSHOT_LOCK_BSD)) {
                         subvolume_fd = xopenat_lock(new_fd, subvolume,
-                                                    O_RDONLY|O_NOCTTY|O_CLOEXEC|O_DIRECTORY|O_NOFOLLOW,
+                                                    O_RDONLY|O_NOCTTY|O_DIRECTORY|O_NOFOLLOW,
                                                     LOCK_BSD,
                                                     LOCK_EX);
                         if (subvolume_fd < 0)
@@ -1638,7 +1638,7 @@ int btrfs_subvol_auto_qgroup_fd(int fd, uint64_t subvol_id, bool insert_intermed
          */
 
         /* Turn this into a proper fd, if it is currently O_PATH */
-        fd = fd_reopen_condition(fd, O_RDONLY|O_CLOEXEC, O_PATH, &real_fd);
+        fd = fd_reopen_condition(fd, O_RDONLY, O_PATH, &real_fd);
         if (fd < 0)
                 return fd;
 

--- a/src/shared/btrfs-util.c
+++ b/src/shared/btrfs-util.c
@@ -58,7 +58,8 @@ int btrfs_subvol_set_read_only_at(int dir_fd, const char *path, bool b) {
 
         assert(dir_fd >= 0 || dir_fd == AT_FDCWD);
 
-        fd = xopenat(dir_fd, path, O_RDONLY|O_NOCTTY|O_DIRECTORY);
+        /* path may be NULL */
+        fd = xopenat_full(dir_fd, path, O_RDONLY|O_NOCTTY|O_DIRECTORY, XO_EMPTY_PATH, MODE_INVALID);
         if (fd < 0)
                 return fd;
 
@@ -111,7 +112,8 @@ int btrfs_get_block_device_at_full(int dir_fd, const char *path, uint64_t *ret_d
 
         assert(wildcard_fd_is_valid(dir_fd));
 
-        fd = xopenat(dir_fd, path, O_RDONLY|O_NONBLOCK|O_NOCTTY);
+        /* path may be NULL */
+        fd = xopenat_full(dir_fd, path, O_RDONLY|O_NONBLOCK|O_NOCTTY, XO_EMPTY_PATH, MODE_INVALID);
         if (fd < 0)
                 return fd;
 
@@ -1414,7 +1416,8 @@ int btrfs_subvol_snapshot_at_full(
         assert(dir_fdt >= 0 || dir_fdt == AT_FDCWD);
         assert(to);
 
-        old_fd = xopenat(dir_fdf, from, O_RDONLY|O_NOCTTY|O_DIRECTORY);
+        /* from may be NULL */
+        old_fd = xopenat_full(dir_fdf, from, O_RDONLY|O_NOCTTY|O_DIRECTORY, XO_EMPTY_PATH, MODE_INVALID);
         if (old_fd < 0)
                 return old_fd;
 

--- a/src/shared/cgroup-setup.c
+++ b/src/shared/cgroup-setup.c
@@ -293,9 +293,9 @@ int cg_set_access_recursive(
         if (r < 0)
                 return r;
 
-        fd = open(fs, O_DIRECTORY|O_CLOEXEC);
+        fd = xopenat(AT_FDCWD, fs, O_DIRECTORY);
         if (fd < 0)
-                return -errno;
+                return fd;
 
         struct access_callback_data d = {
                 .uid = uid,

--- a/src/shared/cgroup-show.c
+++ b/src/shared/cgroup-show.c
@@ -15,6 +15,7 @@
 #include "escape.h"
 #include "fd-util.h"
 #include "format-util.h"
+#include "fs-util.h"
 #include "glyph-util.h"
 #include "hostname-util.h"
 #include "log.h"
@@ -141,9 +142,9 @@ static int show_cgroup_name(
         bool delegate;
         int r;
 
-        fd = open(path, O_PATH|O_CLOEXEC|O_NOFOLLOW|O_DIRECTORY, 0);
+        fd = xopenat(AT_FDCWD, path, O_PATH|O_NOFOLLOW|O_DIRECTORY);
         if (fd < 0)
-                return log_debug_errno(errno, "Failed to open cgroup '%s', ignoring: %m", path);
+                return log_debug_errno(fd, "Failed to open cgroup '%s', ignoring: %m", path);
 
         r = cg_is_delegated_fd(fd);
         if (r < 0)

--- a/src/shared/chown-recursive.c
+++ b/src/shared/chown-recursive.c
@@ -69,9 +69,9 @@ static int chown_recursive_internal(
 
                 /* Let's pin the child inode we want to fix now with an O_PATH fd, so that it cannot be swapped out
                  * while we manipulate it. */
-                path_fd = openat(dirfd(d), de->d_name, O_PATH|O_CLOEXEC|O_NOFOLLOW);
+                path_fd = xopenat(dirfd(d), de->d_name, O_PATH|O_NOFOLLOW);
                 if (path_fd < 0)
-                        return -errno;
+                        return path_fd;
 
                 if (fstat(path_fd, &fst) < 0)
                         return -errno;
@@ -117,9 +117,9 @@ int path_chown_recursive(
 
         assert((flags & ~AT_SYMLINK_FOLLOW) == 0);
 
-        fd = open(path, O_RDONLY|O_DIRECTORY|O_CLOEXEC|O_NOATIME|(FLAGS_SET(flags, AT_SYMLINK_FOLLOW) ? 0 : O_NOFOLLOW));
+        fd = xopenat(AT_FDCWD, path, O_RDONLY|O_DIRECTORY|O_NOATIME|(FLAGS_SET(flags, AT_SYMLINK_FOLLOW) ? 0 : O_NOFOLLOW));
         if (fd < 0)
-                return -errno;
+                return fd;
 
         if (!uid_is_valid(uid) && !gid_is_valid(gid) && FLAGS_SET(mask, 07777))
                 return 0; /* nothing to do */

--- a/src/shared/chown-recursive.c
+++ b/src/shared/chown-recursive.c
@@ -80,7 +80,7 @@ static int chown_recursive_internal(
                         int subdir_fd;
 
                         /* Convert it to a "real" (i.e. non-O_PATH) fd now */
-                        subdir_fd = fd_reopen(path_fd, O_RDONLY|O_CLOEXEC|O_NOATIME);
+                        subdir_fd = fd_reopen(path_fd, O_RDONLY|O_NOATIME);
                         if (subdir_fd < 0)
                                 return subdir_fd;
 

--- a/src/shared/condition.c
+++ b/src/shared/condition.c
@@ -1310,14 +1310,14 @@ static int condition_test_kernel_module_loaded(Condition *c, char **env) {
         if (!p)
                 return log_oom_debug();
 
-        _cleanup_close_ int dir_fd = open(p, O_PATH|O_DIRECTORY|O_CLOEXEC);
+        _cleanup_close_ int dir_fd = xopenat(AT_FDCWD, p, O_PATH|O_DIRECTORY);
         if (dir_fd < 0) {
-                if (errno == ENOENT) {
-                        log_debug_errno(errno, "'%s/' does not exist, kernel module '%s' not loaded.", p, normalized);
+                if (dir_fd == -ENOENT) {
+                        log_debug_errno(dir_fd, "'%s/' does not exist, kernel module '%s' not loaded.", p, normalized);
                         return false;
                 }
 
-                return log_debug_errno(errno, "Failed to open directory '%s/': %m", p);
+                return log_debug_errno(dir_fd, "Failed to open directory '%s/': %m", p);
         }
 
         _cleanup_free_ char *initstate = NULL;

--- a/src/shared/conf-parser.c
+++ b/src/shared/conf-parser.c
@@ -614,9 +614,9 @@ static int normalize_root_fd(const char *root, int *root_fd, int *ret_opened_fd)
                 return 0;
         }
 
-        int fd = open(root, O_CLOEXEC|O_PATH|O_DIRECTORY);
+        int fd = xopenat(AT_FDCWD, root, O_PATH|O_DIRECTORY);
         if (fd < 0)
-                return log_error_errno(errno, "Failed to open root directory '%s': %m", root);
+                return log_error_errno(fd, "Failed to open root directory '%s': %m", root);
 
         *ret_opened_fd = *root_fd = fd;
         return 0;

--- a/src/shared/copy.c
+++ b/src/shared/copy.c
@@ -875,7 +875,7 @@ static int fd_copy_regular(
         if (r > 0) /* worked! */
                 return 0;
 
-        fdf = xopenat_full(df, from, O_RDONLY|O_NOCTTY|O_NOFOLLOW, XO_REGULAR, 0);
+        fdf = xopenat_full(df, from, O_RDONLY|O_NOCTTY|O_NOFOLLOW, XO_REGULAR|XO_EMPTY_PATH, MODE_INVALID); /* from may be NULL */
         if (fdf < 0)
                 return fdf;
 
@@ -1086,7 +1086,7 @@ static int fd_copy_directory(
         if (depth_left == 0)
                 return -ENAMETOOLONG;
 
-        fdf = xopenat(df, from, O_RDONLY|O_DIRECTORY|O_NOCTTY|O_NOFOLLOW);
+        fdf = xopenat_full(df, from, O_RDONLY|O_DIRECTORY|O_NOCTTY|O_NOFOLLOW, XO_EMPTY_PATH, MODE_INVALID); /* from may be NULL */
         if (fdf < 0)
                 return fdf;
 
@@ -1472,7 +1472,7 @@ int copy_file_fd_at_full(
         assert(fdt >= 0);
         assert(!FLAGS_SET(copy_flags, COPY_LOCK_BSD));
 
-        fdf = xopenat_full(dir_fdf, from, O_RDONLY|O_NOCTTY, XO_REGULAR, 0);
+        fdf = xopenat_full(dir_fdf, from, O_RDONLY|O_NOCTTY, XO_REGULAR|XO_EMPTY_PATH, MODE_INVALID); /* from may be NULL */
         if (fdf < 0)
                 return fdf;
 
@@ -1529,7 +1529,7 @@ int copy_file_at_full(
         assert(dir_fdt >= 0 || dir_fdt == AT_FDCWD);
         assert(to);
 
-        fdf = xopenat_full(dir_fdf, from, O_RDONLY|O_NOCTTY, XO_REGULAR, 0);
+        fdf = xopenat_full(dir_fdf, from, O_RDONLY|O_NOCTTY, XO_REGULAR|XO_EMPTY_PATH, MODE_INVALID); /* from may be NULL */
         if (fdf < 0)
                 return fdf;
 

--- a/src/shared/copy.c
+++ b/src/shared/copy.c
@@ -216,10 +216,10 @@ int copy_bytes_full(
         if (ret_remains_size)
                 *ret_remains_size = 0;
 
-        fdf = fd_reopen_condition(fdf, O_CLOEXEC | O_NOCTTY | O_RDONLY, O_PATH, &fdf_opened);
+        fdf = fd_reopen_condition(fdf, O_NOCTTY | O_RDONLY, O_PATH, &fdf_opened);
         if (fdf < 0)
                 return fdf;
-        fdt = fd_reopen_condition(fdt, O_CLOEXEC | O_NOCTTY | O_RDWR, O_PATH, &fdt_opened);
+        fdt = fd_reopen_condition(fdt, O_NOCTTY | O_RDWR, O_PATH, &fdt_opened);
         if (fdt < 0)
                 return fdt;
 
@@ -633,7 +633,7 @@ static int hardlink_context_realize(HardlinkContext *c) {
 
         assert(c->subdir);
 
-        c->dir_fd = open_mkdir_at(c->parent_fd, c->subdir, O_EXCL|O_CLOEXEC, 0700);
+        c->dir_fd = open_mkdir_at(c->parent_fd, c->subdir, O_EXCL, 0700);
         if (c->dir_fd < 0)
                 return c->dir_fd;
 
@@ -804,7 +804,7 @@ static int copy_fs_verity(int fdf, int *fdt) {
         /* Okay. We're doing this now. We need to re-open fdt as read-only because
          * we can't enable fs-verity while writable file descriptors are outstanding. */
         _cleanup_close_ int reopened_fd = -EBADF;
-        r = fd_reopen_condition(*fdt, O_RDONLY|O_CLOEXEC|O_NOCTTY, O_ACCMODE_STRICT|O_PATH, &reopened_fd);
+        r = fd_reopen_condition(*fdt, O_RDONLY|O_NOCTTY, O_ACCMODE_STRICT|O_PATH, &reopened_fd);
         if (r < 0)
                 return r;
         if (reopened_fd >= 0)
@@ -875,7 +875,7 @@ static int fd_copy_regular(
         if (r > 0) /* worked! */
                 return 0;
 
-        fdf = xopenat_full(df, from, O_RDONLY|O_CLOEXEC|O_NOCTTY|O_NOFOLLOW, XO_REGULAR, 0);
+        fdf = xopenat_full(df, from, O_RDONLY|O_NOCTTY|O_NOFOLLOW, XO_REGULAR, 0);
         if (fdf < 0)
                 return fdf;
 
@@ -1090,7 +1090,7 @@ static int fd_copy_directory(
         if (depth_left == 0)
                 return -ENAMETOOLONG;
 
-        fdf = xopenat(df, from, O_RDONLY|O_DIRECTORY|O_CLOEXEC|O_NOCTTY|O_NOFOLLOW);
+        fdf = xopenat(df, from, O_RDONLY|O_DIRECTORY|O_NOCTTY|O_NOFOLLOW);
         if (fdf < 0)
                 return fdf;
 
@@ -1124,7 +1124,7 @@ static int fd_copy_directory(
         }
 
         fdt = xopenat_lock_full(dt, to,
-                                O_RDONLY|O_DIRECTORY|O_CLOEXEC|O_NOCTTY|O_NOFOLLOW|(exists ? 0 : O_CREAT|O_EXCL),
+                                O_RDONLY|O_DIRECTORY|O_NOCTTY|O_NOFOLLOW|(exists ? 0 : O_CREAT|O_EXCL),
                                 flags,
                                 st->st_mode & 07777,
                                 copy_flags & COPY_LOCK_BSD ? LOCK_BSD : LOCK_NONE,
@@ -1476,7 +1476,7 @@ int copy_file_fd_at_full(
         assert(fdt >= 0);
         assert(!FLAGS_SET(copy_flags, COPY_LOCK_BSD));
 
-        fdf = xopenat_full(dir_fdf, from, O_RDONLY|O_CLOEXEC|O_NOCTTY, XO_REGULAR, 0);
+        fdf = xopenat_full(dir_fdf, from, O_RDONLY|O_NOCTTY, XO_REGULAR, 0);
         if (fdf < 0)
                 return fdf;
 
@@ -1533,7 +1533,7 @@ int copy_file_at_full(
         assert(dir_fdt >= 0 || dir_fdt == AT_FDCWD);
         assert(to);
 
-        fdf = xopenat_full(dir_fdf, from, O_RDONLY|O_CLOEXEC|O_NOCTTY, XO_REGULAR, 0);
+        fdf = xopenat_full(dir_fdf, from, O_RDONLY|O_NOCTTY, XO_REGULAR, 0);
         if (fdf < 0)
                 return fdf;
 
@@ -1548,7 +1548,7 @@ int copy_file_at_full(
 
         WITH_UMASK(0000) {
                 fdt = xopenat_lock_full(dir_fdt, to,
-                                        flags|O_WRONLY|O_CREAT|O_CLOEXEC|O_NOCTTY,
+                                        flags|O_WRONLY|O_CREAT|O_NOCTTY,
                                         XO_REGULAR | (copy_flags & COPY_MAC_CREATE ? XO_LABEL : 0),
                                         mode,
                                         copy_flags & COPY_LOCK_BSD ? LOCK_BSD : LOCK_NONE, LOCK_EX);
@@ -1633,7 +1633,7 @@ int copy_file_atomic_at_full(
                 if (r < 0)
                         return r;
         }
-        fdt = open_tmpfile_linkable_at(dir_fdt, to, O_WRONLY|O_CLOEXEC, &t);
+        fdt = open_tmpfile_linkable_at(dir_fdt, to, O_WRONLY, &t);
         if (copy_flags & COPY_MAC_CREATE)
                 mac_selinux_create_file_clear();
         if (fdt < 0)

--- a/src/shared/copy.c
+++ b/src/shared/copy.c
@@ -879,16 +879,12 @@ static int fd_copy_regular(
         if (fdf < 0)
                 return fdf;
 
-        if (copy_flags & COPY_MAC_CREATE) {
-                r = mac_selinux_create_file_prepare_at(dt, to, S_IFREG, /* label_context= */ NULL);
-                if (r < 0)
-                        return r;
-        }
-        fdt = openat(dt, to, O_WRONLY|O_CREAT|O_EXCL|O_CLOEXEC|O_NOCTTY|O_NOFOLLOW, st->st_mode & 07777);
-        if (copy_flags & COPY_MAC_CREATE)
-                mac_selinux_create_file_clear();
+        fdt = xopenat_full(dt, to,
+                           O_WRONLY|O_CREAT|O_EXCL|O_NOCTTY|O_NOFOLLOW,
+                           copy_flags & COPY_MAC_CREATE ? XO_LABEL : 0,
+                           st->st_mode & 07777);
         if (fdt < 0)
-                return -errno;
+                return fdt;
 
         r = prepare_nocow(fdf, /* from= */ NULL, fdt, /* chattr_mask= */ NULL, /* chattr_flags= */ NULL);
         if (r < 0)

--- a/src/shared/creds-util.c
+++ b/src/shared/creds-util.c
@@ -455,7 +455,7 @@ static int make_credential_host_secret(
         assert(dfd >= 0);
         assert(fn);
 
-        fd = open_tmpfile_linkable_at(dfd, fn, O_CLOEXEC|O_WRONLY, &t);
+        fd = open_tmpfile_linkable_at(dfd, fn, O_WRONLY, &t);
         if (fd < 0)
                 return log_debug_errno(fd, "Failed to create temporary file for credential host secret: %m");
 
@@ -540,7 +540,7 @@ int get_credential_host_secret(CredentialSecretFlags flags, struct iovec *ret) {
 
         (void) mkdir_parents(dirname, 0755);
 
-        dfd = open_mkdir(dirname, O_CLOEXEC, 0755);
+        dfd = open_mkdir(dirname, /* flags= */ 0, 0755);
         if (dfd < 0)
                 return log_debug_errno(dfd, "Failed to create or open directory '%s': %m", dirname);
 

--- a/src/shared/creds-util.c
+++ b/src/shared/creds-util.c
@@ -122,7 +122,7 @@ int open_credentials_dir(void) {
         if (r < 0)
                 return r;
 
-        return RET_NERRNO(open(d, O_CLOEXEC|O_DIRECTORY));
+        return xopenat(AT_FDCWD, d, O_DIRECTORY);
 }
 
 int get_system_credentials_dir(const char **ret) {
@@ -564,10 +564,10 @@ int get_credential_host_secret(CredentialSecretFlags flags, struct iovec *ret) {
                         return log_debug_errno(SYNTHETIC_ERRNO(EIO),
                                                "All attempts to create secret store in %s failed.", dirname);
 
-                fd = openat(dfd, filename, O_CLOEXEC|O_RDONLY|O_NOCTTY|O_NOFOLLOW);
+                fd = xopenat(dfd, filename, O_RDONLY|O_NOCTTY|O_NOFOLLOW);
                 if (fd < 0) {
-                        if (errno != ENOENT || !FLAGS_SET(flags, CREDENTIAL_SECRET_GENERATE))
-                                return log_debug_errno(errno,
+                        if (fd != -ENOENT || !FLAGS_SET(flags, CREDENTIAL_SECRET_GENERATE))
+                                return log_debug_errno(fd,
                                                        "Failed to open %s/%s: %m", dirname, filename);
 
                         r = make_credential_host_secret(dfd, machine_id, flags, dirname, filename, ret);

--- a/src/shared/data-fd-util.c
+++ b/src/shared/data-fd-util.c
@@ -72,7 +72,7 @@ int copy_data_fd(int fd) {
 
         /* If we have reason to believe this will fit fine in /tmp, then use that as first fallback. */
         if ((!S_ISREG(st.st_mode) || (uint64_t) st.st_size < DATA_FD_TMP_LIMIT)) {
-                tmp_fd = open_tmpfile_unlinkable(NULL /* NULL as directory means /tmp */, O_RDWR|O_CLOEXEC);
+                tmp_fd = open_tmpfile_unlinkable(NULL /* NULL as directory means /tmp */, O_RDWR);
                 if (tmp_fd < 0)
                         return tmp_fd;
 
@@ -108,7 +108,7 @@ int copy_data_fd(int fd) {
         if (r < 0)
                 return r;
 
-        tmp_fd = open_tmpfile_unlinkable(td, O_RDWR|O_CLOEXEC);
+        tmp_fd = open_tmpfile_unlinkable(td, O_RDWR);
         if (tmp_fd < 0)
                 return tmp_fd;
 
@@ -133,7 +133,7 @@ finish:
         /* Now convert the O_RDWR file descriptor into an O_RDONLY one (and as side effect seek to the beginning of the
          * file again */
 
-        return fd_reopen(tmp_fd, O_RDONLY|O_CLOEXEC);
+        return fd_reopen(tmp_fd, O_RDONLY);
 }
 
 int memfd_clone_fd(int fd, const char *name, int mode) {

--- a/src/shared/data-fd-util.c
+++ b/src/shared/data-fd-util.c
@@ -158,7 +158,7 @@ int memfd_clone_fd(int fd, const char *name, int mode) {
         exec = st.st_mode & 0111;
 
         mfd = memfd_create_wrapper(name,
-                                   ((FLAGS_SET(mode, O_CLOEXEC) || ro) ? MFD_CLOEXEC : 0) |
+                                   MFD_CLOEXEC |
                                    (ro ? MFD_ALLOW_SEALING : 0) |
                                    (exec ? MFD_EXEC : MFD_NOEXEC_SEAL));
         if (mfd < 0)

--- a/src/shared/dev-setup.c
+++ b/src/shared/dev-setup.c
@@ -93,7 +93,7 @@ int make_inaccessible_nodes(
         if (parent_fd < 0)
                 return -errno;
 
-        inaccessible_fd = open_mkdir_at_full(parent_fd, "inaccessible", O_CLOEXEC, XO_LABEL, 0755);
+        inaccessible_fd = open_mkdir_at_full(parent_fd, "inaccessible", /* flags= */ 0, XO_LABEL, 0755);
         if (inaccessible_fd < 0)
                 return inaccessible_fd;
 

--- a/src/shared/dev-setup.c
+++ b/src/shared/dev-setup.c
@@ -89,9 +89,9 @@ int make_inaccessible_nodes(
 
         BLOCK_WITH_UMASK(0000);
 
-        parent_fd = open(parent_dir, O_DIRECTORY|O_CLOEXEC|O_PATH, 0);
+        parent_fd = xopenat(AT_FDCWD, parent_dir, O_DIRECTORY|O_PATH);
         if (parent_fd < 0)
-                return -errno;
+                return parent_fd;
 
         inaccessible_fd = open_mkdir_at_full(parent_fd, "inaccessible", /* flags= */ 0, XO_LABEL, 0755);
         if (inaccessible_fd < 0)

--- a/src/shared/discover-image.c
+++ b/src/shared/discover-image.c
@@ -387,7 +387,7 @@ static int image_update_quota(Image *i, int fd) {
                 fd = fd_close;
         } else {
                 /* Convert from O_PATH to proper fd, if needed */
-                fd = fd_reopen_condition(fd, O_CLOEXEC|O_DIRECTORY, O_PATH, &fd_close);
+                fd = fd_reopen_condition(fd, O_DIRECTORY, O_PATH, &fd_close);
                 if (fd < 0)
                         return fd;
         }
@@ -682,7 +682,7 @@ static int image_make(
                         pretty = pretty_buffer;
                 }
 
-                _cleanup_close_ int block_fd = fd_reopen(fd, O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_NOCTTY);
+                _cleanup_close_ int block_fd = fd_reopen(fd, O_RDONLY|O_NONBLOCK|O_NOCTTY);
                 if (block_fd < 0)
                         log_debug_errno(errno, "Failed to open block device '%s', ignoring: %m", path);
                 else {
@@ -1338,7 +1338,7 @@ static int unpriv_remove_cb(
                                 _exit(EXIT_FAILURE);
                         }
 
-                        _cleanup_close_ int dfd = fd_reopen(tree_fd, O_DIRECTORY|O_CLOEXEC);
+                        _cleanup_close_ int dfd = fd_reopen(tree_fd, O_DIRECTORY);
                         if (dfd < 0) {
                                 log_error_errno(r, "Failed to reopen tree fd: %m");
                                 _exit(EXIT_FAILURE);
@@ -1942,11 +1942,11 @@ static int make_lock_dir(RuntimeScope scope) {
         if (r < 0)
                 return r;
 
-        _cleanup_close_ int pfd = open_mkdir_at(AT_FDCWD, p, O_CLOEXEC, 0755);
+        _cleanup_close_ int pfd = open_mkdir_at(AT_FDCWD, p, /* flags= */ 0, 0755);
         if (pfd < 0)
                 return pfd;
 
-        _cleanup_close_ int nfd = open_mkdir_at(pfd, "nspawn", O_CLOEXEC, 0755);
+        _cleanup_close_ int nfd = open_mkdir_at(pfd, "nspawn", /* flags= */ 0, 0755);
         if (nfd < 0)
                 return nfd;
 

--- a/src/shared/discover-image.c
+++ b/src/shared/discover-image.c
@@ -381,9 +381,9 @@ static int image_update_quota(Image *i, int fd) {
                 return -EOPNOTSUPP;
 
         if (fd < 0) {
-                fd_close = open(i->path, O_CLOEXEC|O_DIRECTORY);
+                fd_close = xopenat(AT_FDCWD, i->path, O_DIRECTORY);
                 if (fd_close < 0)
-                        return -errno;
+                        return fd_close;
                 fd = fd_close;
         } else {
                 /* Convert from O_PATH to proper fd, if needed */
@@ -437,9 +437,9 @@ static int image_make(
         _cleanup_close_ int _fd = -EBADF;
         if (fd < 0) {
                 /* If we didn't get an fd passed in, then let's pin it via O_PATH now */
-                _fd = open(path, O_PATH|O_CLOEXEC);
+                _fd = xopenat(AT_FDCWD, path, O_PATH);
                 if (_fd < 0)
-                        return -errno;
+                        return _fd;
 
                 fd = _fd;
                 st = NULL; /* refresh stat() data now that we have the inode pinned */
@@ -684,7 +684,7 @@ static int image_make(
 
                 _cleanup_close_ int block_fd = fd_reopen(fd, O_RDONLY|O_NONBLOCK|O_NOCTTY);
                 if (block_fd < 0)
-                        log_debug_errno(errno, "Failed to open block device '%s', ignoring: %m", path);
+                        log_debug_errno(block_fd, "Failed to open block device '%s', ignoring: %m", path);
                 else {
                         if (!read_only) {
                                 int state = 0;
@@ -878,9 +878,9 @@ int image_find(RuntimeScope scope,
 
         _cleanup_close_ int rfd = XAT_FDROOT; /* We only expect absolute paths */
         if (root) {
-                rfd = open(root, O_CLOEXEC|O_DIRECTORY|O_PATH);
+                rfd = xopenat(AT_FDCWD, root, O_DIRECTORY|O_PATH);
                 if (rfd < 0)
-                        return log_debug_errno(errno, "Failed to open root directory '%s': %m", root);
+                        return log_debug_errno(rfd, "Failed to open root directory '%s': %m", root);
         }
 
         _cleanup_strv_free_ char **search = NULL;
@@ -1085,9 +1085,9 @@ int image_discover(
 
         _cleanup_close_ int rfd = XAT_FDROOT;  /* We only expect absolute paths */
         if (root) {
-                rfd = open(root, O_CLOEXEC|O_DIRECTORY|O_PATH);
+                rfd = xopenat(AT_FDCWD, root, O_DIRECTORY|O_PATH);
                 if (rfd < 0)
-                        return log_debug_errno(errno, "Failed to open root directory '%s': %m", root);
+                        return log_debug_errno(rfd, "Failed to open root directory '%s': %m", root);
         }
 
         _cleanup_strv_free_ char **search = NULL;
@@ -1340,7 +1340,7 @@ static int unpriv_remove_cb(
 
                         _cleanup_close_ int dfd = fd_reopen(tree_fd, O_DIRECTORY);
                         if (dfd < 0) {
-                                log_error_errno(r, "Failed to reopen tree fd: %m");
+                                log_error_errno(dfd, "Failed to reopen tree fd: %m");
                                 _exit(EXIT_FAILURE);
                         }
 
@@ -1912,9 +1912,9 @@ int image_read_only(Image *i, bool b, RuntimeScope scope) {
                 _cleanup_close_ int fd = -EBADF;
                 int state = b;
 
-                fd = open(i->path, O_CLOEXEC|O_RDONLY|O_NONBLOCK|O_NOCTTY);
+                fd = xopenat(AT_FDCWD, i->path, O_RDONLY|O_NONBLOCK|O_NOCTTY);
                 if (fd < 0)
-                        return -errno;
+                        return fd;
 
                 r = fd_verify_block(fd);
                 if (r < 0)
@@ -2137,9 +2137,9 @@ int image_get_pool_usage(RuntimeScope scope, ImageClass class, uint64_t *ret) {
         if (r < 0)
                 return r;
 
-        _cleanup_close_ int fd = open(pool, O_RDONLY|O_CLOEXEC|O_DIRECTORY);
+        _cleanup_close_ int fd = xopenat(AT_FDCWD, pool, O_RDONLY|O_DIRECTORY);
         if (fd < 0)
-                return -errno;
+                return fd;
 
         BtrfsQuotaInfo q;
         r = btrfs_subvol_get_subtree_quota_fd(fd, /* subvol_id= */ 0, &q);
@@ -2162,9 +2162,9 @@ int image_get_pool_limit(RuntimeScope scope, ImageClass class, uint64_t *ret) {
         if (r < 0)
                 return r;
 
-        _cleanup_close_ int fd = open(pool, O_RDONLY|O_CLOEXEC|O_DIRECTORY);
+        _cleanup_close_ int fd = xopenat(AT_FDCWD, pool, O_RDONLY|O_DIRECTORY);
         if (fd < 0)
-                return -errno;
+                return fd;
 
         BtrfsQuotaInfo q;
         r = btrfs_subvol_get_subtree_quota_fd(fd, /* subvol_id= */ 0, &q);

--- a/src/shared/dissect-image.c
+++ b/src/shared/dissect-image.c
@@ -4399,7 +4399,7 @@ int dissected_image_acquire_metadata(
 
                         default:
                                 NULSTR_FOREACH(p, paths[k]) {
-                                        fd = chase_and_open(p, t, CHASE_PREFIX_ROOT, O_RDONLY|O_CLOEXEC|O_NOCTTY, NULL);
+                                        fd = chase_and_open(p, t, CHASE_PREFIX_ROOT, O_RDONLY|O_NOCTTY, /* ret_path= */ NULL);
                                         if (fd >= 0)
                                                 break;
                                 }
@@ -5234,7 +5234,7 @@ int mountfsd_mount_image_fd(
 
         _cleanup_close_ int reopened_fd = -EBADF;
 
-        image_fd = fd_reopen_condition(image_fd, O_CLOEXEC|O_NOCTTY|O_NONBLOCK|(FLAGS_SET(flags, DISSECT_IMAGE_MOUNT_READ_ONLY) ? O_RDONLY : O_RDWR), O_PATH, &reopened_fd);
+        image_fd = fd_reopen_condition(image_fd, O_NOCTTY|O_NONBLOCK|(FLAGS_SET(flags, DISSECT_IMAGE_MOUNT_READ_ONLY) ? O_RDONLY : O_RDWR), O_PATH, &reopened_fd);
         if (image_fd < 0)
                 return log_debug_errno(image_fd, "Failed to reopen fd: %m");
 
@@ -5693,7 +5693,7 @@ int remove_tree_foreign(const char *path, int userns_fd) {
                         _exit(EXIT_FAILURE);
                 }
 
-                _cleanup_close_ int dfd = fd_reopen(tree_fd, O_DIRECTORY|O_CLOEXEC);
+                _cleanup_close_ int dfd = fd_reopen(tree_fd, O_DIRECTORY);
                 if (dfd < 0) {
                         log_debug_errno(r, "Failed to reopen tree fd: %m");
                         _exit(EXIT_FAILURE);

--- a/src/shared/dissect-image.c
+++ b/src/shared/dissect-image.c
@@ -34,6 +34,7 @@
 #include "fd-util.h"
 #include "fileio.h"
 #include "format-util.h"
+#include "fs-util.h"
 #include "fsck-util.h"
 #include "fstab-util.h"
 #include "gpt.h"
@@ -238,9 +239,9 @@ int probe_filesystem_full(
                 return r;
 
         if (fd < 0) {
-                fd_close = open(path, O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_NOCTTY);
+                fd_close = xopenat(AT_FDCWD, path, O_RDONLY|O_NONBLOCK|O_NOCTTY);
                 if (fd_close < 0)
-                        return -errno;
+                        return fd_close;
 
                 fd = fd_close;
         }
@@ -909,9 +910,9 @@ static int open_partition(
         assert(node);
         assert(loop || !is_partition);
 
-        fd = open(node, O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_NOCTTY);
+        fd = xopenat(AT_FDCWD, node, O_RDONLY|O_NONBLOCK|O_NOCTTY);
         if (fd < 0)
-                return -errno;
+                return fd;
 
         if (!loop)
                 return TAKE_FD(fd);
@@ -2053,9 +2054,9 @@ int dissect_image_file(
 
         assert(path);
 
-        fd = open(path, O_RDONLY|O_CLOEXEC|O_NONBLOCK|O_NOCTTY);
+        fd = xopenat(AT_FDCWD, path, O_RDONLY|O_NONBLOCK|O_NOCTTY);
         if (fd < 0)
-                return -errno;
+                return fd;
 
         if (fstat(fd, &st) < 0)
                 return -errno;
@@ -2285,9 +2286,9 @@ static int fs_grow(const char *node_path, int mount_fd, const char *mount_path) 
         assert(node_path);
         assert(mount_fd >= 0 || mount_path);
 
-        node_fd = open(node_path, O_RDONLY|O_CLOEXEC|O_NONBLOCK|O_NOCTTY);
+        node_fd = xopenat(AT_FDCWD, node_path, O_RDONLY|O_NONBLOCK|O_NOCTTY);
         if (node_fd < 0)
-                return log_debug_errno(errno, "Failed to open node device %s: %m", node_path);
+                return log_debug_errno(node_fd, "Failed to open node device %s: %m", node_path);
 
         r = blockdev_get_device_size(node_fd, &size);
         if (r < 0)
@@ -2296,15 +2297,16 @@ static int fs_grow(const char *node_path, int mount_fd, const char *mount_path) 
         if (mount_fd < 0) {
                 assert(mount_path);
 
-                _mount_fd = open(mount_path, O_RDONLY|O_DIRECTORY|O_CLOEXEC);
+                _mount_fd = xopenat(AT_FDCWD, mount_path, O_RDONLY|O_DIRECTORY);
                 if (_mount_fd < 0)
-                        return log_debug_errno(errno, "Failed to open mounted file system %s: %m", mount_path);
+                        return log_debug_errno(_mount_fd, "Failed to open mounted file system %s: %m", mount_path);
 
                 mount_fd = _mount_fd;
         } else {
-                mount_fd = fd_reopen_condition(mount_fd, O_RDONLY|O_DIRECTORY|O_CLOEXEC, O_RDONLY|O_DIRECTORY|O_CLOEXEC, &_mount_fd);
+                /* Only reopen O_PATH fds (e.g. from fsmount()), regular ones are fine as they are */
+                mount_fd = fd_reopen_condition(mount_fd, O_RDONLY|O_DIRECTORY, O_PATH, &_mount_fd);
                 if (mount_fd < 0)
-                        return log_debug_errno(errno, "Failed to reopen mount node: %m");
+                        return log_debug_errno(mount_fd, "Failed to reopen mount node: %m");
         }
 
         id = mount_path ?: node_path;
@@ -3042,9 +3044,9 @@ static int decrypt_partition(
                 return r == -EPERM ? -EKEYREJECTED : r;
         }
 
-        fd = open(node, O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_NOCTTY);
+        fd = xopenat(AT_FDCWD, node, O_RDONLY|O_NONBLOCK|O_NOCTTY);
         if (fd < 0)
-                return log_debug_errno(errno, "Failed to open %s: %m", node);
+                return log_debug_errno(fd, "Failed to open %s: %m", node);
 
         d->decrypted[d->n_decrypted++] = (DecryptedPartition) {
                 .name = TAKE_PTR(name),
@@ -3429,9 +3431,9 @@ static int verity_partition(
                 _cleanup_close_ int fd = -EBADF;
 
                 /* First, check if the device already exists. */
-                fd = open(node, O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_NOCTTY);
-                if (fd < 0 && !ERRNO_IS_DEVICE_ABSENT(errno))
-                        return log_debug_errno(errno, "Failed to open verity device %s: %m", node);
+                fd = xopenat(AT_FDCWD, node, O_RDONLY|O_NONBLOCK|O_NOCTTY);
+                if (fd < 0 && !ERRNO_IS_DEVICE_ABSENT(fd))
+                        return log_debug_errno(fd, "Failed to open verity device %s: %m", node);
                 if (fd >= 0)
                         goto check; /* The device already exists. Let's check it. */
 
@@ -3496,10 +3498,10 @@ static int verity_partition(
         try_open:
                 if (fd < 0) {
                         /* Now, the device is activated and devlink is created. Let's open it. */
-                        fd = open(node, O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_NOCTTY);
+                        fd = xopenat(AT_FDCWD, node, O_RDONLY|O_NONBLOCK|O_NOCTTY);
                         if (fd < 0) {
-                                if (!ERRNO_IS_DEVICE_ABSENT(errno))
-                                        return log_debug_errno(errno, "Failed to open verity device %s: %m", node);
+                                if (!ERRNO_IS_DEVICE_ABSENT(fd))
+                                        return log_debug_errno(fd, "Failed to open verity device %s: %m", node);
 
                                 /* The device has already been removed?? */
                                 goto try_again;
@@ -4859,9 +4861,9 @@ int mount_image_privately_interactively(
         if (ret_dir_fd) {
                 _cleanup_close_ int dir_fd = -EBADF;
 
-                dir_fd = open("/run/systemd/mount-rootfs", O_CLOEXEC|O_DIRECTORY);
+                dir_fd = xopenat(AT_FDCWD, "/run/systemd/mount-rootfs", O_DIRECTORY);
                 if (dir_fd < 0)
-                        return log_error_errno(errno, "Failed to open mount point directory: %m");
+                        return log_error_errno(dir_fd, "Failed to open mount point directory: %m");
 
                 *ret_dir_fd = TAKE_FD(dir_fd);
         }
@@ -5255,9 +5257,9 @@ int mountfsd_mount_image_fd(
         }
 
         if (verity && verity->data_path) {
-                verity_data_fd = open(verity->data_path, O_RDONLY|O_CLOEXEC);
+                verity_data_fd = xopenat(AT_FDCWD, verity->data_path, O_RDONLY);
                 if (verity_data_fd < 0)
-                        return log_debug_errno(errno, "Failed to open verity data file '%s': %m", verity->data_path);
+                        return log_debug_errno(verity_data_fd, "Failed to open verity data file '%s': %m", verity->data_path);
 
                 r = sd_varlink_push_dup_fd(vl, verity_data_fd);
                 if (r < 0)
@@ -5417,9 +5419,9 @@ int mountfsd_mount_image(
         assert(path);
         assert(ret);
 
-        _cleanup_close_ int image_fd = open(path, O_RDONLY|O_CLOEXEC);
+        _cleanup_close_ int image_fd = xopenat(AT_FDCWD, path, O_RDONLY);
         if (image_fd < 0)
-                return log_debug_errno(errno, "Failed to open '%s': %m", path);
+                return log_debug_errno(image_fd, "Failed to open '%s': %m", path);
 
         _cleanup_(dissected_image_unrefp) DissectedImage *di = NULL;
         r = mountfsd_mount_image_fd(vl, image_fd, userns_fd, options, image_policy, verity, flags, &di);
@@ -5514,9 +5516,9 @@ int mountfsd_mount_directory(
         assert(path);
         assert(ret_mount_fd);
 
-        _cleanup_close_ int directory_fd = open(path, O_DIRECTORY|O_RDONLY|O_CLOEXEC|O_PATH);
+        _cleanup_close_ int directory_fd = xopenat(AT_FDCWD, path, O_DIRECTORY|O_RDONLY|O_PATH);
         if (directory_fd < 0)
-                return log_debug_errno(errno, "Failed to open '%s': %m", path);
+                return log_debug_errno(directory_fd, "Failed to open '%s': %m", path);
 
         return mountfsd_mount_directory_fd(vl, directory_fd, userns_fd, flags, ret_mount_fd);
 }
@@ -5599,9 +5601,9 @@ int mountfsd_make_directory(
         if (r < 0)
                 return log_debug_errno(r, "Failed to extract directory name from '%s': %m", path);
 
-        _cleanup_close_ int fd = open(parent, O_DIRECTORY|O_CLOEXEC);
+        _cleanup_close_ int fd = xopenat(AT_FDCWD, parent, O_DIRECTORY);
         if (fd < 0)
-                return log_debug_errno(errno, "Failed to open '%s': %m", parent);
+                return log_debug_errno(fd, "Failed to open '%s': %m", parent);
 
         return mountfsd_make_directory_fd(vl, fd, dirname, mode, flags, ret_directory_fd);
 }

--- a/src/shared/dm-util.c
+++ b/src/shared/dm-util.c
@@ -6,6 +6,7 @@
 
 #include "dm-util.h"
 #include "fd-util.h"
+#include "fs-util.h"
 #include "string-util.h"
 
 int dm_deferred_remove_cancel(const char *name) {
@@ -42,9 +43,9 @@ int dm_deferred_remove_cancel(const char *name) {
         strncpy_exact(message.combined.dm_ioctl.name, name, sizeof(message.combined.dm_ioctl.name));
         strncpy_exact(message.text, "@cancel_deferred_remove", sizeof(message.text));
 
-        fd = open("/dev/mapper/control", O_RDWR|O_CLOEXEC);
+        fd = xopenat(AT_FDCWD, "/dev/mapper/control", O_RDWR);
         if (fd < 0)
-                return -errno;
+                return fd;
 
         if (ioctl(fd, DM_TARGET_MSG, &message))
                 return -errno;

--- a/src/shared/edit-util.c
+++ b/src/shared/edit-util.c
@@ -455,9 +455,9 @@ static int edit_file_install_one_stdin(EditFile *e, const char *contents, size_t
         if (r < 0)
                 return r;
 
-        _cleanup_close_ int tfd = open(e->temp, O_PATH|O_CLOEXEC);
+        _cleanup_close_ int tfd = xopenat(AT_FDCWD, e->temp, O_PATH);
         if (tfd < 0)
-                return log_error_errno(errno, "Failed to pin temporary file '%s': %m", e->temp);
+                return log_error_errno(tfd, "Failed to pin temporary file '%s': %m", e->temp);
 
         r = edit_file_install_one(e);
         if (r <= 0)

--- a/src/shared/fdisk-util.c
+++ b/src/shared/fdisk-util.c
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
 #include "fdisk-util.h"
+#include "fs-util.h"
 #include "log.h"
 
 #if HAVE_LIBFDISK
@@ -170,9 +171,9 @@ int fdisk_new_context_at(
         assert(ret);
 
         if (!isempty(path)) {
-                fd = openat(dir_fd, path, (read_only ? O_RDONLY : O_RDWR)|O_CLOEXEC);
+                fd = xopenat(dir_fd, path, (read_only ? O_RDONLY : O_RDWR));
                 if (fd < 0)
-                        return -errno;
+                        return fd;
 
                 dir_fd = fd;
         }

--- a/src/shared/find-esp.c
+++ b/src/shared/find-esp.c
@@ -19,6 +19,7 @@
 #include "errno-util.h"
 #include "fd-util.h"
 #include "find-esp.h"
+#include "fs-util.h"
 #include "parse-util.h"
 #include "path-util.h"
 #include "stat-util.h"
@@ -515,9 +516,9 @@ int find_esp_and_warn_full(
         if (empty_or_root(root))
                 rfd = XAT_FDROOT;
         else {
-                rfd = open(root, O_PATH|O_DIRECTORY|O_CLOEXEC);
+                rfd = xopenat(AT_FDCWD, root, O_PATH|O_DIRECTORY);
                 if (rfd < 0)
-                        return -errno;
+                        return rfd;
         }
 
         _cleanup_close_ int fd = -EBADF;
@@ -869,9 +870,9 @@ int find_xbootldr_and_warn_full(
         if (empty_or_root(root))
                 rfd = XAT_FDROOT;
         else {
-                rfd = open(root, O_PATH|O_DIRECTORY|O_CLOEXEC);
+                rfd = xopenat(AT_FDCWD, root, O_PATH|O_DIRECTORY);
                 if (rfd < 0)
-                        return -errno;
+                        return rfd;
         }
 
         _cleanup_close_ int fd = -EBADF;

--- a/src/shared/hibernate-util.c
+++ b/src/shared/hibernate-util.c
@@ -16,6 +16,7 @@
 #include "env-util.h"
 #include "fd-util.h"
 #include "fileio.h"
+#include "fs-util.h"
 #include "hibernate-util.h"
 #include "log.h"
 #include "parse-util.h"
@@ -203,9 +204,9 @@ static int swap_entry_get_resume_config(SwapEntry *swap) {
         assert(swap);
         assert(swap->path);
 
-        fd = open(swap->path, O_RDONLY|O_CLOEXEC|O_NONBLOCK|O_NOCTTY);
+        fd = xopenat(AT_FDCWD, swap->path, O_RDONLY|O_NONBLOCK|O_NOCTTY);
         if (fd < 0)
-                return -errno;
+                return fd;
 
         if (fstat(fd, &st) < 0)
                 return -errno;

--- a/src/shared/hwdb-util.c
+++ b/src/shared/hwdb-util.c
@@ -373,7 +373,7 @@ static int trie_store(struct trie *trie, const char *filename, bool compat) {
         /* calculate size of header, nodes, children entries, value entries */
         trie_store_nodes_size(&t, trie->root, compat);
 
-        r = fopen_tmpfile_linkable(filename, O_WRONLY|O_CLOEXEC, &filename_tmp, &f);
+        r = fopen_tmpfile_linkable(filename, O_WRONLY, &filename_tmp, &f);
         if (r < 0)
                 return r;
 

--- a/src/shared/initrd-cpio.c
+++ b/src/shared/initrd-cpio.c
@@ -172,9 +172,9 @@ int initrd_cpio_credentials_to_tempfile(
         if (r < 0)
                 return log_error_errno(r, "Failed to generate temp file name: %m");
 
-        fd = open(path, O_WRONLY|O_CREAT|O_EXCL|O_CLOEXEC, 0600);
+        fd = xopenat_full(AT_FDCWD, path, O_WRONLY|O_CREAT|O_EXCL, /* xopen_flags= */ 0, 0600);
         if (fd < 0)
-                return log_error_errno(errno, "Failed to create temp file %s: %m", path);
+                return log_error_errno(fd, "Failed to create temp file %s: %m", path);
 
         r = loop_write(fd, buf, buf_size);
         if (r < 0)

--- a/src/shared/install-file.c
+++ b/src/shared/install-file.c
@@ -131,9 +131,9 @@ int install_file(int source_atfd, const char *source_name,
 
                 /* Open an O_PATH fd for the source if we need to sync things or mark things read only. */
 
-                pfd = openat(source_atfd, source_name, O_PATH|O_CLOEXEC|O_NOFOLLOW);
+                pfd = xopenat(source_atfd, source_name, O_PATH|O_NOFOLLOW);
                 if (pfd < 0)
-                        return -errno;
+                        return pfd;
 
                 if (fstat(pfd, &st) < 0)
                         return -errno;
@@ -241,9 +241,9 @@ int install_file(int source_atfd, const char *source_name,
                                  * before the rename()? Mostly because if we have trouble opening the thing
                                  * we want to know before we start actually modifying the file system. */
 
-                                dfd = openat(target_atfd, target_name, O_RDONLY|O_DIRECTORY|O_CLOEXEC, 0);
-                                if (dfd < 0 && errno != ENOTDIR)
-                                        return -errno;
+                                dfd = xopenat(target_atfd, target_name, O_RDONLY|O_DIRECTORY);
+                                if (dfd < 0 && dfd != -ENOTDIR)
+                                        return dfd;
 
                                 if (renameat2(source_atfd, source_name, target_atfd, target_name, RENAME_EXCHANGE) < 0) {
 

--- a/src/shared/install-file.c
+++ b/src/shared/install-file.c
@@ -143,7 +143,7 @@ int install_file(int source_atfd, const char *source_name,
                 case S_IFREG: {
                         _cleanup_close_ int regfd = -EBADF;
 
-                        regfd = fd_reopen(pfd, O_RDONLY|O_CLOEXEC);
+                        regfd = fd_reopen(pfd, O_RDONLY);
                         if (regfd < 0) {
                                 if (!FLAGS_SET(flags, INSTALL_GRACEFUL))
                                         return log_debug_errno(regfd, "Failed to open referenced inode: %m");
@@ -176,7 +176,7 @@ int install_file(int source_atfd, const char *source_name,
                 case S_IFDIR: {
                         _cleanup_close_ int dfd = -EBADF;
 
-                        dfd = fd_reopen(pfd, O_RDONLY|O_DIRECTORY|O_CLOEXEC);
+                        dfd = fd_reopen(pfd, O_RDONLY|O_DIRECTORY);
                         if (dfd < 0) {
                                 if (!FLAGS_SET(flags, INSTALL_GRACEFUL))
                                         return log_debug_errno(dfd, "Failed to open referenced inode: %m");

--- a/src/shared/install.c
+++ b/src/shared/install.c
@@ -1444,7 +1444,7 @@ static int unit_file_load(
                 if (!(flags & SEARCH_LOAD))
                         return 0;
 
-                fd = chase_and_open(path, root_dir, 0, O_RDONLY|O_CLOEXEC|O_NOCTTY, NULL);
+                fd = chase_and_open(path, root_dir, /* chase_flags= */ 0, O_RDONLY|O_NOCTTY, /* ret_path= */ NULL);
                 if (fd < 0)
                         return fd;
         }

--- a/src/shared/install.c
+++ b/src/shared/install.c
@@ -698,7 +698,7 @@ static int remove_marked_symlinks_fd(
                         _cleanup_close_ int nfd = -EBADF;
                         _cleanup_free_ char *p = NULL;
 
-                        nfd = RET_NERRNO(openat(fd, de->d_name, O_DIRECTORY|O_CLOEXEC|O_NOFOLLOW));
+                        nfd = xopenat(fd, de->d_name, O_DIRECTORY|O_NOFOLLOW);
                         if (nfd < 0) {
                                 if (nfd != -ENOENT)
                                         RET_GATHER(ret, nfd);
@@ -813,9 +813,9 @@ static int remove_marked_symlinks(
         if (set_isempty(remove_symlinks_to))
                 return 0;
 
-        fd = open(config_path, O_RDONLY|O_NONBLOCK|O_DIRECTORY|O_CLOEXEC);
+        fd = xopenat(AT_FDCWD, config_path, O_RDONLY|O_NONBLOCK|O_DIRECTORY);
         if (fd < 0)
-                return errno == ENOENT ? 0 : -errno;
+                return fd == -ENOENT ? 0 : fd;
 
         do {
                 int cfd;
@@ -1435,9 +1435,9 @@ static int unit_file_load(
                         return 0;
                 }
 
-                fd = open(path, O_RDONLY|O_CLOEXEC|O_NOCTTY|O_NOFOLLOW);
+                fd = xopenat(AT_FDCWD, path, O_RDONLY|O_NOCTTY|O_NOFOLLOW);
                 if (fd < 0)
-                        return -errno;
+                        return fd;
         } else {
                 /* Operating on a drop-in file. If we aren't supposed to load the unit file drop-ins don't matter, let's hence shortcut this. */
 

--- a/src/shared/journal-authenticate.c
+++ b/src/shared/journal-authenticate.c
@@ -7,6 +7,7 @@
 #include "alloc-util.h"
 #include "crypto-util.h"
 #include "fd-util.h"
+#include "fs-util.h"
 #include "fsprg-openssl.h"
 #include "hexdecoct.h"
 #include "iovec-util.h"
@@ -88,12 +89,12 @@ static int journal_auth_load(JournalAuthContext **ret) {
                      SD_ID128_FORMAT_VAL(machine)) < 0)
                 return -ENOMEM;
 
-        _cleanup_close_ int fd = open(path, O_RDWR|O_CLOEXEC|O_NOCTTY, 0600);
+        _cleanup_close_ int fd = xopenat(AT_FDCWD, path, O_RDWR|O_NOCTTY);
         if (fd < 0) {
-                if (errno != ENOENT)
-                        log_error_errno(errno, "Failed to open %s: %m", path);
+                if (fd != -ENOENT)
+                        log_error_errno(fd, "Failed to open %s: %m", path);
 
-                return -errno;
+                return fd;
         }
 
         struct stat st;

--- a/src/shared/kernel-image.c
+++ b/src/shared/kernel-image.c
@@ -132,7 +132,7 @@ int inspect_kernel_full(
 
         assert(wildcard_fd_is_valid(dir_fd));
 
-        fd = xopenat(dir_fd, filename, O_RDONLY|O_CLOEXEC);
+        fd = xopenat(dir_fd, filename, O_RDONLY);
         if (fd < 0)
                 return log_debug_errno(fd, "Failed to open kernel image file '%s': %m", strna(filename));
 

--- a/src/shared/locale-setup.c
+++ b/src/shared/locale-setup.c
@@ -8,8 +8,8 @@
 #include "efivars.h"
 #include "env-file.h"
 #include "env-util.h"
-#include "errno-util.h"
 #include "fd-util.h"
+#include "fs-util.h"
 #include "iovec-util.h"
 #include "locale-setup.h"
 #include "log.h"
@@ -69,11 +69,11 @@ static int locale_context_load_conf(LocaleContext *c, LocaleLoadFlag flag) {
         if (!FLAGS_SET(flag, LOCALE_LOAD_LOCALE_CONF))
                 return 0;
 
-        fd = RET_NERRNO(open(etc_locale_conf(), O_CLOEXEC | O_PATH));
+        fd = xopenat(AT_FDCWD, etc_locale_conf(), O_PATH);
         if (fd == -ENOENT)
                 return 0;
         if (fd < 0)
-                return log_debug_errno(errno, "Failed to open %s: %m", "/etc/locale.conf");
+                return log_debug_errno(fd, "Failed to open %s: %m", "/etc/locale.conf");
 
         if (fstat(fd, &st) < 0)
                 return log_debug_errno(errno, "Failed to stat /etc/locale.conf: %m");

--- a/src/shared/loop-util.c
+++ b/src/shared/loop-util.c
@@ -62,7 +62,7 @@ static int open_lock_fd(int primary_fd, int operation) {
 
         assert(IN_SET(operation & ~LOCK_NB, LOCK_SH, LOCK_EX));
 
-        lock_fd = fd_reopen(ASSERT_FD(primary_fd), O_RDONLY|O_CLOEXEC|O_NONBLOCK|O_NOCTTY);
+        lock_fd = fd_reopen(ASSERT_FD(primary_fd), O_RDONLY|O_NONBLOCK|O_NOCTTY);
         if (lock_fd < 0)
                 return lock_fd;
 
@@ -436,7 +436,7 @@ static int probe_fd_open(int fd, int f_flags, int *ret_to_close) {
                 return fd;
         }
 
-        r = fd_reopen(fd, O_RDONLY|O_CLOEXEC|O_NONBLOCK);
+        r = fd_reopen(fd, O_RDONLY|O_NONBLOCK);
         if (r < 0)
                 return r;
 
@@ -630,7 +630,7 @@ static int loop_device_make_internal(
                  * Our intention here is that LO_FLAGS_DIRECT_IO is the primary knob, and O_DIRECT derived
                  * from that automatically. */
 
-                reopened_fd = fd_reopen(fd, (FLAGS_SET(loop_flags, LO_FLAGS_DIRECT_IO) ? O_DIRECT : 0)|O_CLOEXEC|O_NONBLOCK|open_flags);
+                reopened_fd = fd_reopen(fd, (FLAGS_SET(loop_flags, LO_FLAGS_DIRECT_IO) ? O_DIRECT : 0)|O_NONBLOCK|open_flags);
                 if (reopened_fd < 0) {
                         if (!FLAGS_SET(loop_flags, LO_FLAGS_DIRECT_IO))
                                 return log_debug_errno(reopened_fd, "Failed to reopen file descriptor without O_DIRECT: %m");
@@ -723,7 +723,7 @@ static int loop_device_make_internal(
                         config.info.lo_flags &= ~LO_FLAGS_DIRECT_IO;
                         open_flags &= ~O_DIRECT;
 
-                        int non_direct_io_fd = fd_reopen(config.fd, O_CLOEXEC|O_NONBLOCK|open_flags);
+                        int non_direct_io_fd = fd_reopen(config.fd, O_NONBLOCK|open_flags);
                         if (non_direct_io_fd < 0)
                                 return log_debug_errno(
                                                 non_direct_io_fd,
@@ -761,7 +761,7 @@ static int loop_device_make_internal(
         if (deferred_partscan) {
                 /* Open+close to drain GD_NEED_PART_SCAN harmlessly (GD_SUPPRESS_PART_SCAN is still
                  * set so no partitions appear). Then enable partscan via LOOP_SET_STATUS64. */
-                int tmp_fd = fd_reopen(d->fd, O_RDONLY|O_CLOEXEC|O_NONBLOCK);
+                int tmp_fd = fd_reopen(d->fd, O_RDONLY|O_NONBLOCK);
                 if (tmp_fd < 0)
                         return log_debug_errno(tmp_fd, "Failed to reopen loop device to drain partscan flag: %m");
                 safe_close(tmp_fd);
@@ -931,7 +931,7 @@ int loop_device_make_by_path_memory(
         if (r < 0)
                 return r;
 
-        mfd = memfd_clone_fd(fd, fn, open_flags|O_CLOEXEC);
+        mfd = memfd_clone_fd(fd, fn, open_flags);
         if (mfd < 0)
                 return mfd;
 

--- a/src/shared/loop-util.c
+++ b/src/shared/loop-util.c
@@ -642,9 +642,9 @@ static int loop_device_make_internal(
                         fd = reopened_fd; /* From now on, operate on our new O_DIRECT fd */
         }
 
-        control = open("/dev/loop-control", O_RDWR|O_CLOEXEC|O_NOCTTY|O_NONBLOCK);
+        control = xopenat(AT_FDCWD, "/dev/loop-control", O_RDWR|O_NOCTTY|O_NONBLOCK);
         if (control < 0)
-                return -errno;
+                return control;
 
         /* Strip LO_FLAGS_PARTSCAN from LOOP_CONFIGURE and enable it afterwards via
          * LOOP_SET_STATUS64 to work around a kernel race: LOOP_CONFIGURE sends a uevent with
@@ -919,9 +919,9 @@ int loop_device_make_by_path_memory(
 
         loop_flags &= ~LO_FLAGS_DIRECT_IO; /* memfds don't support O_DIRECT, hence LO_FLAGS_DIRECT_IO can't be used either */
 
-        fd = open(path, O_CLOEXEC|O_NONBLOCK|O_NOCTTY|O_RDONLY);
+        fd = xopenat(AT_FDCWD, path, O_NONBLOCK|O_NOCTTY|O_RDONLY);
         if (fd < 0)
-                return -errno;
+                return fd;
 
         r = fd_verify_regular_or_block(fd);
         if (r < 0)
@@ -958,9 +958,9 @@ static LoopDevice* loop_device_free(LoopDevice *d) {
          * delete it in a synchronized fashion, and allocators won't needlessly see the block device as free
          * while we are about to delete it. */
         if (!LOOP_DEVICE_IS_FOREIGN(d) && !d->relinquished) {
-                control = open("/dev/loop-control", O_RDWR|O_CLOEXEC|O_NOCTTY|O_NONBLOCK);
+                control = xopenat(AT_FDCWD, "/dev/loop-control", O_RDWR|O_NOCTTY|O_NONBLOCK);
                 if (control < 0)
-                        log_debug_errno(errno, "Failed to open loop control device, cannot remove loop device '%s', ignoring: %m", strna(d->node));
+                        log_debug_errno(control, "Failed to open loop control device, cannot remove loop device '%s', ignoring: %m", strna(d->node));
                 else if (flock(control, LOCK_EX) < 0)
                         log_debug_errno(errno, "Failed to lock loop control device, ignoring: %m");
         }

--- a/src/shared/luo-util.c
+++ b/src/shared/luo-util.c
@@ -12,6 +12,7 @@
 #include "alloc-util.h"
 #include "errno-util.h"
 #include "fd-util.h"
+#include "fs-util.h"
 #include "json-util.h"
 #include "log.h"
 #include "luo-util.h"
@@ -28,7 +29,7 @@
  * caller is responsible for coming up with the token and tracking them. */
 
 int luo_open_device(void) {
-        return RET_NERRNO(open("/dev/liveupdate", O_RDWR|O_CLOEXEC));
+        return xopenat(AT_FDCWD, "/dev/liveupdate", O_RDWR);
 }
 
 int luo_create_session(int device_fd, const char *name) {

--- a/src/shared/machine-id-setup.c
+++ b/src/shared/machine-id-setup.c
@@ -73,7 +73,7 @@ static int acquire_machine_id(const char *root, bool machine_id_from_firmware, s
         }
 
         /* Then, try reading the D-Bus machine ID, unless it is a symlink */
-        fd = chase_and_open("/var/lib/dbus/machine-id", root, CHASE_PREFIX_ROOT|CHASE_NOFOLLOW|CHASE_MUST_BE_REGULAR, O_RDONLY|O_CLOEXEC|O_NOCTTY, NULL);
+        fd = chase_and_open("/var/lib/dbus/machine-id", root, CHASE_PREFIX_ROOT|CHASE_NOFOLLOW|CHASE_MUST_BE_REGULAR, O_RDONLY|O_NOCTTY, /* ret_path= */ NULL);
         if (fd >= 0 && id128_read_fd(fd, ID128_FORMAT_PLAIN | ID128_REFUSE_NULL, ret) >= 0) {
                 log_info("Initializing machine ID from D-Bus machine ID.");
                 return 0;
@@ -178,12 +178,12 @@ int machine_id_setup(const char *root, sd_id128_t machine_id, MachineIdSetupFlag
                 else {
                         /* We pinned the inode, now try to convert it into a writable file */
 
-                        fd = xopenat_full(inode_fd, /* path= */ NULL, O_RDWR|O_CLOEXEC, XO_REGULAR, 0444);
+                        fd = xopenat_full(inode_fd, /* path= */ NULL, O_RDWR, XO_REGULAR, 0444);
                         if (fd < 0) {
                                 log_debug_errno(fd, "Failed to open '%s' in writable mode, retrying in read-only mode: %m", etc_machine_id);
 
                                 /* If that didn't work, convert it into a readable file */
-                                fd = xopenat_full(inode_fd, /* path= */ NULL, O_RDONLY|O_CLOEXEC, XO_REGULAR, MODE_INVALID);
+                                fd = xopenat_full(inode_fd, /* path= */ NULL, O_RDONLY, XO_REGULAR, MODE_INVALID);
                                 if (fd < 0)
                                         return log_error_errno(fd, "Cannot open '%s' in neither writable nor read-only mode: %m", etc_machine_id);
 
@@ -359,7 +359,7 @@ int machine_id_commit(const char *root) {
         /* Read existing machine-id */
 
         _cleanup_close_ int fd = xopenat_full(etc_machine_id_fd, /* path= */ NULL,
-                                              O_RDONLY|O_CLOEXEC|O_NOCTTY, XO_REGULAR, MODE_INVALID);
+                                              O_RDONLY|O_NOCTTY, XO_REGULAR, MODE_INVALID);
         if (fd < 0)
                 return log_error_errno(fd, "Cannot open %s: %m", etc_machine_id);
 

--- a/src/shared/machine-id-setup.c
+++ b/src/shared/machine-id-setup.c
@@ -178,12 +178,12 @@ int machine_id_setup(const char *root, sd_id128_t machine_id, MachineIdSetupFlag
                 else {
                         /* We pinned the inode, now try to convert it into a writable file */
 
-                        fd = xopenat_full(inode_fd, /* path= */ NULL, O_RDWR, XO_REGULAR, 0444);
+                        fd = xopenat_full(inode_fd, /* path= */ NULL, O_RDWR, XO_REGULAR|XO_EMPTY_PATH, MODE_INVALID);
                         if (fd < 0) {
                                 log_debug_errno(fd, "Failed to open '%s' in writable mode, retrying in read-only mode: %m", etc_machine_id);
 
                                 /* If that didn't work, convert it into a readable file */
-                                fd = xopenat_full(inode_fd, /* path= */ NULL, O_RDONLY, XO_REGULAR, MODE_INVALID);
+                                fd = xopenat_full(inode_fd, /* path= */ NULL, O_RDONLY, XO_REGULAR|XO_EMPTY_PATH, MODE_INVALID);
                                 if (fd < 0)
                                         return log_error_errno(fd, "Cannot open '%s' in neither writable nor read-only mode: %m", etc_machine_id);
 
@@ -359,7 +359,7 @@ int machine_id_commit(const char *root) {
         /* Read existing machine-id */
 
         _cleanup_close_ int fd = xopenat_full(etc_machine_id_fd, /* path= */ NULL,
-                                              O_RDONLY|O_NOCTTY, XO_REGULAR, MODE_INVALID);
+                                              O_RDONLY|O_NOCTTY, XO_REGULAR|XO_EMPTY_PATH, MODE_INVALID);
         if (fd < 0)
                 return log_error_errno(fd, "Cannot open %s: %m", etc_machine_id);
 

--- a/src/shared/machine-id-setup.c
+++ b/src/shared/machine-id-setup.c
@@ -156,10 +156,10 @@ int machine_id_setup(const char *root, sd_id128_t machine_id, MachineIdSetupFlag
                          * modify. Of course, since the file will be owned by root it doesn't matter much, but maybe
                          * people look. */
 
-                        fd = openat(etc_fd, "machine-id", O_CREAT|O_EXCL|O_RDWR|O_NOFOLLOW|O_CLOEXEC, 0444);
+                        fd = xopenat_full(etc_fd, "machine-id", O_CREAT|O_EXCL|O_RDWR|O_NOFOLLOW, /* xopen_flags= */ 0, 0444);
                         if (fd < 0) {
-                                if (errno == EROFS)
-                                        return log_error_errno(errno,
+                                if (fd == -EROFS)
+                                        return log_error_errno(fd,
                                                                "System cannot boot: Missing %s and %s/ is read-only.\n"
                                                                "Booting up is supported only when:\n"
                                                                "1) /etc/machine-id exists and is populated.\n"
@@ -168,7 +168,7 @@ int machine_id_setup(const char *root, sd_id128_t machine_id, MachineIdSetupFlag
                                                                etc_machine_id,
                                                                etc);
 
-                                return log_error_errno(errno, "Cannot create '%s': %m", etc_machine_id);
+                                return log_error_errno(fd, "Cannot create '%s': %m", etc_machine_id);
                         }
 
                         log_debug("Successfully opened new '%s' file.", etc_machine_id);

--- a/src/shared/mount-util.c
+++ b/src/shared/mount-util.c
@@ -545,9 +545,9 @@ int mount_switch_root_full(const char *path, unsigned long mount_propagation_fla
         assert(path);
         assert(mount_propagation_flag_is_valid(mount_propagation_flag));
 
-        fd_newroot = open(path, O_PATH|O_DIRECTORY|O_CLOEXEC|O_NOFOLLOW);
+        fd_newroot = xopenat(AT_FDCWD, path, O_PATH|O_DIRECTORY|O_NOFOLLOW);
         if (fd_newroot < 0)
-                return log_debug_errno(errno, "Failed to open new rootfs '%s': %m", path);
+                return log_debug_errno(fd_newroot, "Failed to open new rootfs '%s': %m", path);
 
         is_current_root = path_is_root_at(fd_newroot, NULL);
         if (is_current_root < 0)
@@ -823,9 +823,9 @@ int umountat_detach_verbose(
         if (isempty(where))
                 mnt_fd = fd;
         else {
-                inode_fd = openat(fd, where, O_PATH|O_CLOEXEC|O_NOFOLLOW);
+                inode_fd = xopenat(fd, where, O_PATH|O_NOFOLLOW);
                 if (inode_fd < 0)
-                        return log_full_errno(error_log_level, errno, "Failed to pin '%s': %m", strna(joined));
+                        return log_full_errno(error_log_level, inode_fd, "Failed to pin '%s': %m", strna(joined));
 
                 mnt_fd = inode_fd;
         }

--- a/src/shared/mount-util.c
+++ b/src/shared/mount-util.c
@@ -2248,7 +2248,7 @@ int path_is_network_fs_harder_at(int dir_fd, const char *path) {
 
         assert(dir_fd >= 0 || dir_fd == AT_FDCWD);
 
-        fd = xopenat(dir_fd, path, O_PATH | O_CLOEXEC | O_NOFOLLOW);
+        fd = xopenat(dir_fd, path, O_PATH | O_NOFOLLOW);
         if (fd < 0)
                 return fd;
 

--- a/src/shared/mstack.c
+++ b/src/shared/mstack.c
@@ -116,9 +116,9 @@ static int mstack_load_one(MStack *mstack, const char *dir, int dir_fd, const ch
         assert(dir_fd >= 0);
         assert(fname);
 
-        _cleanup_close_ int what_fd = openat(dir_fd, fname, O_PATH|O_CLOEXEC);
+        _cleanup_close_ int what_fd = xopenat(dir_fd, fname, O_PATH);
         if (what_fd < 0)
-                return log_debug_errno(errno, "Failed to open %s/%s: %m", dir, fname);
+                return log_debug_errno(what_fd, "Failed to open %s/%s: %m", dir, fname);
 
         struct stat st;
         if (fstat(what_fd, &st) < 0)
@@ -392,9 +392,9 @@ static int mstack_normalize(MStack *mstack) {
 
                         if (has_root) {
                                 /* If there's a root dir, let's only bind mount the /usr/ subdir */
-                                _cleanup_close_ int usr_fd = openat(m->what_fd, "usr", O_CLOEXEC|O_PATH|O_NOFOLLOW|O_DIRECTORY);
+                                _cleanup_close_ int usr_fd = xopenat(m->what_fd, "usr", O_PATH|O_NOFOLLOW|O_DIRECTORY);
                                 if (usr_fd < 0)
-                                        return log_debug_errno(errno, "Failed to open /usr/ subdir: %m");
+                                        return log_debug_errno(usr_fd, "Failed to open /usr/ subdir: %m");
 
                                 _cleanup_free_ char *usr = path_join(m->what, "usr");
                                 if (!usr)
@@ -454,9 +454,9 @@ static int mstack_load_now(MStack *mstack, const char *dir, int dir_fd, MStackFl
 
         /* Expects dir_fd already opened. If not, then we'll open it based on 'dir' */
         if (dir_fd < 0) {
-                _dir_fd = openat(AT_FDCWD, isempty(dir) ? "." : dir, O_DIRECTORY|O_CLOEXEC);
+                _dir_fd = xopenat(AT_FDCWD, isempty(dir) ? "." : dir, O_DIRECTORY);
                 if (_dir_fd < 0)
-                        return log_debug_errno(errno, "Failed to open '%s': %m", dir);
+                        return log_debug_errno(_dir_fd, "Failed to open '%s': %m", dir);
 
                 dir_fd = _dir_fd;
         } else {
@@ -794,24 +794,24 @@ static int mstack_make_overlayfs(
                                 report_errno_and_exit(errno_pipe_fds[1], -errno);
 
                         /* Open the layer immediately after attaching */
-                        _cleanup_close_ int temp_fd = open(temp_mount_dir, O_PATH|O_CLOEXEC);
+                        _cleanup_close_ int temp_fd = xopenat(AT_FDCWD, temp_mount_dir, O_PATH);
                         if (temp_fd < 0)
-                                report_errno_and_exit(errno_pipe_fds[1], -errno);
+                                report_errno_and_exit(errno_pipe_fds[1], temp_fd);
 
                         switch (m->mount_type) {
 
                         case MSTACK_RW: {
                                 if (mount_is_ro(m, flags)) {
                                         /* If invoked in read-only mode we'll not create the data dir, but use it if it exists */
-                                        _cleanup_close_ int data_fd = openat(temp_fd, "data", O_CLOEXEC|O_NOFOLLOW|O_DIRECTORY);
+                                        _cleanup_close_ int data_fd = xopenat(temp_fd, "data", O_NOFOLLOW|O_DIRECTORY);
                                         if (data_fd < 0) {
-                                                if (errno == ENOENT) /* If the 'data' dir doesn't exist, just skip
+                                                if (data_fd == -ENOENT) /* If the 'data' dir doesn't exist, just skip
                                                                       * over it, it apparently was never created, but
                                                                       * that's fine for a read-only invocation */
                                                         break;
 
-                                                log_debug_errno(errno, "Failed to open 'data' directory below 'rw' layer: %m");
-                                                report_errno_and_exit(errno_pipe_fds[1], -errno);
+                                                log_debug_errno(data_fd, "Failed to open 'data' directory below 'rw' layer: %m");
+                                                report_errno_and_exit(errno_pipe_fds[1], data_fd);
                                         }
 
                                         /* Downgrade to regular lowerdir if read-only is requested */
@@ -1004,9 +1004,9 @@ int mstack_bind_mounts(
 
         _cleanup_close_ int _where_fd = -EBADF;
         if (where_fd == AT_FDCWD) {
-                _where_fd = open(".", O_CLOEXEC|O_PATH|O_DIRECTORY);
+                _where_fd = fd_reopen(where_fd, O_PATH|O_DIRECTORY);
                 if (_where_fd < 0)
-                        return log_debug_errno(errno, "Failed to open current working directory: %m");
+                        return log_debug_errno(_where_fd, "Failed to open current working directory: %m");
                 where_fd = _where_fd;
         } else if (where_fd < 0) {
                 r = chase(where,
@@ -1026,9 +1026,9 @@ int mstack_bind_mounts(
 
         log_debug("Attached mstack root mount to '%s'.", where);
 
-        _cleanup_close_ int root_fd = open(where, O_CLOEXEC|O_PATH|O_DIRECTORY|O_NOFOLLOW);
+        _cleanup_close_ int root_fd = xopenat(AT_FDCWD, where, O_PATH|O_DIRECTORY|O_NOFOLLOW);
         if (root_fd < 0)
-                return log_debug_errno(errno, "Failed to mount root mount '%s': %m", where);
+                return log_debug_errno(root_fd, "Failed to mount root mount '%s': %m", where);
 
         if (mstack->usr_mount_fd >= 0) {
                 _cleanup_close_ int subdir_fd = -EBADF;

--- a/src/shared/mstack.c
+++ b/src/shared/mstack.c
@@ -461,7 +461,7 @@ static int mstack_load_now(MStack *mstack, const char *dir, int dir_fd, MStackFl
                 dir_fd = _dir_fd;
         } else {
                 /* Possibly convert an O_PATH fd to a real one */
-                dir_fd = fd_reopen_condition(dir_fd, O_DIRECTORY|O_CLOEXEC, O_PATH|O_DIRECTORY, &_dir_fd);
+                dir_fd = fd_reopen_condition(dir_fd, O_DIRECTORY, O_PATH|O_DIRECTORY, &_dir_fd);
                 if (dir_fd < 0)
                         return log_debug_errno(dir_fd, "Failed to reopen '%s': %m", dir);
         }
@@ -822,7 +822,7 @@ static int mstack_make_overlayfs(
                                         }
                                 } else {
                                         /* If invoked in writable mode, let's create the data dir if it is missing */
-                                        _cleanup_close_ int data_fd = open_mkdir_at(temp_fd, "data", O_CLOEXEC|O_NOFOLLOW, 0755);
+                                        _cleanup_close_ int data_fd = open_mkdir_at(temp_fd, "data", O_NOFOLLOW, 0755);
                                         if (data_fd < 0) {
                                                 log_debug_errno(data_fd, "Failed to open 'data' directory below 'rw' layer: %m");
                                                 report_errno_and_exit(errno_pipe_fds[1], data_fd);
@@ -835,7 +835,7 @@ static int mstack_make_overlayfs(
                                         }
 
                                         /* Similar, create the work directory */
-                                        _cleanup_close_ int work_fd = open_mkdir_at(temp_fd, "work", O_CLOEXEC|O_NOFOLLOW, 0755);
+                                        _cleanup_close_ int work_fd = open_mkdir_at(temp_fd, "work", O_NOFOLLOW, 0755);
                                         if (work_fd < 0) {
                                                 log_debug_errno(work_fd, "Failed to open 'work' directory below 'rw' layer: %m");
                                                 report_errno_and_exit(errno_pipe_fds[1], work_fd);

--- a/src/shared/pcrextend-util.c
+++ b/src/shared/pcrextend-util.c
@@ -205,7 +205,7 @@ int pcrextend_file_system_word(const char *path, char **ret_word, char **ret_nor
         assert(path);
         assert(ret_word);
 
-        dfd = chase_and_open(path, NULL, 0, O_DIRECTORY|O_CLOEXEC, &normalized_path);
+        dfd = chase_and_open(path, /* root= */ NULL, /* chase_flags= */ 0, O_DIRECTORY, &normalized_path);
         if (dfd < 0)
                 return log_error_errno(dfd, "Failed to open path '%s': %m", path);
 

--- a/src/shared/ptyfwd.c
+++ b/src/shared/ptyfwd.c
@@ -983,7 +983,7 @@ int pty_forward_new(
                  */
 
                 f->input_fd = fd_reopen_propagate_append_and_position(
-                                STDIN_FILENO, O_RDONLY|O_CLOEXEC|O_NOCTTY|O_NONBLOCK);
+                                STDIN_FILENO, O_RDONLY|O_NOCTTY|O_NONBLOCK);
                 if (f->input_fd < 0) {
                         /* Handle failures gracefully, after all certain fd types cannot be reopened
                          * (sockets, …) */
@@ -998,7 +998,7 @@ int pty_forward_new(
                         f->close_input_fd = true;
 
                 f->output_fd = fd_reopen_propagate_append_and_position(
-                                STDOUT_FILENO, O_WRONLY|O_CLOEXEC|O_NOCTTY|O_NONBLOCK);
+                                STDOUT_FILENO, O_WRONLY|O_NOCTTY|O_NONBLOCK);
                 if (f->output_fd < 0) {
                         log_debug_errno(f->output_fd, "Failed to reopen stdout, using original fd: %m");
 

--- a/src/shared/reboot-util.c
+++ b/src/shared/reboot-util.c
@@ -25,6 +25,7 @@
 #include "copy.h"
 #include "fd-util.h"
 #include "fileio.h"
+#include "fs-util.h"
 #include "io-util.h"
 #include "log.h"
 #include "memfd-util.h"
@@ -184,13 +185,13 @@ static int xen_kexec_command(uint64_t cmd) {
             (cmd == KEXEC_CMD_kexec && sizeof(xen_kexec_exec_t) > size))
                 return log_debug_errno(SYNTHETIC_ERRNO(EINVAL), "page_size is too small for hypercall");
 
-        privcmd_fd = open("/dev/xen/privcmd", O_RDWR|O_CLOEXEC);
+        privcmd_fd = xopenat(AT_FDCWD, "/dev/xen/privcmd", O_RDWR);
         if (privcmd_fd < 0)
-                return log_debug_errno(errno, "Cannot access /dev/xen/privcmd: %m");
+                return log_debug_errno(privcmd_fd, "Cannot access /dev/xen/privcmd: %m");
 
-        buf_fd = open("/dev/xen/hypercall", O_RDWR|O_CLOEXEC);
+        buf_fd = xopenat(AT_FDCWD, "/dev/xen/hypercall", O_RDWR);
         if (buf_fd < 0)
-                return log_debug_errno(errno, "Cannot access /dev/xen/hypercall: %m");
+                return log_debug_errno(buf_fd, "Cannot access /dev/xen/hypercall: %m");
 
         buffer = mmap(NULL, size, PROT_READ|PROT_WRITE, MAP_SHARED, buf_fd, 0);
         if (buffer == MAP_FAILED)

--- a/src/shared/reread-partition-table.c
+++ b/src/shared/reread-partition-table.c
@@ -254,7 +254,7 @@ static int reread_partition_table_full(sd_device *dev, int fd, RereadPartitionTa
 
         _cleanup_close_ int lock_fd = -EBADF;
         if (FLAGS_SET(flags, REREADPT_BSD_LOCK)) {
-                lock_fd = fd_reopen(fd, O_RDONLY|O_CLOEXEC|O_NOCTTY);
+                lock_fd = fd_reopen(fd, O_RDONLY|O_NOCTTY);
                 if (lock_fd < 0)
                         return log_device_debug_errno(dev, lock_fd, "Failed to open lock fd for block device '%s': %m", p);
 

--- a/src/shared/rm-rf.c
+++ b/src/shared/rm-rf.c
@@ -139,7 +139,7 @@ static int openat_harder(int dfd, const char *path, int open_flags, RemoveFlags 
             !FLAGS_SET(open_flags, O_DIRECTORY) ||
             !FLAGS_SET(remove_flags, REMOVE_CHMOD)) {
 
-                fd = RET_NERRNO(openat(dfd, path, open_flags));
+                fd = xopenat(dfd, path, open_flags);
                 if (fd < 0)
                         return fd;
 
@@ -155,7 +155,7 @@ static int openat_harder(int dfd, const char *path, int open_flags, RemoveFlags 
                 return TAKE_FD(fd);
         }
 
-        pfd = RET_NERRNO(openat(dfd, path, (open_flags & (O_CLOEXEC|O_DIRECTORY|O_NOFOLLOW)) | O_PATH));
+        pfd = xopenat(dfd, path, (open_flags & (O_DIRECTORY|O_NOFOLLOW)) | O_PATH);
         if (pfd < 0)
                 return pfd;
 

--- a/src/shared/selinux-util.c
+++ b/src/shared/selinux-util.c
@@ -5,6 +5,7 @@
 #include <sys/stat.h>
 #include <syslog.h>
 
+#include "fs-util.h"
 #include "log.h"
 
 #if HAVE_SELINUX
@@ -519,12 +520,12 @@ int mac_selinux_fix_full(
         }
 
         if (inode_path) {
-                opened_fd = openat(atfd, inode_path, O_NOFOLLOW|O_CLOEXEC|O_PATH);
+                opened_fd = xopenat(atfd, inode_path, O_NOFOLLOW|O_PATH);
                 if (opened_fd < 0) {
-                        if ((flags & LABEL_IGNORE_ENOENT) && errno == ENOENT)
+                        if ((flags & LABEL_IGNORE_ENOENT) && opened_fd == -ENOENT)
                                 return 0;
 
-                        return -errno;
+                        return opened_fd;
                 }
 
                 inode_fd = opened_fd;

--- a/src/shared/shift-uid.c
+++ b/src/shared/shift-uid.c
@@ -33,9 +33,9 @@ static int get_acl(int fd, const char *name, acl_type_t type, acl_t *ret) {
         if (name) {
                 _cleanup_close_ int child_fd = -EBADF;
 
-                child_fd = openat(fd, name, O_PATH|O_CLOEXEC|O_NOFOLLOW);
+                child_fd = xopenat(fd, name, O_PATH|O_NOFOLLOW);
                 if (child_fd < 0)
-                        return -errno;
+                        return child_fd;
 
                 acl = sym_acl_get_file(FORMAT_PROC_FD_PATH(child_fd), type);
         } else if (type == ACL_TYPE_ACCESS)
@@ -58,9 +58,9 @@ static int set_acl(int fd, const char *name, acl_type_t type, acl_t acl) {
         if (name) {
                 _cleanup_close_ int child_fd = -EBADF;
 
-                child_fd = openat(fd, name, O_PATH|O_CLOEXEC|O_NOFOLLOW);
+                child_fd = xopenat(fd, name, O_PATH|O_NOFOLLOW);
                 if (child_fd < 0)
-                        return -errno;
+                        return child_fd;
 
                 r = sym_acl_set_file(FORMAT_PROC_FD_PATH(child_fd), type, acl);
         } else if (type == ACL_TYPE_ACCESS)
@@ -341,9 +341,9 @@ static int recurse_fd(int input_fd, const struct stat *st, uid_t shift, bool is_
                         if (S_ISDIR(fst.st_mode)) {
                                 int subdir_fd;
 
-                                subdir_fd = openat(dirfd(d), de->d_name, O_RDONLY|O_NONBLOCK|O_DIRECTORY|O_CLOEXEC|O_NOFOLLOW|O_NOATIME);
+                                subdir_fd = xopenat(dirfd(d), de->d_name, O_RDONLY|O_NONBLOCK|O_DIRECTORY|O_NOFOLLOW|O_NOATIME);
                                 if (subdir_fd < 0)
-                                        return -errno;
+                                        return subdir_fd;
 
                                 r = recurse_fd(subdir_fd, &fst, shift, false);
                                 if (r < 0)
@@ -392,9 +392,9 @@ int path_patch_uid(const char *path, uid_t shift, uid_t range) {
 
         assert(path);
 
-        fd = open(path, O_RDONLY|O_NONBLOCK|O_DIRECTORY|O_CLOEXEC|O_NOFOLLOW|O_NOATIME);
+        fd = xopenat(AT_FDCWD, path, O_RDONLY|O_NONBLOCK|O_DIRECTORY|O_NOFOLLOW|O_NOATIME);
         if (fd < 0)
-                return log_debug_errno(errno, "Failed to open '%s': %m", path);
+                return log_debug_errno(fd, "Failed to open '%s': %m", path);
 
         /* Recursively adjusts the UID/GIDs of all files of a directory tree. This is used to automatically fix up an
          * OS tree to the used user namespace UID range. Note that this automatic adjustment only works for UID ranges

--- a/src/shared/smack-util.c
+++ b/src/shared/smack-util.c
@@ -13,6 +13,7 @@
 #include "errno-util.h"
 #include "fd-util.h"
 #include "fileio.h"
+#include "fs-util.h"
 #include "label-util.h"
 #include "log.h"
 #include "path-util.h"
@@ -173,12 +174,12 @@ int mac_smack_fix_full(
                 return 0;
 
         if (inode_path) {
-                opened_fd = openat(atfd, inode_path, O_NOFOLLOW|O_CLOEXEC|O_PATH);
+                opened_fd = xopenat(atfd, inode_path, O_NOFOLLOW|O_PATH);
                 if (opened_fd < 0) {
-                        if (errno == ENOENT && FLAGS_SET(flags, LABEL_IGNORE_ENOENT))
+                        if (opened_fd == -ENOENT && FLAGS_SET(flags, LABEL_IGNORE_ENOENT))
                                 return 0;
 
-                        return -errno;
+                        return opened_fd;
                 }
                 inode_fd = opened_fd;
         } else

--- a/src/shared/switch-root.c
+++ b/src/shared/switch-root.c
@@ -10,6 +10,7 @@
 #include "chase.h"
 #include "errno-util.h"
 #include "fd-util.h"
+#include "fs-util.h"
 #include "libmount-util.h"
 #include "log.h"
 #include "mkdir.h"
@@ -194,13 +195,13 @@ int switch_root(const char *new_root,
         assert(new_root);
 
         /* Check if we shall remove the contents of the old root */
-        old_root_fd = open("/", O_DIRECTORY|O_CLOEXEC);
+        old_root_fd = xopenat(AT_FDCWD, "/", O_DIRECTORY);
         if (old_root_fd < 0)
-                return log_error_errno(errno, "Failed to open root directory: %m");
+                return log_error_errno(old_root_fd, "Failed to open root directory: %m");
 
-        new_root_fd = open(new_root, O_PATH|O_DIRECTORY|O_CLOEXEC);
+        new_root_fd = xopenat(AT_FDCWD, new_root, O_PATH|O_DIRECTORY);
         if (new_root_fd < 0)
-                return log_error_errno(errno, "Failed to open target directory '%s': %m", new_root);
+                return log_error_errno(new_root_fd, "Failed to open target directory '%s': %m", new_root);
 
         r = fds_inode_and_mount_same(old_root_fd, new_root_fd); /* checks if referenced inodes and mounts match */
         if (r < 0)
@@ -220,9 +221,9 @@ int switch_root(const char *new_root,
                 /* When the path was not a mount point, then we need to reopen the path, otherwise, it still
                  * points to the underlying directory. */
 
-                fd = open(new_root, O_DIRECTORY|O_CLOEXEC);
+                fd = xopenat(AT_FDCWD, new_root, O_DIRECTORY);
                 if (fd < 0)
-                        return log_error_errno(errno, "Failed to reopen target directory '%s': %m", new_root);
+                        return log_error_errno(fd, "Failed to reopen target directory '%s': %m", new_root);
 
                 close_and_replace(new_root_fd, fd);
         }

--- a/src/shared/swtpm-util.c
+++ b/src/shared/swtpm-util.c
@@ -138,9 +138,9 @@ int manufacture_swtpm(const char *state_dir, const char *secret) {
 
         assert(state_dir);
 
-        _cleanup_close_ int state_dir_fd = open(state_dir, O_RDONLY|O_DIRECTORY|O_CLOEXEC);
+        _cleanup_close_ int state_dir_fd = xopenat(AT_FDCWD, state_dir, O_RDONLY|O_DIRECTORY);
         if (state_dir_fd < 0)
-                return log_error_errno(errno, "Failed to open TPM state directory '%s': %m", state_dir);
+                return log_error_errno(state_dir_fd, "Failed to open TPM state directory '%s': %m", state_dir);
 
         _cleanup_free_ char *swtpm_setup = NULL;
         r = find_executable("swtpm_setup", &swtpm_setup);

--- a/src/shared/swtpm-util.c
+++ b/src/shared/swtpm-util.c
@@ -247,7 +247,7 @@ int manufacture_swtpm(const char *state_dir, const char *secret) {
                 return log_error_errno(r, "Failed to sync TPM state directory: %m");
 
         /* Marker, written last, signals that manufacturing completed successfully. */
-        _cleanup_close_ int marker_fd = xopenat(state_dir_fd, SWTPM_MANUFACTURED_MARKER, O_WRONLY|O_CREAT|O_CLOEXEC|O_NOFOLLOW);
+        _cleanup_close_ int marker_fd = xopenat(state_dir_fd, SWTPM_MANUFACTURED_MARKER, O_WRONLY|O_CREAT|O_NOFOLLOW);
         if (marker_fd < 0)
                 return log_error_errno(marker_fd, "Failed to write '%s' marker: %m", SWTPM_MANUFACTURED_MARKER);
 

--- a/src/shared/tar-util.c
+++ b/src/shared/tar-util.c
@@ -413,9 +413,9 @@ static int archive_unpack_symlink(
         if (r < 0)
                 return log_error_errno(r, "Failed to create symlink '%s' → '%s': %m", path, target);
 
-        _cleanup_close_ int fd = openat(parent_fd, filename, O_CLOEXEC|O_PATH|O_NOFOLLOW);
+        _cleanup_close_ int fd = xopenat(parent_fd, filename, O_PATH|O_NOFOLLOW);
         if (fd < 0)
-                return log_error_errno(errno, "Failed to open symlink '%s' we just created: %m", path);
+                return log_error_errno(fd, "Failed to open symlink '%s' we just created: %m", path);
 
         r = fd_verify_symlink(fd);
         if (r < 0)
@@ -450,9 +450,9 @@ static int archive_unpack_special_inode(
         if (r < 0)
                 return log_error_errno(r, "Failed to create special node '%s': %m", path);
 
-        _cleanup_close_ int fd = openat(parent_fd, filename, O_CLOEXEC|O_PATH|O_NOFOLLOW);
+        _cleanup_close_ int fd = xopenat(parent_fd, filename, O_PATH|O_NOFOLLOW);
         if (fd < 0)
-                return log_error_errno(errno, "Failed to open special node '%s' we just created: %m", path);
+                return log_error_errno(fd, "Failed to open special node '%s' we just created: %m", path);
 
         struct stat st;
         if (fstat(fd, &st) < 0)

--- a/src/shared/tar-util.c
+++ b/src/shared/tar-util.c
@@ -223,7 +223,7 @@ static int archive_unpack_regular(
         assert(path);
 
         _cleanup_free_ char *tmp = NULL;
-        _cleanup_close_ int fd = open_tmpfile_linkable_at(parent_fd, filename, O_CLOEXEC|O_WRONLY, &tmp);
+        _cleanup_close_ int fd = open_tmpfile_linkable_at(parent_fd, filename, O_WRONLY, &tmp);
         if (fd < 0)
                 return log_error_errno(fd, "Failed to create regular file '%s': %m", path);
 
@@ -310,7 +310,7 @@ static int archive_unpack_whiteout(
         assert(path);
 
         _cleanup_free_ char *tmp = NULL;
-        _cleanup_close_ int fd = open_tmpfile_linkable_at(parent_fd, filename, O_CLOEXEC|O_WRONLY, &tmp);
+        _cleanup_close_ int fd = open_tmpfile_linkable_at(parent_fd, filename, O_WRONLY, &tmp);
         if (fd < 0)
                 return log_error_errno(fd, "Failed to create whiteout file for '%s': %m", path);
 
@@ -369,7 +369,7 @@ static int archive_unpack_directory(
          * they are more of a "shared" concept, and we try to reuse existing inodes. Note that we create the
          * dir inode in mode 0700, so that we can fully access it (but others cannot). We'll adjust the modes
          * right before closing the inode. */
-        _cleanup_close_ int fd = open_mkdir_at(parent_fd, filename, O_CLOEXEC, 0700);
+        _cleanup_close_ int fd = open_mkdir_at(parent_fd, filename, /* flags= */ 0, 0700);
         if (fd < 0)
                 return log_error_errno(fd, "Failed to create directory '%s': %m", path);
 
@@ -1047,7 +1047,7 @@ int tar_x(int input_fd, int tree_fd, TarFlags flags) {
                                 }
                         } else {
                                 /* This is some intermediary node in the path that we haven't opened yet. Create it with default attributes */
-                                fd = open_mkdir_at(parent_fd, e, O_CLOEXEC, 0700);
+                                fd = open_mkdir_at(parent_fd, e, /* flags= */ 0, 0700);
                                 if (fd < 0)
                                         return log_error_errno(fd, "Failed to create directory '%s': %m", j);
 
@@ -1539,7 +1539,7 @@ static int archive_item(
         _cleanup_close_ int data_fd = -EBADF;
         if (S_ISREG(sx->stx_mode)) {
                 /* Convert the O_PATH fd into a proper fd */
-                data_fd = fd_reopen(inode_fd, O_RDONLY|O_CLOEXEC);
+                data_fd = fd_reopen(inode_fd, O_RDONLY);
                 if (data_fd < 0)
                         return log_error_errno(data_fd, "Failed to open '%s': %m", path);
 

--- a/src/shared/tpm2-util.c
+++ b/src/shared/tpm2-util.c
@@ -9200,7 +9200,7 @@ int tpm2_nvpcr_initialize(
         /* Open + lock the log file *before* we check for the *.auth flag file. */
         _cleanup_close_ int log_fd = tpm2_userspace_log_open();
 
-        _cleanup_close_ int dfd = open_mkdir("/run/systemd/nvpcr", O_CLOEXEC, 0755);
+        _cleanup_close_ int dfd = open_mkdir("/run/systemd/nvpcr", /* flags= */ 0, 0755);
         if (dfd < 0)
                 return log_debug_errno(dfd, "Failed to open directory '/run/systemd/nvpcr': %m");
 

--- a/src/shared/tpm2-util.c
+++ b/src/shared/tpm2-util.c
@@ -8462,9 +8462,9 @@ static int tpm2_userspace_log_open(void) {
         /* We use access mode 0600 here (even though the measurements should not strictly be confidential),
          * because we use BSD file locking on it, and if anyone but root can access the file they can also
          * lock it, which we want to avoid. */
-        fd = open(e, O_CREAT|O_WRONLY|O_CLOEXEC|O_NOCTTY|O_NOFOLLOW, 0600);
+        fd = xopenat_full(AT_FDCWD, e, O_CREAT|O_WRONLY|O_NOCTTY|O_NOFOLLOW, /* xopen_flags= */ 0, 0600);
         if (fd < 0)
-                return log_debug_errno(errno, "Failed to open TPM log file '%s' for writing, ignoring: %m", e);
+                return log_debug_errno(fd, "Failed to open TPM log file '%s' for writing, ignoring: %m", e);
 
         if (flock(fd, LOCK_EX) < 0)
                 return log_debug_errno(errno, "Failed to lock TPM log file '%s', ignoring: %m", e);
@@ -10084,14 +10084,14 @@ int tpm2_pcrlock_policy_from_credentials(
         if (r < 0)
                 return log_error_errno(r, "Failed to get encrypted system credentials directory: %m");
 
-        dfd = open(dp, O_CLOEXEC|O_DIRECTORY);
+        dfd = xopenat(AT_FDCWD, dp, O_DIRECTORY);
         if (dfd < 0) {
-                if (errno == ENOENT) {
+                if (dfd == -ENOENT) {
                         log_debug("No encrypted system credentials passed.");
                         return 0;
                 }
 
-                return log_error_errno(errno, "Failed to open system credentials directory.");
+                return log_error_errno(dfd, "Failed to open system credentials directory.");
         }
 
         _cleanup_free_ DirectoryEntries *de = NULL;

--- a/src/shared/tsm-report.c
+++ b/src/shared/tsm-report.c
@@ -118,9 +118,9 @@ static int tsm_report_fill(
                 generation++;
         }
 
-        inblob_fd = openat(entry_fd, "inblob", O_WRONLY|O_CLOEXEC);
+        inblob_fd = xopenat(entry_fd, "inblob", O_WRONLY);
         if (inblob_fd < 0)
-                return log_debug_errno(errno, "Failed to open 'inblob' attribute: %m");
+                return log_debug_errno(inblob_fd, "Failed to open 'inblob' attribute: %m");
         r = loop_write(inblob_fd, report_data->iov_base, report_data->iov_len);
         if (r < 0)
                 return log_debug_errno(r, "Failed to write 'inblob' attribute: %m");
@@ -191,12 +191,12 @@ int tsm_report_acquire(
                 return log_debug_errno(SYNTHETIC_ERRNO(EINVAL), "Report data must be %u bytes.",
                                        TSM_REPORT_DATA_SIZE);
 
-        report_fd = open(TSM_REPORT_PATH, O_DIRECTORY|O_CLOEXEC|O_RDONLY);
+        report_fd = xopenat(AT_FDCWD, TSM_REPORT_PATH, O_DIRECTORY|O_RDONLY);
         if (report_fd < 0) {
-                if (errno == ENOENT)
+                if (report_fd == -ENOENT)
                         return log_debug_errno(SYNTHETIC_ERRNO(EOPNOTSUPP),
                                                "configfs-tsm interface not available at " TSM_REPORT_PATH ".");
-                return log_debug_errno(errno, "Failed to open " TSM_REPORT_PATH ": %m");
+                return log_debug_errno(report_fd, "Failed to open " TSM_REPORT_PATH ": %m");
         }
 
         /* Private, unique entry name so we don't race with other callers.

--- a/src/shared/tsm-report.c
+++ b/src/shared/tsm-report.c
@@ -208,7 +208,7 @@ int tsm_report_acquire(
         if (r < 0)
                 return log_oom_debug();
 
-        entry_fd = open_mkdir_at(report_fd, name, O_EXCL|O_RDONLY|O_CLOEXEC, 0700);
+        entry_fd = open_mkdir_at(report_fd, name, O_EXCL|O_RDONLY, 0700);
         if (entry_fd < 0)
                 return log_debug_errno(entry_fd, "Failed to create TSM report entry: %m");
 

--- a/src/shared/vconsole-util.c
+++ b/src/shared/vconsole-util.c
@@ -9,6 +9,7 @@
 #include "extract-word.h"
 #include "fd-util.h"
 #include "fileio.h"
+#include "fs-util.h"
 #include "kbd-util.h"
 #include "log.h"
 #include "string-util.h"
@@ -396,10 +397,10 @@ int find_converted_keymap(const X11Context *xc, char **ret) {
                 _cleanup_close_ int dir_fd = -EBADF;
                 bool uncompressed;
 
-                dir_fd = open(*dir, O_CLOEXEC | O_DIRECTORY | O_PATH);
+                dir_fd = xopenat(AT_FDCWD, *dir, O_DIRECTORY | O_PATH);
                 if (dir_fd < 0) {
-                        if (errno != ENOENT)
-                                log_debug_errno(errno, "Failed to open %s, ignoring: %m", *dir);
+                        if (dir_fd != -ENOENT)
+                                log_debug_errno(dir_fd, "Failed to open %s, ignoring: %m", *dir);
                         continue;
                 }
 

--- a/src/shared/vpick.c
+++ b/src/shared/vpick.c
@@ -376,7 +376,7 @@ static int make_choice(
         /* Underspecified, so we do our enumeration dance */
 
         /* Convert O_PATH to a regular directory fd */
-        _cleanup_close_ int enumerate_fd = fd_reopen(inode_fd, O_DIRECTORY|O_RDONLY|O_CLOEXEC);
+        _cleanup_close_ int enumerate_fd = fd_reopen(inode_fd, O_DIRECTORY|O_RDONLY);
         if (enumerate_fd < 0)
                 return log_debug_errno(enumerate_fd, "Failed to reopen '%s/%s' as directory: %m",
                                        empty_to_root(root_path), skip_leading_slash(inode_path));

--- a/src/shared/vsock-util.c
+++ b/src/shared/vsock-util.c
@@ -7,6 +7,7 @@
 
 #include "fd-util.h"
 #include "fileio.h"
+#include "fs-util.h"
 #include "log.h"
 #include "parse-util.h"
 #include "string-util.h"
@@ -68,9 +69,9 @@ static int smbios_get_accepts_any(void) {
 int vsock_get_local_cid(unsigned *ret) {
         _cleanup_close_ int vsock_fd = -EBADF;
 
-        vsock_fd = open("/dev/vsock", O_RDONLY|O_CLOEXEC);
+        vsock_fd = xopenat(AT_FDCWD, "/dev/vsock", O_RDONLY);
         if (vsock_fd < 0)
-                return log_debug_errno(errno, "Failed to open %s: %m", "/dev/vsock");
+                return log_debug_errno(vsock_fd, "Failed to open %s: %m", "/dev/vsock");
 
         unsigned tmp;
         if (ioctl(vsock_fd, IOCTL_VM_SOCKETS_GET_LOCAL_CID, &tmp) < 0)

--- a/src/shared/wall.c
+++ b/src/shared/wall.c
@@ -7,6 +7,7 @@
 #include "alloc-util.h"
 #include "errno-util.h"
 #include "fd-util.h"
+#include "fs-util.h"
 #include "hostname-setup.h"
 #include "io-util.h"
 #include "path-util.h"
@@ -28,9 +29,9 @@ static int write_to_terminal(const char *tty, const char *message) {
         assert(tty);
         assert(message);
 
-        fd = open(tty, O_WRONLY|O_NONBLOCK|O_NOCTTY|O_CLOEXEC);
+        fd = xopenat(AT_FDCWD, tty, O_WRONLY|O_NONBLOCK|O_NOCTTY);
         if (fd < 0)
-                return -errno;
+                return fd;
 
         if (!isatty_safe(fd))
                 return -ENOTTY;

--- a/src/shared/watchdog.c
+++ b/src/shared/watchdog.c
@@ -14,6 +14,7 @@
 #include "errno-util.h"
 #include "fd-util.h"
 #include "fileio.h"
+#include "fs-util.h"
 #include "log.h"
 #include "path-util.h"
 #include "ratelimit.h"
@@ -382,7 +383,7 @@ static int watchdog_open(bool ignore_ratelimit) {
                 STRV_MAKE("/dev/watchdog0", "/dev/watchdog") : STRV_MAKE(watchdog_device);
 
         STRV_FOREACH(wd, try_order) {
-                watchdog_fd = RET_NERRNO(open(*wd, O_WRONLY|O_CLOEXEC));
+                watchdog_fd = xopenat(AT_FDCWD, *wd, O_WRONLY);
                 if (watchdog_fd >= 0) {
                         if (free_and_strdup(&watchdog_device, *wd) < 0) {
                                 r = log_oom_debug();

--- a/src/shutdown/detach-dm.c
+++ b/src/shutdown/detach-dm.c
@@ -15,6 +15,7 @@
 #include "devnum-util.h"
 #include "errno-util.h"
 #include "fd-util.h"
+#include "fs-util.h"
 #include "list.h"
 #include "shutdown.h"
 
@@ -99,17 +100,17 @@ static int delete_dm(DeviceMapper *m) {
         assert(major(m->devnum) != 0);
         assert(m->path);
 
-        fd = open(m->path, O_RDONLY|O_CLOEXEC|O_NONBLOCK);
+        fd = xopenat(AT_FDCWD, m->path, O_RDONLY|O_NONBLOCK);
         if (fd < 0)
-                log_debug_errno(errno, "Failed to open DM block device %s for syncing, ignoring: %m", m->path);
+                log_debug_errno(fd, "Failed to open DM block device %s for syncing, ignoring: %m", m->path);
         else {
                 (void) sync_with_progress(fd);
                 fd = safe_close(fd);
         }
 
-        fd = open("/dev/mapper/control", O_RDWR|O_CLOEXEC);
+        fd = xopenat(AT_FDCWD, "/dev/mapper/control", O_RDWR);
         if (fd < 0)
-                return log_debug_errno(errno, "Failed to open %s: %m", "/dev/mapper/control");
+                return log_debug_errno(fd, "Failed to open %s: %m", "/dev/mapper/control");
 
         return RET_NERRNO(ioctl(fd, DM_DEV_REMOVE, &(struct dm_ioctl) {
                 .version = {

--- a/src/shutdown/detach-loopback.c
+++ b/src/shutdown/detach-loopback.c
@@ -18,6 +18,7 @@
 #include "device-util.h"
 #include "errno-util.h"
 #include "fd-util.h"
+#include "fs-util.h"
 #include "list.h"
 #include "shutdown.h"
 
@@ -105,14 +106,14 @@ static int delete_loopback(const char *device) {
 
         assert(device);
 
-        fd = open(device, O_RDONLY|O_CLOEXEC);
+        fd = xopenat(AT_FDCWD, device, O_RDONLY);
         if (fd < 0) {
-                if (ERRNO_IS_DEVICE_ABSENT(errno)) {
-                        log_debug_errno(errno, "Tried to open loopback device '%s', but device disappeared by now, ignoring: %m", device);
+                if (ERRNO_IS_DEVICE_ABSENT(fd)) {
+                        log_debug_errno(fd, "Tried to open loopback device '%s', but device disappeared by now, ignoring: %m", device);
                         return 0;
                 }
 
-                return log_debug_errno(errno, "Failed to open loopback device '%s': %m", device);
+                return log_debug_errno(fd, "Failed to open loopback device '%s': %m", device);
         }
 
         /* Loopback block devices don't sync in-flight blocks when we clear the fd, hence sync explicitly

--- a/src/shutdown/detach-md.c
+++ b/src/shutdown/detach-md.c
@@ -16,6 +16,7 @@
 #include "devnum-util.h"
 #include "errno-util.h"
 #include "fd-util.h"
+#include "fs-util.h"
 #include "list.h"
 #include "shutdown.h"
 #include "string-util.h"
@@ -130,14 +131,14 @@ static int delete_md(RaidDevice *m) {
         assert(major(m->devnum) != 0);
         assert(m->path);
 
-        fd = open(m->path, O_RDONLY|O_CLOEXEC|O_EXCL);
+        fd = xopenat(AT_FDCWD, m->path, O_RDONLY|O_EXCL);
         if (fd < 0) {
-                if (ERRNO_IS_DEVICE_ABSENT(errno)) {
-                        log_debug_errno(errno, "Tried to open MD device '%s', but device disappeared by now, ignoring: %m", m->path);
+                if (ERRNO_IS_DEVICE_ABSENT(fd)) {
+                        log_debug_errno(fd, "Tried to open MD device '%s', but device disappeared by now, ignoring: %m", m->path);
                         return 0;
                 }
 
-                return log_debug_errno(errno, "Failed to open MD device '%s': %m", m->path);
+                return log_debug_errno(fd, "Failed to open MD device '%s': %m", m->path);
         }
 
         (void) sync_with_progress(fd);

--- a/src/sleep/sleep.c
+++ b/src/sleep/sleep.c
@@ -32,6 +32,7 @@
 #include "exec-util.h"
 #include "fd-util.h"
 #include "fileio.h"
+#include "fs-util.h"
 #include "hibernate-util.h"
 #include "io-util.h"
 #include "log.h"
@@ -268,9 +269,9 @@ static int execute(
                                        sleep_operation_to_string(operation));
 
         /* This file is opened first, so that if we hit an error, we can abort before modifying any state. */
-        state_fd = open("/sys/power/state", O_WRONLY|O_CLOEXEC);
+        state_fd = xopenat(AT_FDCWD, "/sys/power/state", O_WRONLY);
         if (state_fd < 0)
-                return log_error_errno(errno, "Failed to open %s: %m", "/sys/power/state");
+                return log_error_errno(state_fd, "Failed to open %s: %m", "/sys/power/state");
 
         if (sleep_needs_mem_sleep(sleep_config, operation)) {
                 r = write_mode("/sys/power/mem_sleep", sleep_config->mem_modes);

--- a/src/ssh-generator/ssh-issue.c
+++ b/src/ssh-generator/ssh-issue.c
@@ -76,7 +76,7 @@ static int verb_make_vsock(int argc, char *argv[], uintptr_t _data, void *_userd
                 if (r < 0)
                         return log_error_errno(r, "Failed to create parent directories of '%s': %m", arg_issue_path);
 
-                r = fopen_tmpfile_linkable(arg_issue_path, O_WRONLY|O_CLOEXEC, &t, &f);
+                r = fopen_tmpfile_linkable(arg_issue_path, O_WRONLY, &t, &f);
                 if (r < 0)
                         return log_error_errno(r, "Failed to create '%s': %m", arg_issue_path);
 

--- a/src/storage/storage-fs.c
+++ b/src/storage/storage-fs.c
@@ -88,7 +88,7 @@ static int open_storage_dir(void) {
         if (r < 0)
                 return log_error_errno(r, "Failed to get state directory path: %m");
 
-        _cleanup_close_ int state_fd = chase_and_open(state_dir, /* root= */ NULL, CHASE_TRIGGER_AUTOFS|CHASE_MKDIR_0755|CHASE_MUST_BE_DIRECTORY, O_CLOEXEC|O_CREAT|O_DIRECTORY, /* ret_path= */ NULL);
+        _cleanup_close_ int state_fd = chase_and_open(state_dir, /* root= */ NULL, CHASE_TRIGGER_AUTOFS|CHASE_MKDIR_0755|CHASE_MUST_BE_DIRECTORY, O_CREAT|O_DIRECTORY, /* ret_path= */ NULL);
         if (state_fd < 0)
                 return log_error_errno(state_fd, "Failed to open '%s': %m", state_dir);
 
@@ -96,11 +96,11 @@ static int open_storage_dir(void) {
          * get ENOENT we'll try to create it. If that works, great. If we get EEXIST we'll try to reopen it
          * again, to deal with other instances of ourselves racing with us. We only do this exactly once
          * though, under the assumption that the dir is never removed, only created during runtime. */
-        _cleanup_close_ int storage_fd = chase_and_openat(XAT_FDROOT, state_fd, "storage", CHASE_TRIGGER_AUTOFS|CHASE_MUST_BE_DIRECTORY, O_CLOEXEC|O_DIRECTORY, /* ret_path= */ NULL);
+        _cleanup_close_ int storage_fd = chase_and_openat(XAT_FDROOT, state_fd, "storage", CHASE_TRIGGER_AUTOFS|CHASE_MUST_BE_DIRECTORY, O_DIRECTORY, /* ret_path= */ NULL);
         if (storage_fd == -ENOENT) {
-                storage_fd = xopenat_full(state_fd, "storage", O_EXCL|O_CREAT|O_CLOEXEC|O_DIRECTORY|O_NOFOLLOW, XO_LABEL|XO_SUBVOLUME, 0700);
+                storage_fd = xopenat_full(state_fd, "storage", O_EXCL|O_CREAT|O_DIRECTORY|O_NOFOLLOW, XO_LABEL|XO_SUBVOLUME, 0700);
                 if (storage_fd == -EEXIST)
-                        storage_fd = chase_and_openat(XAT_FDROOT, state_fd, "storage", CHASE_TRIGGER_AUTOFS|CHASE_MUST_BE_DIRECTORY, O_CLOEXEC|O_DIRECTORY, /* ret_path= */ NULL);
+                        storage_fd = chase_and_openat(XAT_FDROOT, state_fd, "storage", CHASE_TRIGGER_AUTOFS|CHASE_MUST_BE_DIRECTORY, O_DIRECTORY, /* ret_path= */ NULL);
         }
         if (storage_fd < 0)
                 return log_error_errno(storage_fd, "Failed to open '%s/storage/': %m", state_dir);
@@ -312,11 +312,11 @@ static int create_volume_dir(
         if (r < 0)
                 return r;
 
-        _cleanup_close_ int volume_fd = xopenat_full(storage_fd, tf, O_CREAT|O_EXCL|O_RDONLY|O_DIRECTORY|O_CLOEXEC|O_NOFOLLOW, xopen_flags, 0700);
+        _cleanup_close_ int volume_fd = xopenat_full(storage_fd, tf, O_CREAT|O_EXCL|O_RDONLY|O_DIRECTORY|O_NOFOLLOW, xopen_flags, 0700);
         if (volume_fd < 0)
                 return volume_fd;
 
-        _cleanup_close_ int root_fd = xopenat_full(volume_fd, "root", O_CREAT|O_EXCL|O_RDONLY|O_DIRECTORY|O_CLOEXEC|O_NOFOLLOW, xopen_flags, 0755);
+        _cleanup_close_ int root_fd = xopenat_full(volume_fd, "root", O_CREAT|O_EXCL|O_RDONLY|O_DIRECTORY|O_NOFOLLOW, xopen_flags, 0755);
         if (root_fd < 0) {
                 r = root_fd;
                 goto fail;
@@ -373,7 +373,7 @@ static int create_volume_reg(
         }
 
         _cleanup_free_ char *tf = NULL;
-        _cleanup_close_ int fd = open_tmpfile_linkable_at(storage_fd, filename, O_RDWR|O_CLOEXEC, &tf);
+        _cleanup_close_ int fd = open_tmpfile_linkable_at(storage_fd, filename, O_RDWR, &tf);
         if (fd < 0)
                 return fd;
 
@@ -624,7 +624,7 @@ static int vl_method_acquire(
                         open_flags |= O_DIRECTORY|O_NOFOLLOW;
                 }
 
-                real_fd = xopenat_full(pin_fd, subdir, open_flags|O_CLOEXEC, xopen_flags, /* mode= */ MODE_INVALID);
+                real_fd = xopenat_full(pin_fd, subdir, open_flags, xopen_flags, /* mode= */ MODE_INVALID);
                 if (real_fd < 0)
                         return log_debug_errno(real_fd, "Failed to reopen volume fd for '%s': %m", filename);
 

--- a/src/storage/storagectl.c
+++ b/src/storage/storagectl.c
@@ -18,6 +18,7 @@
 #include "fd-util.h"
 #include "format-table.h"
 #include "format-util.h"
+#include "fs-util.h"
 #include "machine-util.h"
 #include "main-func.h"
 #include "mount-util.h"
@@ -315,10 +316,10 @@ static int verb_providers(int argc, char *argv[], uintptr_t data, void *userdata
         (void) table_set_sort(t, (size_t) 0);
         table_set_ersatz_string(t, TABLE_ERSATZ_DASH);
 
-        _cleanup_close_ int fd = open(socket_path, O_RDONLY|O_CLOEXEC|O_DIRECTORY);
+        _cleanup_close_ int fd = xopenat(AT_FDCWD, socket_path, O_RDONLY|O_DIRECTORY);
         if (fd < 0) {
-                if (errno != ENOENT)
-                        return log_error_errno(errno, "Failed to open '%s': %m", socket_path);
+                if (fd != -ENOENT)
+                        return log_error_errno(fd, "Failed to open '%s': %m", socket_path);
         } else {
                 _cleanup_free_ DirectoryEntries *dentries = NULL;
                 r = readdir_all(fd, RECURSE_DIR_SORT|RECURSE_DIR_IGNORE_DOT|RECURSE_DIR_MUST_BE_SOCKET, &dentries);

--- a/src/storagetm/storagetm.c
+++ b/src/storagetm/storagetm.c
@@ -398,7 +398,7 @@ static int nvme_subsystem_add(const char *node, int consumed_fd, sd_device *devi
                 return log_error_errno(subsystems_fd, "Failed to open %s: %m", "/sys/kernel/config/nvmet/subsystems");
 
         _cleanup_close_ int subsystem_fd = -EBADF;
-        subsystem_fd = open_mkdir_at(subsystems_fd, j, O_EXCL|O_RDONLY|O_CLOEXEC, 0777);
+        subsystem_fd = open_mkdir_at(subsystems_fd, j, O_EXCL|O_RDONLY, 0777);
         if (subsystem_fd < 0)
                 return log_error_errno(subsystem_fd, "Failed to create NVME subsystem '%s': %m", j);
 
@@ -409,7 +409,7 @@ static int nvme_subsystem_add(const char *node, int consumed_fd, sd_device *devi
         (void) nvme_subsystem_write_metadata(subsystem_fd, device);
 
         _cleanup_close_ int namespace_fd = -EBADF;
-        namespace_fd = open_mkdir_at(subsystem_fd, "namespaces/1", O_EXCL|O_RDONLY|O_CLOEXEC, 0777);
+        namespace_fd = open_mkdir_at(subsystem_fd, "namespaces/1", O_EXCL|O_RDONLY, 0777);
         if (namespace_fd < 0)
                 return log_error_errno(namespace_fd, "Failed to create NVME namespace '1': %m");
 
@@ -542,7 +542,7 @@ static int nvme_port_add_portnr(
                 return log_oom();
 
         _cleanup_close_ int port_fd = -EBADF;
-        port_fd = open_mkdir_at(ports_fd, fname, O_EXCL|O_RDONLY|O_CLOEXEC, 0777);
+        port_fd = open_mkdir_at(ports_fd, fname, O_EXCL|O_RDONLY, 0777);
         if (port_fd < 0) {
                 if (port_fd != -EEXIST)
                         return log_error_errno(port_fd, "Failed to create port %" PRIu16 ": %m", portnr);

--- a/src/storagetm/storagetm.c
+++ b/src/storagetm/storagetm.c
@@ -160,9 +160,9 @@ static int nvme_subsystem_unlink(NvmeSubsystem *s) {
         if (s->nvme_our_subsystem_fd >= 0) {
                 _cleanup_close_ int namespaces_fd = -EBADF;
 
-                namespaces_fd = openat(s->nvme_our_subsystem_fd, "namespaces", O_CLOEXEC|O_DIRECTORY|O_RDONLY);
+                namespaces_fd = xopenat(s->nvme_our_subsystem_fd, "namespaces", O_DIRECTORY|O_RDONLY);
                 if (namespaces_fd < 0)
-                        log_warning_errno(errno, "Failed to open 'namespaces' directory of subsystem '%s': %m", s->name);
+                        log_warning_errno(namespaces_fd, "Failed to open 'namespaces' directory of subsystem '%s': %m", s->name);
                 else {
                         _cleanup_free_ DirectoryEntries *de = NULL;
 
@@ -365,7 +365,7 @@ static int nvme_subsystem_add(const char *node, int consumed_fd, sd_device *devi
                 return log_oom();
 
         if (fd < 0) {
-                fd = RET_NERRNO(open(node, O_RDWR|O_CLOEXEC|O_NONBLOCK));
+                fd = xopenat(AT_FDCWD, node, O_RDWR|O_NONBLOCK);
                 if (fd < 0)
                         return log_error_errno(fd, "Failed to open '%s': %m", node);
         }
@@ -393,7 +393,7 @@ static int nvme_subsystem_add(const char *node, int consumed_fd, sd_device *devi
                 return log_error_errno(r, "Failed to lock block device: %m");
 
         _cleanup_close_ int subsystems_fd = -EBADF;
-        subsystems_fd = RET_NERRNO(open("/sys/kernel/config/nvmet/subsystems", O_DIRECTORY|O_CLOEXEC|O_RDONLY));
+        subsystems_fd = xopenat(AT_FDCWD, "/sys/kernel/config/nvmet/subsystems", O_DIRECTORY|O_RDONLY);
         if (subsystems_fd < 0)
                 return log_error_errno(subsystems_fd, "Failed to open %s: %m", "/sys/kernel/config/nvmet/subsystems");
 
@@ -474,9 +474,9 @@ static int nvme_port_unlink(NvmePort *p) {
         if (p->nvme_port_fd >= 0) {
                 _cleanup_close_ int subsystems_dir_fd = -EBADF;
 
-                subsystems_dir_fd = openat(p->nvme_port_fd, "subsystems", O_DIRECTORY|O_RDONLY|O_CLOEXEC);
+                subsystems_dir_fd = xopenat(p->nvme_port_fd, "subsystems", O_DIRECTORY|O_RDONLY);
                 if (subsystems_dir_fd < 0)
-                        log_warning_errno(errno, "Failed to open 'subsystems' dir of port %" PRIu16 ", ignoring: %m", p->portnr);
+                        log_warning_errno(subsystems_dir_fd, "Failed to open 'subsystems' dir of port %" PRIu16 ", ignoring: %m", p->portnr);
                 else {
                         _cleanup_free_ DirectoryEntries *de = NULL;
 
@@ -608,7 +608,7 @@ static int nvme_port_add(const char *name, int ip_family, NvmePort **ret) {
         assert(ret);
 
         _cleanup_close_ int ports_fd = -EBADF;
-        ports_fd = RET_NERRNO(open("/sys/kernel/config/nvmet/ports", O_DIRECTORY|O_RDONLY|O_CLOEXEC));
+        ports_fd = xopenat(AT_FDCWD, "/sys/kernel/config/nvmet/ports", O_DIRECTORY|O_RDONLY);
         if (ports_fd < 0)
                 return log_error_errno(ports_fd, "Failed to open %s: %m", "/sys/kernel/config/nvmet/ports");
 

--- a/src/sysext/sysext.c
+++ b/src/sysext/sysext.c
@@ -997,7 +997,7 @@ static int resolve_mutable_directory(
                 if (r < 0)
                         return log_error_errno(r, "Failed to chase/create base directory '%s/%s': %m", strempty(root), skip_leading_slash(path));
 
-                chmod_fd = fd_reopen(path_fd, O_CLOEXEC|O_DIRECTORY);
+                chmod_fd = fd_reopen(path_fd, O_DIRECTORY);
                 if (chmod_fd < 0)
                         return log_error_errno(chmod_fd, "Failed to reopen '%s/%s': %m", strempty(root), skip_leading_slash(path));
 

--- a/src/sysext/sysext.c
+++ b/src/sysext/sysext.c
@@ -586,9 +586,9 @@ static int move_submounts(const char *src, const char *dst) {
                 if (r < 0 && r != -EEXIST)
                         return log_error_errno(r, "Failed to create mountpoint %s: %m", t);
 
-                _cleanup_close_ int child_fd = openat(fd, fn, O_PATH|O_CLOEXEC);
+                _cleanup_close_ int child_fd = xopenat(fd, fn, O_PATH);
                 if (child_fd < 0)
-                        return log_error_errno(errno, "Failed to pin mountpoint %s: %m", t);
+                        return log_error_errno(child_fd, "Failed to pin mountpoint %s: %m", t);
 
                 /* Instead of a bind mount we attach the detached clone produced by
                  * open_tree_attr_with_fallback() from get_sub_mounts() because that has no propagation
@@ -1378,9 +1378,9 @@ static int mount_overlayfs_with_op(
         if (r < 0)
                 return log_error_errno(r, "Failed to make directory '%s': %m", meta_path);
 
-        _cleanup_close_ int atfd = open(meta_path, O_DIRECTORY|O_CLOEXEC);
+        _cleanup_close_ int atfd = xopenat(AT_FDCWD, meta_path, O_DIRECTORY);
         if (atfd < 0)
-                return log_error_errno(errno, "Failed to open directory '%s': %m", meta_path);
+                return log_error_errno(atfd, "Failed to open directory '%s': %m", meta_path);
 
         r = mac_selinux_fix_full(atfd, /* inode_path= */ NULL, op->hierarchy, /* flags= */ 0, /* label_context= */ NULL);
         if (r < 0)
@@ -1391,9 +1391,9 @@ static int mount_overlayfs_with_op(
                 if (r < 0)
                         return log_error_errno(r, "Failed to make directory '%s': %m", op->work_dir);
 
-                _cleanup_close_ int dfd = open(op->work_dir, O_DIRECTORY|O_CLOEXEC);
+                _cleanup_close_ int dfd = xopenat(AT_FDCWD, op->work_dir, O_DIRECTORY);
                 if (dfd < 0)
-                        return log_error_errno(errno, "Failed to open directory '%s': %m", op->work_dir);
+                        return log_error_errno(dfd, "Failed to open directory '%s': %m", op->work_dir);
 
                 r = mac_selinux_fix_full(dfd, /* inode_path= */ NULL, op->hierarchy, /* flags= */ 0, /* label_context= */ NULL);
                 if (r < 0)
@@ -1603,9 +1603,9 @@ static int store_info_in_meta(
         if (r < 0)
                 return log_error_errno(r, "Failed to create directory '%s': %m", f);
 
-        _cleanup_close_ int atfd = open(f, O_DIRECTORY|O_CLOEXEC);
+        _cleanup_close_ int atfd = xopenat(AT_FDCWD, f, O_DIRECTORY);
         if (atfd < 0)
-                return log_error_errno(errno, "Failed to open directory '%s': %m", f);
+                return log_error_errno(atfd, "Failed to open directory '%s': %m", f);
 
         r = mac_selinux_fix_full(atfd, /* inode_path= */ NULL, hierarchy, /* flags= */ 0, /* label_context= */ NULL);
         if (r < 0)

--- a/src/sysinstall/sysinstall.c
+++ b/src/sysinstall/sysinstall.c
@@ -1130,7 +1130,7 @@ static int find_current_kernel(
                         /* dir_fd= */ partition_fd,
                         image,
                         CHASE_PROHIBIT_SYMLINKS|CHASE_MUST_BE_REGULAR,
-                        O_RDONLY|O_CLOEXEC,
+                        O_RDONLY,
                         &resolved);
         if (fd < 0)
                 return log_error_errno(fd, "Failed to find EFI binary '%s' on partition '%s': %m", image, partition_path);
@@ -1549,7 +1549,7 @@ static int sysinstall_context_settle_kernel_image(SysInstallContext *context,
                 if (r == O_DIRECTORY)
                         return log_error_errno(SYNTHETIC_ERRNO(EISDIR), "Kernel path '%s' refers to directory, must be regular file, refusing.", kernel_image);
 
-                kernel_fd = xopenat_full(XAT_FDROOT, kernel_image, O_RDONLY|O_CLOEXEC, XO_REGULAR, MODE_INVALID);
+                kernel_fd = xopenat_full(XAT_FDROOT, kernel_image, O_RDONLY, XO_REGULAR, MODE_INVALID);
                 if (kernel_fd < 0)
                         return log_error_errno(kernel_fd, "Failed to open kernel image '%s': %m", kernel_image);
 

--- a/src/systemctl/systemctl-start-special.c
+++ b/src/systemctl/systemctl-start-special.c
@@ -11,6 +11,7 @@
 #include "efivars.h"
 #include "extract-word.h"
 #include "fd-util.h"
+#include "fs-util.h"
 #include "log.h"
 #include "parse-util.h"
 #include "path-util.h"
@@ -131,15 +132,15 @@ static int load_kexec_kernel(void) {
                 return 0;
 
 #if HAVE_KEXEC_FILE_LOAD_SYSCALL
-        _cleanup_close_ int kernel_fd = open(kernel, O_RDONLY|O_CLOEXEC);
+        _cleanup_close_ int kernel_fd = xopenat(AT_FDCWD, kernel, O_RDONLY);
         if (kernel_fd < 0)
-                return log_error_errno(errno, "Failed to open kernel '%s': %m", kernel);
+                return log_error_errno(kernel_fd, "Failed to open kernel '%s': %m", kernel);
 
         _cleanup_close_ int initrd_fd = -EBADF;
         if (initrd) {
-                initrd_fd = open(initrd, O_RDONLY|O_CLOEXEC);
+                initrd_fd = xopenat(AT_FDCWD, initrd, O_RDONLY);
                 if (initrd_fd < 0)
-                        return log_error_errno(errno, "Failed to open initrd '%s': %m", initrd);
+                        return log_error_errno(initrd_fd, "Failed to open initrd '%s': %m", initrd);
         }
 
         unsigned long flags = initrd ? 0 : KEXEC_FILE_NO_INITRAMFS;

--- a/src/sysupdate/sysupdate-cleanup.c
+++ b/src/sysupdate/sysupdate-cleanup.c
@@ -273,7 +273,7 @@ static int context_installdb_process_directory(
                         if (d->d_type != DT_DIR)
                                 continue;
 
-                        _cleanup_close_ int subdir_fd = RET_NERRNO(openat(dir_fd, d->d_name, O_DIRECTORY|O_CLOEXEC|O_NOFOLLOW));
+                        _cleanup_close_ int subdir_fd = xopenat(dir_fd, d->d_name, O_DIRECTORY|O_NOFOLLOW);
                         if (subdir_fd == -ENOENT)
                                 continue;
                         if (subdir_fd < 0) {

--- a/src/sysupdate/sysupdate-cleanup.c
+++ b/src/sysupdate/sysupdate-cleanup.c
@@ -79,7 +79,7 @@ static int context_installdb_acquire_fd(Context *c, bool make) {
                         p,
                         c->root,
                         flags,
-                        O_DIRECTORY|O_CLOEXEC|(make ? O_CREAT : 0),
+                        O_DIRECTORY|(make ? O_CREAT : 0),
                         /* ret_path= */ NULL);
         if (c->installdb_fd == -ENOENT && !make)
                 return 0;
@@ -367,7 +367,7 @@ static int context_installdb_process_entry(
 
         /* NB: We set CHASE_PROHIBIT_SYMLINKS because the path was normalized by the writer of the entry
          * already, and if it isn't anymore, then something is fishy. */
-        _cleanup_close_ int dir_fd = chase_and_open(path, c->root, CHASE_MUST_BE_DIRECTORY|CHASE_PREFIX_ROOT|CHASE_PROHIBIT_SYMLINKS, O_DIRECTORY|O_CLOEXEC, /* ret_path= */ NULL);
+        _cleanup_close_ int dir_fd = chase_and_open(path, c->root, CHASE_MUST_BE_DIRECTORY|CHASE_PREFIX_ROOT|CHASE_PROHIBIT_SYMLINKS, O_DIRECTORY, /* ret_path= */ NULL);
         if (dir_fd == -ENOENT) {
                 log_debug("Install database path '%s' does not exist, expunging database entry.", path);
                 return 0;
@@ -440,7 +440,7 @@ int installdb_list_components(Context *context, char ***ret) {
                         "/var/lib/systemd/sysupdate",
                         context->root,
                         CHASE_MUST_BE_DIRECTORY|CHASE_PREFIX_ROOT,
-                        O_DIRECTORY|O_CLOEXEC,
+                        O_DIRECTORY,
                         /* ret_path= */ NULL);
         if (dir_fd == -ENOENT) {
                 *ret = NULL;

--- a/src/sysupdate/sysupdate-resource.c
+++ b/src/sysupdate/sysupdate-resource.c
@@ -898,7 +898,7 @@ int resource_resolve_path(
                         return 0;
                 }
 
-                real_fd = fd_reopen(fd, O_RDONLY|O_CLOEXEC|O_DIRECTORY);
+                real_fd = fd_reopen(fd, O_RDONLY|O_DIRECTORY);
                 if (real_fd < 0)
                         return log_error_errno(real_fd, "Failed to convert O_PATH file descriptor for %s to regular file descriptor: %m", rr->path);
 

--- a/src/sysupdate/sysupdate-resource.c
+++ b/src/sysupdate/sysupdate-resource.c
@@ -18,6 +18,7 @@
 #include "fdisk-util.h"
 #include "fileio.h"
 #include "find-esp.h"
+#include "fs-util.h"
 #include "glyph-util.h"
 #include "gpt.h"
 #include "hexdecoct.h"
@@ -779,9 +780,9 @@ static int get_sysext_overlay_block(const char *p, dev_t *ret) {
         if (!j)
                 return log_oom_debug();
 
-        _cleanup_close_ int fd = open(j, O_RDONLY|O_DIRECTORY);
+        _cleanup_close_ int fd = xopenat(AT_FDCWD, j, O_RDONLY|O_DIRECTORY);
         if (fd < 0)
-                return log_debug_errno(errno, "Failed to open '%s': %m", j);
+                return log_debug_errno(fd, "Failed to open '%s': %m", j);
 
         r = fd_is_fs_type(fd, OVERLAYFS_SUPER_MAGIC);
         if (r < 0)

--- a/src/sysusers/sysusers.c
+++ b/src/sysusers/sysusers.c
@@ -325,12 +325,12 @@ static int make_backup(const char *target, const char *x, LabelContext *label_co
         assert(target);
         assert(x);
 
-        src = open(x, O_RDONLY|O_CLOEXEC|O_NOCTTY);
+        src = xopenat(AT_FDCWD, x, O_RDONLY|O_NOCTTY);
         if (src < 0) {
-                if (errno == ENOENT) /* No backup necessary... */
+                if (src == -ENOENT) /* No backup necessary... */
                         return 0;
 
-                return -errno;
+                return src;
         }
 
         if (fstat(src, &st) < 0)

--- a/src/test/test-btrfs.c
+++ b/src/test/test-btrfs.c
@@ -96,11 +96,26 @@ TEST(subvol) {
         _unused_ _cleanup_close_ int locked_fd = ASSERT_OK(btrfs_subvol_snapshot_at(dir_fd, "test1", dir_fd, "test4", BTRFS_SNAPSHOT_LOCK_BSD));
         ASSERT_ERROR(xopenat_lock(dir_fd, "test4", 0, LOCK_BSD, LOCK_EX|LOCK_NB), EAGAIN);
 
+        /* The _fd() variants operate on the subvolume the fd refers to */
+        _cleanup_close_ int test1_fd = ASSERT_OK(xopenat(dir_fd, "test1", O_DIRECTORY));
+        ASSERT_OK(btrfs_subvol_set_read_only_fd(test1_fd, true));
+        ASSERT_OK_POSITIVE(btrfs_subvol_get_read_only_fd(test1_fd));
+        ASSERT_OK(btrfs_subvol_set_read_only_fd(test1_fd, false));
+        ASSERT_OK_ZERO(btrfs_subvol_get_read_only_fd(test1_fd));
+        ASSERT_OK(btrfs_subvol_snapshot_at(test1_fd, /* from= */ NULL, dir_fd, "test5", 0));
+
+        dev_t devnum_fd = 0, devnum_path = 0;
+        int r = btrfs_get_block_device_fd(dir_fd, &devnum_fd);
+        ASSERT_EQ(r, btrfs_get_block_device(dir, &devnum_path));
+        if (r > 0)
+                ASSERT_EQ(devnum_fd, devnum_path);
+
         /* The destroy ioctl needs CAP_SYS_ADMIN; without it, leave cleanup to rm_rf_subvolume_and_freep. */
         ASSERT_OK_OR(btrfs_subvol_remove_at(dir_fd, "test1", BTRFS_REMOVE_QUOTA), -EPERM);
         ASSERT_OK_OR(btrfs_subvol_remove_at(dir_fd, "test2", BTRFS_REMOVE_QUOTA), -EPERM);
         ASSERT_OK_OR(btrfs_subvol_remove_at(dir_fd, "test3", BTRFS_REMOVE_QUOTA), -EPERM);
         ASSERT_OK_OR(btrfs_subvol_remove_at(dir_fd, "test4", BTRFS_REMOVE_QUOTA), -EPERM);
+        ASSERT_OK_OR(btrfs_subvol_remove_at(dir_fd, "test5", BTRFS_REMOVE_QUOTA), -EPERM);
 }
 
 TEST(fallback_copy) {

--- a/src/test/test-btrfs.c
+++ b/src/test/test-btrfs.c
@@ -42,7 +42,7 @@ static int open_test_subvol(char **ret_path) {
         if (r < 0)
                 return r;
 
-        int fd = xopenat_full(AT_FDCWD, p, O_DIRECTORY|O_CREAT|O_CLOEXEC, XO_SUBVOLUME, MODE_INVALID);
+        int fd = xopenat_full(AT_FDCWD, p, O_DIRECTORY|O_CREAT, XO_SUBVOLUME, MODE_INVALID);
         if (fd < 0)
                 return fd;
 

--- a/src/test/test-chase.c
+++ b/src/test/test-chase.c
@@ -318,7 +318,7 @@ TEST(chase) {
 
                 ASSERT_OK(pfd);
 
-                fd = fd_reopen(pfd, O_RDONLY|O_CLOEXEC);
+                fd = fd_reopen(pfd, O_RDONLY);
                 ASSERT_OK(fd);
                 safe_close(pfd);
 
@@ -421,14 +421,14 @@ TEST(chase_and_open) {
         /* Test chase_and_open() with various CHASE_PARENT / CHASE_EXTRACT_FILENAME combinations. */
 
         /* No CHASE_PARENT, no CHASE_EXTRACT_FILENAME, with ret_path — opens the target, returns full path. */
-        fd = ASSERT_OK(chase_and_open("/usr/lib", NULL, 0, O_PATH|O_DIRECTORY|O_CLOEXEC, &result));
+        fd = ASSERT_OK(chase_and_open("/usr/lib", /* root= */ NULL, /* chase_flags= */ 0, O_PATH|O_DIRECTORY, &result));
         ASSERT_OK(fd_verify_directory(fd));
         ASSERT_STREQ(result, "/usr/lib");
         fd = safe_close(fd);
         result = mfree(result);
 
         /* CHASE_PARENT with ret_path — opens parent dir, returns full path including final component. */
-        fd = ASSERT_OK(chase_and_open("/usr/lib", NULL, CHASE_PARENT, O_PATH|O_DIRECTORY|O_CLOEXEC, &result));
+        fd = ASSERT_OK(chase_and_open("/usr/lib", /* root= */ NULL, CHASE_PARENT, O_PATH|O_DIRECTORY, &result));
         ASSERT_OK(fd_verify_directory(fd));
         ASSERT_OK_ERRNO(faccessat(fd, "lib", F_OK, 0));
         ASSERT_STREQ(result, "/usr/lib");
@@ -436,7 +436,7 @@ TEST(chase_and_open) {
         result = mfree(result);
 
         /* CHASE_PARENT|CHASE_EXTRACT_FILENAME — opens parent dir, returns just the filename. */
-        fd = ASSERT_OK(chase_and_open("/usr/lib", NULL, CHASE_PARENT|CHASE_EXTRACT_FILENAME, O_PATH|O_DIRECTORY|O_CLOEXEC, &result));
+        fd = ASSERT_OK(chase_and_open("/usr/lib", /* root= */ NULL, CHASE_PARENT|CHASE_EXTRACT_FILENAME, O_PATH|O_DIRECTORY, &result));
         ASSERT_OK(fd_verify_directory(fd));
         ASSERT_OK_ERRNO(faccessat(fd, "lib", F_OK, 0));
         ASSERT_STREQ(result, "lib");
@@ -444,7 +444,7 @@ TEST(chase_and_open) {
         result = mfree(result);
 
         /* CHASE_EXTRACT_FILENAME only — opens the target itself, returns just the filename. */
-        fd = ASSERT_OK(chase_and_open("/usr/lib", NULL, CHASE_EXTRACT_FILENAME, O_PATH|O_DIRECTORY|O_CLOEXEC, &result));
+        fd = ASSERT_OK(chase_and_open("/usr/lib", /* root= */ NULL, CHASE_EXTRACT_FILENAME, O_PATH|O_DIRECTORY, &result));
         ASSERT_OK(fd_verify_directory(fd));
         ASSERT_STREQ(result, "lib");
         fd = safe_close(fd);
@@ -452,14 +452,14 @@ TEST(chase_and_open) {
 
         /* CHASE_EXTRACT_FILENAME on a regular file (regression test for a bug where chase_and_open()
          * reopened the parent directory instead of the target file). */
-        fd = ASSERT_OK(chase_and_open("/etc/os-release", NULL, CHASE_EXTRACT_FILENAME, O_PATH|O_CLOEXEC, &result));
+        fd = ASSERT_OK(chase_and_open("/etc/os-release", /* root= */ NULL, CHASE_EXTRACT_FILENAME, O_PATH, &result));
         ASSERT_STREQ(result, "os-release");
         ASSERT_OK(fd_verify_regular(fd));
         fd = safe_close(fd);
         result = mfree(result);
 
         /* CHASE_PARENT through a symlink — symlink is followed, parent of the target is opened. */
-        fd = ASSERT_OK(chase_and_open("/etc/os-release", NULL, CHASE_PARENT, O_PATH|O_DIRECTORY|O_CLOEXEC, &result));
+        fd = ASSERT_OK(chase_and_open("/etc/os-release", /* root= */ NULL, CHASE_PARENT, O_PATH|O_DIRECTORY, &result));
         ASSERT_OK(fd_verify_directory(fd));
         ASSERT_NOT_NULL(result);
         fd = safe_close(fd);
@@ -467,7 +467,7 @@ TEST(chase_and_open) {
 
         /* CHASE_PARENT|CHASE_NOFOLLOW through a symlink — symlink is NOT followed, parent of the
          * symlink is opened. */
-        fd = ASSERT_OK(chase_and_open("/etc/os-release", NULL, CHASE_PARENT|CHASE_NOFOLLOW, O_PATH|O_DIRECTORY|O_CLOEXEC, &result));
+        fd = ASSERT_OK(chase_and_open("/etc/os-release", /* root= */ NULL, CHASE_PARENT|CHASE_NOFOLLOW, O_PATH|O_DIRECTORY, &result));
         ASSERT_OK(fd_verify_directory(fd));
         ASSERT_OK_ERRNO(faccessat(fd, "os-release", F_OK, AT_SYMLINK_NOFOLLOW));
         ASSERT_STREQ(result, "/etc/os-release");
@@ -476,7 +476,7 @@ TEST(chase_and_open) {
 
         /* CHASE_PARENT|CHASE_NOFOLLOW|CHASE_EXTRACT_FILENAME through a symlink — parent of the symlink
          * is opened, returns just the symlink name. */
-        fd = ASSERT_OK(chase_and_open("/etc/os-release", NULL, CHASE_PARENT|CHASE_NOFOLLOW|CHASE_EXTRACT_FILENAME, O_PATH|O_DIRECTORY|O_CLOEXEC, &result));
+        fd = ASSERT_OK(chase_and_open("/etc/os-release", /* root= */ NULL, CHASE_PARENT|CHASE_NOFOLLOW|CHASE_EXTRACT_FILENAME, O_PATH|O_DIRECTORY, &result));
         ASSERT_OK(fd_verify_directory(fd));
         ASSERT_OK_ERRNO(faccessat(fd, "os-release", F_OK, AT_SYMLINK_NOFOLLOW));
         ASSERT_STREQ(result, "os-release");
@@ -495,7 +495,7 @@ TEST(chase_and_open) {
         ASSERT_OK_ERRNO(symlinkat("/", tfd, "to_root"));
 
         _cleanup_free_ char *link_path = ASSERT_NOT_NULL(path_join(tmpdir, "to_root"));
-        fd = ASSERT_OK(chase_and_open(link_path, tmpdir, 0, O_PATH|O_DIRECTORY|O_CLOEXEC, &result));
+        fd = ASSERT_OK(chase_and_open(link_path, tmpdir, /* chase_flags= */ 0, O_PATH|O_DIRECTORY, &result));
         ASSERT_OK(fd_verify_directory(fd));
         ASSERT_PATH_EQ(result, tmpdir);
         fd = safe_close(fd);
@@ -658,7 +658,7 @@ TEST(chaseat) {
 
         /* Test CHASE_PARENT */
 
-        fd = ASSERT_OK(open_mkdir_at(tfd, "chase", O_CLOEXEC, 0755));
+        fd = ASSERT_OK(open_mkdir_at(tfd, "chase", /* flags= */ 0, 0755));
         ASSERT_OK_ERRNO(symlinkat("/def", fd, "parent"));
         fd = safe_close(fd);
 
@@ -746,22 +746,22 @@ TEST(chaseat) {
 
         /* Test chase_and_openat() */
 
-        fd = ASSERT_OK(chase_and_openat(XAT_FDROOT, tfd, "o/p/e/n/f/i/l/e", CHASE_MKDIR_0755, O_CREAT|O_EXCL|O_CLOEXEC, NULL));
+        fd = ASSERT_OK(chase_and_openat(XAT_FDROOT, tfd, "o/p/e/n/f/i/l/e", CHASE_MKDIR_0755, O_CREAT|O_EXCL, /* ret_path= */ NULL));
         ASSERT_OK(fd_verify_regular(fd));
         fd = safe_close(fd);
 
-        fd = ASSERT_OK(chase_and_openat(XAT_FDROOT, tfd, "o/p/e/n/d/i/r", CHASE_MKDIR_0755, O_DIRECTORY|O_CREAT|O_EXCL|O_CLOEXEC, NULL));
+        fd = ASSERT_OK(chase_and_openat(XAT_FDROOT, tfd, "o/p/e/n/d/i/r", CHASE_MKDIR_0755, O_DIRECTORY|O_CREAT|O_EXCL, /* ret_path= */ NULL));
         ASSERT_OK(fd_verify_directory(fd));
         fd = safe_close(fd);
 
-        fd = ASSERT_OK(chase_and_openat(XAT_FDROOT, tfd, NULL, CHASE_PARENT|CHASE_EXTRACT_FILENAME, O_PATH|O_DIRECTORY|O_CLOEXEC, &result));
+        fd = ASSERT_OK(chase_and_openat(XAT_FDROOT, tfd, /* path= */ NULL, CHASE_PARENT|CHASE_EXTRACT_FILENAME, O_PATH|O_DIRECTORY, &result));
         ASSERT_STREQ(result, ".");
         fd = safe_close(fd);
         result = mfree(result);
 
         /* Test chase_and_openat() with CHASE_MKDIR_0755|CHASE_PARENT — opens parent dir */
 
-        fd = ASSERT_OK(chase_and_openat(XAT_FDROOT, tfd, "mkopen/p/a/r/file.txt", CHASE_MKDIR_0755|CHASE_PARENT, O_RDONLY|O_CLOEXEC, NULL));
+        fd = ASSERT_OK(chase_and_openat(XAT_FDROOT, tfd, "mkopen/p/a/r/file.txt", CHASE_MKDIR_0755|CHASE_PARENT, O_RDONLY, /* ret_path= */ NULL));
         ASSERT_OK(fd_verify_directory(fd));
         ASSERT_OK(faccessat(tfd, "mkopen/p/a/r", F_OK, 0));
         ASSERT_ERROR(RET_NERRNO(faccessat(tfd, "mkopen/p/a/r/file.txt", F_OK, 0)), ENOENT);
@@ -769,7 +769,7 @@ TEST(chaseat) {
 
         /* Test chase_and_openat() with CHASE_MKDIR_0755|CHASE_MUST_BE_DIRECTORY + O_CREAT — creates and opens target dir */
 
-        fd = ASSERT_OK(chase_and_openat(XAT_FDROOT, tfd, "mkopen/d/i/r/target", CHASE_MKDIR_0755|CHASE_MUST_BE_DIRECTORY, O_CREAT|O_RDONLY|O_CLOEXEC, NULL));
+        fd = ASSERT_OK(chase_and_openat(XAT_FDROOT, tfd, "mkopen/d/i/r/target", CHASE_MKDIR_0755|CHASE_MUST_BE_DIRECTORY, O_CREAT|O_RDONLY, /* ret_path= */ NULL));
         ASSERT_OK(fd_verify_directory(fd));
         ASSERT_OK(faccessat(tfd, "mkopen/d/i/r/target", F_OK, 0));
         fd = safe_close(fd);
@@ -777,14 +777,14 @@ TEST(chaseat) {
         /* Test chase_and_openat() with various CHASE_PARENT / CHASE_EXTRACT_FILENAME combinations */
 
         /* No CHASE_PARENT, no CHASE_EXTRACT_FILENAME, with ret_path — opens the target, returns full path. */
-        fd = ASSERT_OK(chase_and_openat(XAT_FDROOT, tfd, "o/p/e/n/d/i/r", 0, O_PATH|O_DIRECTORY|O_CLOEXEC, &result));
+        fd = ASSERT_OK(chase_and_openat(XAT_FDROOT, tfd, "o/p/e/n/d/i/r", /* chase_flags= */ 0, O_PATH|O_DIRECTORY, &result));
         ASSERT_OK(fd_verify_directory(fd));
         ASSERT_STREQ(result, "o/p/e/n/d/i/r");
         fd = safe_close(fd);
         result = mfree(result);
 
         /* CHASE_PARENT with ret_path — opens parent dir, returns full path including final component. */
-        fd = ASSERT_OK(chase_and_openat(XAT_FDROOT, tfd, "o/p/e/n/d/i/r", CHASE_PARENT, O_PATH|O_DIRECTORY|O_CLOEXEC, &result));
+        fd = ASSERT_OK(chase_and_openat(XAT_FDROOT, tfd, "o/p/e/n/d/i/r", CHASE_PARENT, O_PATH|O_DIRECTORY, &result));
         ASSERT_OK(fd_verify_directory(fd));
         ASSERT_OK_ERRNO(faccessat(fd, "r", F_OK, 0));
         ASSERT_STREQ(result, "o/p/e/n/d/i/r");
@@ -793,7 +793,7 @@ TEST(chaseat) {
 
         /* CHASE_PARENT|CHASE_EXTRACT_FILENAME with a real multi-component path — opens parent dir,
          * returns just the filename. */
-        fd = ASSERT_OK(chase_and_openat(XAT_FDROOT, tfd, "o/p/e/n/d/i/r", CHASE_PARENT|CHASE_EXTRACT_FILENAME, O_PATH|O_DIRECTORY|O_CLOEXEC, &result));
+        fd = ASSERT_OK(chase_and_openat(XAT_FDROOT, tfd, "o/p/e/n/d/i/r", CHASE_PARENT|CHASE_EXTRACT_FILENAME, O_PATH|O_DIRECTORY, &result));
         ASSERT_OK(fd_verify_directory(fd));
         ASSERT_OK_ERRNO(faccessat(fd, "r", F_OK, 0));
         ASSERT_STREQ(result, "r");
@@ -802,7 +802,7 @@ TEST(chaseat) {
 
         /* CHASE_EXTRACT_FILENAME only (without CHASE_PARENT) — opens the target itself, returns just
          * the filename. */
-        fd = ASSERT_OK(chase_and_openat(XAT_FDROOT, tfd, "o/p/e/n/d/i/r", CHASE_EXTRACT_FILENAME, O_PATH|O_DIRECTORY|O_CLOEXEC, &result));
+        fd = ASSERT_OK(chase_and_openat(XAT_FDROOT, tfd, "o/p/e/n/d/i/r", CHASE_EXTRACT_FILENAME, O_PATH|O_DIRECTORY, &result));
         ASSERT_OK(fd_verify_directory(fd));
         ASSERT_STREQ(result, "r");
         fd = safe_close(fd);
@@ -810,7 +810,7 @@ TEST(chaseat) {
 
         /* CHASE_PARENT through a symlink — the symlink is followed, parent of the target is opened.
          * "chase/parent" where parent→/def: resolves to /def, parent is the root dir. */
-        fd = ASSERT_OK(chase_and_openat(tfd, tfd, "chase/parent", CHASE_PARENT, O_PATH|O_DIRECTORY|O_CLOEXEC, &result));
+        fd = ASSERT_OK(chase_and_openat(tfd, tfd, "chase/parent", CHASE_PARENT, O_PATH|O_DIRECTORY, &result));
         ASSERT_OK(fd_verify_directory(fd));
         ASSERT_OK_ERRNO(faccessat(fd, "def", F_OK, 0));
         ASSERT_STREQ(result, "def");
@@ -819,7 +819,7 @@ TEST(chaseat) {
 
         /* CHASE_PARENT|CHASE_EXTRACT_FILENAME through a symlink — parent of the target is opened,
          * returns just the target filename. */
-        fd = ASSERT_OK(chase_and_openat(tfd, tfd, "chase/parent", CHASE_PARENT|CHASE_EXTRACT_FILENAME, O_PATH|O_DIRECTORY|O_CLOEXEC, &result));
+        fd = ASSERT_OK(chase_and_openat(tfd, tfd, "chase/parent", CHASE_PARENT|CHASE_EXTRACT_FILENAME, O_PATH|O_DIRECTORY, &result));
         ASSERT_OK(fd_verify_directory(fd));
         ASSERT_OK_ERRNO(faccessat(fd, "def", F_OK, 0));
         ASSERT_STREQ(result, "def");
@@ -828,7 +828,7 @@ TEST(chaseat) {
 
         /* CHASE_PARENT|CHASE_NOFOLLOW through a symlink — the symlink is NOT followed, parent of the
          * symlink is opened. */
-        fd = ASSERT_OK(chase_and_openat(tfd, tfd, "chase/parent", CHASE_PARENT|CHASE_NOFOLLOW, O_PATH|O_DIRECTORY|O_CLOEXEC, &result));
+        fd = ASSERT_OK(chase_and_openat(tfd, tfd, "chase/parent", CHASE_PARENT|CHASE_NOFOLLOW, O_PATH|O_DIRECTORY, &result));
         ASSERT_OK(fd_verify_directory(fd));
         ASSERT_OK_ERRNO(faccessat(fd, "parent", F_OK, AT_SYMLINK_NOFOLLOW));
         ASSERT_STREQ(result, "chase/parent");
@@ -837,7 +837,7 @@ TEST(chaseat) {
 
         /* CHASE_PARENT|CHASE_NOFOLLOW|CHASE_EXTRACT_FILENAME through a symlink — parent of the symlink
          * is opened, returns just the symlink name. */
-        fd = ASSERT_OK(chase_and_openat(tfd, tfd, "chase/parent", CHASE_PARENT|CHASE_NOFOLLOW|CHASE_EXTRACT_FILENAME, O_PATH|O_DIRECTORY|O_CLOEXEC, &result));
+        fd = ASSERT_OK(chase_and_openat(tfd, tfd, "chase/parent", CHASE_PARENT|CHASE_NOFOLLOW|CHASE_EXTRACT_FILENAME, O_PATH|O_DIRECTORY, &result));
         ASSERT_OK(fd_verify_directory(fd));
         ASSERT_OK_ERRNO(faccessat(fd, "parent", F_OK, AT_SYMLINK_NOFOLLOW));
         ASSERT_STREQ(result, "parent");

--- a/src/test/test-chase.c
+++ b/src/test/test-chase.c
@@ -1105,6 +1105,30 @@ TEST(use_chase_as_mkdir_p) {
         ASSERT_OK(rm_rf(fff, REMOVE_PHYSICAL));
 }
 
+TEST(chase_and_open_cloexec) {
+        _cleanup_(rm_rf_physical_and_freep) char *t = NULL;
+        _cleanup_close_ int tfd = -EBADF, fd = -EBADF;
+        int fl;
+
+        ASSERT_OK(tfd = mkdtemp_open(NULL, 0, &t));
+        ASSERT_OK_ERRNO(mkdirat(tfd, "dir", 0755));
+
+        /* O_CLOEXEC is implied, whether requested or not, on the shortcut and on the full chase */
+        ASSERT_OK(fd = chase_and_open(t, /* root= */ NULL, /* chase_flags= */ 0, O_DIRECTORY, /* ret_path= */ NULL));
+        ASSERT_OK_ERRNO(fl = fcntl(fd, F_GETFD));
+        ASSERT_TRUE(FLAGS_SET(fl, FD_CLOEXEC));
+        fd = safe_close(fd);
+
+        ASSERT_OK(fd = chase_and_open(t, /* root= */ NULL, CHASE_PROHIBIT_SYMLINKS, O_DIRECTORY, /* ret_path= */ NULL));
+        ASSERT_OK_ERRNO(fl = fcntl(fd, F_GETFD));
+        ASSERT_TRUE(FLAGS_SET(fl, FD_CLOEXEC));
+        fd = safe_close(fd);
+
+        ASSERT_OK(fd = chase_and_openat(tfd, tfd, "dir", /* chase_flags= */ 0, O_DIRECTORY, /* ret_path= */ NULL));
+        ASSERT_OK_ERRNO(fl = fcntl(fd, F_GETFD));
+        ASSERT_TRUE(FLAGS_SET(fl, FD_CLOEXEC));
+}
+
 static int intro(void) {
         arg_test_dir = saved_argv[1];
         return EXIT_SUCCESS;

--- a/src/test/test-fd-util.c
+++ b/src/test/test-fd-util.c
@@ -917,4 +917,16 @@ TEST(fd_is_writable) {
         TAKE_FD(fd_ro);
 }
 
+TEST(fd_reopen_cloexec) {
+        _cleanup_close_ int fd = -EBADF, reopened = -EBADF;
+        int fl;
+
+        ASSERT_OK_ERRNO(fd = open("/proc", O_DIRECTORY|O_PATH|O_CLOEXEC));
+
+        /* O_CLOEXEC is implied, whether requested or not */
+        ASSERT_OK(reopened = fd_reopen(fd, O_RDONLY|O_DIRECTORY));
+        ASSERT_OK_ERRNO(fl = fcntl(reopened, F_GETFD));
+        ASSERT_TRUE(FLAGS_SET(fl, FD_CLOEXEC));
+}
+
 DEFINE_TEST_MAIN(LOG_DEBUG);

--- a/src/test/test-fd-util.c
+++ b/src/test/test-fd-util.c
@@ -156,6 +156,15 @@ TEST(fd_move_above_stdio) {
         assert_se(close_nointr(new_fd) != EBADF);
 }
 
+static void assert_stdio_not_cloexec(void) {
+        for (int i = 0; i < 3; i++) {
+                int fl;
+
+                ASSERT_OK_ERRNO(fl = fcntl(i, F_GETFD));
+                ASSERT_FALSE(FLAGS_SET(fl, FD_CLOEXEC));
+        }
+}
+
 TEST(rearrange_stdio) {
         int r;
 
@@ -176,6 +185,7 @@ TEST(rearrange_stdio) {
                  * following tests fail, making it slightly less annoying to debug */
                 log_set_target(LOG_TARGET_JOURNAL_OR_KMSG);
                 log_open();
+                assert_stdio_not_cloexec();
 
                 assert_se(fd_get_path(STDIN_FILENO, &path) >= 0);
                 assert_se(path_equal(path, "/dev/null"));
@@ -203,6 +213,7 @@ TEST(rearrange_stdio) {
                 assert_se(memfd_new_and_seal_string("data", "foobar") == 2);
 
                 assert_se(rearrange_stdio(2, 0, 1) >= 0);
+                assert_stdio_not_cloexec();
 
                 assert_se(write(1, "x", 1) < 0 && errno == ENOSPC);
                 assert_se(write(2, "z", 1) == 1);
@@ -211,7 +222,9 @@ TEST(rearrange_stdio) {
                 assert_se(read(0, buffer, sizeof(buffer)) == 6);
                 assert_se(memcmp(buffer, "foobar", 6) == 0);
 
+                ASSERT_OK(fd_cloexec(1, true)); /* stays in place, but the flag must still be cleared */
                 assert_se(rearrange_stdio(-EBADF, 1, 2) >= 0);
+                assert_stdio_not_cloexec();
                 assert_se(write(1, "a", 1) < 0 && errno == ENOSPC);
                 assert_se(write(2, "y", 1) == 1);
                 assert_se(read(pipe_read_fd, buffer, sizeof(buffer)) == 1);

--- a/src/test/test-fd-util.c
+++ b/src/test/test-fd-util.c
@@ -382,10 +382,10 @@ TEST(fd_reopen) {
         assert_se(FLAGS_SET(fl, O_PATH));
 
         /* fd_reopen() with O_NOFOLLOW will systematically fail, since it is implemented via a symlink in /proc/self/fd/ */
-        assert_se(fd_reopen(fd1, O_RDONLY|O_CLOEXEC|O_NOFOLLOW) == -ELOOP);
-        assert_se(fd_reopen(fd1, O_RDONLY|O_CLOEXEC|O_DIRECTORY|O_NOFOLLOW) == -ELOOP);
+        assert_se(fd_reopen(fd1, O_RDONLY|O_NOFOLLOW) == -ELOOP);
+        assert_se(fd_reopen(fd1, O_RDONLY|O_DIRECTORY|O_NOFOLLOW) == -ELOOP);
 
-        fd2 = fd_reopen(fd1, O_RDONLY|O_DIRECTORY|O_CLOEXEC);  /* drop the O_PATH */
+        fd2 = fd_reopen(fd1, O_RDONLY|O_DIRECTORY);  /* drop the O_PATH */
         assert_se(fd2 >= 0);
 
         ASSERT_OK_ERRNO(fstat(fd2, &st2));
@@ -399,7 +399,7 @@ TEST(fd_reopen) {
 
         safe_close(fd1);
 
-        fd1 = fd_reopen(fd2, O_DIRECTORY|O_PATH|O_CLOEXEC);  /* reacquire the O_PATH */
+        fd1 = fd_reopen(fd2, O_DIRECTORY|O_PATH);  /* reacquire the O_PATH */
         assert_se(fd1 >= 0);
 
         ASSERT_OK_ERRNO(fstat(fd1, &st1));
@@ -425,8 +425,8 @@ TEST(fd_reopen) {
         assert_se(!FLAGS_SET(fl, O_DIRECTORY));
         assert_se(FLAGS_SET(fl, O_PATH));
 
-        assert_se(fd_reopen(fd1, O_RDONLY|O_DIRECTORY|O_CLOEXEC) == -ENOTDIR);
-        fd2 = fd_reopen(fd1, O_RDONLY|O_CLOEXEC);  /* drop the O_PATH */
+        assert_se(fd_reopen(fd1, O_RDONLY|O_DIRECTORY) == -ENOTDIR);
+        fd2 = fd_reopen(fd1, O_RDONLY);  /* drop the O_PATH */
         assert_se(fd2 >= 0);
 
         ASSERT_OK_ERRNO(fstat(fd2, &st2));
@@ -440,8 +440,8 @@ TEST(fd_reopen) {
 
         safe_close(fd1);
 
-        assert_se(fd_reopen(fd2, O_DIRECTORY|O_PATH|O_CLOEXEC) == -ENOTDIR);
-        fd1 = fd_reopen(fd2, O_PATH|O_CLOEXEC);  /* reacquire the O_PATH */
+        assert_se(fd_reopen(fd2, O_DIRECTORY|O_PATH) == -ENOTDIR);
+        fd1 = fd_reopen(fd2, O_PATH);  /* reacquire the O_PATH */
         assert_se(fd1 >= 0);
 
         ASSERT_OK_ERRNO(fstat(fd1, &st1));
@@ -455,7 +455,7 @@ TEST(fd_reopen) {
 
         /* Also check the right error is generated if the fd is already closed */
         safe_close(fd1);
-        assert_se(fd_reopen(fd1, O_RDONLY|O_CLOEXEC) == -EBADF);
+        assert_se(fd_reopen(fd1, O_RDONLY) == -EBADF);
         fd1 = -EBADF;
 
         /* Validate what happens if we reopen a symlink */
@@ -464,7 +464,7 @@ TEST(fd_reopen) {
         ASSERT_OK_ERRNO(fstat(fd1, &st1));
         assert_se(S_ISLNK(st1.st_mode));
 
-        fd2 = fd_reopen(fd1, O_PATH|O_CLOEXEC);
+        fd2 = fd_reopen(fd1, O_PATH);
         assert_se(fd2 >= 0);
         ASSERT_OK_ERRNO(fstat(fd2, &st2));
         assert_se(S_ISLNK(st2.st_mode));
@@ -473,7 +473,7 @@ TEST(fd_reopen) {
 
         /* So here's the thing: if we have an O_PATH fd to a symlink, we *cannot* convert it to a regular fd
          * with that. i.e. you cannot have the VFS follow a symlink pinned via an O_PATH fd. */
-        assert_se(fd_reopen(fd1, O_RDONLY|O_CLOEXEC) == -ELOOP);
+        assert_se(fd_reopen(fd1, O_RDONLY) == -ELOOP);
 }
 
 TEST(fd_reopen_condition) {

--- a/src/test/test-fd-util.c
+++ b/src/test/test-fd-util.c
@@ -6,6 +6,8 @@
 #include <unistd.h>
 
 #include "alloc-util.h"
+#include "capability-util.h"
+#include "errno-util.h"
 #include "fd-util.h"
 #include "fs-util.h"
 #include "memfd-util.h"
@@ -928,6 +930,31 @@ TEST(fd_is_writable) {
         safe_close(fd_ro);
         ASSERT_ERROR(fd_is_writable(fd_ro), EBADF);
         TAKE_FD(fd_ro);
+}
+
+TEST(fd_reopen_emptypath) {
+        _cleanup_(rm_rf_physical_and_freep) char *t = NULL;
+        _cleanup_close_ int tfd = -EBADF, dfd = -EBADF, fd = -EBADF;
+
+        ASSERT_OK(tfd = mkdtemp_open(NULL, 0, &t));
+
+        /* Older kernels ignore the flag and miss the empty path */
+        fd = openat(tfd, "", O_PATH|O_CLOEXEC|O_EMPTYPATH);
+        if (fd < 0 && errno == ENOENT)
+                return (void) log_tests_skipped("kernel lacks O_EMPTYPATH");
+        ASSERT_OK_ERRNO(fd);
+        fd = safe_close(fd);
+
+        if (have_effective_cap(CAP_DAC_OVERRIDE) > 0 || have_effective_cap(CAP_DAC_READ_SEARCH) > 0)
+                return (void) log_tests_skipped("directory permissions do not apply to us");
+
+        /* A directory we may read but not search: "." cannot be looked up in it, O_EMPTYPATH needs no lookup */
+        ASSERT_OK_ERRNO(mkdirat(tfd, "noexec", 0400));
+        ASSERT_OK_ERRNO(dfd = openat(tfd, "noexec", O_PATH|O_DIRECTORY|O_CLOEXEC));
+        ASSERT_ERROR(RET_NERRNO(openat(dfd, ".", O_RDONLY|O_DIRECTORY|O_CLOEXEC)), EACCES);
+
+        ASSERT_OK(fd = fd_reopen(dfd, O_RDONLY|O_DIRECTORY));
+        ASSERT_OK_POSITIVE(inode_same_at(dfd, NULL, fd, NULL, AT_EMPTY_PATH));
 }
 
 TEST(fd_reopen_cloexec) {

--- a/src/test/test-fileio.c
+++ b/src/test/test-fileio.c
@@ -607,6 +607,36 @@ TEST(read_full_file_full) {
         ASSERT_OK(read_full_file_full(AT_FDCWD, fn, 10000, 99, 0, NULL, &rbuf, &rbuf_size));
         ASSERT_EQ(rbuf_size, 0U);
         rbuf = mfree(rbuf);
+
+        /* A NULL filename reads the file the fd refers to */
+        _cleanup_close_ int fd = -EBADF;
+        ASSERT_OK_ERRNO(fd = open(fn, O_RDONLY|O_CLOEXEC));
+        ASSERT_OK(read_full_file_at(fd, /* filename= */ NULL, &rbuf, &rbuf_size));
+        ASSERT_EQ(rbuf_size, sizeof(buf));
+        ASSERT_EQ(memcmp(buf, rbuf, rbuf_size), 0);
+}
+
+TEST(xfopenat_empty_path) {
+        _cleanup_(rm_rf_physical_and_freep) char *t = NULL;
+        _cleanup_close_ int tfd = -EBADF, fd = -EBADF;
+        _cleanup_fclose_ FILE *f = NULL;
+        _cleanup_free_ char *line = NULL;
+
+        ASSERT_OK(tfd = mkdtemp_open(NULL, 0, &t));
+        ASSERT_OK(write_string_file_at(tfd, "file", "hello", WRITE_STRING_FILE_CREATE));
+        ASSERT_OK_ERRNO(fd = openat(tfd, "file", O_RDONLY|O_CLOEXEC));
+
+        /* A NULL or empty path reopens the fd for reading... */
+        ASSERT_OK(xfopenat(fd, /* path= */ NULL, "re", 0, &f));
+        ASSERT_OK(read_line(f, SIZE_MAX, &line));
+        ASSERT_STREQ(line, "hello");
+        f = safe_fclose(f);
+        ASSERT_OK(xfopenat(fd, "", "re", 0, &f));
+        f = safe_fclose(f);
+
+        /* ...but creating something needs a name */
+        ASSERT_ERROR(xfopenat(tfd, "", "we", 0, &f), ENOENT);
+        ASSERT_ERROR(xfopenat(tfd, /* path= */ NULL, "ae", 0, &f), ENOENT);
 }
 
 static void test_read_virtual_file_one(size_t max_size) {

--- a/src/test/test-fileio.c
+++ b/src/test/test-fileio.c
@@ -891,6 +891,24 @@ TEST(read_boolean_file) {
         ASSERT_OK_EQ(read_boolean_file_at(dfd, bn), true);
 }
 
+TEST(xfopenat_dangling_symlink) {
+        _cleanup_(rm_rf_physical_and_freep) char *t = NULL;
+        _cleanup_fclose_ FILE *f = NULL;
+        _cleanup_close_ int tfd = -EBADF;
+
+        ASSERT_OK(tfd = mkdtemp_open(NULL, 0, &t));
+        ASSERT_OK_ERRNO(symlinkat("target", tfd, "link"));
+
+        /* The creating modes go through openat_report_new() now, which refuses to create through a dangling symlink */
+        ASSERT_ERROR(xfopenat(tfd, "link", "w", /* open_flags= */ 0, &f), ELOOP);
+        ASSERT_ERROR(xfopenat(tfd, "link", "a", /* open_flags= */ 0, &f), ELOOP);
+
+        /* Once the target exists the symlink is followed as before */
+        ASSERT_OK(xfopenat(tfd, "target", "w", /* open_flags= */ 0, &f));
+        f = safe_fclose(f);
+        ASSERT_OK(xfopenat(tfd, "link", "w", /* open_flags= */ 0, &f));
+}
+
 TEST(xfopenat_cloexec) {
         _cleanup_fclose_ FILE *f = NULL;
         _cleanup_close_ int fd = -EBADF;

--- a/src/test/test-fileio.c
+++ b/src/test/test-fileio.c
@@ -682,7 +682,7 @@ TEST(fdopen_independent) {
         ASSERT_OK_ERRNO(r = fcntl(fileno(f), F_GETFL));
         ASSERT_EQ((r & O_ACCMODE_STRICT), O_RDONLY);
         ASSERT_OK_ERRNO(r = fcntl(fileno(f), F_GETFD));
-        ASSERT_FALSE(FLAGS_SET(r, FD_CLOEXEC));
+        ASSERT_TRUE(FLAGS_SET(r, FD_CLOEXEC));
         f = safe_fclose(f);
 
         ASSERT_OK(fdopen_independent(fd, "r+e", &f));

--- a/src/test/test-fileio.c
+++ b/src/test/test-fileio.c
@@ -891,4 +891,19 @@ TEST(read_boolean_file) {
         ASSERT_OK_EQ(read_boolean_file_at(dfd, bn), true);
 }
 
+TEST(xfopenat_cloexec) {
+        _cleanup_fclose_ FILE *f = NULL;
+        _cleanup_close_ int fd = -EBADF;
+        int fl;
+
+        /* O_CLOEXEC is implied, even without "e" in the mode */
+        ASSERT_OK(xfopenat(AT_FDCWD, "/proc/self/status", "r", /* open_flags= */ 0, &f));
+        ASSERT_OK_ERRNO(fl = fcntl(fileno(f), F_GETFD));
+        ASSERT_TRUE(FLAGS_SET(fl, FD_CLOEXEC));
+
+        ASSERT_OK(search_and_open("/proc/self/status", O_RDONLY, /* root= */ NULL, /* search= */ NULL, &fd, /* ret_path= */ NULL));
+        ASSERT_OK_ERRNO(fl = fcntl(fd, F_GETFD));
+        ASSERT_TRUE(FLAGS_SET(fl, FD_CLOEXEC));
+}
+
 DEFINE_TEST_MAIN(LOG_DEBUG);

--- a/src/test/test-fs-util.c
+++ b/src/test/test-fs-util.c
@@ -712,7 +712,7 @@ TEST(xopenat_full) {
         /* Test that we can reopen an existing fd with xopenat_full() by specifying an empty path. */
 
         assert_se((fd = xopenat_full(tfd, "def", O_PATH, 0, 0)) >= 0);
-        assert_se((fd2 = xopenat_full(fd, "", O_RDWR, 0, 0644)) >= 0);
+        assert_se((fd2 = xopenat_full(fd, "", O_RDWR, XO_EMPTY_PATH, 0644)) >= 0);
 }
 
 TEST(xopenat_tmpfile) {
@@ -798,7 +798,7 @@ TEST(xopenat_socket) {
 
         /* Reopen via empty path should also work. */
         fd = ASSERT_OK(xopenat_full(tfd, "test.sock", O_PATH, 0, 0));
-        _cleanup_close_ int fd2 = xopenat_full(fd, NULL, O_PATH, XO_SOCKET, 0);
+        _cleanup_close_ int fd2 = xopenat_full(fd, NULL, O_PATH, XO_SOCKET|XO_EMPTY_PATH, 0);
         ASSERT_OK(fd2);
         fd = safe_close(fd);
 
@@ -812,11 +812,11 @@ TEST(xopenat_socket) {
 
         /* Reopen via empty path of a non-socket fd must also be rejected. */
         fd = ASSERT_OK(xopenat_full(tfd, "reg", O_PATH, 0, 0));
-        ASSERT_ERROR(xopenat_full(fd, NULL, O_PATH, XO_SOCKET, 0), ENOTSOCK);
+        ASSERT_ERROR(xopenat_full(fd, NULL, O_PATH, XO_SOCKET|XO_EMPTY_PATH, 0), ENOTSOCK);
         fd = safe_close(fd);
 
         fd = ASSERT_OK(xopenat_full(tfd, "dir", O_PATH, 0, 0));
-        ASSERT_ERROR(xopenat_full(fd, NULL, O_PATH, XO_SOCKET, 0), EISDIR);
+        ASSERT_ERROR(xopenat_full(fd, NULL, O_PATH, XO_SOCKET|XO_EMPTY_PATH, 0), EISDIR);
         fd = safe_close(fd);
 }
 
@@ -861,7 +861,7 @@ TEST(xopenat_auto_rw_ro) {
 
         _cleanup_close_ int path_fd = xopenat_full(tfd, "rw", O_PATH, 0, 0);
         assert_se(path_fd >= 0);
-        fd = xopenat_full(path_fd, "", /* open_flags= */ 0, XO_AUTO_RW_RO, 0);
+        fd = xopenat_full(path_fd, "", /* open_flags= */ 0, XO_AUTO_RW_RO|XO_EMPTY_PATH, 0);
         assert_se(fd >= 0);
         ASSERT_OK_ERRNO(fl = fcntl(fd, F_GETFL));
         assert_se((fl & O_ACCMODE) == O_RDWR);
@@ -910,7 +910,7 @@ TEST(xopenat_auto_rw_ro) {
                 /* Also exercise the empty-path/fd-reopen branch. */
                 _cleanup_close_ int ro_path_fd = xopenat_full(tfd, "ro", O_PATH, 0, 0);
                 assert_se(ro_path_fd >= 0);
-                fd = xopenat_full(ro_path_fd, "", /* open_flags= */ 0, XO_AUTO_RW_RO, 0);
+                fd = xopenat_full(ro_path_fd, "", /* open_flags= */ 0, XO_AUTO_RW_RO|XO_EMPTY_PATH, 0);
                 assert_se(fd >= 0);
                 ASSERT_OK_ERRNO(fl = fcntl(fd, F_GETFL));
                 assert_se((fl & O_ACCMODE) == O_RDONLY);

--- a/src/test/test-fs-util.c
+++ b/src/test/test-fs-util.c
@@ -674,6 +674,10 @@ TEST(openat_report_new) {
         fd = openat_report_new(tfd, "link", O_RDWR|O_CREAT, 0666, &b);
         ASSERT_ERROR(fd, ELOOP);
 
+        /* Same through xopenat_full(), and unchanged EEXIST for O_EXCL */
+        ASSERT_ERROR(xopenat_full(tfd, "link", O_RDWR|O_CREAT, /* xopen_flags= */ 0, 0666), ELOOP);
+        ASSERT_ERROR(openat_report_new(tfd, "link", O_RDWR|O_CREAT|O_EXCL, 0666, &b), EEXIST);
+
         fd = openat_report_new(tfd, "target", O_RDWR|O_CREAT, 0666, &b);
         ASSERT_OK(fd);
         fd = safe_close(fd);

--- a/src/test/test-fs-util.c
+++ b/src/test/test-fs-util.c
@@ -9,6 +9,7 @@
 #include "argv-util.h"
 #include "capability-util.h"
 #include "copy.h"
+#include "errno-util.h"
 #include "fd-util.h"
 #include "fs-util.h"
 #include "mkdir.h"
@@ -712,6 +713,38 @@ TEST(xopenat_full) {
 
         assert_se((fd = xopenat_full(tfd, "def", O_PATH|O_CLOEXEC, 0, 0)) >= 0);
         assert_se((fd2 = xopenat_full(fd, "", O_RDWR|O_CLOEXEC, 0, 0644)) >= 0);
+}
+
+TEST(xopenat_tmpfile) {
+        _cleanup_(rm_rf_physical_and_freep) char *t = NULL;
+        _cleanup_close_ int tfd = -EBADF, fd = -EBADF;
+        struct stat st;
+
+        ASSERT_OK(tfd = mkdtemp_open(NULL, 0, &t));
+
+        BLOCK_WITH_UMASK(0022);
+
+        /* The path names the directory to create the anonymous file in */
+        fd = xopenat_full(tfd, ".", O_TMPFILE|O_RDWR, /* xopen_flags= */ 0, MODE_INVALID);
+        if (ERRNO_IS_NEG_NOT_SUPPORTED(fd) || fd == -EISDIR)
+                return (void) log_tests_skipped_errno(fd, "O_TMPFILE not supported");
+        ASSERT_OK(fd);
+        ASSERT_OK_ERRNO(fstat(fd, &st));
+        ASSERT_TRUE(S_ISREG(st.st_mode));
+        ASSERT_EQ(st.st_nlink, 0U);
+        ASSERT_EQ(st.st_mode & 07777, 0644U); /* the regular file default, not the 0755 directory one */
+        fd = safe_close(fd);
+
+        ASSERT_OK(fd = xopenat_full(tfd, ".", O_TMPFILE|O_RDWR|O_EXCL, /* xopen_flags= */ 0, 0600));
+        ASSERT_OK_ERRNO(fstat(fd, &st));
+        ASSERT_TRUE(S_ISREG(st.st_mode));
+        ASSERT_EQ(st.st_mode & 07777, 0600U);
+        fd = safe_close(fd);
+
+        ASSERT_OK(fd = open_parent_at(tfd, "file", O_TMPFILE|O_RDWR, 0600));
+        ASSERT_OK_ERRNO(fstat(fd, &st));
+        ASSERT_TRUE(S_ISREG(st.st_mode));
+        ASSERT_EQ(st.st_nlink, 0U);
 }
 
 TEST(xopenat_regular) {

--- a/src/test/test-fs-util.c
+++ b/src/test/test-fs-util.c
@@ -553,57 +553,57 @@ TEST(open_mkdir_at) {
         _cleanup_(rm_rf_physical_and_freep) char *t = NULL;
         struct stat sta, stb;
 
-        assert_se(open_mkdir_at(AT_FDCWD, "/", O_EXCL|O_CLOEXEC, 0) == -EEXIST);
-        assert_se(open_mkdir_at(AT_FDCWD, ".", O_EXCL|O_CLOEXEC, 0) == -EEXIST);
+        assert_se(open_mkdir_at(AT_FDCWD, "/", O_EXCL, 0) == -EEXIST);
+        assert_se(open_mkdir_at(AT_FDCWD, ".", O_EXCL, 0) == -EEXIST);
 
-        fd = open_mkdir_at(AT_FDCWD, "/", O_CLOEXEC, 0);
+        fd = open_mkdir_at(AT_FDCWD, "/", 0, 0);
         assert_se(fd >= 0);
         assert_se(stat("/", &sta) >= 0);
         ASSERT_OK_ERRNO(fstat(fd, &stb));
         assert_se(stat_inode_same(&sta, &stb));
         fd = safe_close(fd);
 
-        fd = open_mkdir_at(AT_FDCWD, ".", O_CLOEXEC, 0);
+        fd = open_mkdir_at(AT_FDCWD, ".", 0, 0);
         assert_se(stat(".", &sta) >= 0);
         ASSERT_OK_ERRNO(fstat(fd, &stb));
         assert_se(stat_inode_same(&sta, &stb));
         fd = safe_close(fd);
 
-        assert_se(open_mkdir_at(AT_FDCWD, "/proc", O_EXCL|O_CLOEXEC, 0) == -EEXIST);
+        assert_se(open_mkdir_at(AT_FDCWD, "/proc", O_EXCL, 0) == -EEXIST);
 
-        fd = open_mkdir_at(AT_FDCWD, "/proc", O_CLOEXEC, 0);
+        fd = open_mkdir_at(AT_FDCWD, "/proc", 0, 0);
         assert_se(fd >= 0);
         fd = safe_close(fd);
 
-        assert_se(open_mkdir_at(AT_FDCWD, "/bin/sh", O_EXCL|O_CLOEXEC, 0) == -EEXIST);
-        assert_se(open_mkdir_at(AT_FDCWD, "/bin/sh", O_CLOEXEC, 0) == -EEXIST);
+        assert_se(open_mkdir_at(AT_FDCWD, "/bin/sh", O_EXCL, 0) == -EEXIST);
+        assert_se(open_mkdir_at(AT_FDCWD, "/bin/sh", 0, 0) == -EEXIST);
 
         assert_se(mkdtemp_malloc(NULL, &t) >= 0);
 
-        assert_se(open_mkdir_at(AT_FDCWD, t, O_EXCL|O_CLOEXEC, 0) == -EEXIST);
-        assert_se(open_mkdir_at(AT_FDCWD, t, O_PATH|O_EXCL|O_CLOEXEC, 0) == -EEXIST);
+        assert_se(open_mkdir_at(AT_FDCWD, t, O_EXCL, 0) == -EEXIST);
+        assert_se(open_mkdir_at(AT_FDCWD, t, O_PATH|O_EXCL, 0) == -EEXIST);
 
-        fd = open_mkdir_at(AT_FDCWD, t, O_CLOEXEC, 0000);
+        fd = open_mkdir_at(AT_FDCWD, t, 0, 0000);
         assert_se(fd >= 0);
         fd = safe_close(fd);
 
-        fd = open_mkdir_at(AT_FDCWD, t, O_PATH|O_CLOEXEC, 0000);
+        fd = open_mkdir_at(AT_FDCWD, t, O_PATH, 0000);
         assert_se(fd >= 0);
 
-        subdir_fd = open_mkdir_at(fd, "xxx", O_PATH|O_EXCL|O_CLOEXEC, 0700);
+        subdir_fd = open_mkdir_at(fd, "xxx", O_PATH|O_EXCL, 0700);
         assert_se(subdir_fd >= 0);
 
-        assert_se(open_mkdir_at(fd, "xxx", O_PATH|O_EXCL|O_CLOEXEC, 0) == -EEXIST);
+        assert_se(open_mkdir_at(fd, "xxx", O_PATH|O_EXCL, 0) == -EEXIST);
 
-        subsubdir_fd = open_mkdir_at(subdir_fd, "yyy", O_EXCL|O_CLOEXEC, 0700);
+        subsubdir_fd = open_mkdir_at(subdir_fd, "yyy", O_EXCL, 0700);
         assert_se(subsubdir_fd >= 0);
         subsubdir_fd = safe_close(subsubdir_fd);
 
-        assert_se(open_mkdir_at(subdir_fd, "yyy", O_EXCL|O_CLOEXEC, 0) == -EEXIST);
+        assert_se(open_mkdir_at(subdir_fd, "yyy", O_EXCL, 0) == -EEXIST);
 
-        assert_se(open_mkdir_at(fd, "xxx/yyy", O_EXCL|O_CLOEXEC, 0) == -EEXIST);
+        assert_se(open_mkdir_at(fd, "xxx/yyy", O_EXCL, 0) == -EEXIST);
 
-        subsubdir_fd = open_mkdir_at(fd, "xxx/yyy", O_CLOEXEC, 0700);
+        subsubdir_fd = open_mkdir_at(fd, "xxx/yyy", 0, 0700);
         assert_se(subsubdir_fd >= 0);
 }
 
@@ -693,26 +693,26 @@ TEST(xopenat_full) {
 
         /* Test that xopenat_full() creates directories if O_DIRECTORY is specified. */
 
-        assert_se((fd = xopenat_full(tfd, "abc", O_DIRECTORY|O_CREAT|O_EXCL|O_CLOEXEC, 0, 0755)) >= 0);
+        assert_se((fd = xopenat_full(tfd, "abc", O_DIRECTORY|O_CREAT|O_EXCL, 0, 0755)) >= 0);
         assert_se((fd_verify_directory(fd) >= 0));
         fd = safe_close(fd);
 
-        assert_se(xopenat_full(tfd, "abc", O_DIRECTORY|O_CREAT|O_EXCL|O_CLOEXEC, 0, 0755) == -EEXIST);
+        assert_se(xopenat_full(tfd, "abc", O_DIRECTORY|O_CREAT|O_EXCL, 0, 0755) == -EEXIST);
 
-        assert_se((fd = xopenat_full(tfd, "abc", O_DIRECTORY|O_CREAT|O_CLOEXEC, 0, 0755)) >= 0);
+        assert_se((fd = xopenat_full(tfd, "abc", O_DIRECTORY|O_CREAT, 0, 0755)) >= 0);
         assert_se((fd_verify_directory(fd) >= 0));
         fd = safe_close(fd);
 
         /* Test that xopenat_full() creates regular files if O_DIRECTORY is not specified. */
 
-        assert_se((fd = xopenat_full(tfd, "def", O_CREAT|O_EXCL|O_CLOEXEC, 0, 0644)) >= 0);
+        assert_se((fd = xopenat_full(tfd, "def", O_CREAT|O_EXCL, 0, 0644)) >= 0);
         assert_se(fd_verify_regular(fd) >= 0);
         fd = safe_close(fd);
 
         /* Test that we can reopen an existing fd with xopenat_full() by specifying an empty path. */
 
-        assert_se((fd = xopenat_full(tfd, "def", O_PATH|O_CLOEXEC, 0, 0)) >= 0);
-        assert_se((fd2 = xopenat_full(fd, "", O_RDWR|O_CLOEXEC, 0, 0644)) >= 0);
+        assert_se((fd = xopenat_full(tfd, "def", O_PATH, 0, 0)) >= 0);
+        assert_se((fd2 = xopenat_full(fd, "", O_RDWR, 0, 0644)) >= 0);
 }
 
 TEST(xopenat_tmpfile) {
@@ -751,26 +751,26 @@ TEST(xopenat_regular) {
 
         _cleanup_close_ int fd = -EBADF;
 
-        assert_se(xopenat_full(AT_FDCWD, "/dev/null", O_RDWR|O_CLOEXEC, XO_REGULAR, 0) == -EBADFD);
-        assert_se(xopenat_full(AT_FDCWD, "/proc", O_RDONLY|O_CLOEXEC, XO_REGULAR, 0) == -EISDIR);
-        assert_se(xopenat_full(AT_FDCWD, "/proc/self", O_RDONLY|O_CLOEXEC, XO_REGULAR, 0) == -EISDIR);
-        assert_se(xopenat_full(AT_FDCWD, "/proc/self", O_RDONLY|O_CLOEXEC|O_NOFOLLOW, XO_REGULAR, 0) == -ELOOP);
+        assert_se(xopenat_full(AT_FDCWD, "/dev/null", O_RDWR, XO_REGULAR, 0) == -EBADFD);
+        assert_se(xopenat_full(AT_FDCWD, "/proc", O_RDONLY, XO_REGULAR, 0) == -EISDIR);
+        assert_se(xopenat_full(AT_FDCWD, "/proc/self", O_RDONLY, XO_REGULAR, 0) == -EISDIR);
+        assert_se(xopenat_full(AT_FDCWD, "/proc/self", O_RDONLY|O_NOFOLLOW, XO_REGULAR, 0) == -ELOOP);
 
-        fd = xopenat_full(AT_FDCWD, "/proc/mounts", O_RDONLY|O_CLOEXEC, XO_REGULAR, 0);
+        fd = xopenat_full(AT_FDCWD, "/proc/mounts", O_RDONLY, XO_REGULAR, 0);
         assert_se(fd >= 0);
         fd = safe_close(fd);
 
-        assert_se(xopenat_full(AT_FDCWD, "/proc/mounts", O_RDONLY|O_CLOEXEC|O_NOFOLLOW, XO_REGULAR, 0) == -ELOOP);
+        assert_se(xopenat_full(AT_FDCWD, "/proc/mounts", O_RDONLY|O_NOFOLLOW, XO_REGULAR, 0) == -ELOOP);
 
-        fd = xopenat_full(AT_FDCWD, "/proc/mounts", O_RDONLY|O_CLOEXEC|O_PATH, XO_REGULAR, 0);
+        fd = xopenat_full(AT_FDCWD, "/proc/mounts", O_RDONLY|O_PATH, XO_REGULAR, 0);
         assert_se(fd >= 0);
         fd = safe_close(fd);
 
-        fd = xopenat_full(AT_FDCWD, "/tmp/xopenat-regular-test", O_RDWR|O_CLOEXEC|O_CREAT, XO_REGULAR, 0600);
+        fd = xopenat_full(AT_FDCWD, "/tmp/xopenat-regular-test", O_RDWR|O_CREAT, XO_REGULAR, 0600);
         assert_se(fd >= 0);
         fd = safe_close(fd);
 
-        assert_se(xopenat_full(AT_FDCWD, "/tmp/xopenat-regular-test", O_RDWR|O_CLOEXEC|O_CREAT|O_EXCL, XO_REGULAR, 0600) == -EEXIST);
+        assert_se(xopenat_full(AT_FDCWD, "/tmp/xopenat-regular-test", O_RDWR|O_CREAT|O_EXCL, XO_REGULAR, 0600) == -EEXIST);
 
         assert_se(unlink("/tmp/xopenat-regular-test") >= 0);
 }
@@ -792,31 +792,31 @@ TEST(xopenat_socket) {
         fd = safe_close(fd);
 
         /* XO_SOCKET requires O_PATH. */
-        fd = xopenat_full(tfd, "test.sock", O_PATH|O_CLOEXEC, XO_SOCKET, 0);
+        fd = xopenat_full(tfd, "test.sock", O_PATH, XO_SOCKET, 0);
         ASSERT_OK(fd);
         fd = safe_close(fd);
 
         /* Reopen via empty path should also work. */
-        fd = ASSERT_OK(xopenat_full(tfd, "test.sock", O_PATH|O_CLOEXEC, 0, 0));
-        _cleanup_close_ int fd2 = xopenat_full(fd, NULL, O_PATH|O_CLOEXEC, XO_SOCKET, 0);
+        fd = ASSERT_OK(xopenat_full(tfd, "test.sock", O_PATH, 0, 0));
+        _cleanup_close_ int fd2 = xopenat_full(fd, NULL, O_PATH, XO_SOCKET, 0);
         ASSERT_OK(fd2);
         fd = safe_close(fd);
 
         /* Non-socket inodes must be rejected. */
         ASSERT_OK_ERRNO(mkdirat(tfd, "dir", 0755));
-        ASSERT_ERROR(xopenat_full(tfd, "dir", O_PATH|O_CLOEXEC, XO_SOCKET, 0), EISDIR);
+        ASSERT_ERROR(xopenat_full(tfd, "dir", O_PATH, XO_SOCKET, 0), EISDIR);
 
         fd = ASSERT_OK_ERRNO(openat(tfd, "reg", O_CREAT|O_CLOEXEC, 0600));
         fd = safe_close(fd);
-        ASSERT_ERROR(xopenat_full(tfd, "reg", O_PATH|O_CLOEXEC, XO_SOCKET, 0), ENOTSOCK);
+        ASSERT_ERROR(xopenat_full(tfd, "reg", O_PATH, XO_SOCKET, 0), ENOTSOCK);
 
         /* Reopen via empty path of a non-socket fd must also be rejected. */
-        fd = ASSERT_OK(xopenat_full(tfd, "reg", O_PATH|O_CLOEXEC, 0, 0));
-        ASSERT_ERROR(xopenat_full(fd, NULL, O_PATH|O_CLOEXEC, XO_SOCKET, 0), ENOTSOCK);
+        fd = ASSERT_OK(xopenat_full(tfd, "reg", O_PATH, 0, 0));
+        ASSERT_ERROR(xopenat_full(fd, NULL, O_PATH, XO_SOCKET, 0), ENOTSOCK);
         fd = safe_close(fd);
 
-        fd = ASSERT_OK(xopenat_full(tfd, "dir", O_PATH|O_CLOEXEC, 0, 0));
-        ASSERT_ERROR(xopenat_full(fd, NULL, O_PATH|O_CLOEXEC, XO_SOCKET, 0), EISDIR);
+        fd = ASSERT_OK(xopenat_full(tfd, "dir", O_PATH, 0, 0));
+        ASSERT_ERROR(xopenat_full(fd, NULL, O_PATH, XO_SOCKET, 0), EISDIR);
         fd = safe_close(fd);
 }
 
@@ -826,10 +826,10 @@ TEST(xopenat_trigger_automount) {
         /* We can't easily set up an autofs mount in a test, but we can verify that
          * XO_TRIGGER_AUTOMOUNT works on a regular path and produces the same inode as a
          * plain O_PATH open. */
-        fd = xopenat_full(AT_FDCWD, "/usr", O_PATH|O_CLOEXEC|O_DIRECTORY, XO_TRIGGER_AUTOMOUNT, 0);
+        fd = xopenat_full(AT_FDCWD, "/usr", O_PATH|O_DIRECTORY, XO_TRIGGER_AUTOMOUNT, 0);
         ASSERT_OK(fd);
 
-        _cleanup_close_ int fd2 = xopenat_full(AT_FDCWD, "/usr", O_PATH|O_CLOEXEC|O_DIRECTORY, 0, 0);
+        _cleanup_close_ int fd2 = xopenat_full(AT_FDCWD, "/usr", O_PATH|O_DIRECTORY, 0, 0);
         ASSERT_OK(fd2);
         ASSERT_OK_POSITIVE(fd_inode_same(fd, fd2));
 }
@@ -843,7 +843,7 @@ TEST(xopenat_auto_rw_ro) {
 
         /* Regular writable file: XO_AUTO_RW_RO should end up in O_RDWR. */
 
-        fd = xopenat_full(tfd, "rw", O_CREAT|O_EXCL|O_CLOEXEC, XO_AUTO_RW_RO, 0644);
+        fd = xopenat_full(tfd, "rw", O_CREAT|O_EXCL, XO_AUTO_RW_RO, 0644);
         assert_se(fd >= 0);
         ASSERT_OK_ERRNO(fl = fcntl(fd, F_GETFL));
         assert_se((fl & O_ACCMODE) == O_RDWR);
@@ -851,7 +851,7 @@ TEST(xopenat_auto_rw_ro) {
 
         /* Same thing, but with XO_REGULAR set too. */
 
-        fd = xopenat_full(tfd, "rw2", O_CREAT|O_EXCL|O_CLOEXEC, XO_AUTO_RW_RO|XO_REGULAR, 0644);
+        fd = xopenat_full(tfd, "rw2", O_CREAT|O_EXCL, XO_AUTO_RW_RO|XO_REGULAR, 0644);
         assert_se(fd >= 0);
         ASSERT_OK_ERRNO(fl = fcntl(fd, F_GETFL));
         assert_se((fl & O_ACCMODE) == O_RDWR);
@@ -859,9 +859,9 @@ TEST(xopenat_auto_rw_ro) {
 
         /* Reopen via empty path on an O_PATH fd must also end up in O_RDWR. */
 
-        _cleanup_close_ int path_fd = xopenat_full(tfd, "rw", O_PATH|O_CLOEXEC, 0, 0);
+        _cleanup_close_ int path_fd = xopenat_full(tfd, "rw", O_PATH, 0, 0);
         assert_se(path_fd >= 0);
-        fd = xopenat_full(path_fd, "", O_CLOEXEC, XO_AUTO_RW_RO, 0);
+        fd = xopenat_full(path_fd, "", /* open_flags= */ 0, XO_AUTO_RW_RO, 0);
         assert_se(fd >= 0);
         ASSERT_OK_ERRNO(fl = fcntl(fd, F_GETFL));
         assert_se((fl & O_ACCMODE) == O_RDWR);
@@ -869,7 +869,7 @@ TEST(xopenat_auto_rw_ro) {
 
         /* Directories can only be opened read-only: XO_AUTO_RW_RO with O_DIRECTORY must fall back to O_RDONLY. */
 
-        fd = xopenat_full(tfd, "subdir", O_DIRECTORY|O_CREAT|O_CLOEXEC, XO_AUTO_RW_RO, 0755);
+        fd = xopenat_full(tfd, "subdir", O_DIRECTORY|O_CREAT, XO_AUTO_RW_RO, 0755);
         assert_se(fd >= 0);
         ASSERT_OK_ERRNO(fl = fcntl(fd, F_GETFL));
         assert_se((fl & O_ACCMODE) == O_RDONLY);
@@ -877,7 +877,7 @@ TEST(xopenat_auto_rw_ro) {
 
         /* Same for opening an existing directory. */
 
-        fd = xopenat_full(tfd, "subdir", O_DIRECTORY|O_CLOEXEC, XO_AUTO_RW_RO, 0);
+        fd = xopenat_full(tfd, "subdir", O_DIRECTORY, XO_AUTO_RW_RO, 0);
         assert_se(fd >= 0);
         ASSERT_OK_ERRNO(fl = fcntl(fd, F_GETFL));
         assert_se((fl & O_ACCMODE) == O_RDONLY);
@@ -894,23 +894,23 @@ TEST(xopenat_auto_rw_ro) {
                 assert_se(fchmodat(tfd, "ro", 0444, 0) >= 0);
 
                 /* Plain case: no XO_REGULAR. */
-                fd = xopenat_full(tfd, "ro", O_CLOEXEC, XO_AUTO_RW_RO, 0);
+                fd = xopenat_full(tfd, "ro", /* open_flags= */ 0, XO_AUTO_RW_RO, 0);
                 assert_se(fd >= 0);
                 ASSERT_OK_ERRNO(fl = fcntl(fd, F_GETFL));
                 assert_se((fl & O_ACCMODE) == O_RDONLY);
                 fd = safe_close(fd);
 
                 /* With XO_REGULAR (exercises the pin-via-O_PATH + reopen path). */
-                fd = xopenat_full(tfd, "ro", O_CLOEXEC, XO_AUTO_RW_RO|XO_REGULAR, 0);
+                fd = xopenat_full(tfd, "ro", /* open_flags= */ 0, XO_AUTO_RW_RO|XO_REGULAR, 0);
                 assert_se(fd >= 0);
                 ASSERT_OK_ERRNO(fl = fcntl(fd, F_GETFL));
                 assert_se((fl & O_ACCMODE) == O_RDONLY);
                 fd = safe_close(fd);
 
                 /* Also exercise the empty-path/fd-reopen branch. */
-                _cleanup_close_ int ro_path_fd = xopenat_full(tfd, "ro", O_PATH|O_CLOEXEC, 0, 0);
+                _cleanup_close_ int ro_path_fd = xopenat_full(tfd, "ro", O_PATH, 0, 0);
                 assert_se(ro_path_fd >= 0);
-                fd = xopenat_full(ro_path_fd, "", O_CLOEXEC, XO_AUTO_RW_RO, 0);
+                fd = xopenat_full(ro_path_fd, "", /* open_flags= */ 0, XO_AUTO_RW_RO, 0);
                 assert_se(fd >= 0);
                 ASSERT_OK_ERRNO(fl = fcntl(fd, F_GETFL));
                 assert_se((fl & O_ACCMODE) == O_RDONLY);
@@ -930,10 +930,10 @@ TEST(xopenat_lock_full) {
          * and close the file descriptor and still properly create the directory and acquire the lock in
          * another process.  */
 
-        fd = ASSERT_OK(xopenat_lock_full(tfd, "abc", O_CREAT|O_DIRECTORY|O_CLOEXEC, 0, 0755, LOCK_BSD, LOCK_EX));
+        fd = ASSERT_OK(xopenat_lock_full(tfd, "abc", O_CREAT|O_DIRECTORY, 0, 0755, LOCK_BSD, LOCK_EX));
         ASSERT_OK_ERRNO(faccessat(tfd, "abc", F_OK, 0));
         ASSERT_OK(fd_verify_directory(fd));
-        ASSERT_ERROR(xopenat_lock_full(tfd, "abc", O_DIRECTORY|O_CLOEXEC, 0, 0755, LOCK_BSD, LOCK_EX|LOCK_NB), EAGAIN);
+        ASSERT_ERROR(xopenat_lock_full(tfd, "abc", O_DIRECTORY, 0, 0755, LOCK_BSD, LOCK_EX|LOCK_NB), EAGAIN);
 
         _cleanup_(pidref_done) PidRef pidref = PIDREF_NULL;
         r = ASSERT_OK(pidref_safe_fork("(lock)", FORK_DEATHSIG_SIGKILL|FORK_LOG, &pidref));
@@ -941,10 +941,10 @@ TEST(xopenat_lock_full) {
         if (r == 0) {
                 safe_close(fd);
 
-                fd = ASSERT_OK(xopenat_lock_full(tfd, "abc", O_CREAT|O_DIRECTORY|O_CLOEXEC, 0, 0755, LOCK_BSD, LOCK_EX));
+                fd = ASSERT_OK(xopenat_lock_full(tfd, "abc", O_CREAT|O_DIRECTORY, 0, 0755, LOCK_BSD, LOCK_EX));
                 ASSERT_OK_ERRNO(faccessat(tfd, "abc", F_OK, 0));
                 ASSERT_OK(fd_verify_directory(fd));
-                ASSERT_ERROR(xopenat_lock_full(tfd, "abc", O_DIRECTORY|O_CLOEXEC, 0, 0755, LOCK_BSD, LOCK_EX|LOCK_NB), EAGAIN);
+                ASSERT_ERROR(xopenat_lock_full(tfd, "abc", O_DIRECTORY, 0, 0755, LOCK_BSD, LOCK_EX|LOCK_NB), EAGAIN);
 
                 _exit(EXIT_SUCCESS);
         }
@@ -1038,7 +1038,7 @@ TEST(xat_fdroot) {
         ASSERT_STREQ(p, "/");
 
         _cleanup_close_ int fd = -EBADF;
-        fd = fd_reopen(XAT_FDROOT, O_CLOEXEC);
+        fd = fd_reopen(XAT_FDROOT, O_RDONLY);
         ASSERT_OK(fd);
 
         ASSERT_OK_POSITIVE(path_is_root_at(XAT_FDROOT, NULL));

--- a/src/test/test-fs-util.c
+++ b/src/test/test-fs-util.c
@@ -672,7 +672,7 @@ TEST(openat_report_new) {
 
         ASSERT_OK_ERRNO(symlinkat("target", tfd, "link"));
         fd = openat_report_new(tfd, "link", O_RDWR|O_CREAT, 0666, &b);
-        ASSERT_ERROR(fd, EEXIST);
+        ASSERT_ERROR(fd, ELOOP);
 
         fd = openat_report_new(tfd, "target", O_RDWR|O_CREAT, 0666, &b);
         ASSERT_OK(fd);

--- a/src/test/test-fs-util.c
+++ b/src/test/test-fs-util.c
@@ -553,37 +553,37 @@ TEST(open_mkdir_at) {
         _cleanup_(rm_rf_physical_and_freep) char *t = NULL;
         struct stat sta, stb;
 
-        assert_se(open_mkdir_at(AT_FDCWD, "/", O_EXCL, 0) == -EEXIST);
-        assert_se(open_mkdir_at(AT_FDCWD, ".", O_EXCL, 0) == -EEXIST);
+        assert_se(open_mkdir_at(AT_FDCWD, "/", O_EXCL, /* mode= */ 0) == -EEXIST);
+        assert_se(open_mkdir_at(AT_FDCWD, ".", O_EXCL, /* mode= */ 0) == -EEXIST);
 
-        fd = open_mkdir_at(AT_FDCWD, "/", 0, 0);
+        fd = open_mkdir_at(AT_FDCWD, "/", /* flags= */ 0, /* mode= */ 0);
         assert_se(fd >= 0);
         assert_se(stat("/", &sta) >= 0);
         ASSERT_OK_ERRNO(fstat(fd, &stb));
         assert_se(stat_inode_same(&sta, &stb));
         fd = safe_close(fd);
 
-        fd = open_mkdir_at(AT_FDCWD, ".", 0, 0);
+        fd = open_mkdir_at(AT_FDCWD, ".", /* flags= */ 0, /* mode= */ 0);
         assert_se(stat(".", &sta) >= 0);
         ASSERT_OK_ERRNO(fstat(fd, &stb));
         assert_se(stat_inode_same(&sta, &stb));
         fd = safe_close(fd);
 
-        assert_se(open_mkdir_at(AT_FDCWD, "/proc", O_EXCL, 0) == -EEXIST);
+        assert_se(open_mkdir_at(AT_FDCWD, "/proc", O_EXCL, /* mode= */ 0) == -EEXIST);
 
-        fd = open_mkdir_at(AT_FDCWD, "/proc", 0, 0);
+        fd = open_mkdir_at(AT_FDCWD, "/proc", /* flags= */ 0, /* mode= */ 0);
         assert_se(fd >= 0);
         fd = safe_close(fd);
 
-        assert_se(open_mkdir_at(AT_FDCWD, "/bin/sh", O_EXCL, 0) == -EEXIST);
-        assert_se(open_mkdir_at(AT_FDCWD, "/bin/sh", 0, 0) == -EEXIST);
+        assert_se(open_mkdir_at(AT_FDCWD, "/bin/sh", O_EXCL, /* mode= */ 0) == -EEXIST);
+        assert_se(open_mkdir_at(AT_FDCWD, "/bin/sh", /* flags= */ 0, /* mode= */ 0) == -EEXIST);
 
         assert_se(mkdtemp_malloc(NULL, &t) >= 0);
 
-        assert_se(open_mkdir_at(AT_FDCWD, t, O_EXCL, 0) == -EEXIST);
-        assert_se(open_mkdir_at(AT_FDCWD, t, O_PATH|O_EXCL, 0) == -EEXIST);
+        assert_se(open_mkdir_at(AT_FDCWD, t, O_EXCL, /* mode= */ 0) == -EEXIST);
+        assert_se(open_mkdir_at(AT_FDCWD, t, O_PATH|O_EXCL, /* mode= */ 0) == -EEXIST);
 
-        fd = open_mkdir_at(AT_FDCWD, t, 0, 0000);
+        fd = open_mkdir_at(AT_FDCWD, t, /* flags= */ 0, 0000);
         assert_se(fd >= 0);
         fd = safe_close(fd);
 
@@ -593,17 +593,17 @@ TEST(open_mkdir_at) {
         subdir_fd = open_mkdir_at(fd, "xxx", O_PATH|O_EXCL, 0700);
         assert_se(subdir_fd >= 0);
 
-        assert_se(open_mkdir_at(fd, "xxx", O_PATH|O_EXCL, 0) == -EEXIST);
+        assert_se(open_mkdir_at(fd, "xxx", O_PATH|O_EXCL, /* mode= */ 0) == -EEXIST);
 
         subsubdir_fd = open_mkdir_at(subdir_fd, "yyy", O_EXCL, 0700);
         assert_se(subsubdir_fd >= 0);
         subsubdir_fd = safe_close(subsubdir_fd);
 
-        assert_se(open_mkdir_at(subdir_fd, "yyy", O_EXCL, 0) == -EEXIST);
+        assert_se(open_mkdir_at(subdir_fd, "yyy", O_EXCL, /* mode= */ 0) == -EEXIST);
 
-        assert_se(open_mkdir_at(fd, "xxx/yyy", O_EXCL, 0) == -EEXIST);
+        assert_se(open_mkdir_at(fd, "xxx/yyy", O_EXCL, /* mode= */ 0) == -EEXIST);
 
-        subsubdir_fd = open_mkdir_at(fd, "xxx/yyy", 0, 0700);
+        subsubdir_fd = open_mkdir_at(fd, "xxx/yyy", /* flags= */ 0, 0700);
         assert_se(subsubdir_fd >= 0);
 }
 
@@ -697,25 +697,25 @@ TEST(xopenat_full) {
 
         /* Test that xopenat_full() creates directories if O_DIRECTORY is specified. */
 
-        assert_se((fd = xopenat_full(tfd, "abc", O_DIRECTORY|O_CREAT|O_EXCL, 0, 0755)) >= 0);
+        assert_se((fd = xopenat_full(tfd, "abc", O_DIRECTORY|O_CREAT|O_EXCL, /* xopen_flags= */ 0, 0755)) >= 0);
         assert_se((fd_verify_directory(fd) >= 0));
         fd = safe_close(fd);
 
-        assert_se(xopenat_full(tfd, "abc", O_DIRECTORY|O_CREAT|O_EXCL, 0, 0755) == -EEXIST);
+        assert_se(xopenat_full(tfd, "abc", O_DIRECTORY|O_CREAT|O_EXCL, /* xopen_flags= */ 0, 0755) == -EEXIST);
 
-        assert_se((fd = xopenat_full(tfd, "abc", O_DIRECTORY|O_CREAT, 0, 0755)) >= 0);
+        assert_se((fd = xopenat_full(tfd, "abc", O_DIRECTORY|O_CREAT, /* xopen_flags= */ 0, 0755)) >= 0);
         assert_se((fd_verify_directory(fd) >= 0));
         fd = safe_close(fd);
 
         /* Test that xopenat_full() creates regular files if O_DIRECTORY is not specified. */
 
-        assert_se((fd = xopenat_full(tfd, "def", O_CREAT|O_EXCL, 0, 0644)) >= 0);
+        assert_se((fd = xopenat_full(tfd, "def", O_CREAT|O_EXCL, /* xopen_flags= */ 0, 0644)) >= 0);
         assert_se(fd_verify_regular(fd) >= 0);
         fd = safe_close(fd);
 
         /* Test that we can reopen an existing fd with xopenat_full() by specifying an empty path. */
 
-        assert_se((fd = xopenat_full(tfd, "def", O_PATH, 0, 0)) >= 0);
+        assert_se((fd = xopenat_full(tfd, "def", O_PATH, /* xopen_flags= */ 0, /* mode= */ 0)) >= 0);
         assert_se((fd2 = xopenat_full(fd, "", O_RDWR, XO_EMPTY_PATH, 0644)) >= 0);
 }
 
@@ -755,18 +755,18 @@ TEST(xopenat_regular) {
 
         _cleanup_close_ int fd = -EBADF;
 
-        assert_se(xopenat_full(AT_FDCWD, "/dev/null", O_RDWR, XO_REGULAR, 0) == -EBADFD);
-        assert_se(xopenat_full(AT_FDCWD, "/proc", O_RDONLY, XO_REGULAR, 0) == -EISDIR);
-        assert_se(xopenat_full(AT_FDCWD, "/proc/self", O_RDONLY, XO_REGULAR, 0) == -EISDIR);
-        assert_se(xopenat_full(AT_FDCWD, "/proc/self", O_RDONLY|O_NOFOLLOW, XO_REGULAR, 0) == -ELOOP);
+        assert_se(xopenat_full(AT_FDCWD, "/dev/null", O_RDWR, XO_REGULAR, /* mode= */ 0) == -EBADFD);
+        assert_se(xopenat_full(AT_FDCWD, "/proc", O_RDONLY, XO_REGULAR, /* mode= */ 0) == -EISDIR);
+        assert_se(xopenat_full(AT_FDCWD, "/proc/self", O_RDONLY, XO_REGULAR, /* mode= */ 0) == -EISDIR);
+        assert_se(xopenat_full(AT_FDCWD, "/proc/self", O_RDONLY|O_NOFOLLOW, XO_REGULAR, /* mode= */ 0) == -ELOOP);
 
-        fd = xopenat_full(AT_FDCWD, "/proc/mounts", O_RDONLY, XO_REGULAR, 0);
+        fd = xopenat_full(AT_FDCWD, "/proc/mounts", O_RDONLY, XO_REGULAR, /* mode= */ 0);
         assert_se(fd >= 0);
         fd = safe_close(fd);
 
-        assert_se(xopenat_full(AT_FDCWD, "/proc/mounts", O_RDONLY|O_NOFOLLOW, XO_REGULAR, 0) == -ELOOP);
+        assert_se(xopenat_full(AT_FDCWD, "/proc/mounts", O_RDONLY|O_NOFOLLOW, XO_REGULAR, /* mode= */ 0) == -ELOOP);
 
-        fd = xopenat_full(AT_FDCWD, "/proc/mounts", O_RDONLY|O_PATH, XO_REGULAR, 0);
+        fd = xopenat_full(AT_FDCWD, "/proc/mounts", O_RDONLY|O_PATH, XO_REGULAR, /* mode= */ 0);
         assert_se(fd >= 0);
         fd = safe_close(fd);
 
@@ -777,6 +777,41 @@ TEST(xopenat_regular) {
         assert_se(xopenat_full(AT_FDCWD, "/tmp/xopenat-regular-test", O_RDWR|O_CREAT|O_EXCL, XO_REGULAR, 0600) == -EEXIST);
 
         assert_se(unlink("/tmp/xopenat-regular-test") >= 0);
+}
+
+TEST(xopenat_empty_path) {
+        _cleanup_(rm_rf_physical_and_freep) char *t = NULL;
+        _cleanup_close_ int tfd = -EBADF, fd = -EBADF;
+
+        ASSERT_OK(tfd = mkdtemp_open(NULL, 0, &t));
+
+        /* Without XO_EMPTY_PATH an empty path is a missing name, as for open("") */
+        ASSERT_ERROR(xopenat(tfd, "", O_RDONLY|O_DIRECTORY), ENOENT);
+        ASSERT_ERROR(xopenat(tfd, /* path= */ NULL, O_RDONLY|O_DIRECTORY), ENOENT);
+        ASSERT_ERROR(xopenat(AT_FDCWD, "", O_RDONLY|O_DIRECTORY), ENOENT);
+        ASSERT_ERROR(xopenat(XAT_FDROOT, "", O_RDONLY|O_DIRECTORY), ENOENT);
+        ASSERT_ERROR(xopenat_full(tfd, "", O_RDWR|O_CREAT, /* xopen_flags= */ 0, 0644), ENOENT);
+        ASSERT_ERROR(xopenat_full(tfd, "", O_RDWR|O_CREAT|O_EXCL, /* xopen_flags= */ 0, 0644), ENOENT);
+        ASSERT_ERROR(xopenat_full(AT_FDCWD, "", O_WRONLY|O_CREAT, /* xopen_flags= */ 0, 0644), ENOENT);
+        ASSERT_ERROR(xopenat_full(tfd, "", O_RDWR|O_CREAT, XO_EMPTY_PATH, 0644), ENOENT);
+        ASSERT_ERROR(xopenat_full(tfd, /* path= */ NULL, O_RDWR|O_TMPFILE, XO_EMPTY_PATH, 0644), ENOENT);
+
+        /* With the flag it reopens the directory itself, like AT_EMPTY_PATH... */
+        ASSERT_OK(fd = xopenat_full(tfd, "", O_RDONLY|O_DIRECTORY, XO_EMPTY_PATH, MODE_INVALID));
+        ASSERT_OK_POSITIVE(inode_same_at(tfd, NULL, fd, NULL, AT_EMPTY_PATH));
+        fd = safe_close(fd);
+
+        ASSERT_OK(fd = xopenat_full(tfd, /* path= */ NULL, O_RDONLY|O_DIRECTORY, XO_EMPTY_PATH, MODE_INVALID));
+        ASSERT_OK_POSITIVE(inode_same_at(tfd, NULL, fd, NULL, AT_EMPTY_PATH));
+        fd = safe_close(fd);
+
+        ASSERT_OK(fd = xopenat_full(XAT_FDROOT, "", O_RDONLY|O_DIRECTORY, XO_EMPTY_PATH, MODE_INVALID));
+        ASSERT_OK_POSITIVE(inode_same_at(AT_FDCWD, "/", fd, NULL, AT_EMPTY_PATH));
+        fd = safe_close(fd);
+
+        /* ...and a non-empty path is opened as usual */
+        ASSERT_OK(fd = xopenat_full(tfd, "file", O_RDWR|O_CREAT|O_EXCL, XO_EMPTY_PATH, 0644));
+        ASSERT_OK_POSITIVE(inode_same_at(tfd, "file", fd, NULL, AT_EMPTY_PATH));
 }
 
 TEST(xopenat_socket) {
@@ -796,31 +831,31 @@ TEST(xopenat_socket) {
         fd = safe_close(fd);
 
         /* XO_SOCKET requires O_PATH. */
-        fd = xopenat_full(tfd, "test.sock", O_PATH, XO_SOCKET, 0);
+        fd = xopenat_full(tfd, "test.sock", O_PATH, XO_SOCKET, /* mode= */ 0);
         ASSERT_OK(fd);
         fd = safe_close(fd);
 
         /* Reopen via empty path should also work. */
-        fd = ASSERT_OK(xopenat_full(tfd, "test.sock", O_PATH, 0, 0));
-        _cleanup_close_ int fd2 = xopenat_full(fd, NULL, O_PATH, XO_SOCKET|XO_EMPTY_PATH, 0);
+        fd = ASSERT_OK(xopenat_full(tfd, "test.sock", O_PATH, /* xopen_flags= */ 0, /* mode= */ 0));
+        _cleanup_close_ int fd2 = xopenat_full(fd, /* path= */ NULL, O_PATH, XO_SOCKET|XO_EMPTY_PATH, /* mode= */ 0);
         ASSERT_OK(fd2);
         fd = safe_close(fd);
 
         /* Non-socket inodes must be rejected. */
         ASSERT_OK_ERRNO(mkdirat(tfd, "dir", 0755));
-        ASSERT_ERROR(xopenat_full(tfd, "dir", O_PATH, XO_SOCKET, 0), EISDIR);
+        ASSERT_ERROR(xopenat_full(tfd, "dir", O_PATH, XO_SOCKET, /* mode= */ 0), EISDIR);
 
         fd = ASSERT_OK_ERRNO(openat(tfd, "reg", O_CREAT|O_CLOEXEC, 0600));
         fd = safe_close(fd);
-        ASSERT_ERROR(xopenat_full(tfd, "reg", O_PATH, XO_SOCKET, 0), ENOTSOCK);
+        ASSERT_ERROR(xopenat_full(tfd, "reg", O_PATH, XO_SOCKET, /* mode= */ 0), ENOTSOCK);
 
         /* Reopen via empty path of a non-socket fd must also be rejected. */
-        fd = ASSERT_OK(xopenat_full(tfd, "reg", O_PATH, 0, 0));
-        ASSERT_ERROR(xopenat_full(fd, NULL, O_PATH, XO_SOCKET|XO_EMPTY_PATH, 0), ENOTSOCK);
+        fd = ASSERT_OK(xopenat_full(tfd, "reg", O_PATH, /* xopen_flags= */ 0, /* mode= */ 0));
+        ASSERT_ERROR(xopenat_full(fd, /* path= */ NULL, O_PATH, XO_SOCKET|XO_EMPTY_PATH, /* mode= */ 0), ENOTSOCK);
         fd = safe_close(fd);
 
-        fd = ASSERT_OK(xopenat_full(tfd, "dir", O_PATH, 0, 0));
-        ASSERT_ERROR(xopenat_full(fd, NULL, O_PATH, XO_SOCKET|XO_EMPTY_PATH, 0), EISDIR);
+        fd = ASSERT_OK(xopenat_full(tfd, "dir", O_PATH, /* xopen_flags= */ 0, /* mode= */ 0));
+        ASSERT_ERROR(xopenat_full(fd, /* path= */ NULL, O_PATH, XO_SOCKET|XO_EMPTY_PATH, /* mode= */ 0), EISDIR);
         fd = safe_close(fd);
 }
 
@@ -830,10 +865,10 @@ TEST(xopenat_trigger_automount) {
         /* We can't easily set up an autofs mount in a test, but we can verify that
          * XO_TRIGGER_AUTOMOUNT works on a regular path and produces the same inode as a
          * plain O_PATH open. */
-        fd = xopenat_full(AT_FDCWD, "/usr", O_PATH|O_DIRECTORY, XO_TRIGGER_AUTOMOUNT, 0);
+        fd = xopenat_full(AT_FDCWD, "/usr", O_PATH|O_DIRECTORY, XO_TRIGGER_AUTOMOUNT, /* mode= */ 0);
         ASSERT_OK(fd);
 
-        _cleanup_close_ int fd2 = xopenat_full(AT_FDCWD, "/usr", O_PATH|O_DIRECTORY, 0, 0);
+        _cleanup_close_ int fd2 = xopenat_full(AT_FDCWD, "/usr", O_PATH|O_DIRECTORY, /* xopen_flags= */ 0, /* mode= */ 0);
         ASSERT_OK(fd2);
         ASSERT_OK_POSITIVE(fd_inode_same(fd, fd2));
 }
@@ -863,9 +898,9 @@ TEST(xopenat_auto_rw_ro) {
 
         /* Reopen via empty path on an O_PATH fd must also end up in O_RDWR. */
 
-        _cleanup_close_ int path_fd = xopenat_full(tfd, "rw", O_PATH, 0, 0);
+        _cleanup_close_ int path_fd = xopenat_full(tfd, "rw", O_PATH, /* xopen_flags= */ 0, /* mode= */ 0);
         assert_se(path_fd >= 0);
-        fd = xopenat_full(path_fd, "", /* open_flags= */ 0, XO_AUTO_RW_RO|XO_EMPTY_PATH, 0);
+        fd = xopenat_full(path_fd, "", /* open_flags= */ 0, XO_AUTO_RW_RO|XO_EMPTY_PATH, /* mode= */ 0);
         assert_se(fd >= 0);
         ASSERT_OK_ERRNO(fl = fcntl(fd, F_GETFL));
         assert_se((fl & O_ACCMODE) == O_RDWR);
@@ -881,7 +916,7 @@ TEST(xopenat_auto_rw_ro) {
 
         /* Same for opening an existing directory. */
 
-        fd = xopenat_full(tfd, "subdir", O_DIRECTORY, XO_AUTO_RW_RO, 0);
+        fd = xopenat_full(tfd, "subdir", O_DIRECTORY, XO_AUTO_RW_RO, /* mode= */ 0);
         assert_se(fd >= 0);
         ASSERT_OK_ERRNO(fl = fcntl(fd, F_GETFL));
         assert_se((fl & O_ACCMODE) == O_RDONLY);
@@ -898,23 +933,23 @@ TEST(xopenat_auto_rw_ro) {
                 assert_se(fchmodat(tfd, "ro", 0444, 0) >= 0);
 
                 /* Plain case: no XO_REGULAR. */
-                fd = xopenat_full(tfd, "ro", /* open_flags= */ 0, XO_AUTO_RW_RO, 0);
+                fd = xopenat_full(tfd, "ro", /* open_flags= */ 0, XO_AUTO_RW_RO, /* mode= */ 0);
                 assert_se(fd >= 0);
                 ASSERT_OK_ERRNO(fl = fcntl(fd, F_GETFL));
                 assert_se((fl & O_ACCMODE) == O_RDONLY);
                 fd = safe_close(fd);
 
                 /* With XO_REGULAR (exercises the pin-via-O_PATH + reopen path). */
-                fd = xopenat_full(tfd, "ro", /* open_flags= */ 0, XO_AUTO_RW_RO|XO_REGULAR, 0);
+                fd = xopenat_full(tfd, "ro", /* open_flags= */ 0, XO_AUTO_RW_RO|XO_REGULAR, /* mode= */ 0);
                 assert_se(fd >= 0);
                 ASSERT_OK_ERRNO(fl = fcntl(fd, F_GETFL));
                 assert_se((fl & O_ACCMODE) == O_RDONLY);
                 fd = safe_close(fd);
 
                 /* Also exercise the empty-path/fd-reopen branch. */
-                _cleanup_close_ int ro_path_fd = xopenat_full(tfd, "ro", O_PATH, 0, 0);
+                _cleanup_close_ int ro_path_fd = xopenat_full(tfd, "ro", O_PATH, /* xopen_flags= */ 0, /* mode= */ 0);
                 assert_se(ro_path_fd >= 0);
-                fd = xopenat_full(ro_path_fd, "", /* open_flags= */ 0, XO_AUTO_RW_RO|XO_EMPTY_PATH, 0);
+                fd = xopenat_full(ro_path_fd, "", /* open_flags= */ 0, XO_AUTO_RW_RO|XO_EMPTY_PATH, /* mode= */ 0);
                 assert_se(fd >= 0);
                 ASSERT_OK_ERRNO(fl = fcntl(fd, F_GETFL));
                 assert_se((fl & O_ACCMODE) == O_RDONLY);
@@ -934,10 +969,10 @@ TEST(xopenat_lock_full) {
          * and close the file descriptor and still properly create the directory and acquire the lock in
          * another process.  */
 
-        fd = ASSERT_OK(xopenat_lock_full(tfd, "abc", O_CREAT|O_DIRECTORY, 0, 0755, LOCK_BSD, LOCK_EX));
+        fd = ASSERT_OK(xopenat_lock_full(tfd, "abc", O_CREAT|O_DIRECTORY, /* xopen_flags= */ 0, 0755, LOCK_BSD, LOCK_EX));
         ASSERT_OK_ERRNO(faccessat(tfd, "abc", F_OK, 0));
         ASSERT_OK(fd_verify_directory(fd));
-        ASSERT_ERROR(xopenat_lock_full(tfd, "abc", O_DIRECTORY, 0, 0755, LOCK_BSD, LOCK_EX|LOCK_NB), EAGAIN);
+        ASSERT_ERROR(xopenat_lock_full(tfd, "abc", O_DIRECTORY, /* xopen_flags= */ 0, 0755, LOCK_BSD, LOCK_EX|LOCK_NB), EAGAIN);
 
         _cleanup_(pidref_done) PidRef pidref = PIDREF_NULL;
         r = ASSERT_OK(pidref_safe_fork("(lock)", FORK_DEATHSIG_SIGKILL|FORK_LOG, &pidref));
@@ -945,10 +980,10 @@ TEST(xopenat_lock_full) {
         if (r == 0) {
                 safe_close(fd);
 
-                fd = ASSERT_OK(xopenat_lock_full(tfd, "abc", O_CREAT|O_DIRECTORY, 0, 0755, LOCK_BSD, LOCK_EX));
+                fd = ASSERT_OK(xopenat_lock_full(tfd, "abc", O_CREAT|O_DIRECTORY, /* xopen_flags= */ 0, 0755, LOCK_BSD, LOCK_EX));
                 ASSERT_OK_ERRNO(faccessat(tfd, "abc", F_OK, 0));
                 ASSERT_OK(fd_verify_directory(fd));
-                ASSERT_ERROR(xopenat_lock_full(tfd, "abc", O_DIRECTORY, 0, 0755, LOCK_BSD, LOCK_EX|LOCK_NB), EAGAIN);
+                ASSERT_ERROR(xopenat_lock_full(tfd, "abc", O_DIRECTORY, /* xopen_flags= */ 0, 0755, LOCK_BSD, LOCK_EX|LOCK_NB), EAGAIN);
 
                 _exit(EXIT_SUCCESS);
         }
@@ -1108,7 +1143,7 @@ TEST(xopenat_cloexec) {
         ASSERT_TRUE(FLAGS_SET(fl, FD_CLOEXEC));
         fd = safe_close(fd);
 
-        ASSERT_OK(fd = xopenat_full(tfd, "regular", O_PATH, XO_REGULAR, 0));
+        ASSERT_OK(fd = xopenat_full(tfd, "regular", O_PATH, XO_REGULAR, /* mode= */ 0));
         ASSERT_OK_ERRNO(fl = fcntl(fd, F_GETFD));
         ASSERT_TRUE(FLAGS_SET(fl, FD_CLOEXEC));
         fd = safe_close(fd);
@@ -1118,7 +1153,7 @@ TEST(xopenat_cloexec) {
         ASSERT_TRUE(FLAGS_SET(fl, FD_CLOEXEC));
         fd = safe_close(fd);
 
-        ASSERT_OK(fd = open_parent_at(tfd, "regular", O_RDONLY, 0));
+        ASSERT_OK(fd = open_parent_at(tfd, "regular", O_RDONLY, /* mode= */ 0));
         ASSERT_OK_ERRNO(fl = fcntl(fd, F_GETFD));
         ASSERT_TRUE(FLAGS_SET(fl, FD_CLOEXEC));
         fd = safe_close(fd);

--- a/src/test/test-fs-util.c
+++ b/src/test/test-fs-util.c
@@ -1091,6 +1091,39 @@ TEST(xat_fdroot) {
         ASSERT_EQ(a, b);
 }
 
+TEST(xopenat_cloexec) {
+        _cleanup_(rm_rf_physical_and_freep) char *t = NULL;
+        _cleanup_close_ int tfd = -EBADF, fd = -EBADF;
+        int fl;
+
+        ASSERT_OK(tfd = mkdtemp_open(NULL, 0, &t));
+
+        /* O_CLOEXEC is implied, whether requested or not */
+        ASSERT_OK(fd = xopenat(tfd, "regular", O_RDWR|O_CREAT|O_EXCL));
+        ASSERT_OK_ERRNO(fl = fcntl(fd, F_GETFD));
+        ASSERT_TRUE(FLAGS_SET(fl, FD_CLOEXEC));
+        fd = safe_close(fd);
+
+        ASSERT_OK(fd = xopenat_full(tfd, "regular", O_PATH, XO_REGULAR, 0));
+        ASSERT_OK_ERRNO(fl = fcntl(fd, F_GETFD));
+        ASSERT_TRUE(FLAGS_SET(fl, FD_CLOEXEC));
+        fd = safe_close(fd);
+
+        ASSERT_OK(fd = openat_report_new(tfd, "regular", O_RDWR|O_CREAT, 0644, NULL));
+        ASSERT_OK_ERRNO(fl = fcntl(fd, F_GETFD));
+        ASSERT_TRUE(FLAGS_SET(fl, FD_CLOEXEC));
+        fd = safe_close(fd);
+
+        ASSERT_OK(fd = open_parent_at(tfd, "regular", O_RDONLY, 0));
+        ASSERT_OK_ERRNO(fl = fcntl(fd, F_GETFD));
+        ASSERT_TRUE(FLAGS_SET(fl, FD_CLOEXEC));
+        fd = safe_close(fd);
+
+        ASSERT_OK(fd = open_mkdir_at(tfd, "dir", O_EXCL, 0755));
+        ASSERT_OK_ERRNO(fl = fcntl(fd, F_GETFD));
+        ASSERT_TRUE(FLAGS_SET(fl, FD_CLOEXEC));
+}
+
 static int intro(void) {
         arg_test_dir = saved_argv[1];
         return EXIT_SUCCESS;

--- a/src/test/test-label.c
+++ b/src/test/test-label.c
@@ -62,7 +62,7 @@ static int get_dir_fd(const char *dir_path, mode_t mode) {
         int dir_fd = -EBADF;
 
         assert(dir_path);
-        dir_fd = RET_NERRNO(open_mkdir_at(AT_FDCWD, dir_path, O_CLOEXEC, mode));
+        dir_fd = open_mkdir_at(AT_FDCWD, dir_path, /* flags= */ 0, mode);
         if (dir_fd < 0)
                 return log_error_errno(dir_fd, "Error occurred while opening directory =>: %m");
 

--- a/src/test/test-lock-util.c
+++ b/src/test/test-lock-util.c
@@ -44,7 +44,7 @@ static void test_lock_generic_with_timeout_for_type(LockType type) {
         tfd = mkdtemp_open(NULL, 0, &t);
         assert_se(tfd >= 0);
 
-        tfd2 = fd_reopen(tfd, O_CLOEXEC|O_DIRECTORY);
+        tfd2 = fd_reopen(tfd, O_DIRECTORY);
         assert_se(tfd2 >= 0);
 
         assert_se(lock_generic(tfd, LOCK_BSD, LOCK_EX) >= 0);

--- a/src/test/test-mount-util.c
+++ b/src/test/test-mount-util.c
@@ -579,7 +579,7 @@ TEST(umountat) {
         CHECK_PRIV;
 
         _cleanup_(rm_rf_physical_and_freep) char *p = NULL;
-        _cleanup_close_ int dfd = mkdtemp_open(NULL, O_CLOEXEC, &p);
+        _cleanup_close_ int dfd = mkdtemp_open(NULL, 0, &p);
         ASSERT_OK(dfd);
 
         ASSERT_OK(mkdirat(dfd, "foo", 0777));

--- a/src/test/test-recurse-dir.c
+++ b/src/test/test-recurse-dir.c
@@ -151,7 +151,7 @@ static void check_readdir_all(int tfd, RecurseDirFlags flags, char **expected) {
         _cleanup_close_ int fd = -EBADF;
 
         /* readdir_all() consumes the directory fd offset, hence reopen a fresh fd for each enumeration. */
-        ASSERT_OK(fd = fd_reopen(tfd, O_DIRECTORY|O_CLOEXEC));
+        ASSERT_OK(fd = fd_reopen(tfd, O_DIRECTORY));
         ASSERT_OK(readdir_all(fd, flags, &de));
         assert_entries(de, expected);
 }
@@ -165,7 +165,7 @@ static void test_must_be_flags(void) {
         /* Populate a temporary directory with one entry of each interesting type and verify that the
          * RECURSE_DIR_MUST_BE_* flags select exactly the right subset. */
 
-        ASSERT_OK(tfd = mkdtemp_open(NULL, O_DIRECTORY|O_CLOEXEC, &t));
+        ASSERT_OK(tfd = mkdtemp_open(NULL, O_DIRECTORY, &t));
 
         ASSERT_OK_ERRNO(mkdirat(tfd, "dir", 0777));
         ASSERT_OK_ERRNO(reg_fd = openat(tfd, "reg", O_CREAT|O_EXCL|O_WRONLY|O_CLOEXEC, 0666));

--- a/src/test/test-stat-util.c
+++ b/src/test/test-stat-util.c
@@ -232,6 +232,13 @@ TEST(dir_is_empty) {
         assert_se(unlink(jjj) >= 0);
         assert_se(dir_is_empty_at(AT_FDCWD, empty_dir, /* ignore_hidden_or_backup= */ true) > 0);
         assert_se(dir_is_empty_at(AT_FDCWD, empty_dir, /* ignore_hidden_or_backup= */ false) > 0);
+
+        /* A NULL path checks the directory the fd refers to */
+        _cleanup_close_ int fd = -EBADF;
+        ASSERT_OK_ERRNO(fd = open(empty_dir, O_DIRECTORY|O_CLOEXEC));
+        ASSERT_OK_POSITIVE(dir_is_empty_at(fd, /* path= */ NULL, /* ignore_hidden_or_backup= */ false));
+        ASSERT_OK(touch(j));
+        ASSERT_OK_ZERO(dir_is_empty_at(fd, /* path= */ NULL, /* ignore_hidden_or_backup= */ false));
 }
 
 TEST(inode_type_from_string) {

--- a/src/test/test-terminal-util.c
+++ b/src/test/test-terminal-util.c
@@ -574,4 +574,17 @@ TEST(show_menu) {
         }
 }
 
+TEST(open_terminal_cloexec) {
+        _cleanup_free_ char *peer = NULL;
+        _cleanup_close_ int pty_fd = -EBADF, fd = -EBADF;
+        int fl;
+
+        ASSERT_OK(pty_fd = openpt_allocate(O_RDWR|O_NOCTTY, &peer));
+
+        /* O_CLOEXEC is implied, whether requested or not */
+        ASSERT_OK(fd = open_terminal(peer, O_RDWR|O_NOCTTY));
+        ASSERT_OK_ERRNO(fl = fcntl(fd, F_GETFD));
+        ASSERT_TRUE(FLAGS_SET(fl, FD_CLOEXEC));
+}
+
 DEFINE_TEST_MAIN(LOG_INFO);

--- a/src/test/test-terminal-util.c
+++ b/src/test/test-terminal-util.c
@@ -238,7 +238,7 @@ TEST(terminal_get_terminfo_by_dcs) {
         int r;
 
         /* We need a non-blocking read-write fd. */
-        _cleanup_close_ int fd = fd_reopen(STDIN_FILENO, O_RDWR|O_CLOEXEC|O_NONBLOCK|O_NOCTTY);
+        _cleanup_close_ int fd = fd_reopen(STDIN_FILENO, O_RDWR|O_NONBLOCK|O_NOCTTY);
         if (fd < 0)
                 return (void) log_info_errno(fd, "Cannot reopen stdin in read-write mode: %m");
 
@@ -304,7 +304,7 @@ TEST(terminal_is_pty_fd) {
         FOREACH_STRING(p, "/dev/ttyS0", "/dev/tty1") {
                 _cleanup_close_ int tfd = -EBADF;
 
-                tfd = open_terminal(p, O_CLOEXEC|O_NOCTTY|O_RDONLY|O_NONBLOCK);
+                tfd = open_terminal(p, O_NOCTTY|O_RDONLY|O_NONBLOCK);
                 if (tfd == -ENOENT)
                         continue;
                 if (tfd < 0)  {
@@ -375,7 +375,7 @@ TEST(terminal_reset_defensive) {
 TEST(pty_open_peer) {
         _cleanup_free_ char *pty_path = NULL;
 
-        _cleanup_close_ int pty_fd = ASSERT_OK(openpt_allocate(O_RDWR|O_NOCTTY|O_CLOEXEC|O_NONBLOCK, &pty_path));
+        _cleanup_close_ int pty_fd = ASSERT_OK(openpt_allocate(O_RDWR|O_NOCTTY|O_NONBLOCK, &pty_path));
         ASSERT_NOT_NULL(pty_path);
 
         _cleanup_close_ int peer_fd = ASSERT_OK(pty_open_peer(pty_fd, O_RDWR|O_NOCTTY|O_CLOEXEC));
@@ -392,7 +392,7 @@ TEST(pty_open_peer) {
 TEST(terminal_new_session) {
         int r;
 
-        _cleanup_close_ int pty_fd = ASSERT_OK(openpt_allocate(O_RDWR|O_NOCTTY|O_CLOEXEC|O_NONBLOCK, NULL));
+        _cleanup_close_ int pty_fd = ASSERT_OK(openpt_allocate(O_RDWR|O_NOCTTY|O_NONBLOCK, NULL));
         _cleanup_close_ int peer_fd = ASSERT_OK(pty_open_peer(pty_fd, O_RDWR|O_NOCTTY|O_CLOEXEC));
 
         r = pidref_safe_fork_full(

--- a/src/test/test-tmpfile-util.c
+++ b/src/test/test-tmpfile-util.c
@@ -312,7 +312,7 @@ TEST(link_tmpfile) {
 
         pattern = strjoina(p, "/systemd-test-XXXXXX");
 
-        fd = open_tmpfile_unlinkable(p, O_RDWR|O_CLOEXEC);
+        fd = open_tmpfile_unlinkable(p, O_RDWR);
         assert_se(fd >= 0);
 
         assert_se(asprintf(&cmd, "ls -l /proc/"PID_FMT"/fd/%d", getpid_cached(), fd) > 0);
@@ -335,7 +335,7 @@ TEST(link_tmpfile) {
         assert_se(tempfn_random(pattern, NULL, &d) >= 0);
 
         fd = safe_close(fd);
-        fd = open_tmpfile_linkable(d, O_RDWR|O_CLOEXEC, &tmp);
+        fd = open_tmpfile_linkable(d, O_RDWR, &tmp);
         assert_se(fd >= 0);
         assert_se(write(fd, "foobar\n", 7) == 7);
 
@@ -350,7 +350,7 @@ TEST(link_tmpfile) {
         fd = safe_close(fd);
         tmp = mfree(tmp);
 
-        fd = open_tmpfile_linkable(d, O_RDWR|O_CLOEXEC, &tmp);
+        fd = open_tmpfile_linkable(d, O_RDWR, &tmp);
         assert_se(fd >= 0);
 
         assert_se(write(fd, "waumiau\n", 8) == 8);

--- a/src/test/test-tmpfile-util.c
+++ b/src/test/test-tmpfile-util.c
@@ -365,4 +365,23 @@ TEST(link_tmpfile) {
         assert_se(unlink(d) >= 0);
 }
 
+TEST(open_tmpfile_cloexec) {
+        _cleanup_(unlink_and_freep) char *tmp = NULL;
+        _cleanup_free_ char *d = NULL;
+        _cleanup_close_ int fd = -EBADF;
+        const char *p = saved_argv[1] ?: "/tmp";
+        int fl;
+
+        /* O_CLOEXEC is implied, whether requested or not */
+        ASSERT_OK(fd = open_tmpfile_unlinkable(p, O_RDWR));
+        ASSERT_OK_ERRNO(fl = fcntl(fd, F_GETFD));
+        ASSERT_TRUE(FLAGS_SET(fl, FD_CLOEXEC));
+        fd = safe_close(fd);
+
+        ASSERT_OK(tempfn_random_child(p, "cloexec", &d));
+        ASSERT_OK(fd = open_tmpfile_linkable(d, O_RDWR, &tmp));
+        ASSERT_OK_ERRNO(fl = fcntl(fd, F_GETFD));
+        ASSERT_TRUE(FLAGS_SET(fl, FD_CLOEXEC));
+}
+
 DEFINE_TEST_MAIN(LOG_DEBUG);

--- a/src/test/test-vpick.c
+++ b/src/test/test-vpick.c
@@ -15,8 +15,8 @@ TEST(path_pick) {
         _cleanup_(rm_rf_physical_and_freep) char *p = NULL;
         _cleanup_close_ int dfd = -EBADF, sub_dfd = -EBADF;
 
-        dfd = ASSERT_OK(mkdtemp_open(NULL, O_DIRECTORY|O_CLOEXEC, &p));
-        sub_dfd = ASSERT_OK(open_mkdir_at(dfd, "foo.v", O_CLOEXEC, 0777));
+        dfd = ASSERT_OK(mkdtemp_open(NULL, O_DIRECTORY, &p));
+        sub_dfd = ASSERT_OK(open_mkdir_at(dfd, "foo.v", /* flags= */ 0, 0777));
 
         ASSERT_OK(write_string_file_at(sub_dfd, "foo_5.5.raw", "5.5", WRITE_STRING_FILE_CREATE));
         ASSERT_OK(write_string_file_at(sub_dfd, "foo_55.raw", "55", WRITE_STRING_FILE_CREATE));
@@ -188,8 +188,8 @@ TEST(path_uses_vpick) {
 TEST(pick_filter_image_any) {
         _cleanup_(rm_rf_physical_and_freep) char *p = NULL;
 
-        _cleanup_close_ int dfd = ASSERT_OK(mkdtemp_open(NULL, O_DIRECTORY|O_CLOEXEC, &p));
-        _cleanup_close_ int sub_dfd = ASSERT_OK(open_mkdir_at(dfd, "test.v", O_CLOEXEC, 0777));
+        _cleanup_close_ int dfd = ASSERT_OK(mkdtemp_open(NULL, O_DIRECTORY, &p));
+        _cleanup_close_ int sub_dfd = ASSERT_OK(open_mkdir_at(dfd, "test.v", /* flags= */ 0, 0777));
 
         /* Create .raw files (should match with pick_filter_image_raw and pick_filter_image_any) */
         ASSERT_OK(write_string_file_at(sub_dfd, "test_1.raw", "version 1 raw", WRITE_STRING_FILE_CREATE));
@@ -252,7 +252,7 @@ TEST(pick_filter_image_any) {
 
         /* Now test pick_filter_image_dir with a separate directory structure */
         safe_close(sub_dfd);
-        sub_dfd = ASSERT_OK(open_mkdir_at(dfd, "myimage.v", O_CLOEXEC, 0777));
+        sub_dfd = ASSERT_OK(open_mkdir_at(dfd, "myimage.v", /* flags= */ 0, 0777));
 
         /* Create directories that pick_filter_image_dir should find */
         ASSERT_OK(mkdirat(sub_dfd, "myimage_1", 0755));
@@ -279,8 +279,8 @@ TEST(pick_filter_image_any) {
 TEST(path_pick_resolve) {
         _cleanup_(rm_rf_physical_and_freep) char *p = NULL;
 
-        _cleanup_close_ int dfd = ASSERT_OK(mkdtemp_open(NULL, O_DIRECTORY|O_CLOEXEC, &p));
-        _cleanup_close_ int sub_dfd = ASSERT_OK(open_mkdir_at(dfd, "resolve.v", O_CLOEXEC, 0777));
+        _cleanup_close_ int dfd = ASSERT_OK(mkdtemp_open(NULL, O_DIRECTORY, &p));
+        _cleanup_close_ int sub_dfd = ASSERT_OK(open_mkdir_at(dfd, "resolve.v", /* flags= */ 0, 0777));
 
         /* Create a target directory and file for symlinks */
         ASSERT_OK(mkdirat(dfd, "target_dir", 0755));

--- a/src/timedate/hwclock-util.c
+++ b/src/timedate/hwclock-util.c
@@ -7,6 +7,7 @@
 
 #include "errno-util.h"
 #include "fd-util.h"
+#include "fs-util.h"
 #include "hwclock-util.h"
 
 int hwclock_get(struct tm *tm /* input + output! */) {
@@ -14,9 +15,9 @@ int hwclock_get(struct tm *tm /* input + output! */) {
 
         assert(tm);
 
-        fd = open("/dev/rtc", O_RDONLY|O_CLOEXEC);
+        fd = xopenat(AT_FDCWD, "/dev/rtc", O_RDONLY);
         if (fd < 0)
-                return -errno;
+                return fd;
 
         /* This leaves the timezone fields of struct ret uninitialized! */
         if (ioctl(fd, RTC_RD_TIME, tm) < 0)
@@ -35,9 +36,9 @@ int hwclock_set(const struct tm *tm) {
 
         assert(tm);
 
-        fd = open("/dev/rtc", O_RDONLY|O_CLOEXEC);
+        fd = xopenat(AT_FDCWD, "/dev/rtc", O_RDONLY);
         if (fd < 0)
-                return -errno;
+                return fd;
 
         return RET_NERRNO(ioctl(fd, RTC_SET_TIME, tm));
 }

--- a/src/timesync/timesyncd.c
+++ b/src/timesync/timesyncd.c
@@ -10,7 +10,6 @@
 #include "bus-object.h"
 #include "clock-util.h"
 #include "daemon-util.h"
-#include "errno-util.h"
 #include "fd-util.h"
 #include "format-util.h"
 #include "fs-util.h"
@@ -80,7 +79,7 @@ static int load_clock_timestamp(void) {
          * is particularly helpful on systems lacking a battery backed RTC. We also will adjust the time to
          * at least the build time of systemd. */
 
-        fd = RET_NERRNO(open(TIMESYNCD_CLOCK_FILE, O_RDWR|O_CLOEXEC, 0644));
+        fd = xopenat(AT_FDCWD, TIMESYNCD_CLOCK_FILE, O_RDWR);
         if (fd < 0) {
                 if (fd != -ENOENT)
                         log_warning_errno(fd, "Unable to open timestamp file "TIMESYNCD_CLOCK_FILE", ignoring: %m");

--- a/src/tmpfiles/offline-passwd.c
+++ b/src/tmpfiles/offline-passwd.c
@@ -22,7 +22,7 @@ static int open_passwd_file(const char *root, const char *fname, FILE **ret_file
         assert(fname);
         assert(ret_file);
 
-        fd = chase_and_open(fname, root, CHASE_PREFIX_ROOT, O_RDONLY|O_CLOEXEC, &p);
+        fd = chase_and_open(fname, root, CHASE_PREFIX_ROOT, O_RDONLY, &p);
         if (fd < 0)
                 return fd;
 

--- a/src/tmpfiles/tmpfiles.c
+++ b/src/tmpfiles/tmpfiles.c
@@ -872,7 +872,7 @@ static int dir_cleanup(
                                 continue;
 
                         if (!arg_dry_run) {
-                                fd = xopenat(dirfd(d), de->d_name, O_RDONLY|O_CLOEXEC|O_NOFOLLOW|O_NOATIME|O_NONBLOCK|O_NOCTTY);
+                                fd = xopenat(dirfd(d), de->d_name, O_RDONLY|O_NOFOLLOW|O_NOATIME|O_NONBLOCK|O_NOCTTY);
                                 if (fd < 0 && !IN_SET(fd, -ENOENT, -ELOOP))
                                         log_warning_errno(fd, "Opening file \"%s\" failed, proceeding without lock: %m", sub_path);
                                 if (fd >= 0 && flock(fd, LOCK_EX|LOCK_NB) < 0 && errno == EAGAIN) {
@@ -1929,7 +1929,7 @@ static int fd_set_attribute(
         if (!arg_dry_run) {
                 _cleanup_close_ int procfs_fd = -EBADF;
 
-                procfs_fd = fd_reopen(fd, O_RDONLY|O_CLOEXEC|O_NOATIME);
+                procfs_fd = fd_reopen(fd, O_RDONLY|O_NOATIME);
                 if (procfs_fd < 0)
                         return log_error_errno(procfs_fd, "Failed to reopen '%s': %m", path);
 
@@ -3682,7 +3682,7 @@ static int clean_remove_item_instance_at(
 
         _cleanup_close_ int lock_fd = -EBADF;
         if (!arg_dry_run) {
-                lock_fd = xopenat(parent_fd, name, O_RDONLY|O_CLOEXEC|O_NOFOLLOW|O_NOATIME|O_NONBLOCK|O_NOCTTY);
+                lock_fd = xopenat(parent_fd, name, O_RDONLY|O_NOFOLLOW|O_NOATIME|O_NONBLOCK|O_NOCTTY);
                 if (lock_fd < 0 && !IN_SET(lock_fd, -ENOENT, -ELOOP))
                         log_warning_errno(lock_fd, "Opening file \"%s\" failed, proceeding without lock: %m", instance);
 

--- a/src/tmpfiles/tmpfiles.c
+++ b/src/tmpfiles/tmpfiles.c
@@ -2017,18 +2017,18 @@ static int write_one_file(Context *c, Item *i, const char *path, CreationMode cr
                 return dir_fd;
 
         /* Follow symlinks. Open with O_PATH in dry-run mode to make sure we don't use the path inadvertently. */
-        int flags = O_NONBLOCK | O_CLOEXEC | O_WRONLY | O_NOCTTY | i->append_or_force * O_APPEND | arg_dry_run * O_PATH;
-        fd = openat(dir_fd, bn, flags, i->mode);
+        int flags = O_NONBLOCK | O_WRONLY | O_NOCTTY | i->append_or_force * O_APPEND | arg_dry_run * O_PATH;
+        fd = xopenat_full(dir_fd, bn, flags, /* xopen_flags= */ 0, i->mode);
         if (fd < 0) {
-                if (errno == ENOENT) {
-                        log_debug_errno(errno, "Not writing missing file \"%s\": %m", path);
+                if (fd == -ENOENT) {
+                        log_debug_errno(fd, "Not writing missing file \"%s\": %m", path);
                         return 0;
                 }
 
                 if (i->allow_failure)
-                        return log_debug_errno(errno, "Failed to open file \"%s\", ignoring: %m", path);
+                        return log_debug_errno(fd, "Failed to open file \"%s\", ignoring: %m", path);
 
-                return log_error_errno(errno, "Failed to open file \"%s\": %m", path);
+                return log_error_errno(fd, "Failed to open file \"%s\": %m", path);
         }
 
         /* 'w' is allowed to write into any kind of files. */
@@ -2080,7 +2080,7 @@ static int create_file(
 
         WITH_UMASK(0000) {
                 mac_selinux_create_file_prepare(path, S_IFREG, arg_label_context);
-                fd = RET_NERRNO(openat(dir_fd, bn, O_CREAT|O_EXCL|O_NOFOLLOW|O_NONBLOCK|O_CLOEXEC|O_WRONLY|O_NOCTTY, i->mode));
+                fd = xopenat_full(dir_fd, bn, O_CREAT|O_EXCL|O_NOFOLLOW|O_NONBLOCK|O_WRONLY|O_NOCTTY, /* xopen_flags= */ 0, i->mode);
                 mac_selinux_create_file_clear();
         }
 
@@ -2093,9 +2093,9 @@ static int create_file(
                 /* Re-open the file. At that point it must exist since open(2) failed with EEXIST. We still
                  * need to check if the perms/mode need to be changed. For read-only filesystems, we let
                  * fd_set_perms() report the error if the perms need to be modified. */
-                fd = openat(dir_fd, bn, O_NOFOLLOW|O_CLOEXEC|O_PATH, i->mode);
+                fd = xopenat(dir_fd, bn, O_NOFOLLOW|O_PATH);
                 if (fd < 0)
-                        return log_error_errno(errno, "Failed to reopen file %s: %m", path);
+                        return log_error_errno(fd, "Failed to reopen file %s: %m", path);
 
                 if (fstat(fd, &stbuf) < 0)
                         return log_error_errno(errno, "stat(%s) failed: %m", path);
@@ -2157,13 +2157,13 @@ static int truncate_file(
         }
 
         creation = CREATION_EXISTING;
-        fd = RET_NERRNO(openat(dir_fd, bn, O_NOFOLLOW|O_NONBLOCK|O_CLOEXEC|O_WRONLY|O_NOCTTY, i->mode));
+        fd = xopenat_full(dir_fd, bn, O_NOFOLLOW|O_NONBLOCK|O_WRONLY|O_NOCTTY, /* xopen_flags= */ 0, i->mode);
         if (fd == -ENOENT) {
                 creation = CREATION_NORMAL; /* Didn't work without O_CREATE, try again with */
 
                 WITH_UMASK(0000) {
                         mac_selinux_create_file_prepare(path, S_IFREG, arg_label_context);
-                        fd = RET_NERRNO(openat(dir_fd, bn, O_CREAT|O_NOFOLLOW|O_NONBLOCK|O_CLOEXEC|O_WRONLY|O_NOCTTY, i->mode));
+                        fd = xopenat_full(dir_fd, bn, O_CREAT|O_NOFOLLOW|O_NONBLOCK|O_WRONLY|O_NOCTTY, /* xopen_flags= */ 0, i->mode);
                         mac_selinux_create_file_clear();
                 }
         }
@@ -2176,14 +2176,14 @@ static int truncate_file(
                  * perms are set. So we still proceed with the sanity checks and let the remaining operations
                  * fail with EROFS if they try to modify the target file. */
 
-                fd = openat(dir_fd, bn, O_NOFOLLOW|O_CLOEXEC|O_PATH, i->mode);
+                fd = xopenat(dir_fd, bn, O_NOFOLLOW|O_PATH);
                 if (fd < 0) {
-                        if (errno == ENOENT)
+                        if (fd == -ENOENT)
                                 return log_error_errno(SYNTHETIC_ERRNO(EROFS),
                                                        "Cannot create file %s on a read-only file system.",
                                                        path);
 
-                        return log_error_errno(errno, "Failed to reopen file %s: %m", path);
+                        return log_error_errno(fd, "Failed to reopen file %s: %m", path);
                 }
 
                 erofs = true;
@@ -2244,12 +2244,12 @@ static int copy_files(Context *c, Item *i) {
                          ((i->append_or_force) ? COPY_MERGE : COPY_MERGE_EMPTY) | COPY_MAC_CREATE | COPY_HARDLINKS,
                          NULL, NULL);
 
-        fd = openat(dfd, bn, O_NOFOLLOW|O_CLOEXEC|O_PATH);
+        fd = xopenat(dfd, bn, O_NOFOLLOW|O_PATH);
         if (fd < 0) {
                 if (r < 0) /* Look at original error first */
                         return log_error_errno(r, "Failed to copy files to %s: %m", i->path);
 
-                return log_error_errno(errno, "Failed to openat(%s): %m", i->path);
+                return log_error_errno(fd, "Failed to openat(%s): %m", i->path);
         }
 
         if (r < 0 && !IN_SET(r, -EEXIST, -EROFS))
@@ -2331,10 +2331,10 @@ static int create_directory_or_subvolume(
 
         creation = r >= 0 ? CREATION_NORMAL : CREATION_EXISTING;
 
-        fd = openat(pfd, bn, O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH);
+        fd = xopenat(pfd, bn, O_NOFOLLOW|O_DIRECTORY|O_PATH);
         if (fd < 0) {
                 /* We couldn't open it because it is not actually a directory? */
-                if (errno == ENOTDIR)
+                if (fd == -ENOTDIR)
                         return log_error_errno(SYNTHETIC_ERRNO(EEXIST), "\"%s\" already exists and is not a directory.", path);
 
                 /* Then look at the original error */
@@ -2345,7 +2345,7 @@ static int create_directory_or_subvolume(
                                               path,
                                               allow_failure ? ", ignoring" : "");
 
-                return log_error_errno(errno, "Failed to open directory/subvolume we just created '%s': %m", path);
+                return log_error_errno(fd, "Failed to open directory/subvolume we just created '%s': %m", path);
         }
 
         if (fstat(fd, &st) < 0)
@@ -2518,7 +2518,7 @@ static int create_device(
 
         /* Try to open the inode via O_PATH, regardless if we could create it or not. Maybe everything is in
          * order anyway and we hence can ignore the error to create the device node */
-        fd = openat(dfd, bn, O_NOFOLLOW|O_CLOEXEC|O_PATH);
+        fd = xopenat(dfd, bn, O_NOFOLLOW|O_PATH);
         if (fd < 0) {
                 /* OK, so opening the inode failed, let's look at the original error then. */
 
@@ -2529,7 +2529,7 @@ static int create_device(
                         return log_error_errno(r, "Failed to create device node '%s': %m", i->path);
                 }
 
-                return log_error_errno(errno, "Failed to open device node '%s' we just created: %m", i->path);
+                return log_error_errno(fd, "Failed to open device node '%s' we just created: %m", i->path);
         }
 
         if (fstat(fd, &st) < 0)
@@ -2559,9 +2559,9 @@ static int create_device(
                         if (r < 0)
                                 return log_error_errno(r, "Failed to create device node '%s': %m", i->path);
 
-                        fd = openat(dfd, bn, O_NOFOLLOW|O_CLOEXEC|O_PATH);
+                        fd = xopenat(dfd, bn, O_NOFOLLOW|O_PATH);
                         if (fd < 0)
-                                return log_error_errno(errno, "Failed to open device node we just created '%s': %m", i->path);
+                                return log_error_errno(fd, "Failed to open device node we just created '%s': %m", i->path);
 
                         /* Validate type before change ownership below */
                         if (fstat(fd, &st) < 0)
@@ -2628,12 +2628,12 @@ static int create_fifo(Context *c, Item *i) {
         creation = r >= 0 ? CREATION_NORMAL : CREATION_EXISTING;
 
         /* Open the inode via O_PATH, regardless if we managed to create it or not. Maybe it is already the FIFO we want */
-        fd = openat(pfd, bn, O_NOFOLLOW|O_CLOEXEC|O_PATH);
+        fd = xopenat(pfd, bn, O_NOFOLLOW|O_PATH);
         if (fd < 0) {
                 if (r < 0)
                         return log_error_errno(r, "Failed to create FIFO %s: %m", i->path); /* original error! */
 
-                return log_error_errno(errno, "Failed to open FIFO we just created %s: %m", i->path);
+                return log_error_errno(fd, "Failed to open FIFO we just created %s: %m", i->path);
         }
 
         if (fstat(fd, &st) < 0)
@@ -2661,9 +2661,9 @@ static int create_fifo(Context *c, Item *i) {
                         if (r < 0)
                                 return log_error_errno(r, "Failed to create FIFO %s: %m", i->path);
 
-                        fd = openat(pfd, bn, O_NOFOLLOW|O_CLOEXEC|O_PATH);
+                        fd = xopenat(pfd, bn, O_NOFOLLOW|O_PATH);
                         if (fd < 0)
-                                return log_error_errno(errno, "Failed to open FIFO we just created '%s': %m", i->path);
+                                return log_error_errno(fd, "Failed to open FIFO we just created '%s': %m", i->path);
 
                         /* Validate type before change ownership below */
                         if (fstat(fd, &st) < 0)
@@ -2745,12 +2745,12 @@ static int create_symlink(Context *c, Item *i) {
 
         creation = r >= 0 ? CREATION_NORMAL : CREATION_EXISTING;
 
-        fd = openat(pfd, bn, O_NOFOLLOW|O_CLOEXEC|O_PATH);
+        fd = xopenat(pfd, bn, O_NOFOLLOW|O_PATH);
         if (fd < 0) {
                 if (r < 0)
                         return log_error_errno(r, "Failed to create symlink '%s': %m", i->path); /* original error! */
 
-                return log_error_errno(errno, "Failed to open symlink we just created '%s': %m", i->path);
+                return log_error_errno(fd, "Failed to open symlink we just created '%s': %m", i->path);
         }
 
         if (fstat(fd, &st) < 0)
@@ -2786,9 +2786,9 @@ static int create_symlink(Context *c, Item *i) {
                 if (r < 0)
                         return log_error_errno(r, "symlink(%s, %s) failed: %m", i->argument, i->path);
 
-                fd = openat(pfd, bn, O_NOFOLLOW|O_CLOEXEC|O_PATH);
+                fd = xopenat(pfd, bn, O_NOFOLLOW|O_PATH);
                 if (fd < 0)
-                        return log_error_errno(errno, "Failed to open symlink we just created '%s': %m", i->path);
+                        return log_error_errno(fd, "Failed to open symlink we just created '%s': %m", i->path);
 
                 /* Validate type before change ownership below */
                 if (fstat(fd, &st) < 0)
@@ -2850,10 +2850,10 @@ static int item_do(
                         if (dot_or_dot_dot(de->d_name))
                                 continue;
 
-                        de_fd = openat(fd, de->d_name, O_NOFOLLOW|O_CLOEXEC|O_PATH);
+                        de_fd = xopenat(fd, de->d_name, O_NOFOLLOW|O_PATH);
                         if (de_fd < 0) {
-                                if (errno != ENOENT)
-                                        RET_GATHER(r, log_error_errno(errno, "Failed to open file '%s': %m", de->d_name));
+                                if (de_fd != -ENOENT)
+                                        RET_GATHER(r, log_error_errno(de_fd, "Failed to open file '%s': %m", de->d_name));
                                 continue;
                         }
 
@@ -2996,9 +2996,9 @@ static int rm_if_wrong_type_safe(
                 if ((st.st_mode & S_IFMT) == S_IFDIR) {
                         _cleanup_close_ int child_fd = -EBADF;
 
-                        child_fd = openat(parent_fd, name, O_NOCTTY | O_CLOEXEC | O_DIRECTORY);
+                        child_fd = xopenat(parent_fd, name, O_NOCTTY | O_DIRECTORY);
                         if (child_fd < 0)
-                                return log_error_errno(errno, "Failed to open \"%s/%s\": %m", parent_name ?: "...", name);
+                                return log_error_errno(child_fd, "Failed to open \"%s/%s\": %m", parent_name ?: "...", name);
 
                         r = rm_rf_children(TAKE_FD(child_fd), REMOVE_ROOT|REMOVE_SUBVOLUME|REMOVE_PHYSICAL, &st);
                         if (r < 0)
@@ -3037,9 +3037,9 @@ static int mkdir_parents_rm_if_wrong_type(mode_t child_mode, const char *path) {
                                 "Trailing path separators are only allowed if child_mode is not set; got \"%s\"", path);
 
         /* Get the parent_fd and stat. */
-        parent_fd = openat(AT_FDCWD, path_is_absolute(path) ? "/" : ".", O_NOCTTY | O_CLOEXEC | O_DIRECTORY);
+        parent_fd = xopenat(AT_FDCWD, path_is_absolute(path) ? "/" : ".", O_NOCTTY | O_DIRECTORY);
         if (parent_fd < 0)
-                return log_error_errno(errno, "Failed to open root: %m");
+                return log_error_errno(parent_fd, "Failed to open root: %m");
 
         if (fstat(parent_fd, &parent_st) < 0)
                 return log_error_errno(errno, "Failed to stat root: %m");
@@ -3081,7 +3081,7 @@ static int mkdir_parents_rm_if_wrong_type(mode_t child_mode, const char *path) {
                         /* rm_if_wrong_type_safe already logs errors. */
                         return r;
 
-                next_fd = RET_NERRNO(openat(parent_fd, t, O_NOCTTY | O_CLOEXEC | O_DIRECTORY));
+                next_fd = xopenat(parent_fd, t, O_NOCTTY | O_DIRECTORY);
                 if (next_fd < 0) {
                         _cleanup_free_ char *parent_name = NULL;
 
@@ -3469,7 +3469,7 @@ static int item_instance_open_opath(
         assert(ret_fd);
         assert(ret_sx);
 
-        _cleanup_close_ int fd = RET_NERRNO(openat(parent_fd, name, O_PATH|O_CLOEXEC|O_NOFOLLOW));
+        _cleanup_close_ int fd = xopenat(parent_fd, name, O_PATH|O_NOFOLLOW);
         if (IN_SET(fd, -ENOENT, -ENOTDIR))
                 return 0;
         if (fd < 0)

--- a/src/tpm2-setup/tpm2-setup.c
+++ b/src/tpm2-setup/tpm2-setup.c
@@ -301,7 +301,7 @@ static int setup_srk(void) {
         /* Write out public key (note that we only do that as a help to the user, we don't make use of this ever */
         _cleanup_(unlink_and_freep) char *t = NULL;
         _cleanup_fclose_ FILE *f = NULL;
-        r = fopen_tmpfile_linkable(pem_path, O_WRONLY|O_CLOEXEC, &t, &f);
+        r = fopen_tmpfile_linkable(pem_path, O_WRONLY, &t, &f);
         if (r < 0)
                 return log_error_errno(r, "Failed to open SRK public key file '%s' for writing: %m", pem_path);
 
@@ -324,7 +324,7 @@ static int setup_srk(void) {
         (void) mkdir_parents(tpm2b_public_path, 0755);
 
         /* Now also write this out in TPM2B_PUBLIC format */
-        r = fopen_tmpfile_linkable(tpm2b_public_path, O_WRONLY|O_CLOEXEC, &t, &f);
+        r = fopen_tmpfile_linkable(tpm2b_public_path, O_WRONLY, &t, &f);
         if (r < 0)
                 return log_error_errno(r, "Failed to open SRK public key file '%s' for writing: %m", tpm2b_public_path);
 

--- a/src/tpm2-setup/tpm2-swtpm.c
+++ b/src/tpm2-setup/tpm2-swtpm.c
@@ -131,7 +131,7 @@ static int setup_swtpm(const char *state_dir, int state_fd, const char *secret) 
                 return log_error_errno(SYNTHETIC_ERRNO(ESTALE), "swtpm TPM state directory has not been initialized in the initrd, refusing.");
 
         /* Cleanup incomplete state before recreating. */
-        _cleanup_close_ int wipe_fd = fd_reopen(state_fd, O_RDONLY|O_DIRECTORY|O_CLOEXEC);
+        _cleanup_close_ int wipe_fd = fd_reopen(state_fd, O_RDONLY|O_DIRECTORY);
         if (wipe_fd < 0)
                 return log_error_errno(wipe_fd, "Failed to reopen swtpm state directory: %m");
         r = rm_rf_children(TAKE_FD(wipe_fd), REMOVE_PHYSICAL, /* root_dev= */ NULL);

--- a/src/tty-ask-password-agent/tty-ask-password-agent.c
+++ b/src/tty-ask-password-agent/tty-ask-password-agent.c
@@ -27,6 +27,7 @@
 #include "fd-util.h"
 #include "fileio.h"
 #include "format-util.h"
+#include "fs-util.h"
 #include "inotify-util.h"
 #include "io-util.h"
 #include "main-func.h"
@@ -125,9 +126,9 @@ static bool wall_tty_match(const char *path, bool is_local, void *userdata) {
                 return true;
         }
 
-        _cleanup_close_ int fd = open(p, O_WRONLY|O_CLOEXEC|O_NONBLOCK|O_NOCTTY);
+        _cleanup_close_ int fd = xopenat(AT_FDCWD, p, O_WRONLY|O_NONBLOCK|O_NOCTTY);
         if (fd < 0) {
-                log_debug_errno(errno, "Failed to open the wall pipe for TTY '%s', not restricting wall: %m", path);
+                log_debug_errno(fd, "Failed to open the wall pipe for TTY '%s', not restricting wall: %m", path);
                 return 1;
         }
 
@@ -311,9 +312,9 @@ static int wall_tty_block(void) {
         (void) mkdir_parents_label(p, 0700);
         (void) mkfifo(p, 0600);
 
-        fd = open(p, O_RDONLY|O_CLOEXEC|O_NONBLOCK|O_NOCTTY);
+        fd = xopenat(AT_FDCWD, p, O_RDONLY|O_NONBLOCK|O_NOCTTY);
         if (fd < 0)
-                return log_debug_errno(errno, "Failed to open %s: %m", p);
+                return log_debug_errno(fd, "Failed to open %s: %m", p);
 
         return fd;
 }

--- a/src/udev/ata_id/ata_id.c
+++ b/src/udev/ata_id/ata_id.c
@@ -19,6 +19,7 @@
 #include "device-nodes.h"
 #include "errno-util.h"
 #include "fd-util.h"
+#include "fs-util.h"
 #include "log.h"
 #include "main-func.h"
 #include "strv.h"
@@ -415,13 +416,13 @@ static int run(int argc, char *argv[]) {
         if (r <= 0)
                 return r;
 
-        fd = open(ASSERT_PTR(arg_device), O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_NOCTTY);
+        fd = xopenat(AT_FDCWD, ASSERT_PTR(arg_device), O_RDONLY|O_NONBLOCK|O_NOCTTY);
         if (fd < 0) {
-                bool ignore = ERRNO_IS_DEVICE_ABSENT_OR_EMPTY(errno);
-                log_full_errno(ignore ? LOG_DEBUG : LOG_WARNING, errno,
+                bool ignore = ERRNO_IS_DEVICE_ABSENT_OR_EMPTY(fd);
+                log_full_errno(ignore ? LOG_DEBUG : LOG_WARNING, fd,
                                "Failed to open device node '%s'%s: %m",
                                arg_device, ignore ? ", ignoring" : "");
-                return ignore ? 0 : -errno;
+                return ignore ? 0 : fd;
         }
 
         if (disk_identify(fd, identify.byte, &peripheral_device_type) >= 0) {

--- a/src/udev/cdrom_id/cdrom_id.c
+++ b/src/udev/cdrom_id/cdrom_id.c
@@ -14,6 +14,7 @@
 #include "build.h"
 #include "errno-util.h"
 #include "fd-util.h"
+#include "fs-util.h"
 #include "main-func.h"
 #include "random-util.h"
 #include "sort-util.h"
@@ -753,11 +754,11 @@ static int open_drive(Context *c) {
         assert(c->fd < 0);
 
         for (int cnt = 0;; cnt++) {
-                fd = open(arg_node, O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_NOCTTY);
+                fd = xopenat(AT_FDCWD, arg_node, O_RDONLY|O_NONBLOCK|O_NOCTTY);
                 if (fd >= 0)
                         break;
-                if (++cnt >= 20 || errno != EBUSY)
-                        return log_debug_errno(errno, "Unable to open '%s': %m", arg_node);
+                if (++cnt >= 20 || fd != -EBUSY)
+                        return log_debug_errno(fd, "Unable to open '%s': %m", arg_node);
 
                 (void) usleep_safe(100 * USEC_PER_MSEC + random_u64_range(100 * USEC_PER_MSEC));
         }

--- a/src/udev/fido_id/fido_id.c
+++ b/src/udev/fido_id/fido_id.c
@@ -19,6 +19,7 @@
 #include "device-util.h"
 #include "fd-util.h"
 #include "fido_id_desc.h"
+#include "fs-util.h"
 #include "log.h"
 #include "main-func.h"
 #include "path-util.h"
@@ -100,9 +101,9 @@ static int run(int argc, char **argv) {
         if (!desc_path)
                 return log_oom();
 
-        fd = open(desc_path, O_RDONLY | O_NOFOLLOW | O_CLOEXEC | O_NOCTTY);
+        fd = xopenat(AT_FDCWD, desc_path, O_RDONLY | O_NOFOLLOW | O_NOCTTY);
         if (fd < 0)
-                return log_device_error_errno(hid_device, errno,
+                return log_device_error_errno(hid_device, fd,
                                               "Failed to open report descriptor at '%s': %m", desc_path);
 
         desc_len = read(fd, desc, sizeof(desc));

--- a/src/udev/mtd_probe/mtd_probe.c
+++ b/src/udev/mtd_probe/mtd_probe.c
@@ -27,6 +27,7 @@
 #include "build.h"
 #include "errno-util.h"
 #include "fd-util.h"
+#include "fs-util.h"
 #include "log.h"
 #include "main-func.h"
 #include "mtd_probe.h"
@@ -77,13 +78,13 @@ static int run(int argc, char** argv) {
         if (r <= 0)
                 return r;
 
-        mtd_fd = open(arg_device, O_RDONLY|O_CLOEXEC|O_NOCTTY);
+        mtd_fd = xopenat(AT_FDCWD, arg_device, O_RDONLY|O_NOCTTY);
         if (mtd_fd < 0) {
-                bool ignore = ERRNO_IS_DEVICE_ABSENT_OR_EMPTY(errno);
-                log_full_errno(ignore ? LOG_DEBUG : LOG_WARNING, errno,
+                bool ignore = ERRNO_IS_DEVICE_ABSENT_OR_EMPTY(mtd_fd);
+                log_full_errno(ignore ? LOG_DEBUG : LOG_WARNING, mtd_fd,
                                "Failed to open device node '%s'%s: %m",
                                arg_device, ignore ? ", ignoring" : "");
-                return ignore ? 0 : -errno;
+                return ignore ? 0 : mtd_fd;
         }
 
         if (ioctl(mtd_fd, MEMGETINFO, &mtd_info) < 0)

--- a/src/udev/scsi_id/scsi_serial.c
+++ b/src/udev/scsi_id/scsi_serial.c
@@ -16,6 +16,7 @@
 
 #include "devnum-util.h"
 #include "fd-util.h"
+#include "fs-util.h"
 #include "hexdecoct.h"
 #include "log.h"
 #include "random-util.h"
@@ -767,9 +768,9 @@ int scsi_std_inquiry(struct scsi_id_device *dev_scsi, const char *devname) {
         struct stat statbuf;
         int r;
 
-        _cleanup_close_ int fd = open(devname, O_RDONLY | O_NONBLOCK | O_CLOEXEC | O_NOCTTY);
+        _cleanup_close_ int fd = xopenat(AT_FDCWD, devname, O_RDONLY | O_NONBLOCK | O_NOCTTY);
         if (fd < 0)
-                return log_debug_errno(errno, "scsi_id: cannot open %s: %m", devname);
+                return log_debug_errno(fd, "scsi_id: cannot open %s: %m", devname);
 
         if (fstat(fd, &statbuf) < 0)
                 return log_debug_errno(errno, "scsi_id: cannot stat %s: %m", devname);
@@ -800,8 +801,8 @@ int scsi_get_serial(struct scsi_id_device *dev_scsi, const char *devname,
 
         memzero(dev_scsi->serial, len);
         for (cnt = 20; cnt > 0; cnt--) {
-                fd = open(devname, O_RDONLY | O_NONBLOCK | O_CLOEXEC | O_NOCTTY);
-                if (fd >= 0 || errno != EBUSY)
+                fd = xopenat(AT_FDCWD, devname, O_RDONLY | O_NONBLOCK | O_NOCTTY);
+                if (fd >= 0 || fd != -EBUSY)
                         break;
 
                 usleep_safe(200U*USEC_PER_MSEC + random_u64_range(100U*USEC_PER_MSEC));

--- a/src/udev/udev-builtin-btrfs.c
+++ b/src/udev/udev-builtin-btrfs.c
@@ -7,6 +7,7 @@
 #include "device-util.h"
 #include "errno-util.h"
 #include "fd-util.h"
+#include "fs-util.h"
 #include "string-util.h"
 #include "udev-builtin.h"
 
@@ -33,9 +34,9 @@ static int builtin_btrfs(UdevEvent *event, int argc, char *argv[]) {
                 return 0;
         }
 
-        _cleanup_close_ int fd = open("/dev/btrfs-control", O_RDWR|O_CLOEXEC|O_NOCTTY);
+        _cleanup_close_ int fd = xopenat(AT_FDCWD, "/dev/btrfs-control", O_RDWR|O_NOCTTY);
         if (fd < 0) {
-                if (ERRNO_IS_DEVICE_ABSENT_OR_EMPTY(errno)) {
+                if (ERRNO_IS_DEVICE_ABSENT_OR_EMPTY(fd)) {
                         /* Driver not installed? Then we aren't ready. This is useful in initrds that lack
                          * btrfs.ko. After the host transition (where btrfs.ko will hopefully become
                          * available) the device can be retriggered and will then be considered ready. */
@@ -43,7 +44,7 @@ static int builtin_btrfs(UdevEvent *event, int argc, char *argv[]) {
                         return 0;
                 }
 
-                return log_device_debug_errno(dev, errno, "Failed to open %s: %m", "/dev/btrfs-control");
+                return log_device_debug_errno(dev, fd, "Failed to open %s: %m", "/dev/btrfs-control");
         }
 
         struct btrfs_ioctl_vol_args args = {};

--- a/src/udev/udev-builtin-usb_id.c
+++ b/src/udev/udev-builtin-usb_id.c
@@ -14,6 +14,7 @@
 #include "device-private.h"
 #include "device-util.h"
 #include "fd-util.h"
+#include "fs-util.h"
 #include "string-util.h"
 #include "strxcpyx.h"
 #include "udev-builtin.h"
@@ -117,9 +118,9 @@ static int dev_if_packed_info(sd_device *dev, char *ifs_str, size_t len) {
                 return r;
 
         filename = strjoina(syspath, "/descriptors");
-        fd = open(filename, O_RDONLY|O_CLOEXEC|O_NOCTTY);
+        fd = xopenat(AT_FDCWD, filename, O_RDONLY|O_NOCTTY);
         if (fd < 0)
-                return log_device_debug_errno(dev, errno, "Failed to open \"%s\": %m", filename);
+                return log_device_debug_errno(dev, fd, "Failed to open \"%s\": %m", filename);
 
         size = read(fd, buf, sizeof(buf));
         if (size < 18)

--- a/src/udev/udev-node.c
+++ b/src/udev/udev-node.c
@@ -351,7 +351,7 @@ static int stack_directory_open_and_lock(
         if (!dirpath)
                 return -ENOMEM;
 
-        dirfd = open_mkdir(dirpath, O_CLOEXEC | O_DIRECTORY | O_NOFOLLOW | O_RDONLY, 0755);
+        dirfd = open_mkdir(dirpath, O_DIRECTORY | O_NOFOLLOW | O_RDONLY, 0755);
         if (dirfd < 0)
                 return log_device_debug_errno(dev, dirfd, "Failed to open stack directory '%s': %m", dirpath);
 

--- a/src/udev/udev-node.c
+++ b/src/udev/udev-node.c
@@ -747,13 +747,13 @@ int static_node_apply_permissions(
 
         devnode = strjoina("/dev/", name);
 
-        node_fd = open(devnode, O_PATH|O_CLOEXEC);
+        node_fd = xopenat(AT_FDCWD, devnode, O_PATH);
         if (node_fd < 0) {
-                bool ignore = ERRNO_IS_DEVICE_ABSENT_OR_EMPTY(errno);
-                log_full_errno(ignore ? LOG_DEBUG : LOG_WARNING, errno,
+                bool ignore = ERRNO_IS_DEVICE_ABSENT_OR_EMPTY(node_fd);
+                log_full_errno(ignore ? LOG_DEBUG : LOG_WARNING, node_fd,
                                "Failed to open device node '%s'%s: %m",
                                devnode, ignore ? ", ignoring" : "");
-                return ignore ? 0 : -errno;
+                return ignore ? 0 : node_fd;
         }
 
         if (fstat(node_fd, &stats) < 0)

--- a/src/udev/udev-watch.c
+++ b/src/udev/udev-watch.c
@@ -560,7 +560,7 @@ int manager_add_watch(Manager *manager, sd_device *dev) {
         if (r < 0)
                 return log_device_debug_errno(dev, r, "Failed to get device ID: %m");
 
-        r = dirfd = open_mkdir("/run/udev/watch", O_CLOEXEC | O_RDONLY, 0755);
+        r = dirfd = open_mkdir("/run/udev/watch", O_RDONLY, 0755);
         if (r < 0)
                 return log_device_debug_errno(dev, r, "Failed to create and open '/run/udev/watch/': %m");
 

--- a/src/udev/udev-watch.c
+++ b/src/udev/udev-watch.c
@@ -428,7 +428,7 @@ static int udev_watch_clear_by_wd(sd_device *dev, int dirfd, int wd) {
 
         _cleanup_close_ int dirfd_close = -EBADF;
         if (dirfd < 0) {
-                dirfd_close = RET_NERRNO(open("/run/udev/watch/", O_CLOEXEC | O_DIRECTORY | O_NOFOLLOW | O_RDONLY));
+                dirfd_close = xopenat(AT_FDCWD, "/run/udev/watch/", O_DIRECTORY | O_NOFOLLOW | O_RDONLY);
                 if (dirfd_close < 0)
                         return log_device_debug_errno(dev, dirfd_close, "Failed to open %s: %m", "/run/udev/watch/");
 
@@ -606,7 +606,7 @@ int manager_remove_watch(Manager *manager, sd_device *dev) {
         assert(manager);
         assert(dev);
 
-        dirfd = RET_NERRNO(open("/run/udev/watch", O_CLOEXEC | O_DIRECTORY | O_NOFOLLOW | O_RDONLY));
+        dirfd = xopenat(AT_FDCWD, "/run/udev/watch", O_DIRECTORY | O_NOFOLLOW | O_RDONLY);
         if (dirfd == -ENOENT)
                 return 0;
         if (dirfd < 0)

--- a/src/udev/udevadm-lock.c
+++ b/src/udev/udevadm-lock.c
@@ -11,6 +11,7 @@
 #include "device-util.h"
 #include "fd-util.h"
 #include "fdset.h"
+#include "fs-util.h"
 #include "glyph-util.h"
 #include "hash-funcs.h"
 #include "lock-util.h"
@@ -149,9 +150,9 @@ static int lock_device(
         int r;
 
         /* We open in O_WRONLY mode here, to trigger a rescan in udev once we are done */
-        fd = open(path, O_WRONLY|O_CLOEXEC|O_NONBLOCK|O_NOCTTY);
+        fd = xopenat(AT_FDCWD, path, O_WRONLY|O_NONBLOCK|O_NOCTTY);
         if (fd < 0)
-                return log_error_errno(errno, "Failed to open '%s': %m", path);
+                return log_error_errno(fd, "Failed to open '%s': %m", path);
 
         if (fstat(fd, &st) < 0)
                 return log_error_errno(errno, "Failed to stat '%s': %m", path);

--- a/src/udev/v4l_id/v4l_id.c
+++ b/src/udev/v4l_id/v4l_id.c
@@ -13,6 +13,7 @@
 #include "build.h"
 #include "errno-util.h"
 #include "fd-util.h"
+#include "fs-util.h"
 #include "log.h"
 #include "main-func.h"
 #include "string-util.h"
@@ -65,13 +66,13 @@ static int run(int argc, char *argv[]) {
         if (r <= 0)
                 return r;
 
-        fd = open(arg_device, O_RDONLY|O_CLOEXEC|O_NOCTTY);
+        fd = xopenat(AT_FDCWD, arg_device, O_RDONLY|O_NOCTTY);
         if (fd < 0) {
-                bool ignore = ERRNO_IS_DEVICE_ABSENT_OR_EMPTY(errno);
-                log_full_errno(ignore ? LOG_DEBUG : LOG_WARNING, errno,
+                bool ignore = ERRNO_IS_DEVICE_ABSENT_OR_EMPTY(fd);
+                log_full_errno(ignore ? LOG_DEBUG : LOG_WARNING, fd,
                                "Failed to open device node '%s'%s: %m",
                                arg_device, ignore ? ", ignoring" : "");
-                return ignore ? 0 : -errno;
+                return ignore ? 0 : fd;
         }
 
         if (ioctl(fd, VIDIOC_QUERYCAP, &v2cap) == 0) {

--- a/src/update-done/update-done.c
+++ b/src/update-done/update-done.c
@@ -41,7 +41,7 @@ static int save_timestamp(const char *dir, struct timespec *ts) {
 
         fd = chase_and_open(dir, arg_root,
                             CHASE_PREFIX_ROOT | CHASE_WARN | CHASE_MUST_BE_DIRECTORY,
-                            O_DIRECTORY | O_CLOEXEC | O_CREAT,
+                            O_DIRECTORY | O_CREAT,
                             &dirpath);
         if (fd < 0)
                 return log_error_errno(fd, "Failed to open %s%s: %m", strempty(arg_root), dir);

--- a/src/userdb/userdbctl.c
+++ b/src/userdb/userdbctl.c
@@ -1274,7 +1274,7 @@ static int load_credential_one(
         int *userdb_dir_fd = transient ? userdb_dir_transient_fd : userdb_dir_persist_fd;
         if (*userdb_dir_fd == -EBADF) {
                 *userdb_dir_fd = xopenat_full(AT_FDCWD, userdb_dir,
-                                              /* open_flags= */ O_DIRECTORY|O_CREAT|O_CLOEXEC,
+                                              /* open_flags= */ O_DIRECTORY|O_CREAT,
                                               /* xopen_flags= */ XO_LABEL,
                                               /* mode= */ 0755);
                 if (*userdb_dir_fd < 0)

--- a/src/userdb/userdbctl.c
+++ b/src/userdb/userdbctl.c
@@ -1233,9 +1233,9 @@ static int write_membership(int dir_fd, const char *dir, const char *user, const
         if (!membership)
                 return log_oom();
 
-        _cleanup_close_ int fd = openat(dir_fd, membership, O_WRONLY|O_CREAT|O_CLOEXEC, 0644);
+        _cleanup_close_ int fd = xopenat_full(dir_fd, membership, O_WRONLY|O_CREAT, /* xopen_flags= */ 0, 0644);
         if (fd < 0)
-                return log_error_errno(errno, "Failed to create %s/%s: %m", dir, membership);
+                return log_error_errno(fd, "Failed to create %s/%s: %m", dir, membership);
 
         r = loop_write(fd, "{}\n", SIZE_MAX);
         if (r < 0)

--- a/src/validatefs/validatefs.c
+++ b/src/validatefs/validatefs.c
@@ -392,7 +392,7 @@ static int run(int argc, char *argv[]) {
                 return r;
 
         _cleanup_free_ char *resolved = NULL;
-        _cleanup_close_ int target_fd = chase_and_open(arg_target, arg_root, CHASE_MUST_BE_DIRECTORY, O_DIRECTORY|O_CLOEXEC, &resolved);
+        _cleanup_close_ int target_fd = chase_and_open(arg_target, arg_root, CHASE_MUST_BE_DIRECTORY, O_DIRECTORY, &resolved);
         if (target_fd < 0)
                 return log_error_errno(target_fd, "Failed to open directory '%s': %m", arg_target);
 

--- a/src/varlinkctl/varlinkctl.c
+++ b/src/varlinkctl/varlinkctl.c
@@ -188,9 +188,9 @@ static int parse_argv(int argc, char *argv[], char ***ret_args) {
                                 /* We usually expect a numeric fd spec, but as an extension let's treat this
                                  * as a path to open in read-only mode in case this is clearly an absolute or
                                  * relative path */
-                                add_fd = open(opts.arg, O_CLOEXEC|O_RDONLY|O_NOCTTY);
+                                add_fd = xopenat(AT_FDCWD, opts.arg, O_RDONLY|O_NOCTTY);
                                 if (add_fd < 0)
-                                        return log_error_errno(errno, "Failed to open '%s': %m", opts.arg);
+                                        return log_error_errno(add_fd, "Failed to open '%s': %m", opts.arg);
                         } else {
                                 int parsed_fd = parse_fd(opts.arg);
                                 if (parsed_fd < 0)
@@ -233,9 +233,9 @@ static int varlink_connect_auto(sd_varlink **ret, const char *where) {
                 _cleanup_close_ int fd = -EBADF;
                 struct stat st;
 
-                fd = open(where, O_PATH|O_CLOEXEC);
+                fd = xopenat(AT_FDCWD, where, O_PATH);
                 if (fd < 0)
-                        return log_error_errno(errno, "Failed to open '%s': %m", where);
+                        return log_error_errno(fd, "Failed to open '%s': %m", where);
 
                 if (fstat(fd, &st) < 0)
                         return log_error_errno(errno, "Failed to stat '%s': %m", where);
@@ -1050,10 +1050,10 @@ static int verb_list_registry(int argc, char *argv[], uintptr_t _data, void *use
 
         (void) table_set_sort(table, (size_t) 0);
 
-        _cleanup_close_ int regfd = open(reg_path, O_DIRECTORY|O_CLOEXEC);
+        _cleanup_close_ int regfd = xopenat(AT_FDCWD, reg_path, O_DIRECTORY);
         if (regfd < 0)  {
-                if (errno != ENOENT)
-                        return log_error_errno(errno, "Failed to open '%s': %m", reg_path);
+                if (regfd != -ENOENT)
+                        return log_error_errno(regfd, "Failed to open '%s': %m", reg_path);
         } else {
                 _cleanup_free_ DirectoryEntries *des = NULL;
                 r = readdir_all(regfd, RECURSE_DIR_IGNORE_DOT|RECURSE_DIR_ENSURE_TYPE, &des);
@@ -1234,9 +1234,9 @@ static int verb_list_sockets(int argc, char *argv[], uintptr_t _data, void *user
                  * symlink), and verify it really is a socket whose inode and backing device match what
                  * netlink told us. This guards against the path having been unlinked/replaced in the
                  * meantime, so that we only ever read xattrs off the right inode. */
-                _cleanup_close_ int fd = open(path, O_PATH|O_CLOEXEC|O_NOFOLLOW);
+                _cleanup_close_ int fd = xopenat(AT_FDCWD, path, O_PATH|O_NOFOLLOW);
                 if (fd < 0) {
-                        log_debug_errno(errno, "Failed to open reported AF_UNIX socket path '%s', skipping: %m", path);
+                        log_debug_errno(fd, "Failed to open reported AF_UNIX socket path '%s', skipping: %m", path);
                         continue;
                 }
 

--- a/src/vconsole/vconsole-setup.c
+++ b/src/vconsole/vconsole-setup.c
@@ -577,7 +577,7 @@ static void setup_remaining_vcs(int src_fd, unsigned src_idx, bool utf8) {
 
                 /* try to open terminal */
                 xsprintf(ttyname, "/dev/tty%u", i);
-                fd_d = open_terminal(ttyname, O_RDWR|O_CLOEXEC|O_NOCTTY);
+                fd_d = open_terminal(ttyname, O_RDWR|O_NOCTTY);
                 if (fd_d < 0) {
                         log_warning_errno(fd_d, "Unable to open tty%u, fonts will not be copied: %m", i);
                         continue;
@@ -647,7 +647,7 @@ static int find_source_vc(char **ret_path, unsigned *ret_idx) {
                 if (asprintf(&path, "/dev/tty%u", i) < 0)
                         return log_oom();
 
-                fd = open_terminal(path, O_RDWR|O_CLOEXEC|O_NOCTTY);
+                fd = open_terminal(path, O_RDWR|O_NOCTTY);
                 if (fd < 0) {
                         log_debug_errno(fd, "Failed to open terminal %s, ignoring: %m", path);
                         if (IN_SET(err, 0, -EBUSY, -ENOENT))
@@ -689,7 +689,7 @@ static int verify_source_vc(char **ret_path, const char *src_vc) {
 
         assert(ret_path);
 
-        fd = open_terminal(src_vc, O_RDWR|O_CLOEXEC|O_NOCTTY);
+        fd = open_terminal(src_vc, O_RDWR|O_NOCTTY);
         if (fd < 0)
                 return log_error_errno(fd, "Failed to open %s: %m", src_vc);
 

--- a/src/vmspawn/vmspawn-util.c
+++ b/src/vmspawn/vmspawn-util.c
@@ -12,6 +12,7 @@
 #include "conf-files.h"
 #include "errno-util.h"
 #include "fd-util.h"
+#include "fs-util.h"
 #include "hashmap.h"
 #include "json-util.h"
 #include "log.h"
@@ -120,19 +121,19 @@ int qemu_check_vsock_support(void) {
          * If not this should return ENODEV.
          */
 
-        fd = open("/dev/vhost-vsock", O_RDWR|O_CLOEXEC);
+        fd = xopenat(AT_FDCWD, "/dev/vhost-vsock", O_RDWR);
         if (fd >= 0)
                 return true;
-        if (ERRNO_IS_DEVICE_ABSENT(errno)) {
-                log_debug_errno(errno, "/dev/vhost-vsock device doesn't exist. Not adding a vsock device to the virtual machine.");
+        if (ERRNO_IS_DEVICE_ABSENT(fd)) {
+                log_debug_errno(fd, "/dev/vhost-vsock device doesn't exist. Not adding a vsock device to the virtual machine.");
                 return false;
         }
-        if (ERRNO_IS_PRIVILEGE(errno)) {
-                log_debug_errno(errno, "Permission denied to access /dev/vhost-vsock. Not adding a vsock device to the virtual machine.");
+        if (ERRNO_IS_PRIVILEGE(fd)) {
+                log_debug_errno(fd, "Permission denied to access /dev/vhost-vsock. Not adding a vsock device to the virtual machine.");
                 return false;
         }
 
-        return -errno;
+        return fd;
 }
 
 typedef struct FirmwareTarget {

--- a/src/vmspawn/vmspawn.c
+++ b/src/vmspawn/vmspawn.c
@@ -53,7 +53,6 @@
 #include "machine-credential.h"
 #include "machine-register.h"
 #include "main-func.h"
-#include "memfd-util.h"
 #include "mkdir.h"
 #include "namespace-util.h"
 #include "netif-util.h"
@@ -2369,16 +2368,10 @@ static int prepare_primary_drive(const char *runtime_dir, DriveInfos *drives) {
          * as qcow2 via blockdev-create, so no filesystem path is needed.
          * Skip for read-only drives (e.g. CDROM) where overlays are not meaningful. */
         if (arg_ephemeral && !FLAGS_SET(d->flags, QMP_DRIVE_READ_ONLY)) {
-                _cleanup_close_ int overlay_fd = open(runtime_dir, O_TMPFILE | O_RDWR | O_CLOEXEC, 0600);
-                if (overlay_fd < 0) {
-                        if (!ERRNO_IS_NOT_SUPPORTED(errno))
-                                return log_error_errno(errno, "Failed to create ephemeral overlay in '%s': %m", runtime_dir);
+                _cleanup_close_ int overlay_fd = open_tmpfile_unlinkable(runtime_dir, O_RDWR);
+                if (overlay_fd < 0)
+                        return log_error_errno(overlay_fd, "Failed to create ephemeral overlay in '%s': %m", runtime_dir);
 
-                        /* Fallback to memfd if O_TMPFILE is not supported */
-                        overlay_fd = memfd_new("vmspawn-overlay");
-                        if (overlay_fd < 0)
-                                return log_error_errno(overlay_fd, "Failed to create ephemeral overlay via memfd: %m");
-                }
                 d->overlay_fd = TAKE_FD(overlay_fd);
                 d->flags |= QMP_DRIVE_NO_FLUSH;
                 d->grow_to = arg_grow_image;

--- a/src/vmspawn/vmspawn.c
+++ b/src/vmspawn/vmspawn.c
@@ -2056,7 +2056,7 @@ static int grow_image(const char *path, uint64_t size) {
         if (size == 0)
                 return 0;
 
-        _cleanup_close_ int fd = xopenat_full(AT_FDCWD, path, O_RDWR|O_CLOEXEC, XO_REGULAR, /* mode= */ 0);
+        _cleanup_close_ int fd = xopenat_full(AT_FDCWD, path, O_RDWR, XO_REGULAR, /* mode= */ 0);
         if (fd < 0)
                 return log_error_errno(fd, "Failed to open image file '%s': %m", path);
 
@@ -2185,7 +2185,7 @@ static int cmdline_add_ovmf(FILE *config_file, const OvmfConfig *ovmf_config, ch
                 if (!d)
                         return log_oom();
 
-                target_fd = openat_report_new(AT_FDCWD, arg_efi_nvram_state_path, O_WRONLY|O_CREAT|O_CLOEXEC, 0600, &newly_created);
+                target_fd = openat_report_new(AT_FDCWD, arg_efi_nvram_state_path, O_WRONLY|O_CREAT, 0600, &newly_created);
                 if (target_fd < 0)
                         return log_error_errno(target_fd, "Failed to open file for OVMF vars at %s: %m", arg_efi_nvram_state_path);
 

--- a/src/vmspawn/vmspawn.c
+++ b/src/vmspawn/vmspawn.c
@@ -1724,7 +1724,7 @@ static int start_virtiofsd(
                 if (userns_fd < 0)
                         return log_error_errno(userns_fd, "Failed to allocate user namespace for virtiofsd: %m");
 
-                _cleanup_close_ int directory_fd = open(directory, O_DIRECTORY|O_CLOEXEC|O_PATH);
+                _cleanup_close_ int directory_fd = xopenat(AT_FDCWD, directory, O_DIRECTORY|O_PATH);
                 if (directory_fd < 0)
                         return log_error_errno(directory_fd, "Failed to open '%s': %m", directory);
 
@@ -1971,9 +1971,9 @@ static int merge_initrds(char **ret) {
         if (r < 0)
                 return log_error_errno(r, "Failed to create temporary file: %m");
 
-        ofd = open(merged_initrd, O_WRONLY|O_CREAT|O_EXCL|O_CLOEXEC, 0600);
+        ofd = xopenat_full(AT_FDCWD, merged_initrd, O_WRONLY|O_CREAT|O_EXCL, /* xopen_flags= */ 0, 0600);
         if (ofd < 0)
-                return log_error_errno(errno, "Failed to create regular file %s: %m", merged_initrd);
+                return log_error_errno(ofd, "Failed to create regular file %s: %m", merged_initrd);
 
         STRV_FOREACH(i, arg_initrds) {
                 _cleanup_close_ int ifd = -EBADF;
@@ -1989,9 +1989,9 @@ static int merge_initrds(char **ret) {
                 if (to_seek != 0 && lseek(ofd, to_seek, SEEK_CUR) < 0)
                         return log_error_errno(errno, "Failed to seek %s: %m", merged_initrd);
 
-                ifd = open(*i, O_RDONLY|O_CLOEXEC);
+                ifd = xopenat(AT_FDCWD, *i, O_RDONLY);
                 if (ifd < 0)
-                        return log_error_errno(errno, "Failed to open %s: %m", *i);
+                        return log_error_errno(ifd, "Failed to open %s: %m", *i);
 
                 r = copy_bytes(ifd, ofd, UINT64_MAX, /* copy_flags= */ 0);
                 if (r < 0)
@@ -2203,18 +2203,18 @@ static int cmdline_add_ovmf(FILE *config_file, const OvmfConfig *ovmf_config, ch
                 if (r < 0)
                         return log_error_errno(r, "Failed to create temporary filename: %m");
 
-                target_fd = open(t, O_WRONLY|O_CREAT|O_EXCL|O_CLOEXEC, 0600);
+                target_fd = xopenat_full(AT_FDCWD, t, O_WRONLY|O_CREAT|O_EXCL, /* xopen_flags= */ 0, 0600);
                 if (target_fd < 0)
-                        return log_error_errno(errno, "Failed to create regular file for OVMF vars at %s: %m", t);
+                        return log_error_errno(target_fd, "Failed to create regular file for OVMF vars at %s: %m", t);
 
                 newly_created = true;
                 state = *ret_ovmf_vars = TAKE_PTR(t);
         }
 
         if (newly_created) {
-                _cleanup_close_ int source_fd = open(vars_source, O_RDONLY|O_CLOEXEC);
+                _cleanup_close_ int source_fd = xopenat(AT_FDCWD, vars_source, O_RDONLY);
                 if (source_fd < 0)
-                        return log_error_errno(errno, "Failed to open OVMF vars file %s: %m", vars_source);
+                        return log_error_errno(source_fd, "Failed to open OVMF vars file %s: %m", vars_source);
 
                 r = copy_bytes(source_fd, target_fd, UINT64_MAX, /* copy_flags= */ 0);
                 if (r < 0)
@@ -2339,11 +2339,11 @@ static int prepare_primary_drive(const char *runtime_dir, DriveInfos *drives) {
         if (r < 0)
                 return log_error_errno(r, "Failed to resolve disk driver for '%s': %m", image_fn);
 
-        int open_flags = ((arg_ephemeral || FLAGS_SET(d->flags, QMP_DRIVE_READ_ONLY)) ? O_RDONLY : O_RDWR) | O_CLOEXEC | O_NOCTTY;
+        int open_flags = ((arg_ephemeral || FLAGS_SET(d->flags, QMP_DRIVE_READ_ONLY)) ? O_RDONLY : O_RDWR) | O_NOCTTY;
 
-        _cleanup_close_ int image_fd = open(arg_image, open_flags);
+        _cleanup_close_ int image_fd = xopenat(AT_FDCWD, arg_image, open_flags);
         if (image_fd < 0)
-                return log_error_errno(errno, "Failed to open '%s': %m", arg_image);
+                return log_error_errno(image_fd, "Failed to open '%s': %m", arg_image);
 
         struct stat st;
         if (fstat(image_fd, &st) < 0)
@@ -2402,9 +2402,9 @@ static int prepare_extra_drives(DriveInfos *drives) {
                 if (r < 0)
                         return log_error_errno(r, "Failed to resolve disk driver for '%s': %m", drive_fn);
 
-                _cleanup_close_ int drive_fd = open(drive->path, (FLAGS_SET(d->flags, QMP_DRIVE_READ_ONLY) ? O_RDONLY : O_RDWR) | O_CLOEXEC | O_NOCTTY);
+                _cleanup_close_ int drive_fd = xopenat(AT_FDCWD, drive->path, (FLAGS_SET(d->flags, QMP_DRIVE_READ_ONLY) ? O_RDONLY : O_RDWR) | O_NOCTTY);
                 if (drive_fd < 0)
-                        return log_error_errno(errno, "Failed to open '%s': %m", drive->path);
+                        return log_error_errno(drive_fd, "Failed to open '%s': %m", drive->path);
 
                 struct stat drive_st;
                 if (fstat(drive_fd, &drive_st) < 0)
@@ -3011,9 +3011,9 @@ static int run_virtual_machine(int kvm_device_fd, int vhost_device_fd) {
                 config.vsock.fd = TAKE_FD(vhost_device_fd);
 
                 if (config.vsock.fd < 0) {
-                        config.vsock.fd = open("/dev/vhost-vsock", O_RDWR|O_CLOEXEC);
+                        config.vsock.fd = xopenat(AT_FDCWD, "/dev/vhost-vsock", O_RDWR);
                         if (config.vsock.fd < 0)
-                                return log_error_errno(errno, "Failed to open /dev/vhost-vsock as read/write: %m");
+                                return log_error_errno(config.vsock.fd, "Failed to open /dev/vhost-vsock as read/write: %m");
                 }
 
                 r = vsock_fix_child_cid(config.vsock.fd, &child_cid, arg_machine);

--- a/test/units/TEST-23-UNIT-FILE.StandardOutput.sh
+++ b/test/units/TEST-23-UNIT-FILE.StandardOutput.sh
@@ -54,3 +54,17 @@ EOF
 cmp /tmp/stderr <<EOF
 b
 EOF
+
+# A dangling symlink as the output file is not followed when creating it: the unit must fail to start while
+# setting up stdout, and the symlink target must not be created.
+rm -f /tmp/stdout /tmp/stdout-target
+ln -s /tmp/stdout-target /tmp/stdout
+(! systemd-run --wait --unit=TEST-23-UNIT-FILE-standard-output-five \
+            -p StandardOutput=file:/tmp/stdout \
+            -p Type=exec \
+            true)
+[[ "$(systemctl show -P Result TEST-23-UNIT-FILE-standard-output-five.service)" == "exit-code" ]]
+[[ "$(systemctl show -P ExecMainStatus TEST-23-UNIT-FILE-standard-output-five.service)" == "209" ]] # EXIT_STDOUT
+systemctl reset-failed TEST-23-UNIT-FILE-standard-output-five.service
+test ! -e /tmp/stdout-target
+rm -f /tmp/stdout


### PR DESCRIPTION
In any modern codebase `O_CLOEXEC` should be the default and file descriptor inheritance must be explicitly enabled. Flip the switch and port everyone to our internal open helpers as well.

Signed-off-by: Christian Brauner (Amutable) <brauner@kernel.org>