### PR TITLE
nspawn: map owning group for `rootidmap` and `owneridmap` binds

### DIFF
--- a/man/systemd-nspawn.xml
+++ b/man/systemd-nspawn.xml
@@ -1673,38 +1673,40 @@ After=sys-subsystem-net-devices-ens1.device</programlisting>
         <para>Using <option>idmap</option>, <option>rootidmap</option> or <option>owneridmap</option> requires support
         by the source filesystem for user/group ID mapped mounts. Defaults to <option>noidmap</option>. With
         <option>x</option> being the container's UID range offset, <option>y</option> being the length of the
-        container's UID range, and <option>p</option> being the owner UID of the bind mount source inode on the host:
+        container's UID range, and <option>p</option> and <option>q</option> being the UID and GID of the bind mount
+        source inode on the host:
 
         <itemizedlist>
           <listitem><para>If <option>noidmap</option> is used, any user <option>z</option> in the range
           <option>0 … y</option> seen from inside of the container is mapped to <option>x + z</option> in the
-          <option>x … x + y</option> range on the host. Other host users are mapped to
+          <option>x … x + y</option> range on the host. Other host users and groups are mapped to
           <option>nobody</option> inside the container.</para></listitem>
 
           <listitem><para>If <option>idmap</option> is used, any user <option>z</option> in the UID range
           <option>0 … y</option> as seen from inside the container is mapped to the same <option>z</option>
-          in the same <option>0 … y</option> range on the host. Other host users are mapped to
+          in the same <option>0 … y</option> range on the host. Other host users and groups are mapped to
           <option>nobody</option> inside the container.</para></listitem>
 
           <listitem><para>If <option>rootidmap</option> is used, the user <option>0</option> seen from inside
-          of the container is mapped to <option>p</option> on the host. Other host users are mapped to
-          <option>nobody</option> inside the container.</para></listitem>
+          of the container is mapped to <option>p</option> on the host, and the group <option>0</option> to
+          <option>q</option>. Other host users and groups are mapped to <option>nobody</option> inside the
+          container.</para></listitem>
 
-          <listitem><para>If <option>owneridmap</option> is used, the owner of the target directory inside of the
-          container is mapped to <option>p</option> on the host. Other host users are mapped to
-          <option>nobody</option> inside the container.</para></listitem>
+          <listitem><para>If <option>owneridmap</option> is used, the user owning the target directory inside of
+          the container is mapped to <option>p</option> on the host, and the group owning that directory to
+          <option>q</option>. Other host users and groups are mapped to <option>nobody</option> inside the
+          container.</para></listitem>
         </itemizedlist></para>
 
-        <para>Whichever ID mapping option is used, the same mapping will be used for users and groups IDs. If
-        <option>rootidmap</option> or <option>owneridmap</option> are used, the group owning the bind mounted directory
-        will have no effect.</para>
+        <para>With <option>noidmap</option> and <option>idmap</option>, the same mapping is used for user and
+        group IDs.</para>
 
         <para>Note that when this option is used in combination with <option>--private-users</option>, the resulting
         mount points will be owned by the <constant>nobody</constant> user. That's because the mount and its files and
         directories continue to be owned by the relevant host users and groups, which do not exist in the container,
         and thus show up under the wildcard UID 65534 (nobody). If such bind mounts are created, it is recommended to
-        make them read-only, using <option>--bind-ro=</option>. Alternatively you can use the "idmap" mount option to
-        map the filesystem IDs.</para>
+        make them read-only, using <option>--bind-ro=</option>. Alternatively you can use the <option>idmap</option>,
+        <option>rootidmap</option> or <option>owneridmap</option> mount options to map the filesystem IDs.</para>
 
         <xi:include href="version-info.xml" xpointer="v198"/></listitem>
       </varlistentry>

--- a/src/nspawn/nspawn-mount.c
+++ b/src/nspawn/nspawn-mount.c
@@ -45,6 +45,7 @@ CustomMount* custom_mount_add(CustomMount **l, size_t *n, CustomMountType t) {
         *ret = (CustomMount) {
                 .type = t,
                 .destination_uid = UID_INVALID,
+                .destination_gid = GID_INVALID,
         };
 
         return ret;
@@ -804,6 +805,7 @@ static int mount_bind(const char *dest, CustomMount *m, uid_t uid_shift, uid_t u
         unsigned long open_tree_flags = OPEN_TREE_CLONE | OPEN_TREE_CLOEXEC | AT_RECURSIVE;
         struct stat source_st, dest_st;
         uid_t dest_uid = UID_INVALID;
+        gid_t dest_gid = GID_INVALID;
         int r;
         RemountIdmapping idmapping = REMOUNT_IDMAPPING_NONE;
 
@@ -864,6 +866,7 @@ static int mount_bind(const char *dest, CustomMount *m, uid_t uid_shift, uid_t u
                         return log_error_errno(errno, "Failed to stat %s: %m", where);
 
                 dest_uid = uid_is_valid(m->destination_uid) ? chown_uid + m->destination_uid : dest_st.st_uid;
+                dest_gid = gid_is_valid(m->destination_gid) ? chown_uid + m->destination_gid : dest_st.st_gid;
 
                 if (S_ISDIR(source_st.st_mode) && !S_ISDIR(dest_st.st_mode))
                         return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
@@ -895,6 +898,7 @@ static int mount_bind(const char *dest, CustomMount *m, uid_t uid_shift, uid_t u
                         return log_error_errno(errno, "Failed to chown %s: %m", where);
 
                 dest_uid = chown_uid + (uid_is_valid(m->destination_uid) ? m->destination_uid : 0);
+                dest_gid = chown_uid + (gid_is_valid(m->destination_gid) ? m->destination_gid : 0);
         }
 
         if (move_mount(fd_clone, "", AT_FDCWD, where, MOVE_MOUNT_F_EMPTY_PATH) < 0)
@@ -909,7 +913,15 @@ static int mount_bind(const char *dest, CustomMount *m, uid_t uid_shift, uid_t u
         }
 
         if (idmapping != REMOUNT_IDMAPPING_NONE) {
-                r = remount_idmap(STRV_MAKE(where), uid_shift, uid_range, source_st.st_uid, dest_uid, idmapping);
+                r = remount_idmap(
+                                STRV_MAKE(where),
+                                uid_shift,
+                                uid_range,
+                                source_st.st_uid,
+                                source_st.st_gid,
+                                dest_uid,
+                                dest_gid,
+                                idmapping);
                 if (r < 0)
                         return log_error_errno(r, "Failed to map ids for bind mount %s: %m", where);
         }

--- a/src/nspawn/nspawn-mount.h
+++ b/src/nspawn/nspawn-mount.h
@@ -39,6 +39,7 @@ typedef struct CustomMount {
         char *source; /* for overlayfs this is the upper directory */
         char *destination;
         uid_t destination_uid;
+        gid_t destination_gid;
         char *options;
         char *work_dir;
         char **lower;

--- a/src/nspawn/nspawn.c
+++ b/src/nspawn/nspawn.c
@@ -58,6 +58,7 @@
 #include "format-util.h"
 #include "fs-util.h"
 #include "gpt.h"
+#include "group-record.h"
 #include "hexdecoct.h"
 #include "hostname-setup.h"
 #include "hostname-util.h"
@@ -2618,6 +2619,7 @@ static int setup_journal(const char *directory, uid_t uid_shift, uid_t uid_range
                                 .source = p,
                                 .destination = p,
                                 .destination_uid = UID_INVALID,
+                                .destination_gid = GID_INVALID,
                         },
                         /* n= */ 1,
                         uid_shift,
@@ -4125,6 +4127,7 @@ static int outer_child(
                                 .destination = TAKE_PTR(sd),
                                 .options = TAKE_PTR(options),
                                 .destination_uid = bind_user->payload_user->uid,
+                                .destination_gid = bind_user->payload_group->gid,
                         };
                 }
 
@@ -4195,8 +4198,10 @@ static int outer_child(
                                 dirs,
                                 chown_uid,
                                 chown_range,
-                                /* source_owner= */ UID_INVALID,
-                                /* dest_owner= */ UID_INVALID,
+                                /* source_uid= */ UID_INVALID,
+                                /* source_gid= */ GID_INVALID,
+                                /* dest_uid= */ UID_INVALID,
+                                /* dest_gid= */ GID_INVALID,
                                 mapping);
                 if (r == -EINVAL || ERRNO_IS_NEG_NOT_SUPPORTED(r)) {
                         /* This might fail because the kernel or file system doesn't support idmapping. We

--- a/src/shared/dissect-image.c
+++ b/src/shared/dissect-image.c
@@ -2674,7 +2674,14 @@ int dissected_image_mount(
 
         if (userns_fd < 0 && need_user_mapping(uid_shift, uid_range) && FLAGS_SET(flags, DISSECT_IMAGE_MOUNT_IDMAPPED)) {
 
-                my_userns_fd = make_userns(uid_shift, uid_range, UID_INVALID, UID_INVALID, REMOUNT_IDMAPPING_HOST_ROOT);
+                my_userns_fd = make_userns(
+                                uid_shift,
+                                uid_range,
+                                /* source_uid= */ UID_INVALID,
+                                /* source_gid= */ GID_INVALID,
+                                /* dest_uid= */ UID_INVALID,
+                                /* dest_gid= */ GID_INVALID,
+                                REMOUNT_IDMAPPING_HOST_ROOT);
                 if (my_userns_fd < 0)
                         return my_userns_fd;
 

--- a/src/shared/mount-util.c
+++ b/src/shared/mount-util.c
@@ -1516,14 +1516,17 @@ int mount_fd_clone(int mount_fd, bool recursive, int *replacement_fd) {
         return TAKE_FD(fd1);
 }
 
-int make_userns(uid_t uid_shift,
+int make_userns(
+                uid_t uid_shift,
                 uid_t uid_range,
-                uid_t source_owner,
-                uid_t dest_owner,
+                uid_t source_uid,
+                gid_t source_gid,
+                uid_t dest_uid,
+                gid_t dest_gid,
                 RemountIdmapping idmapping) {
 
         _cleanup_close_ int userns_fd = -EBADF;
-        _cleanup_free_ char *line = NULL;
+        _cleanup_free_ char *uid_line = NULL, *gid_line = NULL;
         uid_t source_base = 0;
 
         /* Allocates a userns file descriptor with the mapping we need. For this we'll fork off a child
@@ -1541,7 +1544,7 @@ int make_userns(uid_t uid_shift,
         case REMOUNT_IDMAPPING_NONE:
         case REMOUNT_IDMAPPING_HOST_ROOT:
 
-                if (asprintf(&line,
+                if (asprintf(&uid_line,
                              UID_FMT " " UID_FMT " " UID_FMT "\n",
                              source_base, uid_shift, uid_range) < 0)
                         return log_oom_debug();
@@ -1558,7 +1561,7 @@ int make_userns(uid_t uid_shift,
                  * to the container's own UID range, but it's good to have a safety net, in case we
                  * forget it.) */
                 if (idmapping == REMOUNT_IDMAPPING_HOST_ROOT)
-                        if (strextendf(&line,
+                        if (strextendf(&uid_line,
                                        UID_FMT " " UID_FMT " " UID_FMT "\n",
                                        UID_MAPPED_ROOT, (uid_t) 0u, (uid_t) 1u) < 0)
                                 return log_oom_debug();
@@ -1569,10 +1572,16 @@ int make_userns(uid_t uid_shift,
                 /* Remap the owner of the bind mounted directory to the root user within the container. This
                  * way every file written by root within the container to the bind-mounted directory will
                  * be owned by the original user from the host. All other users will remain unmapped. */
-                if (asprintf(&line,
+                if (asprintf(&uid_line,
                              UID_FMT " " UID_FMT " " UID_FMT "\n",
-                             source_owner, uid_shift, (uid_t) 1u) < 0)
+                             source_uid, uid_shift, (uid_t) 1u) < 0)
                         return log_oom_debug();
+
+                if (asprintf(&gid_line,
+                             GID_FMT " " GID_FMT " " GID_FMT "\n",
+                             source_gid, (gid_t) uid_shift, (gid_t) 1u) < 0)
+                        return log_oom_debug();
+
                 break;
 
         case REMOUNT_IDMAPPING_HOST_OWNER_TO_TARGET_OWNER:
@@ -1580,18 +1589,23 @@ int make_userns(uid_t uid_shift,
                  * within the container. This way every file written by target directory owner within the
                  * container to the bind-mounted directory will be owned by the original host user.
                  * All other users will remain unmapped. */
-                if (asprintf(&line,
+                if (asprintf(&uid_line,
                              UID_FMT " " UID_FMT " " UID_FMT "\n",
-                             source_owner, dest_owner, (uid_t) 1u) < 0)
+                             source_uid, dest_uid, (uid_t) 1u) < 0)
                         return log_oom_debug();
+
+                if (asprintf(&gid_line,
+                             GID_FMT " " GID_FMT " " GID_FMT "\n",
+                             source_gid, dest_gid, (gid_t) 1u) < 0)
+                        return log_oom_debug();
+
                 break;
 
         default:
                 assert_not_reached();
         }
 
-        /* We always assign the same UID and GID ranges */
-        userns_fd = userns_acquire(line, line, /* setgroups_deny= */ true);
+        userns_fd = userns_acquire(uid_line, gid_line ?: uid_line, /* setgroups_deny= */ true);
         if (userns_fd < 0)
                 return log_debug_errno(userns_fd, "Failed to acquire new userns: %m");
 
@@ -1728,13 +1742,22 @@ int remount_idmap(
                 char **p,
                 uid_t uid_shift,
                 uid_t uid_range,
-                uid_t source_owner,
-                uid_t dest_owner,
+                uid_t source_uid,
+                gid_t source_gid,
+                uid_t dest_uid,
+                gid_t dest_gid,
                 RemountIdmapping idmapping) {
 
         _cleanup_close_ int userns_fd = -EBADF;
 
-        userns_fd = make_userns(uid_shift, uid_range, source_owner, dest_owner, idmapping);
+        userns_fd = make_userns(
+                        uid_shift,
+                        uid_range,
+                        source_uid,
+                        source_gid,
+                        dest_uid,
+                        dest_gid,
+                        idmapping);
         if (userns_fd < 0)
                 return userns_fd;
 

--- a/src/shared/mount-util.h
+++ b/src/shared/mount-util.h
@@ -150,14 +150,23 @@ typedef enum RemountIdmapping {
 int open_tree_attr_with_fallback(int dir_fd, const char *path, unsigned flags, struct mount_attr *attr);
 int open_tree_try_drop_idmap(int dir_fd, const char *path, unsigned flags);
 
-int make_userns(uid_t uid_shift, uid_t uid_range, uid_t source_owner, uid_t dest_owner, RemountIdmapping idmapping);
+int make_userns(
+                uid_t uid_shift,
+                uid_t uid_range,
+                uid_t source_uid,
+                gid_t source_gid,
+                uid_t dest_uid,
+                gid_t dest_gid,
+                RemountIdmapping idmapping);
 int remount_idmap_fd(char **p, int userns_fd, uint64_t extra_mount_attr_set);
 int remount_idmap(
                 char **p,
                 uid_t uid_shift,
                 uid_t uid_range,
-                uid_t source_owner,
-                uid_t dest_owner,
+                uid_t source_uid,
+                gid_t source_gid,
+                uid_t dest_uid,
+                gid_t dest_gid,
                 RemountIdmapping idmapping);
 
 /* Creates a mount point (without any parents) based on the source path or mode - i.e., a file or a directory */

--- a/test/units/TEST-13-NSPAWN.nspawn.sh
+++ b/test/units/TEST-13-NSPAWN.nspawn.sh
@@ -854,7 +854,7 @@ rootidmap_cleanup() {
 
 testcase_rootidmap() {
     local root cmd permissions
-    local owner=1000
+    local uid=1000 gid=1001
 
     root="$(mktemp -d /var/lib/machines/TEST-13-NSPAWN.rootidmap-path.XXX)"
     # Create ext4 image, as ext4 supports idmapped-mounts.
@@ -865,10 +865,10 @@ testcase_rootidmap() {
     trap "rootidmap_cleanup /tmp/rootidmap/" RETURN
 
     touch /tmp/rootidmap/bind/file
-    chown -R "$owner:$owner" /tmp/rootidmap/bind
+    chown -R "$uid:$gid" /tmp/rootidmap/bind
 
     create_dummy_container "$root"
-    cmd='PERMISSIONS=$(stat -c "%u:%g" /mnt/file); if [[ $PERMISSIONS != "0:0" ]]; then echo "*** wrong permissions: $PERMISSIONS"; return 1; fi; touch /mnt/other_file'
+    cmd='PERMISSIONS=$(stat -c "%u:%g" /mnt/file); if [[ $PERMISSIONS != "0:0" ]]; then echo "*** wrong permissions: $PERMISSIONS"; exit 1; fi; touch /mnt/other_file'
     if ! SYSTEMD_LOG_TARGET=console \
             systemd-nspawn --register=no \
                            --directory="$root" \
@@ -883,7 +883,7 @@ testcase_rootidmap() {
     fi
 
     permissions=$(stat -c "%u:%g" /tmp/rootidmap/bind/other_file)
-    if [[ $permissions != "$owner:$owner" ]]; then
+    if [[ $permissions != "$uid:$gid" ]]; then
         echo "*** wrong permissions: $permissions"
         [[ "$IS_USERNS_SUPPORTED" == "yes" ]] && return 1
     fi
@@ -898,7 +898,7 @@ owneridmap_cleanup() {
 
 testcase_owneridmap() {
     local root cmd permissions
-    local owner=1000
+    local uid=1000 gid=1001
 
     root="$(mktemp -d /var/lib/machines/TEST-13-NSPAWN.owneridmap-path.XXX)"
     # Create ext4 image, as ext4 supports idmapped-mounts.
@@ -909,7 +909,7 @@ testcase_owneridmap() {
     trap "owneridmap_cleanup /tmp/owneridmap/" RETURN
 
     touch /tmp/owneridmap/bind/file
-    chown -R "$owner:$owner" /tmp/owneridmap/bind
+    chown -R "$uid:$gid" /tmp/owneridmap/bind
 
     # Allow users to read and execute / in order to execute binaries
     chmod o+rx "$root"
@@ -937,7 +937,7 @@ EOF
     # as bash isn't invoked with the necessary environment variables for that.
     useradd --root="$root" --uid 1010 --user-group --create-home testuser
 
-    cmd='PERMISSIONS=$(stat -c "%u:%g" /home/testuser/file); if [[ $PERMISSIONS != "1010:1010" ]]; then echo "*** wrong permissions: $PERMISSIONS"; return 1; fi; touch /home/testuser/other_file'
+    cmd='PERMISSIONS=$(stat -c "%u:%g" /home/testuser/file); if [[ $PERMISSIONS != "1010:1010" ]]; then echo "*** wrong permissions: $PERMISSIONS"; exit 1; fi; touch /home/testuser/other_file'
     if ! SYSTEMD_LOG_TARGET=console \
             systemd-nspawn --register=no \
                            --directory="$root" \
@@ -955,7 +955,7 @@ EOF
     fi
 
     permissions=$(stat -c "%u:%g" /tmp/owneridmap/bind/other_file)
-    if [[ $permissions != "$owner:$owner" ]]; then
+    if [[ $permissions != "$uid:$gid" ]]; then
         echo "*** wrong permissions: $permissions"
         [[ "$IS_USERNS_SUPPORTED" == "yes" ]] && return 1
     fi
@@ -1549,15 +1549,14 @@ testcase_link_journal_host() {
 
     hoge="/var/log/journal/$(cat "$root"/etc/machine-id)/"
     mkdir -p "$hoge"
-    # The systemd-journal group is not mapped, so ensure the directory is owned by root:root
-    chown root:root "$hoge"
+    chown root:systemd-journal "$hoge"
 
     for i in no yes pick; do
         systemd-nspawn \
             --register=no --directory="$root" --private-users="$i" --link-journal=host \
-            bash -xec 'p="/var/log/journal/$(cat /etc/machine-id)"; mountpoint "$p"; [[ "$(stat "$p" --format=%u)" == 0 ]]; touch "$p/hoge"'
+            bash -xec 'p="/var/log/journal/$(cat /etc/machine-id)"; mountpoint "$p"; [[ "$(stat "$p" --format=%u:%g)" == 0:0 ]]; touch "$p/hoge"'
 
-        [[ "$(stat "${hoge}/hoge" --format=%u)" == 0 ]]
+        [[ "$(stat "${hoge}/hoge" --format=%U:%G)" == root:systemd-journal ]]
         rm "${hoge}/hoge"
     done
 


### PR DESCRIPTION
The GID map for these bind mounts was a copy of the UID map, so the group owning the source was never mapped unless its GID happened to equal the owner's UID.

This meant some mounts would show up inside the container with group "nobody", blocking writes. `--link-journal=host` hit this issue specifically.

Fixes #39302
