### PR TITLE
hwdb: ignore duplicate mic mute key on Lenovo ThinkBook 14 G7 ARP

### DIFF
--- a/hwdb.d/60-keyboard.hwdb
+++ b/hwdb.d/60-keyboard.hwdb
@@ -1171,6 +1171,11 @@ evdev:atkbd:dmi:bvn*:bvr*:bd*:svnLENOVO:pn21N5*:pvrThinkBook16pG5IRX:*
  KEYBOARD_KEY_a1=!calc
  KEYBOARD_KEY_d7=unknown                                # Fn+F4 mic mute, also emitted by "Ideapad extra buttons", ignore
 
+# Lenovo ThinkBook 14 G7 ARP
+# Both mic mute events come from this device: 0x8 (ACPI) and 0x13e (WMI)
+evdev:name:Ideapad extra buttons:dmi:*:svnLENOVO:pn21MV:pvrThinkBook14G7ARP:*
+ KEYBOARD_KEY_13e=unknown                               # Fn+F4 mic mute, also emitted as scan code 0x8, ignore
+
 evdev:atkbd:dmi:*:svnLENOVO:*:pvrLenovoYoga300-11IBR:*
  KEYBOARD_KEY_62=unknown                                # Touchpad on, also emitted by "Ideapad extra buttons", ignore
  KEYBOARD_KEY_63=unknown                                # Touchpad off, also emitted by "Ideapad extra buttons", ignore


### PR DESCRIPTION
On the Lenovo ThinkBook 14 G7 ARP (21MV), the mic mute key (Fn+F4) is reported twice per keypress and therefore appears not to work at all: userspace toggles the mute state twice within a few milliseconds and it returns to its previous value. Roughly one press out of several takes effect, presumably when the firmware drops one of the two notifications.

`ideapad-laptop` is bound to both the ACPI device (`VPC2004:00`) and the WMI device (`8FC0DE0C-B4E4-43FD-B0F3-8871711C1294`) at the same time, and both report the key into the same input device, `Ideapad extra buttons`, with **different scan codes**. Raw evdev, three physical keypresses:

```
+7.176s   MSC_SCAN = 0x8     KEY_MICMUTE (248) pressed/released
+7.182s   MSC_SCAN = 0x13e   KEY_MICMUTE (248) pressed/released
+10.878s  MSC_SCAN = 0x8     KEY_MICMUTE (248) pressed/released
+10.878s  MSC_SCAN = 0x13e   KEY_MICMUTE (248) pressed/released
+14.747s  MSC_SCAN = 0x8     KEY_MICMUTE (248) pressed/released
+14.752s  MSC_SCAN = 0x13e   KEY_MICMUTE (248) pressed/released
```

`0x8` is the ACPI path and `0x13e` is the WMI path. I confirmed this directly by unbinding `ideapad_wmi`, which leaves only the `0x8` events:

```
+8.816s   MSC_SCAN = 0x8     KEY_MICMUTE (248) pressed/released
+9.785s   MSC_SCAN = 0x8     KEY_MICMUTE (248) pressed/released
+10.909s  MSC_SCAN = 0x8     KEY_MICMUTE (248) pressed/released
```

With this rule applied, the second event is reported as `KEY_UNKNOWN` (240) instead of `KEY_MICMUTE`, and the key toggles the microphone reliably on every press, mic mute LED included:

```
+5.268s   MSC_SCAN = 0x8     EV_KEY 248 pressed/released
+5.273s   MSC_SCAN = 0x13e   EV_KEY 240 pressed/released
```

This is the same symptom already handled for the ThinkBook 16p G5 IRX a few lines above, with one difference: there the duplicate comes from the AT keyboard, while here both events originate from `Ideapad extra buttons` itself, which is why this entry matches on the device name rather than on `atkbd`.

The approach was suggested on the platform-driver-x86 mailing list, in preference to unbinding the WMI driver.

Tested on Fedora 44, kernel 7.2.4-200.fc44.x86_64, BIOS P6CN34WW.

<details>
<summary><code>udevadm info /dev/input/event12</code> with the rule applied</summary>

```
P: /devices/pci0000:00/0000:00:14.3/PNP0C09:00/VPC2004:00/input/input14/event12
M: event12
R: 12
J: c13:76
U: input
D: c 13:76
N: input/event12
L: 0
S: input/by-path/pci-0000:00:14.3-platform-VPC2004:00-event
E: DEVPATH=/devices/pci0000:00/0000:00:14.3/PNP0C09:00/VPC2004:00/input/input14/event12
E: DEVNAME=/dev/input/event12
E: MAJOR=13
E: MINOR=76
E: SUBSYSTEM=input
E: USEC_INITIALIZED=9002942
E: KEYBOARD_KEY_13e=unknown
E: KEYBOARD_KEY_0d=rfkill
E: ID_INPUT=1
E: ID_INPUT_KEY=1
E: ID_PATH=pci-0000:00:14.3-platform-VPC2004:00
E: ID_PATH_TAG=pci-0000_00_14_3-platform-VPC2004_00
E: NVME_HOST_IFACE=none
E: LIBINPUT_DEVICE_GROUP=19/0/0:ideapad
E: DEVLINKS=/dev/input/by-path/pci-0000:00:14.3-platform-VPC2004:00-event
E: TAGS=:power-switch:
E: CURRENT_TAGS=:power-switch:

```

</details>
