### PR TITLE
network/netdev: add a `NULL` check

### DIFF
--- a/src/network/netdev/netdev.c
+++ b/src/network/netdev/netdev.c
@@ -464,6 +464,7 @@ int netdev_set_ifindex_internal(NetDev *netdev, int ifindex) {
 
 static int netdev_set_ifindex_impl(NetDev *netdev, const char *name, int ifindex) {
         assert(netdev);
+        assert(netdev->ifname);
         assert(name);
         assert(ifindex > 0);
 


### PR DESCRIPTION
... for `netdev->ifname`.

This follows the same pattern as followed by other functions and fixes this issue reported by Coverity:

```
Error: NULL_FIELD (CWE-476):
systemd-262-rc1/src/network/netdev/netdev.c:466:9: path: Condition "netdev", taking true branch.
systemd-262-rc1/src/network/netdev/netdev.c:466:9: path: Falling through to end of if statement.
systemd-262-rc1/src/network/netdev/netdev.c:467:9: path: Condition "name", taking true branch.
systemd-262-rc1/src/network/netdev/netdev.c:467:9: path: Falling through to end of if statement.
systemd-262-rc1/src/network/netdev/netdev.c:468:9: path: Condition "ifindex > 0", taking true branch.
systemd-262-rc1/src/network/netdev/netdev.c:468:9: path: Falling through to end of if statement.
systemd-262-rc1/src/network/netdev/netdev.c:470:9: path: Condition "netdev->kind != _NETDEV_KIND_INVALID", taking true branch.
systemd-262-rc1/src/network/netdev/netdev.c:470:9: path: Condition "((netdev->kind != _NETDEV_KIND_INVALID) ? netdev_vtable[netdev->kind] : NULL)->set_ifindex", taking false branch.
systemd-262-rc1/src/network/netdev/netdev.c:473:9: null_field: Reading field "ifname", which is expected to possibly be "NULL" in "netdev->ifname" (checked 204 out of 233 times).
systemd-262-rc1/src/network/netdev/netdev.c:473:9: dereference: Passing null pointer "netdev->ifname" to "strcmp", which dereferences it.
systemd-262-rc1/src/network/netdev/bareudp.c:51:24: example_checked: Example 1: "_n->ifname" has its value checked in "_ifname".
systemd-262-rc1/src/network/netdev/batadv.c:176:24: example_checked: Example 2: "_n->ifname" has its value checked in "_ifname".
systemd-262-rc1/src/network/netdev/bridge.c:180:24: example_checked: Example 3: "_n->ifname" has its value checked in "_ifname".
systemd-262-rc1/src/network/netdev/fou-tunnel.c:93:24: example_checked: Example 4: "_n->ifname" has its value checked in "_ifname".
systemd-262-rc1/src/network/netdev/geneve.c:245:24: example_checked: Example 5: "_n->ifname" has its value checked in "_ifname".
#  471|                   return NETDEV_VTABLE(netdev)->set_ifindex(netdev, name, ifindex);
#  472|   
#  473|->         if (!streq(netdev->ifname, name))
#  474|                   return log_netdev_warning_errno(netdev, SYNTHETIC_ERRNO(EINVAL),
#  475|                                                   "Received netlink message with unexpected interface name %s (ifindex=%i).",
```