### PR TITLE
network: find pending address in IPv4 ACD callback

### DIFF
--- a/src/network/networkd-ipv4acd.c
+++ b/src/network/networkd-ipv4acd.c
@@ -152,7 +152,7 @@ static void on_acd(sd_ipv4acd *acd, int event, void *userdata) {
         void *val, *key;
         HASHMAP_FOREACH_KEY(val, key, link->ipv4acd_by_address)
                 if (val == acd) {
-                        (void) address_get(link, key, &address);
+                        (void) address_get_harder(link, key, &address);
                         break;
                 }
 


### PR DESCRIPTION
When IPv4 ACD is enabled for a DHCPv4 address, the address remains in the request queue until ACD succeeds. Hence, when ACD detects a conflict, the address may not be present in link->addresses yet.

on_acd() currently looks up the address with address_get(), which only searches link->addresses. This makes the callback return early and prevents dhcp4_address_on_conflict() from sending DHCPDECLINE.

Use address_get_harder(), which also looks up pending address requests.

Fixes #39460