### PR TITLE
networkctl: add `networkctl verify` for .{network,netdev} files

### DIFF
--- a/man/networkctl.xml
+++ b/man/networkctl.xml
@@ -649,6 +649,35 @@ s - Service VLAN, m - Two-port MAC Relay (TPMR)
           <xi:include href="version-info.xml" xpointer="v256"/>
         </listitem>
       </varlistentry>
+
+      <varlistentry>
+        <term>
+          <command>verify</command>
+          <replaceable>FILE</replaceable>…
+        </term>
+        <listitem>
+          <para>Load the given <filename>.network</filename> and <filename>.netdev</filename> files with the
+          configuration parser of
+          <citerefentry><refentrytitle>systemd-networkd.service</refentrytitle><manvolnum>8</manvolnum></citerefentry>,
+          without applying anything, and exit non-zero if any file could not be loaded or made the parser
+          complain, e.g. about an unknown section, an unknown key or an unparsable value. All files are checked;
+          netdevs are loaded first so that <filename>.network</filename> files may refer to them regardless of
+          argument order. Files that the daemon would skip are skipped here as well and reported: empty or
+          masked files, and files whose <varname>Condition*=</varname> settings do not match the host running
+          the check.</para>
+
+          <para>Conflicting settings that the daemon would override or drop, for example
+          <varname>MTUBytes=</varname> together with <varname>UseMTU=</varname>, or a
+          <varname>Bridge=</varname> naming a netdev that is not among the verified files, fail the check as
+          well. Problems the daemon only detects when applying the configuration to an interface are not
+          covered. Key material referenced via <varname>PrivateKeyFile=</varname> or
+          <varname>KeyFile=</varname> is not read. Drop-in directories are looked up by file name in the usual
+          configuration directories of the host, and <filename>networkd.conf</filename> is not
+          consulted.</para>
+
+          <xi:include href="version-info.xml" xpointer="v263"/>
+        </listitem>
+      </varlistentry>
     </variablelist>
   </refsect1>
 

--- a/src/network/meson.build
+++ b/src/network/meson.build
@@ -140,6 +140,7 @@ networkctl_sources = files(
         'networkctl-status-link.c',
         'networkctl-status-system.c',
         'networkctl-util.c',
+        'networkctl-verify.c',
 )
 
 networkd_network_gperf_gperf = files('networkd-network-gperf.gperf')
@@ -217,7 +218,9 @@ executables += [
                 'public' : true,
                 'conditions' : ['ENABLE_NETWORKD'],
                 'sources' : networkctl_sources,
-                'include_directories' : libsystemd_network_includes,
+                # The verify verb loads .network/.netdev files with the daemon's parsers.
+                'import' : ['systemd-networkd'],
+                'include_directories' : network_includes,
                 'link_with' : [
                         libshared,
                         libsystemd_network,

--- a/src/network/netdev/macsec.c
+++ b/src/network/netdev/macsec.c
@@ -974,6 +974,14 @@ int config_parse_macsec_use_for_encoding(
         return 0;
 }
 
+static bool macsec_key_configured(NetDev *netdev, const SecurityAssociation *sa) {
+        assert(netdev);
+        assert(sa);
+
+        /* In test mode the key file is not read, see macsec_read_key_file(), so having one is enough. */
+        return sa->key_len > 0 || (netdev->manager->test_mode && sa->key_file);
+}
+
 static int macsec_read_key_file(NetDev *netdev, SecurityAssociation *sa) {
         _cleanup_(erase_and_freep) uint8_t *key = NULL;
         size_t key_len;
@@ -982,7 +990,8 @@ static int macsec_read_key_file(NetDev *netdev, SecurityAssociation *sa) {
         assert(netdev);
         assert(sa);
 
-        if (!sa->key_file)
+        /* See wireguard_verify(): no key material I/O outside the daemon. */
+        if (!sa->key_file || netdev->manager->test_mode)
                 return 0;
 
         r = read_full_file_full(
@@ -1071,7 +1080,7 @@ static int macsec_transmit_association_verify(TransmitAssociation *t) {
         if (r < 0)
                 return r;
 
-        if (t->sa.key_len <= 0)
+        if (!macsec_key_configured(netdev, &t->sa))
                 return log_netdev_error_errno(netdev, SYNTHETIC_ERRNO(EINVAL),
                                               "%s: MACsec transmit secure association without key configured. "
                                               "Ignoring [MACsecTransmitAssociation] section from line %u",
@@ -1097,7 +1106,7 @@ static int macsec_receive_association_verify(ReceiveAssociation *a) {
         if (r < 0)
                 return r;
 
-        if (a->sa.key_len <= 0)
+        if (!macsec_key_configured(netdev, &a->sa))
                 return log_netdev_error_errno(netdev, SYNTHETIC_ERRNO(EINVAL),
                                               "%s: MACsec receive secure association without key configured. "
                                               "Ignoring [MACsecReceiveAssociation] section from line %u",

--- a/src/network/netdev/netdev.c
+++ b/src/network/netdev/netdev.c
@@ -307,7 +307,7 @@ int netdev_attach_name(NetDev *netdev, const char *name) {
         return netdev_attach_name_full(netdev, name, &netdev->manager->netdevs);
 }
 
-static int netdev_attach(NetDev *netdev) {
+int netdev_attach(NetDev *netdev) {
         int r;
 
         assert(netdev);

--- a/src/network/netdev/netdev.h
+++ b/src/network/netdev/netdev.h
@@ -216,6 +216,7 @@ extern const NetDevVTable * const netdev_vtable[_NETDEV_KIND_MAX];
 #define NETDEV(n) (&(n)->meta)
 
 int netdev_attach_name(NetDev *netdev, const char *name);
+int netdev_attach(NetDev *netdev);
 NetDev* netdev_detach_name(NetDev *netdev, const char *name);
 void netdev_detach(NetDev *netdev);
 int netdev_set_ifindex_internal(NetDev *netdev, int ifindex);

--- a/src/network/netdev/wireguard.c
+++ b/src/network/netdev/wireguard.c
@@ -1121,27 +1121,32 @@ static int wireguard_peer_verify(WireguardPeer *peer) {
         if (section_is_invalid(peer->section))
                 return -EINVAL;
 
-        r = wireguard_read_key_file(peer->public_key_file, peer->public_key);
-        if (r < 0)
-                return log_netdev_error_errno(netdev, r,
-                                              "%s: Failed to read public key from '%s'. "
-                                              "Ignoring [WireGuardPeer] section from line %u.",
-                                              peer->section->filename, peer->public_key_file,
-                                              peer->section->line);
+        /* See wireguard_verify(): in test mode key files are not read, but a configured one counts as a key. */
+        if (!netdev->manager->test_mode) {
+                r = wireguard_read_key_file(peer->public_key_file, peer->public_key);
+                if (r < 0)
+                        return log_netdev_error_errno(netdev, r,
+                                                      "%s: Failed to read public key from '%s'. "
+                                                      "Ignoring [WireGuardPeer] section from line %u.",
+                                                      peer->section->filename, peer->public_key_file,
+                                                      peer->section->line);
+        }
 
-        if (eqzero(peer->public_key))
+        if (eqzero(peer->public_key) && !(netdev->manager->test_mode && peer->public_key_file))
                 return log_netdev_error_errno(netdev, SYNTHETIC_ERRNO(EINVAL),
                                               "%s: WireGuardPeer section without PublicKey= configured. "
                                               "Ignoring [WireGuardPeer] section from line %u.",
                                               peer->section->filename, peer->section->line);
 
-        r = wireguard_read_key_file(peer->preshared_key_file, peer->preshared_key);
-        if (r < 0)
-                return log_netdev_error_errno(netdev, r,
-                                              "%s: Failed to read preshared key from '%s'. "
-                                              "Ignoring [WireGuardPeer] section from line %u.",
-                                              peer->section->filename, peer->preshared_key_file,
-                                              peer->section->line);
+        if (!netdev->manager->test_mode) {
+                r = wireguard_read_key_file(peer->preshared_key_file, peer->preshared_key);
+                if (r < 0)
+                        return log_netdev_error_errno(netdev, r,
+                                                      "%s: Failed to read preshared key from '%s'. "
+                                                      "Ignoring [WireGuardPeer] section from line %u.",
+                                                      peer->section->filename, peer->preshared_key_file,
+                                                      peer->section->line);
+        }
 
         return 0;
 }
@@ -1199,13 +1204,17 @@ static int wireguard_verify(NetDev *netdev, const char *filename) {
         Wireguard *w = WIREGUARD(netdev);
         int r;
 
-        r = wireguard_read_key_file(w->private_key_file, w->private_key);
-        if (r < 0)
-                return log_netdev_error_errno(netdev, r,
-                                              "Failed to read private key from '%s', ignoring network device: %m",
-                                              w->private_key_file);
+        /* Key material is read from paths and credentials named by the file. Verification and tests
+         * must neither depend on it being present nor block on what those paths turn out to be. */
+        if (!netdev->manager->test_mode) {
+                r = wireguard_read_key_file(w->private_key_file, w->private_key);
+                if (r < 0)
+                        return log_netdev_error_errno(netdev, r,
+                                                      "Failed to read private key from '%s', ignoring network device: %m",
+                                                      w->private_key_file);
+        }
 
-        if (eqzero(w->private_key)) {
+        if (eqzero(w->private_key) && !netdev->manager->test_mode) {
                 r = wireguard_read_default_key_cred(netdev, filename);
                 if (r < 0)
                         return r;

--- a/src/network/networkctl-verify.c
+++ b/src/network/networkctl-verify.c
@@ -1,0 +1,128 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include "alloc-util.h"
+#include "errno-util.h"
+#include "hashmap.h"
+#include "log.h"
+#include "netdev.h"
+#include "networkd-manager.h"
+#include "networkd-network.h"
+#include "networkctl-verify.h"
+#include "path-util.h"
+#include "stat-util.h"
+#include "string-util.h"
+#include "strv.h"
+
+/* Only the configuration parser reports through log_syntax(): unknown sections and keys, unparsable
+ * values. networkd logs those and drops the setting, which is exactly what verification is for, so any
+ * of them fails the file. Plain log_warning() calls elsewhere do not reach this hook. */
+static void log_syntax_callback(const char *unit, int level, void *userdata) {
+        bool *warned = ASSERT_PTR(userdata);
+
+        if (level <= LOG_WARNING)
+                *warned = true;
+}
+
+/* Returns > 0 if the file was skipped the way the daemon would skip it, 0 if it verified, < 0 on
+ * failure. Failures are logged here or by the loaders. */
+static int verify_one(Manager *manager, const char *path, bool is_netdev, bool *warned) {
+        int r;
+
+        assert(manager);
+        assert(path);
+        assert(warned);
+
+        /* The loaders disagree on empty and masked files; settle it before they see the file. */
+        r = null_or_empty_path(path);
+        if (r < 0)
+                return log_error_errno(r, "Failed to check '%s': %m", path);
+        if (r > 0) {
+                log_notice("'%s': Masked or empty, skipping.", path);
+                return 1;
+        }
+
+        *warned = false;
+
+        if (is_netdev) {
+                _cleanup_(netdev_unrefp) NetDev *netdev = NULL;
+
+                r = netdev_load_one(manager, path, &netdev);
+                if (r >= 0) {
+                        /* Attach so that .network files verified later resolve Bridge=, Bond=, VLAN=
+                         * and friends against it, as they would in the daemon. */
+                        r = netdev_attach(netdev);
+                        if (r >= 0)
+                                TAKE_PTR(netdev);
+                }
+        } else {
+                /* Per file, not the manager's map: it is keyed by file stem, and the daemon never sees
+                 * two files with the same name because it enumerates directories. */
+                _cleanup_(ordered_hashmap_freep) OrderedHashmap *networks = NULL;
+
+                r = network_load_one(manager, &networks, path);
+        }
+        /* Checked first: a file the daemon would skip has still been parsed in full. */
+        if (*warned)
+                return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
+                                       "'%s': The configuration parser reported problems, see above.", path);
+        if (r == -ESTALE) {
+                log_notice("'%s': Conditions do not match this host, skipping.", path);
+                return 1;
+        }
+        if (r < 0)
+                return r; /* The loaders log internally. */
+
+        return 0;
+}
+
+int verb_verify(int argc, char *argv[], uintptr_t _data, void *userdata) {
+        _cleanup_(manager_freep) Manager *manager = NULL;
+        _cleanup_strv_free_ char **netdevs = NULL, **networks = NULL;
+        _unused_ _cleanup_(clear_log_syntax_callback) dummy_t dummy;
+        bool warned = false;
+        int r, ret = 0;
+
+        STRV_FOREACH(f, strv_skip(argv, 1)) {
+                _cleanup_free_ char *path = NULL;
+
+                /* Drop-ins are looked up by basename in the usual configuration directories, so an
+                 * absolute path only settles where the file itself is read from. */
+                r = path_make_absolute_cwd(*f, &path);
+                if (r < 0) {
+                        RET_GATHER(ret, log_error_errno(r, "Failed to make path '%s' absolute: %m", *f));
+                        continue;
+                }
+
+                if (endswith(path, ".netdev"))
+                        r = strv_consume(&netdevs, TAKE_PTR(path));
+                else if (endswith(path, ".network"))
+                        r = strv_consume(&networks, TAKE_PTR(path));
+                else {
+                        RET_GATHER(ret, log_error_errno(SYNTHETIC_ERRNO(EINVAL),
+                                                        "'%s': Not a .network or .netdev file.", *f));
+                        continue;
+                }
+                if (r < 0)
+                        return log_oom();
+        }
+
+        /* The same netdev twice would be a name clash with itself. */
+        strv_uniq(netdevs);
+        strv_uniq(networks);
+
+        r = manager_new(&manager, /* test_mode= */ true);
+        if (r < 0)
+                return log_error_errno(r, "Failed to allocate manager: %m");
+
+        /* Ensure we have at least warnings enabled even if SYSTEMD_LOG_LEVEL= lowers the level. */
+        log_set_max_level(MAX(log_get_max_level(), LOG_WARNING));
+        set_log_syntax_callback(log_syntax_callback, &warned);
+
+        /* Netdevs first, whatever the argument order, so .network files can refer to them. */
+        STRV_FOREACH(p, netdevs)
+                RET_GATHER(ret, verify_one(manager, *p, /* is_netdev= */ true, &warned));
+        STRV_FOREACH(p, networks)
+                RET_GATHER(ret, verify_one(manager, *p, /* is_netdev= */ false, &warned));
+
+        return ret;
+}

--- a/src/network/networkctl-verify.h
+++ b/src/network/networkctl-verify.h
@@ -1,0 +1,6 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#pragma once
+
+#include "forward.h"
+
+int verb_verify(int argc, char *argv[], uintptr_t _data, void *userdata);

--- a/src/network/networkctl.c
+++ b/src/network/networkctl.c
@@ -16,6 +16,7 @@
 #include "networkctl-lldp.h"
 #include "networkctl-misc.h"
 #include "networkctl-status-link.h"
+#include "networkctl-verify.h"
 #include "parse-argument.h"
 #include "parse-util.h"
 #include "path-util.h"
@@ -79,6 +80,8 @@ VERB_SCOPE(, verb_unmask,                     "unmask",             "FILES...\0"
            "Unmask network configuration files");
 VERB_SCOPE(, verb_persistent_storage,         "persistent-storage", "BOOL\0",          2,        2,        0,
            "Notify systemd-networkd if persistent storage is ready");
+VERB_SCOPE(, verb_verify,                     "verify",             "FILES...\0",      2,        VERB_ANY, 0,
+           "Check .network and .netdev files offline");
 
 VERB_COMMON_HELP_AUTO_HIDDEN();
 

--- a/src/network/networkd-network.c
+++ b/src/network/networkd-network.c
@@ -51,6 +51,14 @@ DEFINE_PRIVATE_HASH_OPS_WITH_VALUE_DESTRUCTOR(
                 char, string_hash_func, string_compare_func,
                 NetDev, netdev_unref);
 
+/* For complaints about the content of a .network file. Routed through log_syntax(), so that they carry
+ * CONFIG_FILE= and reach the log_syntax() callback like the parser's own diagnostics. */
+#define log_network_warning_errno(network, error, fmt, ...)                                             \
+        log_syntax(/* unit= */ NULL, LOG_WARNING, (network)->filename, /* config_line= */ 0, error,     \
+                   fmt, ##__VA_ARGS__)
+#define log_network_warning(network, fmt, ...)                                                          \
+        log_network_warning_errno(network, /* error= */ 0, fmt, ##__VA_ARGS__)
+
 static int network_resolve_netdev_one(Network *network, const char *name, NetDevKind kind, NetDev **ret) {
         const char *kind_string;
         NetDev *netdev;
@@ -70,15 +78,15 @@ static int network_resolve_netdev_one(Network *network, const char *name, NetDev
         else {
                 kind_string = netdev_kind_to_string(kind);
                 if (!kind_string)
-                        return log_warning_errno(SYNTHETIC_ERRNO(EINVAL),
-                                                 "%s: Invalid NetDev kind of %s, ignoring assignment.",
-                                                 network->filename, name);
+                        return log_network_warning_errno(network, SYNTHETIC_ERRNO(EINVAL),
+                                                         "Invalid NetDev kind of %s, ignoring assignment.",
+                                                         name);
         }
 
         r = netdev_get(network->manager, name, &netdev);
         if (r < 0)
-                return log_warning_errno(r, "%s: %s NetDev could not be found, ignoring assignment.",
-                                         network->filename, name);
+                return log_network_warning_errno(network, r,
+                                                 "%s NetDev could not be found, ignoring assignment.", name);
 
         if (netdev->kind != kind && !(kind == _NETDEV_KIND_TUNNEL &&
                                       IN_SET(netdev->kind,
@@ -92,9 +100,9 @@ static int network_resolve_netdev_one(Network *network, const char *name, NetDev
                                              NETDEV_KIND_SIT,
                                              NETDEV_KIND_VTI,
                                              NETDEV_KIND_VTI6)))
-                return log_warning_errno(SYNTHETIC_ERRNO(EINVAL),
-                                         "%s: NetDev %s is not a %s, ignoring assignment",
-                                         network->filename, name, kind_string);
+                return log_network_warning_errno(network, SYNTHETIC_ERRNO(EINVAL),
+                                                 "NetDev %s is not a %s, ignoring assignment",
+                                                 name, kind_string);
 
         *ret = netdev_ref(netdev);
         return 1;
@@ -116,8 +124,9 @@ static int network_resolve_stacked_netdevs(Network *network) {
                 if (r == -ENOMEM)
                         return log_oom();
                 if (r < 0)
-                        log_warning_errno(r, "%s: Failed to add NetDev '%s' to network, ignoring: %m",
-                                          network->filename, (const char *) name);
+                        log_network_warning_errno(network, r,
+                                                  "Failed to add NetDev '%s' to network, ignoring: %m",
+                                                  (const char *) name);
 
                 TAKE_PTR(netdev);
         }
@@ -133,10 +142,10 @@ int network_verify(Network *network) {
         assert(network->filename);
 
         if (net_match_is_empty(&network->match) && !network->conditions)
-                return log_warning_errno(SYNTHETIC_ERRNO(EINVAL),
-                                         "%s: No valid settings found in the [Match] section, ignoring file. "
-                                         "To match all interfaces, add Name=* in the [Match] section.",
-                                         network->filename);
+                return log_network_warning_errno(
+                                network, SYNTHETIC_ERRNO(EINVAL),
+                                "No valid settings found in the [Match] section, ignoring file. "
+                                "To match all interfaces, add Name=* in the [Match] section.");
 
         /* skip out early if configuration does not match the environment */
         if (!condition_test_list_net(network->conditions, environ, NULL, NULL, NULL))
@@ -146,17 +155,16 @@ int network_verify(Network *network) {
 
         if (network->keep_master) {
                 if (network->batadv_name)
-                        log_warning("%s: BatmanAdvanced= set with KeepMaster= enabled, ignoring BatmanAdvanced=.",
-                                    network->filename);
+                        log_network_warning(network,
+                                            "BatmanAdvanced= set with KeepMaster= enabled, "
+                                            "ignoring BatmanAdvanced=.");
                 if (network->bond_name)
-                        log_warning("%s: Bond= set with KeepMaster= enabled, ignoring Bond=.",
-                                    network->filename);
+                        log_network_warning(network, "Bond= set with KeepMaster= enabled, ignoring Bond=.");
                 if (network->bridge_name)
-                        log_warning("%s: Bridge= set with KeepMaster= enabled, ignoring Bridge=.",
-                                    network->filename);
+                        log_network_warning(network,
+                                            "Bridge= set with KeepMaster= enabled, ignoring Bridge=.");
                 if (network->vrf_name)
-                        log_warning("%s: VRF= set with KeepMaster= enabled, ignoring VRF=.",
-                                    network->filename);
+                        log_network_warning(network, "VRF= set with KeepMaster= enabled, ignoring VRF=.");
 
                 network->batadv_name = mfree(network->batadv_name);
                 network->bond_name = mfree(network->bond_name);
@@ -182,16 +190,18 @@ int network_verify(Network *network) {
         if (network->bond) {
                 /* Bonding slave does not support addressing. */
                 if (network->link_local >= 0 && network->link_local != ADDRESS_FAMILY_NO) {
-                        log_warning("%s: Cannot enable LinkLocalAddressing= when Bond= is specified, disabling LinkLocalAddressing=.",
-                                    network->filename);
+                        log_network_warning(network,
+                                            "Cannot enable LinkLocalAddressing= when Bond= is specified, "
+                                            "disabling LinkLocalAddressing=.");
                         network->link_local = ADDRESS_FAMILY_NO;
                 }
                 if (!ordered_hashmap_isempty(network->addresses_by_section))
-                        log_warning("%s: Cannot set addresses when Bond= is specified, ignoring addresses.",
-                                    network->filename);
+                        log_network_warning(network,
+                                            "Cannot set addresses when Bond= is specified, "
+                                            "ignoring addresses.");
                 if (!hashmap_isempty(network->routes_by_section))
-                        log_warning("%s: Cannot set routes when Bond= is specified, ignoring routes.",
-                                    network->filename);
+                        log_network_warning(network,
+                                            "Cannot set routes when Bond= is specified, ignoring routes.");
 
                 network->addresses_by_section = ordered_hashmap_free(network->addresses_by_section);
                 network->routes_by_section = hashmap_free(network->routes_by_section);
@@ -238,16 +248,19 @@ int network_verify(Network *network) {
         network_adjust_bridge_vlan(network);
 
         if (network->mtu > 0 && network->dhcp_use_mtu) {
-                log_warning("%s: MTUBytes= in [Link] section and UseMTU= in [DHCP] section are set. "
-                            "Disabling UseMTU=.", network->filename);
+                log_network_warning(network,
+                                    "MTUBytes= in [Link] section and UseMTU= in [DHCP] section are set. "
+                                    "Disabling UseMTU=.");
                 network->dhcp_use_mtu = false;
         }
 
         if (network->dhcp_critical >= 0) {
                 if (network->keep_configuration >= 0) {
                         if (network->manager->keep_configuration < 0)
-                                log_warning("%s: Both KeepConfiguration= and deprecated CriticalConnection= are set. "
-                                            "Ignoring CriticalConnection=.", network->filename);
+                                log_network_warning(
+                                                network,
+                                                "Both KeepConfiguration= and deprecated CriticalConnection= "
+                                                "are set. Ignoring CriticalConnection=.");
                 } else if (network->dhcp_critical)
                         /* CriticalConnection=yes also preserve foreign static configurations. */
                         network->keep_configuration = KEEP_CONFIGURATION_YES;
@@ -257,12 +270,14 @@ int network_verify(Network *network) {
 
         if (!strv_isempty(network->bind_carrier)) {
                 if (!IN_SET(network->activation_policy, _ACTIVATION_POLICY_INVALID, ACTIVATION_POLICY_BOUND))
-                        log_warning("%s: ActivationPolicy=bound is required with BindCarrier=. "
-                                    "Setting ActivationPolicy=bound.", network->filename);
+                        log_network_warning(network,
+                                            "ActivationPolicy=bound is required with BindCarrier=. "
+                                            "Setting ActivationPolicy=bound.");
                 network->activation_policy = ACTIVATION_POLICY_BOUND;
         } else if (network->activation_policy == ACTIVATION_POLICY_BOUND) {
-                log_warning("%s: ActivationPolicy=bound requires BindCarrier=. "
-                            "Ignoring ActivationPolicy=bound.", network->filename);
+                log_network_warning(network,
+                                    "ActivationPolicy=bound requires BindCarrier=. "
+                                    "Ignoring ActivationPolicy=bound.");
                 network->activation_policy = ACTIVATION_POLICY_UP;
         }
 
@@ -271,8 +286,9 @@ int network_verify(Network *network) {
 
         if (network->activation_policy == ACTIVATION_POLICY_ALWAYS_UP) {
                 if (network->ignore_carrier_loss_set && network->ignore_carrier_loss_usec < USEC_INFINITY)
-                        log_warning("%s: IgnoreCarrierLoss=no or finite timespan conflicts with ActivationPolicy=always-up. "
-                                    "Setting IgnoreCarrierLoss=yes.", network->filename);
+                        log_network_warning(network,
+                                            "IgnoreCarrierLoss=no or finite timespan conflicts with "
+                                            "ActivationPolicy=always-up. Setting IgnoreCarrierLoss=yes.");
                 network->ignore_carrier_loss_set = true;
                 network->ignore_carrier_loss_usec = USEC_INFINITY;
         }
@@ -287,9 +303,10 @@ int network_verify(Network *network) {
                                   activation_policy_to_string(network->activation_policy));
                         network->required_for_online = false;
                 } else if (network->required_for_online == true)
-                        log_warning("%s: RequiredForOnline=yes and ActivationPolicy=%s, "
-                                    "this may cause a delay at boot.", network->filename,
-                                    activation_policy_to_string(network->activation_policy));
+                        log_network_warning(network,
+                                            "RequiredForOnline=yes and ActivationPolicy=%s, "
+                                            "this may cause a delay at boot.",
+                                            activation_policy_to_string(network->activation_policy));
         }
 
         if (network->required_for_online < 0)

--- a/src/network/networkd-network.c
+++ b/src/network/networkd-network.c
@@ -147,9 +147,10 @@ int network_verify(Network *network) {
                                 "No valid settings found in the [Match] section, ignoring file. "
                                 "To match all interfaces, add Name=* in the [Match] section.");
 
-        /* skip out early if configuration does not match the environment */
+        /* Skip out early if configuration does not match the environment. ESTALE, as for netdevs,
+         * so that callers can tell a skipped file from a broken one. */
         if (!condition_test_list_net(network->conditions, environ, NULL, NULL, NULL))
-                return log_debug_errno(SYNTHETIC_ERRNO(EINVAL),
+                return log_debug_errno(SYNTHETIC_ERRNO(ESTALE),
                                        "%s: Conditions in the file do not match the system environment, skipping.",
                                        network->filename);
 

--- a/src/shared/conf-parser.c
+++ b/src/shared/conf-parser.c
@@ -1481,12 +1481,12 @@ int config_parse_warn_compat(
                 break;
 
         case DISABLED_LEGACY:
-                log_syntax(unit, LOG_INFO, filename, line, 0,
+                log_syntax(unit, LOG_WARNING, filename, line, 0,
                            "Support for option %s= has been removed and it is ignored", lvalue);
                 break;
 
         case DISABLED_EXPERIMENTAL:
-                log_syntax(unit, LOG_INFO, filename, line, 0,
+                log_syntax(unit, LOG_WARNING, filename, line, 0,
                            "Support for option %s= has not yet been enabled and it is ignored", lvalue);
                 break;
         }

--- a/test/units/TEST-74-AUX-UTILS.networkctl.sh
+++ b/test/units/TEST-74-AUX-UTILS.networkctl.sh
@@ -17,6 +17,9 @@ at_exit() {
     fi
 
     rm -f /run/systemd/networkd.conf.d/10-hoge.conf
+    if [[ -v VERIFY_DIR ]]; then
+        rm -rf "$VERIFY_DIR"
+    fi
 }
 
 trap at_exit EXIT
@@ -131,6 +134,188 @@ if systemctl --quiet is-active systemd-udevd; then
 
     assert_in 'alias test_alias' "$ip_link"
 fi
+
+# Test verify
+
+VERIFY_DIR="$(mktemp -d)"
+mkdir "$VERIFY_DIR/other"
+cat >"$VERIFY_DIR/10-good.network" <<EOF
+[Match]
+Name=test3
+
+[Network]
+DHCP=yes
+EOF
+cp "$VERIFY_DIR/10-good.network" "$VERIFY_DIR/other/10-good.network"
+cat >"$VERIFY_DIR/10-unknown-key.network" <<EOF
+[Match]
+Name=test3
+
+[Network]
+DHCP=yes
+Foo=bar
+EOF
+cat >"$VERIFY_DIR/10-no-match.network" <<EOF
+[Network]
+DHCP=yes
+EOF
+cat >"$VERIFY_DIR/10-condition.network" <<EOF
+[Match]
+Name=test3
+Host=networkctl-test-no-such-host
+
+[Network]
+DHCP=yes
+EOF
+cat >"$VERIFY_DIR/10-condition-unknown-key.network" <<EOF
+[Match]
+Name=test3
+Host=networkctl-test-no-such-host
+
+[Network]
+DHCP=yes
+Foo=bar
+EOF
+cat >"$VERIFY_DIR/10-removed-key.network" <<EOF
+[Match]
+Name=test3
+
+[Network]
+L2TP=foo
+EOF
+cat >"$VERIFY_DIR/10-member.network" <<EOF
+[Match]
+Name=test3
+
+[Network]
+Bridge=test3-br
+EOF
+cat >"$VERIFY_DIR/10-mtu.network" <<EOF
+[Match]
+Name=test3
+
+[Link]
+MTUBytes=1400
+
+[DHCP]
+UseMTU=yes
+
+[Network]
+DHCP=yes
+EOF
+cat >"$VERIFY_DIR/10-good.netdev" <<EOF
+[NetDev]
+Name=test3
+Kind=dummy
+EOF
+cat >"$VERIFY_DIR/10-unknown-key.netdev" <<EOF
+[NetDev]
+Name=test3
+Kind=dummy
+Foo=bar
+EOF
+cat >"$VERIFY_DIR/10-no-kind.netdev" <<EOF
+[NetDev]
+Name=test3
+EOF
+cat >"$VERIFY_DIR/10-bridge.netdev" <<EOF
+[NetDev]
+Name=test3-br
+Kind=bridge
+EOF
+cat >"$VERIFY_DIR/10-wireguard.netdev" <<EOF
+[NetDev]
+Name=test3-wg
+Kind=wireguard
+
+[WireGuard]
+PrivateKeyFile=$VERIFY_DIR/does-not-exist.key
+
+[WireGuardPeer]
+PublicKeyFile=$VERIFY_DIR/does-not-exist.key
+AllowedIPs=10.0.0.0/24
+EOF
+cat >"$VERIFY_DIR/10-wireguard-no-key.netdev" <<EOF
+[NetDev]
+Name=test3-wg
+Kind=wireguard
+
+[WireGuardPeer]
+AllowedIPs=10.0.0.0/24
+EOF
+cat >"$VERIFY_DIR/10-macsec.netdev" <<EOF
+[NetDev]
+Name=test3-macsec
+Kind=macsec
+
+[MACsecTransmitAssociation]
+PacketNumber=1
+KeyId=01
+KeyFile=$VERIFY_DIR/does-not-exist.key
+EOF
+: >"$VERIFY_DIR/10-empty.network"
+ln -s /dev/null "$VERIFY_DIR/10-masked.netdev"
+
+VERIFY=(networkctl verify)
+
+# Fails, and says why: $1 is the expected message, the rest are the files to verify.
+assert_verify_fails() {
+    local expected="$1" output
+    shift
+
+    if output="$("${VERIFY[@]}" "$@" 2>&1)"; then
+        echo "FAIL: ${VERIFY[*]} $* unexpectedly succeeded" >&2
+        return 1
+    fi
+    assert_in "$expected" "$output"
+}
+
+networkctl --help | grep '^  verify ' >/dev/null
+(! "${VERIFY[@]}")
+
+"${VERIFY[@]}" "$VERIFY_DIR/10-good.network" "$VERIFY_DIR/10-good.netdev"
+# relative paths work too
+(cd "$VERIFY_DIR" && "${VERIFY[@]}" 10-good.network)
+# the same file name in two directories is two files, not a conflict, and the same file twice is one file
+"${VERIFY[@]}" "$VERIFY_DIR/10-good.network" "$VERIFY_DIR/other/10-good.network"
+"${VERIFY[@]}" "$VERIFY_DIR/10-good.netdev" "$VERIFY_DIR/10-good.netdev"
+# a .network may refer to a .netdev given in the same invocation, in any order
+output=$("${VERIFY[@]}" "$VERIFY_DIR/10-member.network" "$VERIFY_DIR/10-bridge.netdev" 2>&1)
+assert_not_in "could not be found" "$output"
+output=$("${VERIFY[@]}" "$VERIFY_DIR/10-bridge.netdev" "$VERIFY_DIR/10-member.network" 2>&1)
+assert_not_in "could not be found" "$output"
+# masked or empty files and files whose conditions do not match are skipped, as the daemon skips them
+output=$("${VERIFY[@]}" "$VERIFY_DIR/10-empty.network" "$VERIFY_DIR/10-masked.netdev" 2>&1)
+assert_in "Masked or empty, skipping" "$output"
+output=$("${VERIFY[@]}" "$VERIFY_DIR/10-condition.network" 2>&1)
+assert_in "Conditions do not match this host, skipping" "$output"
+# key files are not read, so they need not exist, but they count as keys
+"${VERIFY[@]}" "$VERIFY_DIR/10-wireguard.netdev"
+output=$("${VERIFY[@]}" "$VERIFY_DIR/10-macsec.netdev" 2>&1)
+assert_not_in "without key configured" "$output"
+# a peer without a key is dropped with an error, as in the daemon, but the netdev itself still loads
+output=$("${VERIFY[@]}" "$VERIFY_DIR/10-wireguard-no-key.netdev" 2>&1)
+assert_in "without PublicKey= configured" "$output"
+
+# a parser warning networkd would only log is an error here
+assert_verify_fails "Unknown key 'Foo'" "$VERIFY_DIR/10-unknown-key.network"
+assert_verify_fails "The configuration parser reported problems" "$VERIFY_DIR/10-unknown-key.network"
+assert_verify_fails "The configuration parser reported problems" "$VERIFY_DIR/10-unknown-key.netdev"
+# even in a file that is skipped otherwise, and even if the log level would hide the message
+assert_verify_fails "Unknown key 'Foo'" "$VERIFY_DIR/10-condition-unknown-key.network"
+SYSTEMD_LOG_LEVEL=err assert_verify_fails "Unknown key 'Foo'" "$VERIFY_DIR/10-unknown-key.network"
+# a removed option is a warning like an unknown key
+assert_verify_fails "Support for option L2TP= has been removed" "$VERIFY_DIR/10-removed-key.network"
+assert_verify_fails "No valid settings found in the \[Match\] section" "$VERIFY_DIR/10-no-match.network"
+# so are settings networkd would accept and then override or drop
+assert_verify_fails "could not be found" "$VERIFY_DIR/10-member.network"
+assert_verify_fails "Disabling UseMTU=" "$VERIFY_DIR/10-mtu.network"
+assert_verify_fails "NetDev has no Kind= configured" "$VERIFY_DIR/10-no-kind.netdev"
+# one bad file fails the whole invocation, wherever it is in the list
+assert_verify_fails "NetDev has no Kind= configured" "$VERIFY_DIR/10-good.network" "$VERIFY_DIR/10-no-kind.netdev"
+assert_verify_fails "NetDev has no Kind= configured" "$VERIFY_DIR/10-no-kind.netdev" "$VERIFY_DIR/10-good.network"
+assert_verify_fails "Not a .network or .netdev file" "/usr/lib/systemd/network/$LINK_NAME"
+assert_verify_fails "No such file or directory" "$VERIFY_DIR/does-not-exist.network"
 
 mkdir -p /run/systemd/networkd.conf.d
 cat >/run/systemd/networkd.conf.d/10-hoge.conf <<EOF


### PR DESCRIPTION
See the individual commits:

----

networkd: add `networkctl verify` for .{network,netdev} files

When dealing with network or netdev files it would be nice to be
able to validate that they have the correct syntax. This is useful
for e.g. static checking of configuration.

There is currently no way to validate a file without loading it
in a running systemd-networkd.

Add verify via a new `networkctl verify` (inspired by
systemd-analyze verify) that takes network or netdev files
and checks that they has the correct syntax. Any warning is
turned into an error (so e.g. unknown keys become an error).

Adding it to networkctl b increases the size by about 1MB
as it would pull in a lot of code that is currently not needed.
Longer term we should probably follow what udevadm/systemd-udevd
is doing and just make it a multi-call binary.

---

conf-parser: make DISABLED_{LEGACY,EXPERIMENTAL} LOG_WARNING

We currently log unknown keys with LOG_WARNING so that
users are aware of unknown keys that have no effect. However
for keys that used to work but no longer work we only use
LOG_INFO. For consistency we should log those with WARNING
as well as they have the same effect: a key that has no effect
(arguably DISABLED_LEGACY is worse because the key used to work
and now it no longer works so the user should be informed even
louder). For consistency the same is done for
DISABLED_EXPERIMENTAL.

This surfaced while working on `networkctl verify`.
