### PR TITLE
tree-wide: reference UAPI.20 spec that has been published for Varlink…

### DIFF
--- a/man/sd-varlink.xml
+++ b/man/sd-varlink.xml
@@ -36,8 +36,10 @@
 
     <para><filename>sd-varlink.h</filename> is part of
     <citerefentry><refentrytitle>libsystemd</refentrytitle><manvolnum>3</manvolnum></citerefentry> and
-    provides APIs for implementing Varlink IPC clients and services. See <ulink url="https://varlink.org/"/>
-    for more information about Varlink IPC.</para>
+    provides APIs for implementing Varlink IPC clients and services. See <ulink
+    url="https://varlink.org/">Varlink IPC</ulink> for more information about Varlink IPC, as well as the <ulink
+    url="https://uapi-group.org/specifications/specs/varlink/">UAPI.20 Varlink IPC</ulink>
+    specification.</para>
 
     <para>Varlink IPC uses <ulink url="https://json.org/">JSON</ulink> as marshalling format. The sd-varlink
     API relies on the

--- a/man/varlinkctl.xml
+++ b/man/varlinkctl.xml
@@ -105,7 +105,9 @@
     <title>Description</title>
 
     <para><command>varlinkctl</command> may be used to introspect and invoke <ulink
-    url="https://varlink.org/">Varlink</ulink> services.</para>
+    url="https://varlink.org/">Varlink IPC</ulink> services, following the <ulink
+    url="https://uapi-group.org/specifications/specs/varlink/">UAPI.20 Varlink IPC</ulink>
+    specification.</para>
 
     <para>Services are referenced by one of the following:</para>
 

--- a/src/libsystemd/sd-varlink/sd-varlink.c
+++ b/src/libsystemd/sd-varlink/sd-varlink.c
@@ -3748,8 +3748,8 @@ _public_ int sd_varlink_server_listen_name(sd_varlink_server *s, const char *nam
         /* Adds all passed fds marked as "name" to our varlink server. These fds can either refer to a
          * listening socket or to a connection socket.
          *
-         * See https://varlink.org/#activation for the environment variables this is backed by and the
-         * recommended "varlink" identifier in $LISTEN_FDNAMES. */
+         * See https://uapi-group.org/specifications/specs/varlink/#socket-activation for the environment
+         * variables this is backed by and the recommended "varlink" identifier in $LISTEN_FDNAMES. */
 
         m = sd_listen_fds_with_names(/* unset_environment= */ false, &names);
         if (m < 0)

--- a/src/systemd/sd-varlink-idl.h
+++ b/src/systemd/sd-varlink-idl.h
@@ -25,7 +25,7 @@
 _SD_BEGIN_DECLARATIONS;
 
 /* This implements the Varlink Interface Definition Language ("Varlink IDL"),
- * i.e. https://varlink.org/Interface-Definition
+ * i.e. https://uapi-group.org/specifications/specs/varlink/#interface-definition
  *
  * Primarily allows encoding static interface definitions in C code, that can be converted to the textual IDL
  * format on-the-fly. Can also parse the textual format back to C structures. Validates the interface


### PR DESCRIPTION
… now

This updates a couple of links talking about Varlink:

1. anything that refers to specific Varlink concepts now point to the UAPI.20 spec

2. More general references to Varlink as a whole point to both the varlink.org domain and the spec.