### PR TITLE
inhibit: Default delay locks to sleep:shutdown

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,12 @@
 systemd System and Service Manager
 
+CHANGES WITH 263 in spe:
+
+        Changes in systemd-logind:
+
+        * systemd-inhibit --mode=delay now defaults to --what=sleep:shutdown,
+          since logind does not accept delay locks for any other operation.
+
 CHANGES WITH 262 in spe:
 
         Announcements of Future Feature Removals and Incompatible Changes:

--- a/man/systemd-inhibit.xml
+++ b/man/systemd-inhibit.xml
@@ -71,7 +71,9 @@
         suspending/hibernating, the automatic idle detection, or the
         low-level handling of the power/reboot/sleep key and the lid switch,
         respectively. If omitted, defaults to
-        <literal>idle:sleep:shutdown</literal>.</para></listitem>
+        <literal>idle:sleep:shutdown</literal>, or to <literal>sleep:shutdown</literal> if
+        <option>--mode=delay</option> is used, since delay locks are only supported for
+        <literal>sleep</literal> and <literal>shutdown</literal>.</para></listitem>
       </varlistentry>
 
       <varlistentry>

--- a/src/login/inhibit.c
+++ b/src/login/inhibit.c
@@ -280,8 +280,12 @@ static int run(int argc, char *argv[]) {
                 /* Ignore SIGINT and allow the forked process to receive it */
                 (void) ignore_signals(SIGINT);
 
+                if (!arg_mode)
+                        arg_mode = "block";
+
                 if (!arg_what)
-                        arg_what = "idle:sleep:shutdown";
+                        /* logind only accepts delay locks for sleep and shutdown. */
+                        arg_what = streq(arg_mode, "delay") ? "sleep:shutdown" : "idle:sleep:shutdown";
 
                 if (!arg_who) {
                         w = strv_join(args, " ");
@@ -293,9 +297,6 @@ static int run(int argc, char *argv[]) {
 
                 if (!arg_why)
                         arg_why = "Unknown reason";
-
-                if (!arg_mode)
-                        arg_mode = "block";
 
                 fd = inhibit(bus, &error);
                 if (fd < 0)

--- a/test/units/TEST-35-LOGIN.sh
+++ b/test/units/TEST-35-LOGIN.sh
@@ -1032,6 +1032,10 @@ testcase_restart() {
     done
 }
 
+testcase_inhibit_default() {
+    systemd-inhibit --mode=delay true
+}
+
 setup_test_user
 test_write_dropin
 run_testcases


### PR DESCRIPTION
logind refuses delay locks for anything but sleep and shutdown, so the old default doesn't make a whole lot of sense.