### PR TITLE
docs: clarify ConditionPathExists= semantics

### DIFF
--- a/man/systemd.unit.xml
+++ b/man/systemd.unit.xml
@@ -1781,9 +1781,14 @@
         <varlistentry>
           <term><varname>ConditionPathExists=</varname></term>
 
-          <listitem><para>Check for the existence of a file. If the specified absolute path name does not exist,
-          the condition will fail. If the absolute path name passed to
-          <varname>ConditionPathExists=</varname> is prefixed with an exclamation mark
+          <listitem><para>Check for the existence of a path. This applies to any file system object (such as a
+          regular file, directory, device node, FIFO, or socket), not only regular files. The check is
+          implemented via
+          <citerefentry><refentrytitle>access</refentrytitle><manvolnum>2</manvolnum></citerefentry>
+          with <constant>F_OK</constant>, which follows symbolic links. Hence, a symbolic link is considered
+          to exist only if its target does, and broken symbolic links are not considered to exist. If the
+          specified absolute path name does not exist, the condition will fail. If the absolute path name
+          passed to <varname>ConditionPathExists=</varname> is prefixed with an exclamation mark
           (<literal>!</literal>), the test is negated, and the unit is only started if the path does not
           exist.</para>
 

--- a/man/systemd.unit.xml
+++ b/man/systemd.unit.xml
@@ -1782,13 +1782,10 @@
           <term><varname>ConditionPathExists=</varname></term>
 
           <listitem><para>Check for the existence of a path. This applies to any file system object (such as a
-          regular file, directory, device node, FIFO, or socket), not only regular files. The check is
-          implemented via
-          <citerefentry><refentrytitle>access</refentrytitle><manvolnum>2</manvolnum></citerefentry>
-          with <constant>F_OK</constant>, which follows symbolic links. Hence, a symbolic link is considered
-          to exist only if its target does, and broken symbolic links are not considered to exist. If the
-          specified absolute path name does not exist, the condition will fail. If the absolute path name
-          passed to <varname>ConditionPathExists=</varname> is prefixed with an exclamation mark
+          regular file, directory, device node, FIFO, or socket), not only regular files. Symbolic links
+          are followed, so a broken symbolic link is not considered to exist. If the specified absolute
+          path name does not exist, the condition will fail. If the absolute path name passed to
+          <varname>ConditionPathExists=</varname> is prefixed with an exclamation mark
           (<literal>!</literal>), the test is negated, and the unit is only started if the path does not
           exist.</para>
 


### PR DESCRIPTION
## Summary

Clarify `ConditionPathExists=` in `systemd.unit(5)`:

- It checks for any filesystem object (regular file, directory, device node, FIFO, socket), not only regular files.
- Symbolic links are followed, so a broken symbolic link is not considered to exist.

Fixes #41900

## Test plan

- [ ] Review the updated man page text for accuracy and consistency with neighboring `ConditionPath*` directives
- [ ] Confirm the wording describes user-visible behavior only (no implementation details)