### PR TITLE
timedated: Don't tell the kernel our timezone if RTC is in UTC

### DIFF
--- a/src/core/main.c
+++ b/src/core/main.c
@@ -1918,7 +1918,7 @@ static void initialize_clock_timewarp(void) {
                  * take care of maintaining the RTC and do all adjustments. This matches the behavior of
                  * Windows, which leaves the RTC alone if the registry tells that the RTC runs in UTC.
                  */
-                r = clock_set_timezone(&min);
+                r = clock_set_timezone(true, &min);
                 if (r < 0)
                         log_error_errno(r, "Failed to apply local time delta, ignoring: %m");
                 else

--- a/src/shared/clock-util.c
+++ b/src/shared/clock-util.c
@@ -50,15 +50,19 @@ int clock_is_localtime(const char *adjtime_path) {
         return streq(line, "LOCAL");
 }
 
-int clock_set_timezone(int *ret_minutesdelta) {
-        struct tm tm;
-        int r;
+int clock_set_timezone(bool is_localtime, int *ret_minutesdelta) {
+        int minutesdelta = 0;
 
-        r = localtime_or_gmtime_usec(now(CLOCK_REALTIME), /* utc= */ false, &tm);
-        if (r < 0)
-                return r;
+        if (is_localtime) {
+                struct tm tm;
+                int r;
 
-        int minutesdelta = tm.tm_gmtoff / 60;
+                r = localtime_or_gmtime_usec(now(CLOCK_REALTIME), /* utc= */ false, &tm);
+                if (r < 0)
+                        return r;
+
+                minutesdelta = tm.tm_gmtoff / 60;
+        }
 
         struct timezone tz = {
                 .tz_minuteswest = -minutesdelta,

--- a/src/shared/clock-util.h
+++ b/src/shared/clock-util.h
@@ -1,8 +1,10 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 #pragma once
 
+#include <stdbool.h>
+
 int clock_is_localtime(const char *adjtime_path);
-int clock_set_timezone(int *ret_minutesdelta);
+int clock_set_timezone(bool is_localtime, int *ret_minutesdelta);
 
 #define EPOCH_CLOCK_FILE "/usr/lib/clock-epoch"
 #define TIMESYNCD_CLOCK_FILE_DIR "/var/lib/systemd/timesync/"

--- a/src/timedate/timedated.c
+++ b/src/timedate/timedated.c
@@ -722,7 +722,7 @@ static int method_set_timezone(sd_bus_message *m, void *userdata, sd_bus_error *
         tzset();
 
         /* 3. Tell the kernel our timezone */
-        r = clock_set_timezone(NULL);
+        r = clock_set_timezone(c->local_rtc, NULL);
         if (r < 0)
                 log_debug_errno(r, "Failed to tell kernel about timezone, ignoring: %m");
 
@@ -798,7 +798,7 @@ static int method_set_local_rtc(sd_bus_message *m, void *userdata, sd_bus_error 
         }
 
         /* 2. Tell the kernel our timezone */
-        r = clock_set_timezone(NULL);
+        r = clock_set_timezone(c->local_rtc, NULL);
         if (r < 0)
                 log_debug_errno(r, "Failed to tell kernel about timezone, ignoring: %m");
 


### PR DESCRIPTION
Commit c264aeab4b0e ("core: only set the kernel's timezone when the RTC runs in local time") intentionally drops the clock_set_timezone call on boot when RTC is in UTC, so that the kernel's notion of the timezone remains UTC.

However, method_set_timezone in timedated calls clock_set_timezone on any user-initiated timezone change, which defeats the purpose of the above and syncs the local timezone to the kernel.

Fix this by explicitly setting the kernel timezone to UTC whenever timedated does a config update, if the RTC mode ends up being UTC.