### PR TITLE
compress: avoid shifting null pointer

### DIFF
--- a/src/basic/compress.c
+++ b/src/basic/compress.c
@@ -2071,8 +2071,11 @@ int decompressor_push(Decompressor *c, const void *data, size_t size, Decompress
                             produced > COMPRESS_PIPE_BUFFER_SIZE)
                                 return -EIO;
 
-                        src += consumed;
-                        src_remaining -= consumed;
+                        if (consumed > 0) {
+                                assert(src);
+                                src += consumed;
+                                src_remaining -= consumed;
+                        }
 
                         if (produced > 0) {
                                 r = callback(buffer, produced, userdata);


### PR DESCRIPTION
Otherwise, UBSAN complains when src is NULL even the shift is zero:

../src/basic/compress.c:2074:29: runtime error: applying zero offset to null pointer