### PR TITLE
nspawn: align config `PrivateUsersOwnership` default with CLI

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -149,6 +149,11 @@ CHANGES WITH 262 in spe:
           and the "documentation" key is now an array of strings. Consumers
           of this interface must update their JSON parsing accordingly.
 
+        * The PrivateUsersOwnership= setting in .nspawn files now defaults to
+          "auto" when PrivateUsers= is "pick" or "managed", matching the
+          --private-users-ownership= command line switch. Previously "pick"
+          defaulted to "chown", and "managed" to "off".
+
         Changes in the system and service manager:
 
         * The manager now embeds a basic set of unit files (basic.target,

--- a/man/systemd-nspawn.xml
+++ b/man/systemd-nspawn.xml
@@ -953,8 +953,8 @@
         currently.</para>
 
         <para>The <option>--private-users-ownership=auto</option> option is implied if
-        <option>--private-users=pick</option> is used. This option has no effect if user namespacing is not
-        used.</para>
+        <option>--private-users=pick</option> or <option>--private-users=managed</option> is used. This
+        option has no effect if user namespacing is not used.</para>
 
         <para><citerefentry><refentrytitle>systemd-dissect</refentrytitle><manvolnum>1</manvolnum></citerefentry>'s
         <option>--shift</option> switch may be used to shift UID/GID ownership from or to the 0, foreign or

--- a/man/systemd.nspawn.xml
+++ b/man/systemd.nspawn.xml
@@ -582,9 +582,11 @@
         <term><varname>PrivateUsersOwnership=</varname></term>
 
         <listitem><para>Configures whether the ownership of the files and directories in the container tree
-        shall be adjusted to the UID/GID range used, if necessary and user namespacing is enabled. This is
-        equivalent to the <option>--private-users-ownership=</option> command line switch. This option is
-        privileged (see above).</para>
+        shall be adjusted to the UID/GID range used, if necessary. This is equivalent to the
+        <option>--private-users-ownership=</option> command line switch. This option is privileged (see
+        above). Defaults to <literal>auto</literal> if <varname>PrivateUsers=pick</varname> or
+        <varname>PrivateUsers=managed</varname> is used. This option has no effect if user namespacing is
+        not used.</para>
 
         <xi:include href="version-info.xml" xpointer="v249"/></listitem>
       </varlistentry>

--- a/src/nspawn/nspawn-settings.c
+++ b/src/nspawn/nspawn-settings.c
@@ -95,7 +95,9 @@ int settings_load(FILE *f, const char *path, Settings **ret) {
         /* Make sure that if userns_mode is set, userns_chown is set to something appropriate, and vice versa. Either
          * both fields shall be initialized or neither. */
         if (s->userns_mode >= 0 && s->userns_ownership < 0)
-                s->userns_ownership = s->userns_mode == USER_NAMESPACE_PICK ? USER_NAMESPACE_OWNERSHIP_CHOWN : USER_NAMESPACE_OWNERSHIP_OFF;
+                s->userns_ownership = IN_SET(s->userns_mode, USER_NAMESPACE_PICK, USER_NAMESPACE_MANAGED)
+                        ? USER_NAMESPACE_OWNERSHIP_AUTO
+                        : USER_NAMESPACE_OWNERSHIP_OFF;
         if (s->userns_ownership >= 0 && s->userns_mode < 0)
                 s->userns_mode = USER_NAMESPACE_NO;
 


### PR DESCRIPTION
The `systemd-nspawn` manpage says:

    The `--private-users-ownership=auto` option is implied if
    `--private-users=pick` is used.

This is true for the CLI, but not when set in a `.nspawn` file. Assuming these defaults should be the same across both.

This default was also not updated when `managed` was added by #35685.

As a result, this is a change in behavior for users who didn't set an explicit `PrivateUsersOwnership=` value in their `.nspawn` file.