### PR TITLE
docs: list AGENTS.md in LICENSES/README.md

### DIFF
--- a/LICENSES/README.md
+++ b/LICENSES/README.md
@@ -61,6 +61,7 @@ The following exceptions apply:
    - hostname-wordlist/weather
    - hostname-wordlist/worlds
    - src/systemd/sd-dlopen.h
+   - AGENTS.md
  * the following sources are under **Public Domain** (LicenseRef-murmurhash2-public-domain):
    - src/basic/MurmurHash2.c
    - src/basic/MurmurHash2.h


### PR DESCRIPTION
It doesn't use the default project license anymore so it needs to be listed

Follow-up for 75344c78297c2141c3f96012355fb49d6206e45c