### PR TITLE
btrfs-util: validate that `sh.len` is large enough

### DIFF
--- a/src/shared/btrfs-util.c
+++ b/src/shared/btrfs-util.c
@@ -1947,11 +1947,21 @@ static int btrfs_read_chunk_tree_fd(int fd, BtrfsChunkTree *ret) {
                         if (sh.type != BTRFS_CHUNK_ITEM_KEY)
                                 continue;
 
+                        if (sh.len < sizeof(struct btrfs_chunk))
+                                return -EBADMSG;
+
                         chunk = new(BtrfsChunk, 1);
                         if (!chunk)
                                 return -ENOMEM;
 
                         const struct btrfs_chunk *item = body;
+
+                        if (le16toh(item->num_stripes) == 0 || le64toh(item->stripe_len) == 0)
+                                return -EBADMSG;
+
+                        if ((sh.len - sizeof(struct btrfs_chunk)) / sizeof(struct btrfs_stripe) + 1 < le16toh(item->num_stripes))
+                                return -EBADMSG;
+
                         *chunk = (BtrfsChunk) {
                                 .offset = sh.offset,
                                 .length = le64toh(item->length),


### PR DESCRIPTION
... to contain the `struct btrfs_chunk` header and all declared stripes before using `num_stripes` as a loop bound.

This may only happen if kernel validation fails. Fixes this issue reported by Coverity:

```
Error: TAINTED_SCALAR (CWE-20):
systemd-262-rc1/src/shared/btrfs-util.c:1925:9: path: Condition "!!(fd >= 0)", taking true branch.
systemd-262-rc1/src/shared/btrfs-util.c:1926:9: path: Condition "!!ret", taking true branch.
systemd-262-rc1/src/shared/btrfs-util.c:1928:9: path: Condition "btrfs_ioctl_search_args_compare(&search_args) <= 0", taking true branch.
systemd-262-rc1/src/shared/btrfs-util.c:1934:17: path: Condition "ioctl(fd, 3489698833UL /* ((((2U | 1U) << 0 + 8 + 8 + 14) | (0x94 << 0 + 8)) | (0x11 << 0)) | (sizeof (struct btrfs_ioctl_search_args) << 0 + 8 + 8) */, &search_args) < 0", taking false branch.
systemd-262-rc1/src/shared/btrfs-util.c:1937:17: path: Condition "search_args.key.nr_items == 0", taking false branch.
systemd-262-rc1/src/shared/btrfs-util.c:1940:17: path: Condition "btrfs_iterate(&iterator) > 0", taking true branch.
systemd-262-rc1/src/shared/btrfs-util.c:1945:25: path: Condition "sh.objectid != 256ULL", taking false branch.
systemd-262-rc1/src/shared/btrfs-util.c:1947:25: path: Condition "sh.type != 228", taking false branch.
systemd-262-rc1/src/shared/btrfs-util.c:1951:25: path: Condition "!chunk", taking false branch.
systemd-262-rc1/src/shared/btrfs-util.c:1954:25: tainted_data_downcast: Downcasting "body" from "void const *" to "struct btrfs_chunk" implies that the data that this pointer points to is tainted.
systemd-262-rc1/src/shared/btrfs-util.c:1954:25: var_assign_var: Assigning: "item" = "body". Both are now tainted.
systemd-262-rc1/src/shared/btrfs-util.c:1955:25: identity_transfer: Passing "item->num_stripes" as argument 1 to function "le16toh", which returns that argument.
systemd-262-rc1/src/basic/sparse-endian.h:82:48: return_parm: Returning "value".
systemd-262-rc1/src/shared/btrfs-util.c:1955:25: tainted_data_transitive: Call to function "le16toh" with tainted argument "item->num_stripes" returns tainted data.
systemd-262-rc1/src/basic/sparse-endian.h:82:48: return_tainted_data: Returning tainted data "(uint16_t)value".
systemd-262-rc1/src/shared/btrfs-util.c:1955:25: var_assign: Assigning: "<temporary>.n_stripes" = "le16toh(item->num_stripes)", which taints "<temporary>.n_stripes".
systemd-262-rc1/src/shared/btrfs-util.c:1955:25: var_assign: Assigning: "*chunk" = "BtrfsChunk({.offset = sh.offset, .length = le64toh(item->length), .type = le64toh(item->type), .n_stripes = le16toh(item->num_stripes), .stripe_len = le64toh(item->stripe_len)})", which taints "*chunk".
systemd-262-rc1/src/shared/btrfs-util.c:1964:25: path: Condition "!chunk->stripes", taking false branch.
systemd-262-rc1/src/shared/btrfs-util.c:1967:25: tainted_data: Using tainted variable "chunk->n_stripes" as a loop boundary.
systemd-262-rc1/src/shared/btrfs-util.c:1967:25: remediation: Ensure that tainted values are properly sanitized, by checking that their values are within a permissible range.
# 1965|                                   return -ENOMEM;
# 1966|   
# 1967|->                         for (size_t j = 0; j < chunk->n_stripes; j++) {
# 1968|                                   const struct btrfs_stripe *stripe = &item->stripe + j;
# 1969|   
```