### PR TITLE
journalctl: Restore listing the whole catalog when no ID is given

### DIFF
--- a/src/journal/journalctl.c
+++ b/src/journal/journalctl.c
@@ -991,11 +991,10 @@ static int parse_argv(int argc, char *argv[], char ***remaining_args) {
         if (!arg_follow)
                 arg_journal_additional_open_flags = SD_JOURNAL_ASSUME_IMMUTABLE;
 
-        args = strv_copy(args);
-        if (!args)
+        r = strv_copy_unless_empty(args, remaining_args);
+        if (r < 0)
                 return log_oom();
 
-        *remaining_args = args;
         return 1;
 }
 

--- a/test/units/TEST-04-JOURNAL.journal.sh
+++ b/test/units/TEST-04-JOURNAL.journal.sh
@@ -195,6 +195,9 @@ journalctl --fields
 journalctl --list-boots
 journalctl --update-catalog
 journalctl --list-catalog
+[[ "$(journalctl --list-catalog | wc -l)" -gt 1 ]]
+[[ "$(journalctl --list-catalog f77379a8490b408bbe5f6940505a777b | wc -l)" -eq 1 ]]
+[[ "$(journalctl --dump-catalog | wc -l)" -gt "$(journalctl --dump-catalog f77379a8490b408bbe5f6940505a777b | wc -l)" ]]
 
 # Add new tests before here, the journald restarts below
 # may make tests flappy.


### PR DESCRIPTION
The conversion to the OPTION macros in c3f4c1b8d6b9 ("journalctl: convert to OPTION macros") replaced strv_copy_unless_empty() with strv_copy().

This is problematic because the positional arguments are now an empty strv rather than NULL when none are given, but `--{list,dump}-catalog` rely on that.

Instead let's hand NULL back to them when there is nothing on the command line.