### PR TITLE
sd-varlink: introduce io.systemd.GetServerCredentials method

### DIFF
--- a/src/libsystemd/sd-varlink/sd-varlink.c
+++ b/src/libsystemd/sd-varlink/sd-varlink.c
@@ -981,6 +981,41 @@ static int generic_method_get_info(
                         SD_JSON_BUILD_PAIR_STRV("interfaces", interfaces));
 }
 
+static int generic_method_get_server_credentials(
+                sd_varlink *link,
+                sd_json_variant *parameters,
+                sd_varlink_method_flags_t flags,
+                void *userdata) {
+
+        _cleanup_close_ int pidfd = -EBADF;
+        int pidfd_idx = -EBADF;
+        int r;
+
+        assert(link);
+
+        r = sd_varlink_dispatch(link, parameters, /* dispatch_table= */ NULL, /* userdata= */ NULL);
+        if (r != 0)
+                return r;
+
+        /* Try to get the PIDFD for the current process and pass it over Varlink. This will work only on
+         * kernels with PIDFD support and when the Varlink server has FD passing enabled (see
+         * SD_VARLINK_SERVER_ALLOW_FD_PASSING_OUTPUT). If either of these condition fails, don't send the
+         * pidfdIndex field at all. */
+        pidfd = pidfd_open(getpid_cached(), 0);
+        if (pidfd >= 0) {
+                pidfd_idx = sd_varlink_push_fd(link, pidfd);
+                if (pidfd_idx >= 0)
+                        TAKE_FD(pidfd);
+        }
+
+        return sd_varlink_replybo(
+                        link,
+                        SD_JSON_BUILD_PAIR_INTEGER("uid", getuid()),
+                        SD_JSON_BUILD_PAIR_INTEGER("gid", getgid()),
+                        SD_JSON_BUILD_PAIR_CONDITION(pidfd_idx >= 0, "pidfdIndex", SD_JSON_BUILD_INTEGER(pidfd_idx)),
+                        SD_JSON_BUILD_PAIR_INTEGER("pid", getpid_cached()));
+}
+
 static int generic_method_get_interface_description(
                 sd_varlink *link,
                 sd_json_variant *parameters,
@@ -1301,6 +1336,8 @@ static int varlink_dispatch_method(sd_varlink *v) {
                         callback = generic_method_get_info;
                 else if (streq(method, "org.varlink.service.GetInterfaceDescription"))
                         callback = generic_method_get_interface_description;
+                else if (streq(method, "io.systemd.GetServerCredentials"))
+                        callback = generic_method_get_server_credentials;
         }
 
         if (callback) {

--- a/src/libsystemd/sd-varlink/varlink-io.systemd.c
+++ b/src/libsystemd/sd-varlink/varlink-io.systemd.c
@@ -2,6 +2,17 @@
 
 #include "varlink-io.systemd.h"
 
+static SD_VARLINK_DEFINE_METHOD(
+                GetServerCredentials,
+                SD_VARLINK_FIELD_COMMENT("The UID of the server process."),
+                SD_VARLINK_DEFINE_OUTPUT(uid, SD_VARLINK_INT, 0),
+                SD_VARLINK_FIELD_COMMENT("The GID of the server process."),
+                SD_VARLINK_DEFINE_OUTPUT(gid, SD_VARLINK_INT, 0),
+                SD_VARLINK_FIELD_COMMENT("Index into the file descriptor array identifying a PIDFD of the server process, if file descriptor passing is enabled on the connection."),
+                SD_VARLINK_DEFINE_OUTPUT(pidfdIndex, SD_VARLINK_INT, SD_VARLINK_NULLABLE),
+                SD_VARLINK_FIELD_COMMENT("The PID of the server process."),
+                SD_VARLINK_DEFINE_OUTPUT(pid, SD_VARLINK_INT, 0));
+
 /* These are local errors that never cross the wire, and are our own invention */
 static SD_VARLINK_DEFINE_ERROR(Disconnected);
 static SD_VARLINK_DEFINE_ERROR(TimedOut);
@@ -20,6 +31,8 @@ static SD_VARLINK_DEFINE_ERROR(
 SD_VARLINK_DEFINE_INTERFACE(
                 io_systemd,
                 "io.systemd",
+                SD_VARLINK_SYMBOL_COMMENT("Returns credentials of the server process handling this connection."),
+                &vl_method_GetServerCredentials,
                 SD_VARLINK_SYMBOL_COMMENT("Local error if a Varlink connection is disconnected (this never crosses the wire and is synthesized locally only)."),
                 &vl_error_Disconnected,
                 SD_VARLINK_SYMBOL_COMMENT("A method call time-out has been reached (also synthesized locally, does not cross wire)"),

--- a/test/units/TEST-74-AUX-UTILS.varlinkctl.sh
+++ b/test/units/TEST-74-AUX-UTILS.varlinkctl.sh
@@ -222,6 +222,37 @@ systemd-run --wait --pipe --user --machine testuser@ \
 systemd-run --wait --pipe --user --machine testuser@ \
         varlinkctl call "/run/user/$testuser_uid/systemd/io.systemd.Manager" io.systemd.Manager.Describe '{}'
 
+# Test io.systemd.GetServerCredentials method
+LOGIND_PID="$(systemctl show -P MainPID systemd-logind.service)"
+RESOLVED_PID="$(systemctl show -P MainPID systemd-resolved.service)"
+RESOLVED_UID="$(id -u systemd-resolve)"
+RESOLVED_GID="$(id -g systemd-resolve)"
+LOGFILE="$(mktemp)"
+# systemd-logind runs under root and supports FD passing (SD_VARLINK_SERVER_ALLOW_FD_PASSING_OUTPUT)
+varlinkctl call /run/systemd/io.systemd.Login io.systemd.GetServerCredentials '{}' | tee "$LOGFILE" | jq .
+jq -e ".uid == 0" "$LOGFILE"
+jq -e ".gid == 0" "$LOGFILE"
+jq -e ".pid == $LOGIND_PID" "$LOGFILE"
+# Test PIDFD passing when supported by kernel
+if systemd-analyze compare-versions "$(uname -r)" ge 6.5; then
+    jq -e ".pidfdIndex == 0" "$LOGFILE"
+    # varlinkctl passes the received FD's into the exec'ed process where the first FD should be at
+    # position SD_LISTEN_FDS_START, i.e. 3 ATTOW
+    varlinkctl call /run/systemd/io.systemd.Login io.systemd.GetServerCredentials '{}' --exec -- \
+        bash -xec 'cat /proc/self/fdinfo/3' | tee "$LOGFILE"
+    grep -E "^Pid:\s*$LOGIND_PID$" "$LOGFILE"
+
+else
+    jq -e 'has("pidfdIndex") | not' "$LOGFILE"
+fi
+# systemd-resolved runs under its own user/group and doesn't support FD passing
+varlinkctl call /run/systemd/resolve/io.systemd.Resolve io.systemd.GetServerCredentials '{}' | tee "$LOGFILE" | jq .
+jq -e ".uid == $RESOLVED_UID" "$LOGFILE"
+jq -e ".gid == $RESOLVED_GID" "$LOGFILE"
+jq -e ".pid == $RESOLVED_PID" "$LOGFILE"
+jq -e 'has("pidfdIndex") | not' "$LOGFILE"
+rm -f "$LOGFILE"
+
 # test --upgrade (protocol upgrade)
 # The basic --upgrade proxy test is covered by the "varlinkctl serve" tests below (which use
 # serve+rev/gunzip as the server). The tests here exercise features that need the Python


### PR DESCRIPTION
To get the credentials (PID/UID/GID) of the Varlink server on the other end of a Varlink socket, one can use SO_PEERCRED on the socket which works just fine - except when the Varlink server is socket activated, as in that case the socket is owned by PID 1 instead of the target Varlink server.

Given this is pretty systemd-specific, as it affects only socket-activated Varlink services, let's extend our io.systemd interface with GetServerCredentials method that more-or-less mimics D-Bus' GetConnectionCredentials - when called, it returns UID, GID, PIDFD, and PID of the Varlink server. The PIDFD is a bit special as the field is set only when the kernel supports PIDFDs and when the Varlink server supports passing FDs (i.e. it has SD_VARLINK_SERVER_ALLOW_FD_PASSING_OUTPUT set), as the PIDFD is passed via the SCM_RIGHTS ancillary message.

---

The PIDFD stuff is a bit more limited that I originally anticipated, because only a handful of our Varlink services set `SD_VARLINK_SERVER_ALLOW_FD_PASSING_OUTPUT`. Other systemd Varlink services get around this (not sure if that was the original intention) by passing a ProcessId triplet instead (PID/PIDFD inode number/boot ID), which then needs to be resolved and checked by the client. I found the current approach of passing the PIDFD directly a bit more convenient, but I don't have a strong feeling about this if of the other approach should be used instead (I guess it would make it a slightly more useful given the FD-passing limitations).