### PR TITLE
hwdb: add Dell Latitude 5320 accelerometer

### DIFF
--- a/hwdb.d/60-sensor.hwdb
+++ b/hwdb.d/60-sensor.hwdb
@@ -381,6 +381,7 @@ sensor:modalias:platform:HID-SENSOR-200073:dmi:*:svnDellInc.:*:sku0CC4:*    # La
 sensor:modalias:platform:HID-SENSOR-200073:dmi:*:svnDellInc.:*:sku0CC5:*
 sensor:modalias:platform:HID-SENSOR-200073:dmi:*:svnDellInc.:*:sku0CC7:*    # Precision 5490
 sensor:modalias:platform:HID-SENSOR-200073:dmi:*:svnDellInc.:*:sku0CC8:*    # Precision 5690
+sensor:modalias:acpi:HID-SENSOR-200076:dmi:*:svnDellInc.:*:sku0A42:*    # Latitude 5320
  ACCEL_LOCATION=base
 
 sensor:modalias:acpi:INVN6500:*:dmi:*:svnDellInc.:pnVenue8Pro3845:*         # Venue 8 Pro 3845


### PR DESCRIPTION
Add the Dell Latitude 5320 accelerometer modalias to 60-sensor.hwdb and mark it as a base sensor, enabling correct screen rotation handling for this convertible model.

Closes #43547

Validation:
- ./test/hwdb-test.sh /usr/bin/systemd-hwdb